### PR TITLE
Fix typo in input-httpjson.asciidoc

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -33,10 +33,10 @@ filebeat.inputs:
   config_version: 2
   interval: 1m
   request.url: https://api.ipify.org/?format=json
-  processors:
-    - decode_json_fields:
-        fields: [message]
-        target: json
+processors:
+- decode_json_fields:
+    fields: ["message"]
+    target: "json"
 ----
 
 ["source","yaml",subs="attributes"]
@@ -829,10 +829,10 @@ filebeat.inputs:
   cursor:
     last_requested_at:
       value: '[[now]]'
-  processors:
-    - decode_json_fields:
-        fields: [message]
-        target: json
+processors:
+- decode_json_fields:
+    fields: ["message"]
+    target: "json"
 ----
 
 [float]

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -33,10 +33,10 @@ filebeat.inputs:
   config_version: 2
   interval: 1m
   request.url: https://api.ipify.org/?format=json
-processors:
-- decode_json_fields:
-    fields: ["message"]
-    target: "json"
+  processors:
+  - decode_json_fields:
+      fields: ["message"]
+      target: "json"
 ----
 
 ["source","yaml",subs="attributes"]
@@ -829,10 +829,10 @@ filebeat.inputs:
   cursor:
     last_requested_at:
       value: '[[now]]'
-processors:
-- decode_json_fields:
-    fields: ["message"]
-    target: "json"
+  processors:
+  - decode_json_fields:
+      fields: ["message"]
+      target: "json"
 ----
 
 [float]

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -34,7 +34,7 @@ filebeat.inputs:
   interval: 1m
   request.url: https://api.ipify.org/?format=json
   processors:
-    - decode_json_fields
+    - decode_json_fields:
         fields: [message]
         target: json
 ----
@@ -830,7 +830,7 @@ filebeat.inputs:
     last_requested_at:
       value: '[[now]]'
   processors:
-    - decode_json_fields
+    - decode_json_fields:
         fields: [message]
         target: json
 ----

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -34,9 +34,9 @@ filebeat.inputs:
   interval: 1m
   request.url: https://api.ipify.org/?format=json
   processors:
-  - decode_json_fields:
-      fields: ["message"]
-      target: "json"
+    - decode_json_fields:
+        fields: ["message"]
+        target: "json"
 ----
 
 ["source","yaml",subs="attributes"]
@@ -830,9 +830,9 @@ filebeat.inputs:
     last_requested_at:
       value: '[[now]]'
   processors:
-  - decode_json_fields:
-      fields: ["message"]
-      target: "json"
+    - decode_json_fields:
+        fields: ["message"]
+        target: "json"
 ----
 
 [float]


### PR DESCRIPTION
This PR is to add the missing `:` in `input-httpjson.asciidoc`. 
