### PR TITLE
[CI] Use branches instead all

### DIFF
--- a/.ci/jobs/beats-schedule-weekly.yml
+++ b/.ci/jobs/beats-schedule-weekly.yml
@@ -15,7 +15,7 @@
       scm:
         - git:
             url: git@github.com:elastic/beats.git
-            refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*
+            refspec: +refs/heads/*:refs/remotes/origin/*
             wipe-workspace: 'True'
             name: origin
             shallow-clone: true


### PR DESCRIPTION
## What does this PR do?

Use branches

## Why is it important?

Fixes

```
13:11:43  using GIT_SSH to set credentials GitHub user @elasticmachine SSH key
13:11:43   > git fetch --tags --progress --depth=1 -- git@github.com:elastic/beats.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/* # timeout=10
13:11:43  ERROR: Error fetching remote repo 'origin'
13:11:43  hudson.plugins.git.GitException: Failed to fetch from git@github.com:elastic/beats.git
13:11:43  	at hudson.plugins.git.GitSCM.fetchFrom(GitSCM.java:1001)
13:11:43  	at hudson.plugins.git.GitSCM.retrieveChanges(GitSCM.java:1242)
13:11:43  	at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1302)
13:11:43  	at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:125)
13:11:43  	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:155)
13:11:43  	at org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition.create(CpsScmFlowDefinition.java:69)
13:11:43  	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:309)
13:11:43  	at hudson.model.ResourceController.execute(ResourceController.java:97)
13:11:43  	at hudson.model.Executor.run(Executor.java:428)
13:11:43  Caused by: hudson.plugins.git.GitException: Command "git fetch --tags --progress --depth=1 -- git@github.com:elastic/beats.git +refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*" returned status code 128:
13:11:43  stdout: 
13:11:43  stderr: fatal: Cannot fetch both refs/heads/pr/19387 and refs/pull/19387/head to refs/remotes/origin/pr/19387
13:11:43  
13:11:43  	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:2450)
13:11:43  	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:2051)
13:11:43  	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$500(CliGitAPIImpl.java:84)
13:11:43  	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:573)
13:11:43  	at hudson.plugins.git.GitSCM.fetchFrom(GitSCM.java:999)
13:11:43  	... 8 more
13:11:43  ERROR: Error fetching remote repo 'origin'
```