### PR TITLE
Cherry-pick #23001 to 7.11: [build] add MADVDONTNEED to builds

### DIFF
--- a/dev-tools/packaging/templates/deb/elastic-agent.init.sh.tmpl
+++ b/dev-tools/packaging/templates/deb/elastic-agent.init.sh.tmpl
@@ -24,11 +24,15 @@ BEAT_USER="{{.BeatUser}}"
 WRAPPER_ARGS="-r / -n -p $PIDFILE"
 SCRIPTNAME=/etc/init.d/{{.ServiceName}}
 
+
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
 
 # Read configuration variable file if it is present
 [ -r /etc/default/{{.ServiceName}} ] && . /etc/default/{{.ServiceName}}
+
+DEFAULT_GODEBUG="madvdontneed=1"
+export GODEBUG=${GODEBUG-$DEFAULT_GODEBUG}
 
 [ "$BEAT_USER" != "root" ] && WRAPPER_ARGS="$WRAPPER_ARGS -u $BEAT_USER"
 USER_WRAPPER="su"

--- a/dev-tools/packaging/templates/deb/init.sh.tmpl
+++ b/dev-tools/packaging/templates/deb/init.sh.tmpl
@@ -25,11 +25,15 @@ BEAT_USER="{{.BeatUser}}"
 WRAPPER_ARGS="-r / -n -p $PIDFILE"
 SCRIPTNAME=/etc/init.d/{{.ServiceName}}
 
+
 # Exit if the package is not installed
 [ -x "$DAEMON" ] || exit 0
 
 # Read configuration variable file if it is present
 [ -r /etc/default/{{.ServiceName}} ] && . /etc/default/{{.ServiceName}}
+
+DEFAULT_GODEBUG="madvdontneed=1"
+export GODEBUG=${GODEBUG-$DEFAULT_GODEBUG}
 
 [ "$BEAT_USER" != "root" ] && WRAPPER_ARGS="$WRAPPER_ARGS -u $BEAT_USER"
 USER_WRAPPER="su"

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -67,6 +67,7 @@ LABEL \
 
 ENV ELASTIC_CONTAINER "true"
 ENV PATH={{ $beatHome }}:$PATH
+ENV GODEBUG="madvdontneed=1"
 
 # Add an init process, check the checksum to make sure it's a match
 RUN set -e ; \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -59,6 +59,7 @@ LABEL \
 
 ENV ELASTIC_CONTAINER "true"
 ENV PATH={{ $beatHome }}:$PATH
+ENV GODEBUG="madvdontneed=1"
 
 # Add an init process, check the checksum to make sure it's a match
 RUN set -e ; \

--- a/dev-tools/packaging/templates/linux/elastic-agent.unit.tmpl
+++ b/dev-tools/packaging/templates/linux/elastic-agent.unit.tmpl
@@ -9,6 +9,7 @@ After=network-online.target
 User={{ .BeatUser }}
 Group={{ .BeatUser }}
 {{- end }}
+Environment="GODEBUG='madvdontneed=1'"
 Environment="BEAT_CONFIG_OPTS=-c /etc/{{.BeatName}}/{{.BeatName}}.yml"
 ExecStart=/usr/bin/{{.BeatName}} run --environment systemd $BEAT_CONFIG_OPTS
 Restart=always

--- a/dev-tools/packaging/templates/linux/systemd.unit.tmpl
+++ b/dev-tools/packaging/templates/linux/systemd.unit.tmpl
@@ -9,6 +9,7 @@ After=network-online.target
 User={{ .BeatUser }}
 Group={{ .BeatUser }}
 {{- end }}
+Environment="GODEBUG='madvdontneed=1'"
 Environment="BEAT_LOG_OPTS="
 Environment="BEAT_CONFIG_OPTS=-c /etc/{{.BeatName}}/{{.BeatName}}.yml"
 Environment="BEAT_PATH_OPTS=--path.home /usr/share/{{.BeatName}} --path.config /etc/{{.BeatName}} --path.data /var/lib/{{.BeatName}} --path.logs /var/log/{{.BeatName}}"

--- a/dev-tools/packaging/templates/rpm/elastic-agent.init.sh.tmpl
+++ b/dev-tools/packaging/templates/rpm/elastic-agent.init.sh.tmpl
@@ -32,6 +32,8 @@ wrapperopts="-r / -n -p $pidfile"
 user_wrapper="su"
 user_wrapperopts="$beat_user -c"
 RETVAL=0
+DEFAULT_GODEBUG="madvdontneed=1"
+export GODEBUG=${GODEBUG-$DEFAULT_GODEBUG}
 
 # Source function library.
 . /etc/rc.d/init.d/functions

--- a/dev-tools/packaging/templates/rpm/init.sh.tmpl
+++ b/dev-tools/packaging/templates/rpm/init.sh.tmpl
@@ -33,6 +33,8 @@ wrapperopts="-r / -n -p $pidfile"
 user_wrapper="su"
 user_wrapperopts="$beat_user -c"
 RETVAL=0
+DEFAULT_GODEBUG="madvdontneed=1"
+export GODEBUG=${GODEBUG-$DEFAULT_GODEBUG}
 
 # Source function library.
 . /etc/rc.d/init.d/functions


### PR DESCRIPTION
Cherry-pick of PR #23001 to 7.11 branch. Original message: 

## What does this PR do?

This adds `GODEBUG="madvdontneed=1"` to the docker images and init scripts.
Note that I haven't tested this yet as I'm not sure what to check beyond "the env var exists in the final builds"

## Why is it important?

See https://github.com/elastic/beats/issues/22786 From the linked issue:

> The go runtime defaults to MADV_FREE by default. In that case pages are still assigned with the Beat, even after the pages have been "returned" to the OS. The kernel will eventually claim these pages, but RSS memory usage is reported as very high (which it is not necessarily). This seems to mess with the OOM killer at times.

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- https://github.com/elastic/beats/issues/22786

