### PR TITLE
Remove duplicate line from the reference config

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -102,7 +102,6 @@ auditbeat.modules:
   scan_rate_per_sec: 50 MiB
 
   # Limit on the size of files that will be hashed. Default is "100 MiB".
-  # Limit on the size of files that will be hashed. Default is "100 MiB".
   max_file_size: 100 MiB
 
   # Hash types to compute when the file changes. Supported types are

--- a/auditbeat/module/file_integrity/_meta/config.yml.tmpl
+++ b/auditbeat/module/file_integrity/_meta/config.yml.tmpl
@@ -64,7 +64,6 @@
   scan_rate_per_sec: 50 MiB
 
   # Limit on the size of files that will be hashed. Default is "100 MiB".
-  # Limit on the size of files that will be hashed. Default is "100 MiB".
   max_file_size: 100 MiB
 
   # Hash types to compute when the file changes. Supported types are

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -102,7 +102,6 @@ auditbeat.modules:
   scan_rate_per_sec: 50 MiB
 
   # Limit on the size of files that will be hashed. Default is "100 MiB".
-  # Limit on the size of files that will be hashed. Default is "100 MiB".
   max_file_size: 100 MiB
 
   # Hash types to compute when the file changes. Supported types are


### PR DESCRIPTION
Fixes a duplicate line in Auditbeat's reference config.

Continuation of #21165