### PR TITLE
Cherry-pick #23534 to 7.11: [Filebeat] Prevent mutable script params reference from leaking into pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -253,6 +253,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Simplify regex for organization custom prefix in AWS/CloudTrail fileset. {issue}23203[23203] {pull}23204[23204]
 - Fix CredentialsJSON unpacking for `gcp-pubsub` and `httpjson` inputs. {pull}23277[23277]
 - Fix syslog header parsing in infoblox module. {issue}23272[23272] {pull}23273[23273]
+- Fix concurrent modification exception in Suricata ingest node pipeline. {pull}23534[23534]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/suricata/eve/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/suricata/eve/ingest/pipeline.yml
@@ -95,6 +95,8 @@ processors:
                 } else {
                     ctx.network.protocol = v;
                 }
+            } else if (v instanceof List) {
+                ctx.event[k] = new ArrayList(v);
             } else {
                 ctx.event[k] = v;
             }


### PR DESCRIPTION
Cherry-pick of PR #23534 to 7.11 branch. Original message: 

## What does this PR do?

A reference to a list contained in the `script` processor's `params` was
leaking into the rest of the pipeline and then being modified by later
processors. Now a copy of the List is written into the event.

For concurrent processing this resulted in `ConcurrentModificationException`s,
but I assume it led to incorrect `event.type` values in single worker deployments
because the `params` object was modified.

## Why is it important?

This fixes processing issues when multiple workers or Filebeats are used.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

