### PR TITLE
Add support for ARM64 Docker images for all Beats

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -157,7 +157,7 @@ pipeline {
                 }
               }
               stage('Package Docker images for linux/arm64'){
-                agent { label 'worker-0eaeecf32aca4fe3a' } // TODO: use 'arm' once the problem has been fixed in all the ARM workers.
+                agent { label 'arm' }
                 options { skipDefaultCheckout() }
                 when {
                   beforeAgent true

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -172,7 +172,7 @@ pipeline {
                   ].join(' ')
                 }
                 steps {
-                  withGithubNotify(context: "Packaging Linux ${BEATS_FOLDER}") {
+                  withGithubNotify(context: "Packaging linux/arm64 ${BEATS_FOLDER}") {
                     deleteDir()
                     release()
                     pushCIDockerImages()

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -204,7 +204,6 @@ pipeline {
                   'packetbeat',
                   'x-pack/auditbeat',
                   'x-pack/elastic-agent',
-                  'x-pack/dockerlogbeat',
                   'x-pack/filebeat',
                   'x-pack/heartbeat',
                   'x-pack/metricbeat',

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -156,36 +156,6 @@ pipeline {
                   prepareE2ETestForPackage("${BEATS_FOLDER}")
                 }
               }
-              stage('Package Docker images for linux/arm64'){
-                agent { label 'arm' }
-                options { skipDefaultCheckout() }
-                when {
-                  beforeAgent true
-                  expression {
-                    return params.arm
-                  }
-                }
-                environment {
-                  HOME = "${env.WORKSPACE}"
-                  PACKAGES = "docker"
-                  PLATFORMS = [
-                    'linux/arm64',
-                  ].join(' ')
-                }
-                steps {
-                  withGithubNotify(context: "Packaging linux/arm64 ${BEATS_FOLDER}") {
-                    deleteWorkspace()
-                    release()
-                    pushCIDockerImages()
-                  }
-                }
-                post {
-                  always {
-                    // static workers require this
-                    deleteWorkspace()
-                  }
-                }
-              }
               stage('Package Mac OS'){
                 agent { label 'macosx-10.12' }
                 options { skipDefaultCheckout() }
@@ -208,6 +178,62 @@ pipeline {
                     withMacOSEnv(){
                       release()
                     }
+                  }
+                }
+                post {
+                  always {
+                    // static workers require this
+                    deleteWorkspace()
+                  }
+                }
+              }
+            }
+          }
+        }
+        stage('Build Packages ARM'){
+          matrix {
+            axes {
+              axis {
+                name 'BEATS_FOLDER'
+                values (
+                  'auditbeat',
+                  'filebeat',
+                  'heartbeat',
+                  'journalbeat',
+                  'metricbeat',
+                  'packetbeat',
+                  'x-pack/auditbeat',
+                  'x-pack/elastic-agent',
+                  'x-pack/dockerlogbeat',
+                  'x-pack/filebeat',
+                  'x-pack/heartbeat',
+                  'x-pack/metricbeat',
+                  'x-pack/packetbeat'
+                )
+              }
+            }
+            stages {
+              stage('Package Docker images for linux/arm64'){
+                agent { label 'arm' }
+                options { skipDefaultCheckout() }
+                when {
+                  beforeAgent true
+                  expression {
+                    return params.arm
+                  }
+                }
+                environment {
+                  HOME = "${env.WORKSPACE}"
+                  PACKAGES = "docker"
+                  PLATFORMS = [
+                    'linux/arm64',
+                  ].join(' ')
+                }
+                steps {
+                  withGithubNotify(context: "Packaging linux/arm64 ${BEATS_FOLDER}") {
+                    deleteWorkspace()
+                    release()
+                    pushCIDockerImages()
                   }
                 }
                 post {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -174,7 +174,7 @@ pipeline {
                 }
                 steps {
                   withGithubNotify(context: "Packaging linux/arm64 ${BEATS_FOLDER}") {
-                    deleteDir()
+                    deleteWorkspace()
                     release()
                     pushCIDockerImages()
                   }
@@ -182,7 +182,7 @@ pipeline {
                 post {
                   always {
                     // static workers require this
-                    deleteDir()
+                    deleteWorkspace()
                   }
                 }
               }
@@ -204,7 +204,7 @@ pipeline {
                 }
                 steps {
                   withGithubNotify(context: "Packaging MacOS ${BEATS_FOLDER}") {
-                    deleteDir()
+                    deleteWorkspace()
                     withMacOSEnv(){
                       release()
                     }
@@ -213,7 +213,7 @@ pipeline {
                 post {
                   always {
                     // static workers require this
-                    deleteDir()
+                    deleteWorkspace()
                   }
                 }
               }
@@ -454,6 +454,24 @@ def withBeatsEnv(Closure body) {
       dir("${env.BASE_DIR}"){
         body()
       }
+    }
+  }
+}
+
+/**
+* This method fixes the filesystem permissions after the build has happenend. The reason is to
+* ensure any non-ephemeral workers don't have any leftovers that could cause some environmental
+* issues.
+*/
+def deleteWorkspace() {
+  if(isUnix()) {
+    catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
+      sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+        set +x
+        source ./dev-tools/common.bash
+        docker_setup
+        script/fix_permissions.sh ${WORKSPACE}""", returnStatus: true)
+      deleteDir()
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -466,11 +466,13 @@ def withBeatsEnv(Closure body) {
 def deleteWorkspace() {
   if(isUnix()) {
     catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
-      sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
-        set +x
-        source ./dev-tools/common.bash
-        docker_setup
-        script/fix_permissions.sh ${WORKSPACE}""", returnStatus: true)
+      dir("${env.BASE_DIR}") {
+        sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+          set +x
+          source ./dev-tools/common.bash
+          docker_setup
+          script/fix_permissions.sh ${WORKSPACE}""", returnStatus: true)
+      }
       deleteDir()
     }
   }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -174,7 +174,7 @@ pipeline {
                 }
                 steps {
                   withGithubNotify(context: "Packaging linux/arm64 ${BEATS_FOLDER}") {
-                    deleteWorkspace()
+                    deleteDir()
                     release()
                     pushCIDockerImages()
                   }
@@ -182,7 +182,7 @@ pipeline {
                 post {
                   always {
                     // static workers require this
-                    deleteWorkspace()
+                    deleteDir()
                   }
                 }
               }
@@ -204,7 +204,7 @@ pipeline {
                 }
                 steps {
                   withGithubNotify(context: "Packaging MacOS ${BEATS_FOLDER}") {
-                    deleteWorkspace()
+                    deleteDir()
                     withMacOSEnv(){
                       release()
                     }
@@ -213,7 +213,7 @@ pipeline {
                 post {
                   always {
                     // static workers require this
-                    deleteWorkspace()
+                    deleteDir()
                   }
                 }
               }
@@ -454,24 +454,6 @@ def withBeatsEnv(Closure body) {
       dir("${env.BASE_DIR}"){
         body()
       }
-    }
-  }
-}
-
-/**
-* This method fixes the filesystem permissions after the build has happenend. The reason is to
-* ensure any non-ephemeral workers don't have any leftovers that could cause some environmental
-* issues.
-*/
-def deleteWorkspace() {
-  if(isUnix()) {
-    catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
-      sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
-        set +x
-        source ./dev-tools/common.bash
-        docker_setup
-        script/fix_permissions.sh ${WORKSPACE}""", returnStatus: true)
-      deleteDir()
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -467,11 +467,13 @@ def deleteWorkspace() {
   if(isUnix()) {
     catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
       dir("${env.BASE_DIR}") {
-        sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
-          set +x
-          source ./dev-tools/common.bash
-          docker_setup
-          script/fix_permissions.sh ${WORKSPACE}""", returnStatus: true)
+        if (fileExists('script/fix_permissions.sh')) {
+          sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+            set +x
+            source ./dev-tools/common.bash
+            docker_setup
+            script/fix_permissions.sh ${WORKSPACE}""", returnStatus: true)
+        }
       }
       deleteDir()
     }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -156,7 +156,7 @@ pipeline {
                 }
               }
               stage('Package Docker images for linux/arm64'){
-                agent { label 'arm' }
+                agent { label 'worker-0eaeecf32aca4fe3a' } // TODO: use 'arm' once the problem has been fixed in all the ARM workers.
                 options { skipDefaultCheckout() }
                 when {
                   beforeAgent true

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -472,6 +472,7 @@ def getBeatsName(baseDir) {
 
 def withBeatsEnv(Closure body) {
   unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+  fixPermissions()
   withMageEnv(){
     withEnv([
       "PYTHON_ENV=${WORKSPACE}/python-env"
@@ -489,6 +490,13 @@ def withBeatsEnv(Closure body) {
 * issues.
 */
 def deleteWorkspace() {
+  catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
+    fixPermissions()
+    deleteDir()
+  }
+}
+
+def fixPermissions() {
   if(isUnix()) {
     catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
       dir("${env.BASE_DIR}") {
@@ -500,7 +508,6 @@ def deleteWorkspace() {
             script/fix_permissions.sh ${WORKSPACE}""", returnStatus: true)
         }
       }
-      deleteDir()
     }
   }
 }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -161,7 +161,7 @@ pipeline {
                 when {
                   beforeAgent true
                   expression {
-                    return params.linux
+                    return params.arm
                   }
                 }
                 environment {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -177,7 +177,6 @@ pipeline {
                     release()
                     pushCIDockerImages()
                   }
-                  prepareE2ETestForPackage("${BEATS_FOLDER}")
                 }
               }
               stage('Package Mac OS'){

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -179,6 +179,12 @@ pipeline {
                     pushCIDockerImages()
                   }
                 }
+                post {
+                  always {
+                    // static workers require this
+                    deleteDir()
+                  }
+                }
               }
               stage('Package Mac OS'){
                 agent { label 'macosx-10.12' }
@@ -202,6 +208,12 @@ pipeline {
                     withMacOSEnv(){
                       release()
                     }
+                  }
+                }
+                post {
+                  always {
+                    // static workers require this
+                    deleteDir()
                   }
                 }
               }

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -92,6 +92,7 @@ func GolangCrossBuild(params BuildArgs) error {
 	}
 
 	defer DockerChown(filepath.Join(params.OutputDir, params.Name+binaryExtension(GOOS)))
+	defer DockerChown(filepath.Join(params.OutputDir))
 	return Build(params)
 }
 

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -208,6 +208,9 @@ func crossBuildImage(platform string) (string, error) {
 		tagSuffix = "darwin"
 	case strings.HasPrefix(platform, "linux/arm"):
 		tagSuffix = "arm"
+		if runtime.GOARCH == "arm" {
+			tagSuffix = "main-arm"
+		}
 	case strings.HasPrefix(platform, "linux/mips"):
 		tagSuffix = "mips"
 	case strings.HasPrefix(platform, "linux/ppc"):

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -208,8 +208,9 @@ func crossBuildImage(platform string) (string, error) {
 		tagSuffix = "darwin"
 	case strings.HasPrefix(platform, "linux/arm"):
 		tagSuffix = "arm"
+		fmt.Println(runtime.GOARCH)
 		if runtime.GOARCH == "arm" {
-			tagSuffix = "main-arm"
+			tagSuffix = "main-arm-debian9"
 		}
 	case strings.HasPrefix(platform, "linux/mips"):
 		tagSuffix = "mips"

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -189,10 +189,6 @@ func CrossBuildXPack(options ...CrossBuildOption) error {
 // mage -compile is done only once rather than in each Docker container.
 func buildMage() error {
 	arch := runtime.GOARCH
-	if arch == "" {
-		return fmt.Errorf("architecture value cannot be empty")
-	}
-
 	return sh.RunWith(map[string]string{"CGO_ENABLED": "0"}, "mage", "-f", "-goos=linux", "-goarch="+arch,
 		"-compile", CreateDir(filepath.Join("build", "mage-linux-"+arch)))
 }

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -43,10 +43,25 @@ const defaultCrossBuildTarget = "golangCrossBuild"
 // See NewPlatformList for details about platform filtering expressions.
 var Platforms = BuildPlatforms.Defaults()
 
+// Types is the list of package types
+var SelectedPackageTypes []PackageType
+
 func init() {
 	// Allow overriding via PLATFORMS.
 	if expression := os.Getenv("PLATFORMS"); len(expression) > 0 {
 		Platforms = NewPlatformList(expression)
+	}
+
+	// Allow overriding via PACKAGES.
+	if packageTypes := os.Getenv("PACKAGES"); len(packageTypes) > 0 {
+		for _, pkgtype := range strings.Split(packageTypes, ",") {
+			var p PackageType
+			err := p.UnmarshalText([]byte(pkgtype))
+			if err != nil {
+				continue
+			}
+			SelectedPackageTypes = append(SelectedPackageTypes, p)
+		}
 	}
 }
 

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -184,14 +184,11 @@ func CrossBuildXPack(options ...CrossBuildOption) error {
 	return CrossBuild(o...)
 }
 
-func buildMage() error {
-	return buildMageForArch(runtime.GOARCH)
-}
-
-// buildMageForArch pre-compiles the magefile to a binary using the GOARCH parameter.
+// buildMage pre-compiles the magefile to a binary using the GOARCH parameter.
 // It has the benefit of speeding up the build because the
 // mage -compile is done only once rather than in each Docker container.
-func buildMageForArch(arch string) error {
+func buildMage() error {
+	arch := runtime.GOARH
 	if arch == "" {
 		return fmt.Errorf("architecture value cannot be empty")
 	}
@@ -208,7 +205,6 @@ func crossBuildImage(platform string) (string, error) {
 		tagSuffix = "darwin"
 	case strings.HasPrefix(platform, "linux/arm"):
 		tagSuffix = "arm"
-		fmt.Println(runtime.GOARCH)
 		if runtime.GOARCH == "arm64" {
 			tagSuffix = "base-arm-debian9"
 		}

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -188,7 +188,7 @@ func CrossBuildXPack(options ...CrossBuildOption) error {
 // It has the benefit of speeding up the build because the
 // mage -compile is done only once rather than in each Docker container.
 func buildMage() error {
-	arch := runtime.GOARH
+	arch := runtime.GOARCH
 	if arch == "" {
 		return fmt.Errorf("architecture value cannot be empty")
 	}

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -209,7 +209,7 @@ func crossBuildImage(platform string) (string, error) {
 	case strings.HasPrefix(platform, "linux/arm"):
 		tagSuffix = "arm"
 		fmt.Println(runtime.GOARCH)
-		if runtime.GOARCH == "arm" {
+		if runtime.GOARCH == "arm64" {
 			tagSuffix = "main-arm-debian9"
 		}
 	case strings.HasPrefix(platform, "linux/mips"):

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -210,7 +210,7 @@ func crossBuildImage(platform string) (string, error) {
 		tagSuffix = "arm"
 		fmt.Println(runtime.GOARCH)
 		if runtime.GOARCH == "arm64" {
-			tagSuffix = "main-arm-debian9"
+			tagSuffix = "base-arm-debian9"
 		}
 	case strings.HasPrefix(platform, "linux/mips"):
 		tagSuffix = "mips"

--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -70,15 +70,17 @@ func (b *dockerBuilder) Build() error {
 		return errors.Wrap(err, "failed to prepare build")
 	}
 
+	tries := 3
 	tag, err := b.dockerBuild()
-	if err != nil {
+	for err != nil && tries != 0 {
 		fmt.Println(">> Building docker images again (after 10 seconds)")
 		// This sleep is to avoid hitting the docker build issues when resources are not available.
 		time.Sleep(10)
 		tag, err = b.dockerBuild()
-		if err != nil {
-			return errors.Wrap(err, "failed to build docker")
-		}
+		tries -= 1
+	}
+	if err != nil {
+		return errors.Wrap(err, "failed to build docker")
 	}
 
 	if err := b.dockerSave(tag); err != nil {

--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -199,6 +199,12 @@ func (b *dockerBuilder) dockerBuild() (string, error) {
 }
 
 func (b *dockerBuilder) dockerSave(tag string) error {
+	if _, err := os.Stat(distributionsDir); os.IsNotExist(err) {
+		err := os.MkdirAll(distributionsDir, 0750)
+		if err != nil {
+			return fmt.Errorf("cannot create folder for docker artifacts: %+v", err)
+		}
+	}
 	// Save the container as artifact
 	outputFile := b.OutputFile
 	if outputFile == "" {

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -60,6 +60,11 @@ func Package() error {
 					continue
 				}
 
+				if target.Name == "linux/arm64" && pkgType == Docker && runtime.GOARCH != "arm" {
+					log.Printf("Skipping Docker package type because build host isn't arm")
+					continue
+				}
+
 				packageArch, err := getOSArchName(target, pkgType)
 				if err != nil {
 					log.Printf("Skipping arch %v for package type %v: %v", target.Arch(), pkgType, err)

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -45,7 +45,7 @@ func Package() error {
 	var tasks []interface{}
 	for _, target := range Platforms {
 		for _, pkg := range Packages {
-			if pkg.OS != target.GOOS() {
+			if pkg.OS != target.GOOS() || pkg.Arch != "" && pkg.Arch != target.Arch() {
 				continue
 			}
 

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -49,7 +49,6 @@ func Package() error {
 				continue
 			}
 
-			fmt.Println(SelectedPackageTypes)
 			for _, pkgType := range pkg.Types {
 				if !isPackageTypeSelected(pkgType) {
 					log.Printf("Skipping %s package type because it is not selected", pkgType)

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -49,6 +49,7 @@ func Package() error {
 				continue
 			}
 
+			fmt.Println(SelectedPackageTypes)
 			for _, pkgType := range pkg.Types {
 				if !isPackageTypeSelected(pkgType) {
 					log.Printf("Skipping %s package type because it is not selected", pkgType)
@@ -60,7 +61,7 @@ func Package() error {
 					continue
 				}
 
-				if target.Name == "linux/arm64" && pkgType == Docker && runtime.GOARCH != "arm" {
+				if target.Name == "linux/arm64" && pkgType == Docker && runtime.GOARCH != "arm64" {
 					log.Printf("Skipping Docker package type because build host isn't arm")
 					continue
 				}

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -50,6 +50,11 @@ func Package() error {
 			}
 
 			for _, pkgType := range pkg.Types {
+				if !isPackageTypeSelected(pkgType) {
+					log.Printf("Skipping %s package type because it is not selected", pkgType)
+					continue
+				}
+
 				if pkgType == DMG && runtime.GOOS != "darwin" {
 					log.Printf("Skipping DMG package type because build host isn't darwin")
 					continue
@@ -104,6 +109,19 @@ func Package() error {
 
 	Parallel(tasks...)
 	return nil
+}
+
+func isPackageTypeSelected(pkgType PackageType) bool {
+	if SelectedPackageTypes != nil {
+		selected := false
+		for _, t := range SelectedPackageTypes {
+			if t == pkgType {
+				selected = true
+			}
+		}
+		return selected
+	}
+	return true
 }
 
 type packageBuilder struct {

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -68,6 +68,7 @@ const (
 // system using the contained PackageSpec.
 type OSPackageArgs struct {
 	OS    string        `yaml:"os"`
+	Arch  string        `yaml:"arch",omitempty`
 	Types []PackageType `yaml:"types"`
 	Spec  PackageSpec   `yaml:"spec"`
 }

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -68,7 +68,7 @@ const (
 // system using the contained PackageSpec.
 type OSPackageArgs struct {
 	OS    string        `yaml:"os"`
-	Arch  string        `yaml:"arch",omitempty`
+	Arch  string        `yaml:"arch,omitempty"`
 	Types []PackageType `yaml:"types"`
 	Spec  PackageSpec   `yaml:"spec"`
 }

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -172,6 +172,7 @@ var OSArchNames = map[string]map[PackageType]map[string]string{
 		},
 		Docker: map[string]string{
 			"amd64": "amd64",
+			"arm64": "arm64",
 		},
 	},
 }

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -736,7 +736,7 @@ specs:
         <<: *elastic_license_for_binaries
 
     - os: linux
-      arch: '!arm64'
+      arch: amd64
       types: [docker]
       spec:
         <<: *docker_spec
@@ -838,7 +838,7 @@ specs:
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
-      arch: '!arm64'
+      arch: amd64
       types: [docker]
       spec:
         <<: *docker_spec
@@ -930,7 +930,7 @@ specs:
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
-      arch: '!arm64'
+      arch: amd64
       types: [docker]
       spec:
         <<: *agent_docker_spec

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -561,6 +561,11 @@ shared:
       image_name: '{{.BeatName}}-ubi8'
       from: 'docker.elastic.co/ubi8/ubi-minimal'
 
+  - &docker_arm_ubi_spec
+    extra_vars:
+      image_name: '{{.BeatName}}-ubi8'
+      from: 'registry.access.redhat.com/ubi8/ubi-minimal:8.2'
+
   - &elastic_docker_spec
     extra_vars:
       repository: 'docker.elastic.co/beats'
@@ -731,10 +736,20 @@ specs:
         <<: *elastic_license_for_binaries
 
     - os: linux
+      arch: '!arm64'
       types: [docker]
       spec:
         <<: *docker_spec
         <<: *docker_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
 
@@ -823,10 +838,23 @@ specs:
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
+      arch: '!arm64'
       types: [docker]
       spec:
         <<: *docker_spec
         <<: *docker_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_spec
+        <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
@@ -902,10 +930,23 @@ specs:
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
+      arch: '!arm64'
       types: [docker]
       spec:
         <<: *agent_docker_spec
         <<: *docker_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+        files:
+          '{{.BeatName}}{{.BinaryExt}}':
+            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
+
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *agent_docker_spec
+        <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -402,6 +402,12 @@ shared:
           {{ commit }}
         mode: 0644
 
+  - &agent_docker_arm_spec
+    <<: *agent_docker_spec
+    extra_vars:
+      from: 'arm64v8/centos:7'
+      buildFrom: 'arm64v8/centos:7'
+
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec
     <<: *common
@@ -556,6 +562,12 @@ shared:
         mode: 0600
         config: true
 
+  - &docker_arm_spec
+    <<: *docker_spec
+    extra_vars:
+      from: 'arm64v8/centos:7'
+      buildFrom: 'arm64v8/centos:7'
+
   - &docker_ubi_spec
     extra_vars:
       image_name: '{{.BeatName}}-ubi8'
@@ -564,7 +576,7 @@ shared:
   - &docker_arm_ubi_spec
     extra_vars:
       image_name: '{{.BeatName}}-ubi8'
-      from: 'registry.access.redhat.com/ubi8/ubi-minimal:8.2'
+      buildFrom: 'registry.access.redhat.com/ubi8/ubi-minimal:8.2'
 
   - &elastic_docker_spec
     extra_vars:
@@ -729,13 +741,6 @@ specs:
         <<: *elastic_license_for_deb_rpm
 
     - os: linux
-      types: [docker]
-      spec:
-        <<: *docker_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-
-    - os: linux
       arch: amd64
       types: [docker]
       spec:
@@ -748,7 +753,7 @@ specs:
       arch: arm64
       types: [docker]
       spec:
-        <<: *docker_spec
+        <<: *docker_arm_spec
         <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
@@ -828,16 +833,6 @@ specs:
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
-      types: [docker]
-      spec:
-        <<: *docker_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    - os: linux
       arch: amd64
       types: [docker]
       spec:
@@ -853,7 +848,7 @@ specs:
       arch: arm64
       types: [docker]
       spec:
-        <<: *docker_spec
+        <<: *docker_arm_spec
         <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
@@ -920,16 +915,6 @@ specs:
             mode: 0755
 
     - os: linux
-      types: [docker]
-      spec:
-        <<: *agent_docker_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-        files:
-          '{{.BeatName}}{{.BinaryExt}}':
-            source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
-
-    - os: linux
       arch: amd64
       types: [docker]
       spec:
@@ -945,7 +930,7 @@ specs:
       arch: arm64
       types: [docker]
       spec:
-        <<: *agent_docker_spec
+        <<: *agent_docker_arm_spec
         <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -576,7 +576,7 @@ shared:
   - &docker_arm_ubi_spec
     extra_vars:
       image_name: '{{.BeatName}}-ubi8'
-      buildFrom: 'registry.access.redhat.com/ubi8/ubi-minimal:8.2'
+      from: 'registry.access.redhat.com/ubi8/ubi-minimal:8.2'
 
   - &elastic_docker_spec
     extra_vars:

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -29,8 +29,18 @@ FROM {{ .from }}
 
 {{- if contains .from "ubi-minimal" }}
 RUN for iter in {1..10}; do microdnf update -y && microdnf install -y shadow-utils &&  microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
-RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && \
-    chmod +x /usr/local/bin/jq
+RUN case "$(arch)" in \
+    x86_64) \
+        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && \
+        chmod +x /usr/local/bin/jq \
+        ;; \
+    aarch64) \
+        microdnf install -y jq ; \
+        ;; \
+    *) \
+        echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+        ;; \
+  esac ;
 {{- else }}
 # Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
 RUN for iter in {1..10}; do yum update --setopt=tsflags=nodocs -y && yum install --setopt=tsflags=nodocs -y epel-release &&  yum clean all && exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -28,19 +28,7 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
 FROM {{ .from }}
 
 {{- if contains .from "ubi-minimal" }}
-RUN for iter in {1..10}; do microdnf update -y && microdnf install -y shadow-utils &&  microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
-RUN case "$(arch)" in \
-    x86_64) \
-        curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && \
-        chmod +x /usr/local/bin/jq \
-        ;; \
-    aarch64) \
-        microdnf install -y jq ; \
-        ;; \
-    *) \
-        echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
-        ;; \
-  esac ;
+RUN for iter in {1..10}; do microdnf update -y && microdnf install -y shadow-utils jq &&  microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
 {{- else }}
 # Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
 RUN for iter in {1..10}; do yum update --setopt=tsflags=nodocs -y && yum install --setopt=tsflags=nodocs -y epel-release &&  yum clean all && exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -69,9 +69,22 @@ ENV GODEBUG="madvdontneed=1"
 
 # Add an init process, check the checksum to make sure it's a match
 RUN set -e ; \
-  TINI_VERSION='v0.19.0' ; \
-  TINI_BIN='tini-amd64' ; \
-  TINI_SHA256='93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c' ; \
+  TINI_BIN=""; \
+  TINI_SHA256=""; \
+  TINI_VERSION="v0.19.0"; \
+  case "$(arch)" in \
+    x86_64) \
+        TINI_BIN="tini-amd64"; \
+        TINI_SHA256="93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c"; \
+        ;; \
+    aarch64) \
+        TINI_BIN="tini-arm64"; \
+        TINI_SHA256="07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81"; \
+        ;; \
+    *) \
+        echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+        ;; \
+  esac ; \
   curl --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}" ; \
   echo "${TINI_SHA256} ${TINI_BIN}" | sha256sum -c - ; \
   mv "${TINI_BIN}" /usr/bin/tini ; \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -83,9 +83,22 @@ ENV GODEBUG="madvdontneed=1"
 
 # Add an init process, check the checksum to make sure it's a match
 RUN set -e ; \
-  TINI_VERSION='v0.19.0' ; \
-  TINI_BIN='tini-amd64' ; \
-  TINI_SHA256='93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c' ; \
+  TINI_BIN=""; \
+  TINI_SHA256=""; \
+  TINI_VERSION="v0.19.0"; \
+  case "$(arch)" in \
+    x86_64) \
+        TINI_BIN="tini-amd64"; \
+        TINI_SHA256="93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c"; \
+        ;; \
+    aarch64) \
+        TINI_BIN="tini-arm64"; \
+        TINI_SHA256="07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81"; \
+        ;; \
+    *) \
+        echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+        ;; \
+  esac ; \
   curl --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}" ; \
   echo "${TINI_SHA256} ${TINI_BIN}" | sha256sum -c - ; \
   mv "${TINI_BIN}" /usr/bin/tini ; \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -30,11 +30,24 @@ RUN microdnf -y --setopt=tsflags=nodocs update && \
 {{- else }}
 RUN yum -y --setopt=tsflags=nodocs update \
   {{- if (eq .BeatName "heartbeat") }}
+    && PACKAGES_TO_INSTALL="atk cups gtk gdk xrandr ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
+xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc" \
+    && case "$(arch)" in \
+         x86_64) \
+            PACKAGES_TO_INSTALL="$PACKAGES_TO_INSTALL pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 \
+libXext.x86_64 libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 \
+alsa-lib.x86_64 atk.x86_64 gtk3.x86_64" \
+             ;; \
+         aarch64) \
+            PACKAGES_TO_INSTALL="$PACKAGES_TO_INSTALL pango libXcomposite libXcursor libXdamage \
+libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 alsa-lib gtk3" \
+             ;; \
+         *) \
+             echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+             ;; \
+       esac \
     && yum -y install epel-release \
-    && yum -y install atk cups gtk gdk xrandr pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 \
-	  libXext.x86_64 libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 \
-	  alsa-lib.x86_64 atk.x86_64 gtk3.x86_64 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
-	  xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
+    && yum -y install ${PACKAGES_TO_INSTALL} \
   {{- end }}
   && yum clean all && rm -rf /var/cache/yum
   # See https://access.redhat.com/discussions/3195102 for why rm is needed
@@ -132,8 +145,20 @@ ENV PATH="$NODE_PATH/node/bin:$PATH"
 # cached node_modules, heartbeat then calls the global executable to run test suites
 # Setup node
 RUN cd /usr/share/heartbeat/.node \
+  && NODE_DOWNLOAD_URL="" \
+  && case "$(arch)" in \
+       x86_64) \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz \
+           ;; \
+       aarch64) \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-arm64.tar.xz \
+           ;; \
+       *) \
+           echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+           ;; \
+     esac \
   && mkdir -p node \
-  && curl https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz | tar -xJ --strip 1 -C node \
+  && curl ${NODE_DOWNLOAD_URL} | tar -xJ --strip 1 -C node \
   && chmod ug+rwX -R $NODE_PATH \
   && npm i -g -f @elastic/synthetics && chmod ug+rwX -R $NODE_PATH
 {{- end }}

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -145,13 +145,14 @@ ENV PATH="$NODE_PATH/node/bin:$PATH"
 # cached node_modules, heartbeat then calls the global executable to run test suites
 # Setup node
 RUN cd /usr/share/heartbeat/.node \
+  && NODE_VERSION="v12.18.4" \
   && NODE_DOWNLOAD_URL="" \
   && case "$(arch)" in \
        x86_64) \
-           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz \
            ;; \
        aarch64) \
-           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v14.15.4/node-v14.15.4-linux-arm64.tar.xz \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-arm64.tar.xz \
            ;; \
        *) \
            echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -30,24 +30,11 @@ RUN microdnf -y --setopt=tsflags=nodocs update && \
 {{- else }}
 RUN yum -y --setopt=tsflags=nodocs update \
   {{- if (eq .BeatName "heartbeat") }}
-    && PACKAGES_TO_INSTALL="atk cups gtk gdk xrandr ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
-xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc" \
-    && case "$(arch)" in \
-         x86_64) \
-            PACKAGES_TO_INSTALL="$PACKAGES_TO_INSTALL pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 \
-libXext.x86_64 libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 \
-alsa-lib.x86_64 atk.x86_64 gtk3.x86_64" \
-             ;; \
-         aarch64) \
-            PACKAGES_TO_INSTALL="$PACKAGES_TO_INSTALL pango libXcomposite libXcursor libXdamage \
-libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 alsa-lib gtk3" \
-             ;; \
-         *) \
-             echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
-             ;; \
-       esac \
     && yum -y install epel-release \
-    && yum -y install ${PACKAGES_TO_INSTALL} \
+    && yum -y install atk cups gtk gdk xrandr pango libXcomposite libXcursor libXdamage \
+        libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 \
+        alsa-lib atk gtk3 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
+        xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
   {{- end }}
   && yum clean all && rm -rf /var/cache/yum
   # See https://access.redhat.com/discussions/3195102 for why rm is needed

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -145,12 +145,13 @@ ENV PATH="$NODE_PATH/node/bin:$PATH"
 # cached node_modules, heartbeat then calls the global executable to run test suites
 # Setup node
 RUN cd /usr/share/heartbeat/.node \
+  && NODE_DOWNLOAD_URL="" \
   && case "$(arch)" in \
        x86_64) \
-           NODE_DOWNLOAD_URL=https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
            ;; \
        aarch64) \
-           NODE_DOWNLOAD_URL=https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-arm64.tar.xz \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-arm64.tar.xz \
            ;; \
        *) \
            echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -145,8 +145,6 @@ ENV PATH="$NODE_PATH/node/bin:$PATH"
 # cached node_modules, heartbeat then calls the global executable to run test suites
 # Setup node
 RUN cd /usr/share/heartbeat/.node \
-  && NODE_VERSION="v12.18.4" \
-  && NODE_DOWNLOAD_URL="" \
   && case "$(arch)" in \
        x86_64) \
            NODE_DOWNLOAD_URL=https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.xz \

--- a/journalbeat/magefile.go
+++ b/journalbeat/magefile.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -138,6 +139,9 @@ func selectImage(platform string) (string, error) {
 	switch {
 	case strings.HasPrefix(platform, "linux/arm"):
 		tagSuffix = "arm"
+		if runtime.GOARCH == "arm64" {
+			tagSuffix = "base-arm-debian9"
+		}
 	case strings.HasPrefix(platform, "linux/mips"):
 		tagSuffix = "mips"
 	case strings.HasPrefix(platform, "linux/ppc"):

--- a/script/fix_permissions.sh
+++ b/script/fix_permissions.sh
@@ -5,7 +5,14 @@ readonly LOCATION="${1?Please define the path where the fix permissions should r
 if ! docker version ; then
   echo "It requires Docker daemon to be installed and running"
 else
+  ## Detect architecture to support ARM specific docker images.
+  ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+  if [ "${ARCH}" == "aarch64" ] ; then
+    DOCKER_IMAGE=arm64v8/alpine:3
+  else
+    DOCKER_IMAGE=alpine:3.4
+  fi
   set -e
   # Change ownership of all files inside the specific folder from root/root to current user/group
-  docker run -v ${LOCATION}:/beat alpine:3.4 sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
+  docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
 fi

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -590,7 +590,10 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 				cmd.Dir = pwd
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
-				cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on", "PACKAGES=targz")
+				cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on")
+				if len(devtools.SelectedPackageTypes) == 1 && devtools.SelectedPackageTypes[0] == devtools.Docker {
+					cmd.Env = append(cmd.Env, "PACKAGES=targz")
+				}
 
 				if err := cmd.Run(); err != nil {
 					panic(err)

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -590,7 +590,7 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 				cmd.Dir = pwd
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
-				cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on")
+				cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on", "PACKAGES=targz")
 
 				if err := cmd.Run(); err != nil {
 					panic(err)

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -591,8 +591,8 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on")
-				if len(devtools.SelectedPackageTypes) == 1 && devtools.SelectedPackageTypes[0] == devtools.Docker {
-					cmd.Env = append(cmd.Env, "PACKAGES=targz")
+				if envVar := selectedPackageTypes(); envVar != "" {
+					cmd.Env = append(cmd.Env, envVar)
 				}
 
 				if err := cmd.Run(); err != nil {
@@ -614,6 +614,22 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 	mg.Deps(Update)
 	mg.Deps(CrossBuild, CrossBuildGoDaemon)
 	mg.SerialDeps(devtools.Package, TestPackages)
+}
+
+func selectedPackageTypes() string {
+	if len(devtools.SelectedPackageTypes) == 0 {
+		return ""
+	}
+
+	envVar := "PACKAGES="
+	for _, p := range devtools.SelectedPackageTypes {
+		if p == devtools.Docker {
+			envVar += "targz,"
+		} else {
+			envVar += p.String() + ","
+		}
+	}
+	return envVar[:len(envVar)-1]
 }
 
 func copyAll(from, to string) error {


### PR DESCRIPTION
This PR adds support for building ARM64 Docker images for all Beats on ARM64 machines.

To limit what packages should be built I have added the new environment variable named `PACKAGES`. It expects a comma-separated list of packages types. Available options: rpm, deb, tgz, dmg, docker, zip. If nothing is specified all available package types are built for the given platform.

This PR relies on the newly added crossbuild image with the suffix `base-arm-debian9`. This image is automatically selected if the runtime of the builder machine is ARM64.

A possible enhancement to this solution is described in #23775.

