### PR TITLE
Cherry-pick #23438 to 7.x: Upgrade redis client

### DIFF
--- a/filebeat/input/redis/harvester.go
+++ b/filebeat/input/redis/harvester.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"time"
 
-	rd "github.com/garyburd/redigo/redis"
 	"github.com/gofrs/uuid"
+	rd "github.com/gomodule/redigo/redis"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"

--- a/filebeat/input/redis/input.go
+++ b/filebeat/input/redis/input.go
@@ -20,7 +20,7 @@ package redis
 import (
 	"time"
 
-	rd "github.com/garyburd/redigo/redis"
+	rd "github.com/gomodule/redigo/redis"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
 	"github.com/elastic/beats/v7/filebeat/harvester"

--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,6 @@ require (
 	github.com/fatih/color v1.5.0
 	github.com/fsnotify/fsevents v0.1.1
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/garyburd/redigo v1.0.1-0.20160525165706-b8dc90050f24
 	github.com/go-ole/go-ole v1.2.5-0.20190920104607-14974a1cf647 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.2+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.4.1
@@ -88,6 +87,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.4.2
 	github.com/golang/snappy v0.0.1
+	github.com/gomodule/redigo v1.8.3
 	github.com/google/flatbuffers v1.7.2-0.20170925184458-7a6b2bf521e9
 	github.com/google/go-cmp v0.4.0
 	github.com/google/gopacket v1.1.18-0.20191009163724-0ad7f2610e34

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,6 @@ github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.7.2 h1:2QxQoC1TS09S7fhCPsrvqYdvP1H5M1P1ih5ABm3BTYk=
 github.com/frankban/quicktest v1.7.2/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
-github.com/garyburd/redigo v1.0.1-0.20160525165706-b8dc90050f24 h1:nREVDi4H8mwnNqfxFU9NMzZrDCg8TXbEatMvHozxKwU=
-github.com/garyburd/redigo v1.0.1-0.20160525165706-b8dc90050f24/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -369,6 +367,8 @@ github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc=
+github.com/gomodule/redigo v1.8.3/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v1.7.2-0.20170925184458-7a6b2bf521e9 h1:b4EyQBj8pgtcWOr7YCSxK6NUQzJr0n4hxJ3mc+dtKk4=

--- a/libbeat/outputs/redis/backoff.go
+++ b/libbeat/outputs/redis/backoff.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 
 	b "github.com/elastic/beats/v7/libbeat/common/backoff"
 	"github.com/elastic/beats/v7/libbeat/publisher"

--- a/libbeat/outputs/redis/client.go
+++ b/libbeat/outputs/redis/client.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"

--- a/libbeat/outputs/redis/redis_integration_test.go
+++ b/libbeat/outputs/redis/redis_integration_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"

--- a/metricbeat/module/redis/key/key_integration_test.go
+++ b/metricbeat/module/redis/key/key_integration_test.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"testing"
 
-	rd "github.com/garyburd/redigo/redis"
+	rd "github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"

--- a/metricbeat/module/redis/keyspace/keyspace_integration_test.go
+++ b/metricbeat/module/redis/keyspace/keyspace_integration_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/tests/compose"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 
-	rd "github.com/garyburd/redigo/redis"
+	rd "github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/metricbeat/module/redis/metricset.go
+++ b/metricbeat/module/redis/metricset.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	rd "github.com/garyburd/redigo/redis"
+	rd "github.com/gomodule/redigo/redis"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"

--- a/metricbeat/module/redis/metricset_integration_test.go
+++ b/metricbeat/module/redis/metricset_integration_test.go
@@ -22,7 +22,7 @@ package redis
 import (
 	"testing"
 
-	rd "github.com/garyburd/redigo/redis"
+	rd "github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/metricbeat/module/redis/redis.go
+++ b/metricbeat/module/redis/redis.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	rd "github.com/garyburd/redigo/redis"
+	rd "github.com/gomodule/redigo/redis"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 )

--- a/metricbeat/module/redis/redis_integration_test.go
+++ b/metricbeat/module/redis/redis_integration_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	rd "github.com/garyburd/redigo/redis"
+	rd "github.com/gomodule/redigo/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
Cherry-pick of PR #23438 to 7.x branch. Original message: 

## What does this PR do?
This PR updates redis client library used by Metribceat module , redis output and redis filebeat input.

## Why is it important?
So as to support URLs and TLS settings.

## How to test this PR locally

#### Test Metricbeat Redis module
1) run a redis target service running `docker-compose up` inside `module/redis` directory
2) enable redis module and set the proper host ie `0.0.0.0:32837` (run docker ps to find the exposed port in your case)
3) Exec inside redis container and run `redis-cli` to populate keys: `SET mykey "Hello"`
4) Start metricbeat and verify that metrics are being collected 

#### Test Filebeat Redis slowlog fileset
1) Enable redis slowlog with the proper host and start Filebeat.
2) Execute again inside the redis container and create some keys.  Then feed slowlog with `CONFIG SET slowlog-log-slower-than 5` and `keys *`.
3) Verify that metrics are being collected.

#### Test redis output 
1) Define redis output for metribceat ie (set the proper host):
```
output.redis:
  hosts: ["0.0.0.0:32837"]
  key: "metricbeat"
  db: 0
  timeout: 5
```
2) Metricbeat module to collect some metrics
2) Using redis-cli verify that metrics are sent to Redis with `lrange metricbeat 0 1`

#### Test Filebeat redis input
1) Enable redis input
```
filebeat.inputs:
- type: redis
  hosts: ["0.0.0.0:32837"]
``` 
2) Start Filebeat
3) Execute again inside the redis container and create some keys.  Then feed slowlog with `CONFIG SET slowlog-log-slower-than 5` and `keys *`.
4) Verify that metrics are being collected.


## Related issues

https://github.com/elastic/beats/issues/16522
https://github.com/elastic/integrations/issues/361


