### PR TITLE
Cherry-pick #23579 to 7.x: Fix flaky TestConfigurable* unit tests 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -100,6 +100,16 @@ func TestConfigurableRun(t *testing.T) {
 		return nil
 	})
 
+	// wait to finish configuring
+	waitFor(t, func() error {
+		items := operator.State()
+		item, ok := items[p.ID()]
+		if ok && item.Status == state.Configuring {
+			return fmt.Errorf("process still configuring")
+		}
+		return nil
+	})
+
 	items := operator.State()
 	item0, ok := items[p.ID()]
 	if !ok || item0.Status != state.Running {
@@ -379,8 +389,6 @@ func TestConfigurableStartStop(t *testing.T) {
 }
 
 func TestConfigurableService(t *testing.T) {
-	t.Skipf("flaky see https://github.com/elastic/beats/issues/20836")
-
 	p := getProgram("serviceable", "1.0")
 
 	operator := getTestOperator(t, downloadPath, installPath, p)
@@ -423,6 +431,16 @@ func TestConfigurableService(t *testing.T) {
 	waitFor(t, func() error {
 		if s, err := os.Stat(tstFilePath); err != nil || s == nil {
 			return fmt.Errorf("failed to create a file using Config call %s", tstFilePath)
+		}
+		return nil
+	})
+
+	// wait to finish configuring
+	waitFor(t, func() error {
+		items := operator.State()
+		item, ok := items[p.ID()]
+		if ok && item.Status == state.Configuring {
+			return fmt.Errorf("process still configuring")
 		}
 		return nil
 	})


### PR DESCRIPTION
Cherry-pick of PR #23579 to 7.x branch. Original message:

## What does this PR do?

This PR adds a waitFor clause to `TestConfigurableRun` and `TestConfigurableService` tests.
Sometimes it happened that we were checking if process is not running anymore by checking `state != Running` but the process was (due to heavier load on the CI machine) still in the Configuring state. This condition then evaluated that process is not running and failed test.

Now we perform this check after we verify that status exited Configuring.

As i'm reenabling `TestConfigurableService` i will rekick tests multiple times and watch weekly failures mail.

## Why is it important?

Flaky tests #20836

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
