### PR TITLE
[CI] disable aws cloud testing by default

### DIFF
--- a/.ci/jobs/beats-schedule-weekly.yml
+++ b/.ci/jobs/beats-schedule-weekly.yml
@@ -1,0 +1,27 @@
+---
+- job:
+    name: beats-schedule-weekly
+    display-name: Jobs scheduled weekly (Monday)
+    description: Jobs scheduled weekly (Monday)
+    view: APM-CI
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/schedule-weekly.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/beats.git
+            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/beats.git
+            branches:
+              - $branch_specifier
+    triggers:
+      - timed: 'H H(1-4) * * 1'

--- a/.ci/jobs/beats-schedule-weekly.yml
+++ b/.ci/jobs/beats-schedule-weekly.yml
@@ -1,9 +1,9 @@
 ---
 - job:
     name: beats-schedule-weekly
-    display-name: Jobs scheduled weekly (Monday)
-    description: Jobs scheduled weekly (Monday)
-    view: APM-CI
+    display-name: Jobs scheduled weekly (Sunday)
+    description: Jobs scheduled weekly (Sunday)
+    view: Beats
     project-type: pipeline
     parameters:
       - string:
@@ -24,4 +24,4 @@
             branches:
               - $branch_specifier
     triggers:
-      - timed: 'H H(1-4) * * 1'
+      - timed: 'H H(1-4) * * 0'

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -1,0 +1,33 @@
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'master' }
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL = 'INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron('H H(1-4) * * 1')
+  }
+  stages {
+    stage('Nighly beats builds') {
+      steps {
+        echo 'TBD'
+        // awsCloudTests
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -1,7 +1,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'master' }
+  agent none
   environment {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL = 'INFO'
@@ -15,19 +15,19 @@ pipeline {
     durabilityHint('PERFORMANCE_OPTIMIZED')
   }
   triggers {
-    cron('H H(1-4) * * 1')
+    cron('H H(1-4) * * 0')
   }
   stages {
     stage('Nighly beats builds') {
       steps {
-        echo 'TBD'
-        // awsCloudTests
+        build(quietPeriod: 0, job: 'Beats/beats/master', parameters: [booleanParam(name: 'awsCloudTests', value: true)])
+        build(quietPeriod: 1000, job: 'Beats/beats/7.x', parameters: [booleanParam(name: 'awsCloudTests', value: true)])
       }
     }
   }
   post {
     cleanup {
-      notifyBuildResult()
+      notifyBuildResult(prComment: false)
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'allCloudTests', defaultValue: false, description: 'Run all cloud integration tests.')
-    booleanParam(name: 'awsCloudTests', defaultValue: true, description: 'Run AWS cloud integration tests.')
+    booleanParam(name: 'awsCloudTests', defaultValue: false, description: 'Run AWS cloud integration tests.')
     string(name: 'awsRegion', defaultValue: 'eu-central-1', description: 'Default AWS region to use for testing.')
     booleanParam(name: 'runAllStages', defaultValue: false, description: 'Allow to run all stages.')
     booleanParam(name: 'armTest', defaultValue: false, description: 'Allow ARM stages.')

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -19,7 +19,7 @@ stages:
           make -C x-pack/metricbeat update;
           make check-no-changes;
     unitTest:
-        make: "mage build unitTest"
+        mage: "mage build unitTest"
     cloud:
         cloud: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -19,10 +19,20 @@ stages:
           make -C x-pack/metricbeat update;
           make check-no-changes;
     build:
+        make: "mage build test"
+        withModule: true       ## run the ITs only if the changeset affects a specific module.
+    cloud:
         cloud: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
         dirs:                  ## run the cloud tests for the given modules.
             - "x-pack/metricbeat/module/aws"
+        when:                  ## Override the top-level when.
+            parameters:
+                - "awsCloudTests"
+            comments:
+                - "/test x-pack/metricbeat for aws cloud"
+            labels:
+                - "aws"
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -18,9 +18,8 @@ stages:
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
           make check-no-changes;
-    build:
-        make: "mage build test"
-        withModule: true       ## run the ITs only if the changeset affects a specific module.
+    unitTest:
+        make: "mage build unitTest"
     cloud:
         cloud: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.


### PR DESCRIPTION
## What does this PR do?

Run Cloud Testing on demand using the UI, comments or labels or on a weekly basis for the `master` and `7.x` branches.

### Triggers:

- UI based with the parameter `awsCloudTests`
- GH comment `/test x-pack/metricbeat for aws cloud`
- GH Label `aws`

## Why is it important?

Cloud Testing got a limitation with the number of db instances concurrently with the current service account used in the CI

```
[2020-12-14T15:41:25.769Z] Error: Error creating DB Instance: InstanceQuotaExceeded: DB Instance quota exceeded
[2020-12-14T15:41:25.769Z] 	status code: 400, request id: 7ce18407-a537-4d4e-ad21-75cd3730160b
[2020-12-14T15:41:25.769Z] 
[2020-12-14T15:41:25.769Z]   on terraform.tf line 18, in resource "aws_db_instance" "test":
[2020-12-14T15:41:25.769Z]   18: resource "aws_db_instance" "test" {
```

The quotas and limitations can be found in the [limits](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Limits) section.

## Issues

See https://github.com/elastic/beats/pull/23105#issuecomment-744687256

cc @jsoriano  and @ph as you commented in https://github.com/elastic/beats/pull/23105#issuecomment-744687256