### PR TITLE
Clean up naming conventions for namespace and dataset settings

### DIFF
--- a/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
@@ -11,22 +11,12 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-    # Index names must meet the following criteria:
-    #   Lowercase only
-    #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-    #   Cannot start with -, _, +
-    #   Cannot be . or ..
+    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-        # Index names must meet the following criteria:
-        #   Lowercase only
-        #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-        #   Cannot start with -, _, +
-        #   Cannot be . or ..
+        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
@@ -11,12 +11,13 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+    # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
+    # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+        # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
@@ -11,22 +11,12 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-    # Index names must meet the following criteria:
-    #   Lowercase only
-    #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-    #   Cannot start with -, _, +
-    #   Cannot be . or ..
+    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-        # Index names must meet the following criteria:
-        #   Lowercase only
-        #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-        #   Cannot start with -, _, +
-        #   Cannot be . or ..
+        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
@@ -11,12 +11,13 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+    # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
+    # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+        # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
@@ -11,22 +11,12 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-    # Index names must meet the following criteria:
-    #   Lowercase only
-    #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-    #   Cannot start with -, _, +
-    #   Cannot be . or ..
+    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-        # Index names must meet the following criteria:
-        #   Lowercase only
-        #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-        #   Cannot start with -, _, +
-        #   Cannot be . or ..
+        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
@@ -11,12 +11,13 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+    # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
+    # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+        # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/_meta/elastic-agent.yml
+++ b/x-pack/elastic-agent/_meta/elastic-agent.yml
@@ -11,22 +11,12 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-    # Index names must meet the following criteria:
-    #   Lowercase only
-    #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-    #   Cannot start with -, _, +
-    #   Cannot be . or ..
+    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-        # Index names must meet the following criteria:
-        #   Lowercase only
-        #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-        #   Cannot start with -, _, +
-        #   Cannot be . or ..
+        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/_meta/elastic-agent.yml
+++ b/x-pack/elastic-agent/_meta/elastic-agent.yml
@@ -11,12 +11,13 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+    # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
+    # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+        # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/elastic-agent.docker.yml
@@ -11,22 +11,12 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-    # Index names must meet the following criteria:
-    #   Lowercase only
-    #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-    #   Cannot start with -, _, +
-    #   Cannot be . or ..
+    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-        # Index names must meet the following criteria:
-        #   Lowercase only
-        #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-        #   Cannot start with -, _, +
-        #   Cannot be . or ..
+        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/elastic-agent.docker.yml
@@ -11,12 +11,13 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+    # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
+    # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+        # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/elastic-agent.reference.yml
+++ b/x-pack/elastic-agent/elastic-agent.reference.yml
@@ -17,12 +17,13 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+    # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
+    # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+        # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/elastic-agent.reference.yml
+++ b/x-pack/elastic-agent/elastic-agent.reference.yml
@@ -17,22 +17,12 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-    # Index names must meet the following criteria:
-    #   Lowercase only
-    #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-    #   Cannot start with -, _, +
-    #   Cannot be . or ..
+    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-        # Index names must meet the following criteria:
-        #   Lowercase only
-        #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-        #   Cannot start with -, _, +
-        #   Cannot be . or ..
+        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/elastic-agent.yml
+++ b/x-pack/elastic-agent/elastic-agent.yml
@@ -17,12 +17,13 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+    # Namespace name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
+    # For index naming restrictions, see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
+        # Dataset name must conform to the naming conventions for Elasticsearch indices, cannot contain dashes (-), and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory

--- a/x-pack/elastic-agent/elastic-agent.yml
+++ b/x-pack/elastic-agent/elastic-agent.yml
@@ -17,22 +17,12 @@ outputs:
 inputs:
   - type: system/metrics
 
-    # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-    # Index names must meet the following criteria:
-    #   Lowercase only
-    #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-    #   Cannot start with -, _, +
-    #   Cannot be . or ..
+    # Namespace name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
     data_stream.namespace: default
     use_output: default
     streams:
       - metricset: cpu
-        # The only two requirement are that it has only characters allowed in an Elasticsearch index name
-        # Index names must meet the following criteria:
-        #   Lowercase only
-        #   Cannot include \, /, *, ?, ", <, >, |, ` ` (space character), ,, #
-        #   Cannot start with -, _, +
-        #   Cannot be . or ..
+        # Dataset name must conform to the naming conventions for Elasticsearch indices and cannot exceed 100 bytes
         data_stream.dataset: system.cpu
       - metricset: memory
         data_stream.dataset: system.memory


### PR DESCRIPTION
## What does this PR do?

Closes elastic/beats#23351

(I realize that Namespace name sounds a little redundant, but I think it's necessary for clarity since we also give a byte restriction. Am I overthinking this?)

## Why is it important?

The ES index naming conventions as documented in the Elastic Agent YAML file were not complete and therefore were misleading. The Elasticsearch docs are the source of truth for naming restrictions, so we should not duplicate this info in the config files.

## Checklist

- [x] My code follows the style guidelines of this project


## Related issues

- Closes elastic/beats#23351

