### PR TITLE
Cherry-pick #23381 to 7.x: [Auditbeat] Fix docs and config for arm builds

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -180,6 +180,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - file_integrity: stop monitoring excluded paths {issue}21278[21278] {pull}21282[21282]
 - system/socket: Fixed startup error with some 5.x kernels. {issue}18755[18755] {pull}22787[22787]
 - system/socket: Having some CPUs unavailable to Auditbeat could cause startup errors or event loss. {pull}22827[22827]
+- Note incompatibility of system/socket on ARM. {pull}23381[23381]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/docs/modules/system.asciidoc
+++ b/x-pack/auditbeat/docs/modules/system.asciidoc
@@ -15,7 +15,7 @@ a system. All datasets send both periodic state information (e.g. all currently
 running processes) and real-time changes (e.g. when a new process starts
 or stops).
 
-The module is fully implemented for Linux. Some datasets are also available
+The module is fully implemented for Linux on x86. Currently, the `socket` module is not available on ARM. Some datasets are also available
 for macOS (Darwin) and Windows.
 
 [float]

--- a/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
+++ b/x-pack/auditbeat/module/system/_meta/config.yml.tmpl
@@ -20,8 +20,10 @@
     - login   # User logins, logouts, and system boots.
     {{- end }}
     - process # Started and stopped processes
-    {{- if eq .GOOS "linux" }}
+    {{- if and (eq .GOOS "linux") (or (eq .GOARCH "amd64") (eq .GOARCH "386")) }}
     - socket  # Opened and closed sockets
+    {{- end }}
+    {{- if eq .GOOS "linux" }}
     - user    # User information
     {{- end }}
 

--- a/x-pack/auditbeat/module/system/_meta/docs.asciidoc
+++ b/x-pack/auditbeat/module/system/_meta/docs.asciidoc
@@ -8,7 +8,7 @@ a system. All datasets send both periodic state information (e.g. all currently
 running processes) and real-time changes (e.g. when a new process starts
 or stops).
 
-The module is fully implemented for Linux. Some datasets are also available
+The module is fully implemented for Linux on x86. Currently, the `socket` module is not available on ARM. Some datasets are also available
 for macOS (Darwin) and Windows.
 
 [float]


### PR DESCRIPTION
Cherry-pick of PR #23381 to 7.x branch. Original message: 



## What does this PR do?

It looks like the `socket` module isn't supported on ARM. Here we're adding another conditional to skip printing it in the config, and adding a note to the docs. I've asked @adriansr to review this, since I'm not sure if there's other modules we'll want to exclude.

## Why is it important?

The socket module is enabled by default, which is an issue on ARM builds where it isn't supported.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- https://github.com/elastic/beats/issues/23349

