### PR TITLE
[Elastic Agent] Set status Failed if configuration applying fails

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -36,6 +36,7 @@
 - Fixed fetching DBus service PID {pull}23496[23496]
 - Fix issue of missing log messages from filebeat monitor {pull}23514[23514]
 - Increase checkin grace period to 30 seconds {pull}23568[23568]
+- Fix libbeat from reporting back degraded on config update {pull}23537[23537]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/core/plugin/process/status.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/status.go
@@ -35,9 +35,6 @@ func (a *Application) OnStatusChange(s *server.ApplicationState, status proto.St
 			return
 		}
 
-		// it was a crash, cleanup anything required
-		go a.cleanUp()
-
 		// kill the process
 		if a.state.ProcessInfo != nil {
 			_ = a.state.ProcessInfo.Process.Kill()

--- a/x-pack/libbeat/management/fleet/manager.go
+++ b/x-pack/libbeat/management/fleet/manager.go
@@ -169,7 +169,7 @@ func (cm *Manager) OnConfig(s string) {
 
 	if errs := cm.apply(blocks); !errs.IsEmpty() {
 		// `cm.apply` already logs the errors; currently allow beat to run degraded
-		cm.UpdateStatus(management.Degraded, errs.Error())
+		cm.UpdateStatus(management.Failed, errs.Error())
 		return
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adjusted `libbeat` to report the failure of reloading the configuration as failed.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this the running beat will stay degraded until the next configuration reload. If applying configuration fails then it is really an error and Elastic Agent should kill it and restart the beat (which it will do with this change).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #23518

