### PR TITLE
Cherry-pick #23444 to 7.11: [Elastic-Agent] Do not take ownership of Endpoint log path

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -30,6 +30,7 @@
 - Fix shell wrapper for deb/rpm packaging {pull}23038[23038]
 - Fixed parsing of npipe URI {pull}22978[22978]
 - Remove artifacts on transient download errors {pull}23235[23235]
+- Do not take ownership of Endpoint log path {pull}23444[23444]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
@@ -85,7 +85,12 @@ func (b *Monitor) generateLoggingFile(spec program.Spec, pipelineID string) stri
 
 func (b *Monitor) generateLoggingPath(spec program.Spec, pipelineID string) string {
 	return filepath.Dir(b.generateLoggingFile(spec, pipelineID))
+}
 
+func (b *Monitor) ownLoggingPath(spec program.Spec) bool {
+	// if the spec file defines a custom log path then agent will not take ownership of the logging path
+	_, ok := spec.LogPaths[b.operatingSystem]
+	return !ok
 }
 
 // EnrichArgs enriches arguments provided to application, in order to enable
@@ -139,6 +144,7 @@ func (b *Monitor) Cleanup(spec program.Spec, pipelineID string) error {
 
 // Prepare executes steps in order for monitoring to work correctly
 func (b *Monitor) Prepare(spec program.Spec, pipelineID string, uid, gid int) error {
+	takeOwnership := b.ownLoggingPath(spec)
 	drops := []string{b.generateLoggingPath(spec, pipelineID)}
 	if drop := b.monitoringDrop(spec, pipelineID); drop != "" {
 		drops = append(drops, drop)
@@ -161,8 +167,10 @@ func (b *Monitor) Prepare(spec program.Spec, pipelineID string, uid, gid int) er
 			}
 		}
 
-		if err := changeOwner(drop, uid, gid); err != nil {
-			return err
+		if takeOwnership {
+			if err := changeOwner(drop, uid, gid); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #23444 to 7.11 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

No longer takes ownership of the log path when the program spec file defines custom log paths.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When custom log paths are used they do not exist with in the same path of Elastic Agent, so ownership of those files should not be changed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #23441
