### PR TITLE
Fix docs of MSSQL filebeat module referencing Traefik plus change paths from Linux to MS Windows

### DIFF
--- a/filebeat/docs/modules/mssql.asciidoc
+++ b/filebeat/docs/modules/mssql.asciidoc
@@ -27,7 +27,7 @@ file to override the default paths for MSSQL logs:
 - module: mssql
   log:
     enabled: true
-    var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
+    var.paths: ['C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*']
 -----
 
 
@@ -35,7 +35,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
--M "mssql.log.var.paths=[C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*]"
+-M "mssql.log.var.paths=['C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*']"
 -----
 
 //set the fileset name used in the included example

--- a/filebeat/docs/modules/mssql.asciidoc
+++ b/filebeat/docs/modules/mssql.asciidoc
@@ -20,14 +20,14 @@ include::../include/gs-link.asciidoc[]
 include::../include/configuring-intro.asciidoc[]
 
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
-file to override the default paths for Træfik logs:
+file to override the default paths for MSSQL logs:
 
 ["source","yaml",subs="attributes"]
 -----
 - module: mssql
   log:
     enabled: true
-    var.paths: ["/var/opt/mssql/log/error*"]
+    var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
 -----
 
 
@@ -35,7 +35,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
--M "mssql.log.var.paths=[/var/opt/mssql/log/error*]"
+-M "mssql.log.var.paths=[C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*]"
 -----
 
 //set the fileset name used in the included example

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1410,7 +1410,7 @@ filebeat.modules:
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
-    #var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
+    #var.paths: ['C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*']
 
 #-------------------------------- MySQL Module --------------------------------
 #- module: mysql

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1410,7 +1410,7 @@ filebeat.modules:
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
-    #var.paths:
+    #var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
 
 #-------------------------------- MySQL Module --------------------------------
 #- module: mysql

--- a/x-pack/filebeat/module/mssql/_meta/config.yml
+++ b/x-pack/filebeat/module/mssql/_meta/config.yml
@@ -5,4 +5,4 @@
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
-    #var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
+    #var.paths: ['C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*']

--- a/x-pack/filebeat/module/mssql/_meta/config.yml
+++ b/x-pack/filebeat/module/mssql/_meta/config.yml
@@ -5,4 +5,4 @@
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
-    #var.paths:
+    #var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]

--- a/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
@@ -15,14 +15,14 @@ include::../include/gs-link.asciidoc[]
 include::../include/configuring-intro.asciidoc[]
 
 The following example shows how to set paths in the +modules.d/{modulename}.yml+
-file to override the default paths for Træfik logs:
+file to override the default paths for MSSQL logs:
 
 ["source","yaml",subs="attributes"]
 -----
 - module: mssql
   log:
     enabled: true
-    var.paths: ["/var/opt/mssql/log/error*"]
+    var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
 -----
 
 
@@ -30,7 +30,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
--M "mssql.log.var.paths=[/var/opt/mssql/log/error*]"
+-M "mssql.log.var.paths=[C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*]"
 -----
 
 //set the fileset name used in the included example

--- a/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/mssql/_meta/docs.asciidoc
@@ -22,7 +22,7 @@ file to override the default paths for MSSQL logs:
 - module: mssql
   log:
     enabled: true
-    var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
+    var.paths: ['C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*']
 -----
 
 
@@ -30,7 +30,7 @@ To specify the same settings at the command line, you use:
 
 ["source","sh",subs="attributes"]
 -----
--M "mssql.log.var.paths=[C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*]"
+-M "mssql.log.var.paths=['C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*']"
 -----
 
 //set the fileset name used in the included example

--- a/x-pack/filebeat/modules.d/mssql.yml.disabled
+++ b/x-pack/filebeat/modules.d/mssql.yml.disabled
@@ -8,4 +8,4 @@
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
-    #var.paths:
+    #var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]

--- a/x-pack/filebeat/modules.d/mssql.yml.disabled
+++ b/x-pack/filebeat/modules.d/mssql.yml.disabled
@@ -8,4 +8,4 @@
 
     # Set custom paths for the log files. If left empty,
     # Filebeat will choose the paths depending on your OS.
-    #var.paths: ["C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*"]
+    #var.paths: ['C:\Program Files\Microsoft SQL Server\MSSQL.150\MSSQL\LOG\ERRORLOG*']


### PR DESCRIPTION
Fixes MSSQL docs that had references to Traefik plus changing the config paths from a Linux based path (also compatible with MSSQL) to a MS Windows path, which is probably more common.

## Related issues

- Closes #20761