### PR TITLE
[CI] Run make notice linting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,7 @@ pipeline {
             whenTrue(env.ONLY_DOCS == 'false') {
               cmd(label: "make check-python", script: "make check-python")
               cmd(label: "make check-go", script: "make check-go")
+              cmd(label: "make notice", script: "make notice")
               cmd(label: "Check for changes", script: "make check-no-changes")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,6 @@ pipeline {
         dir("${BASE_DIR}"){
           // Skip all the stages except docs for PR's with asciidoc and md changes only
           setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true).toString())
-          setEnvVar('LICENSE_CHANGES', isGitRegionMatch(patterns: [ '^(go.mod|LICENSE.txt)' ], shouldMatchAll: false).toString())
           setEnvVar('GO_MOD_CHANGES', isGitRegionMatch(patterns: [ '^go.mod' ], shouldMatchAll: false).toString())
           setEnvVar('PACKAGING_CHANGES', isGitRegionMatch(patterns: [ '^dev-tools/packaging/.*' ], shouldMatchAll: false).toString())
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
@@ -75,7 +74,7 @@ pipeline {
           withBeatsEnv(archive: false, id: "lint") {
             dumpVariables()
             setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
-            whenTrue(env.ONLY_DOCS == 'true' || env.LICENSE_CHANGES == 'true') {
+            whenTrue(env.ONLY_DOCS == 'true') {
               cmd(label: "make check", script: "make check")
             }
             whenTrue(env.ONLY_DOCS == 'false') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
         dir("${BASE_DIR}"){
           // Skip all the stages except docs for PR's with asciidoc and md changes only
           setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true).toString())
+          setEnvVar('LICENSE_CHANGES', isGitRegionMatch(patterns: [ '^(go.mod|LICENSE.txt)' ], shouldMatchAll: false).toString())
           setEnvVar('GO_MOD_CHANGES', isGitRegionMatch(patterns: [ '^go.mod' ], shouldMatchAll: false).toString())
           setEnvVar('PACKAGING_CHANGES', isGitRegionMatch(patterns: [ '^dev-tools/packaging/.*' ], shouldMatchAll: false).toString())
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
@@ -74,7 +75,7 @@ pipeline {
           withBeatsEnv(archive: false, id: "lint") {
             dumpVariables()
             setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
-            whenTrue(env.ONLY_DOCS == 'true') {
+            whenTrue(env.ONLY_DOCS == 'true' || env.LICENSE_CHANGES == 'true') {
               cmd(label: "make check", script: "make check")
             }
             whenTrue(env.ONLY_DOCS == 'false') {


### PR DESCRIPTION
## What does this PR do?

@jsoriano pointed that the `make check` didn't run when go.mod changes:

> Beats keep a `NOTICE.txt` file with references to the copyright statements of third party libraries.
This file should be up-to-date with the libraries used, for that, CI should be able to detect changes in dependencies so we don't forget to update this file, and it used to.
Recently a new dependency was added in https://github.com/elastic/beats/pull/23484 (or https://github.com/elastic/beats/pull/22541), without updating the `NOTICE.txt` file, and CI didn't detect it. We found the issue when it was detected in other PRs like https://github.com/elastic/beats/pull/23536. This was fixed in https://github.com/elastic/beats/pull/23549.
So it seems that this is being detected in some PRs and not in others, we should be able to prevent these issues in CI as they can be important for license compliance, and to prevent us including dependencies on software with forbidden licenses.

## Why is it important?

Ensure there are no missing licenses in the NOTICE.txt file.