### PR TITLE
Cherry-pick #23235 to 7.11: elastic-agent: don't swallow download errors

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -29,6 +29,7 @@
 - Fix sysv init files for deb/rpm installation {pull}22543[22543]
 - Fix shell wrapper for deb/rpm packaging {pull}23038[23038]
 - Fixed parsing of npipe URI {pull}22978[22978]
+- Remove artifacts on transient download errors {pull}23235[23235]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/artifact/download/http/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/downloader.go
@@ -151,5 +151,9 @@ func (e *Downloader) downloadFile(ctx context.Context, artifactName, filename, f
 	}
 
 	_, err = io.Copy(destinationFile, resp.Body)
+	if err != nil {
+		return "", errors.New(err, "fetching package failed", errors.TypeNetwork, errors.M(errors.MetaKeyURI, sourceURI))
+	}
+
 	return fullPath, nil
 }

--- a/x-pack/elastic-agent/pkg/artifact/download/http/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/downloader_test.go
@@ -1,0 +1,55 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package http
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+)
+
+func TestDownloadBodyError(t *testing.T) {
+	// This tests the scenario where the download encounters a network error
+	// part way through the download, while copying the response body.
+
+	type connKey struct{}
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		conn := r.Context().Value(connKey{}).(net.Conn)
+		conn.Close()
+	}))
+	defer srv.Close()
+	client := srv.Client()
+	srv.Config.ConnContext = func(ctx context.Context, c net.Conn) context.Context {
+		return context.WithValue(ctx, connKey{}, c)
+	}
+
+	targetDir, err := ioutil.TempDir(os.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := &artifact.Config{
+		SourceURI:       srv.URL,
+		TargetDirectory: targetDir,
+		OperatingSystem: "linux",
+		Architecture:    "64",
+	}
+
+	testClient := NewDownloaderWithClient(config, *client)
+	artifactPath, err := testClient.Download(context.Background(), beatSpec, version)
+	if err == nil {
+		os.Remove(artifactPath)
+		t.Fatal("expected Download to return an error")
+	}
+}


### PR DESCRIPTION
Cherry-pick of PR #23235 to 7.11 branch. Original message: 

## What does this PR do?

Stop swallowing the error from io.Copy when reading from response bodies in the http downloader.

## Why is it important?

This prevents storing a partial artifact download, which leads to a permanent error state.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Move to Australia, run elastic-agent with sourceURI pointed at the staging artifacts URL for 7.11.0 BC1 (https://staging.elastic.co/7.11.0-710164a0/summary-7.11.0.html) :)

(It seems there's no CDN on staging, and it's super slow from here. It's going to be a transient issue, but the last few attempts to fetch apm-server have failed part way through.)

More seriously, you would have to set up something (e.g. a reverse proxy) to inject faults into responses to elastic-agent.

## Related issues

None.

## Logs

```
2020-12-22T11:03:32.446+0800    INFO    operation/operation_fetch.go:75 operation 'operation-fetch' downloaded apm-server.7.11.0 into /tmp/zinga/elastic-agent-7.11.0-linux-x86_64/data/elastic-agent-fc48a3/downloads/apm-server-7.11.0-linux-x86_64.tar.gz                      
...
2020-12-22T11:03:32.515+0800    ERROR   log/reporter.go:36      2020-12-22T11:03:32+08:00: type: 'ERROR': sub_type: 'FAILED' message: Application: apm-server--7.11.0[aa633810-4400-11eb-bc64-2b65e7226012]: State changed to FAILED: operation 'operation-verify' marked 'apm-server.7.11.0' corrupted: /go/src/github.com/elastic/beats/x-pack/elastic-agent/pkg/agent/operation/operation_verify.go[77]: unknown error
...
2020-12-22T11:03:37.978+0800    INFO    operation/operation_fetch.go:61 apm-server.7.11.0 already exists in /tmp/zinga/elastic-agent-7.11.0-linux-x86_64/data/elastic-agent-fc48a3/downloads/apm-server-7.11.0-linux-x86_64.tar.gz. Skipping operation operation-fetch
...
2020-12-22T11:03:38.043+0800    ERROR   application/fleet_gateway.go:168        failed to dispatch actions, error: operator: failed to execute step sc-run, error: operation 'operation-verify' marked 'apm-server.7.11.0' corrupted: /go/src/github.com/elastic/beats/x-pack/elastic-agent/pkg/agent/operation/operation_verify.go[77]: unknown error: operation 'operation-verify' marked 'apm-server.7.11.0' corrupted: /go/src/github.com/elastic/beats/x-pack/elastic-agent/pkg/agent/operation/operation_verify.go[77]: unknown error
```