### PR TITLE
Provide more ways to set AWS credentials in Functionbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -935,6 +935,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add basic ECS categorization and `cloud` fields. {pull}19174[19174]
 - Add support for parallelization factor for kinesis. {pull}20727[20727]
+- Provide more ways to set AWS credentials. {issue}12464[12464] {pull}23344[23344]
 
 *Winlogbeat*
 

--- a/x-pack/functionbeat/_meta/config/beat.reference.yml.tmpl
+++ b/x-pack/functionbeat/_meta/config/beat.reference.yml.tmpl
@@ -19,14 +19,14 @@ functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 # Configure credentials of Functionbeat while deploying to AWS.
 # Available options:
 # * access_key_id, secret_access_key and/or session_token
-#functionbeat.provider.aws.credentials.access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-#functionbeat.provider.aws.credentials.secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-#functionbeat.provider.aws.credentials.session_token: '${AWS_SESSION_TOKEN:""}'
+#functionbeat.provider.aws.access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+#functionbeat.provider.aws.secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+#functionbeat.provider.aws.session_token: '${AWS_SESSION_TOKEN:""}'
 # * role_arn
-#functionbeat.provider.aws.credentials.role_arn: arn:aws:iam::123456789012:role/test-fnb
+#functionbeat.provider.aws.role_arn: arn:aws:iam::123456789012:role/test-fnb
 # * credential_profile_name and/or shared_credential_file
-#functionbeat.provider.aws.credentials.credential_profile_name: fnb-aws
-#functionbeat.provider.aws.credentials.shared_credential_file: /etc/functionbeat/aws_credentials
+#functionbeat.provider.aws.credential_profile_name: fnb-aws
+#functionbeat.provider.aws.shared_credential_file: /etc/functionbeat/aws_credentials
 
 functionbeat.provider.aws.functions:
   # Define the list of function availables, each function required to have a unique name.

--- a/x-pack/functionbeat/_meta/config/beat.reference.yml.tmpl
+++ b/x-pack/functionbeat/_meta/config/beat.reference.yml.tmpl
@@ -16,6 +16,18 @@ functionbeat.provider.aws.endpoint: "s3.amazonaws.com"
 # Configure which S3 bucket we should upload the lambda artifact.
 functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 
+# Configure credentials of Functionbeat while deploying to AWS.
+# Available options:
+# * access_key_id, secret_access_key and/or session_token
+#functionbeat.provider.aws.credentials.access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+#functionbeat.provider.aws.credentials.secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+#functionbeat.provider.aws.credentials.session_token: '${AWS_SESSION_TOKEN:""}'
+# * role_arn
+#functionbeat.provider.aws.credentials.role_arn: arn:aws:iam::123456789012:role/test-fnb
+# * credential_profile_name and/or shared_credential_file
+#functionbeat.provider.aws.credentials.credential_profile_name: fnb-aws
+#functionbeat.provider.aws.credentials.shared_credential_file: /etc/functionbeat/aws_credentials
+
 functionbeat.provider.aws.functions:
   # Define the list of function availables, each function required to have a unique name.
   # Create a function that accepts events coming from cloudwatchlogs.

--- a/x-pack/functionbeat/docs/config-options-aws.asciidoc
+++ b/x-pack/functionbeat/docs/config-options-aws.asciidoc
@@ -1,5 +1,8 @@
 [id="configuration-{beatname_lc}-options"]
 [role="xpack"]
+
+:libbeat-xpack-dir: ../../../../x-pack/libbeat
+
 == Configure AWS functions
 
 ++++

--- a/x-pack/functionbeat/docs/config-options-aws.asciidoc
+++ b/x-pack/functionbeat/docs/config-options-aws.asciidoc
@@ -61,11 +61,8 @@ to deploy.
 TIP: If you change the configuration after deploying the function, use
 the <<update-command,`update` command>> to update your deployment.
 
-[float]
-[id="{beatname_lc}-endpoint"]
-==== `provider.aws.endpoint`
-
-AWS endpoint to use in the URL template to load functions.
+[id="aws-credentials-config"]
+include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
 
 [float]
 [id="{beatname_lc}-deploy-bucket"]

--- a/x-pack/functionbeat/docs/config-options-aws.asciidoc
+++ b/x-pack/functionbeat/docs/config-options-aws.asciidoc
@@ -15,6 +15,11 @@ You configure the functions in the the +{beatname_lc}.yml+ configuration file.
 When you're done, you can <<deploy-to-cloud-provider,deploy the functions>>
 to your serverless environment.
 
+The `aws` functions require AWS credentials configuration in order to make AWS API calls.
+Users can either use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
+`AWS_SESSION_TOKEN`, or use shared AWS credentials file.
+Please see <<aws-credentials-config,AWS credentials options>> for more details.
+
 The following example configures two functions: `cloudwatch` and `sqs`. The
 `cloudwatch` function collects events from CloudWatch Logs. The `sqs` function
 collects messages from Amazon Simple Queue Service (SQS). Both functions forward

--- a/x-pack/functionbeat/docs/config-options-aws.asciidoc
+++ b/x-pack/functionbeat/docs/config-options-aws.asciidoc
@@ -1,7 +1,7 @@
 [id="configuration-{beatname_lc}-options"]
 [role="xpack"]
 
-:libbeat-xpack-dir: ../../../../x-pack/libbeat
+:libbeat-xpack-dir: ../../../x-pack/libbeat
 
 == Configure AWS functions
 
@@ -63,9 +63,6 @@ to deploy.
 
 TIP: If you change the configuration after deploying the function, use
 the <<update-command,`update` command>> to update your deployment.
-
-[id="aws-credentials-config"]
-include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
 
 [float]
 [id="{beatname_lc}-deploy-bucket"]
@@ -217,3 +214,6 @@ version and the event timestamp; for access to dynamic fields, use
 
 Example value: `"%{[agent.name]}-myindex-%{+yyyy.MM.dd}"` might
 expand to `"functionbeat-myindex-2019.12.13"`.
+
+[id="aws-credentials-config"]
+include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -19,14 +19,14 @@ functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 # Configure credentials of Functionbeat while deploying to AWS.
 # Available options:
 # * access_key_id, secret_access_key and/or session_token
-#functionbeat.provider.aws.credentials.access_key_id: '${AWS_ACCESS_KEY_ID:""}'
-#functionbeat.provider.aws.credentials.secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
-#functionbeat.provider.aws.credentials.session_token: '${AWS_SESSION_TOKEN:""}'
+#functionbeat.provider.aws.access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+#functionbeat.provider.aws.secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+#functionbeat.provider.aws.session_token: '${AWS_SESSION_TOKEN:""}'
 # * role_arn
-#functionbeat.provider.aws.credentials.role_arn: arn:aws:iam::123456789012:role/test-fnb
+#functionbeat.provider.aws.role_arn: arn:aws:iam::123456789012:role/test-fnb
 # * credential_profile_name and/or shared_credential_file
-#functionbeat.provider.aws.credentials.credential_profile_name: fnb-aws
-#functionbeat.provider.aws.credentials.shared_credential_file: /etc/functionbeat/aws_credentials
+#functionbeat.provider.aws.credential_profile_name: fnb-aws
+#functionbeat.provider.aws.shared_credential_file: /etc/functionbeat/aws_credentials
 
 functionbeat.provider.aws.functions:
   # Define the list of function availables, each function required to have a unique name.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -16,6 +16,18 @@ functionbeat.provider.aws.endpoint: "s3.amazonaws.com"
 # Configure which S3 bucket we should upload the lambda artifact.
 functionbeat.provider.aws.deploy_bucket: "functionbeat-deploy"
 
+# Configure credentials of Functionbeat while deploying to AWS.
+# Available options:
+# * access_key_id, secret_access_key and/or session_token
+#functionbeat.provider.aws.credentials.access_key_id: '${AWS_ACCESS_KEY_ID:""}'
+#functionbeat.provider.aws.credentials.secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
+#functionbeat.provider.aws.credentials.session_token: '${AWS_SESSION_TOKEN:""}'
+# * role_arn
+#functionbeat.provider.aws.credentials.role_arn: arn:aws:iam::123456789012:role/test-fnb
+# * credential_profile_name and/or shared_credential_file
+#functionbeat.provider.aws.credentials.credential_profile_name: fnb-aws
+#functionbeat.provider.aws.credentials.shared_credential_file: /etc/functionbeat/aws_credentials
+
 functionbeat.provider.aws.functions:
   # Define the list of function availables, each function required to have a unique name.
   # Create a function that accepts events coming from cloudwatchlogs.

--- a/x-pack/functionbeat/manager/aws/cli_manager.go
+++ b/x-pack/functionbeat/manager/aws/cli_manager.go
@@ -210,7 +210,7 @@ func NewCLI(
 	cfg *common.Config,
 	provider provider.Provider,
 ) (provider.CLIManager, error) {
-	config := &fnaws.Config{}
+	config := fnaws.DefaultConfig()
 	if err := cfg.Unpack(config); err != nil {
 		return nil, err
 	}

--- a/x-pack/functionbeat/manager/aws/cli_manager.go
+++ b/x-pack/functionbeat/manager/aws/cli_manager.go
@@ -67,6 +67,12 @@ func (c *CLIManager) deployTemplate(update bool, name string) error {
 	}
 
 	c.log.Debugf("Using cloudformation template:\n%s", templateData.json)
+
+	_, err = c.awsCfg.Credentials.Retrieve()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve aws credentials, please check AWS credential in config: %+v", err)
+	}
+
 	svcCF := cf.New(c.awsCfg)
 
 	executer := executor.NewExecutor(c.log)
@@ -144,6 +150,11 @@ func (c *CLIManager) Remove(name string) error {
 	c.log.Debugf("Removing function: %s", name)
 	defer c.log.Debugf("Removal of function '%s' complete", name)
 
+	_, err := c.awsCfg.Credentials.Retrieve()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve aws credentials, please check AWS credential in config: %+v", err)
+	}
+
 	svc := cf.New(c.awsCfg)
 	executer := executor.NewExecutor(c.log)
 	executer.Add(newOpDeleteCloudFormation(c.log, svc, c.stackName(name)))
@@ -206,11 +217,6 @@ func NewCLI(
 	awsCfg, err := awscommon.GetAWSCredentials(config.Credentials)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get aws credentials, please check AWS credential in config: %+v", err)
-	}
-
-	_, err = awsCfg.Credentials.Retrieve()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve aws credentials, please check AWS credential in config: %+v", err)
 	}
 
 	builder, err := provider.TemplateBuilder()

--- a/x-pack/functionbeat/manager/aws/template_builder.go
+++ b/x-pack/functionbeat/manager/aws/template_builder.go
@@ -66,7 +66,7 @@ func NewTemplateBuilder(log *logp.Logger, cfg *common.Config, p provider.Provide
 	return &defaultTemplateBuilder{
 		provider: p,
 		log:      log,
-		endpoint: config.Endpoint,
+		endpoint: config.Credentials.Endpoint,
 		bucket:   string(config.DeployBucket),
 	}, nil
 }

--- a/x-pack/functionbeat/provider/aws/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/aws/config.go
@@ -24,6 +24,14 @@ type Config struct {
 	Credentials  awscommon.ConfigAWS `config:",inline"`
 }
 
+func DefaultConfig() *Config {
+	return &Config{
+		Credentials: awscommon.ConfigAWS{
+			Endpoint: "s3.amazonaws.com",
+		},
+	}
+}
+
 // maxMegabytes maximums memory that a lambda can use.
 const maxMegabytes = 3008
 

--- a/x-pack/functionbeat/provider/aws/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/aws/config.go
@@ -20,9 +20,8 @@ import (
 
 // Config expose the configuration option the AWS provider.
 type Config struct {
-	Endpoint     string              `config:"endpoint" validate:"nonzero,required"`
 	DeployBucket bucket              `config:"deploy_bucket" validate:"nonzero,required"`
-	Credentials  awscommon.ConfigAWS `config:"credentials"`
+	Credentials  awscommon.ConfigAWS `config:",inline"`
 }
 
 // maxMegabytes maximums memory that a lambda can use.

--- a/x-pack/functionbeat/provider/aws/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/aws/config.go
@@ -32,6 +32,13 @@ func DefaultConfig() *Config {
 	}
 }
 
+func (c *Config) Validate() error {
+	if c.Credentials.Endpoint == "" {
+		return fmt.Errorf("functionbeat.providers.aws.enpoint cannot be empty")
+	}
+	return nil
+}
+
 // maxMegabytes maximums memory that a lambda can use.
 const maxMegabytes = 3008
 

--- a/x-pack/functionbeat/provider/aws/aws/config.go
+++ b/x-pack/functionbeat/provider/aws/aws/config.go
@@ -15,12 +15,14 @@ import (
 	"github.com/dustin/go-humanize"
 
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
+	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 )
 
 // Config expose the configuration option the AWS provider.
 type Config struct {
-	Endpoint     string `config:"endpoint" validate:"nonzero,required"`
-	DeployBucket bucket `config:"deploy_bucket" validate:"nonzero,required"`
+	Endpoint     string              `config:"endpoint" validate:"nonzero,required"`
+	DeployBucket bucket              `config:"deploy_bucket" validate:"nonzero,required"`
+	Credentials  awscommon.ConfigAWS `config:"credentials"`
 }
 
 // maxMegabytes maximums memory that a lambda can use.

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -38,12 +38,26 @@ given, the default profile will be used.
 `shared_credential_file` is optional to specify the directory of your shared
 credentials file. If it's empty, the default directory will be used.
 In Windows, shared credentials file is at `C:\Users\<yourUserName>\.aws\credentials`.
-For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. When running as a service, 
+For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. When running as a service,
 the home path depends on the user that manages the service, so the `shared_credential_file` parameter can be used to avoid ambiguity. Please see
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
 for more details.
 
-include::../../../{beatname_lc}/docs/aws-credentials-examples.asciidoc[]
+ifeval::["{beatname_lc}"=="filebeat"]
+include::../../../filebeat/docs/aws-credentials-examples.asciidoc[]
+endif::[]
+
+ifeval::["{beatname_lc}"=="heartbeat"]
+include::../../../heartbeat/docs/aws-credentials-examples.asciidoc[]
+endif::[]
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+include::../../../metricbeat/docs/aws-credentials-examples.asciidoc[]
+endif::[]
+
+ifeval::["{beatname_lc}"=="functionbeat"]
+include::../../../filebeat/docs/aws-credentials-examples.asciidoc[]
+endif::[]
 
 [float]
 ==== AWS Credentials Types


### PR DESCRIPTION
## What does this PR do?

This PR makes credential settings when deploying Lambdas to AWS more flexible. New options are introduced:

1. `access_key_id`, `secret_access_key` and/or `session_token` for tokens

```yaml
functionbeat.provider.aws.access_key_id: '${AWS_ACCESS_KEY_ID:""}'
functionbeat.provider.aws.secret_access_key: '${AWS_SECRET_ACCESS_KEY:""}'
functionbeat.provider.aws.session_token: '${AWS_SESSION_TOKEN:""}'
``` 
2. `role_arn` for assuming IAM roles
```yaml
functionbeat.provider.aws.role_arn: arn:aws:iam::123456789012:role/test-fnb
```

3. `credential_profile_name` and/or `shared_credential_file` for credential files
```yaml
functionbeat.provider.aws.credential_profile_name: fnb-aws
functionbeat.provider.aws.shared_credential_file: /etc/functionbeat/aws_credentials
```

## Why is it important?

Credential configuration becomes more flexible and follows the same pattern as in Filebeat and Metricbeat.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Based on #17658
Closes #12464