### PR TITLE
[Uptime] Copy synthetics suites to tmpdir before running

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -793,6 +793,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Heartbeat*
 
 - Add mime type detection for http responses. {pull}22976[22976]
+- Copy suite directories for synthetic checks to tmp dir before running. {pull}23347[23347]
 
 *Journalbeat*
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -169,7 +169,7 @@ func (bt *Heartbeat) RunReloadableMonitors(b *beat.Beat) (err error) {
 }
 
 // Provide hook to define journey list discovery from x-pack
-type JourneyLister func(ctx context.Context, suiteFile string, params common.MapStr) ([]string, error)
+type JourneyLister func(ctx context.Context, suitePath string, params common.MapStr) ([]string, error)
 
 var mainJourneyLister JourneyLister
 


### PR DESCRIPTION
The rationale here is that doing so resolves any file permissions issues that may be present due to the suite directory being shared to the container as read only OR due to incompatible UIDs between the docker container and the host.

Fixes https://github.com/elastic/synthetics/issues/156

As a note, no tests are added here due to the complexity of testing this small amount of I/O functionality, however, any issues should be caught by our E2E tests in https://github.com/elastic/synthetics/tree/master/__tests__/e2e . I've opened an issue to improve this situation here: https://github.com/elastic/beats/issues/23346

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## How to test this PR locally


You can test this manually by running ` mage build && ./heartbeat -e --path.config sample-synthetics-config/` and ensuring that there's still output.
