### PR TITLE
[docs] Make shared content about autodiscovery beats-agnostic

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -252,8 +252,11 @@ running configuration for a container, 60s by default.
   and `add_resource_metadata` settings are not taken into account.
 `leader_lease`:: (Optional) Defaults to `{beatname_lc}-cluster-leader`. This will be name of the lock lease.
   One can monitor the status of the lease with `kubectl describe lease beats-cluster-leader`.
-  Different Beats that refer to the same leader lease will be competetitors in holding the lease
-  and only one will be elected as leader each time. Example:
+  Different Beats that refer to the same leader lease will be competitors in holding the lease
+  and only one will be elected as leader each time.
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+Example:
 
 ["source","yaml",subs="attributes"]
 -------------------------------------------------------------------------------------
@@ -278,7 +281,7 @@ The above configuration when deployed on one or more Metribceat instances will e
 metricset only for the Metricbeat instance that will gain the leader lease/lock. With this deployment
 strategy we can ensure that cluster-wide metricsets are only enabled by one Beat instance when
 deploying a Beat as Daemonset.
-
+endif::[]
 
 include::../../{beatname_lc}/docs/autodiscover-kubernetes-config.asciidoc[]
 
@@ -304,7 +307,7 @@ application to find the more suitable way to set them in your case.
 
 Jolokia Discovery is based on UDP multicast requests. Agents join the multicast
 group 239.192.48.84, port 24884, and discovery is done by sending queries to
-this group. You have to take into account that UDP traffic between Metricbeat
+this group. You have to take into account that UDP traffic between {beatname_uc}
 and the Jolokia agents has to be allowed. Also notice that this multicast
 address is in the 239.0.0.0/8 range, that is reserved for private use within an
 organization, so it can only be used in private networks.
@@ -389,8 +392,12 @@ ifdef::autodiscoverAWSEC2[]
 *Note: This provider is experimental*
 
 The Amazon EC2 autodiscover provider discovers https://aws.amazon.com/ec2/[EC2 instances].
-This is useful for users to launch Metricbeat modules to monitor services running on AWS EC2 instances.
-For example, to gather MySQL metrics from mysql servers running on EC2 instances with specific tag `service: mysql`.
+This is useful for users to launch {beatname_uc} modules to monitor services running on AWS EC2 instances.
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+For example, you can use this provider to gather MySQL metrics from MySQL
+servers running on EC2 instances that have a specific tag, `service: mysql`.
+endif::[]
 
 This provider will load AWS credentials using the standard AWS environment variables and shared credentials files
 see https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html[Best Practices for Managing AWS Access Keys]


### PR DESCRIPTION
## What does this PR do?

Removes hard-coded references and adds conditional coding so that the word "Metricbeat" only appears in the Metricbeat Reference. 

NOTE: If we need examples for other Beats under the `leader_lease` description, let me know. I think `leader_lease` matters mainly for Metricbeat, but I'm not sure.

## Why is it important?

Users are confused when they see Metricbeat-specific info and examples in the Filebeat Reference.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


