### PR TITLE
[CI] cross linting with full match support

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -35,13 +35,11 @@ stages:
     build:
         mage: "mage build test"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     crosscompile:
         make: "make -C auditbeat crosscompile"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -62,8 +60,7 @@ stages:
             #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19831
             #- "windows-2008-r2" https://github.com/elastic/beats/issues/19799
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -36,8 +36,7 @@ stages:
         mage: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -57,8 +56,7 @@ stages:
             - "windows-2019"
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19795
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -35,8 +35,7 @@ stages:
     build:
         mage: "mage build test"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -55,8 +54,7 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -35,5 +35,4 @@ stages:
     unitTest:
         mage: "mage build unitTest"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -32,15 +32,12 @@ stages:
     build:
         mage: "mage build test"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     crosscompile:
         make: "make -C libbeat crosscompile"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     stress-tests:
         make: "make STRESS_TEST_OPTIONS='-timeout=20m -race -v -parallel 1' -C libbeat stress-tests"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -22,25 +22,21 @@ stages:
     unitTest:
         mage: "mage build unitTest"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     goIntegTest:
         mage: "mage goIntegTest"
         withModule: true
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     pythonIntegTest:
         mage: "mage pythonIntegTest"
         withModule: true
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     crosscompile:
         make: "make -C metricbeat crosscompile"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -61,8 +57,7 @@ stages:
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19800
             #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19835
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -35,8 +35,7 @@ stages:
     build:
         mage: "mage build test"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -55,8 +54,7 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -22,16 +22,14 @@ stages:
     crosscompile:
         make: "make -C winlogbeat crosscompile"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
             - "windows-2008-r2"
         when:                  ## Override the top-level when.
-            not_changeset:
-                - "^x-pack/.*" ## A generic match
+            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

Mandatory fields should always run if no x-pack full matches when a cross project linting is required.

## Why is it important?

Otherwise, there is a corner case when a particular PR touches both components, then the mandatory fields won't be executed.

## Issues
 
Originally implemented with #23378 but it uses partial matches

Depends on https://github.com/elastic/apm-pipeline-library/pull/890