### PR TITLE
Cherry-pick #23401 to 7.x: Launch packaging jobs when packaging files are changed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
           // Skip all the stages except docs for PR's with asciidoc and md changes only
           setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true).toString())
           setEnvVar('GO_MOD_CHANGES', isGitRegionMatch(patterns: [ '^go.mod' ], shouldMatchAll: false).toString())
+          setEnvVar('PACKAGING_CHANGES', isGitRegionMatch(patterns: [ '^dev-tools/packaging/.*' ], shouldMatchAll: false).toString())
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
@@ -127,7 +128,10 @@ pipeline {
       options { skipDefaultCheckout() }
       when {
         allOf {
-          expression { return env.GO_MOD_CHANGES == "true" }
+          anyOf {
+            expression { return env.GO_MOD_CHANGES == "true" }
+            expression { return env.PACKAGING_CHANGES == "true" }
+          }
           changeRequest()
         }
       }


### PR DESCRIPTION
Cherry-pick of PR #23401 to 7.x branch. Original message: 

Fix heartbeat build and launch packaging jobs when packaging files
change to detect these issues.

Packaging jobs should be launched for this change.