### PR TITLE
Cherry-pick #23496 to 7.11: Agent fetching DBus service PID fix 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -32,6 +32,8 @@
 - Remove artifacts on transient download errors {pull}23235[23235]
 - Skip top level files when unziping archive during upgrade {pull}23456[23456]
 - Do not take ownership of Endpoint log path {pull}23444[23444]
+- Fixed fetching DBus service PID {pull}23496[23496]
+- Fix issue of missing log messages from filebeat monitor {pull}23514[23514]
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -33,7 +33,6 @@
 - Skip top level files when unziping archive during upgrade {pull}23456[23456]
 - Do not take ownership of Endpoint log path {pull}23444[23444]
 - Fixed fetching DBus service PID {pull}23496[23496]
-- Fix issue of missing log messages from filebeat monitor {pull}23514[23514]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
@@ -171,7 +171,12 @@ func (p *dbusPidProvider) Close() {
 }
 
 func (p *dbusPidProvider) PID(ctx context.Context) (int, error) {
-	prop, err := p.dbusConn.GetServiceProperty(install.ServiceName, "MainPID")
+	sn := install.ServiceName
+	if !strings.HasSuffix(sn, ".service") {
+		sn += ".service"
+	}
+
+	prop, err := p.dbusConn.GetServiceProperty(sn, "MainPID")
 	if err != nil {
 		return 0, errors.New("failed to read service", err)
 	}


### PR DESCRIPTION
Cherry-pick of PR #23496 to 7.11 branch. Original message:

## What does this PR do?

For some reason debian9 is not happy when quering service without `.service` suffix just by a service name. 
Adding that debian does not complain anymore

## Why is it important?

This prevents us from monitoring PID and checking agent crashes. If agent crashes constantly status checker will know and rollback instead of this crash checker, so i would not say it's that critical.

Fixes: #23488

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

