### PR TITLE
Cherry-pick #23280 to 7.x: Move changelog entry to correct file

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -97,6 +97,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Add packaging for docker image based on UBI minimal 8. {pull}20576[20576]
 - Make the mage binary used by the build process in the docker container to be statically compiled. {pull}20827[20827]
 - Add support for customized monitoring API. {pull}22605[22605]
-
-- Update ecszap to v0.3.0 for using ECS 1.6.0 in logs {pull}22267[22267]
 - Add support for customized monitoring API. {pull}22605[22605]

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -98,3 +98,5 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Make the mage binary used by the build process in the docker container to be statically compiled. {pull}20827[20827]
 - Add support for customized monitoring API. {pull}22605[22605]
 
+- Update ecszap to v0.3.0 for using ECS 1.6.0 in logs {pull}22267[22267]
+- Add support for customized monitoring API. {pull}22605[22605]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -386,6 +386,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Improve equals check. {pull}22778[22778]
+- Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -386,7 +386,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Improve equals check. {pull}22778[22778]
-- Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #23280 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Changelog

## What does this PR do?

Move changelog entry to developer changelog.

## Why is it important?

The original PR did introduce an internal API for adding custom HTTP handler, but no user-visible feature. 