### PR TITLE
The parameter is called "hosts" and not "endpoint"

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -982,6 +982,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Elastic Log Driver*
 
 - Add support for `docker logs` command {pull}19531[19531]
+- Fixed docs for hosts {pull}23644[23644]
 
 ==== Deprecated
 

--- a/x-pack/dockerlogbeat/readme.md
+++ b/x-pack/dockerlogbeat/readme.md
@@ -18,7 +18,7 @@ The Plugin supports a number of Elasticsearch config options:
 
 ```
 docker run --log-driver=elastic/{log-driver-alias}:{version} \
-           --log-opt endpoint="myhost:9200" \
+           --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
            -it debian:jessie /bin/bash


### PR DESCRIPTION
See https://github.com/elastic/beats/blob/621c9e2cf614235a104a170229cb324ebfbea811/x-pack/dockerlogbeat/pipelinemanager/config.go#L37 for reference

## What does this PR do?

Fixes the documentation stating endpoint as parameter, even though it must be hosts.

## Why is it important?

Otherwise it's missleading and people are confused.


## Checklist

- [x] I have made corresponding changes to the documentation

## How to test this PR locally

Check the docs in readme.md