### PR TITLE
Cherry-pick #21325 to 7.11: [Winlogbeat] Add IP validation to Security module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -327,6 +327,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Winlogbeat*
 
 - Protect against accessing an undefined variable in Security module. {pull}22937[22937]
+- Add source.ip validation for event ID 4778 in the Security module. {issue}19627[19627]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -1500,11 +1500,12 @@ var security = (function () {
             fields: [
                 {from: "winlog.event_data.AccountName", to: "user.name"},
                 {from: "winlog.event_data.AccountDomain", to: "user.domain"},
-                {from: "winlog.event_data.ClientAddress", to: "source.ip"},
+                {from: "winlog.event_data.ClientAddress", to: "source.ip", type: "ip"},
                 {from: "winlog.event_data.ClientName", to: "source.domain"},
                 {from: "winlog.event_data.LogonID", to: "winlog.logon.id"},
             ],
             ignore_missing: true,
+            fail_on_error: false,
         })
         .Add(function(evt) {
             var user = evt.Get("winlog.event_data.AccountName");


### PR DESCRIPTION
Cherry-pick of PR #21325 to 7.11 branch. Original message: 

## What does this PR do?

For event 4778 (A session was reconnected to a Window Station) the `winlog.event_data.ClientAddress`
could be "LOCAL" which is obviosuly not a valid IP so we don't want to copy it into `source.ip` in that case.

## Why is it important?

This bug can causes mapping exceptions.

## Checklist

- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes elastic/beats#19627

