### PR TITLE
chore: update test environments for 7.10.2

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -15,11 +15,11 @@ services:
 
   # Used by base tests
   elasticsearch:
-    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.10.1}-1
     build:
       context: ./module/elasticsearch/_meta
       args:
-        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.10.0}
+        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.10.1}
     environment:
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
       - "network.host="
@@ -37,11 +37,11 @@ services:
 
   # Used by base tests
   kibana:
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.1}-1
     build:
       context: ./module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-7.10.0}
+        KIBANA_VERSION: ${KIBANA_VERSION:-7.10.1}
     depends_on:
       - elasticsearch
     ports:
@@ -49,11 +49,11 @@ services:
 
   # Used by base tests
   metricbeat:
-    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-7.10.1}-1
     build:
       context: ./module/beat/_meta
       args:
-        BEAT_VERSION: ${BEAT_VERSION:-7.10.0}
+        BEAT_VERSION: ${BEAT_VERSION:-7.10.1}
     command: '-e'
     ports:
       - 5066

--- a/metricbeat/module/logstash/docker-compose.yml
+++ b/metricbeat/module/logstash/docker-compose.yml
@@ -2,22 +2,22 @@ version: '2.3'
 
 services:
   logstash:
-    image: docker.elastic.co/integrations-ci/beats-logstash:${LOGSTASH_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-logstash:${LOGSTASH_VERSION:-7.10.1}-1
     build:
       context: ./_meta
       args:
-        LOGSTASH_VERSION: ${LOGSTASH_VERSION:-7.10.0}
+        LOGSTASH_VERSION: ${LOGSTASH_VERSION:-7.10.1}
     ports:
       - 9600
     depends_on:
       - elasticsearch
 
   elasticsearch:
-    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.10.1}-1
     build:
       context: ../elasticsearch/_meta
       args:
-        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.10.0}
+        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.10.1}
     environment:
       - "network.host="
       - "transport.host=127.0.0.1"

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -16,7 +16,7 @@ services:
       - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.10.0
+    image: docker.elastic.co/logstash/logstash:7.10.1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.0
+    image: docker.elastic.co/kibana/kibana:7.10.1
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -15,7 +15,7 @@ services:
     - "http.host=0.0.0.0"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.10.1-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.10.2-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -25,7 +25,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.10.1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.10.2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -16,7 +16,7 @@ services:
     - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.10.1-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.10.2-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.10.1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.10.2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -24,11 +24,11 @@ services:
   kibana:
     # Copied configuration from OSS metricbeat because services with depends_on
     # cannot be extended with extends
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.0}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-7.10.1}-1
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-7.10.0}
+        KIBANA_VERSION: ${KIBANA_VERSION:-7.10.1}
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
Updates test environments for 7.10.2.

Merge after first [7.10.2-SNAPSHOT Docker image](https://artifacts-api.elastic.co/v1/versions/7.10.2-SNAPSHOT)