### PR TITLE
[DOCS] Re-add Stack Monitoring section in elasticsearch module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -483,6 +483,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove io.time from windows {pull}22237[22237]
 - Change vsphere.datastore.capacity.used.pct value to betweeen 0 and 1. {pull}23148[23148]
 - Update config in `windows.yml` file. {issue}23027[23027]{pull}23327[23327]
+- Add stack monitoring section to elasticsearch module documentation {pull}#23286[23286]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -13,6 +13,14 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
+=== Usage for Stack Monitoring
+
+The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
+`metricbeat modules enable elasticsearch-xpack`.
+
+[float]
 === Module-specific configuration notes
 
 Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
@@ -23,11 +31,6 @@ the `hosts` list is interpreted by the module.
   {es} cluster.
 * If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
   {es} cluster (for example, a load-balancing proxy fronting the cluster).
-
-The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
-UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
-from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
-`metricbeat modules enable elasticsearch-xpack`.
 
 
 [float]

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -6,6 +6,14 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
+=== Usage for Stack Monitoring
+
+The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
+from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
+`metricbeat modules enable elasticsearch-xpack`.
+
+[float]
 === Module-specific configuration notes
 
 Like other {beatname_uc} modules, the `elasticsearch` module accepts a `hosts` configuration setting.
@@ -16,8 +24,3 @@ the `hosts` list is interpreted by the module.
   {es} cluster.
 * If `scope` is set to `cluster`, each entry in the `hosts` list indicates a single endpoint for a distinct
   {es} cluster (for example, a load-balancing proxy fronting the cluster).
-
-The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
-UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
-from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
-`metricbeat modules enable elasticsearch-xpack`.


### PR DESCRIPTION
## What does this PR do?

This PR re-adds the "Usage for Stack Monitoring" section in the Metricbeat Elasticsearch module documentation (https://www.elastic.co/guide/en/beats/metricbeat/7.9/metricbeat-module-elasticsearch.html), which was removed in 7.10 and later versions by https://github.com/elastic/beats/pull/18547

## Why is it important?

This "Usage for Stack Monitoring" section appears in the [Beat](https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-beat.html), [Kibana](https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html), and [Logstash](https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html) module docs and gives us something to link to from the stack monitoring setup docs.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Relates https://github.com/elastic/elasticsearch/pull/64497 

