### PR TITLE
Add support for copytruncate method when rotating input logs with an external tool in `filestream` input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -827,6 +827,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - RFC 5424 and UNIX socket support in the Syslog input are now GA {pull}26293[26293]
 - Update grok patterns for HA Proxy module {issue}25827[25827] {pull}25835[25835]
 
+- Add support for `copytruncate` method when rotating input logs with an external tool in `filestream` input. {pull}23457[23457]
+
 *Heartbeat*
 
 - Add mime type detection for http responses. {pull}22976[22976]

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -292,6 +292,14 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
+  # When an external tools rotates the input files with copytruncate strategy
+  # use this section to help the input find the rotated files.
+  #rotation.external.strategy.copytruncate:
+  # Regex that matches the rotated files.
+  #  suffix_regex: \.\d$
+  # If the rotated filename suffix is a datetime, set it here. 
+  #  dateformat: 20060102
+
   ### State options
 
   # Files for the modification data is older then clean_inactive the state from the registry is removed

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -292,13 +292,15 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
-  # When an external tools rotates the input files with copytruncate strategy
+  ### Log rotation
+
+  # When an external tool rotates the input files with copytruncate strategy
   # use this section to help the input find the rotated files.
   #rotation.external.strategy.copytruncate:
   # Regex that matches the rotated files.
   #  suffix_regex: \.\d$
   # If the rotated filename suffix is a datetime, set it here. 
-  #  dateformat: 20060102
+  #  dateformat: -20060102
 
   ### State options
 

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -482,3 +482,60 @@ Set the location of the marker file the following way:
 ----
 file_identity.inode_marker.path: /logs/.filebeat-marker
 ----
+
+==== Log rotation
+
+As log files are constantly written, they must be rotated and purged to prevent
+the logger application from filling up the disk. Rotation is done by an external
+application, thus, {beatname_uc} needs information how to cooperate with it.
+
+When reading from rotating files make sure the paths configuration includes
+both the active file and all rotated files.
+
+By default, {beatname_uc} is able to track files correctly in the following strategies:
+* create: new active file with a unique name is created on rotation
+* rename: rotated files are renamed
+
+However, in case of copytruncate strategy, you should provide additional configuration
+to {beatname_uc}.
+
+[float]
+===== rotation.external.strategy.copytruncate
+
+If the log rotating application copies the contents of the active file and then
+truncates the original file, use these options to help {beatname_uc} to read files
+correctly.
+
+Set the option `suffix_regex` so {beatname_uc} can tell active and rotated files apart. There are
+two supported suffix types in the input: numberic and date.
+
+====== Numeric suffix
+
+If your rotated files have an incrementing index appended to the end of the filename, e.g.
+active file `apache.log` and the rotated files are named `apache.log.1`, `apache.log.2`, etc,
+use the following configuration.
+
+[source,yaml]
+---
+rotation.external.strategy.copytruncate:
+  suffix_regex: \.\d$
+  count: 7
+---
+
+`count` is the number of rotated files. {beatname_uc} needs this information to clean the
+registry when the rotated file has been purged.
+
+====== Date suffix
+
+If the rotation date is appended to the end of the filename, e.g. active file `apache.log` and the
+rotated files are named `apache.log-20210526`, `apache.log-20210527`, etc. use the following configuration:
+
+[source,yaml]
+---
+rotation.external.strategy.copytruncate:
+  suffix_regex: \-\d{6}$
+  count: 7
+  dateformat: -20060504
+---
+
+Configure `count` as described above.

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -502,6 +502,8 @@ to {beatname_uc}.
 [float]
 ==== rotation.external.strategy.copytruncate
 
+experimental[]
+
 If the log rotating application copies the contents of the active file and then
 truncates the original file, use these options to help {beatname_uc} to read files
 correctly.

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -535,7 +535,7 @@ rotated files are named `apache.log-20210526`, `apache.log-20210527`, etc. use t
 rotation.external.strategy.copytruncate:
   suffix_regex: \-\d{6}$
   count: 7
-  dateformat: -20060504
+  dateformat: -20060102
 ---
 
 Configure `count` as described above.

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -509,7 +509,7 @@ correctly.
 Set the option `suffix_regex` so {beatname_uc} can tell active and rotated files apart. There are
 two supported suffix types in the input: numberic and date.
 
-===== Numeric suffix
+==== Numeric suffix
 
 If your rotated files have an incrementing index appended to the end of the filename, e.g.
 active file `apache.log` and the rotated files are named `apache.log.1`, `apache.log.2`, etc,
@@ -525,7 +525,7 @@ rotation.external.strategy.copytruncate:
 `count` is the number of rotated files. {beatname_uc} needs this information to clean the
 registry when the rotated file has been purged.
 
-===== Date suffix
+==== Date suffix
 
 If the rotation date is appended to the end of the filename, e.g. active file `apache.log` and the
 rotated files are named `apache.log-20210526`, `apache.log-20210527`, etc. use the following configuration:

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -483,7 +483,7 @@ Set the location of the marker file the following way:
 file_identity.inode_marker.path: /logs/.filebeat-marker
 ----
 
-==== Log rotation
+=== Log rotation
 
 As log files are constantly written, they must be rotated and purged to prevent
 the logger application from filling up the disk. Rotation is done by an external
@@ -500,7 +500,7 @@ However, in case of copytruncate strategy, you should provide additional configu
 to {beatname_uc}.
 
 [float]
-===== rotation.external.strategy.copytruncate
+==== rotation.external.strategy.copytruncate
 
 If the log rotating application copies the contents of the active file and then
 truncates the original file, use these options to help {beatname_uc} to read files
@@ -509,7 +509,7 @@ correctly.
 Set the option `suffix_regex` so {beatname_uc} can tell active and rotated files apart. There are
 two supported suffix types in the input: numberic and date.
 
-====== Numeric suffix
+===== Numeric suffix
 
 If your rotated files have an incrementing index appended to the end of the filename, e.g.
 active file `apache.log` and the rotated files are named `apache.log.1`, `apache.log.2`, etc,
@@ -525,7 +525,7 @@ rotation.external.strategy.copytruncate:
 `count` is the number of rotated files. {beatname_uc} needs this information to clean the
 registry when the rotated file has been purged.
 
-====== Date suffix
+===== Date suffix
 
 If the rotation date is appended to the end of the filename, e.g. active file `apache.log` and the
 rotated files are named `apache.log-20210526`, `apache.log-20210527`, etc. use the following configuration:

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -519,11 +519,7 @@ use the following configuration.
 ---
 rotation.external.strategy.copytruncate:
   suffix_regex: \.\d$
-  count: 7
 ---
-
-`count` is the number of rotated files. {beatname_uc} needs this information to clean the
-registry when the rotated file has been purged.
 
 ==== Date suffix
 
@@ -534,8 +530,6 @@ rotated files are named `apache.log-20210526`, `apache.log-20210527`, etc. use t
 ---
 rotation.external.strategy.copytruncate:
   suffix_regex: \-\d{6}$
-  count: 7
   dateformat: -20060102
 ---
 
-Configure `count` as described above.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -699,6 +699,14 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
+  # When an external tools rotates the input files with copytruncate strategy
+  # use this section to help the input find the rotated files.
+  #rotation.external.strategy.copytruncate:
+  # Regex that matches the rotated files.
+  #  suffix_regex: \.\d$
+  # If the rotated filename suffix is a datetime, set it here. 
+  #  dateformat: 20060102
+
   ### State options
 
   # Files for the modification data is older then clean_inactive the state from the registry is removed

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -699,13 +699,15 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
-  # When an external tools rotates the input files with copytruncate strategy
+  ### Log rotation
+
+  # When an external tool rotates the input files with copytruncate strategy
   # use this section to help the input find the rotated files.
   #rotation.external.strategy.copytruncate:
   # Regex that matches the rotated files.
   #  suffix_regex: \.\d$
   # If the rotated filename suffix is a datetime, set it here. 
-  #  dateformat: 20060102
+  #  dateformat: -20060102
 
   ### State options
 

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -79,9 +79,17 @@ type backoffConfig struct {
 	Max  time.Duration `config:"max" validate:"nonzero"`
 }
 
-type commonRotationConfig struct {
-	SuffixRegex string `config:"suffix_regex" validate:"required"`
+type rotationConfig struct {
+	Strategy *common.ConfigNamespace `config:"strategy" validate:"required"`
 }
+
+type commonRotationConfig struct {
+	Count       int    `config:"count" validate:"required"`
+	SuffixRegex string `config:"suffix_regex" validate:"required"`
+	DateFormat  string `config:"dateformat"`
+}
+
+type copyTruncateConfig commonRotationConfig
 
 func defaultConfig() config {
 	return config{

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -41,7 +41,7 @@ type config struct {
 	HarvesterLimit uint32                  `config:"harvester_limit" validate:"min=0"`
 	IgnoreOlder    time.Duration           `config:"ignore_older"`
 	IgnoreInactive ignoreInactiveType      `config:"ignore_inactive"`
-	Rotation       rotationConfig          `config:"rotation"`
+	Rotation       *common.ConfigNamespace `config:"rotation"`
 }
 
 type closerConfig struct {
@@ -79,35 +79,8 @@ type backoffConfig struct {
 	Max  time.Duration `config:"max" validate:"nonzero"`
 }
 
-type rotationMethod uint8
-
-const (
-	CopyTruncate rotationMethod = iota
-)
-
-var rotationMethods = map[string]rotationMethod{
-	"copytruncate": CopyTruncate,
-}
-
-func (m *rotationMethod) Unpack(value string) error {
-	setting, ok := rotationMethods[value]
-	if !ok {
-		availableTypes := make([]string, len(rotationMethods))
-		i := 0
-		for t := range rotationMethods {
-			availableTypes[i] = t
-			i++
-		}
-		return fmt.Errorf("unknown socket type: %s, supported types: %v", value, availableTypes)
-	}
-
-	*m = setting
-	return nil
-}
-
-type rotationConfig struct {
-	Method      rotationMethod `config:"method"`
-	SuffixRegex string         `config:"suffix_regex" validate:"required"`
+type commonRotationConfig struct {
+	SuffixRegex string
 }
 
 func defaultConfig() config {

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -81,8 +81,6 @@ type backoffConfig struct {
 
 type commonRotationConfig struct {
 	SuffixRegex string `config:"suffix_regex" validate:"required"`
-	Rotate      int    `config:"rotate_count" validate:"required"`
-	MissingOk   bool   `config:"missing_ok"`
 }
 
 func defaultConfig() config {

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -84,7 +84,6 @@ type rotationConfig struct {
 }
 
 type commonRotationConfig struct {
-	Count       int    `config:"count" validate:"required,min=1,nonzero"`
 	SuffixRegex string `config:"suffix_regex" validate:"required"`
 	DateFormat  string `config:"dateformat"`
 }

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -80,7 +80,9 @@ type backoffConfig struct {
 }
 
 type commonRotationConfig struct {
-	SuffixRegex string
+	SuffixRegex string `config:"suffix_regex" validate:"required"`
+	Rotate      int    `config:"rotate_count" validate:"required"`
+	MissingOk   bool   `config:"missing_ok"`
 }
 
 func defaultConfig() config {

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -84,7 +84,7 @@ type rotationConfig struct {
 }
 
 type commonRotationConfig struct {
-	Count       int    `config:"count" validate:"required"`
+	Count       int    `config:"count" validate:"required,min=1,nonzero"`
 	SuffixRegex string `config:"suffix_regex" validate:"required"`
 	DateFormat  string `config:"dateformat"`
 }

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -1,0 +1,200 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"os"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/urso/sderr"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/go-concert/unison"
+)
+
+const (
+	copyTruncateProspectorDebugKey = "copy_truncate_file_prospector"
+)
+
+type rotatedFileInfo struct {
+	path string
+	src  loginp.Source
+}
+
+type rotatedFileGroup struct {
+	originalSrc loginp.Source
+	rotated     []rotatedFileInfo
+}
+
+// addRotatedFile adds a new rotated file to the list and returns its index.
+func (r *rotatedFileGroup) addRotatedFile(path string, src loginp.Source) int {
+	for i, info := range r.rotated {
+		if info.path == path {
+			return i
+		}
+	}
+
+	r.rotated = append(r.rotated, rotatedFileInfo{path, src})
+	sort.Slice(r.rotated, func(i, j int) bool {
+		return r.rotated[i].path < r.rotated[j].path
+	})
+
+	for i, info := range r.rotated {
+		if info.path == path {
+			return i
+		}
+	}
+	return -1
+}
+
+type copyTruncateFileProspector struct {
+	fileProspector
+	rotatedSuffix *regexp.Regexp
+	rotatedFiles  map[string]*rotatedFileGroup
+}
+
+// Run starts the fileProspector which accepts FS events from a file watcher.
+func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, hg loginp.HarvesterGroup) {
+	log := ctx.Logger.With("prospector", copyTruncateProspectorDebugKey)
+	log.Debug("Starting prospector")
+	defer log.Debug("Prospector has stopped")
+
+	defer p.stopHarvesterGroup(log, hg)
+
+	var tg unison.MultiErrGroup
+
+	tg.Go(func() error {
+		p.filewatcher.Run(ctx.Cancelation)
+		return nil
+	})
+
+	tg.Go(func() error {
+		for ctx.Cancelation.Err() == nil {
+			fe := p.filewatcher.Event()
+
+			if fe.Op == loginp.OpDone {
+				return nil
+			}
+
+			src := p.identifier.GetSource(fe)
+			switch fe.Op {
+			case loginp.OpCreate, loginp.OpWrite:
+				if fe.Op == loginp.OpCreate {
+					log.Debugf("A new file %s has been found", fe.NewPath)
+				} else if fe.Op == loginp.OpWrite {
+					log.Debugf("File %s has been updated", fe.NewPath)
+				}
+
+				if p.ignoreOlder > 0 {
+					now := time.Now()
+					if now.Sub(fe.Info.ModTime()) > p.ignoreOlder {
+						log.Debugf("Ignore file because ignore_older reached. File %s", fe.NewPath)
+						break
+					}
+				}
+
+				// check if the event belongs to a rotated file
+				if p.isRotated(fe) {
+					// Continue reading the rotated file from where we have left off with the original.
+					// The original will be picked up again when updated and read from the beginning.
+					originalPath := p.rotatedSuffix.ReplaceAllLiteralString(fe.NewPath, "")
+					// if we haven't encountered the original file which was rotated, get its information
+					if _, ok := p.rotatedFiles[originalPath]; !ok {
+						fi, err := os.Stat(originalPath)
+						if err != nil {
+							log.Errorf("Cannot continue file, error while getting the information of the original file: %+v", err)
+							log.Debugf("Starting possibly rotated file from the beginning: %s", fe.NewPath)
+							hg.Start(ctx, src)
+							continue
+						}
+						originalSrc := p.identifier.GetSource(loginp.FSEvent{NewPath: originalPath, Info: fi})
+						p.rotatedFiles[originalPath] = &rotatedFileGroup{originalSrc: originalSrc, rotated: make([]rotatedFileInfo, 0)}
+					}
+					currentIdx := p.rotatedFiles[originalPath].addRotatedFile(fe.NewPath, src)
+					previousSrc := p.rotatedFiles[originalPath].originalSrc
+					if currentIdx != 0 {
+						previousSrc = p.rotatedFiles[originalPath].rotated[currentIdx-1].src
+					}
+					hg.Continue(ctx, previousSrc, src)
+				} else {
+					// if file is original, add it to the bookeeper
+					if _, ok := p.rotatedFiles[fe.NewPath]; !ok {
+						p.rotatedFiles[fe.NewPath] = &rotatedFileGroup{originalSrc: src, rotated: make([]rotatedFileInfo, 0)}
+					}
+					hg.Start(ctx, src)
+				}
+
+			case loginp.OpDelete:
+				log.Debugf("File %s has been removed", fe.OldPath)
+
+				if p.rotatedSuffix.MatchString(fe.OldPath) {
+					originalPath := p.rotatedSuffix.ReplaceAllLiteralString(fe.OldPath, "")
+					rotatedFilesCount := len(p.rotatedFiles[originalPath].rotated)
+					if fe.OldPath == p.rotatedFiles[originalPath].rotated[rotatedFilesCount-1].path {
+						p.rotatedFiles[originalPath].rotated = p.rotatedFiles[originalPath].rotated[:rotatedFilesCount-1]
+					} else {
+						log.Debug("Unexpected rotated file has been removed.")
+					}
+				} else {
+					log.Debug("Original file has been removed unexpectedly.")
+					delete(p.rotatedFiles, fe.OldPath)
+				}
+
+				if p.stateChangeCloser.Removed {
+					log.Debugf("Stopping harvester as file %s has been removed and close.on_state_change.removed is enabled.", src.Name())
+					hg.Stop(src)
+				}
+
+				if p.cleanRemoved {
+					log.Debugf("Remove state for file as file removed: %s", fe.OldPath)
+
+					err := s.Remove(src)
+					if err != nil {
+						log.Errorf("Error while removing state from statestore: %v", err)
+					}
+				}
+
+			case loginp.OpRename:
+				// Renames are not supported when using copytruncate method.
+
+			default:
+				log.Error("Unkown return value %v", fe.Op)
+			}
+		}
+		return nil
+	})
+
+	errs := tg.Wait()
+	if len(errs) > 0 {
+		log.Error("%s", sderr.WrapAll(errs, "running prospector failed"))
+	}
+}
+
+func (p *copyTruncateFileProspector) isRotated(event loginp.FSEvent) bool {
+	if event.Op != loginp.OpCreate {
+		return false
+	}
+
+	if p.rotatedSuffix.MatchString(event.NewPath) {
+		return true
+	}
+	return false
+}

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -32,8 +32,6 @@ const (
 	copyTruncateProspectorDebugKey = "copy_truncate_file_prospector"
 )
 
-type copyTruncateConfig commonRotationConfig
-
 // rotatedFileInfo stores the file information of a rotated file.
 type rotatedFileInfo struct {
 	path string
@@ -56,6 +54,7 @@ func newRotatedFiles(config copyTruncateConfig) *rotatedFilestreams {
 // rotatedFilestreams is a map of original files and their rotated instances.
 type rotatedFilestreams struct {
 	table map[string]*rotatedFilestream
+	count int
 }
 
 // addOriginalFile adds a new original file and its identifying information

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -37,6 +37,10 @@ const (
 	copiedFileIdx                  = 0
 )
 
+var (
+	numericSuffixRegexp = regexp.MustCompile("\\d*$")
+)
+
 // sorter is required for ordering rotated log files
 // The slice is ordered so the newest rotated file comes first.
 type sorter interface {
@@ -84,7 +88,7 @@ type numericSorter struct {
 
 func newNumericSorter() sorter {
 	return &numericSorter{
-		suffix: regexp.MustCompile("\\d*$"),
+		suffix: numericSuffixRegexp,
 	}
 }
 

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -281,24 +281,7 @@ func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetada
 			case loginp.OpDelete:
 				log.Debugf("File %s has been removed", fe.OldPath)
 
-				// if file is rotated, stop harvester and clean up state
-				if p.isRotated(fe) {
-					log.Debugf("Stopping harvester as rotated file %s has been removed.", src.Name())
-
-					hg.Stop(src)
-
-					log.Debugf("Remove state for file as rotated file has been removed: %s", fe.OldPath)
-
-					err := s.Remove(src)
-					if err != nil {
-						log.Errorf("Error while removing state from statestore: %v", err)
-					}
-
-					originalPath := p.rotatedSuffix.ReplaceAllLiteralString(fe.OldPath, "")
-					p.rotatedFiles.removeRotatedFile(originalPath, fe.OldPath)
-				} else {
-					p.fileProspector.onRemove(log, fe, src, s, hg)
-				}
+				p.fileProspector.onRemove(log, fe, src, s, hg)
 
 			case loginp.OpRename:
 				log.Debugf("File %s has been renamed to %s", fe.OldPath, fe.NewPath)

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -37,6 +37,7 @@ const (
 	copiedFileIdx                  = 0
 )
 
+// sorter is required for ordering rotated log files
 type sorter interface {
 	sort([]rotatedFileInfo)
 }
@@ -72,6 +73,8 @@ func newRotatedFilestreams(cfg *copyTruncateConfig) *rotatedFilestreams {
 	}
 }
 
+// defaultSorter sorts rotated log files that have a numeric suffix.
+// Example: apache.log.1, apache.log.2
 type defaultSorter struct{}
 
 func (s *defaultSorter) sort(files []rotatedFileInfo) {
@@ -83,6 +86,9 @@ func (s *defaultSorter) sort(files []rotatedFileInfo) {
 	)
 }
 
+// dateSorter sorts rotated log files that have a date suffix
+// based on the configured format.
+// Example: apache.log-21210526, apache.log-20210527
 type dateSorter struct {
 	format string
 }

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -75,7 +75,6 @@ func newRotatedFilestreams(cfg *copyTruncateConfig) *rotatedFilestreams {
 	}
 	return &rotatedFilestreams{
 		table:  make(map[string]*rotatedFilestream, 0),
-		count:  cfg.Count,
 		sorter: sorter,
 	}
 }
@@ -152,7 +151,6 @@ func (s *dateSorter) GetTs(fi *rotatedFileInfo) time.Time {
 // rotatedFilestreams is a map of original files and their rotated instances.
 type rotatedFilestreams struct {
 	table  map[string]*rotatedFilestream
-	count  int
 	sorter sorter
 }
 
@@ -162,7 +160,7 @@ func (r rotatedFilestreams) addOriginalFile(path string, src loginp.Source) {
 	if _, ok := r.table[path]; ok {
 		return
 	}
-	r.table[path] = &rotatedFilestream{originalSrc: src, rotated: make([]rotatedFileInfo, 0, r.count)}
+	r.table[path] = &rotatedFilestream{originalSrc: src, rotated: make([]rotatedFileInfo, 0)}
 }
 
 // isOriginalAdded checks if an original file has been found.

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -240,6 +240,8 @@ func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetada
 			}
 
 			src := p.identifier.GetSource(fe)
+			log = loggerWithEvent(log, fe, src)
+
 			switch fe.Op {
 			case loginp.OpCreate, loginp.OpWrite:
 				if fe.Op == loginp.OpCreate {

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -162,6 +162,7 @@ func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetada
 						originalSrc := p.identifier.GetSource(loginp.FSEvent{NewPath: originalPath, Info: fi})
 						p.rotatedFiles.addOriginalFile(originalPath, originalSrc)
 					}
+					p.rotatedFiles.addRotatedFile(originalPath, fe.NewPath, src)
 					previousSrc := p.rotatedFiles.table[originalPath].originalSrc
 					hg.Continue(ctx, previousSrc, src)
 

--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -103,12 +103,12 @@ func (r rotatedFiles) addRotatedFile(original, rotated string, src loginp.Source
 		}
 	}
 
-	r[original].rotated = append(r[original].rotated, rotatedFileInfo{rotated, src})
-	sort.Slice(r[original].rotated, func(i, j int) bool {
-		return r[original].rotated[i].path < r[original].rotated[j].path
+	r.table[original].rotated = append(r.table[original].rotated, rotatedFileInfo{rotated, src})
+	sort.Slice(r.table[original].rotated, func(i, j int) bool {
+		return r.table[original].rotated[i].path < r.table[original].rotated[j].path
 	})
 
-	for i, info := range r[original].rotated {
+	for i, info := range r.table[original].rotated {
 		if info.path == rotated {
 			return i
 		}
@@ -195,15 +195,15 @@ func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetada
 
 				if p.rotatedSuffix.MatchString(fe.OldPath) {
 					originalPath := p.rotatedSuffix.ReplaceAllLiteralString(fe.OldPath, "")
-					rotatedFilesCount := len(p.rotatedFiles[originalPath].rotated)
-					if fe.OldPath == p.rotatedFiles[originalPath].rotated[rotatedFilesCount-1].path {
-						p.rotatedFiles[originalPath].rotated = p.rotatedFiles[originalPath].rotated[:rotatedFilesCount-1]
+					rotatedFilesCount := len(p.rotatedFiles.table[originalPath].rotated)
+					if fe.OldPath == p.rotatedFiles.table[originalPath].rotated[rotatedFilesCount-1].path {
+						p.rotatedFiles.table[originalPath].rotated = p.rotatedFiles.table[originalPath].rotated[:rotatedFilesCount-1]
 					} else {
 						log.Debug("Unexpected rotated file has been removed.")
 					}
 				} else {
 					log.Debug("Original file has been removed unexpectedly.")
-					delete(p.rotatedFiles, fe.OldPath)
+					delete(p.rotatedFiles.table, fe.OldPath)
 				}
 
 				if p.stateChangeCloser.Removed {

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -1,0 +1,186 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	input "github.com/elastic/beats/v7/filebeat/input/v2"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func TestCopyTruncateProspector_Create(t *testing.T) {
+	testCases := map[string]struct {
+		events               []loginp.FSEvent
+		expectedEvents       []harvesterEvent
+		expectedRotatedFiles map[string][]string
+	}{
+		"one new file, then rotated": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file"},
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file.1"},
+			},
+			expectedEvents: []harvesterEvent{
+				harvesterStart("path::/path/to/file"),
+				harvesterContinue("path::/path/to/file.1"),
+				harvesterGroupStop{},
+			},
+			expectedRotatedFiles: map[string][]string{
+				"/path/to/file": []string{"/path/to/file.1"},
+			},
+		},
+		"one new file, then rotated twice in order": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file"},
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file.1"},
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file.2"},
+			},
+			expectedEvents: []harvesterEvent{
+				harvesterStart("path::/path/to/file"),
+				harvesterContinue("path::/path/to/file.1"),
+				harvesterContinue("path::/path/to/file.2"),
+				harvesterGroupStop{},
+			},
+			expectedRotatedFiles: map[string][]string{
+				"/path/to/file": []string{"/path/to/file.1", "/path/to/file.2"},
+			},
+		},
+		"one new file, then rotated twice unordered": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file"},
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file.2"},
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file.1"},
+			},
+			expectedEvents: []harvesterEvent{
+				harvesterStart("path::/path/to/file"),
+				harvesterContinue("path::/path/to/file.1"),
+				harvesterContinue("path::/path/to/file.2"),
+				harvesterGroupStop{},
+			},
+			expectedRotatedFiles: map[string][]string{
+				"/path/to/file": []string{"/path/to/file.1", "/path/to/file.2"},
+			},
+		},
+		"first rotated file, when rotated file not exist": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file.1"},
+			},
+			expectedEvents: []harvesterEvent{
+				harvesterStart("path::/path/to/file.1"),
+				harvesterGroupStop{},
+			},
+			expectedRotatedFiles: map[string][]string{},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			p := copyTruncateFileProspector{
+				fileProspector{
+					filewatcher: &mockFileWatcher{events: test.events},
+					identifier:  mustPathIdentifier(false),
+				},
+				regexp.MustCompile("\\.\\d$"),
+				make(map[string]*rotatedFileGroup),
+			}
+			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
+			hg := newTestHarvesterGroup()
+
+			p.Run(ctx, newMockMetadataUpdater(), hg)
+
+			assert.ElementsMatch(t, test.expectedEvents, hg.events)
+
+			for originalFile, rotatedFiles := range test.expectedRotatedFiles {
+				rFiles, ok := p.rotatedFiles[originalFile]
+				if !ok {
+					fmt.Printf("cannot find %s in original file\n", originalFile)
+					t.FailNow()
+				}
+				assert.Equal(t, len(rFiles.rotated), len(rotatedFiles))
+				for i := 0; i < len(rotatedFiles); i++ {
+					if rFiles.rotated[i].path != rotatedFiles[i] {
+						fmt.Printf("cannot find %s in actual rotated files\n", rotatedFiles[i])
+						t.FailNow()
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCopyTruncateProspector_Delete(t *testing.T) {
+	testCases := map[string]struct {
+		events               []loginp.FSEvent
+		rotated              map[string]*rotatedFileGroup
+		expectedRotatedFiles map[string][]string
+	}{
+		"remove last rotated file": {
+			events: []loginp.FSEvent{
+				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "/path/to/file.1"},
+			},
+			rotated: map[string]*rotatedFileGroup{
+				"/path/to/file": &rotatedFileGroup{rotated: []rotatedFileInfo{rotatedFileInfo{path: "/path/to/file.1"}}},
+			},
+			expectedRotatedFiles: map[string][]string{
+				"/path/to/file": []string{},
+			},
+		},
+	}
+
+	for name, test := range testCases {
+		test := test
+
+		t.Run(name, func(t *testing.T) {
+			p := copyTruncateFileProspector{
+				fileProspector{
+					filewatcher: &mockFileWatcher{events: test.events},
+					identifier:  mustPathIdentifier(false),
+				},
+				regexp.MustCompile("\\.\\d$"),
+				test.rotated,
+			}
+			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
+			hg := newTestHarvesterGroup()
+
+			p.Run(ctx, newMockMetadataUpdater(), hg)
+
+			for originalFile, rotatedFiles := range test.expectedRotatedFiles {
+				rFiles, ok := p.rotatedFiles[originalFile]
+				if !ok {
+					fmt.Printf("cannot find %s in original file\n", originalFile)
+					t.FailNow()
+				}
+				assert.Equal(t, len(rFiles.rotated), len(rotatedFiles))
+				for i := 0; i < len(rotatedFiles); i++ {
+					if rFiles.rotated[i].path != rotatedFiles[i] {
+						fmt.Printf("cannot find %s in actual rotated files\n", rotatedFiles[i])
+						t.FailNow()
+					}
+				}
+			}
+		})
+	}
+}

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -130,7 +130,7 @@ func TestCopyTruncateProspector_Create(t *testing.T) {
 					identifier:  mustPathIdentifier(false),
 				},
 				regexp.MustCompile("\\.\\d$"),
-				&rotatedFilestreams{make(map[string]*rotatedFilestream), 10, newNumericSorter()},
+				&rotatedFilestreams{make(map[string]*rotatedFilestream), newNumericSorter()},
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
 			hg := newTestHarvesterGroup()

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -104,7 +104,7 @@ func TestCopyTruncateProspector_Create(t *testing.T) {
 					identifier:  mustPathIdentifier(false),
 				},
 				regexp.MustCompile("\\.\\d$"),
-				make(map[string]*rotatedFileGroup),
+				rotatedFiles{make(map[string]*rotatedFileGroup), 10},
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
 			hg := newTestHarvesterGroup()
@@ -114,7 +114,7 @@ func TestCopyTruncateProspector_Create(t *testing.T) {
 			assert.ElementsMatch(t, test.expectedEvents, hg.events)
 
 			for originalFile, rotatedFiles := range test.expectedRotatedFiles {
-				rFiles, ok := p.rotatedFiles[originalFile]
+				rFiles, ok := p.rotatedFiles.table[originalFile]
 				if !ok {
 					fmt.Printf("cannot find %s in original file\n", originalFile)
 					t.FailNow()
@@ -160,7 +160,7 @@ func TestCopyTruncateProspector_Delete(t *testing.T) {
 					identifier:  mustPathIdentifier(false),
 				},
 				regexp.MustCompile("\\.\\d$"),
-				test.rotated,
+				rotatedFiles{test.rotated, 10},
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
 			hg := newTestHarvesterGroup()
@@ -168,7 +168,7 @@ func TestCopyTruncateProspector_Delete(t *testing.T) {
 			p.Run(ctx, newMockMetadataUpdater(), hg)
 
 			for originalFile, rotatedFiles := range test.expectedRotatedFiles {
-				rFiles, ok := p.rotatedFiles[originalFile]
+				rFiles, ok := p.rotatedFiles.table[originalFile]
 				if !ok {
 					fmt.Printf("cannot find %s in original file\n", originalFile)
 					t.FailNow()

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -129,69 +129,69 @@ func TestFileWatchNewDeleteModified(t *testing.T) {
 		"one new file": {
 			prevFiles: map[string]os.FileInfo{},
 			nextFiles: map[string]os.FileInfo{
-				"new_path": testFileInfo{"new_path", 5, oldTs},
+				"new_path": testFileInfo{"new_path", 5, oldTs, nil},
 			},
 			expectedEvents: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpCreate, OldPath: "", NewPath: "new_path", Info: testFileInfo{"new_path", 5, oldTs}},
+				loginp.FSEvent{Op: loginp.OpCreate, OldPath: "", NewPath: "new_path", Info: testFileInfo{"new_path", 5, oldTs, nil}},
 			},
 		},
 		"one deleted file": {
 			prevFiles: map[string]os.FileInfo{
-				"old_path": testFileInfo{"old_path", 5, oldTs},
+				"old_path": testFileInfo{"old_path", 5, oldTs, nil},
 			},
 			nextFiles: map[string]os.FileInfo{},
 			expectedEvents: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "old_path", NewPath: "", Info: testFileInfo{"old_path", 5, oldTs}},
+				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "old_path", NewPath: "", Info: testFileInfo{"old_path", 5, oldTs, nil}},
 			},
 		},
 		"one modified file": {
 			prevFiles: map[string]os.FileInfo{
-				"path": testFileInfo{"path", 5, oldTs},
+				"path": testFileInfo{"path", 5, oldTs, nil},
 			},
 			nextFiles: map[string]os.FileInfo{
-				"path": testFileInfo{"path", 10, newTs},
+				"path": testFileInfo{"path", 10, newTs, nil},
 			},
 			expectedEvents: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path", NewPath: "path", Info: testFileInfo{"path", 10, newTs}},
+				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path", NewPath: "path", Info: testFileInfo{"path", 10, newTs, nil}},
 			},
 		},
 		"two modified files": {
 			prevFiles: map[string]os.FileInfo{
-				"path1": testFileInfo{"path1", 5, oldTs},
-				"path2": testFileInfo{"path2", 5, oldTs},
+				"path1": testFileInfo{"path1", 5, oldTs, nil},
+				"path2": testFileInfo{"path2", 5, oldTs, nil},
 			},
 			nextFiles: map[string]os.FileInfo{
-				"path1": testFileInfo{"path1", 10, newTs},
-				"path2": testFileInfo{"path2", 10, newTs},
+				"path1": testFileInfo{"path1", 10, newTs, nil},
+				"path2": testFileInfo{"path2", 10, newTs, nil},
 			},
 			expectedEvents: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path1", NewPath: "path1", Info: testFileInfo{"path1", 10, newTs}},
-				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path2", NewPath: "path2", Info: testFileInfo{"path2", 10, newTs}},
+				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path1", NewPath: "path1", Info: testFileInfo{"path1", 10, newTs, nil}},
+				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path2", NewPath: "path2", Info: testFileInfo{"path2", 10, newTs, nil}},
 			},
 		},
 		"one modified file, one new file": {
 			prevFiles: map[string]os.FileInfo{
-				"path1": testFileInfo{"path1", 5, oldTs},
+				"path1": testFileInfo{"path1", 5, oldTs, nil},
 			},
 			nextFiles: map[string]os.FileInfo{
-				"path1": testFileInfo{"path1", 10, newTs},
-				"path2": testFileInfo{"path2", 10, newTs},
+				"path1": testFileInfo{"path1", 10, newTs, nil},
+				"path2": testFileInfo{"path2", 10, newTs, nil},
 			},
 			expectedEvents: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path1", NewPath: "path1", Info: testFileInfo{"path1", 10, newTs}},
-				loginp.FSEvent{Op: loginp.OpCreate, OldPath: "", NewPath: "path2", Info: testFileInfo{"path2", 10, newTs}},
+				loginp.FSEvent{Op: loginp.OpWrite, OldPath: "path1", NewPath: "path1", Info: testFileInfo{"path1", 10, newTs, nil}},
+				loginp.FSEvent{Op: loginp.OpCreate, OldPath: "", NewPath: "path2", Info: testFileInfo{"path2", 10, newTs, nil}},
 			},
 		},
 		"one new file, one deleted file": {
 			prevFiles: map[string]os.FileInfo{
-				"path_deleted": testFileInfo{"path_deleted", 5, oldTs},
+				"path_deleted": testFileInfo{"path_deleted", 5, oldTs, nil},
 			},
 			nextFiles: map[string]os.FileInfo{
-				"path_new": testFileInfo{"path_new", 10, newTs},
+				"path_new": testFileInfo{"path_new", 10, newTs, nil},
 			},
 			expectedEvents: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "path_deleted", NewPath: "", Info: testFileInfo{"path_deleted", 5, oldTs}},
-				loginp.FSEvent{Op: loginp.OpCreate, OldPath: "", NewPath: "path_new", Info: testFileInfo{"path_new", 10, newTs}},
+				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "path_deleted", NewPath: "", Info: testFileInfo{"path_deleted", 5, oldTs, nil}},
+				loginp.FSEvent{Op: loginp.OpCreate, OldPath: "", NewPath: "path_new", Info: testFileInfo{"path_new", 10, newTs, nil}},
 			},
 		},
 	}
@@ -232,6 +232,7 @@ type testFileInfo struct {
 	path string
 	size int64
 	time time.Time
+	sys  interface{}
 }
 
 func (t testFileInfo) Name() string       { return t.path }
@@ -239,7 +240,7 @@ func (t testFileInfo) Size() int64        { return t.size }
 func (t testFileInfo) Mode() os.FileMode  { return 0 }
 func (t testFileInfo) ModTime() time.Time { return t.time }
 func (t testFileInfo) IsDir() bool        { return false }
-func (t testFileInfo) Sys() interface{}   { return nil }
+func (t testFileInfo) Sys() interface{}   { return t.sys }
 
 func mustDuration(durStr string) time.Duration {
 	dur, err := time.ParseDuration(durStr)

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -239,7 +240,7 @@ func (t testFileInfo) Size() int64        { return t.size }
 func (t testFileInfo) Mode() os.FileMode  { return 0 }
 func (t testFileInfo) ModTime() time.Time { return t.time }
 func (t testFileInfo) IsDir() bool        { return false }
-func (t testFileInfo) Sys() interface{}   { return nil }
+func (t testFileInfo) Sys() interface{}   { return &syscall.Stat_t{} }
 
 func mustDuration(durStr string) time.Duration {
 	dur, err := time.ParseDuration(durStr)

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -240,7 +239,7 @@ func (t testFileInfo) Size() int64        { return t.size }
 func (t testFileInfo) Mode() os.FileMode  { return 0 }
 func (t testFileInfo) ModTime() time.Time { return t.time }
 func (t testFileInfo) IsDir() bool        { return false }
-func (t testFileInfo) Sys() interface{}   { return &syscall.Stat_t{} }
+func (t testFileInfo) Sys() interface{}   { return nil }
 
 func mustDuration(durStr string) time.Duration {
 	dur, err := time.ParseDuration(durStr)

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -64,6 +64,7 @@ type fileSource struct {
 	newPath   string
 	oldPath   string
 	truncated bool
+	rotated   bool
 
 	name                string
 	identifierGenerator string

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -64,7 +64,7 @@ type fileSource struct {
 	newPath   string
 	oldPath   string
 	truncated bool
-	rotated   bool
+	archived  bool
 
 	name                string
 	identifierGenerator string
@@ -106,6 +106,7 @@ func (i *inodeDeviceIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
 		truncated:           e.Op == loginp.OpTruncate,
+		archived:            e.Op == loginp.OpArchived,
 		name:                i.name + identitySep + file.GetOSState(e.Info).String(),
 		identifierGenerator: i.name,
 	}
@@ -144,6 +145,7 @@ func (p *pathIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
 		truncated:           e.Op == loginp.OpTruncate,
+		archived:            e.Op == loginp.OpArchived,
 		name:                p.name + identitySep + path,
 		identifierGenerator: p.name,
 	}

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -99,6 +99,7 @@ func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
 		truncated:           e.Op == loginp.OpTruncate,
+		archived:            e.Op == loginp.OpArchived,
 		name:                i.name + identitySep + osstate.InodeString() + "-" + i.markerContents(),
 		identifierGenerator: i.name,
 	}

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -217,7 +217,7 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, fs fileSo
 
 	r = readfile.NewStripNewline(r, inp.readerConfig.LineTerminator)
 
-	r = readfile.NewFilemeta(r, path)
+	r = readfile.NewFilemeta(r, fs.newPath)
 
 	r, err = newParsers(r, parserConfig{maxBytes: inp.readerConfig.MaxBytes, lineTerminator: inp.readerConfig.LineTerminator}, inp.readerConfig.Parsers)
 	if err != nil {

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -85,7 +85,7 @@ func configure(cfg *common.Config) (loginp.Prospector, loginp.Harvester, error) 
 
 	prospector, err := newProspector(config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot create prospector: %+v", err)
+		return nil, nil, fmt.Errorf("cannot create prospector: %w", err)
 	}
 
 	encodingFactory, ok := encoding.FindEncoding(config.Reader.Encoding)

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -83,24 +83,14 @@ func configure(cfg *common.Config) (loginp.Prospector, loginp.Harvester, error) 
 		return nil, nil, err
 	}
 
-	filewatcher, err := newFileWatcher(config.Paths, config.FileWatcher)
+	prospector, err := newProspector(config)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error while creating filewatcher %v", err)
-	}
-
-	identifier, err := newFileIdentifier(config.FileIdentity)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error while creating file identifier: %v", err)
+		return nil, nil, fmt.Errorf("cannot create prospector: %+v", err)
 	}
 
 	encodingFactory, ok := encoding.FindEncoding(config.Reader.Encoding)
 	if !ok || encodingFactory == nil {
 		return nil, nil, fmt.Errorf("unknown encoding('%v')", config.Reader.Encoding)
-	}
-
-	prospector, err := newProspector(config)
-	if err != nil {
-		return nil, nil, fmt.Errorf("cannot create prospector: %+v", err)
 	}
 
 	filestream := &filestream{
@@ -317,10 +307,6 @@ func (inp *filestream) readFromSource(
 				log.Infof("File was truncated. Begin reading file from offset 0. Path=%s", path)
 			case ErrClosed:
 				log.Info("Reader was closed. Closing.")
-			case reader.ErrLineUnparsable:
-				log.Info("Skipping unparsable line in file.")
-				s.Offset += int64(message.Bytes)
-				continue
 			default:
 				log.Errorf("Read line error: %v", err)
 			}

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -30,6 +30,7 @@ const (
 	OpDelete
 	OpRename
 	OpTruncate
+	OpArchived
 )
 
 // Operation describes what happened to a file.

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -33,8 +33,28 @@ const (
 	OpArchived
 )
 
+var (
+	operationNames = map[Operation]string{
+		OpDone:     "done",
+		OpCreate:   "create",
+		OpWrite:    "write",
+		OpDelete:   "delete",
+		OpRename:   "rename",
+		OpTruncate: "truncate",
+		OpArchived: "archive",
+	}
+)
+
 // Operation describes what happened to a file.
 type Operation uint8
+
+func (o *Operation) String() string {
+	name, ok := operationNames[*o]
+	if !ok {
+		return ""
+	}
+	return name
+}
 
 // FSEvent returns inforamation about file system changes.
 type FSEvent struct {

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -119,6 +119,8 @@ type HarvesterGroup interface {
 	Start(input.Context, Source)
 	// Restart starts a Harvester if it might be already running.
 	Restart(input.Context, Source)
+	// Continue starts a new Harvester with the state information of the previous.
+	Continue(ctx input.Context, previous, next Source)
 	// Stop cancels the reader of a given Source.
 	Stop(Source)
 	// StopGroup cancels all running Harvesters.
@@ -215,6 +217,32 @@ func startHarvester(ctx input.Context, hg *defaultHarvesterGroup, s Source, rest
 
 		return nil
 	}
+}
+
+// Continue start a new Harvester with the state information from a different Source.
+func (hg *defaultHarvesterGroup) Continue(ctx input.Context, previous, next Source) {
+	hg.tg.Go(func(canceler unison.Canceler) error {
+		previousResource, err := lock(ctx, hg.store, previous.Name())
+		if err != nil {
+			return fmt.Errorf("error while locking previous resource: %v", err)
+		}
+		// mark previous state out of date
+		// so when reading starts again the offset is set to zero
+		hg.store.UpdateTTL(previousResource, -1)
+
+		nextResource, err := lock(ctx, hg.store, next.Name())
+		if err != nil {
+			return fmt.Errorf("error while locking next resource: %v", err)
+		}
+		hg.store.UpdateTTL(nextResource, hg.cleanTimeout)
+
+		nextResource = previousResource.CopyWithNewKey(next.Name())
+		releaseResource(nextResource)
+		releaseResource(previousResource)
+
+		hg.Start(ctx, next)
+		return nil
+	})
 }
 
 // Stop stops the running Harvester for a given Source.

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -232,7 +232,7 @@ func (hg *defaultHarvesterGroup) Continue(ctx input.Context, previous, next Sour
 		}
 		// mark previous state out of date
 		// so when reading starts again the offset is set to zero
-		hg.store.UpdateTTL(previousResource, -1)
+		hg.store.remove(prevID)
 
 		nextResource, err := lock(ctx, hg.store, nextID)
 		if err != nil {

--- a/filebeat/input/filestream/internal/input-logfile/publish.go
+++ b/filebeat/input/filestream/internal/input-logfile/publish.go
@@ -128,7 +128,7 @@ func (op *updateOp) Execute(n uint) {
 	resource.stateMutex.Lock()
 	defer resource.stateMutex.Unlock()
 
-	if resource.lockedVersion != op.resource.version {
+	if resource.lockedVersion != op.resource.version || resource.isDeleted() {
 		return
 	}
 

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -239,7 +239,7 @@ func (s *sourceStore) UpdateIdentifiers(getNewID func(v Value) (string, interfac
 			// the copy start from the last known ACKed position.
 			// This might lead to duplicates if configurations are adapted
 			// for inputs with the same ID are changed.
-			r := res.copyWithNewKey(newKey)
+			r := res.CopyWithNewKey(newKey)
 			r.cursorMeta = updatedMeta
 			r.stored = false
 			s.store.writeState(r)
@@ -430,7 +430,7 @@ func (r *resource) inSyncStateSnapshot() state {
 	}
 }
 
-func (r *resource) copyWithNewKey(key string) *resource {
+func (r *resource) CopyWithNewKey(key string) *resource {
 	internalState := r.internalState
 
 	// This is required to prevent the cleaner from removing the

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -332,8 +332,6 @@ func (s *store) remove(key string) error {
 	if resource == nil {
 		return fmt.Errorf("resource '%s' not found", key)
 	}
-	resource.version++
-
 	s.UpdateTTL(resource, 0)
 	return nil
 }
@@ -352,6 +350,13 @@ func (s *store) UpdateTTL(resource *resource, ttl time.Duration) {
 	resource.internalState.TTL = ttl
 	if resource.internalState.Updated.IsZero() {
 		resource.internalState.Updated = time.Now()
+	}
+
+	if resource.internalState.TTL == 0 {
+		// version must be incremented to make sure existing resource
+		// instances do not overwrite the removal of the entry
+		resource.version++
+
 	}
 
 	s.writeState(resource)

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -363,7 +363,7 @@ func (s *states) Find(key string, create bool) *resource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if resource := s.table[key]; resource != nil && resource.internalState.TTL != 0 {
+	if resource := s.table[key]; resource != nil && !resource.isDeleted() {
 		resource.Retain()
 		return resource
 	}
@@ -388,6 +388,10 @@ func (r *resource) IsNew() bool {
 	r.stateMutex.Lock()
 	defer r.stateMutex.Unlock()
 	return r.pendingCursor == nil && r.cursor == nil
+}
+
+func (r *resource) isDeleted() bool {
+	return !r.internalState.Updated.IsZero() && r.internalState.TTL == 0
 }
 
 // Retain is used to indicate that 'resource' gets an additional 'owner'.

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -332,6 +332,7 @@ func (s *store) remove(key string) error {
 	if resource == nil {
 		return fmt.Errorf("resource '%s' not found", key)
 	}
+	resource.version++
 
 	s.UpdateTTL(resource, 0)
 	return nil
@@ -362,7 +363,7 @@ func (s *states) Find(key string, create bool) *resource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if resource := s.table[key]; resource != nil {
+	if resource := s.table[key]; resource != nil && resource.internalState.TTL != 0 {
 		resource.Retain()
 		return resource
 	}

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -28,7 +28,7 @@ func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Sourc
 		"operation", event.Op,
 		"source_name", src.Name(),
 	)
-	if event.Info.Sys() != nil {
+	if event.Info != nil && event.Info.Sys() != nil {
 		log = log.With("os_id", file.GetOSState(event.Info))
 	}
 	if event.NewPath != "" {

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -27,8 +27,10 @@ func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Sourc
 	log := logger.With(
 		"operation", event.Op,
 		"source_name", src.Name(),
-		"os_id", file.GetOSState(event.Info),
 	)
+	if event.Info != nil {
+		log = log.With("os_id", file.GetOSState(event.Info))
+	}
 	if event.NewPath != "" {
 		log = log.With("new_path", event.NewPath)
 	}

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -28,7 +28,7 @@ func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Sourc
 		"operation", event.Op,
 		"source_name", src.Name(),
 	)
-	if event.Info != nil {
+	if event.Info.Sys() != nil {
 		log = log.With("os_id", file.GetOSState(event.Info))
 	}
 	if event.NewPath != "" {

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/common/file"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Source) *logp.Logger {
+	log := logger.With(
+		"operation", event.Op,
+		"source_name", src.Name(),
+		"os_id", file.GetOSState(event.Info),
+	)
+	if event.NewPath != "" {
+		log = log.With("new_path", event.NewPath)
+	}
+	if event.OldPath != "" {
+		log = log.With("old_path", event.OldPath)
+	}
+	return log
+}

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -129,6 +129,8 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 			}
 
 			src := p.identifier.GetSource(fe)
+			log = loggerWithEvent(log, fe, src)
+
 			switch fe.Op {
 			case loginp.OpCreate, loginp.OpWrite:
 				if fe.Op == loginp.OpCreate {

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -143,15 +143,7 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 					log.Debugf("File %s has been updated", fe.NewPath)
 				}
 
-				if p.ignoreOlder > 0 {
-					now := time.Now()
-					if now.Sub(fe.Info.ModTime()) > p.ignoreOlder {
-						log.Debugf("Ignore file because ignore_older reached. File %s", fe.NewPath)
-						break
-					}
-				}
-				if !ignoreInactiveSince.IsZero() && fe.Info.ModTime().Sub(ignoreInactiveSince) <= 0 {
-					log.Debugf("Ignore file because ignore_since.* reached time %v. File %s", p.ignoreInactiveSince, fe.NewPath)
+				if p.isFileIgnored(log, fe, ignoreInactiveSince) {
 					break
 				}
 
@@ -166,58 +158,12 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 			case loginp.OpDelete:
 				log.Debugf("File %s has been removed", fe.OldPath)
 
-				if p.stateChangeCloser.Removed {
-					log.Debugf("Stopping harvester as file %s has been removed and close.on_state_change.removed is enabled.", src.Name())
-					hg.Stop(src)
-				}
-
-				if p.cleanRemoved {
-					log.Debugf("Remove state for file as file removed: %s", fe.OldPath)
-
-					err := s.Remove(src)
-					if err != nil {
-						log.Errorf("Error while removing state from statestore: %v", err)
-					}
-				}
+				p.onRemove(log, fe, src, s, hg)
 
 			case loginp.OpRename:
 				log.Debugf("File %s has been renamed to %s", fe.OldPath, fe.NewPath)
 
-				// if file_identity is based on path, the current reader has to be cancelled
-				// and a new one has to start.
-				if !p.identifier.Supports(trackRename) {
-					prevSrc := p.identifier.GetSource(loginp.FSEvent{NewPath: fe.OldPath})
-					hg.Stop(prevSrc)
-
-					log.Debugf("Remove state for file as file renamed and path file_identity is configured: %s", fe.OldPath)
-					err := s.Remove(prevSrc)
-					if err != nil {
-						log.Errorf("Error while removing old state of renamed file (%s): %v", fe.OldPath, err)
-					}
-
-					hg.Start(ctx, src)
-				} else {
-					// update file metadata as the path has changed
-					var meta fileMeta
-					err := s.FindCursorMeta(src, meta)
-					if err != nil {
-						log.Errorf("Error while getting cursor meta data of entry %s: %v", src.Name(), err)
-
-						meta.IdentifierName = p.identifier.Name()
-					}
-					err = s.UpdateMetadata(src, fileMeta{Source: src.newPath, IdentifierName: meta.IdentifierName})
-					if err != nil {
-						log.Errorf("Failed to update cursor meta data of entry %s: %v", src.Name(), err)
-					}
-
-					if p.stateChangeCloser.Renamed {
-						log.Debugf("Stopping harvester as file %s has been renamed and close.on_state_change.renamed is enabled.", src.Name())
-
-						fe.Op = loginp.OpDelete
-						srcToClose := p.identifier.GetSource(fe)
-						hg.Stop(srcToClose)
-					}
-				}
+				p.onRename(log, ctx, fe, src, s, hg)
 
 			default:
 				log.Error("Unkown return value %v", fe.Op)
@@ -229,6 +175,75 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 	errs := tg.Wait()
 	if len(errs) > 0 {
 		log.Error("%s", sderr.WrapAll(errs, "running prospector failed"))
+	}
+}
+
+func (p *fileProspector) isFileIgnored(log *logp.Logger, fe loginp.FSEvent, ignoreInactiveSince time.Time) bool {
+	if p.ignoreOlder > 0 {
+		now := time.Now()
+		if now.Sub(fe.Info.ModTime()) > p.ignoreOlder {
+			log.Debugf("Ignore file because ignore_older reached. File %s", fe.NewPath)
+			return true
+		}
+	}
+	if !ignoreInactiveSince.IsZero() && fe.Info.ModTime().Sub(ignoreInactiveSince) <= 0 {
+		log.Debugf("Ignore file because ignore_since.* reached time %v. File %s", p.ignoreInactiveSince, fe.NewPath)
+		return true
+	}
+	return false
+}
+
+func (p *fileProspector) onRemove(log *logp.Logger, fe loginp.FSEvent, src loginp.Source, s loginp.StateMetadataUpdater, hg loginp.HarvesterGroup) {
+	if p.stateChangeCloser.Removed {
+		log.Debugf("Stopping harvester as file %s has been removed and close.on_state_change.removed is enabled.", src.Name())
+		hg.Stop(src)
+	}
+
+	if p.cleanRemoved {
+		log.Debugf("Remove state for file as file removed: %s", fe.OldPath)
+
+		err := s.Remove(src)
+		if err != nil {
+			log.Errorf("Error while removing state from statestore: %v", err)
+		}
+	}
+}
+
+func (p *fileProspector) onRename(log *logp.Logger, ctx input.Context, fe loginp.FSEvent, src loginp.Source, s loginp.StateMetadataUpdater, hg loginp.HarvesterGroup) {
+	// if file_identity is based on path, the current reader has to be cancelled
+	// and a new one has to start.
+	if !p.identifier.Supports(trackRename) {
+		prevSrc := p.identifier.GetSource(loginp.FSEvent{NewPath: fe.OldPath})
+		hg.Stop(prevSrc)
+
+		log.Debugf("Remove state for file as file renamed and path file_identity is configured: %s", fe.OldPath)
+		err := s.Remove(prevSrc)
+		if err != nil {
+			log.Errorf("Error while removing old state of renamed file (%s): %v", fe.OldPath, err)
+		}
+
+		hg.Start(ctx, src)
+	} else {
+		// update file metadata as the path has changed
+		var meta fileMeta
+		err := s.FindCursorMeta(src, meta)
+		if err != nil {
+			log.Errorf("Error while getting cursor meta data of entry %s: %v", src.Name(), err)
+
+			meta.IdentifierName = p.identifier.Name()
+		}
+		err = s.UpdateMetadata(src, fileMeta{Source: fe.NewPath, IdentifierName: meta.IdentifierName})
+		if err != nil {
+			log.Errorf("Failed to update cursor meta data of entry %s: %v", src.Name(), err)
+		}
+
+		if p.stateChangeCloser.Renamed {
+			log.Debugf("Stopping harvester as file %s has been renamed and close.on_state_change.renamed is enabled.", src.Name())
+
+			fe.Op = loginp.OpDelete
+			srcToClose := p.identifier.GetSource(fe)
+			hg.Stop(srcToClose)
+		}
 	}
 }
 

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -84,10 +84,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 			return &copyTruncateFileProspector{
 				fileprospector,
 				suffix,
-				rotatedFilestreams{
-					make(map[string]*rotatedFilestream),
-					cpCfg.Count,
-				},
+				newRotatedFilestreams(cpCfg),
 			}, nil
 		default:
 		}

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"fmt"
+	"regexp"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+)
+
+const (
+	createMethod       = "create"
+	copyTruncateMethod = "copytruncate"
+)
+
+func newProspector(config config) (loginp.Prospector, error) {
+	filewatcher, err := newFileWatcher(config.Paths, config.FileWatcher)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating filewatcher %v", err)
+	}
+
+	identifier, err := newFileIdentifier(config.FileIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("error while creating file identifier: %v", err)
+	}
+
+	fileprospector := fileProspector{
+		filewatcher:       filewatcher,
+		identifier:        identifier,
+		ignoreOlder:       config.IgnoreOlder,
+		cleanRemoved:      config.CleanRemoved,
+		stateChangeCloser: config.Close.OnStateChange,
+	}
+	if config.Rotation == nil {
+		return &fileprospector, nil
+	}
+
+	rotationMethod := config.Rotation.Name()
+	switch rotationMethod {
+	case createMethod:
+		return &fileprospector, nil
+
+	case copyTruncateMethod:
+		rotationConfig := &copyTruncateConfig{}
+		err := config.Rotation.Config().Unpack(&rotationConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack configuration of copytruncate rotation: %+v", err)
+		}
+		suffix, err := regexp.Compile(rotationConfig.SuffixRegex)
+		if err != nil {
+			return nil, fmt.Errorf("invalid suffix regex for copytruncate rotation")
+		}
+		return &copyTruncateFileProspector{fileprospector, suffix, make(map[string]*rotatedFileGroup)}, nil
+
+	default:
+	}
+	return nil, fmt.Errorf("no such rotation method: %s", rotationMethod)
+}

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -66,7 +66,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid suffix regex for copytruncate rotation")
 		}
-		return &copyTruncateFileProspector{fileprospector, suffix, make(map[string]*rotatedFileGroup)}, nil
+		return &copyTruncateFileProspector{fileprospector, suffix, rotatedFiles{make(map[string]*rotatedFileGroup), 10}}, nil
 
 	default:
 	}

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -66,6 +66,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid suffix regex for copytruncate rotation")
 		}
+		fileprospector.stateChangeCloser.Renamed = false
 		return &copyTruncateFileProspector{fileprospector, suffix, rotatedFilestreams{make(map[string]*rotatedFilestream)}}, nil
 
 	default:

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -66,7 +66,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid suffix regex for copytruncate rotation")
 		}
-		return &copyTruncateFileProspector{fileprospector, suffix, rotatedFiles{make(map[string]*rotatedFileGroup), 10}}, nil
+		return &copyTruncateFileProspector{fileprospector, suffix, rotatedFilestreams{make(map[string]*rotatedFilestream)}}, nil
 
 	default:
 	}

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	createMethod       = "create"
+	copyMethod         = "copy"
 	copyTruncateMethod = "copytruncate"
 )
 
@@ -53,7 +53,7 @@ func newProspector(config config) (loginp.Prospector, error) {
 
 	rotationMethod := config.Rotation.Name()
 	switch rotationMethod {
-	case createMethod:
+	case copyMethod, "":
 		return &fileprospector, nil
 
 	case copyTruncateMethod:

--- a/filebeat/input/filestream/prospector_creator.go
+++ b/filebeat/input/filestream/prospector_creator.go
@@ -20,8 +20,10 @@ package filestream
 import (
 	"fmt"
 	"regexp"
+	"sync"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 )
 
 const (
@@ -29,6 +31,10 @@ const (
 	internalMode = "internal"
 
 	copytruncateStrategy = "copytruncate"
+)
+
+var (
+	experimentalWarning sync.Once
 )
 
 func newProspector(config config) (loginp.Prospector, error) {
@@ -71,6 +77,10 @@ func newProspector(config config) (loginp.Prospector, error) {
 		strategy := cfg.Strategy.Name()
 		switch strategy {
 		case copytruncateStrategy:
+			experimentalWarning.Do(func() {
+				cfgwarn.Experimental("rotation.external.copytruncate is used.")
+			})
+
 			cpCfg := &copyTruncateConfig{}
 			err = cfg.Strategy.Config().Unpack(&cpCfg)
 			if err != nil {

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -396,6 +396,10 @@ type harvesterRestart string
 
 func (h harvesterRestart) String() string { return string(h) }
 
+type harvesterContinue string
+
+func (h harvesterContinue) String() string { return string(h) }
+
 type harvesterStop string
 
 func (h harvesterStop) String() string { return string(h) }
@@ -418,6 +422,10 @@ func (t *testHarvesterGroup) Start(_ input.Context, s loginp.Source) {
 
 func (t *testHarvesterGroup) Restart(_ input.Context, s loginp.Source) {
 	t.events = append(t.events, harvesterRestart(s.Name()))
+}
+
+func (t *testHarvesterGroup) Continue(_ input.Context, p, s loginp.Source) {
+	t.events = append(t.events, harvesterContinue(s.Name()))
 }
 
 func (t *testHarvesterGroup) Stop(s loginp.Source) {

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -170,8 +170,8 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 	}{
 		"two new files": {
 			events: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file"},
-				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/other/file"},
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/file", Info: testFileInfo{}},
+				loginp.FSEvent{Op: loginp.OpCreate, NewPath: "/path/to/other/file", Info: testFileInfo{}},
 			},
 			expectedEvents: []harvesterEvent{
 				harvesterStart("path::/path/to/file"),
@@ -181,7 +181,7 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 		},
 		"one updated file": {
 			events: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpWrite, NewPath: "/path/to/file"},
+				loginp.FSEvent{Op: loginp.OpWrite, NewPath: "/path/to/file", Info: testFileInfo{}},
 			},
 			expectedEvents: []harvesterEvent{
 				harvesterStart("path::/path/to/file"),
@@ -190,8 +190,8 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 		},
 		"one updated then truncated file": {
 			events: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpWrite, NewPath: "/path/to/file"},
-				loginp.FSEvent{Op: loginp.OpTruncate, NewPath: "/path/to/file"},
+				loginp.FSEvent{Op: loginp.OpWrite, NewPath: "/path/to/file", Info: testFileInfo{}},
+				loginp.FSEvent{Op: loginp.OpTruncate, NewPath: "/path/to/file", Info: testFileInfo{}},
 			},
 			expectedEvents: []harvesterEvent{
 				harvesterStart("path::/path/to/file"),
@@ -204,12 +204,12 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 				loginp.FSEvent{
 					Op:      loginp.OpCreate,
 					NewPath: "/path/to/file",
-					Info:    testFileInfo{"/path/to/file", 5, minuteAgo},
+					Info:    testFileInfo{"/path/to/file", 5, minuteAgo, nil},
 				},
 				loginp.FSEvent{
 					Op:      loginp.OpWrite,
 					NewPath: "/path/to/other/file",
-					Info:    testFileInfo{"/path/to/other/file", 5, minuteAgo},
+					Info:    testFileInfo{"/path/to/other/file", 5, minuteAgo, nil},
 				},
 			},
 			ignoreOlder: 10 * time.Second,
@@ -222,12 +222,12 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 				loginp.FSEvent{
 					Op:      loginp.OpCreate,
 					NewPath: "/path/to/file",
-					Info:    testFileInfo{"/path/to/file", 5, minuteAgo},
+					Info:    testFileInfo{"/path/to/file", 5, minuteAgo, nil},
 				},
 				loginp.FSEvent{
 					Op:      loginp.OpWrite,
 					NewPath: "/path/to/other/file",
-					Info:    testFileInfo{"/path/to/other/file", 5, minuteAgo},
+					Info:    testFileInfo{"/path/to/other/file", 5, minuteAgo, nil},
 				},
 			},
 			ignoreOlder: 5 * time.Minute,
@@ -265,13 +265,13 @@ func TestProspectorDeletedFile(t *testing.T) {
 	}{
 		"one deleted file without clean removed": {
 			events: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "/path/to/file"},
+				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "/path/to/file", Info: testFileInfo{}},
 			},
 			cleanRemoved: false,
 		},
 		"one deleted file with clean removed": {
 			events: []loginp.FSEvent{
-				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "/path/to/file"},
+				loginp.FSEvent{Op: loginp.OpDelete, OldPath: "/path/to/file", Info: testFileInfo{}},
 			},
 			cleanRemoved: true,
 		},
@@ -318,6 +318,7 @@ func TestProspectorRenamedFile(t *testing.T) {
 					Op:      loginp.OpRename,
 					OldPath: "/old/path/to/file",
 					NewPath: "/new/path/to/file",
+					Info:    testFileInfo{},
 				},
 			},
 			expectedEvents: []harvesterEvent{
@@ -332,6 +333,7 @@ func TestProspectorRenamedFile(t *testing.T) {
 					Op:      loginp.OpRename,
 					OldPath: "/old/path/to/file",
 					NewPath: "/new/path/to/file",
+					Info:    testFileInfo{},
 				},
 			},
 			trackRename: true,
@@ -345,6 +347,7 @@ func TestProspectorRenamedFile(t *testing.T) {
 					Op:      loginp.OpRename,
 					OldPath: "/old/path/to/file",
 					NewPath: "/new/path/to/file",
+					Info:    testFileInfo{},
 				},
 			},
 			trackRename:  true,

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -425,7 +425,7 @@ func (t *testHarvesterGroup) Restart(_ input.Context, s loginp.Source) {
 }
 
 func (t *testHarvesterGroup) Continue(_ input.Context, p, s loginp.Source) {
-	t.events = append(t.events, harvesterContinue(s.Name()))
+	t.events = append(t.events, harvesterContinue(p.Name()+" -> "+s.Name()))
 }
 
 func (t *testHarvesterGroup) Stop(s loginp.Source) {

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2725,6 +2725,14 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
+  # When an external tools rotates the input files with copytruncate strategy
+  # use this section to help the input find the rotated files.
+  #rotation.external.strategy.copytruncate:
+  # Regex that matches the rotated files.
+  #  suffix_regex: \.\d$
+  # If the rotated filename suffix is a datetime, set it here. 
+  #  dateformat: 20060102
+
   ### State options
 
   # Files for the modification data is older then clean_inactive the state from the registry is removed

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2725,13 +2725,15 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
-  # When an external tools rotates the input files with copytruncate strategy
+  ### Log rotation
+
+  # When an external tool rotates the input files with copytruncate strategy
   # use this section to help the input find the rotated files.
   #rotation.external.strategy.copytruncate:
   # Regex that matches the rotated files.
   #  suffix_regex: \.\d$
   # If the rotated filename suffix is a datetime, set it here. 
-  #  dateformat: 20060102
+  #  dateformat: -20060102
 
   ### State options
 


### PR DESCRIPTION
## What does this PR do?

The PR makes the `filestream` log rotation aware to make sure Filebeat can cooperate better with external log rotation tools. The first supported strategy is `copytruncate`.

When `logrotate` rotates e.g. `boot.log` with `copytruncate` the following things happen:
1. all archived files are renamed e.g. `boot.log.2` is renamed `boot.log.3` until `boot.log.1` no longer exists
2. `boot.log` is copied to `boot.log.1`
3. `boot.log` is truncated

You can see my tests on my machine:

Before rotation:
```
root@sleipnir:/home/n# ls -lisaht /var/log/boot.log*
130476 30K -rw------- 1 root root 28K Jan 29 08:59 /var/log/boot.log
130577 36K -rw------- 1 root root 34K Jan 29 08:59 /var/log/boot.log.1
130657 60K -rw------- 1 root root 57K Jan  7 09:51 /var/log/boot.log.2
```
After rotation:
```
root@sleipnir:/home/n# ls -lisaht /var/log/boot.log*
130476   0 -rw------- 1 root root   0 May 25 12:41 /var/log/boot.log
130430 30K -rw------- 1 root root 28K May 25 12:41 /var/log/boot.log.1
130577 36K -rw------- 1 root root 34K Jan 29 08:59 /var/log/boot.log.2
130657 60K -rw------- 1 root root 57K Jan  7 09:51 /var/log/boot.log.3
```

On rotation, the active file is continued and archived files are kept open until EOF is reached.

### Configuration

```yaml
rotation.external.strategy.copytruncate:
  suffix_regex: \.\d$
  count: 10
```

Note: when Filebeat will be able to rotate input logs, its configuration will be under `rotation.internal.*`.

## Why is it important?

Previously, Filebeat was not able to cooperate with external log rotation tools that used `copytruncate` method.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.