### PR TITLE
Update geoip info to include Autonomous System

### DIFF
--- a/libbeat/docs/shared-geoip.asciidoc
+++ b/libbeat/docs/shared-geoip.asciidoc
@@ -49,10 +49,34 @@ PUT _ingest/pipeline/geoip-info
       }
     },
     {
+      "geoip" : {
+        "database_file": "GeoLite2-ASN.mmdb",
+        "field": "client.ip",
+        "target_field": "client.as",
+        "properties": [
+          "asn",
+          "organization_name"
+          ],
+          "ignore_missing": true
+      }
+    },
+    {
       "geoip": {
         "field": "source.ip",
         "target_field": "source.geo",
         "ignore_missing": true
+      }
+    },
+    {
+      "geoip" : {
+        "database_file": "GeoLite2-ASN.mmdb",
+        "field": "source.ip",
+        "target_field": "source.as",
+        "properties": [
+          "asn",
+          "organization_name"
+          ],
+          "ignore_missing": true
       }
     },
     {
@@ -63,10 +87,34 @@ PUT _ingest/pipeline/geoip-info
       }
     },
     {
+      "geoip" : {
+        "database_file": "GeoLite2-ASN.mmdb",
+        "field": "destination.ip",
+        "target_field": "destination.as",
+        "properties": [
+          "asn",
+          "organization_name"
+          ],
+          "ignore_missing": true
+      }
+    },
+    {
       "geoip": {
         "field": "server.ip",
         "target_field": "server.geo",
         "ignore_missing": true
+      }
+    },
+    {
+      "geoip" : {
+        "database_file": "GeoLite2-ASN.mmdb",
+        "field": "server.ip",
+        "target_field": "server.as",
+        "properties": [
+          "asn",
+          "organization_name"
+          ],
+          "ignore_missing": true
       }
     },
     {
@@ -75,7 +123,63 @@ PUT _ingest/pipeline/geoip-info
         "target_field": "host.geo",
         "ignore_missing": true
       }
-    }
+    },
+          {
+        "rename": {
+          "field": "server.as.asn",
+          "target_field": "server.as.number",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "server.as.organization_name",
+          "target_field": "server.as.organization.name",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "client.as.asn",
+          "target_field": "client.as.number",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "client.as.organization_name",
+          "target_field": "client.as.organization.name",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "source.as.asn",
+          "target_field": "source.as.number",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "source.as.organization_name",
+          "target_field": "source.as.organization.name",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "destination.as.asn",
+          "target_field": "destination.as.number",
+          "ignore_missing": true
+        }
+      },
+      {
+        "rename": {
+          "field": "destination.as.organization_name",
+          "target_field": "destination.as.organization.name",
+          "ignore_missing": true
+        }
+      }
   ]
 }
 ----

--- a/libbeat/docs/shared-geoip.asciidoc
+++ b/libbeat/docs/shared-geoip.asciidoc
@@ -49,15 +49,15 @@ PUT _ingest/pipeline/geoip-info
       }
     },
     {
-      "geoip" : {
+      "geoip": {
         "database_file": "GeoLite2-ASN.mmdb",
         "field": "client.ip",
         "target_field": "client.as",
         "properties": [
           "asn",
           "organization_name"
-          ],
-          "ignore_missing": true
+        ],
+        "ignore_missing": true
       }
     },
     {
@@ -68,15 +68,15 @@ PUT _ingest/pipeline/geoip-info
       }
     },
     {
-      "geoip" : {
+      "geoip": {
         "database_file": "GeoLite2-ASN.mmdb",
         "field": "source.ip",
         "target_field": "source.as",
         "properties": [
           "asn",
           "organization_name"
-          ],
-          "ignore_missing": true
+        ],
+        "ignore_missing": true
       }
     },
     {
@@ -87,15 +87,15 @@ PUT _ingest/pipeline/geoip-info
       }
     },
     {
-      "geoip" : {
+      "geoip": {
         "database_file": "GeoLite2-ASN.mmdb",
         "field": "destination.ip",
         "target_field": "destination.as",
         "properties": [
           "asn",
           "organization_name"
-          ],
-          "ignore_missing": true
+        ],
+        "ignore_missing": true
       }
     },
     {
@@ -106,15 +106,15 @@ PUT _ingest/pipeline/geoip-info
       }
     },
     {
-      "geoip" : {
+      "geoip": {
         "database_file": "GeoLite2-ASN.mmdb",
         "field": "server.ip",
         "target_field": "server.as",
         "properties": [
           "asn",
           "organization_name"
-          ],
-          "ignore_missing": true
+        ],
+        "ignore_missing": true
       }
     },
     {
@@ -124,62 +124,62 @@ PUT _ingest/pipeline/geoip-info
         "ignore_missing": true
       }
     },
-          {
-        "rename": {
-          "field": "server.as.asn",
-          "target_field": "server.as.number",
-          "ignore_missing": true
-        }
-      },
-      {
-        "rename": {
-          "field": "server.as.organization_name",
-          "target_field": "server.as.organization.name",
-          "ignore_missing": true
-        }
-      },
-      {
-        "rename": {
-          "field": "client.as.asn",
-          "target_field": "client.as.number",
-          "ignore_missing": true
-        }
-      },
-      {
-        "rename": {
-          "field": "client.as.organization_name",
-          "target_field": "client.as.organization.name",
-          "ignore_missing": true
-        }
-      },
-      {
-        "rename": {
-          "field": "source.as.asn",
-          "target_field": "source.as.number",
-          "ignore_missing": true
-        }
-      },
-      {
-        "rename": {
-          "field": "source.as.organization_name",
-          "target_field": "source.as.organization.name",
-          "ignore_missing": true
-        }
-      },
-      {
-        "rename": {
-          "field": "destination.as.asn",
-          "target_field": "destination.as.number",
-          "ignore_missing": true
-        }
-      },
-      {
-        "rename": {
-          "field": "destination.as.organization_name",
-          "target_field": "destination.as.organization.name",
-          "ignore_missing": true
-        }
+    {
+      "rename": {
+        "field": "server.as.asn",
+        "target_field": "server.as.number",
+        "ignore_missing": true
       }
+    },
+    {
+      "rename": {
+        "field": "server.as.organization_name",
+        "target_field": "server.as.organization.name",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "client.as.asn",
+        "target_field": "client.as.number",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "client.as.organization_name",
+        "target_field": "client.as.organization.name",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "source.as.asn",
+        "target_field": "source.as.number",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "source.as.organization_name",
+        "target_field": "source.as.organization.name",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "destination.as.asn",
+        "target_field": "destination.as.number",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "destination.as.organization_name",
+        "target_field": "destination.as.organization.name",
+        "ignore_missing": true
+      }
+    }
   ]
 }
 ----


### PR DESCRIPTION
Update the ingest geo-ip pipeline to include Autonomous System in ECS compliant format


- Enhancement
- Docs
## What does this PR do?

Updated our sample ingest pipeline for geo information in packetbeat documentation to include Autonomous System in ECS format.

## Why is it important?

Currently the security application Network is not displaying  Autonomous System which is interesting for security investigation and alerting.


## How to test this PR locally

Used this pipeline in production with default packetbeat setup

## Related issues


## Use cases

Currently the security application Network is not displaying  Autonomous System which is interesting for security investigation and alerting.
