### PR TITLE
Cherry-pick #22512 to 7.x: chore: use string join to concatenate strings

### DIFF
--- a/libbeat/conditions/and.go
+++ b/libbeat/conditions/and.go
@@ -17,6 +17,8 @@
 
 package conditions
 
+import "strings"
+
 // And is a compound condition that combines multiple conditions with logical AND.
 type And []Condition
 
@@ -36,9 +38,10 @@ func (c And) Check(event ValuesMap) bool {
 }
 
 func (c And) String() (s string) {
-	for _, cond := range c {
-		s = s + cond.String() + " and "
+	var strSlice = make([]string, len(c))
+
+	for i, cond := range c {
+		strSlice[i] = cond.String()
 	}
-	s = s[:len(s)-len(" and ")] //delete the last and
-	return s
+	return strings.Join(strSlice, " and ")
 }

--- a/libbeat/conditions/or.go
+++ b/libbeat/conditions/or.go
@@ -17,6 +17,8 @@
 
 package conditions
 
+import "strings"
+
 // Or is a compound condition that combines multiple conditions with logical OR.
 type Or []Condition
 
@@ -36,9 +38,10 @@ func (c Or) Check(event ValuesMap) bool {
 }
 
 func (c Or) String() (s string) {
-	for _, cond := range c {
-		s = s + cond.String() + " or "
+	var strSlice = make([]string, len(c))
+
+	for i, cond := range c {
+		strSlice[i] = cond.String()
 	}
-	s = s[:len(s)-len(" or ")] //delete the last or
-	return s
+	return strings.Join(strSlice, " or ")
 }


### PR DESCRIPTION
Cherry-pick of PR #22512 to 7.x branch. Original message: 

Signed-off-by: OhBonsai <letbonsaibe@gmail.com>

## What does this PR do?
Use `strings.Join` to concatenate condition strings

## Why is it important?
`strings.Join` is efficiently than `+`


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



