### PR TITLE
Enable sharding of beats when running in cluster mode of Kubernetes autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -938,6 +938,10 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Move IIS module to GA and map fields. {issue}22609[22609] {pull}23024[23024]
 - Apache: convert status.total_kbytes to status.total_bytes in fleet mode. {pull}23022[23022]
 - Release MSSQL as GA {pull}23146[23146]
+- Enrich events of `state_service` metricset with kubernetes services' metadata. {pull}23730[23730]
+- Add support for Darwin/arm M1. {pull}24019[24019]
+- Check fields are documented in aws metricsets. {pull}23887[23887]
+- Add support for defining metrics_filters for prometheus module in hints. {pull}24264[24264]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -578,6 +578,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 - Add autodiscover provider and metadata processor for Nomad. {pull}14954[14954] {pull}23324[23324]
 - Add `processors.rate_limit.n.dropped` monitoring counter metric for the `rate_limit` processor. {pull}23330[23330]
+- Add support for customized monitoring API. {pull}22605[22605]
+- Enable sharding of beats when running in cluster mode of Kubernetes autodiscover [pull]23257{23257}
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - API address is a required setting in `add_cloudfoundry_metadata`. {pull}21759[21759]
 - Update to ECS 1.7.0. {pull}22571[22571]
 - Add support for SCRAM-SHA-512 and SCRAM-SHA-256 in Kafka output. {pull}12867[12867]
+- Fix panic with inline SSL when the certificate or key were small than 256 bytes. {pull}23820[23820]
+- Use alias to report container image in k8s metadata. {pull}24380[24380]
+- Add support for providing label selectors in kubernetes autodiscover {pull}24574[24574]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -35,13 +35,14 @@ import (
 // Config for kubernetes autodiscover provider
 type Config struct {
 	KubeConfig     string        `config:"kube_config"`
-	Namespace      string        `config:"namespace"`
 	SyncPeriod     time.Duration `config:"sync_period"`
 	CleanupTimeout time.Duration `config:"cleanup_timeout" validate:"positive"`
 
 	// Needed when resource is a pod
-	HostDeprecated string `config:"host"`
-	Node           string `config:"node"`
+	HostDeprecated string            `config:"host"`
+	Node           string            `config:"node"`
+	Namespace      string            `config:"namespace"`
+	Selector       common.MapStr     `config:"selector"`
 	// Scope can be either node or cluster.
 	Scope    string `config:"scope"`
 	Resource string `config:"resource"`

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -67,6 +67,7 @@ func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pu
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, kubernetes.WatchOptions{
 		SyncTimeout:  config.SyncPeriod,
 		Node:         config.Node,
+		Selector:     config.Selector,
 		IsUpdated:    isUpdated,
 		HonorReSyncs: true,
 		Instance:     config.Sharding.Instance,

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -69,6 +69,8 @@ func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pu
 		Node:         config.Node,
 		IsUpdated:    isUpdated,
 		HonorReSyncs: true,
+		Instance:     config.Sharding.Instance,
+		ShardCount:   config.Sharding.Count,
 	}, nil)
 
 	if err != nil {

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -66,11 +66,14 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 
 	logger.Debugf("Initializing a new Kubernetes watcher using node: %v", config.Node)
 
+	fmt.Println(config.Sharding)
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 		SyncTimeout:  config.SyncPeriod,
 		Node:         config.Node,
 		Namespace:    config.Namespace,
 		HonorReSyncs: true,
+		Instance:     config.Sharding.Instance,
+		ShardCount:   config.Sharding.Count,
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Pod{}, err)

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -66,7 +66,6 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 
 	logger.Debugf("Initializing a new Kubernetes watcher using node: %v", config.Node)
 
-	fmt.Println(config.Sharding)
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 		SyncTimeout:  config.SyncPeriod,
 		Node:         config.Node,

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -70,6 +70,7 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 		SyncTimeout:  config.SyncPeriod,
 		Node:         config.Node,
 		Namespace:    config.Namespace,
+		Selector:     config.Selector,
 		HonorReSyncs: true,
 		Instance:     config.Sharding.Instance,
 		ShardCount:   config.Sharding.Count,

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -57,6 +57,8 @@ func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface,
 		SyncTimeout:  config.SyncPeriod,
 		Namespace:    config.Namespace,
 		HonorReSyncs: true,
+		Instance:     config.Sharding.Instance,
+		ShardCount:   config.Sharding.Count,
 	}, nil)
 
 	if err != nil {

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -56,6 +56,7 @@ func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface,
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
 		SyncTimeout:  config.SyncPeriod,
 		Namespace:    config.Namespace,
+		Selector:     config.Selector,
 		HonorReSyncs: true,
 		Instance:     config.Sharding.Instance,
 		ShardCount:   config.Sharding.Count,

--- a/libbeat/common/kubernetes/informer.go
+++ b/libbeat/common/kubernetes/informer.go
@@ -153,9 +153,11 @@ func NewInformer(client kubernetes.Interface, resource Resource, opts WatchOptio
 		return nil, "", fmt.Errorf("unsupported resource type for watching %T", resource)
 	}
 
+	// Create a sharded list watch in case the Beat is configured to run in cluster mode with multiple shards.
+	slw := NewShardedListWatch(opts.Instance, opts.ShardCount, listwatch)
 	if indexers != nil {
-		return cache.NewSharedIndexInformer(listwatch, resource, opts.SyncTimeout, indexers), objType, nil
+		return cache.NewSharedIndexInformer(slw, resource, opts.SyncTimeout, indexers), objType, nil
 	}
 
-	return cache.NewSharedInformer(listwatch, resource, opts.SyncTimeout), objType, nil
+	return cache.NewSharedInformer(slw, resource, opts.SyncTimeout), objType, nil
 }

--- a/libbeat/common/kubernetes/sharded_lister_watcher.go
+++ b/libbeat/common/kubernetes/sharded_lister_watcher.go
@@ -32,6 +32,8 @@ type shardedListWatch struct {
 	instance uint64
 }
 
+// NewShardedListWatch creates a kubernetes ListerWatcher that can take an instance number and total number of instances
+// as input and use them to return a moded subset of the lists and watches that the client sees based on the instance number.
 func NewShardedListWatch(instance int, count int, lw cache.ListerWatcher) cache.ListerWatcher {
 	if count == 0 {
 		return lw

--- a/libbeat/common/kubernetes/sharded_lister_watcher.go
+++ b/libbeat/common/kubernetes/sharded_lister_watcher.go
@@ -1,0 +1,96 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"github.com/cespare/xxhash/v2"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+type shardedListWatch struct {
+	lw       cache.ListerWatcher
+	count    uint64
+	instance uint64
+}
+
+func NewShardedListWatch(instance int, count int, lw cache.ListerWatcher) cache.ListerWatcher {
+	if count == 0 {
+		return lw
+	}
+
+	return &shardedListWatch{
+		lw:       lw,
+		count:    uint64(count),
+		instance: uint64(instance),
+	}
+}
+
+func (s *shardedListWatch) List(options metav1.ListOptions) (runtime.Object, error) {
+	list, err := s.lw.List(options)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &metav1.List{
+		Items: make([]runtime.RawExtension, 0, len(items)),
+	}
+
+	for _, item := range items {
+		a, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+
+		if s.filter(a) {
+			res.Items = append(res.Items, runtime.RawExtension{Object: item})
+		}
+	}
+
+	return res, nil
+}
+
+func (s *shardedListWatch) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	w, err := s.lw.Watch(options)
+	if err != nil {
+		return nil, err
+	}
+
+	return watch.Filter(w, func(in watch.Event) (out watch.Event, keep bool) {
+		a, err := meta.Accessor(in.Object)
+		if err != nil {
+			return in, true
+		}
+
+		return in, s.filter(a)
+	}), nil
+}
+
+func (s *shardedListWatch) filter(o metav1.Object) bool {
+	h := xxhash.New()
+	h.Write([]byte(o.GetUID()))
+	return (h.Sum64() % s.count) == s.instance
+}

--- a/libbeat/common/kubernetes/util.go
+++ b/libbeat/common/kubernetes/util.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -167,4 +168,26 @@ func InClusterNamespace() (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(data)), nil
+}
+
+// DiscoverPodInstanceNumber tries in a best effort manner to use the Pod's hostname to discover what is the instance in an
+// N sized stateful set it is.
+func DiscoverPodInstanceNumber() (int, bool) {
+	instance := -1
+	pod, _ := os.Hostname()
+	i := strings.LastIndex(pod, "-")
+
+	if i != -1 {
+		ins := pod[i+1:]
+		var err error
+		instance, err = strconv.Atoi(ins)
+
+		if err != nil {
+			return -1, false
+		}
+
+		return instance, true
+	}
+
+	return instance, false
 }

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -71,6 +71,10 @@ type WatchOptions struct {
 	IsUpdated func(old, new interface{}) bool
 	// HonorReSyncs allows resync events to be requeued on the worker
 	HonorReSyncs bool
+	// ShardCount defines the total number of instances that the beat has been sharded into.
+	ShardCount int
+	// Instance defines the nth instance of a sharded fleet a given beat is
+	Instance int
 }
 
 type item struct {

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -66,6 +67,8 @@ type WatchOptions struct {
 	Node string
 	// Namespace is used for filtering watched resource to given namespace, use "" for all namespaces
 	Namespace string
+	// Selector allows you to choose what are the labels based off of which resources need to be watched on
+	Selector common.MapStr
 	// IsUpdated allows registering a func that allows the invoker of the Watch to decide what amounts to an update
 	// vs what does not.
 	IsUpdated func(old, new interface{}) bool

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -217,6 +217,8 @@ The `kubernetes` autodiscover provider has the following configuration settings:
   metadata. If it is not set, the processor collects metadata from all
   namespaces. It is unset by default. The namespace configuration only applies to
   kubernetes resources that are namespace scoped.
+`selector`:: (Optional) Selector allows configuring a map of label key/value pairs based
+on which the Kubernetes objects are queried by the Kubernetes client
 `cleanup_timeout`:: (Optional) Specify the time of inactivity before stopping the
 running configuration for a container, 60s by default.
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -38,16 +38,17 @@ func init() {
 }
 
 const (
-	module      = "module"
-	namespace   = "namespace"
-	hosts       = "hosts"
-	metricsets  = "metricsets"
-	period      = "period"
-	timeout     = "timeout"
-	ssl         = "ssl"
-	metricspath = "metrics_path"
-	username    = "username"
-	password    = "password"
+	module         = "module"
+	namespace      = "namespace"
+	hosts          = "hosts"
+	metricsets     = "metricsets"
+	period         = "period"
+	timeout        = "timeout"
+	ssl            = "ssl"
+	metricsfilters = "metrics_filters"
+	metricspath    = "metrics_path"
+	username       = "username"
+	password       = "password"
 
 	defaultTimeout = "3s"
 	defaultPeriod  = "1m"
@@ -138,6 +139,10 @@ func (m *metricHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*c
 			"enabled":    true,
 			"ssl":        sslConf,
 			"processors": procs,
+		}
+
+		if mod == "prometheus" {
+			moduleConfig[metricsfilters] = m.getMetricsFilters(hint)
 		}
 
 		if ns != "" {
@@ -298,6 +303,14 @@ func (m *metricHints) getTimeout(hints common.MapStr) string {
 
 func (m *metricHints) getSSLConfig(hints common.MapStr) common.MapStr {
 	return builder.GetHintMapStr(hints, m.Key, ssl)
+}
+
+func (m *metricHints) getMetricsFilters(hints common.MapStr) common.MapStr {
+	mf := common.MapStr{}
+	for k := range builder.GetHintMapStr(hints, m.Key, metricsfilters) {
+		mf[k] = builder.GetHintAsList(hints, m.Key, metricsfilters+"."+k)
+	}
+	return mf
 }
 
 func (m *metricHints) getModuleConfigs(hints common.MapStr) []common.MapStr {

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -57,6 +57,18 @@ can make use of Kuberentes Secrets as described in <<kubernetes-secrets>>.
 SSL parameters, as seen in <<configuration-ssl>>.
 
 [float]
+===== `co.elastic.metrics/metrics_filters.*`
+
+Metrics filters (for prometheus module only).
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+co.elastic.metrics/module: prometheus
+co.elastic.metrics/metrics_filters.include: node_filesystem_*
+co.elastic.metrics/metrics_filters.exclude: node_filesystem_device_foo,node_filesystem_device_bar
+-------------------------------------------------------------------------------------
+
+[float]
 ===== `co.elastic.metrics/raw`
 When an entire module configuration needs to be completely set the `raw` hint can be used. You can provide a
 stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create both a single or


### PR DESCRIPTION


<!-- Type of change
- Enhancement
-->

## What does this PR do?

This PR allows running metricbeat/heartbeat in a sharded mode when running in cluster scope. 

## Why is it important?

A single pod is always not sufficient to run centralized polling especially when the cluster size is large. We have seen that running metricbeat/heartbeat in daemonset mode is extremely wasteful in resource fragmentation and this feature will allow us to scale the cluster scoped metricbeat instances especially when cluster sizes are of few thousand nodes and there are more than 100000 targets to scrape. 

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this PR locally

```

http:
  enabled: true
  host: 0.0.0.0
  port: 5002

metricbeat.autodiscover:
  providers:
    - type: kubernetes
      scope: cluster
      sharding:
        count: 2
        instance: 0
      sync_period: 1m
      kube_config: ${HOME}/.kube/config
      namespace: <>
      builders:
        - type: hints

```

annotating a few pods should not monitor all of them. Changing the value of instance to `1` should monitor the remainign. changing `count` to `0` should monitor all of them. 


## Related issues

## Use cases


## Screenshots

## Logs
