### PR TITLE
[CI] Run mandatory stages when only x-pack changes on branches/tags

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -36,10 +36,14 @@ stages:
         mage: "mage build test"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     crosscompile:
         make: "make -C auditbeat crosscompile"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -61,6 +65,8 @@ stages:
             #- "windows-2008-r2" https://github.com/elastic/beats/issues/19799
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -37,6 +37,8 @@ stages:
         withModule: true       ## run the ITs only if the changeset affects a specific module.
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -57,6 +59,8 @@ stages:
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19795
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -36,6 +36,8 @@ stages:
         mage: "mage build test"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -55,6 +57,8 @@ stages:
             - "windows-2019"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -36,3 +36,5 @@ stages:
         mage: "mage build unitTest"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -33,11 +33,17 @@ stages:
         mage: "mage build test"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     crosscompile:
         make: "make -C libbeat crosscompile"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     stress-tests:
         make: "make STRESS_TEST_OPTIONS='-timeout=20m -race -v -parallel 1' -C libbeat stress-tests"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -23,20 +23,28 @@ stages:
         mage: "mage build unitTest"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     goIntegTest:
         mage: "mage goIntegTest"
         withModule: true
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     pythonIntegTest:
         mage: "mage pythonIntegTest"
         withModule: true
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     crosscompile:
         make: "make -C metricbeat crosscompile"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -58,6 +66,8 @@ stages:
             #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19835
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -36,6 +36,8 @@ stages:
         mage: "mage build test"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -55,6 +57,8 @@ stages:
             - "windows-2019"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -23,6 +23,8 @@ stages:
         make: "make -C winlogbeat crosscompile"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
@@ -30,6 +32,8 @@ stages:
             - "windows-2008-r2"
         when:                  ## Override the top-level when.
             not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
+            branches: true                         ## for all the branches
+            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

I hope this will be my last attempt.

Mandatory stages should run always for branches and tags.
Changeset evaluations only for PRs.

## Why is it important?

Run all the mandatory stages by default fro branches/tags


![image](https://user-images.githubusercontent.com/2871786/104472837-4846b600-55b4-11eb-9260-56fb1f18cdd0.png)
