### PR TITLE
Cherry-pick to 7.10: chore: rename variable for e2e (#23382)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -346,7 +346,7 @@ def triggerE2ETests(String suite) {
   ]
   if (isPR()) {
     def version = "pr-${env.CHANGE_ID}"
-    parameters.push(booleanParam(name: 'USE_CI_SNAPSHOTS', value: true))
+    parameters.push(booleanParam(name: 'BEATS_USE_CI_SNAPSHOTS', value: true))
     parameters.push(string(name: 'ELASTIC_AGENT_VERSION', value: "${version}"))
     parameters.push(string(name: 'METRICBEAT_VERSION', value: "${version}"))
   }


### PR DESCRIPTION
Backports the following commits to 7.10:
 - chore: rename variable for e2e (#23382)