### PR TITLE
Cherry-pick #23609 to 7.x: Fixed nil pointer during unenroll 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@
 - Fix Windows service installation script {pull}20203[20203]
 - Fix timeout issue stopping service applications {pull}20256[20256]
 - Fix incorrect hash when upgrading agent {pull}22322[22322]
+- Fixed nil pointer during unenroll {pull}23609[23609]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/lazy_acker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/lazy_acker.go
@@ -7,6 +7,7 @@ package application
 import (
 	"context"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 )
 
@@ -19,19 +20,22 @@ type ackForcer interface {
 }
 
 type lazyAcker struct {
+	log   *logger.Logger
 	acker batchAcker
 	queue []fleetapi.Action
 }
 
-func newLazyAcker(baseAcker batchAcker) *lazyAcker {
+func newLazyAcker(baseAcker batchAcker, log *logger.Logger) *lazyAcker {
 	return &lazyAcker{
 		acker: baseAcker,
 		queue: make([]fleetapi.Action, 0),
+		log:   log,
 	}
 }
 
 func (f *lazyAcker) Ack(ctx context.Context, action fleetapi.Action) error {
 	f.queue = append(f.queue, action)
+	f.log.Debugf("appending action with id '%s' to the queue", action.ID())
 
 	if _, isAckForced := action.(ackForcer); isAckForced {
 		return f.Commit(ctx)

--- a/x-pack/elastic-agent/pkg/agent/application/lazy_acker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/lazy_acker_test.go
@@ -32,7 +32,7 @@ func TestLazyAcker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lacker := newLazyAcker(acker)
+	lacker := newLazyAcker(acker, log)
 
 	if acker == nil {
 		t.Fatal("acker not initialized")

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -187,7 +187,7 @@ func newManaged(
 		return nil, err
 	}
 
-	batchedAcker := newLazyAcker(acker)
+	batchedAcker := newLazyAcker(acker, log)
 
 	// Create the state store that will persist the last good policy change on disk.
 	stateStore, err := newStateStoreWithMigration(log, info.AgentActionStoreFile(), info.AgentStateStoreFile())

--- a/x-pack/elastic-agent/pkg/agent/application/state_store.go
+++ b/x-pack/elastic-agent/pkg/agent/application/state_store.go
@@ -225,7 +225,7 @@ func (s *stateStore) Save() error {
 		if apc, ok := s.state.action.(*fleetapi.ActionPolicyChange); ok {
 			serialize.Action = &actionSerializer{apc.ActionID, apc.ActionType, apc.Policy, nil}
 		} else if aun, ok := s.state.action.(*fleetapi.ActionUnenroll); ok {
-			serialize.Action = &actionSerializer{apc.ActionID, apc.ActionType, nil, &aun.IsDetected}
+			serialize.Action = &actionSerializer{aun.ActionID, aun.ActionType, nil, &aun.IsDetected}
 		} else {
 			return fmt.Errorf("incompatible type, expected ActionPolicyChange and received %T", s.state.action)
 		}


### PR DESCRIPTION
Cherry-pick of PR #23609 to 7.x branch. Original message:

## What does this PR do?

Fixes issue with unenroll serialization when nil pointer prevented unenrollment to be finished and caused agent to get into restart loop

## Why is it important?

Makes agent unusable after unenroll. Unenroll is not acked so agent appears online

Fixes: #23593

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
