### PR TITLE
remove use of 7.2 container input from 6.8.10

### DIFF
--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -9,9 +9,9 @@ metadata:
 data:
   filebeat.yml: |-
     filebeat.inputs:
-    - type: container
-      paths:
-        - /var/log/containers/*.log
+    - type: docker
+      containers.ids:
+      - "*"
       processors:
         - add_kubernetes_metadata:
             host: ${NODE_NAME}


### PR DESCRIPTION
There is no input called container prior to 7.2, so the example configuration for k8s resources in 6.8.10 using such input does not work

## What does this PR do?

Just correct the configuration in 6.8.10 for k8s filebeat branch mentioning input `container` which was only added from 7.2.

I am not sure why there is a 6.8.10 branch, 6.8 branch never had the issue, if there is no current reason to have a 6.8.10 branch, deleting that branch may be a better fix here