### PR TITLE
[Filebeat] Fix ASA/FTD Sample Log lines

### DIFF
--- a/x-pack/filebeat/module/cisco/asa/test/sample.log
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log
@@ -38,7 +38,7 @@ Apr 30 2013 09:23:43: %ASA-5-106100: access-list acl_in est-allowed tcp inside/1
 Apr 30 2013 09:23:43: %ASA-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.16(2013) -> outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]
 Apr 15 2018 09:34:34 EDT: %ASA-session-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2241) -> outside/192.0.0.99(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]
 Dec 11 2018 08:01:24 <IP>: %ASA-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)
-Dec 11 2018 08:01:24 <IP>: %ASA-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80port> (10.0.13.13/80)
+Dec 11 2018 08:01:24 <IP>: %ASA-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)
 Dec 11 2018 08:01:24 <IP>: %ASA-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group "dmz" [0x123a465e, 0x4c7bf613]
 Dec 11 2018 08:01:24 <IP>: %ASA-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group "dmz" [0x123a465e, 0x4c7bf613]
 Dec 11 2018 08:01:31 <IP>: %ASA-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)

--- a/x-pack/filebeat/module/cisco/ftd/test/sample.log
+++ b/x-pack/filebeat/module/cisco/ftd/test/sample.log
@@ -38,7 +38,7 @@ Apr 30 2013 09:23:43: %FTD-5-106100: access-list acl_in est-allowed tcp inside/1
 Apr 30 2013 09:23:43: %FTD-5-106100: access-list acl_in est-allowed tcp inside/10.0.0.16(2013) -> outside/192.0.0.89(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]
 Apr 15 2018 09:34:34 EDT: %FTD-session-5-106100: access-list acl_in permitted tcp inside/10.0.0.16(2241) -> outside/192.0.0.99(2000) hit-cnt 1 first hit [0x71a87d94, 0x0]
 Dec 11 2018 08:01:24 127.0.0.1: %FTD-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)
-Dec 11 2018 08:01:24 127.0.0.1: %FTD-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80port> (10.0.13.13/80)
+Dec 11 2018 08:01:24 127.0.0.1: %FTD-6-302015: Built outbound UDP connection 447235 for outside:192.168.77.12/11180 (192.168.77.12/11180) to identity:10.0.13.13/80 (10.0.13.13/80)
 Dec 11 2018 08:01:24 127.0.0.1: %FTD-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group "dmz" [0x123a465e, 0x4c7bf613]
 Dec 11 2018 08:01:24 127.0.0.1: %FTD-4-106023: Deny udp src dmz:192.168.1.33/5555 dst outside:192.0.0.12/53 by access-group "dmz" [0x123a465e, 0x4c7bf613]
 Dec 11 2018 08:01:31 127.0.0.1: %FTD-6-302013: Built outbound TCP connection 447236 for outside:192.0.2.222/1234 (192.0.2.222/1234) to dmz:OCSP_Server/5678 (OCSP_Server/5678)


### PR DESCRIPTION
<!-- Type of change
-->
- Bug
 
## What does this PR do?

Fixed malformed log sample on line 41 of ASA and FTD log samples (had text 'port>' at the end of the port number; shouldn't be there per cisco docs)

## Why is it important?
Prevent need to make changes to ingest parsing to account for bad log line
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
