### PR TITLE
Cherry-pick #23608 to 7.x: Skip flaky TestConfigurableService in agent

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -389,6 +389,7 @@ func TestConfigurableStartStop(t *testing.T) {
 }
 
 func TestConfigurableService(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/23607")
 	p := getProgram("serviceable", "1.0")
 
 	operator := getTestOperator(t, downloadPath, installPath, p)


### PR DESCRIPTION
Cherry-pick of PR #23608 to 7.x branch. Original message: 

Issue: https://github.com/elastic/beats/issues/23607