### PR TITLE
[Filebeat] Add pubsub_alternative_host to gcp pubsub input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -786,6 +786,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Misp improvements: Migration to httpjson v2 config, pagination and deduplication ID {pull}23070[23070]
 - Add Google Workspace module and mark Gsuite module as deprecated {pull}22950[22950]
 - Mark m365 defender, defender atp, okta and google workspace modules as GA {pull}23113[23113]
+- Added `alternative_host` option to google pubsub input {pull}23215[23215]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/gcppubsub/config.go
+++ b/x-pack/filebeat/input/gcppubsub/config.go
@@ -36,6 +36,8 @@ type config struct {
 
 	// JSON blob containing authentication credentials and key.
 	CredentialsJSON []byte `config:"credentials_json"`
+
+	PubsubAlternativeHost string `config:"pubsub_alternative_host"`
 }
 
 func (c *config) Validate() error {

--- a/x-pack/filebeat/input/gcppubsub/config.go
+++ b/x-pack/filebeat/input/gcppubsub/config.go
@@ -37,6 +37,7 @@ type config struct {
 	// JSON blob containing authentication credentials and key.
 	CredentialsJSON []byte `config:"credentials_json"`
 
+	// Overrides the default Pub/Sub service address and disables TLS. For testing.
 	AlternativeHost string `config:"alternative_host"`
 }
 

--- a/x-pack/filebeat/input/gcppubsub/config.go
+++ b/x-pack/filebeat/input/gcppubsub/config.go
@@ -37,7 +37,7 @@ type config struct {
 	// JSON blob containing authentication credentials and key.
 	CredentialsJSON []byte `config:"credentials_json"`
 
-	PubsubAlternativeHost string `config:"pubsub_alternative_host"`
+	AlternativeHost string `config:"alternative_host"`
 }
 
 func (c *config) Validate() error {

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -8,8 +8,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"sync"
 	"time"
+
+	"google.golang.org/grpc"
 
 	"cloud.google.com/go/pubsub"
 	"github.com/pkg/errors"
@@ -147,15 +150,7 @@ func (in *pubsubInput) run() error {
 	ctx, cancel := context.WithCancel(in.workerCtx)
 	defer cancel()
 
-	// Make pubsub client.
-	opts := []option.ClientOption{option.WithUserAgent(useragent.UserAgent("Filebeat"))}
-	if in.CredentialsFile != "" {
-		opts = append(opts, option.WithCredentialsFile(in.CredentialsFile))
-	} else if len(in.CredentialsJSON) > 0 {
-		option.WithCredentialsJSON(in.CredentialsJSON)
-	}
-
-	client, err := pubsub.NewClient(ctx, in.ProjectID, opts...)
+	client, err := in.newPubsubClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -249,4 +244,21 @@ func (in *pubsubInput) getOrCreateSubscription(ctx context.Context, client *pubs
 	}
 
 	return nil, errors.New("no subscription exists and 'subscription.create' is not enabled")
+}
+
+func (in *pubsubInput) newPubsubClient(ctx context.Context) (*pubsub.Client, error) {
+	opts := []option.ClientOption{option.WithUserAgent(useragent.UserAgent("Filebeat"))}
+	if in.PubsubAlternativeHost != "" {
+		// this will be typically set because we want to point the input to a testing pubsub emulator
+		conn, err := grpc.Dial(in.PubsubAlternativeHost, grpc.WithInsecure())
+		if err != nil {
+			return nil, fmt.Errorf("grpc.Dial: %v", err)
+		}
+		opts = append(opts, option.WithGRPCConn(conn), option.WithTelemetryDisabled())
+	} else if in.CredentialsFile != "" {
+		opts = append(opts, option.WithCredentialsFile(in.CredentialsFile))
+	} else if len(in.CredentialsJSON) > 0 {
+		opts = append(opts, option.WithCredentialsJSON(in.CredentialsJSON))
+	}
+	return pubsub.NewClient(ctx, in.ProjectID, opts...)
 }

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -12,11 +12,10 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc"
-
 	"cloud.google.com/go/pubsub"
 	"github.com/pkg/errors"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
 	"github.com/elastic/beats/v7/filebeat/input"
@@ -253,7 +252,7 @@ func (in *pubsubInput) newPubsubClient(ctx context.Context) (*pubsub.Client, err
 		// this will be typically set because we want to point the input to a testing pubsub emulator
 		conn, err := grpc.Dial(in.AlternativeHost, grpc.WithInsecure())
 		if err != nil {
-			return nil, fmt.Errorf("grpc.Dial: %w", err)
+			return nil, fmt.Errorf("cannot connect to alternative host %q: %w", in.AlternativeHost, err)
 		}
 		opts = append(opts, option.WithGRPCConn(conn), option.WithTelemetryDisabled())
 	}

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -248,17 +248,21 @@ func (in *pubsubInput) getOrCreateSubscription(ctx context.Context, client *pubs
 
 func (in *pubsubInput) newPubsubClient(ctx context.Context) (*pubsub.Client, error) {
 	opts := []option.ClientOption{option.WithUserAgent(useragent.UserAgent("Filebeat"))}
-	if in.PubsubAlternativeHost != "" {
+
+	if in.AlternativeHost != "" {
 		// this will be typically set because we want to point the input to a testing pubsub emulator
-		conn, err := grpc.Dial(in.PubsubAlternativeHost, grpc.WithInsecure())
+		conn, err := grpc.Dial(in.AlternativeHost, grpc.WithInsecure())
 		if err != nil {
-			return nil, fmt.Errorf("grpc.Dial: %v", err)
+			return nil, fmt.Errorf("grpc.Dial: %w", err)
 		}
 		opts = append(opts, option.WithGRPCConn(conn), option.WithTelemetryDisabled())
-	} else if in.CredentialsFile != "" {
+	}
+
+	if in.CredentialsFile != "" {
 		opts = append(opts, option.WithCredentialsFile(in.CredentialsFile))
 	} else if len(in.CredentialsJSON) > 0 {
 		opts = append(opts, option.WithCredentialsJSON(in.CredentialsJSON))
 	}
+
 	return pubsub.NewClient(ctx, in.ProjectID, opts...)
 }


### PR DESCRIPTION
## What does this PR do?

Adds an option to set a custom pubsub alternative host to pubsub input.

## Why is it important?

To be able to start the input using the GCP Pubsub emulator we needed a way to configure it to point to our testing host and bypass credential initialization.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~ (we do not want to document that as it is intended for testing)
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
