### PR TITLE
Cherry-pick #22668 to 7.x: Honor kube event resysncs to handle missed watch events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -384,6 +384,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Improve equals check. {pull}22778[22778]
+- Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -169,8 +169,6 @@ func (a *Autodiscover) worker() {
 }
 
 func (a *Autodiscover) handleStart(event bus.Event) bool {
-	var updated bool
-
 	a.logger.Debugf("Got a start event: %v", event)
 
 	eventID := getID(event)
@@ -181,7 +179,7 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 
 	// Ensure configs list exists for this instance
 	if _, ok := a.configs[eventID]; !ok {
-		a.configs[eventID] = map[uint64]*reload.ConfigWithMeta{}
+		a.configs[eventID] = make(map[uint64]*reload.ConfigWithMeta)
 	}
 
 	configs, err := a.configurer.CreateConfig(event)
@@ -195,6 +193,11 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 			a.logger.Debugf("Generated config: %+v", common.DebugString(c, true))
 		}
 	}
+
+	var (
+		updated bool
+		newCfg  = make(map[uint64]*reload.ConfigWithMeta)
+	)
 
 	meta := a.getMeta(event)
 	for _, config := range configs {
@@ -215,16 +218,30 @@ func (a *Autodiscover) handleStart(event bus.Event) bool {
 		// Update meta no matter what
 		dynFields := a.meta.Store(hash, meta)
 
-		if a.configs[eventID][hash] != nil {
+		if cfg, ok := a.configs[eventID][hash]; ok {
 			a.logger.Debugf("Config %v is already running", common.DebugString(config, true))
+			newCfg[hash] = cfg
 			continue
+		} else {
+			newCfg[hash] = &reload.ConfigWithMeta{
+				Config: config,
+				Meta:   &dynFields,
+			}
 		}
 
-		a.configs[eventID][hash] = &reload.ConfigWithMeta{
-			Config: config,
-			Meta:   &dynFields,
-		}
 		updated = true
+	}
+
+	// If the new add event has lesser configs than the previous stable configuration then it means that there were
+	// configs that were removed in something like a resync event.
+	if len(newCfg) < len(a.configs[eventID]) {
+		updated = true
+	}
+
+	// By replacing the config's for eventID we make sure that all old configs that are no longer in use
+	// are stopped correctly. This will ensure that a resync event is handled correctly.
+	if updated {
+		a.configs[eventID] = newCfg
 	}
 
 	return updated

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -39,7 +39,7 @@ type pod struct {
 	config           *Config
 	metagen          metadata.MetaGen
 	logger           *logp.Logger
-	publish          func(bus.Event)
+	publish          func([]bus.Event)
 	watcher          kubernetes.Watcher
 	nodeWatcher      kubernetes.Watcher
 	namespaceWatcher kubernetes.Watcher
@@ -47,7 +47,7 @@ type pod struct {
 }
 
 // NewPodEventer creates an eventer that can discover and process pod objects
-func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event bus.Event)) (Eventer, error) {
+func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event []bus.Event)) (Eventer, error) {
 	logger := logp.NewLogger("autodiscover.pod")
 
 	config := defaultConfig()
@@ -67,9 +67,10 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 	logger.Debugf("Initializing a new Kubernetes watcher using node: %v", config.Node)
 
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
-		SyncTimeout: config.SyncPeriod,
-		Node:        config.Node,
-		Namespace:   config.Namespace,
+		SyncTimeout:  config.SyncPeriod,
+		Node:         config.Node,
+		Namespace:    config.Namespace,
+		HonorReSyncs: true,
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Pod{}, err)
@@ -317,7 +318,8 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 	var (
 		annotations = common.MapStr{}
 		nsAnn       = common.MapStr{}
-		events      = make([]bus.Event, 0)
+		podPorts    = common.MapStr{}
+		eventList   = make([][]bus.Event, 0)
 	)
 	for k, v := range pod.GetObjectMeta().GetAnnotations() {
 		safemapstr.Put(annotations, k, v)
@@ -333,7 +335,6 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 		}
 	}
 
-	podPorts := common.MapStr{}
 	// Emit container and port information
 	for _, c := range containers {
 		// If it doesn't have an ID, container doesn't exist in
@@ -375,6 +376,7 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 			kubemeta["namespace_annotations"] = nsAnn
 		}
 
+		var events []bus.Event
 		// Without this check there would be overlapping configurations with and without ports.
 		if len(c.Ports) == 0 {
 			// Set a zero port on the event to signify that the event is from a container
@@ -409,6 +411,9 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 			}
 			events = append(events, event)
 		}
+		if len(events) != 0 {
+			eventList = append(eventList, events)
+		}
 	}
 
 	// Publish a pod level event so that hints that have no exposed ports can get processed.
@@ -416,7 +421,7 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 	// Publish the pod level hint only if at least one container level hint was generated. This ensures that there is
 	// no unnecessary pod level events emitted prematurely.
 	// We publish the pod level hint first so that it doesn't override a valid container level event.
-	if len(events) != 0 {
+	if len(eventList) != 0 {
 		meta := p.metagen.Generate(pod)
 
 		// Information that can be used in discovering a workload
@@ -438,11 +443,11 @@ func (p *pod) emitEvents(pod *kubernetes.Pod, flag string, containers []kubernet
 				"kubernetes": meta,
 			},
 		}
-		p.publish(event)
+		p.publish([]bus.Event{event})
 	}
 
-	// Publish the container level hints finally.
-	for _, event := range events {
-		p.publish(event)
+	// Ensure that the pod level event is published first to avoid pod metadata overriding a valid container metadata
+	for _, events := range eventList {
+		p.publish(events)
 	}
 }

--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -1505,10 +1505,11 @@ func TestEmitEvent(t *testing.T) {
 				logger:    logp.NewLogger("kubernetes"),
 			}
 
+			pub := &publisher{b: p.bus}
 			pod := &pod{
 				metagen: metaGen,
 				config:  defaultConfig(),
-				publish: p.publish,
+				publish: pub.publish,
 				uuid:    UUID,
 				logger:  logp.NewLogger("kubernetes.pod"),
 			}
@@ -1543,6 +1544,20 @@ func NewMockPodEventerManager(pod *pod) EventManager {
 	em := &eventerManager{}
 	em.eventer = pod
 	return em
+}
+
+type publisher struct {
+	b bus.Bus
+}
+
+func (p *publisher) publish(events []bus.Event) {
+	if len(events) == 0 {
+		return
+	}
+	for _, event := range events {
+		event["config"] = []*common.Config{}
+		p.b.Publish(event)
+	}
 }
 
 func getNestedAnnotations(in common.MapStr) common.MapStr {

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -39,13 +39,13 @@ type service struct {
 	config           *Config
 	metagen          metadata.MetaGen
 	logger           *logp.Logger
-	publish          func(bus.Event)
+	publish          func([]bus.Event)
 	watcher          kubernetes.Watcher
 	namespaceWatcher kubernetes.Watcher
 }
 
 // NewServiceEventer creates an eventer that can discover and process service objects
-func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event bus.Event)) (Eventer, error) {
+func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, publish func(event []bus.Event)) (Eventer, error) {
 	logger := logp.NewLogger("autodiscover.service")
 
 	config := defaultConfig()
@@ -55,8 +55,9 @@ func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface,
 	}
 
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
-		SyncTimeout: config.SyncPeriod,
-		Namespace:   config.Namespace,
+		SyncTimeout:  config.SyncPeriod,
+		Namespace:    config.Namespace,
+		HonorReSyncs: true,
 	}, nil)
 
 	if err != nil {
@@ -214,6 +215,7 @@ func (s *service) emit(svc *kubernetes.Service, flag string) {
 		}
 	}
 
+	var events []bus.Event
 	for _, port := range svc.Spec.Ports {
 		event := bus.Event{
 			"provider":   s.uuid,
@@ -226,7 +228,8 @@ func (s *service) emit(svc *kubernetes.Service, flag string) {
 				"kubernetes": meta,
 			},
 		}
-		s.publish(event)
+		events = append(events, event)
 	}
+	s.publish(events)
 
 }

--- a/libbeat/autodiscover/providers/kubernetes/service_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/service_test.go
@@ -279,7 +279,6 @@ func TestEmitEvent_Service(t *testing.T) {
 				"host":     "192.168.0.1",
 				"id":       uid,
 				"provider": UUID,
-				"port":     8080,
 				"kubernetes": common.MapStr{
 					"service": common.MapStr{
 						"name": "metricbeat",
@@ -366,7 +365,6 @@ func TestEmitEvent_Service(t *testing.T) {
 				"stop":     true,
 				"host":     "",
 				"id":       uid,
-				"port":     8080,
 				"provider": UUID,
 				"kubernetes": common.MapStr{
 					"service": common.MapStr{

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -69,6 +69,8 @@ type WatchOptions struct {
 	// IsUpdated allows registering a func that allows the invoker of the Watch to decide what amounts to an update
 	// vs what does not.
 	IsUpdated func(old, new interface{}) bool
+	// HonorReSyncs allows resync events to be requeued on the worker
+	HonorReSyncs bool
 }
 
 type item struct {
@@ -137,6 +139,15 @@ func NewWatcher(client kubernetes.Interface, resource Resource, opts WatchOption
 		UpdateFunc: func(o, n interface{}) {
 			if opts.IsUpdated(o, n) {
 				w.enqueue(n, update)
+			} else if opts.HonorReSyncs {
+				// HonorReSyncs ensure that at the time when the kubernetes client does a "resync", i.e, a full list of all
+				// objects we make sure that autodiscover processes them. Why is this necessary? An effective control loop works
+				// based on two state changes, a list and a watch. A watch is triggered each time the state of the system changes.
+				// However, there is no guarantee that all events from a watch are processed by the receiver. To ensure that missed events
+				// are properly handled, a period re-list is done to ensure that every state within the system is effectively handled.
+				// In this case, we are making sure that we are enqueueing an "add" event because, an runner that is already in Running
+				// state should just be deduped by autodiscover and not stop/started periodically as would be the case with an update.
+				w.enqueue(n, add)
 			}
 		},
 	})


### PR DESCRIPTION
Cherry-pick of PR #22668 to 7.x branch. Original message: 

Enhancement

## What does this PR do?

This PR adds a `HonorReSyncs` watcher option to allow resyncs to be queued in as add events. The deduplication on the autodiscover module would ensure that we don't spin up more than one. 

## Why is it important?

This is needed if beats has been up and running and we add namespace level default hints. Without a resync it would require beats to be restarted. The resync will make sure that every x minutes we reconcile and ensure that these configurations are added in. It also makes sure that any missed add/update events are handled properly. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```
http:
  enabled: true
  host: 0.0.0.0
  port: 5002

metricbeat.autodiscover:
  providers:
    - type: kubernetes
      scope: cluster
      sync_period: 1m
      kube_config: ${HOME}/.kube/config
      namespace: test
      add_resource_metadata:
        namespace:
          enabled: true
      builders:
        - type: hints
```

```
kubectl create ns testresync
kubectl run prometheus --image=prom/prometheus -n testresync
```

Add annotations at the namespace level
```
kubectl annotate ns testresync co.elastic.module=prometheus
kubectl annotate ns testresync co.elastic.hosts='${data.host}:9090'
```

wait for 1 minute:
curl localhost:5002/dataset?pretty 

this should how a runner for the prometheus metrics endpoint

kubectl annotate ns testresync co.elastic.hosts='${data.host}:9091' --overwrite

wait for 1 more minute and this should change teh runner to an incorrect port of 9091

delete all the annotations and this should remove the runner completely.  

**prior to this change, adding namespace level annotations would require restarting of beats to take effect**

## Related issues

## Use cases
