### PR TITLE
Update suricata fields in filebeat

### DIFF
--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -142335,13 +142335,6 @@ alias to: source.packets
 
 --
 
-*`suricata.eve.flow.end`*::
-+
---
-type: date
-
---
-
 *`suricata.eve.flow.alerted`*::
 +
 --


### PR DESCRIPTION
Fix OSS filebeat lint builds.

This should have been detected by CI in #23236, pinging @elastic/observablt-robots.