### PR TITLE
[DOCS] Add setup content to Kubernetes and Cloud Foundry docs

### DIFF
--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -112,6 +112,36 @@ oc patch namespace kube-system -p \
 This command sets the node selector for the project to an empty string. If you
 don't run this command, the default node selector will skip master nodes.
 
+[float]
+==== Load {kib} dashboards
+
+{beatname_uc} comes packaged with example {kib} dashboards,
+visualizations, and searches for visualizing {beatname_uc} data in {kib}.
+
+
+Before you can use the dashboards, you need to create the index pattern,
++{beatname_lc}-*+, and load the dashboards into {kib}. To do this, run the `setup`
+command to load the recommended {ref}/indices-templates.html[index template]
+for writing to {es} and to deploy the sample dashboards for visualizing the data in {kib}.
+For details, see <<load-kibana-dashboards>>.
+
+Otherwise, you can
+<<configuration-dashboards,configure dashboard loading>> in the
++{beatname_lc}.yml+ config file.
+
+The `setup` command does not load the ingest pipelines used to parse log lines. By default, ingest pipelines
+are set up automatically the first time you run {beatname_uc} and connect to {es}.
+
+[IMPORTANT]
+=======================================
+If you are using a different output other than {es}, such as {ls}, you
+need to:
+
+* <<load-template-manually>>
+* <<load-kibana-dashboards>>
+* <<load-ingest-pipelines>>
+=======================================
+
 
 [float]
 ==== Deploy

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -115,19 +115,12 @@ don't run this command, the default node selector will skip master nodes.
 [float]
 ==== Load {kib} dashboards
 
-{beatname_uc} comes packaged with example {kib} dashboards,
-visualizations, and searches for visualizing {beatname_uc} data in {kib}.
+{beatname_uc} comes packaged with various pre-built {kib} dashboards
+that you can use to visualize logs from your Kubernetes environment.
 
-
-Before you can use the dashboards, you need to create the index pattern,
-+{beatname_lc}-*+, and load the dashboards into {kib}. To do this, run the `setup`
-command to load the recommended {ref}/indices-templates.html[index template]
-for writing to {es} and to deploy the sample dashboards for visualizing the data in {kib}.
-For details, see <<load-kibana-dashboards>>.
-
-Otherwise, you can
-<<configuration-dashboards,configure dashboard loading>> in the
-+{beatname_lc}.yml+ config file.
+If these dashboards are not already loaded into {kib}, you must <<{beatname_lc}-installation-configuration,install {beatname_uc}>>
+on any system that can connect to the {stack}, and then run the `setup` command to load the dashboards.
+To learn how, see <<load-kibana-dashboards,Load {kib} dashboards>>.
 
 The `setup` command does not load the ingest pipelines used to parse log lines. By default, ingest pipelines
 are set up automatically the first time you run {beatname_uc} and connect to {es}.
@@ -141,7 +134,6 @@ need to:
 * <<load-kibana-dashboards>>
 * <<load-ingest-pipelines>>
 =======================================
-
 
 [float]
 ==== Deploy

--- a/libbeat/docs/howto/load-dashboards.asciidoc
+++ b/libbeat/docs/howto/load-dashboards.asciidoc
@@ -15,98 +15,44 @@
 ifdef::has_solutions[]
 TIP: For deeper observability into your infrastructure, you can use the
 {metrics-app} and the {logs-app} in {kib}.
-For more details, see {observability-guide}/analyze-metrics.html[Analyze metrics]
-and {observability-guide}/monitor-logs.html[Monitor logs].
+For more details, see {observability-guide}/analyze-metrics.html[Metrics monitoring]
+and {observability-guide}/monitor-logs.html[Log monitoring].
 endif::has_solutions[]
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
 and searches for visualizing {beatname_uc} data in Kibana. Before you can use
 the dashboards, you need to create the index pattern, +{beat_default_index_prefix}-*+, and
-load the dashboards into Kibana. To do this, you can either run the `setup`
+load the dashboards into Kibana.
+
+To do this, you can either run the `setup`
 command (as described here) or
 <<configuration-dashboards,configure dashboard loading>> in the
-+{beatname_lc}.yml+ config file.
-
-This requires a Kibana endpoint configuration. If you didn't already configure
++{beatname_lc}.yml+ config file. This requires a Kibana endpoint configuration. If you didn't already configure
 a Kibana endpoint, see <<setup-kibana-endpoint>>.
+
+[float]
+[[load-dashboards]]
+=== Load dashboards
 
 Make sure Kibana is running before you perform this step. If you are accessing a
 secured Kibana instance, make sure you've configured credentials as described in
 the <<{beatname_lc}-installation-configuration>>.
 
-To set up the Kibana dashboards for {beatname_uc}, use the appropriate command
-for your system. The command shown here loads the dashboards from the {beatname_uc}
-package. For more options, such as loading customized dashboards, see
-{beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards] in
-the _Beats Developer Guide_.
-ifndef::no-output-logstash[]
-If you've configured the Logstash output, see
-<<load-dashboards-logstash>>.
-endif::[]
+To load the recommended index template for writing to {es} and deploy the sample dashboards
+for visualizing the data in {kib}, use the command that works with your system.
 
 ifdef::requires-sudo[]
 include::{libbeat-dir}/shared-note-sudo.asciidoc[]
 endif::requires-sudo[]
 
-ifdef::deb_os,rpm_os[]
-*deb and rpm:*
+include::{libbeat-dir}/tab-widgets/load-dashboards-widget.asciidoc[]
 
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-{beatname_lc} setup --dashboards
-----------------------------------------------------------------------
-endif::deb_os,rpm_os[]
-
-ifdef::mac_os[]
-*mac:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-./{beatname_lc} setup --dashboards
-----------------------------------------------------------------------
-
-*brew:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-{beatname_lc} setup --dashboards
-----------------------------------------------------------------------
-endif::mac_os[]
-
-ifdef::linux_os[]
-*linux:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-./{beatname_lc} setup --dashboards
-----------------------------------------------------------------------
-endif::linux_os[]
-
-ifdef::docker_platform[]
-*docker:*
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-docker run --net="host" {dockerimage} setup --dashboards
-----------------------------------------------------------------------
-endif::docker_platform[]
-
-ifdef::win_os[]
-ifndef::win_only[]
-*win:*
-endif::win_only[]
-
-Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*).
-
-From the PowerShell prompt, change to the directory where you installed {beatname_uc},
-and run:
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-PS > .{backslash}{beatname_lc}.exe setup --dashboards
-----------------------------------------------------------------------
-endif::win_os[]
+For more options, such as loading customized dashboards, see
+{beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards].
+ifndef::no-output-logstash[]
+If you've configured the Logstash output, see
+<<load-dashboards-logstash>>.
+endif::[]
 
 ifndef::no-output-logstash[]
 [float]
@@ -128,95 +74,9 @@ ifdef::serverless[]
 in environment variables.
 endif::[]
 
-ifdef::deb_os,rpm_os[]
-*deb and rpm:*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} setup -e \
-  -E output.logstash.enabled=false \
-  -E output.elasticsearch.hosts=['localhost:9200'] \
-  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
-  -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601
-----
-endif::deb_os,rpm_os[]
-
-ifdef::mac_os[]
-*mac:*
-
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} setup -e \
-  -E output.logstash.enabled=false \
-  -E output.elasticsearch.hosts=['localhost:9200'] \
-  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
-  -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601
-----
-
-*brew:*
-
-["source","sh",subs="attributes"]
-----
-{beatname_lc} setup -e \
-  -E output.logstash.enabled=false \
-  -E output.elasticsearch.hosts=['localhost:9200'] \
-  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
-  -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601
-----
-endif::mac_os[]
-
-ifdef::linux_os[]
-*linux:*
-
-["source","sh",subs="attributes"]
-----
-./{beatname_lc} setup -e \
-  -E output.logstash.enabled=false \
-  -E output.elasticsearch.hosts=['localhost:9200'] \
-  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
-  -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601
-----
-endif::linux_os[]
-
-ifdef::docker_platform[]
-*docker:*
-
-["source","sh",subs="attributes"]
-----
-docker run --net="host" {dockerimage} setup -e \
-  -E output.logstash.enabled=false \
-  -E output.elasticsearch.hosts=['localhost:9200'] \
-  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
-  -E output.elasticsearch.password={pwd} \
-  -E setup.kibana.host=localhost:5601
-----
-endif::docker_platform[]
-
-ifdef::win_os[]
-ifndef::win_only[]
-*win:*
-endif::win_only[]
-
-Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
-and select *Run As Administrator*).
-
-From the PowerShell prompt, change to the directory where you installed {beatname_uc},
-and run:
-
-["source","sh",subs="attributes"]
-----
-PS > .{backslash}{beatname_lc}.exe setup -e `
-  -E output.logstash.enabled=false `
-  -E output.elasticsearch.hosts=['localhost:9200'] `
-  -E output.elasticsearch.username={beat_default_index_prefix}_internal `
-  -E output.elasticsearch.password={pwd} `
-  -E setup.kibana.host=localhost:5601
-----
-endif::win_os[]
-
 endif::no-output-logstash[]
 
+include::{libbeat-dir}/tab-widgets/load-dashboards-logstash-widget.asciidoc[]
+
+// Add Javascript and CSS for tabbed panels
+include::{libbeat-dir}/tab-widgets/code.asciidoc[]

--- a/libbeat/docs/shared-cloudfoundry.asciidoc
+++ b/libbeat/docs/shared-cloudfoundry.asciidoc
@@ -53,6 +53,42 @@ curl -L -O https://raw.githubusercontent.com/elastic/beats/{branch}/deploy/cloud
 You need to modify the +{beatname_lc}.yml+ file to set the `api_address`,
 `client_id` and `client_secret`.
 
+==== Load {kib} dashboards
+
+{beatname_uc} comes packaged with example {kib} dashboards,
+visualizations, and searches for visualizing {beatname_uc} data in {kib}.
+
+Before you can use the dashboards, you need to create the index pattern,
++{beatname_lc}-*+, and load the dashboards into {kib}. To do this, run the `setup`
+command to load the recommended {ref}/indices-templates.html[index template]
+for writing to {es} and to deploy the sample dashboards for visualizing the data in {kib}.
+For details, see <<load-kibana-dashboards>>.
+
+Otherwise, you can
+<<configuration-dashboards,configure dashboard loading>> in the
++{beatname_lc}.yml+ config file.
+
+ifeval::["{beatname_lc}"=="metricbeat"]
+[IMPORTANT]
+=======================================
+If you are using a different output other than {es}, such as {ls}, you
+need to <<load-template-manually>> and <<load-kibana-dashboards>>.
+=======================================
+endif::[]
+ifeval::["{beatname_lc}"=="filebeat"]
+The `setup` command does not load the ingest pipelines used to parse log lines. By default, ingest pipelines
+are set up automatically the first time you run {beatname_uc} and connect to {es}.
+
+[IMPORTANT]
+=======================================
+If you are using a different output other than {es}, such as {ls}, you
+need to:
+
+* <<load-template-manually>>
+* <<load-kibana-dashboards>>
+* <<load-ingest-pipelines>>
+=======================================
+endif::[]
 
 ==== Deploy {beatname_uc}
 

--- a/libbeat/docs/shared-cloudfoundry.asciidoc
+++ b/libbeat/docs/shared-cloudfoundry.asciidoc
@@ -55,18 +55,11 @@ You need to modify the +{beatname_lc}.yml+ file to set the `api_address`,
 
 ==== Load {kib} dashboards
 
-{beatname_uc} comes packaged with example {kib} dashboards,
-visualizations, and searches for visualizing {beatname_uc} data in {kib}.
+{beatname_uc} comes packaged with various pre-built {kib} dashboards
+that you can use to visualize data in {kib}.
 
-Before you can use the dashboards, you need to create the index pattern,
-+{beatname_lc}-*+, and load the dashboards into {kib}. To do this, run the `setup`
-command to load the recommended {ref}/indices-templates.html[index template]
-for writing to {es} and to deploy the sample dashboards for visualizing the data in {kib}.
-For details, see <<load-kibana-dashboards>>.
-
-Otherwise, you can
-<<configuration-dashboards,configure dashboard loading>> in the
-+{beatname_lc}.yml+ config file.
+If these dashboards are not already loaded into {kib}, you must run the {beatname_uc} `setup` command.
+To learn how, see <<load-kibana-dashboards,Load {kib} dashboards>>.
 
 ifeval::["{beatname_lc}"=="metricbeat"]
 [IMPORTANT]

--- a/libbeat/docs/tab-widgets/load-dashboards-logstash-widget.asciidoc
+++ b/libbeat/docs/tab-widgets/load-dashboards-logstash-widget.asciidoc
@@ -1,0 +1,130 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Load dashboards Logstash">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-dashboards-logstash"
+            id="deb-dashboards-logstash">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-dashboards-logstash"
+            id="rpm-dashboards-logstash"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-dashboards-logstash"
+            id="mac-dashboards-logstash"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-dashboards-logstash"
+            id="brew-dashboards-logstash"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-dashboards-logstash"
+            id="linux-dashboards-logstash"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="docker-tab-dashboards-logstash"
+            id="docker-dashboards-logstash"
+            tabindex="-1">
+      Docker
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-dashboards-logstash"
+            id="win-dashboards-logstash"
+            tabindex="-1">            
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-dashboards-logstash"
+       aria-labelledby="deb-dashboards-logstash">
+++++
+
+include::load-dashboards-logstash.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-dashboards-logstash"
+       aria-labelledby="rpm-dashboards-logstash"
+       hidden="">
+++++
+
+include::load-dashboards-logstash.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-dashboards-logstash"
+       aria-labelledby="mac-dashboards-logstash"
+       hidden="">
+++++
+
+include::load-dashboards-logstash.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-dashboards-logstash"
+       aria-labelledby="brew-dashboards-logstash"
+       hidden="">
+++++
+
+include::load-dashboards-logstash.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-dashboards-logstash"
+       aria-labelledby="linux-dashboards-logstash"
+       hidden="">
+++++
+
+include::load-dashboards-logstash.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-tab-dashboards-logstash"
+       aria-labelledby="docker-dashboards-logstash"
+       hidden="">
+++++
+
+include::load-dashboards-logstash.asciidoc[tag=docker]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="win-tab-dashboards-logstash"
+       aria-labelledby="win-dashboards-logstash"
+       hidden="">
+++++
+
+include::load-dashboards-logstash.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/load-dashboards-logstash.asciidoc
+++ b/libbeat/docs/tab-widgets/load-dashboards-logstash.asciidoc
@@ -1,0 +1,88 @@
+// tag::deb[]
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+// end::deb[]
+
+// tag::rpm[]
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+// end::rpm[]
+
+// tag::mac[]
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+// end::mac[]
+
+// tag::brew[]
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+// end::brew[]
+
+// tag::linux[]
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+// end::linux[]
+
+// tag::docker[]
+["source","sh",subs="attributes"]
+----
+docker run --net="host" {dockerimage} setup -e \
+  -E output.logstash.enabled=false \
+  -E output.elasticsearch.hosts=['localhost:9200'] \
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal \
+  -E output.elasticsearch.password={pwd} \
+  -E setup.kibana.host=localhost:5601
+----
+// end::docker[]
+
+// tag::win[]
+
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*).
+
+From the PowerShell prompt, change to the directory where you installed {beatname_uc}, and run:
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe setup -e `
+  -E output.logstash.enabled=false `
+  -E output.elasticsearch.hosts=['localhost:9200'] `
+  -E output.elasticsearch.username={beat_default_index_prefix}_internal `
+  -E output.elasticsearch.password={pwd} `
+  -E setup.kibana.host=localhost:5601
+----
+// end::win[]

--- a/libbeat/docs/tab-widgets/load-dashboards-widget.asciidoc
+++ b/libbeat/docs/tab-widgets/load-dashboards-widget.asciidoc
@@ -1,0 +1,130 @@
+++++
+<div class="tabs" data-tab-group="os">
+  <div role="tablist" aria-label="Load dashboards">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="deb-tab-load-dashboards"
+            id="deb-load-dashboards">
+      DEB
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="rpm-tab-load-dashboards"
+            id="rpm-load-dashboards"
+            tabindex="-1">
+      RPM
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="mac-tab-load-dashboards"
+            id="mac-load-dashboards"
+            tabindex="-1">
+      MacOS
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="brew-tab-load-dashboards"
+            id="brew-load-dashboards"
+            tabindex="-1">
+      Brew
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="linux-tab-load-dashboards"
+            id="linux-load-dashboards"
+            tabindex="-1">
+      Linux
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="docker-tab-load-dashboards"
+            id="docker-load-dashboards"
+            tabindex="-1">
+      Docker
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="win-tab-load-dashboards"
+            id="win-load-dashboards"
+            tabindex="-1">            
+      Windows
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="deb-tab-load-dashboards"
+       aria-labelledby="deb-load-dashboards">
+++++
+
+include::load-dashboards.asciidoc[tag=deb]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="rpm-tab-load-dashboards"
+       aria-labelledby="rpm-load-dashboards"
+       hidden="">
+++++
+
+include::load-dashboards.asciidoc[tag=rpm]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="mac-tab-load-dashboards"
+       aria-labelledby="mac-load-dashboards"
+       hidden="">
+++++
+
+include::load-dashboards.asciidoc[tag=mac]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="brew-tab-load-dashboards"
+       aria-labelledby="brew-load-dashboards"
+       hidden="">
+++++
+
+include::load-dashboards.asciidoc[tag=brew]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="linux-tab-load-dashboards"
+       aria-labelledby="linux-load-dashboards"
+       hidden="">
+++++
+
+include::load-dashboards.asciidoc[tag=linux]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="docker-tab-load-dashboards"
+       aria-labelledby="docker-load-dashboards"
+       hidden="">
+++++
+
+include::load-dashboards.asciidoc[tag=docker]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"v
+       id="win-tab-load-dashboards"
+       aria-labelledby="win-load-dashboards"
+       hidden="">
+++++
+
+include::load-dashboards.asciidoc[tag=win]
+
+++++
+  </div>
+</div>
+++++

--- a/libbeat/docs/tab-widgets/load-dashboards.asciidoc
+++ b/libbeat/docs/tab-widgets/load-dashboards.asciidoc
@@ -1,0 +1,55 @@
+// tag::deb[]
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup --dashboards
+----
+// end::deb[]
+
+// tag::rpm[]
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup --dashboards
+----
+// end::rpm[]
+
+// tag::mac[]
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup --dashboards
+----
+// end::mac[]
+
+// tag::brew[]
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup --dashboards
+----
+// end::brew[]
+
+// tag::linux[]
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup --dashboards
+----
+// end::linux[]
+
+// tag::docker[]
+["source","sh",subs="attributes"]
+----
+docker run --net="host" {dockerimage} setup --dashboards
+----
+// end::docker[]
+
+// tag::win[]
+
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*).
+
+From the PowerShell prompt, change to the directory where you installed {beatname_uc},
+and run:
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe setup --dashboards
+----
+// end::win[]

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -170,6 +170,29 @@ This command sets the node selector for the project to an empty string. If you
 don't run this command, the default node selector will skip master nodes.
 
 [float]
+==== Load {kib} dashboards
+
+{beatname_uc} comes packaged with example {kib} dashboards,
+visualizations, and searches for visualizing {beatname_uc} data in {kib}.
+
+
+Before you can use the dashboards, you need to create the index pattern,
++{beatname_lc}-*+, and load the dashboards into {kib}. To do this, run the `setup`
+command to load the recommended {ref}/indices-templates.html[index template]
+for writing to {es} and to deploy the sample dashboards for visualizing the data in {kib}.
+For details, see <<load-kibana-dashboards>>.
+
+Otherwise, you can
+<<configuration-dashboards,configure dashboard loading>> in the
++{beatname_lc}.yml+ config file.
+
+[IMPORTANT]
+=======================================
+If you are using a different output other than {es}, such as {ls}, you
+need to <<load-template-manually>> and <<load-kibana-dashboards>>.
+=======================================
+
+[float]
 ==== Deploy
 
 Metricbeat gets some metrics from https://github.com/kubernetes/kube-state-metrics#usage[kube-state-metrics].

--- a/metricbeat/docs/running-on-kubernetes.asciidoc
+++ b/metricbeat/docs/running-on-kubernetes.asciidoc
@@ -172,19 +172,12 @@ don't run this command, the default node selector will skip master nodes.
 [float]
 ==== Load {kib} dashboards
 
-{beatname_uc} comes packaged with example {kib} dashboards,
-visualizations, and searches for visualizing {beatname_uc} data in {kib}.
+{beatname_uc} comes packaged with various pre-built {kib} dashboards
+that you can use to visualize metrics about your Kubernetes environment.
 
-
-Before you can use the dashboards, you need to create the index pattern,
-+{beatname_lc}-*+, and load the dashboards into {kib}. To do this, run the `setup`
-command to load the recommended {ref}/indices-templates.html[index template]
-for writing to {es} and to deploy the sample dashboards for visualizing the data in {kib}.
-For details, see <<load-kibana-dashboards>>.
-
-Otherwise, you can
-<<configuration-dashboards,configure dashboard loading>> in the
-+{beatname_lc}.yml+ config file.
+If these dashboards are not already loaded into {kib}, you must <<{beatname_lc}-installation-configuration,install {beatname_uc}>>
+on any system that can connect to the {stack}, and then run the `setup` command to load the dashboards. To learn how,
+see <<load-kibana-dashboards,Load {kib} dashboards>>.
 
 [IMPORTANT]
 =======================================


### PR DESCRIPTION
## Summary

This PR adds the setup content to both the Kubernetes and Cloud Foundry docs for Filebeat and Metricbeat.

The PR also adds the tabbed widgets to the Load Kibana dashboards topic. 

**NOTE**: In a follow-up PR, I plan to single-source the Kubernetes content for both the Filebeat and Metricbeat docs. 

### HTML preview

**Run Filebeat on Cloud Foundry**: https://beats_23580.docs-preview.app.elstc.co/guide/en/beats/filebeat/master/running-on-cloudfoundry.html

**Run Metricbeat on Cloud Foundry**: https://beats_23580.docs-preview.app.elstc.co/guide/en/beats/metricbeat/master/running-on-cloudfoundry.html

**Run Filebeat on Kubernetes**: https://beats_23580.docs-preview.app.elstc.co/guide/en/beats/filebeat/master/running-on-kubernetes.html

**Run Metricbeat on Kubernetes**: https://beats_23580.docs-preview.app.elstc.co/guide/en/beats/metricbeat/master/running-on-kubernetes.html

**Load Kibana dashboards**: https://beats_23580.docs-preview.app.elstc.co/guide/en/beats/auditbeat/master/load-kibana-dashboards.html


## Related issue

Closes https://github.com/elastic/beats/issues/22772