### PR TITLE
[7.x] [Rate limit processor] Add counter metric for dropped events (#23330)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -394,6 +394,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve equals check. {pull}22778[22778]
 - Honor kube event resysncs to handle missed watch events {pull}22668[22668]
 - Add autodiscover provider and metadata processor for Nomad. {pull}14954[14954] {pull}23324[23324]
+- Add `processors.rate_limit.n.dropped` monitoring counter metric for the `rate_limit` processor. {pull}23330[23330]
 
 *Auditbeat*
 
@@ -695,3 +696,6 @@ port. {pull}19209[19209]
 ==== Known Issue
 
 *Journalbeat*
+
+
+

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -696,6 +696,3 @@ port. {pull}19209[19209]
 ==== Known Issue
 
 *Journalbeat*
-
-
-

--- a/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
+++ b/libbeat/processors/ratelimit/docs/rate_limit.asciidoc
@@ -9,6 +9,9 @@ beta[]
 The `rate_limit` processor limits the throughput of events based on
 the specified configuration.
 
+In the current implementation, rate-limited events are dropped. Future
+implementations may allow rate-limited events to be handled differently.
+
 [source,yaml]
 -----------------------------------------------------
 processors:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Rate limit processor] Add counter metric for dropped events  (#23330)