### PR TITLE
Cherry-pick #23456 to 7.x: Skip top level files when unziping archive during upgrade

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -30,6 +30,7 @@
 - Fix shell wrapper for deb/rpm packaging {pull}23038[23038]
 - Fixed parsing of npipe URI {pull}22978[22978]
 - Remove artifacts on transient download errors {pull}23235[23235]
+- Skip top level files when unziping archive during upgrade {pull}23456[23456]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_unpack.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_unpack.go
@@ -104,7 +104,8 @@ func unzip(version, archivePath string) (string, error) {
 
 	for _, f := range r.File {
 		if rootDir == "" && filepath.Base(f.Name) == filepath.Dir(f.Name) {
-			return f.Name, nil
+			// skip top level files
+			continue
 		}
 		if currentDir := filepath.Dir(f.Name); rootDir == "" || len(currentDir) < len(rootDir) {
 			rootDir = currentDir


### PR DESCRIPTION
Cherry-pick of PR #23456 to 7.x branch. Original message:

## What does this PR do?

Fixes codepath for top level files which was completely incorrect.

## Why is it important?

Upgrade working properly, without this it leads to incorrect paths generation and target files wont be found

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
