### PR TITLE
Cherry-pick #23666 to 7.x: Update X-Pack Packetbeat config

### DIFF
--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -80,7 +80,7 @@ packetbeat.flows:
 
 packetbeat.protocols:
 - type: icmp
-  # Enable ICMPv4 and ICMPv6 monitoring. Default: true
+  # Enable ICMPv4 and ICMPv6 monitoring. The default is true.
   #enabled: true
 
   # Set to true to publish fields with null values in events.

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -38,7 +38,7 @@ packetbeat.flows:
 
 packetbeat.protocols:
 - type: icmp
-  # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+  # Enable ICMPv4 and ICMPv6 monitoring. The default is true.
   enabled: true
 
 - type: amqp
@@ -47,7 +47,8 @@ packetbeat.protocols:
   ports: [5672]
 
 - type: cassandra
-  #Cassandra port for traffic monitoring.
+  # Configure the ports where to listen for Cassandra traffic. You can disable
+  # the Cassandra protocol by commenting out the list of ports.
   ports: [9042]
 
 - type: dhcpv4
@@ -112,7 +113,8 @@ packetbeat.protocols:
     - 9243  # Elasticsearch
 
 - type: sip
-  # Configure the ports where to listen for SIP traffic. You can disable the SIP protocol by commenting out the list of ports.
+  # Configure the ports where to listen for SIP traffic. You can disable
+  # the SIP protocol by commenting out the list of ports.
   ports: [5060]
 
 # ======================= Elasticsearch template setting =======================


### PR DESCRIPTION
Cherry-pick of PR #23666 to 7.x branch. Original message: 

## What does this PR do?

Fixes broken build caused by out-of-date config files from https://github.com/elastic/beats/pull/22584.

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/pull/22584
