### PR TITLE
Cherry-pick #23313 to 7.11: Ensure mage is installed to the expected version

### DIFF
--- a/dev-tools/make/mage-install.mk
+++ b/dev-tools/make/mage-install.mk
@@ -7,7 +7,7 @@ export MAGE_IMPORT_PATH
 mage:
 ifndef MAGE_PRESENT
 	@echo Installing mage $(MAGE_VERSION).
-	@go get -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}
+	@go get -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
 	@-mage -clean
 endif
 	@true


### PR DESCRIPTION
Cherry-pick of PR #23313 to 7.11 branch. Original message: 

## What does this PR do?

Ensure mage is installed to the expected version in makefile target.

## Why is it important?

Fix linting in master branch.

Mage 0.11 has been released and installation using the make target is not specifying a version, which changes go mod files, breaking linting.