### PR TITLE
Cherry-pick to 7.8: Add placeholder readme to prevent build failure (#23256)

### DIFF
--- a/x-pack/elastic-agent/docs/README.md
+++ b/x-pack/elastic-agent/docs/README.md
@@ -1,0 +1,6 @@
+# elastic-agent-docs
+
+Elastic Agent Documentation
+
+The source files for the Elastic Agent documentation are currently stored
+in the [observability-docs](https://github.com/elastic/observability-docs) repo.


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Add placeholder readme to prevent build failure (#23256)