### PR TITLE
Update system.asciidoc

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -8,10 +8,11 @@ This file is generated! See scripts/mage/docs_collector.go
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
-`process_summary`. To disable a default metricset, comment it out in the
-`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
-and the System module is enabled, {beatname_uc} uses the default metricsets.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`,
+`process_summary`, `socket_summary`, `filesystem`, `fsstat`, and `uptime`. 
+To disable a default metricset, comment it out in the `modules.d/system.yml` 
+configuration file. If _all_ metricsets are commented out and the System module 
+is enabled, {beatname_uc} uses the default metricsets.
 
 Note that certain metricsets may access `/proc` to gather process information,
 and the resulting `ptrace_may_access()` call by the kernel to check for

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -1,10 +1,11 @@
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
-`process_summary`. To disable a default metricset, comment it out in the
-`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
-and the System module is enabled, {beatname_uc} uses the default metricsets.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`,
+`process_summary`, `socket_summary`, `filesystem`, `fsstat`, and `uptime`. 
+To disable a default metricset, comment it out in the `modules.d/system.yml` 
+configuration file. If _all_ metricsets are commented out and the System module 
+is enabled, {beatname_uc} uses the default metricsets.
 
 Note that certain metricsets may access `/proc` to gather process information,
 and the resulting `ptrace_may_access()` call by the kernel to check for


### PR DESCRIPTION
## What does this PR do?

The default metricsets have more than current documentation and it makes some confusion.
Please check the latest `system.yml` configuration and consider to add all default metricset in the documentation.
Feel free to change my suggestion.

## Why is it important?

It might give the wrong information and the user might try to find a way to add metricset that was already provided as a default configuration.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

