### PR TITLE
Cherry-pick to 7.10: Make shared content beats-agnostic (#23234)

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -248,8 +248,11 @@ running configuration for a container, 60s by default.
   and `add_resource_metadata` settings are not taken into account.
 `leader_lease`:: (Optional) Defaults to `{beatname_lc}-cluster-leader`. This will be name of the lock lease.
   One can monitor the status of the lease with `kubectl describe lease beats-cluster-leader`.
-  Different Beats that refer to the same leader lease will be competetitors in holding the lease
-  and only one will be elected as leader each time. Example:
+  Different Beats that refer to the same leader lease will be competitors in holding the lease
+  and only one will be elected as leader each time.
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+Example:
 
 ["source","yaml",subs="attributes"]
 -------------------------------------------------------------------------------------
@@ -274,6 +277,7 @@ The above configuration when deployed on one or more Metribceat instances will e
 metricset only for the Metricbeat instance that will gain the leader lease/lock. With this deployment
 strategy we can ensure that cluster-wide metricsets are only enabled by one Beat instance when
 deploying a Beat as Daemonset.
+endif::[]
 
 include::../../{beatname_lc}/docs/autodiscover-kubernetes-config.asciidoc[]
 
@@ -299,7 +303,7 @@ application to find the more suitable way to set them in your case.
 
 Jolokia Discovery is based on UDP multicast requests. Agents join the multicast
 group 239.192.48.84, port 24884, and discovery is done by sending queries to
-this group. You have to take into account that UDP traffic between Metricbeat
+this group. You have to take into account that UDP traffic between {beatname_uc}
 and the Jolokia agents has to be allowed. Also notice that this multicast
 address is in the 239.0.0.0/8 range, that is reserved for private use within an
 organization, so it can only be used in private networks.
@@ -384,8 +388,12 @@ ifdef::autodiscoverAWSEC2[]
 *Note: This provider is experimental*
 
 The Amazon EC2 autodiscover provider discovers https://aws.amazon.com/ec2/[EC2 instances].
-This is useful for users to launch Metricbeat modules to monitor services running on AWS EC2 instances.
-For example, to gather MySQL metrics from mysql servers running on EC2 instances with specific tag `service: mysql`.
+This is useful for users to launch {beatname_uc} modules to monitor services running on AWS EC2 instances.
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+For example, you can use this provider to gather MySQL metrics from MySQL
+servers running on EC2 instances that have a specific tag, `service: mysql`.
+endif::[]
 
 This provider will load AWS credentials using the standard AWS environment variables and shared credentials files
 see https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html[Best Practices for Managing AWS Access Keys]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Make shared content beats-agnostic (#23234)