### PR TITLE
Cherry-pick #23320 to 7.x: Skip flaky TestAutodiscoverWithMutlipleEntries test

### DIFF
--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -378,6 +378,8 @@ func TestAutodiscoverWithConfigCheckFailures(t *testing.T) {
 }
 
 func TestAutodiscoverWithMutlipleEntries(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/23319")
+
 	goroutines := resources.NewGoroutinesChecker()
 	defer goroutines.Check(t)
 


### PR DESCRIPTION
Cherry-pick of PR #23320 to 7.x branch. Original message: 

See #23319.