### PR TITLE
simplify regex for org & custom prefix in aws/cloudtrail

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -355,6 +355,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix aws s3 overview dashboard. {pull}23045[23045]
 - Fix bad `network.direction` values in Fortinet/firewall fileset. {pull}23072[23072]
 - Add support for organization and custom prefix in AWS/CloudTrail fileset. {issue}23109[23109] {pull}23126[23126]
+- Simplify regex for organization custom prefix in AWS/CloudTrail fileset. {issue}23203[23203] {pull}23204[23204]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/s3.yml
@@ -2,16 +2,16 @@ type: s3
 queue_url: {{ .queue_url }}
 file_selectors:
 {{ if .process_cloudtrail_logs }}
-  - regex: 'AWSLogs/\d+/CloudTrail/'
+  - regex: '/CloudTrail/'
     expand_event_list_from_field: 'Records'
 {{ end }}
 
 {{ if .process_digest_logs }}
-  - regex: 'AWSLogs/\d+/CloudTrail-Digest/'
+  - regex: '/CloudTrail-Digest/'
 {{ end }}
 
 {{ if .process_insight_logs }}
-  - regex: 'AWSLogs/\d+/CloudTrail-Insight/'
+  - regex: '/CloudTrail-Insight/'
     expand_event_list_from_field: 'Records'
 {{ end }}
 


### PR DESCRIPTION
## What does this PR do?

changes regex to only match on /CloudTrail/, /CloudTrail-Digest/ and
/CloudTrail-Insight/.  This removes the prefix which is variable based
on custom prefix and organization.

## Why is it important?

cloudtrail will work if you have custom prefix or organization.  And
you will still be able to skip Digest or Insight logs if necessary.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Need to test in AWS with custom prefix or organization.  Did test
regex against known cloudtrail filename patterns.

```
custom-prefix/AWSLogs/1234567890/CloudTrail/....
o-xxxxxxx/AWSLogs/1234567890/CloudTrail/...
AWSLogs/1234567890/CloudTrail/
AWSLogs/o-xxxxxxx/1234567890/CloudTrail/...
```

## Related issues

- Closes #23203