### PR TITLE
Fix uwsig worker.rss field data type

### DIFF
--- a/metricbeat/module/uwsgi/status/_meta/fields.yml
+++ b/metricbeat/module/uwsgi/status/_meta/fields.yml
@@ -65,7 +65,7 @@
       description: >
         Worker status (cheap, pause, sig, busy, idle)
     - name: worker.rss
-      type: keyword
+      type: long
       description: >
         Resident Set Size. memory currently used by a process. if always zero try `--memory-report` option of uwsgi
     - name: worker.vsz


### PR DESCRIPTION
uwsig `worker.rss` was mapped to a `keyword` data type but needs to be mapped to `long`