### PR TITLE
Update filestream reader offset when line is skipped

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -271,6 +271,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix CredentialsJSON unpacking for `gcp-pubsub` and `httpjson` inputs. {pull}23277[23277]
 - Change the `event.created` in Netflow events to be the time the event was created by Filebeat
   to be consistent with ECS. {pull}23094[23094]
+- Update `filestream` reader offset when a line is skipped. {pull}23417[23417]
 
 *Filebeat*
 

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -311,6 +311,7 @@ func (inp *filestream) readFromSource(
 				log.Info("Reader was closed. Closing.")
 			case reader.ErrLineUnparsable:
 				log.Info("Skipping unparsable line in file.")
+				s.Offset += int64(message.Bytes)
 				continue
 			default:
 				log.Errorf("Read line error: %v", err)
@@ -318,13 +319,13 @@ func (inp *filestream) readFromSource(
 			return nil
 		}
 
+		s.Offset += int64(message.Bytes)
+
 		if message.IsEmpty() || inp.isDroppedLine(log, string(message.Content)) {
 			continue
 		}
 
 		event := inp.eventFromMessage(message, path)
-		s.Offset += int64(message.Bytes)
-
 		if err := p.Publish(event, s); err != nil {
 			return err
 		}

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -311,7 +311,6 @@ func (inp *filestream) readFromSource(
 				log.Info("Reader was closed. Closing.")
 			case reader.ErrLineUnparsable:
 				log.Info("Skipping unparsable line in file.")
-				s.Offset += int64(message.Bytes)
 				continue
 			default:
 				log.Errorf("Read line error: %v", err)


### PR DESCRIPTION
## What does this PR do?

This PR adds two previously missing offset updates to the `filestream` reader when a line is skipped.

## Why is it important?

The offset could be incorrect if Filebeat skips the line for the following reasons:
1. The line is unparsable
2. The line should not be published because of user configuration in `export_line` or `import_line`

If the offset is not updated in the reader, the state information of newer published events become incorrect. This might lead to duplicated events if Filebeat is restarted.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Start Filebeat with the following configuration

```yaml
filebeat.inputs:
- type: filestream
  enabled: true
  paths:
    - test.log
  exclude_lines: ['^DONOTPUBLISH']

output.elasticsearch:
  enabled: true
  hosts: ["localhost:9200"]
```

Reading this file

```
line 1
DONOTPUBLISH line2
line 3
DONOTPUBLISH line4
line 5
```

2. Stop Filebeat
3. Add new lines to the input file which will be published
4. Start Filebeat

Validate that Filebeat does not send duplicate messages. 

