### PR TITLE
[Elastic Agent] [DONT MERGE] Add debug log for receiving configuration.

### DIFF
--- a/x-pack/libbeat/management/fleet/manager.go
+++ b/x-pack/libbeat/management/fleet/manager.go
@@ -140,6 +140,7 @@ func (cm *Manager) UpdateStatus(status management.Status, msg string) {
 }
 
 func (cm *Manager) OnConfig(s string) {
+	cm.logger.Debugf("Received configuration: %s\n", s)
 	cm.UpdateStatus(management.Configuring, "Updating configuration")
 
 	var configMap common.MapStr


### PR DESCRIPTION
Adds debug statement to write entire configuration to log file.

We are using this to track down a issue, this should **NOT** be merged.