### PR TITLE
synchronous I/O may cause DiskPressure

### DIFF
--- a/filebeat/registrar/registrar.go
+++ b/filebeat/registrar/registrar.go
@@ -411,7 +411,7 @@ func writeTmpFile(baseName string, perm os.FileMode, states []file.State) (strin
 	logp.Debug("registrar", "Write registry file: %s (%v)", baseName, len(states))
 
 	tempfile := baseName + ".new"
-	f, err := os.OpenFile(tempfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC|os.O_SYNC, perm)
+	f, err := os.OpenFile(tempfile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
 		logp.Err("Failed to create tempfile (%s) for writing: %s", tempfile, err)
 		return "", err


### PR DESCRIPTION
Enhancement

Team:*

change the writing way of the tmp file in registrar.From synchronous I/O to async

## Why is it important?

This may cause huge disk I/O pressure, and I think synchronous writing here is not necessary.


