### PR TITLE
Cherry-pick #23536 to 7.x: Fix typo in input-httpjson.asciidoc

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -34,9 +34,9 @@ filebeat.inputs:
   interval: 1m
   request.url: https://api.ipify.org/?format=json
   processors:
-    - decode_json_fields
-        fields: [message]
-        target: json
+    - decode_json_fields:
+        fields: ["message"]
+        target: "json"
 ----
 
 ["source","yaml",subs="attributes"]
@@ -819,9 +819,9 @@ filebeat.inputs:
     last_requested_at:
       value: '[[now]]'
   processors:
-    - decode_json_fields
-        fields: [message]
-        target: json
+    - decode_json_fields:
+        fields: ["message"]
+        target: "json"
 ----
 
 [float]


### PR DESCRIPTION
Cherry-pick of PR #23536 to 7.x branch. Original message: 

This PR is to add the missing `:` in `input-httpjson.asciidoc`. 
