### PR TITLE
Cherry-pick #23505 to 7.11: [fix][metricbeat]Fix metricbeat/perfmon measurement grouping

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -325,6 +325,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `logstash` module when `xpack.enabled: true` is set from emitting redundant events. {pull}22808[22808]
 - Change vsphere.datastore.capacity.used.pct value to betweeen 0 and 1. {pull}23148[23148]
 - Update config in `windows.yml` file. {issue}23027[23027]{pull}23327[23327]
+- Fix metric grouping for windows/perfmon module {issue}23489[23489] {pull}23505[23505]
 
 *Packetbeat*
 

--- a/metricbeat/module/windows/perfmon/data_test.go
+++ b/metricbeat/module/windows/perfmon/data_test.go
@@ -30,6 +30,9 @@ import (
 
 func TestGroupToEvents(t *testing.T) {
 	reader := Reader{
+		config: Config{
+			GroupMeasurements: true,
+		},
 		query:    pdh.Query{},
 		executed: true,
 		log:      nil,
@@ -42,6 +45,26 @@ func TestGroupToEvents(t *testing.T) {
 				ObjectField:  "object",
 				ChildQueries: []string{`\UDPv4\Datagrams Sent/sec`},
 			},
+			{
+				QueryField:    "%_processor_time",
+				QueryName:     `\Processor Information(_Total)\% Processor Time`,
+				Format:        "float",
+				ObjectName:    "Processor Information",
+				ObjectField:   "object",
+				InstanceName:  "_Total",
+				InstanceField: "instance",
+				ChildQueries:  []string{`\Processor Information(_Total)\% Processor Time`},
+			},
+			{
+				QueryField:    "current_disk_queue_length",
+				QueryName:     `\PhysicalDisk(_Total)\Current Disk Queue Length`,
+				Format:        "float",
+				ObjectName:    "PhysicalDisk",
+				ObjectField:   "object",
+				InstanceName:  "_Total",
+				InstanceField: "instance",
+				ChildQueries:  []string{`\PhysicalDisk(_Total)\Current Disk Queue Length`},
+			},
 		},
 	}
 	counters := map[string][]pdh.CounterValue{
@@ -52,23 +75,76 @@ func TestGroupToEvents(t *testing.T) {
 				Err:         pdh.CounterValueError{},
 			},
 		},
+		`\Processor Information(_Total)\% Processor Time`: {
+			{
+				Instance:    "_Total",
+				Measurement: 11,
+			},
+		},
+		`\PhysicalDisk(_Total)\Current Disk Queue Length`: {
+			{
+				Instance:    "_Total",
+				Measurement: 20,
+			},
+		},
 	}
+
 	events := reader.groupToEvents(counters)
 	assert.NotNil(t, events)
-	assert.Equal(t, len(events), 1)
-	ok, err := events[0].MetricSetFields.HasKey("datagrams_sent_per_sec")
-	assert.NoError(t, err)
-	assert.True(t, ok)
-	ok, err = events[0].MetricSetFields.HasKey("object")
-	assert.NoError(t, err)
-	assert.True(t, ok)
-	val, err := events[0].MetricSetFields.GetValue("datagrams_sent_per_sec")
-	assert.NoError(t, err)
-	assert.Equal(t, val, 23)
-	val, err = events[0].MetricSetFields.GetValue("object")
-	assert.NoError(t, err)
-	assert.Equal(t, val, "UDPv4")
+	assert.Equal(t, 3, len(events))
 
+	for _, event := range events {
+		ok, err := event.MetricSetFields.HasKey("datagrams_sent_per_sec")
+		if ok {
+			assert.NoError(t, err)
+			assert.True(t, ok)
+			ok, err = event.MetricSetFields.HasKey("object")
+			assert.NoError(t, err)
+			assert.True(t, ok)
+
+			val, err := event.MetricSetFields.GetValue("datagrams_sent_per_sec")
+			assert.NoError(t, err)
+			assert.Equal(t, val, 23)
+
+			val, err = event.MetricSetFields.GetValue("object")
+			assert.NoError(t, err)
+			assert.Equal(t, val, "UDPv4")
+		} else {
+			ok, err := event.MetricSetFields.HasKey("%_processor_time")
+			if ok {
+				assert.NoError(t, err)
+				assert.True(t, ok)
+
+				ok, err = event.MetricSetFields.HasKey("object")
+				assert.NoError(t, err)
+				assert.True(t, ok)
+
+				val, err := event.MetricSetFields.GetValue("%_processor_time")
+				assert.NoError(t, err)
+				assert.Equal(t, val, 11)
+
+				val, err = event.MetricSetFields.GetValue("object")
+				assert.NoError(t, err)
+				assert.Equal(t, val, "Processor Information")
+			} else {
+				ok, err = event.MetricSetFields.HasKey("current_disk_queue_length")
+				assert.NoError(t, err)
+				assert.True(t, ok)
+
+				ok, err = event.MetricSetFields.HasKey("object")
+				assert.NoError(t, err)
+				assert.True(t, ok)
+
+				val, err := event.MetricSetFields.GetValue("current_disk_queue_length")
+				assert.NoError(t, err)
+				assert.Equal(t, val, 20)
+
+				val, err = event.MetricSetFields.GetValue("object")
+				assert.NoError(t, err)
+				assert.Equal(t, val, "PhysicalDisk")
+			}
+		}
+	}
 }
 
 func TestGroupToSingleEvent(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of PR #23505 and https://github.com/elastic/beats/pull/23617 to 7.11 branch. Original message: 

## What does this PR do?

Fixes measurement grouping on metricbeat windows/perfmon.

## Why is it important?

Counter from different metric objects were being mixed when measurement grouping was enabled.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

With a config like:

```
metricbeat.modules:
  - module: windows
    metricsets: [perfmon]
    period: 10s
    perfmon.ignore_non_existent_counters: false
    perfmon.group_measurements_by_instance: true
    perfmon.queries:

    - object: "Processor Information"
      instance: "_Total"
      counters:
      - name: "% Processor Time"

    - object: "PhysicalDisk"
      instance: "_Total"
      counters:
      - name: "Current Disk Queue Length"
      - name: "Disk Read Bytes/sec"
      - name: "Disk Write Bytes/sec"

output.console:
  pretty: true
```

We were getting an output like:

```
{
  "@timestamp": "2021-01-13T15:27:09.161Z",
  "@metadata": {
    "beat": "metricbeat",
    "type": "_doc",
    "version": "8.0.0"
  },
  "event": {
    "dataset": "windows.perfmon",
    "module": "windows",
    "duration": 8027600
  },
  "metricset": {
    "name": "perfmon",
    "period": 10000
  },
  "service": {
    "type": "windows"
  },
  "windows": {
    "perfmon": {
      "metrics": {
        "disk_write_bytes_per_sec": 8381.215716061084,
        "%_processor_time": 0.10681524439283274,
        "current_disk_queue_length": 0,
        "disk_read_bytes_per_sec": 0
      },
      "object": "PhysicalDisk",
      "instance": "_Total"
    }
  },
  "host": {
    "name": "vagrant"
  },
  "agent": {
    "type": "metricbeat",
    "version": "8.0.0",
    "ephemeral_id": "e3c6902f-c539-4517-a0be-74d700709309",
    "id": "5159c10f-36f4-4489-9a9b-3a82cbd924d7",
    "name": "vagrant"
  },
  "ecs": {
    "version": "1.7.0"
  }
}
```

Note `%_processor_time` being merged with `PhysicalDisk` object metrics.

After the fix we get the following output instead:

```
{
  "@timestamp": "2021-01-14T10:56:06.684Z",
  "@metadata": {
    "beat": "metricbeat",
    "type": "_doc",
    "version": "8.0.0"
  },
  "event": {
    "duration": 5860100,
    "dataset": "windows.perfmon",
    "module": "windows"
  },
  "metricset": {
    "name": "perfmon",
    "period": 10000
  },
  "service": {
    "type": "windows"
  },
  "windows": {
    "perfmon": {
      "instance": "_Total",
      "metrics": {
        "current_disk_queue_length": 0,
        "disk_read_bytes_per_sec": 0,
        "disk_write_bytes_per_sec": 15860.12885215545
      },
      "object": "PhysicalDisk"
    }
  },
  "ecs": {
    "version": "1.7.0"
  },
  "host": {
    "name": "vagrant"
  },
  "agent": {
    "version": "8.0.0",
    "ephemeral_id": "4a737200-e1be-4d13-9eb5-cb81249f4a7f",
    "id": "5159c10f-36f4-4489-9a9b-3a82cbd924d7",
    "name": "vagrant",
    "type": "metricbeat"
  }
}
{
  "@timestamp": "2021-01-14T10:56:06.684Z",
  "@metadata": {
    "beat": "metricbeat",
    "type": "_doc",
    "version": "8.0.0"
  },
  "metricset": {
    "period": 10000,
    "name": "perfmon"
  },
  "ecs": {
    "version": "1.7.0"
  },
  "host": {
    "name": "vagrant"
  },
  "agent": {
    "version": "8.0.0",
    "ephemeral_id": "4a737200-e1be-4d13-9eb5-cb81249f4a7f",
    "id": "5159c10f-36f4-4489-9a9b-3a82cbd924d7",
    "name": "vagrant",
    "type": "metricbeat"
  },
  "service": {
    "type": "windows"
  },
  "windows": {
    "perfmon": {
      "instance": "_Total",
      "metrics": {
        "%_processor_time": 0.1124404001576429
      },
      "object": "Processor Information"
    }
  },
  "event": {
    "dataset": "windows.perfmon",
    "module": "windows",
    "duration": 5860100
  }
}
```

Now we get a different event for each object.

Fixes https://github.com/elastic/beats/issues/23489
