### PR TITLE
Cherry-pick #23094 to 7.x: Bug: Set netflow event.created to use current timestamp

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,6 +256,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix syslog header parsing in infoblox module. {issue}23272[23272] {pull}23273[23273]
 - Fix CredentialsJSON unpacking for `gcp-pubsub` and `httpjson` inputs. {pull}23277[23277]
 - Fix various processing errors in the Suricata module. {pull}23236[23236]
+- Change the `event.created` in Netflow events to be the time the event was created by Filebeat
+  to be consistent with ECS. {pull}23094[23094]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/netflow/convert.go
+++ b/x-pack/filebeat/input/netflow/convert.go
@@ -65,7 +65,7 @@ func toBeatEventCommon(flow record.Record) (event beat.Event) {
 
 	// ECS Fields -- event
 	ecsEvent := common.MapStr{
-		"created":  flow.Timestamp,
+		"created":  time.Now().UTC(),
 		"kind":     "event",
 		"category": []string{"network_traffic", "network"},
 		"action":   flow.Fields["type"],

--- a/x-pack/filebeat/input/netflow/netflow_test.go
+++ b/x-pack/filebeat/input/netflow/netflow_test.go
@@ -197,7 +197,9 @@ func getFlowsFromDat(t testing.TB, name string, testCase TestCase) TestResult {
 			}
 			ev := make([]beat.Event, len(flows))
 			for i := range flows {
-				ev[i] = toBeatEvent(flows[i], []string{"private"})
+				flow := toBeatEvent(flows[i], []string{"private"})
+				flow.Fields.Delete("event.created")
+				ev[i] = flow
 			}
 			//return TestResult{Name: name, Error: err.Error(), Events: flowsToEvents(flows)}
 			events = append(events, ev...)
@@ -242,7 +244,9 @@ func getFlowsFromPCAP(t testing.TB, name, pcapFile string) TestResult {
 		}
 		ev := make([]beat.Event, len(flows))
 		for i := range flows {
-			ev[i] = toBeatEvent(flows[i], []string{"private"})
+			flow := toBeatEvent(flows[i], []string{"private"})
+			flow.Fields.Delete("event.created")
+			ev[i] = flow
 		}
 		events = append(events, ev...)
 	}

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-18T08:16:47Z",
           "duration": 0,
           "kind": "event",
           "type": [
@@ -109,7 +108,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-18T08:16:47Z",
           "duration": 0,
           "kind": "event",
           "type": [

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20269000000,
           "kind": "event",
           "type": [
@@ -97,7 +96,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20269000000,
           "kind": "event",
           "type": [
@@ -178,7 +176,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20306000000,
           "kind": "event",
           "type": [
@@ -259,7 +256,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20306000000,
           "kind": "event",
           "type": [
@@ -340,7 +336,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20317000000,
           "kind": "event",
           "type": [
@@ -421,7 +416,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20317000000,
           "kind": "event",
           "type": [
@@ -502,7 +496,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20368000000,
           "kind": "event",
           "type": [
@@ -583,7 +576,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-29T13:58:28Z",
           "duration": 20368000000,
           "kind": "event",
           "type": [

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -95,7 +94,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -174,7 +172,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -253,7 +250,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -332,7 +328,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -411,7 +406,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -490,7 +484,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -569,7 +562,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -648,7 +640,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -727,7 +718,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -806,7 +796,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -885,7 +874,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -964,7 +952,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1043,7 +1030,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1122,7 +1108,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1201,7 +1186,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1280,7 +1264,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1359,7 +1342,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1438,7 +1420,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1517,7 +1498,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1596,7 +1576,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1675,7 +1654,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1754,7 +1732,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1833,7 +1810,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1912,7 +1888,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1991,7 +1966,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2070,7 +2044,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2149,7 +2122,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2226,7 +2198,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2293,7 +2264,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2360,7 +2330,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2427,7 +2396,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2494,7 +2462,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2561,7 +2528,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2628,7 +2594,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2695,7 +2660,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2762,7 +2726,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2829,7 +2792,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2896,7 +2858,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2963,7 +2924,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -3030,7 +2990,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -3097,7 +3056,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -3164,7 +3122,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -3231,7 +3188,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -3298,7 +3254,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"
@@ -3365,7 +3320,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-19T16:18:08Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-11-11T12:09:19Z",
           "kind": "event",
           "type": [
             "connection"
@@ -118,7 +117,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-11-11T12:09:19Z",
           "kind": "event",
           "type": [
             "connection"
@@ -208,7 +206,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-11-11T12:09:19Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-12-14T07:23:45Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -91,7 +90,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -166,7 +164,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -241,7 +238,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -316,7 +312,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -391,7 +386,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -466,7 +460,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -541,7 +534,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -616,7 +608,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -691,7 +682,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -766,7 +756,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -841,7 +830,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -916,7 +904,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -991,7 +978,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1066,7 +1052,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1141,7 +1126,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1216,7 +1200,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1291,7 +1274,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1366,7 +1348,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1441,7 +1422,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1516,7 +1496,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1591,7 +1570,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1666,7 +1644,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1741,7 +1718,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1816,7 +1792,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1891,7 +1866,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:30:37Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -98,7 +97,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -180,7 +178,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -262,7 +259,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -344,7 +340,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -426,7 +421,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -508,7 +502,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -590,7 +583,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-04-15T03:30:00Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-22T12:17:52Z",
           "kind": "event",
           "type": [
             "connection"
@@ -100,7 +99,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-22T12:17:56Z",
           "kind": "event",
           "type": [
             "connection"
@@ -184,7 +182,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-22T12:17:56Z",
           "kind": "event",
           "type": [
             "connection"
@@ -268,7 +265,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-22T12:26:04Z",
           "kind": "event",
           "type": [
             "connection"
@@ -350,7 +346,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-22T12:26:04Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
@@ -18,7 +18,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-25T13:03:38Z",
           "kind": "event",
           "type": [
             "connection"
@@ -103,7 +102,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-25T12:58:38Z",
           "kind": "event",
           "type": [
             "connection"
@@ -187,7 +185,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-25T13:03:33Z",
           "kind": "event"
         },
         "netflow": {

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-11-11T12:09:19Z",
           "kind": "event",
           "type": [
             "connection"
@@ -118,7 +117,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-11-11T12:09:19Z",
           "kind": "event",
           "type": [
             "connection"
@@ -208,7 +206,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-11-11T12:09:19Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-options-template-from-Juniper-MX240-JunOS-15.1-R6-S3.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-06-01T15:11:53Z",
           "kind": "event"
         },
         "netflow": {

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-21T14:32:15Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event"
         },
         "netflow": {
@@ -55,7 +54,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event",
           "type": [
             "connection"
@@ -134,7 +132,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event",
           "type": [
             "connection"
@@ -213,7 +210,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event",
           "type": [
             "connection"
@@ -292,7 +288,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event",
           "type": [
             "connection"
@@ -371,7 +366,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event",
           "type": [
             "connection"
@@ -450,7 +444,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event",
           "type": [
             "connection"
@@ -529,7 +522,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:26Z",
           "kind": "event",
           "type": [
             "connection"
@@ -608,7 +600,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:28Z",
           "kind": "event",
           "type": [
             "connection"
@@ -687,7 +678,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:28Z",
           "kind": "event",
           "type": [
             "connection"
@@ -766,7 +756,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:28Z",
           "kind": "event",
           "type": [
             "connection"
@@ -845,7 +834,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:28Z",
           "kind": "event",
           "type": [
             "connection"
@@ -924,7 +912,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-05-13T11:20:28Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -95,7 +94,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -174,7 +172,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -253,7 +250,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -332,7 +328,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -411,7 +406,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -490,7 +484,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -569,7 +562,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -648,7 +640,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -727,7 +718,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -806,7 +796,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -885,7 +874,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -964,7 +952,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1043,7 +1030,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1122,7 +1108,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1201,7 +1186,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1280,7 +1264,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1359,7 +1342,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1438,7 +1420,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1517,7 +1498,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1596,7 +1576,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1675,7 +1654,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1754,7 +1732,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1833,7 +1810,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1912,7 +1888,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1991,7 +1966,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2070,7 +2044,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2149,7 +2122,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2228,7 +2200,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-03T17:03:39Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
@@ -17,7 +17,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -99,7 +98,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -181,7 +179,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -263,7 +260,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -345,7 +341,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -427,7 +422,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -509,7 +503,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -590,7 +583,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -671,7 +663,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -753,7 +744,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -834,7 +824,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -915,7 +904,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -997,7 +985,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1078,7 +1065,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1159,7 +1145,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1241,7 +1226,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1322,7 +1306,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1403,7 +1386,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1485,7 +1467,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-07-21T13:50:37Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -99,7 +98,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -182,7 +180,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -265,7 +262,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -348,7 +344,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -431,7 +426,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -514,7 +508,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -597,7 +590,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -680,7 +672,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -763,7 +754,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -846,7 +836,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -929,7 +918,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1012,7 +1000,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1095,7 +1082,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-09T09:47:51Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-options-template-256.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -48,7 +47,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -85,7 +83,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -122,7 +119,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -159,7 +155,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -196,7 +191,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -233,7 +227,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -270,7 +263,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -307,7 +299,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -344,7 +335,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -381,7 +371,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -418,7 +407,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -455,7 +443,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -492,7 +479,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -529,7 +515,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -566,7 +551,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -603,7 +587,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -640,7 +623,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {
@@ -677,7 +659,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:48Z",
           "kind": "event"
         },
         "netflow": {

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.94Z",
           "kind": "event",
@@ -104,7 +103,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 641000000,
           "end": "2016-12-06T10:08:54.583Z",
           "kind": "event",
@@ -192,7 +190,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.945Z",
           "kind": "event",
@@ -280,7 +277,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.947Z",
           "kind": "event",
@@ -368,7 +364,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.948Z",
           "kind": "event",
@@ -456,7 +451,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 83000000,
           "end": "2016-12-06T10:08:53.948Z",
           "kind": "event",
@@ -544,7 +538,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.951Z",
           "kind": "event",
@@ -632,7 +625,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.951Z",
           "kind": "event",
@@ -720,7 +712,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 5418000000,
           "end": "2016-12-06T10:08:53.952Z",
           "kind": "event",
@@ -808,7 +799,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 3317000000,
           "end": "2016-12-06T10:08:57.27Z",
           "kind": "event",
@@ -896,7 +886,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 19894000000,
           "end": "2016-12-06T10:09:04.383Z",
           "kind": "event",
@@ -984,7 +973,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.955Z",
           "kind": "event",
@@ -1072,7 +1060,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.957Z",
           "kind": "event",
@@ -1160,7 +1147,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 89000000,
           "end": "2016-12-06T10:08:53.959Z",
           "kind": "event",
@@ -1248,7 +1234,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 17325000000,
           "end": "2016-12-06T10:09:05.882Z",
           "kind": "event",
@@ -1336,7 +1321,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 2705000000,
           "end": "2016-12-06T10:08:56.186Z",
           "kind": "event",
@@ -1424,7 +1408,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 361000000,
           "end": "2016-12-06T10:08:54.28Z",
           "kind": "event",
@@ -1512,7 +1495,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 378000000,
           "end": "2016-12-06T10:08:54.037Z",
           "kind": "event",
@@ -1600,7 +1582,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 11106000000,
           "end": "2016-12-06T10:09:03.759Z",
           "kind": "event",
@@ -1688,7 +1669,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 0,
           "end": "2016-12-06T10:08:53.964Z",
           "kind": "event",
@@ -1776,7 +1756,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-06T10:09:24Z",
           "duration": 1587000000,
           "end": "2016-12-06T10:08:53.964Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -94,7 +93,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -172,7 +170,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -250,7 +247,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -328,7 +324,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -406,7 +401,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -484,7 +478,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -562,7 +555,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -640,7 +632,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -718,7 +709,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -796,7 +786,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -874,7 +863,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -952,7 +940,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1030,7 +1017,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1108,7 +1094,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1186,7 +1171,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1264,7 +1248,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1342,7 +1325,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1420,7 +1402,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1498,7 +1479,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1576,7 +1556,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1654,7 +1633,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1732,7 +1710,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1810,7 +1787,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1888,7 +1864,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-10-09T20:22:35Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
@@ -17,7 +17,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.368Z",
           "kind": "event",
@@ -110,7 +109,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.368Z",
           "kind": "event",
@@ -203,7 +201,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.924Z",
           "kind": "event",
@@ -296,7 +293,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:10:36Z",
           "duration": 0,
           "end": "2017-02-14T11:10:19.996Z",
           "kind": "event",
@@ -389,7 +385,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:10:36Z",
           "duration": 72000000,
           "end": "2017-02-14T11:10:20.008Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-options-template-260.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -49,7 +48,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -87,7 +85,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -125,7 +122,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -163,7 +159,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -201,7 +196,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -239,7 +233,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -277,7 +270,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -315,7 +307,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -353,7 +344,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -391,7 +381,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -429,7 +418,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -467,7 +455,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -505,7 +492,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {
@@ -543,7 +529,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-02-14T11:09:59Z",
           "kind": "event"
         },
         "netflow": {

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
@@ -14,7 +14,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -80,7 +79,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -142,7 +140,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -208,7 +205,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -270,7 +266,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -334,7 +329,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -400,7 +394,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -462,7 +455,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -528,7 +520,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -590,7 +581,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -656,7 +646,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -718,7 +707,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -784,7 +772,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -846,7 +833,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -912,7 +898,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -974,7 +959,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1040,7 +1024,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1102,7 +1085,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1168,7 +1150,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-06-22T06:31:14Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-18T05:42:14Z",
           "kind": "event"
         },
         "netflow": {
@@ -58,7 +57,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-07-18T05:41:59Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.99Z",
           "kind": "event",
@@ -102,7 +101,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 1130000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
@@ -188,7 +186,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 1130000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
@@ -274,7 +271,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 1040000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
@@ -360,7 +356,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 1040000000,
           "end": "2018-05-11T00:54:09.74Z",
           "kind": "event",
@@ -446,7 +441,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.11Z",
           "kind": "event",
@@ -532,7 +526,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 410000000,
           "end": "2018-05-11T00:54:09.11Z",
           "kind": "event",
@@ -618,7 +611,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 370000000,
           "end": "2018-05-11T00:54:08.53Z",
           "kind": "event",
@@ -704,7 +696,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 370000000,
           "end": "2018-05-11T00:54:08.53Z",
           "kind": "event",
@@ -790,7 +781,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
@@ -872,7 +862,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
@@ -954,7 +943,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
@@ -1036,7 +1024,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 80000000,
           "end": "2018-05-11T00:51:08.63Z",
           "kind": "event",
@@ -1118,7 +1105,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 2020000000,
           "end": "2018-05-11T00:54:06.21Z",
           "kind": "event",
@@ -1200,7 +1186,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 2020000000,
           "end": "2018-05-11T00:54:06.21Z",
           "kind": "event",
@@ -1282,7 +1267,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 4000000000,
           "end": "2018-05-11T00:54:00.19Z",
           "kind": "event",
@@ -1364,7 +1348,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-11T00:54:11Z",
           "duration": 4000000000,
           "end": "2018-05-11T00:54:00.19Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-07-18T01:35:35Z",
           "duration": 29695000000,
           "end": "2018-07-18T01:35:02.969Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 89519000000,
           "end": "2018-05-21T09:25:03.677Z",
           "kind": "event",
@@ -107,7 +106,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 60005000000,
           "end": "2018-05-21T09:25:03.662Z",
           "kind": "event",
@@ -198,7 +196,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 60016000000,
           "end": "2018-05-21T09:25:03.656Z",
           "kind": "event",
@@ -289,7 +286,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 90011000000,
           "end": "2018-05-21T09:25:03.643Z",
           "kind": "event",
@@ -380,7 +376,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.629Z",
           "kind": "event",
@@ -471,7 +466,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 29467000000,
           "end": "2018-05-21T09:24:03.669Z",
           "kind": "event",
@@ -562,7 +556,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 29452000000,
           "end": "2018-05-21T09:24:03.67Z",
           "kind": "event",
@@ -653,7 +646,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 29449000000,
           "end": "2018-05-21T09:24:03.684Z",
           "kind": "event",
@@ -744,7 +736,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.685Z",
           "kind": "event",
@@ -835,7 +826,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 29391000000,
           "end": "2018-05-21T09:24:03.691Z",
           "kind": "event",
@@ -926,7 +916,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 29196000000,
           "end": "2018-05-21T09:24:03.699Z",
           "kind": "event",
@@ -1017,7 +1006,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 30000000000,
           "end": "2018-05-21T09:24:03.753Z",
           "kind": "event",
@@ -1108,7 +1096,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 89282000000,
           "end": "2018-05-21T09:25:03.971Z",
           "kind": "event",
@@ -1199,7 +1186,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 90012000000,
           "end": "2018-05-21T09:25:03.95Z",
           "kind": "event",
@@ -1290,7 +1276,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 60005000000,
           "end": "2018-05-21T09:25:03.938Z",
           "kind": "event",
@@ -1381,7 +1366,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-05-21T09:25:04Z",
           "duration": 60006000000,
           "end": "2018-05-21T09:25:03.928Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
@@ -17,7 +17,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-01-29T03:02:20Z",
           "duration": 327060000000,
           "end": "2018-01-29T03:02:19Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-12-01T17:04:39Z",
           "kind": "event",
           "type": [
             "connection"
@@ -94,7 +93,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-12-01T17:04:39Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-06-06T13:20:17Z",
           "duration": 0,
           "end": "2018-06-06T13:20:02Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
@@ -100,7 +99,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 339000000000,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
@@ -184,7 +182,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
@@ -268,7 +265,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
@@ -352,7 +348,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
@@ -436,7 +431,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
@@ -520,7 +514,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",
@@ -604,7 +597,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-11-13T14:39:31Z",
           "duration": 0,
           "end": "2017-11-13T14:39:31Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-01-11T11:48:15Z",
           "duration": 6012000000,
           "end": "2017-01-11T11:47:28.879Z",
           "kind": "event",
@@ -95,7 +94,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-01-11T11:48:15Z",
           "duration": 6020000000,
           "end": "2017-01-11T11:47:28.886Z",
           "kind": "event",
@@ -174,7 +172,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-01-11T11:23:51Z",
           "duration": 50997000000,
           "end": "2017-01-11T11:23:34.936Z",
           "kind": "event",
@@ -253,7 +250,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2017-01-11T11:23:51Z",
           "duration": 51015000000,
           "end": "2017-01-11T11:23:34.954Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
@@ -17,7 +17,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:25.825Z",
           "kind": "event",
@@ -105,7 +104,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:25.825Z",
           "kind": "event",
@@ -193,7 +191,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 140227000000,
           "end": "2016-09-10T15:22:30.891Z",
           "kind": "event",
@@ -281,7 +278,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 140227000000,
           "end": "2016-09-10T15:22:30.891Z",
           "kind": "event",
@@ -369,7 +365,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 177102000000,
           "end": "2016-09-10T16:20:32.763Z",
           "kind": "event",
@@ -457,7 +452,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 176903000000,
           "end": "2016-09-10T16:20:32.666Z",
           "kind": "event",
@@ -545,7 +539,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T15:22:36.207Z",
           "kind": "event",
@@ -633,7 +626,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:23:30Z",
           "duration": 0,
           "end": "2016-09-10T16:17:35.661Z",
           "kind": "event",
@@ -720,7 +712,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 116000000,
           "end": "2016-09-10T15:23:38.951Z",
           "kind": "event",
@@ -806,7 +797,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
@@ -892,7 +882,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
@@ -978,7 +967,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
@@ -1064,7 +1052,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
@@ -1150,7 +1137,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
@@ -1236,7 +1222,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 0,
           "end": "2016-09-10T16:18:39.443Z",
           "kind": "event",
@@ -1322,7 +1307,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-09-10T16:24:08Z",
           "duration": 1250988000000,
           "end": "2016-09-10T15:23:44.363Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-01-16T09:45:02Z",
           "duration": 0,
           "end": "2018-01-16T09:44:47Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
@@ -17,7 +17,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 8996000000,
           "end": "2018-02-18T05:46:53.996Z",
           "kind": "event",
@@ -105,7 +104,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 0,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
@@ -193,7 +191,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 7652000000,
           "end": "2018-02-18T05:46:53.988Z",
           "kind": "event",
@@ -281,7 +278,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 16000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
@@ -369,7 +365,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 1168000000,
           "end": "2018-02-18T05:46:53.988Z",
           "kind": "event",
@@ -457,7 +452,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 8992000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
@@ -545,7 +539,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 4432000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
@@ -633,7 +626,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 80000000,
           "end": "2018-02-18T05:46:53.996Z",
           "kind": "event",
@@ -721,7 +713,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 400000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
@@ -809,7 +800,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 9024000000,
           "end": "2018-02-18T05:46:53.988Z",
           "kind": "event",
@@ -897,7 +887,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 60000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",
@@ -985,7 +974,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-02-18T05:47:09Z",
           "duration": 192000000,
           "end": "2018-02-18T05:46:53.992Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:46:56Z",
           "kind": "event"
         },
         "netflow": {
@@ -54,7 +53,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -122,7 +120,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -190,7 +187,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -258,7 +254,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -326,7 +321,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -394,7 +388,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -462,7 +455,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -530,7 +522,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -598,7 +589,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -666,7 +656,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -734,7 +723,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -802,7 +790,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -870,7 +857,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -938,7 +924,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1006,7 +991,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1074,7 +1058,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1142,7 +1125,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1210,7 +1192,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1278,7 +1259,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1346,7 +1326,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1414,7 +1393,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1482,7 +1460,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1550,7 +1527,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1618,7 +1594,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1686,7 +1661,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1754,7 +1728,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1822,7 +1795,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1890,7 +1862,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1958,7 +1929,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-10T08:47:01Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:06:29Z",
           "kind": "event"
         },
         "netflow": {
@@ -53,7 +52,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
@@ -133,7 +131,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
@@ -213,7 +210,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
@@ -293,7 +289,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
@@ -373,7 +368,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
@@ -453,7 +447,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
@@ -531,7 +524,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 38081000000,
           "end": "2015-10-08T19:04:25.9Z",
           "kind": "event",
@@ -603,7 +595,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:06:29Z",
           "duration": 5000000,
           "end": "2015-10-08T19:05:55.015Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "1970-01-01T00:08:22Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-options-template-with-scope-fields.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:06:29Z",
           "kind": "event"
         },
         "netflow": {

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:48.299Z",
           "kind": "event",
@@ -100,7 +99,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:48.299Z",
           "kind": "event",
@@ -184,7 +182,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
@@ -268,7 +265,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
@@ -352,7 +348,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
@@ -436,7 +431,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.469Z",
           "kind": "event",
@@ -520,7 +514,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",
@@ -604,7 +597,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",
@@ -688,7 +680,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",
@@ -772,7 +763,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-12-23T01:35:31Z",
           "duration": 0,
           "end": "2016-12-23T01:34:51.569Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
@@ -96,7 +95,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:46.141Z",
           "kind": "event",
@@ -176,7 +174,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
@@ -256,7 +253,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 1000000,
           "end": "2015-10-08T19:03:51.814Z",
           "kind": "event",
@@ -336,7 +332,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
@@ -416,7 +411,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 0,
           "end": "2015-10-08T19:03:55.958Z",
           "kind": "event",
@@ -494,7 +488,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2015-10-08T19:04:30Z",
           "duration": 38081000000,
           "end": "2015-10-08T19:04:25.9Z",
           "kind": "event",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow9-Juniper-SRX-options-template-with-0-scope-field-length.golden.json
@@ -11,7 +11,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2016-11-29T00:21:56Z",
           "kind": "event"
         },
         "netflow": {

--- a/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
@@ -16,7 +16,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -104,7 +103,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -192,7 +190,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -280,7 +277,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -368,7 +364,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -456,7 +451,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -544,7 +538,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -632,7 +625,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -720,7 +712,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -808,7 +799,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -896,7 +886,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -984,7 +973,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1072,7 +1060,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1160,7 +1147,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1248,7 +1234,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1336,7 +1321,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1424,7 +1408,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1512,7 +1495,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1600,7 +1582,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1688,7 +1669,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1776,7 +1756,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1864,7 +1843,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -1952,7 +1930,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2040,7 +2017,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2128,7 +2104,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2216,7 +2191,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2304,7 +2278,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2392,7 +2365,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"
@@ -2480,7 +2452,6 @@
         "event": {
           "action": "netflow_flow",
           "category": "network_session",
-          "created": "2018-07-03T10:47:00Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_e10s_4_7byte_pad.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_e10s_4_7byte_pad.pcap.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2020-04-16T23:22:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -92,7 +91,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2020-04-16T23:22:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -168,7 +166,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2020-04-16T23:22:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -244,7 +241,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2020-04-16T23:22:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -320,7 +316,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2020-04-16T23:22:51Z",
           "kind": "event",
           "type": [
             "connection"
@@ -396,7 +391,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2020-04-16T23:22:51Z",
           "kind": "event",
           "type": [
             "connection"

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
@@ -16,7 +16,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 287000000,
           "end": "2018-08-09T16:43:00.307Z",
           "kind": "event",
@@ -102,7 +101,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 30209000000,
           "end": "2018-08-09T16:43:01.317Z",
           "kind": "event",
@@ -188,7 +186,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 0,
           "end": "2018-08-09T16:43:01.41Z",
           "kind": "event",
@@ -274,7 +271,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 59651000000,
           "end": "2018-08-09T16:43:02.334Z",
           "kind": "event",
@@ -360,7 +356,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 40015000000,
           "end": "2018-08-09T16:43:02.876Z",
           "kind": "event",
@@ -446,7 +441,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 37121000000,
           "end": "2018-08-09T16:43:02.43Z",
           "kind": "event",
@@ -532,7 +526,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 31322000000,
           "end": "2018-08-09T16:43:02.43Z",
           "kind": "event",
@@ -618,7 +611,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 31226000000,
           "end": "2018-08-09T16:43:02.334Z",
           "kind": "event",
@@ -704,7 +696,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 30976000000,
           "end": "2018-08-09T16:43:02.334Z",
           "kind": "event",
@@ -790,7 +781,6 @@
             "network_traffic",
             "network"
           ],
-          "created": "2018-08-09T16:49:04Z",
           "duration": 0,
           "end": "2018-08-09T16:43:06.28Z",
           "kind": "event",


### PR DESCRIPTION
Cherry-pick of PR #23094 to 7.x branch. Original message: 

## What does this PR do?
Set netflow event.created field to current time instead of using flow.Timestamp

## Why is it important?
As per [https://github.com/elastic/ecs/blob/master/code/go/ecs/event.go#L163](the doc), event.created contains the date/time when the event was first read by an agent/pipeline.
But for netflow input type, it is being copied from flow.Timestamp field.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.