### PR TITLE
Application logging alternative

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -44,10 +44,10 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 ==== Other installation options
 
 * <<setup-repositories,APT or YUM>>
-* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page] 
+* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 * <<running-on-docker,Docker>>
-* <<running-on-kubernetes,Kubernetes>> 
-* <<running-on-cloudfoundry,Cloud Foundry>> 
+* <<running-on-kubernetes,Kubernetes>>
+* <<running-on-cloudfoundry,Cloud Foundry>>
 
 [float]
 [[set-connection]]
@@ -56,75 +56,18 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 include::{libbeat-dir}/shared/connecting-to-es.asciidoc[]
 
 [float]
-[[enable-modules]]
-=== Step 3: Enable and configure data collection modules
+[[collect-data]]
+=== Step 3: Collect data
 
 {beatname_uc} uses modules to collect and parse log data.
+You can also use {beatname_uc} to collect application logs.
+Select your use case below.
 
-. Identify the modules you need to enable. To see a list of available
-<<filebeat-modules,modules>>, run:
-+
---
-include::{libbeat-dir}/tab-widgets/list-modules-widget.asciidoc[]
---
-+
-Can't find a module for your file type? Skip this section and
-<<configuration-filebeat-options,configure the input>> manually.
-
-. From the installation directory, enable one or more modules. For example, the
-following command enables the `system`, `nginx`, and `mysql` module
-configs:
-+
---
-include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
---
-
-. In the module configs under `modules.d`, change the module settings to match
-your environment.
-+
-For example, log locations are set based on the OS. If your logs aren't in
-default locations, set the `paths` variable:
-+
---
-[source,yaml]
-----
-- module: nginx
-  access:
-    var.paths: ["/var/log/nginx/access.log*"] <1> 
-----
---
-
-To see the full list of variables for a module, see the documentation under
-<<filebeat-modules>>.
-
-include::{libbeat-dir}/shared/config-check.asciidoc[]
-
-[float]
-[[setup-application-logs]]
-=== Step 4: Ingest application logs
-
-This section is about best practices for ingesting logs from your own applications,
-as well as for off-the-shelf applications for which we don't have suitable built-in modules.
-
-Although you can ingest raw plain-text logs, we recommend you structure
-your logs at ingest time.
-This lets you extract fields such as log level and exception stack traces.
-
-If you can change your application's log output,
-we recommend configuring your application to use the log formatters
-provided by {ecs-logging-ref}/intro.html[ECS logging].
-These plugins format your logs into ECS-compatible JSON.
-This simplifies configuration by removing the need to manually parse logs.
-
-If you can't change your application's log output or if
-there is no appropriate ECS logging plugin for your language or preferred
-logging framework, you will need to manually your logs using an
-<<configuring-ingest-node,ingest node processors>>.
-
+include::{libbeat-dir}/tab-widgets/ingest-data-widget.asciidoc[]
 
 [float]
 [[setup-assets]]
-=== Step 5: Set up assets
+=== Step 4: Set up assets
 
 {beatname_uc} comes with predefined assets for parsing, indexing, and
 visualizing your data. To load these assets:

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -106,21 +106,20 @@ include::{libbeat-dir}/shared/config-check.asciidoc[]
 This section is about best practices for ingesting logs from your own applications,
 as well as for off-the-shelf applications for which we don't have suitable built-in modules.
 
-Although you can ingest raw plain-text logs, we recommend you to structure
-your logs on ingest time.
-This lets you extract fields such as the log level and exception stack traces.
+Although you can ingest raw plain-text logs, we recommend you structure
+your logs at ingest time.
+This lets you extract fields such as log level and exception stack traces.
 
-If you can change the log output of your application,
+If you can change your application's log output,
 we recommend configuring your application to use the log formatters
 provided by {ecs-logging-ref}/intro.html[ECS logging].
 These plugins format your logs into ECS-compatible JSON.
-This makes the configuration particularly easy as you don't have to
-manually parse your logs.
+This simplifies configuration by removing the need to manually parse logs.
 
-If it is not possible to configure the logging for your application or if
+If you can't change your application's log output or if
 there is no appropriate ECS logging plugin for your language or preferred
-logging framework, you will need to manually
-<<configuring-ingest-node, parse the logs using ingest node processors>>.
+logging framework, you will need to manually your logs using an
+<<configuring-ingest-node,ingest node processors>>.
 
 
 [float]

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -100,8 +100,32 @@ To see the full list of variables for a module, see the documentation under
 include::{libbeat-dir}/shared/config-check.asciidoc[]
 
 [float]
+[[setup-application-logs]]
+=== Step 4: Ingest application logs
+
+This section is about best practices for ingesting logs from your own applications,
+as well as for off-the-shelf applications for which we don't have suitable built-in modules.
+
+Although you can ingest raw plain-text logs, we recommend you to structure
+your logs on ingest time.
+This lets you extract fields such as the log level and exception stack traces.
+
+If you can change the log output of your application,
+we recommend configuring your application to use the log formatters
+provided by {ecs-logging-ref}/intro.html[ECS logging].
+These plugins format your logs into ECS-compatible JSON.
+This makes the configuration particularly easy as you don't have to
+manually parse your logs.
+
+If it is not possible to configure the logging for your application or if
+there is no appropriate ECS logging plugin for your language or preferred
+logging framework, you will need to manually
+<<configuring-ingest-node, parse the logs using ingest node processors>>.
+
+
+[float]
 [[setup-assets]]
-=== Step 4: Set up assets
+=== Step 5: Set up assets
 
 {beatname_uc} comes with predefined assets for parsing, indexing, and
 visualizing your data. To load these assets:

--- a/libbeat/docs/tab-widgets/ingest-data-widget.asciidoc
+++ b/libbeat/docs/tab-widgets/ingest-data-widget.asciidoc
@@ -1,0 +1,40 @@
+++++
+<div class="tabs" data-tab-group="ingest-data">
+  <div role="tablist" aria-label="Ingest data">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="use-modules-tab"
+            id="use-modules">
+      Data collection modules
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="application-logs-tab"
+            id="application-logs"
+            tabindex="-1">
+      Application logs
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="use-modules-tab"
+       aria-labelledby="use-modules">
+++++
+
+include::ingest-data.asciidoc[tag=modules]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="application-logs-tab"
+       aria-labelledby="application-logs"
+       hidden="">
+++++
+
+include::ingest-data.asciidoc[tag=application-logs]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/ingest-data.asciidoc
+++ b/libbeat/docs/tab-widgets/ingest-data.asciidoc
@@ -1,0 +1,68 @@
+// tag::modules[]
+[float]
+[[enable-modules]]
+===== Enable and configure data collection modules
+
+. Identify the modules you need to enable. To see a list of available
+<<filebeat-modules,modules>>, run:
++
+--
+include::{libbeat-dir}/tab-widgets/list-modules-widget.asciidoc[]
+--
++
+Can't find a module for your file type? Skip this section and
+<<configuration-filebeat-options,configure the input>> manually.
+
+. From the installation directory, enable one or more modules. For example, the
+following command enables the `system`, `nginx`, and `mysql` module
+configs:
++
+--
+include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
+--
+
+. In the module configs under `modules.d`, change the module settings to match
+your environment.
++
+For example, log locations are set based on the OS. If your logs aren't in
+default locations, set the `paths` variable:
++
+--
+[source,yaml]
+----
+- module: nginx
+  access:
+    var.paths: ["/var/log/nginx/access.log*"] <1>
+----
+--
+
+To see the full list of variables for a module, see the documentation under
+<<filebeat-modules>>.
+
+include::{libbeat-dir}/shared/config-check.asciidoc[]
+
+// end::modules[]
+
+// tag::application-logs[]
+[float]
+[[setup-application-logs]]
+===== Ingest application logs
+
+This section is about best practices for ingesting logs from your own applications,
+as well as for off-the-shelf applications for which we don't have suitable built-in modules.
+
+Although you can ingest raw plain-text logs, we recommend you structure
+your logs at ingest time.
+This lets you extract fields such as log level and exception stack traces.
+
+If you can change your application's log output,
+we recommend configuring your application to use the log formatters
+provided by {ecs-logging-ref}/intro.html[ECS logging].
+These plugins format your logs into ECS-compatible JSON.
+This simplifies configuration by removing the need to manually parse logs.
+
+If you can't change your application's log output or if
+there is no appropriate ECS logging plugin for your language or preferred
+logging framework, you will need to manually your logs using an
+<<configuring-ingest-node,ingest node processors>>.
+// end::application-logs[]


### PR DESCRIPTION
## Summary

Tabs inside of tabs 🤯 — another idea for adding application logs to the Filebeat Quickstart.

![screencapture-localhost-8000-guide-filebeat-installation-configuration-html-2021-01-05-17_48_03](https://user-images.githubusercontent.com/5618806/103719696-6b52e380-4f7e-11eb-89cc-86c68c902202.png)

cc @dedemorton / @felixbarny 