### PR TITLE
Cherry-pick #23463 to 7.x: [Elastic Agent] install -f should reinstall (#23463)

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -51,7 +51,8 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, 
 		return fmt.Errorf("unable to perform install command, not executed with %s permissions", install.PermissionUser)
 	}
 	status, reason := install.Status()
-	if status == install.Installed {
+	force, _ := cmd.Flags().GetBool("force")
+	if status == install.Installed && !force {
 		return fmt.Errorf("already installed at: %s", install.InstallPath)
 	}
 
@@ -66,7 +67,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, 
 	locker.Unlock()
 
 	warn.PrintNotGA(streams.Out)
-	force, _ := cmd.Flags().GetBool("force")
+
 	if status == install.Broken {
 		if !force {
 			fmt.Fprintf(streams.Out, "Elastic Agent is installed but currently broken: %s\n", reason)


### PR DESCRIPTION
Cherry-pick of PR #23463 to 7.x branch. Original message:

## What does this PR do?
fixes https://github.com/elastic/beats/issues/21990

Adds behavior described in #21990 where `-f` flag reinstalls over the current agent. That also matches my interpretation  of the flag in https://github.com/elastic/beats/blob/ccd7805ea11b6476c54e9e22b26dd4a5b83394be/x-pack/elastic-agent/pkg/agent/cmd/install.go#L42 


## Why is it important?
fixes https://github.com/elastic/beats/issues/21990 which says it's a regression from `7.9`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

**Let me know which, if any, of the above should be added**

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
 0. On a system with `elastic-agent` already installed
 1. run `./elastic-agent install` without the `-f` flag and observe `Error: already installed at:` message
 2. run `./elastic-agent install -f` and observe `Installation was successful and Elastic Agent is running.` message

See *Logs* section

## Related issues

- Closes https://github.com/elastic/beats/issues/21990

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Logs

`master`
```
$ sudo ./elastic-agent install --kibana-url=http://localhost:5601/czx--enrollment-token=c2hTczhuWUJ1Nk9tMmVVZWxjbG46YS1vcWxjbUhRdEtfZGlRU2dsbUJhdw== --insecure
Error: already installed at: /Library/Elastic/Agent
```

PR
```
$ sudo ./elastic-agent install -f --kibana-url=http://localhost:5601/czx--enrollment-token=c2hTczhuWUJ1Nk9tMmVVZWxjbG46YS1vcWxjbUhRdEtfZGlRU2dsbUJhdw== --insecure
The Elastic Agent is currently in BETA and should not be used in production

Installation was successful and Elastic Agent is running.
```