### PR TITLE
[docs] Update shared-env-vars.asciidoc

### DIFF
--- a/libbeat/docs/shared-env-vars.asciidoc
+++ b/libbeat/docs/shared-env-vars.asciidoc
@@ -87,7 +87,10 @@ As with JSON, dictionaries and lists are constructed using `{}` and `[]`. But
 unlike JSON, the syntax allows for trailing commas and slightly different string
 quotation rules. Strings can be unquoted, single-quoted, or double-quoted, as a
 convenience for simple settings and to make it easier for you to mix quotation
-usage in the shell. Arrays at the top-level do not require brackets (`[]`).
+usage in the shell.
+
+NOTE: Do not use brackets (`[]`) for arrays at the top-level, or it will be interpreted as a character.
+For now, you can't set an empty array (e.g. to set coordinating only nodes) with this syntax.
 
 For example, the following environment variable is set to a list:
 

--- a/libbeat/docs/shared-env-vars.asciidoc
+++ b/libbeat/docs/shared-env-vars.asciidoc
@@ -90,7 +90,7 @@ convenience for simple settings and to make it easier for you to mix quotation
 usage in the shell.
 
 NOTE: Do not use brackets (`[]`) for arrays at the top-level, or it will be interpreted as a character.
-For now, you can't set an empty array (e.g. to set coordinating only nodes) with this syntax.
+For now, you can't set an empty array (e.g. to set {ref}/modules-node.html#coordinating-only-node[Coordinating only node]) with this syntax.
 
 For example, the following environment variable is set to a list:
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

I updated docs for using environment variables in the configuration.
I emphasized that this syntax does not allow the representation of arrays using brackets ( `[]` ), and added that there is currently no way to set an empty array in this syntax.

For more information on this issue, please see [this issue](https://github.com/elastic/elasticsearch/issues/65577).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Without emphasizing this fact, users might end up later need to rewrite the configuration significantly.
For example, an empty array is a necessary value when setting [coordinating only nodes](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-node.html#coordinating-only-node).
In my case, after learning this fact, I partially stopped using environment variables in the configuration.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

This is a one-liner docs change. I don't think most of these are relevant.
Not sure about the last one.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
