### PR TITLE
Cherry-pick #23619 to 7.x: Fix refresh of monitoring configuration 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@
 - Fix Windows service installation script {pull}20203[20203]
 - Fix timeout issue stopping service applications {pull}20256[20256]
 - Fix incorrect hash when upgrading agent {pull}22322[22322]
+- Fix refresh of monitoring configuration {pull}23619[23619]
 - Fixed nil pointer during unenroll {pull}23609[23609]
 
 ==== New features

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -129,8 +129,9 @@ func (o *Operator) generateMonitoringSteps(version string, output interface{}) [
 	watchLogs := o.monitor.WatchLogs()
 	watchMetrics := o.monitor.WatchMetrics()
 
-	// generate only on change
-	if watchLogs != o.isMonitoringLogs() {
+	// generate only when monitoring is running (for config refresh) or
+	// state changes (turning on/off)
+	if watchLogs != o.isMonitoringLogs() || watchLogs {
 		fbConfig, any := o.getMonitoringFilebeatConfig(output)
 		stepID := configrequest.StepRun
 		if !watchLogs || !any {
@@ -151,7 +152,7 @@ func (o *Operator) generateMonitoringSteps(version string, output interface{}) [
 
 		steps = append(steps, filebeatStep)
 	}
-	if watchMetrics != o.isMonitoringMetrics() {
+	if watchMetrics != o.isMonitoringMetrics() || watchMetrics {
 		mbConfig, any := o.getMonitoringMetricbeatConfig(output)
 		stepID := configrequest.StepRun
 		if !watchMetrics || !any {
@@ -552,7 +553,19 @@ func (o *Operator) getMetricbeatEndpoints() map[string][]string {
 	for _, a := range o.apps {
 		metricEndpoint := a.Monitor().MetricsPathPrefixed(a.Spec(), o.pipelineID)
 		if metricEndpoint != "" {
-			endpoints[strings.ReplaceAll(a.Name(), "-", "_")] = append(endpoints[a.Name()], metricEndpoint)
+			safeName := strings.ReplaceAll(a.Name(), "-", "_")
+			// prevent duplicates
+			var found bool
+			for _, ep := range endpoints[safeName] {
+				if ep == metricEndpoint {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				endpoints[safeName] = append(endpoints[safeName], metricEndpoint)
+			}
 		}
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/stateresolver/stateresolver.go
+++ b/x-pack/elastic-agent/pkg/agent/stateresolver/stateresolver.go
@@ -47,6 +47,10 @@ func (s *StateResolver) Resolve(
 
 	s.l.Infof("New State ID is %s", newStateID)
 	s.l.Infof("Converging state requires execution of %d step(s)", len(steps))
+	for i, step := range steps {
+		// more detailed debug log
+		s.l.Debugf("step %d: %s", i, step.String())
+	}
 
 	// Allow the operator to ack the should state when applying the steps is done correctly.
 	ack := func() {


### PR DESCRIPTION
Cherry-pick of PR #23619 to 7.x branch. Original message:

## What does this PR do?

This PR fixes few things
1. tests for decorator were out of date

2. More sensitive monitoring change detection.
We were only regenerating on program list change now we regenerate even on internal config change

3. Generate monitoring steps for operator not only when switch is changed but also when config is changed for agent and monitoring is running. New config will be generated and picked up by monitoring beats.

## Why is it important?

Fixes: #23599

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
