### PR TITLE
[docs] Update misleading phrasing for logging.metrics.enabled

### DIFF
--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -153,10 +153,11 @@ endif::serverless[]
 [float]
 ==== `logging.metrics.enabled`
 
-If enabled, {beatname_uc} periodically logs its internal metrics that have
+By default, {beatname_uc} periodically logs its internal metrics that have
 changed in the last period. For each metric that changed, the delta from the
 value at the beginning of the period is logged. Also, the total values for all
-non-zero internal metrics are logged on shutdown. The default is true.
+non-zero internal metrics are logged on shutdown. Set this to false to disable 
+this behavior. The default is true.
 
 Here is an example log line:
 


### PR DESCRIPTION
## What does this PR do?

The documentation for this option opens with **If enabled**... which I find rather misleading since the option is **enabled by default**. 

This is an effort to clarify this with slightly different wording.

## Why is it important?

People skim the docs, don't actually read them :slightly_smiling_face: 

## Checklist

This is a one-liner docs change. I don't think most of these are relevant.
Not sure about the last one.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

