### PR TITLE
[Rate limit processor] Add counter metric for dropped events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -572,6 +572,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 - Add autodiscover provider and metadata processor for Nomad. {pull}14954[14954] {pull}23324[23324]
 - Add optional `metric_field` setting to `rate_limit` processor. {pull}23330[23330]
+- Add `processors.rate_limit.n.dropped` monitoring counter metric for the `rate_limit` processor. {pull}23330[23330]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -571,7 +571,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 - Add autodiscover provider and metadata processor for Nomad. {pull}14954[14954] {pull}23324[23324]
-- Add optional `metric_field` setting to `rate_limit` processor. {pull}23330[23330]
 - Add `processors.rate_limit.n.dropped` monitoring counter metric for the `rate_limit` processor. {pull}23330[23330]
 
 *Auditbeat*
@@ -991,7 +990,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 ==== Known Issue
 
 *Journalbeat*
-
 
 
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -571,6 +571,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 - Add autodiscover provider and metadata processor for Nomad. {pull}14954[14954] {pull}23324[23324]
+- Add optional `metric_field` setting to `rate_limit` processor. {pull}23330[23330]
 
 *Auditbeat*
 

--- a/libbeat/processors/ratelimit/config.go
+++ b/libbeat/processors/ratelimit/config.go
@@ -25,9 +25,10 @@ import (
 
 // config for rate limit processor.
 type config struct {
-	Limit     rate                   `config:"limit" validate:"required"`
-	Fields    []string               `config:"fields"`
-	Algorithm common.ConfigNamespace `config:"algorithm"`
+	Limit          rate                   `config:"limit" validate:"required"`
+	Fields         []string               `config:"fields"`
+	ThrottledField string                 `config:"throttled_field"`
+	Algorithm      common.ConfigNamespace `config:"algorithm"`
 }
 
 func (c *config) setDefaults() error {

--- a/libbeat/processors/ratelimit/config.go
+++ b/libbeat/processors/ratelimit/config.go
@@ -25,10 +25,10 @@ import (
 
 // config for rate limit processor.
 type config struct {
-	Limit          rate                   `config:"limit" validate:"required"`
-	Fields         []string               `config:"fields"`
-	ThrottledField string                 `config:"throttled_field"`
-	Algorithm      common.ConfigNamespace `config:"algorithm"`
+	Limit       rate                   `config:"limit" validate:"required"`
+	Fields      []string               `config:"fields"`
+	MetricField string                 `config:"metric_field"`
+	Algorithm   common.ConfigNamespace `config:"algorithm"`
 }
 
 func (c *config) setDefaults() error {

--- a/libbeat/processors/ratelimit/config.go
+++ b/libbeat/processors/ratelimit/config.go
@@ -25,10 +25,9 @@ import (
 
 // config for rate limit processor.
 type config struct {
-	Limit       rate                   `config:"limit" validate:"required"`
-	Fields      []string               `config:"fields"`
-	MetricField string                 `config:"metric_field"`
-	Algorithm   common.ConfigNamespace `config:"algorithm"`
+	Limit     rate                   `config:"limit" validate:"required"`
+	Fields    []string               `config:"fields"`
+	Algorithm common.ConfigNamespace `config:"algorithm"`
 }
 
 func (c *config) setDefaults() error {

--- a/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
+++ b/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
@@ -38,3 +38,4 @@ The following settings are supported:
 
 `limit`:: The rate limit. Supported time units for the rate are `s` (per second), `m` (per minute), and `h` (per hour).
 `fields`:: (Optional) List of fields. The rate limit will be applied to each distinct value derived by combining the values of these fields.
+`throttled_field`:: (Optional) When events are rate limited, the first event that is allowed to pass through after rate limiting will contain this field. The value of the field will be the number of events that were rate limited since the last time an event was allowed to pass through.

--- a/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
+++ b/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
@@ -9,6 +9,9 @@ beta[]
 The `rate_limit` processor limits the throughput of events based on
 the specified configuration.
 
+In the current implementation, rate-limited events are dropped. Future implementations may allow rate-limited events to
+be handled differently.
+
 [source,yaml]
 -----------------------------------------------------
 processors:

--- a/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
+++ b/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
@@ -9,8 +9,8 @@ beta[]
 The `rate_limit` processor limits the throughput of events based on
 the specified configuration.
 
-In the current implementation, rate-limited events are dropped. Future implementations may allow rate-limited events to
-be handled differently.
+In the current implementation, rate-limited events are dropped. Future
+implementations may allow rate-limited events to be handled differently.
 
 [source,yaml]
 -----------------------------------------------------

--- a/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
+++ b/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
@@ -41,4 +41,4 @@ The following settings are supported:
 
 `limit`:: The rate limit. Supported time units for the rate are `s` (per second), `m` (per minute), and `h` (per hour).
 `fields`:: (Optional) List of fields. The rate limit will be applied to each distinct value derived by combining the values of these fields.
-`throttled_field`:: (Optional) When events are rate limited, the first event that is allowed to pass through after rate limiting will contain this field. The value of the field will be the number of events that were rate limited since the last time an event was allowed to pass through.
+`metric_field`:: (Optional) When events are rate limited, the first event that is allowed to pass through after rate limiting will contain this field. The value of the field will be the number of events that were rate limited since the last time an event was allowed to pass through.

--- a/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
+++ b/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
@@ -41,4 +41,3 @@ The following settings are supported:
 
 `limit`:: The rate limit. Supported time units for the rate are `s` (per second), `m` (per minute), and `h` (per hour).
 `fields`:: (Optional) List of fields. The rate limit will be applied to each distinct value derived by combining the values of these fields.
-`metric_field`:: (Optional) When events are rate limited, the first event that is allowed to pass through after rate limiting will contain this field. The value of the field will be the number of events that were rate limited since the last time an event was allowed to pass through.

--- a/libbeat/processors/ratelimit/rate_limit.go
+++ b/libbeat/processors/ratelimit/rate_limit.go
@@ -20,6 +20,7 @@ package ratelimit
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/mitchellh/hashstructure"
@@ -29,22 +30,30 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/beats/v7/libbeat/processors"
 )
+
+// instanceID is used to assign each instance a unique monitoring namespace.
+var instanceID = atomic.MakeUint32(0)
+
+const processorName = "rate_limit"
+const logName = "processor." + processorName
 
 func init() {
 	processors.RegisterPlugin(processorName, new)
 }
 
-const processorName = "rate_limit"
+type metrics struct {
+	Dropped *monitoring.Int
+}
 
 type rateLimit struct {
 	config    config
 	algorithm algorithm
 
-	numRateLimited atomic.Uint64
-
-	logger *logp.Logger
+	logger  *logp.Logger
+	metrics metrics
 }
 
 // new constructs a new rate limit processor.
@@ -67,10 +76,20 @@ func new(cfg *common.Config) (processors.Processor, error) {
 		return nil, errors.Wrap(err, "could not construct rate limiting algorithm")
 	}
 
+	// Logging and metrics (each processor instance has a unique ID).
+	var (
+		id  = int(instanceID.Inc())
+		log = logp.NewLogger(logName).With("instance_id", id)
+		reg = monitoring.Default.NewRegistry(logName+"."+strconv.Itoa(id), monitoring.DoNotReport)
+	)
+
 	p := &rateLimit{
 		config:    config,
 		algorithm: algo,
-		logger:    logp.NewLogger("rate_limit"),
+		logger:    log,
+		metrics: metrics{
+			Dropped: monitoring.NewInt(reg, "dropped"),
+		},
 	}
 
 	p.setClock(clockwork.NewRealClock())
@@ -87,12 +106,11 @@ func (p *rateLimit) Run(event *beat.Event) (*beat.Event, error) {
 	}
 
 	if p.algorithm.IsAllowed(key) {
-		p.tagEvent(event)
 		return event, nil
 	}
 
-	p.numRateLimited.Inc()
 	p.logger.Debugf("event [%v] dropped by rate_limit processor", event)
+	p.metrics.Dropped.Inc()
 	return nil, nil
 }
 
@@ -124,13 +142,6 @@ func (p *rateLimit) makeKey(event *beat.Event) (uint64, error) {
 	}
 
 	return hashstructure.Hash(values, nil)
-}
-
-func (p *rateLimit) tagEvent(event *beat.Event) {
-	if p.config.MetricField != "" && p.numRateLimited.Load() > 0 {
-		event.PutValue(p.config.MetricField, p.numRateLimited.Load())
-		p.numRateLimited.Store(0)
-	}
 }
 
 // setClock allows test code to inject a fake clock

--- a/libbeat/processors/ratelimit/rate_limit_test.go
+++ b/libbeat/processors/ratelimit/rate_limit_test.go
@@ -147,20 +147,6 @@ func TestRateLimit(t *testing.T) {
 			inEvents:  inEvents,
 			outEvents: inEvents,
 		},
-		"with_metric": {
-			config: common.MapStr{
-				"limit":        "2/s",
-				"metric_field": "num_dropped",
-			},
-			delay:    200 * time.Millisecond,
-			inEvents: inEvents,
-			outEvents: []beat.Event{
-				inEvents[0],
-				inEvents[1],
-				withField(inEvents[3], "num_dropped", uint64(1)),
-				withField(inEvents[5], "num_dropped", uint64(1)),
-			},
-		},
 	}
 
 	for name, test := range cases {


### PR DESCRIPTION
## What does this PR do?

This PR adds a monitoring counter metric, `processors.rate_limit.n.dropped` where `n` is the the `n`th instance (1-based) of a `rate_limit` processor used in a Beat's configuration. This counter is incremented each time the processor drops an event due to rate limiting.

## Why is it important?

This allows users of the processor to understand whether their events are being rate limited and by how much.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Create a minimal Filebeat configuration with this processor in it.
   ```
   # filebeat.test.yml

   filebeat.inputs:
   - type: stdin

   processors:
     - rate_limit:
         limit: "1/m"

   output.console:
     enabled: true
     pretty: true

   http.enabled: true
   ```

2. Run Filebeat with the above configuration.
   ```
   filebeat -c filebeat.test.yml
   ```

3. Send events to Filebeat via STDIN at a rate faster than one event per minute (the rate limit).
4. In another window check that the Filebeat Stats API has the monitoring counter implemented by this PR and that it is incrementing as expected.
   ```
   curl -s 'http://localhost:5066/stats' | jq -c '.processor.rate_limit."1".dropped' 
   ```

## Related issues

- Closes #21020
