### PR TITLE
[7.11] Sync changelog (#23455)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -884,7 +884,7 @@ https://github.com/elastic/beats/compare/v7.6.2\...v7.7.0[View commits]
 - Add `aws_ec2` provider for autodiscovery. {issue}12518[12518] {pull}14823[14823]
 - Add support for multiple passwords in redis output. {issue}16058[16058] {pull}16206[16206]
 - Add support for Histogram type in fields.yml. {pull}16570[16570]
-- Windows .exe files now have embedded file version info. {issue}15232[15232]t
+- Windows .exe files now have embedded file version info. {issue}15232[15232]
 - Remove experimental flag from `setup.template.append_fields`. {pull}16576[16576]
 - Add `add_cloudfoundry_metadata` processor to annotate events with Cloud Foundry application data. {pull}16621[16621]
 - Add `translate_sid` processor on Windows for converting Windows security identifier (SID) values to names. {issue}7451[7451] {pull}16013[16013]
@@ -1282,7 +1282,7 @@ https://github.com/elastic/beats/compare/v7.5.0\...v7.5.1[View commits]
 - Fix `proxy_url` option in Elasticsearch output. {pull}14950[14950]
 - Fix bug with potential concurrent reads and writes from event.Meta map by Kafka output. {issue}14542[14542] {pull}14568[14568]
 - Fix license detection, when a beats successfully connect to Elasticsearch the detected license will be show in the log at info level. {pull}15834[15834]
-- Fix the `parameters` option configured in the Elasticsearch output so the values are added to the query string on bulk request. {issues}18325[18325]
+- Fix the `parameters` option configured in the Elasticsearch output so the values are added to the query string on bulk request. {issue}18325[18325]
 
 *Filebeat*
 
@@ -1822,11 +1822,11 @@ https://github.com/elastic/beats/compare/v7.2.0\...v7.3.0[View commits]
 - Add a system/entropy metricset {pull}12450[12450]
 - Add kubernetes metricset `controllermanager` {pull}12409[12409]
 - Allow redis URL format in redis hosts config. {pull}12408[12408]
-- Add tags into ec2 metricset. {issue}[12263]12263 {pull}12372[12372]
+- Add tags into ec2 metricset. {issue}12263[12263] {pull}12372[12372]
 - Add kubernetes metricset `scheduler` {pull}12521[12521]
 - Add Kubernetes scheduler dashboard to Kubernetes module {pull}12749[12749]
 - Add `beat` module. {pull}12181[12181] {pull}12615[12615]
-- Collect tags for cloudwatch metricset in aws module. {issue}[12263]12263 {pull}12480[12480]
+- Collect tags for cloudwatch metricset in aws module. {issue}12263[12263] {pull}12480[12480]
 - Add AWS RDS metricset. {pull}11620[11620] {issue}10054[10054]
 - Add Oracle Module {pull}11890[11890]
 - Add Kubernetes proxy dashboard to Kubernetes module {pull}12734[12734]
@@ -2790,7 +2790,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha1\...v7.0.0-alpha2[Check th
 - Add `host.os.name` field to add_host_metadata processor. {issue}8948[8948] {pull}9405[9405]
 - Add more TCP statuses to `socket_summary` metricset. {pull}9430[9430]
 - Remove experimental tag from ceph metricsets. {pull}9708[9708]
-- Add MS SQL module to X-Pack {pull}9414[9414
+- Add MS SQL module to X-Pack {pull}9414[9414]
 
 ==== Deprecated
 
@@ -2898,6 +2898,46 @@ https://github.com/elastic/beats/compare/v6.5.0\...v7.0.0-alpha1[View commits]
 - Add support to decode HTTP bodies compressed with `gzip` and `deflate`. {pull}7915[7915]
 - Added support to calculate certificates' fingerprints (MD5, SHA-1, SHA-256). {issue}8180[8180]
 - Support new TLS version negotiation introduced in TLS 1.3. {issue}8647[8647].
+
+[[release-notes-6.8.13]]
+=== Beats version 6.8.13
+https://github.com/elastic/beats/compare/v6.8.12\...v6.8.13[View commits]
+
+==== Added
+
+*Filebeat*
+
+- Add container image in Kubernetes metadata. {pull}13356[13356] {issue}12688[12688]
+
+[[release-notes-6.8.12]]
+=== Beats version 6.8.12
+https://github.com/elastic/beats/compare/v6.8.11\...v6.8.12[View commits]
+
+==== Bugfixes
+
+*Filebeat*
+
+- Fix Filebeat OOMs on very long lines {issue}19500[19500], {pull}19552[19552]
+
+[[release-notes-6.8.11]]
+=== Beats version 6.8.11
+https://github.com/elastic/beats/compare/v6.8.10\...v6.8.11[View commits]
+
+==== Bugfixes
+
+*Metricbeat*
+
+- Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
+
+[[release-notes-6.8.10]]
+=== Beats version 6.8.10
+https://github.com/elastic/beats/compare/v6.8.9\...v6.8.10[View commits]
+
+==== Bugfixes
+
+*Affecting all Beats*
+
+- Fix `add_cloud_metadata` to better support modifying sub-fields with other processors. {pull}13808[13808]
 
 [[release-notes-6.8.9]]
 === Beats version 6.8.9
@@ -3015,7 +3055,7 @@ https://github.com/elastic/beats/compare/v6.8.1\...v6.8.2[View commits]
 
 *Packetbeat*
 
-- Limit memory usage of Redis replication sessions. {issue}12657[12657
+- Limit memory usage of Redis replication sessions. {issue}12657[12657]
 
 [[release-notes-6.8.1]]
 === Beats version 6.8.1
@@ -3462,7 +3502,7 @@ https://github.com/elastic/beats/compare/v6.5.4\...6.6[View commits]
 - Added the `redirect_stderr` option that allows panics to be logged to log files. {pull}8430[8430]
 - Add cache.ttl to add_host_metadata. {pull}9359[9359]
 - Add support for index lifecycle management (beta). {pull}7963[7963]
-- Always include Pod UID as part of Pod metadata. {pull]9517[9517]
+- Always include Pod UID as part of Pod metadata. {pull}9517[9517]
 - Release Jolokia autodiscover as GA. {pull}9706[9706]
 
 *Auditbeat*
@@ -3885,7 +3925,7 @@ The issue will be fixed in the 6.4.1 release.
 
 *Filebeat*
 
-- Fix a data race between stopping and starting of the harvesters. {issue}#6879[6879]
+- Fix a data race between stopping and starting of the harvesters. {issue}6879[6879]
 - Fix an issue when parsing ISO8601 dates with timezone definition {issue}7367[7367]
 - Fix Grok pattern of MongoDB module. {pull}7568[7568]
 - Fix registry duplicates and log resending on upgrade. {issue}7634[7634]
@@ -4113,7 +4153,7 @@ https://github.com/elastic/beats/compare/v6.2.3\...v6.3.0[View commits]
 - Fix system.filesystem.used.pct value to match what df reports. {issue}5494[5494]
 - Fix namespace disambiguation in Kubernetes state_* metricsets. {issue}6281[6281]
 - Fix Windows perfmon metricset so that it sends metrics when an error occurs. {pull}6542[6542]
-- Fix Kubernetes calculated fields store. {pull}6564{6564}
+- Fix Kubernetes calculated fields store. {pull}6564[6564]
 - Exclude bind mounts in fsstat and filesystem metricsets. {pull}6819[6819]
 - Don't stop Metricbeat if aerospike server is down. {pull}6874[6874]
 - disk reads and write count metrics in RabbitMQ queue metricset made optional. {issue}6876[6876]
@@ -4122,7 +4162,7 @@ https://github.com/elastic/beats/compare/v6.2.3\...v6.3.0[View commits]
 *Winlogbeat*
 
 - Fixed a crash under Windows 2003 and XP when an event had less insert strings than required by its format string. {pull}6247[6247]
-- Fix config validation to allow `event_logs.processors`. [pull]6217[6217]
+- Fix config validation to allow `event_logs.processors`. {pull}6217[6217]
 
 ==== Added
 
@@ -4271,7 +4311,7 @@ https://github.com/elastic/beats/compare/v6.2.2\...v6.2.3[View commits]
 
 *Metricbeat*
 
-- Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395{6395}
+- Fix Kubernetes overview dashboard views for non default time ranges. {issue}6395[6395]
 
 
 [[release-notes-6.2.2]]
@@ -4838,7 +4878,7 @@ https://github.com/elastic/beats/compare/v6.0.0-alpha2\...v6.0.0-beta1[View comm
 - Add `test output` command, to test Elasticsearch and Logstash output settings. {pull}4590[4590]
 - Introduce configurable event queue settings: queue.mem.events, queue.mem.flush.min_events and queue.mem.flush.timeout. {pull}4650[4650]
 - Enable pipelining in Logstash output by default. {pull}4650[4650]
-- Added 'result' field to Elasticsearch QueryResult struct for compatibility with 6.x Index and Delete API responses. {issue]4661[4661]
+- Added 'result' field to Elasticsearch QueryResult struct for compatibility with 6.x Index and Delete API responses. {issue}4661[4661]
 - The sample dashboards are now included in the Beats packages. {pull}4675[4675]
 - Add `pattern` option to be used in the fields.yml to specify the pattern for a number field. {pull}4731[4731]
 
@@ -6596,7 +6636,7 @@ https://github.com/elastic/beats/compare/v1.0.0\...v1.0.1[Check 1.0.1 diff]
 - Improve redis parser performance. {issue}442[422]
 - Fix panic on nil in redis protocol parser. {issue}384[384]
 - Fix errors redis parser when messages are split in multiple TCP segments. {issue}402[402]
-- Fix errors in redis parser when length prefixed strings contain sequences of CRLF. {issue}#402[402]
+- Fix errors in redis parser when length prefixed strings contain sequences of CRLF. {issue}402[402]
 - Fix errors in redis parser when dealing with nested arrays. {issue}402[402]
 
 [[release-notes-1.0.0]]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -15,8 +15,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Libbeat: Do not overwrite agent.*, ecs.version, and host.name. {pull}14407[14407]
 - Libbeat: Cleanup the x-pack licenser code to use the new license endpoint and the new format. {pull}15091[15091]
 - Refactor metadata generator to support adding metadata across resources {pull}14875[14875]
-- Variable substitution from environment variables is not longer supported. {pull}15937{15937}
-- Change aws_elb autodiscover provider field name from elb_listener.* to aws.elb.*. {issue}16219[16219] {pull}16402{16402}
+- Variable substitution from environment variables is not longer supported. {pull}15937[15937]
+- Change aws_elb autodiscover provider field name from elb_listener.* to aws.elb.*. {issue}16219[16219] {pull}16402[16402]
 - Remove `AddDockerMetadata` and `AddKubernetesMetadata` processors from the `script` processor. They can still be used as normal processors in the configuration. {issue}16349[16349] {pull}16514[16514]
 - Introduce APM libbeat instrumentation, active when running the beat with ELASTIC_APM_ACTIVE=true. {pull}17938[17938]
 - Make error message about locked data path actionable. {pull}18667[18667]
@@ -24,7 +24,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Autodiscover doesn't generate any configuration when a variable is missing. Previously it generated an incomplete configuration. {pull}20898[20898]
 - Added `certificate` TLS verification mode to ignore server name mismatch. {issue}12283[12283] {pull}20293[20293]
 - Remove redundant `cloudfoundry.*.timestamp` fields. This value is set in `@timestamp`. {pull}21175[21175]
-- Allow embedding of CAs, Certificate of private keys for anything that support TLS in ouputs and inputs https://github.com/elastic/beats/pull/21179
+- Allow embedding of CAs, Certificate of private keys for anything that support TLS in ouputs and inputs. {pull}21179[21179]
 - API address is a required setting in `add_cloudfoundry_metadata`. {pull}21759[21759]
 - Update to ECS 1.7.0. {pull}22571[22571]
 - Add support for SCRAM-SHA-512 and SCRAM-SHA-256 in Kafka output. {pull}12867[12867]
@@ -116,12 +116,12 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `add_cloud_metadata` to better support modifying sub-fields with other processors. {pull}13808[13808]
 - Fix missing output in dockerlogbeat {pull}15719[15719]
 - Do not load dashboards where not available. {pull}15802[15802]
-- Fix issue where TLS settings would be ignored when a forward proxy was in use. {pull}15516{15516}
+- Fix issue where TLS settings would be ignored when a forward proxy was in use. {pull}15516[15516]
 - Remove superfluous use of number_of_routing_shards setting from the default template. {pull}16038[16038]
 - Fix index names for indexing not always guaranteed to be lower case. {pull}16081[16081]
-- Upgrade go-ucfg to latest v0.8.1. {pull}15937{15937}
+- Upgrade go-ucfg to latest v0.8.1. {pull}15937[15937]
 - Fix loading processors from annotation hints. {pull}16348[16348]
-- Upgrade go-ucfg to latest v0.8.3. {pull}16450{16450}
+- Upgrade go-ucfg to latest v0.8.3. {pull}16450[16450]
 - Add `ssl.ca_sha256` option to the supported TLS option, this allow to check that a specific certificate is used as part of the verified chain. {issue}15717[15717]
 - Fix `NewContainerMetadataEnricher` to use default config for kubernetes module. {pull}16857[16857]
 - Improve some logging messages for add_kubernetes_metadata processor {pull}16866{16866}
@@ -186,7 +186,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed dashboard for Cisco ASA Firewall. {issue}15420[15420] {pull}15553[15553]
 - Add shared_credential_file to cloudtrail config {issue}15652[15652] {pull}15656[15656]
 - Fix s3 input with cloudtrail fileset reading json file. {issue}16374[16374] {pull}16441[16441]
-- Fix merging of fileset inputs to replace paths and append processors. {pull}16450{16450}
+- Fix merging of fileset inputs to replace paths and append processors. {pull}16450[16450]
 - Add queue_url definition in manifest file for aws module. {pull}16640{16640}
 - Fixed various Cisco FTD parsing issues. {issue}16863[16863] {pull}16889[16889]
 - Fix default index pattern in IBM MQ filebeat dashboard. {pull}17146[17146]
@@ -686,7 +686,3 @@ port. {pull}19209[19209]
 ==== Known Issue
 
 *Journalbeat*
-
-
-
-

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -42,6 +42,10 @@ upgrade.
 * <<release-notes-7.0.0-beta1>>
 * <<release-notes-7.0.0-alpha2>>
 * <<release-notes-7.0.0-alpha1>>
+* <<release-notes-6.8.13>>
+* <<release-notes-6.8.12>>
+* <<release-notes-6.8.11>>
+* <<release-notes-6.8.10>>
 * <<release-notes-6.8.9>>
 * <<release-notes-6.8.8>>
 * <<release-notes-6.8.7>>


### PR DESCRIPTION
Syncs the `7.11` changelog with `master` by adding missing cherry-picks.

Related to #23454.