### PR TITLE
Cherry-pick #23185 to 7.x: [docs] Fix typo in elastic agent config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -161,6 +161,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   as gauges (rather than counters). {pull}22877[22877]
 - Use PROGRAMDATA environment variable instead of C:\ProgramData for windows install service {pull}22874[22874]
 - Fix reporting of cgroup metrics when running under Docker {pull}22879[22879]
+- Fix typo in config docs {pull}23185[23185]
 - Fix `nested` subfield handling in generated Elasticsearch templates. {issue}23178[23178] {pull}23183[23183]
 
 

--- a/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
@@ -43,7 +43,7 @@ inputs:
 #   # enables metrics monitoring
 #   metrics: true
 
-# # Allow fleet to reload his configuration locally on disk.
+# # Allow fleet to reload its configuration locally on disk.
 # # Notes: Only specific process configuration will be reloaded.
 # agent.reload:
 #   # enabled configure the Elastic Agent to reload or not the local configuration.

--- a/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
@@ -117,7 +117,7 @@ inputs:
 #   # enables metrics monitoring
 #   metrics: false
 
-# # Allow fleet to reload his configuration locally on disk.
+# # Allow fleet to reload its configuration locally on disk.
 # # Notes: Only specific process configuration will be reloaded.
 # agent.reload:
 #   # enabled configure the Elastic Agent to reload or not the local configuration.

--- a/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
@@ -117,7 +117,7 @@ inputs:
 #   # enables metrics monitoring
 #   metrics: false
 
-# # Allow fleet to reload his configuration locally on disk.
+# # Allow fleet to reload its configuration locally on disk.
 # # Notes: Only specific process configuration will be reloaded.
 # agent.reload:
 #   # enabled configure the Elastic Agent to reload or not the local configuration.

--- a/x-pack/elastic-agent/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/elastic-agent.docker.yml
@@ -117,7 +117,7 @@ inputs:
 #   # enables metrics monitoring
 #   metrics: false
 
-# # Allow fleet to reload his configuration locally on disk.
+# # Allow fleet to reload its configuration locally on disk.
 # # Notes: Only specific process configuration will be reloaded.
 # agent.reload:
 #   # enabled configure the Elastic Agent to reload or not the local configuration.

--- a/x-pack/elastic-agent/elastic-agent.reference.yml
+++ b/x-pack/elastic-agent/elastic-agent.reference.yml
@@ -123,7 +123,7 @@ inputs:
 #   # enables metrics monitoring
 #   metrics: false
 
-# # Allow fleet to reload his configuration locally on disk.
+# # Allow fleet to reload its configuration locally on disk.
 # # Notes: Only specific process configuration will be reloaded.
 # agent.reload:
 #   # enabled configure the Elastic Agent to reload or not the local configuration.

--- a/x-pack/elastic-agent/elastic-agent.yml
+++ b/x-pack/elastic-agent/elastic-agent.yml
@@ -49,7 +49,7 @@ inputs:
 #   # enables metrics monitoring
 #   metrics: true
 
-# # Allow fleet to reload his configuration locally on disk.
+# # Allow fleet to reload its configuration locally on disk.
 # # Notes: Only specific process configuration will be reloaded.
 # agent.reload:
 #   # enabled configure the Elastic Agent to reload or not the local configuration.


### PR DESCRIPTION
Cherry-pick of PR #23185 to 7.x branch. Original message: 

## What does this PR do?

This fixes what I assume is a typo, as we don't normally refer to the agent as a "him."

## Why is it important?

This is a typo.

## Checklist 

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [] I have made corresponding changes to the documentation~~
- [X] I have made corresponding change to the default configuration files
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

