### PR TITLE
[libbeat] Expose the new Sarama flag 'DisablePAFXFAST' in the Kafka output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -585,6 +585,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Deprecate aws_partition config parameter for AWS, use endpoint instead. {pull}23539[23539]
 - Update the baseline version of Sarama (Kafka support library) to 1.27.2. {pull}23595[23595]
 - Add kubernetes.volume.fs.used.pct field. {pull}23564[23564]
+- Add the `disable_krb5_fast` flag to the Kafka output, for better Active Directory compatibility. {pull}23629[23629]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -585,7 +585,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Deprecate aws_partition config parameter for AWS, use endpoint instead. {pull}23539[23539]
 - Update the baseline version of Sarama (Kafka support library) to 1.27.2. {pull}23595[23595]
 - Add kubernetes.volume.fs.used.pct field. {pull}23564[23564]
-- Add the `disable_krb5_fast` flag to the Kafka output, for better Active Directory compatibility. {pull}23629[23629]
+- Add the `enable_krb5_fast` flag to the Kafka output to explicitly opt-in to FAST authentication. {pull}23629[23629]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -844,6 +844,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -844,9 +844,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1724,6 +1724,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1724,9 +1724,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1022,6 +1022,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1022,9 +1022,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -787,6 +787,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -787,9 +787,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/libbeat/_meta/config/output-kafka.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-kafka.reference.yml.tmpl
@@ -131,9 +131,9 @@
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
 {{include "ssl.reference.yml.tmpl" . | indent 2 }}
   # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.

--- a/libbeat/_meta/config/output-kafka.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-kafka.reference.yml.tmpl
@@ -131,6 +131,10 @@
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
 {{include "ssl.reference.yml.tmpl" . | indent 2 }}
   # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
   #kerberos.enabled: true

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -69,6 +69,7 @@ type kafkaConfig struct {
 	Password           string                    `config:"password"`
 	Codec              codec.Config              `config:"codec"`
 	Sasl               saslConfig                `config:"sasl"`
+	DisableFAST        bool                      `config:"disable_krb5_fast"`
 }
 
 type saslConfig struct {
@@ -244,6 +245,7 @@ func newSaramaConfig(log *logp.Logger, config *kafkaConfig) (*sarama.Config, err
 			Username:           config.Kerberos.Username,
 			Password:           config.Kerberos.Password,
 			Realm:              config.Kerberos.Realm,
+			DisablePAFXFAST:    config.DisableFAST,
 		}
 
 	case config.Username != "":

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -69,7 +69,7 @@ type kafkaConfig struct {
 	Password           string                    `config:"password"`
 	Codec              codec.Config              `config:"codec"`
 	Sasl               saslConfig                `config:"sasl"`
-	DisableFAST        bool                      `config:"disable_krb5_fast"`
+	EnableFAST         bool                      `config:"enable_krb5_fast"`
 }
 
 type saslConfig struct {
@@ -245,7 +245,7 @@ func newSaramaConfig(log *logp.Logger, config *kafkaConfig) (*sarama.Config, err
 			Username:           config.Kerberos.Username,
 			Password:           config.Kerberos.Password,
 			Realm:              config.Kerberos.Realm,
-			DisablePAFXFAST:    config.DisableFAST,
+			DisablePAFXFAST:    !config.EnableFAST,
 		}
 
 	case config.Username != "":

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -309,11 +309,11 @@ The ACK reliability level required from broker. 0=no response, 1=wait for local 
 
 Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silently on error.
 
-===== `disable_krb5_fast`
+===== `enable_krb5_fast`
 
 beta[]
 
-Disable Kerberos FAST authentication. This flag may be required to authenticate successfully on some Active Directory installations. It is separate from the standard Kerberos settings because this flag only applies to the Kafka output.
+Enable Kerberos FAST authentication. This may conflict with some Active Directory installations. It is separate from the standard Kerberos settings because this flag only applies to the Kafka output. The default is `false`.
 
 ===== `ssl`
 

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -309,6 +309,12 @@ The ACK reliability level required from broker. 0=no response, 1=wait for local 
 
 Note: If set to 0, no ACKs are returned by Kafka. Messages might be lost silently on error.
 
+===== `disable_krb5_fast`
+
+beta[]
+
+Disable Kerberos FAST authentication. This flag may be required to authenticate successfully on some Active Directory installations. It is separate from the standard Kerberos settings because this flag only applies to the Kafka output.
+
 ===== `ssl`
 
 Configuration options for SSL parameters like the root CA for Kafka connections.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1621,9 +1621,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1621,6 +1621,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1339,6 +1339,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1339,9 +1339,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -767,9 +767,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -767,6 +767,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -900,9 +900,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -900,6 +900,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3522,9 +3522,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3522,6 +3522,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1022,6 +1022,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1022,9 +1022,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2122,9 +2122,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2122,6 +2122,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -1339,6 +1339,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -1339,9 +1339,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -810,9 +810,9 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
-  # Disables Kerberos FAST authentication in the Kafka output. This flag
-  # is needed to authenticate with certain Active Directory configurations.
-  #disable_krb5_fast: false
+  # Enables Kerberos FAST authentication in the Kafka output. This may
+  # conflict with certain Active Directory configurations.
+  #enable_krb5_fast: false
 
   # Use SSL settings for HTTPS.
   #ssl.enabled: true

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -810,6 +810,10 @@ output.elasticsearch:
   # purposes.  The default is "beats".
   #client_id: beats
 
+  # Disables Kerberos FAST authentication in the Kafka output. This flag
+  # is needed to authenticate with certain Active Directory configurations.
+  #disable_krb5_fast: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 


### PR DESCRIPTION
## What does this PR do?

This PR adds the new flag `enable_krb5_fast` to the Kafka output, which (un)sets the `DisablePAFXFAST` flag added in Sarama 1.27.0. FAST authentication via Sarama can conflict with Active Directory, so this flag is off by default.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

