### PR TITLE
Cherry-pick to 7.11: [CI][lint] Enable OSS linting when x-pack changes (#23378)

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -2,6 +2,7 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^auditbeat/.*"
+        - "^x-pack/auditbeat/.*"  ## when changes in the x-pack/auditbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -33,8 +34,14 @@ stages:
             tags: true         ## for all the tags
     build:
         mage: "mage build test"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     crosscompile:
         make: "make -C auditbeat crosscompile"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -54,6 +61,9 @@ stages:
             - "windows-2019"
             #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19831
             #- "windows-2008-r2" https://github.com/elastic/beats/issues/19799
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -2,6 +2,7 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^filebeat/.*"
+        - "^x-pack/filebeat/.*"  ## when changes in the x-pack/filebeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -34,6 +35,9 @@ stages:
     build:
         mage: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -52,6 +56,9 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19795
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -2,6 +2,7 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^heartbeat/.*"
+        - "^x-pack/heartbeat/.*"  ## when changes in the x-pack/heartbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -33,6 +34,9 @@ stages:
             tags: true         ## for all the tags
     build:
         mage: "mage build test"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -50,6 +54,9 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -2,6 +2,7 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^journalbeat/.*"
+        - "^x-pack/journalbeat/.*"  ## when changes in the x-pack/journalbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -33,3 +34,6 @@ stages:
             tags: true         ## for all the tags
     unitTest:
         mage: "mage build unitTest"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -1,6 +1,7 @@
 when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
+        - "^x-pack/libbeat/.*" ## when changes in the x-pack/libbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -30,7 +31,16 @@ stages:
                 - "armTest"
     build:
         mage: "mage build test"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     crosscompile:
         make: "make -C libbeat crosscompile"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     stress-tests:
         make: "make STRESS_TEST_OPTIONS='-timeout=20m -race -v -parallel 1' -C libbeat stress-tests"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -2,6 +2,7 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^metricbeat/.*"
+        - "^x-pack/metricbeat/.*"  ## when changes in the x-pack/metricbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -20,14 +21,26 @@ stages:
           make check-no-changes;
     unitTest:
         mage: "mage build unitTest"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     goIntegTest:
         mage: "mage goIntegTest"
         withModule: true
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     pythonIntegTest:
         mage: "mage pythonIntegTest"
         withModule: true
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     crosscompile:
         make: "make -C metricbeat crosscompile"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -47,6 +60,9 @@ stages:
             - "windows-2019"
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19800
             #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19835
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -2,6 +2,7 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^packetbeat/.*"
+        - "^x-pack/packetbeat/.*"  ## when changes in the x-pack/packetbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -33,6 +34,9 @@ stages:
             tags: true         ## for all the tags
     build:
         mage: "mage build test"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -50,6 +54,9 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -2,6 +2,7 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^winlogbeat/.*"
+        - "^x-pack/winlogbeat/.*"  ## when changes in the x-pack/winlogbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -20,11 +21,17 @@ stages:
           make check-no-changes;
     crosscompile:
         make: "make -C winlogbeat crosscompile"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
             - "windows-2008-r2"
+        when:                  ## Override the top-level when.
+            not_changeset:
+                - "^x-pack/.*" ## A generic match
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [CI][lint] Enable OSS linting when x-pack changes (#23378)