### PR TITLE
[Filebeat] httpjson input add support for POST x-www-form-urlencoded

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -790,6 +790,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Google Workspace module and mark Gsuite module as deprecated {pull}22950[22950]
 - Mark m365 defender, defender atp, okta and google workspace modules as GA {pull}23113[23113]
 - Added `alternative_host` option to google pubsub input {pull}23215[23215]
+- Add POST x-www-form-urlencoded support to httpjson input {pull}23379[23379]
 
 *Heartbeat*
 


### PR DESCRIPTION
- For POST if params are set but no body, encode params and use as
  body, set Content-Type to x-www-form-urlencoded
- For POST if body is set but no params, marshal body to json and
  set Content-Type to application/json

## What does this PR do?

add support for POST x-www-form-urlencoded to httpjson input

## Why is it important?

Some endpoints require a POST of form data

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.