### PR TITLE
Cherry-pick #23413 to 7.11: libbeat/cmd/instance/metrics: fix error message

### DIFF
--- a/libbeat/cmd/instance/metrics/metrics.go
+++ b/libbeat/cmd/instance/metrics/metrics.go
@@ -298,7 +298,7 @@ func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
 	}
 	selfStats, err := cgroups.GetStatsForProcess(pid)
 	if err != nil {
-		logp.Err("error getting group status: %v", err)
+		logp.Err("error getting cgroup stats: %v", err)
 		return
 	}
 	// GetStatsForProcess returns a nil selfStats and no error when there's no stats


### PR DESCRIPTION
Cherry-pick of PR #23413 to 7.11 branch. Original message: 

## What does this PR do?

Upon failure to retrieve cgroup stats, the log
message should say "error getting cgroup stats"
and not "error getting group status".

## Why is it important?

Because the invalid log message is confusing.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

N/A (trivial change)

## Related issues

https://github.com/elastic/beats/pull/21113/files#r554442805