### PR TITLE
fix index_closed_exception when there are frozen indices in cold …

### DIFF
--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -39,7 +39,7 @@ func init() {
 
 const (
 	statsMetrics = "docs,fielddata,indexing,merge,search,segments,store,refresh,query_cache,request_cache"
-	statsPath    = "/_stats/" + statsMetrics + "?filter_path=indices"
+	statsPath    = "/_stats/" + statsMetrics + "?filter_path=indices&forbid_closed_indices=false"
 )
 
 // MetricSet type defines all fields of the MetricSet

--- a/metricbeat/module/elasticsearch/index_summary/index_summary.go
+++ b/metricbeat/module/elasticsearch/index_summary/index_summary.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 const (
-	statsPath = "/_stats"
+	statsPath = "/_stats?forbid_closed_indices=false"
 )
 
 var (


### PR DESCRIPTION
…phase and be closed.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
fix `index_closed_exception` exception when there are frozen indices in cold phase and be closed.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
Config  elasticsearch  cluster `xpack.security.enabled` is `true` and  there is a index rollover to cold phase and be frozen, then close the index.  The request `GET /_stats` will return `index_closed_exception`, such as:
```json
{
  "error" : {
    "root_cause" : [
      {
        "type" : "index_closed_exception",
        "reason" : "closed",
        "index_uuid" : "uyMRLRtoSSacicGFA3ItJw",
        "index" : "frozen_close_index-000002"
      }
    ],
    "type" : "index_closed_exception",
    "reason" : "closed",
    "index_uuid" : "uyMRLRtoSSacicGFA3ItJw",
    "index" : "frozen_close_index-000002"
  },
  "status" : 400
}
```
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
