### PR TITLE
[Filebeat] add encode form and decode ndjson to httpjson input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -801,6 +801,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add parsing of tcp flags to AWS vpcflow fileset {issue}228020[22820] {pull}23157[23157]
 - Added `alternative_host` option to google pubsub input {pull}23215[23215]
 - Added `encode_as` and `decode_as` options to httpjson along with pluggable encoders/decoders {pull}23478[23478]
+- Added `application/x-ndjson` as decode option for httpjson input {pull}23521[23521]
+- Added `application/x-www-form-urlencoded` as encode option for httpjson input {pull}23521[23521]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -349,7 +349,7 @@ HTTP method to use when making requests. `GET` or `POST` are the options. Defaul
 [float]
 ==== `request.encode_as`
 
-ContentType used for encoding the request body. If set it will force the encoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. By default the requests are sent with `Content-Type: application/json`. Supported values: `application/json`. It is not set by default.
+ContentType used for encoding the request body. If set it will force the encoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. By default the requests are sent with `Content-Type: application/json`. Supported values: `application/json` and `application\x-www-form-urlencoded`. `application/x-www-form-encoded` will url encode the `url.params` and set them as the body. It is not set by default.
 
 [float]
 ==== `request.body`
@@ -457,7 +457,7 @@ filebeat.inputs:
 [float]
 ==== `response.decode_as`
 
-ContentType used for decoding the response body. If set it will force the decoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. Supported values: `application/json`. It is not set by default.
+ContentType used for decoding the response body. If set it will force the decoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. Supported values: `application/json, application/x-ndjson`. It is not set by default.
 
 [[response-transforms]]
 [float]

--- a/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
@@ -5,8 +5,10 @@
 package v2
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -77,17 +79,47 @@ func decode(contentType string, p []byte, dst *response) error {
 func registerEncoders() {
 	log := logp.L().Named(logName)
 	log.Debug(registerEncoder("application/json", encodeAsJSON))
+	log.Debug(registerEncoder("application/x-www-form-urlencoded", encodeAsForm))
 }
 
 func registerDecoders() {
 	log := logp.L().Named(logName)
 	log.Debug(registerDecoder("application/json", decodeAsJSON))
+	log.Debug(registerDecoder("application/x-ndjson", decodeAsNdjson))
 }
 
 func encodeAsJSON(trReq transformable) ([]byte, error) {
+	if len(trReq.body()) == 0 {
+		return nil, nil
+	}
 	return json.Marshal(trReq.body())
 }
 
 func decodeAsJSON(p []byte, dst *response) error {
 	return json.Unmarshal(p, &dst.body)
+}
+
+func encodeAsForm(trReq transformable) ([]byte, error) {
+	url := trReq.url()
+	body := []byte(url.RawQuery)
+	url.RawQuery = ""
+	trReq.setURL(url)
+	return body, nil
+}
+
+func decodeAsNdjson(p []byte, dst *response) error {
+	var results []interface{}
+	dec := json.NewDecoder(bytes.NewReader(p))
+	for {
+		var o interface{}
+		err := dec.Decode(&o)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		results = append(results, o)
+	}
+	dst.body = results
+	return nil
 }

--- a/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -110,12 +109,9 @@ func encodeAsForm(trReq transformable) ([]byte, error) {
 func decodeAsNdjson(p []byte, dst *response) error {
 	var results []interface{}
 	dec := json.NewDecoder(bytes.NewReader(p))
-	for {
+	for dec.More() {
 		var o interface{}
-		err := dec.Decode(&o)
-		if err == io.EOF {
-			break
-		} else if err != nil {
+		if err := dec.Decode(&o); err != nil {
 			return err
 		}
 		results = append(results, o)

--- a/x-pack/filebeat/input/httpjson/internal/v2/encoding_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/encoding_test.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package v2
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeNdjson(t *testing.T) {
+	tests := []struct {
+		body   string
+		result string
+	}{
+		{"{}", "[{}]"},
+		{"{\"a\":\"b\"}", "[{\"a\":\"b\"}]"},
+		{"{\"a\":\"b\"}\n{\"c\":\"d\"}", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
+		{"{\"a\":\"b\"}\r\n{\"c\":\"d\"}", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
+		{"{\"a\":\"b\"}\r\n{\"c\":\"d\"}\n", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
+		{"{\"a\":\"b\"}\r\n{\"c\":\"d\"}\r\n", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
+	}
+	for _, test := range tests {
+		resp := &response{}
+		err := decodeAsNdjson([]byte(test.body), resp)
+		if err != nil {
+			t.Fatalf("decodeAsNdjson failed: %v", err)
+		}
+		j, err := json.Marshal(resp.body)
+		if err != nil {
+			t.Fatalf("Marshal failed: %v", err)
+		}
+		assert.Equal(t, test.result, string(j))
+	}
+}
+
+func TestEncodeAsForm(t *testing.T) {
+	tests := []struct {
+		params map[string]string
+		body   string
+	}{
+		{map[string]string{"a": "b"}, "a=b"},
+		{map[string]string{"a": "b", "c": "d"}, "a=b&c=d"},
+		{nil, ""},
+	}
+	for _, test := range tests {
+		u, err := url.Parse("http://localhost")
+		if err != nil {
+			t.Fatalf("url parse failed: %v", err)
+		}
+		q := u.Query()
+		for k, v := range test.params {
+			q.Set(k, v)
+		}
+		u.RawQuery = q.Encode()
+		trReq := transformable{}
+		trReq.setURL(*u)
+		res, err := encodeAsForm(trReq)
+		assert.Equal(t, test.body, string(res))
+	}
+}

--- a/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
@@ -31,7 +31,13 @@ type pagination struct {
 
 func newPagination(config config, httpClient *httpClient, log *logp.Logger) *pagination {
 	pagination := &pagination{httpClient: httpClient, log: log}
-	if config.Response == nil || len(config.Response.Pagination) == 0 {
+	if config.Response == nil {
+		return pagination
+	}
+
+	pagination.decoder = registeredDecoders[config.Response.DecodeAs]
+
+	if len(config.Response.Pagination) == 0 {
 		return pagination
 	}
 
@@ -55,7 +61,6 @@ func newPagination(config config, httpClient *httpClient, log *logp.Logger) *pag
 		log,
 	)
 	pagination.requestFactory = requestFactory
-	pagination.decoder = registeredDecoders[config.Response.DecodeAs]
 	return pagination
 }
 

--- a/x-pack/filebeat/input/httpjson/internal/v2/request.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/request.go
@@ -56,9 +56,6 @@ func (rf *requestFactory) newRequest(ctx *transformContext) (transformable, erro
 	header := http.Header{}
 	header.Set("Accept", "application/json")
 	header.Set("User-Agent", userAgent)
-	if rf.method == "POST" {
-		header.Set("Content-Type", "application/json")
-	}
 	req.setHeader(header)
 
 	var err error
@@ -66,6 +63,14 @@ func (rf *requestFactory) newRequest(ctx *transformContext) (transformable, erro
 		req, err = t.run(ctx, req)
 		if err != nil {
 			return transformable{}, err
+		}
+	}
+
+	if rf.method == "POST" {
+		header = req.header()
+		if header.Get("Content-Type") == "" {
+			header.Set("Content-Type", "application/json")
+			req.setHeader(header)
 		}
 	}
 
@@ -110,19 +115,14 @@ func (rf *requestFactory) newHTTPRequest(stdCtx context.Context, trCtx *transfor
 	}
 
 	var body []byte
-	if len(trReq.body()) > 0 {
-		switch rf.method {
-		case "POST":
-			if rf.encoder != nil {
-				body, err = rf.encoder(trReq)
-			} else {
-				body, err = encode(trReq.header().Get("Content-Type"), trReq)
-			}
-			if err != nil {
-				return nil, err
-			}
-		default:
-			rf.log.Errorf("A body is set, but method is not POST. The body will be ignored.")
+	if rf.method == "POST" {
+		if rf.encoder != nil {
+			body, err = rf.encoder(trReq)
+		} else {
+			body, err = encode(trReq.header().Get("Content-Type"), trReq)
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

- adds support "application/x-www-form-urlencoded", as supported
  `request.encode_as` option.  url parameters are encoded and sent in
  the body
- adds support "application/x-ndjson", as supported
  `response.decode_as` option.  json objects are decoded and returned
  in an array at root level 

## Why is it important?

Some API endpoints require posting data as
`application/x-www-form-urlencoded`

Some API endpoints only return `application/x-ndjson` not json


## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.