### PR TITLE
Cherry-pick #23156 to 7.11: GA Elastic Log Driver in docs

### DIFF
--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -6,7 +6,6 @@
 <titleabbrev>Configuration options</titleabbrev>
 ++++
 
-experimental[]
 
 Use the following options to configure the {log-driver-long}. You can
 pass these options with the `--log-opt` flag when you start a container, or

--- a/x-pack/dockerlogbeat/docs/install.asciidoc
+++ b/x-pack/dockerlogbeat/docs/install.asciidoc
@@ -6,7 +6,6 @@
 <titleabbrev>Install and configure</titleabbrev>
 ++++
 
-experimental[]
 
 [float]
 === Before you begin

--- a/x-pack/dockerlogbeat/docs/limitations.asciidoc
+++ b/x-pack/dockerlogbeat/docs/limitations.asciidoc
@@ -2,7 +2,6 @@
 [role="xpack"]
 == Known problems and limitations
 
-experimental[]
 
 This release of the {log-driver} has the following known problems and
 limitations:

--- a/x-pack/dockerlogbeat/docs/overview.asciidoc
+++ b/x-pack/dockerlogbeat/docs/overview.asciidoc
@@ -2,7 +2,6 @@
 [role="xpack"]
 == {log-driver} overview
 
-experimental[]
 
 The {log-driver} is a Docker plugin that sends container logs to the
 https://www.elastic.co/elastic-stack[{stack}], where you can search, analyze,

--- a/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
+++ b/x-pack/dockerlogbeat/docs/troubleshooting.asciidoc
@@ -2,7 +2,6 @@
 [role="xpack"]
 == Troubleshoot
 
-experimental[]
 
 You can set the debug level to capture debugging output about the {log-driver}.
 To set the debug level:

--- a/x-pack/dockerlogbeat/docs/usage.asciidoc
+++ b/x-pack/dockerlogbeat/docs/usage.asciidoc
@@ -5,7 +5,6 @@
 <titleabbrev>Usage examples</titleabbrev>
 ++++
 
-experimental[]
 
 The following examples show common configurations for the {log-driver}.
 


### PR DESCRIPTION
Cherry-pick of PR #23156 to 7.11 branch. Original message: 

## What does this PR do?

This PR GAs the Elastic Log Driver from the perspective of the docs, and removes the `experimental` warning from the docs.

## Why is it important?

We want to GA the Elastic Log Driver in 7.11.

## Checklist

- [X] I have made corresponding changes to the documentation
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

