### PR TITLE
Ensure _count and _sum is created only when there are Prometheus buckets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -914,6 +914,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Move IIS module to GA and map fields. {issue}22609[22609] {pull}23024[23024]
 - Apache: convert status.total_kbytes to status.total_bytes in fleet mode. {pull}23022[23022]
 - Release MSSQL as GA {pull}23146[23146]
+- Ensure _count and _sum is created only when there are Prometheus buckets {pull}23228[23228]
 
 *Packetbeat*
 

--- a/metricbeat/module/prometheus/collector/collector_test.go
+++ b/metricbeat/module/prometheus/collector/collector_test.go
@@ -181,6 +181,23 @@ func TestGetPromEventsFromMetricFamily(t *testing.T) {
 		},
 		{
 			Family: &dto.MetricFamily{
+				Name: proto.String("foo_seconds"),
+				Help: proto.String("foo"),
+				Type: dto.MetricType_HISTOGRAM.Enum(),
+				Metric: []*dto.Metric{
+					{
+						Histogram: &dto.Histogram{
+							SampleCount: proto.Uint64(0),
+							SampleSum:   proto.Float64(0),
+							Bucket:      []*dto.Bucket{},
+						},
+					},
+				},
+			},
+			Event: nil,
+		},
+		{
+			Family: &dto.MetricFamily{
 				Name: proto.String("http_request_duration_microseconds"),
 				Help: proto.String("foo"),
 				Type: dto.MetricType_UNTYPED.Enum(),

--- a/metricbeat/module/prometheus/collector/data.go
+++ b/metricbeat/module/prometheus/collector/data.go
@@ -56,6 +56,7 @@ func (p *promEventGenerator) GeneratePromEvents(mf *dto.MetricFamily) []PromEven
 
 	name := *mf.Name
 	metrics := mf.Metric
+
 	for _, metric := range metrics {
 		labels := common.MapStr{}
 
@@ -129,7 +130,7 @@ func (p *promEventGenerator) GeneratePromEvents(mf *dto.MetricFamily) []PromEven
 
 		histogram := metric.GetHistogram()
 		if histogram != nil {
-			if !math.IsNaN(histogram.GetSampleSum()) && !math.IsInf(histogram.GetSampleSum(), 0) {
+			if !math.IsNaN(histogram.GetSampleSum()) && !math.IsInf(histogram.GetSampleSum(), 0) && len(histogram.GetBucket()) != 0 {
 				events = append(events, PromEvent{
 					Data: common.MapStr{
 						"metrics": common.MapStr{


### PR DESCRIPTION

- Enhancement

## What does this PR do?

This PR ensures that we create _sum and _count metrics only when there are non zero number of buckets on the Prometheus histogram

## Why is it important?

Instrumentation frameworks like Micrometer expose Prometheus endpoints for their data types like Timers which create both a summary and a histogram under the same metricname. This breaks functionality in metricbeat today causing _count and _sum metrics to be created for those quantiles as they share the same datatype in a faulty manner.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally


## Related issues
