### PR TITLE
Cherry-pick #23478 to 7.x: [Filebeat][httpjson] Allow for custom encoders and decoders

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -547,6 +547,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Google Workspace module and mark Gsuite module as deprecated {pull}22950[22950]
 - Mark m365 defender, defender atp, okta and google workspace modules as GA {pull}23113[23113]
 - Added `alternative_host` option to google pubsub input {pull}23215[23215]
+- Added `encode_as` and `decode_as` options to httpjson along with pluggable encoders/decoders {pull}23478[23478]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -346,6 +346,11 @@ The URL of the HTTP API. Required.
 HTTP method to use when making requests. `GET` or `POST` are the options. Default: `GET`.
 
 [float]
+==== `request.encode_as`
+
+ContentType used for encoding the request body. If set it will force the encoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. By default the requests are sent with `Content-Type: application/json`. Supported values: `application/json`. It is not set by default.
+
+[float]
 ==== `request.body`
 
 An optional HTTP POST body. The configuration value must be an object, and it
@@ -447,6 +452,11 @@ filebeat.inputs:
         target: body.from
         value: '[[now (parseDuration "-1h")]]'
 ----
+
+[float]
+==== `response.decode_as`
+
+ContentType used for decoding the response body. If set it will force the decoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. Supported values: `application/json`. It is not set by default.
 
 [[response-transforms]]
 [float]

--- a/x-pack/filebeat/input/httpjson/internal/v2/config_request.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/config_request.go
@@ -79,6 +79,7 @@ type requestConfig struct {
 	URL                    *urlConfig        `config:"url" validate:"required"`
 	Method                 string            `config:"method" validate:"required"`
 	Body                   *common.MapStr    `config:"body"`
+	EncodeAs               string            `config:"encode_as"`
 	Timeout                *time.Duration    `config:"timeout"`
 	SSL                    *tlscommon.Config `config:"ssl"`
 	Retry                  retryConfig       `config:"retry"`
@@ -114,6 +115,12 @@ func (c *requestConfig) Validate() error {
 
 	if _, err := newBasicTransformsFromConfig(c.Transforms, requestNamespace, nil); err != nil {
 		return err
+	}
+
+	if c.EncodeAs != "" {
+		if _, found := registeredEncoders[c.EncodeAs]; !found {
+			return fmt.Errorf("encoder not found for contentType: %v", c.EncodeAs)
+		}
 	}
 
 	return nil

--- a/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
@@ -15,6 +15,7 @@ const (
 )
 
 type responseConfig struct {
+	DecodeAs                string           `config:"decode_as"`
 	RequestBodyOnPagination bool             `config:"request_body_on_pagination"`
 	Transforms              transformsConfig `config:"transforms"`
 	Pagination              transformsConfig `config:"pagination"`
@@ -36,6 +37,11 @@ func (c *responseConfig) Validate() error {
 	}
 	if _, err := newBasicTransformsFromConfig(c.Pagination, paginationNamespace, nil); err != nil {
 		return err
+	}
+	if c.DecodeAs != "" {
+		if _, found := registeredDecoders[c.DecodeAs]; !found {
+			return fmt.Errorf("decoder not found for contentType: %v", c.DecodeAs)
+		}
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
@@ -1,0 +1,93 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package v2
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+type encoderFunc func(trReq transformable) ([]byte, error)
+
+type decoderFunc func(p []byte, dst *response) error
+
+var (
+	registeredEncoders             = map[string]encoderFunc{}
+	registeredDecoders             = map[string]decoderFunc{}
+	defaultEncoder     encoderFunc = encodeAsJSON
+	defaultDecoder     decoderFunc = decodeAsJSON
+)
+
+func registerEncoder(contentType string, enc encoderFunc) error {
+	if contentType == "" {
+		return errors.New("content-type can't be empty")
+	}
+
+	if enc == nil {
+		return errors.New("encoder can't be nil")
+	}
+
+	if _, found := registeredEncoders[contentType]; found {
+		return errors.New("already registered")
+	}
+
+	registeredEncoders[contentType] = enc
+
+	return nil
+}
+
+func registerDecoder(contentType string, dec decoderFunc) error {
+	if contentType == "" {
+		return errors.New("content-type can't be empty")
+	}
+
+	if dec == nil {
+		return errors.New("decoder can't be nil")
+	}
+
+	if _, found := registeredDecoders[contentType]; found {
+		return errors.New("already registered")
+	}
+
+	registeredDecoders[contentType] = dec
+
+	return nil
+}
+
+func encode(contentType string, trReq transformable) ([]byte, error) {
+	enc, found := registeredEncoders[contentType]
+	if !found {
+		return defaultEncoder(trReq)
+	}
+	return enc(trReq)
+}
+
+func decode(contentType string, p []byte, dst *response) error {
+	dec, found := registeredDecoders[contentType]
+	if !found {
+		return defaultDecoder(p, dst)
+	}
+	return dec(p, dst)
+}
+
+func registerEncoders() {
+	log := logp.L().Named(logName)
+	log.Debug(registerEncoder("application/json", encodeAsJSON))
+}
+
+func registerDecoders() {
+	log := logp.L().Named(logName)
+	log.Debug(registerDecoder("application/json", decodeAsJSON))
+}
+
+func encodeAsJSON(trReq transformable) ([]byte, error) {
+	return json.Marshal(trReq.body())
+}
+
+func decodeAsJSON(p []byte, dst *response) error {
+	return json.Unmarshal(p, &dst.body)
+}

--- a/x-pack/filebeat/input/httpjson/internal/v2/input_manager.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/input_manager.go
@@ -44,6 +44,8 @@ func (m InputManager) Init(grp unison.Group, mode v2.Mode) error {
 	registerRequestTransforms()
 	registerResponseTransforms()
 	registerPaginationTransforms()
+	registerEncoders()
+	registerDecoders()
 	return multierr.Append(
 		m.stateless.Init(grp, mode),
 		m.cursor.Init(grp, mode),

--- a/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
@@ -6,7 +6,6 @@ package v2
 
 import (
 	"context"
-	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -27,6 +26,7 @@ type pagination struct {
 	log            *logp.Logger
 	httpClient     *httpClient
 	requestFactory *requestFactory
+	decoder        decoderFunc
 }
 
 func newPagination(config config, httpClient *httpClient, log *logp.Logger) *pagination {
@@ -47,6 +47,7 @@ func newPagination(config config, httpClient *httpClient, log *logp.Logger) *pag
 
 	requestFactory := newPaginationRequestFactory(
 		config.Request.Method,
+		config.Request.EncodeAs,
 		*config.Request.URL.URL,
 		body,
 		append(rts, pts...),
@@ -54,10 +55,11 @@ func newPagination(config config, httpClient *httpClient, log *logp.Logger) *pag
 		log,
 	)
 	pagination.requestFactory = requestFactory
+	pagination.decoder = registeredDecoders[config.Response.DecodeAs]
 	return pagination
 }
 
-func newPaginationRequestFactory(method string, url url.URL, body *common.MapStr, ts []basicTransform, authConfig *authConfig, log *logp.Logger) *requestFactory {
+func newPaginationRequestFactory(method, encodeAs string, url url.URL, body *common.MapStr, ts []basicTransform, authConfig *authConfig, log *logp.Logger) *requestFactory {
 	// config validation already checked for errors here
 	rf := &requestFactory{
 		url:        url,
@@ -65,6 +67,7 @@ func newPaginationRequestFactory(method string, url url.URL, body *common.MapStr
 		body:       body,
 		transforms: ts,
 		log:        log,
+		encoder:    registeredEncoders[encodeAs],
 	}
 	if authConfig != nil && authConfig.Basic.isEnabled() {
 		rf.user = authConfig.Basic.User
@@ -160,7 +163,12 @@ func (iter *pageIterator) getPage() (*response, error) {
 	r.page = iter.n
 
 	if len(bodyBytes) > 0 {
-		if err := json.Unmarshal(bodyBytes, &r.body); err != nil {
+		if iter.pagination.decoder != nil {
+			err = iter.pagination.decoder(bodyBytes, &r)
+		} else {
+			err = decode(iter.resp.Header.Get("Content-Type"), bodyBytes, &r)
+		}
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/x-pack/filebeat/input/httpjson/internal/v2/request.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/request.go
@@ -7,7 +7,6 @@ package v2
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -83,6 +82,7 @@ type requestFactory struct {
 	user       string
 	password   string
 	log        *logp.Logger
+	encoder    encoderFunc
 }
 
 func newRequestFactory(config *requestConfig, authConfig *authConfig, log *logp.Logger) *requestFactory {
@@ -94,6 +94,7 @@ func newRequestFactory(config *requestConfig, authConfig *authConfig, log *logp.
 		body:       config.Body,
 		transforms: ts,
 		log:        log,
+		encoder:    registeredEncoders[config.EncodeAs],
 	}
 	if authConfig != nil && authConfig.Basic.isEnabled() {
 		rf.user = authConfig.Basic.User
@@ -112,7 +113,11 @@ func (rf *requestFactory) newHTTPRequest(stdCtx context.Context, trCtx *transfor
 	if len(trReq.body()) > 0 {
 		switch rf.method {
 		case "POST":
-			body, err = json.Marshal(trReq.body())
+			if rf.encoder != nil {
+				body, err = rf.encoder(trReq)
+			} else {
+				body, err = encode(trReq.header().Get("Content-Type"), trReq)
+			}
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Cherry-pick of PR #23478 to 7.x branch. Original message: 

## What does this PR do?

Allows to develop custom encoder/decoders for httpjson and the ability to force usage of a specific one.

## Why is it important?

Will help for future development of supported formats.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

