### PR TITLE
Drop `@timestamp` for juniper.junos system tests

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -249,6 +249,7 @@ def clean_keys(obj):
         "imperva.securesphere",
         "infoblox.nios",
         "iptables.log",
+        "juniper.junos",
         "juniper.netscreen",
         "netscout.sightline",
         "proofpoint.emailsecurity",


### PR DESCRIPTION
## What does this PR do?

Configure Filebeat system tests to drop `@timestamp` from  `juniper.junos` golden files.

## Why is it important?

Some autogenerated logs in `juniper.junos` contain timestamps without a year in them, meaning that once a year the extracted timestamp will be different.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
