### PR TITLE
Changed ilmDefaultPattern to start with 0 insted of 1

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - API address is a required setting in `add_cloudfoundry_metadata`. {pull}21759[21759]
 - Update to ECS 1.7.0. {pull}22571[22571]
 - Add support for SCRAM-SHA-512 and SCRAM-SHA-256 in Kafka output. {pull}12867[12867]
+- Changed Changed ilmDefaultPattern to start with 0 insted of 1 {issue}20648[20648] {pull}23295[23295]
 
 *Auditbeat*
 

--- a/libbeat/idxmgmt/ilm/config.go
+++ b/libbeat/idxmgmt/ilm/config.go
@@ -58,7 +58,7 @@ const (
 	ModeDisabled
 )
 
-const ilmDefaultPattern = "{now/d}-000001"
+const ilmDefaultPattern = "{now/d}-000000"
 
 // DefaultPolicy defines the default policy to be used if no custom policy is
 // configured.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Changed the Default ILM Pattern to start counting at 0 instead of 1 as suggested in #20648

## Why is it important?

Copied from issue #20648 "We do try to index from 0 after all :)"

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ X] My code follows the style guidelines of this project
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] I have made corresponding change to the default configuration files
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Closes #20648