### PR TITLE
Sync beats changelog [master]

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,31 +16,31 @@ https://github.com/elastic/beats/compare/v7.10.0\...v7.10.1[View commits]
 
 *Auditbeat*
 
-- auditd: Fix an error condition causing a lot of `audit_send_reply` kernel threads being created. {pull}22673[22673]
-- system/socket: Fixed start failure when run under config reloader. {issue}20851[20851] {pull}21693[21693]
-- system/socket: Fixed startup error with some 5.x kernels. {issue}18755[18755] {pull}22787[22787]
-- system/socket: Having some CPUs unavailable to Auditbeat could cause startup errors or event loss. {pull}22827[22827]
+- auditd: Fix error condition that caused a lot of `audit_send_reply` kernel threads to be created. {pull}22673[22673]
+- system/socket: Fix start failure when run under config reloader. {issue}20851[20851] {pull}21693[21693]
+- system/socket: Fix startup error with some 5.x kernels. {issue}18755[18755] {pull}22787[22787]
+- system/socket: Fix startup errors and event loss caused by some CPUs being unavailable to Auditbeat. {pull}22827[22827]
 
 *Filebeat*
 
 - Fix missing variable when loading aws pipelines. {pull}22645[22645]
-- Drop aws.vpcflow.pkt_srcaddr and aws.vpcflow.pkt_dstaddr when equal to "-". {pull}22721[22721] {issue}22716[22716]
+- Fix parsing error by dropping `aws.vpcflow.pkt_srcaddr` and `aws.vpcflow.pkt_dstaddr` when equal to "-". {pull}22721[22721] {issue}22716[22716]
 
 *Heartbeat*
 
-- The `service_name` monitor option is being replaced with `service.name` which is more correct. We will support the old option till 8.0. {pull}20330[20330]
-- Fix exit on monitors with `enabled: false` {pull}22829[22829]
+- Replace the `service_name` monitor option with `service.name`, which is more correct. We will support the old option until 8.0. {pull}20330[20330]
+- Fix problem where the `enabled: false` setting on monitors prevented Heartbeat from starting. {pull}22829[22829]
 
 *Metricbeat*
 
 - Stop generating NaN values from Cloud Foundry module to avoid errors in outputs. {pull}22634[22634]
-- Fix `logstash` module when `xpack.enabled: true` is set from emitting redundant events. {pull}22808[22808]
+- Fix Logstash module to no longer emit redundant events when `xpack.enabled: true` is set. {pull}22808[22808]
 
 ==== Added
 
 *Filebeat*
 
-- Added DNS response IP addresses to `related.ip` in Suricata module. {pull}22291[22291]
+- Add DNS response IP addresses to `related.ip` in Suricata module. {pull}22291[22291]
 
 *Functionbeat*
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -11,6 +11,7 @@ https://github.com/elastic/beats/compare/v7.10.0\...v7.10.1[View commits]
 
 *Affecting all Beats*
 
+- Fix denial of service flaw where a remote attacker could cause the {beats} process to crash by presenting a specially malformed TLS public key. For more information, see https://discuss.elastic.co/t/beats-7-10-1-security-update/258160[Beats 7.10.1 Security Update].
 - Fix index template loading when the new index format is selected. {issue}22482[22482] {pull}22682[22682]
 
 *Auditbeat*


### PR DESCRIPTION
Adds missing changelog cherry-picks to master.

See also:
* 7.x https://github.com/elastic/beats/pull/23455
* 7.11 https://github.com/elastic/beats/pull/23464
* 7.10 https://github.com/elastic/beats/pull/23461