### PR TITLE
Recover x-pack Packetbeat packaging in 7.x

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -112,7 +112,7 @@ pipeline {
                    'x-pack/heartbeat',
                   // 'x-pack/journalbeat',
                   'x-pack/metricbeat',
-                  // 'x-pack/packetbeat',
+                  'x-pack/packetbeat',
                   'x-pack/winlogbeat'
                 )
               }

--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -16,11 +16,11 @@ projects:
     - "x-pack/functionbeat"
     - "x-pack/libbeat"
     - "x-pack/metricbeat"
+    - "x-pack/packetbeat"
     - "x-pack/winlogbeat"
     - "dev-tools"
     ##- "x-pack/heartbeat"    It's not yet in the 1.0 pipeline.
     ##- "x-pack/journalbeat"  It's not yet in the 1.0 pipeline.
-    ##- "x-pack/packetbeat"   It's not yet in the 1.0 pipeline.
 
 ## Changeset macros that are defined here and used in each specific 2.0 pipeline.
 changeset:


### PR DESCRIPTION
* Change in `.ci/packaging.groovy` had been done by #21979, but reverted possibly by mistake in #23142.
* Change in `Jenkinsfile.yml` (#22252) was never backported, not sure if this was intended.