### PR TITLE
Cherry-pick #23227 to 7.x: Add user-facing changelog entry for dynamic cpu changes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -163,6 +163,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix reporting of cgroup metrics when running under Docker {pull}22879[22879]
 - Fix typo in config docs {pull}23185[23185]
 - Fix `nested` subfield handling in generated Elasticsearch templates. {issue}23178[23178] {pull}23183[23183]
+- Fix CPU usage metrics on VMs with dynamic CPU config {pull}23154[23154]
 
 
 *Auditbeat*


### PR DESCRIPTION
Cherry-pick of PR #23227 to 7.x branch. Original message: 



## What does this PR do?

#23154 Added a developer changelog entry, but this is technically a user-facing change as well, so we should have a changelog entry here.

## Why is it important?

This needs to be documented in both the dev changelog and the user-facing changelog.

## Checklist

- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
