### PR TITLE
Add Winlogbeat Security Module Doc

### DIFF
--- a/winlogbeat/docs/modules/security.asciidoc
+++ b/winlogbeat/docs/modules/security.asciidoc
@@ -16,6 +16,7 @@ The module has transformations for the following event IDs:
 * 4634 - An account was logged off.
 * 4647 - User initiated logoff (interactive logon types).
 * 4648 - A logon was attempted using explicit credentials.
+* 4670 - Permissions on an object were changed.
 * 4672 - Special privileges assigned to new logon.
 * 4673 - A privileged service was called.
 * 4674 - An operation was attempted on a privileged object.
@@ -27,6 +28,12 @@ The module has transformations for the following event IDs:
 * 4700 - A scheduled task was enabled.
 * 4701 - A scheduled task was disabled.
 * 4702 - A scheduled task was updated.
+* 4706 - A new trust was created to a domain.
+* 4707 - A trust to a domain was removed.
+* 4713 - Kerberos policy was changed.
+* 4716 - Trusted domain information was modified.
+* 4717 - System security access was granted to an account.
+* 4718 - System security access was removed from an account.
 * 4719 - System audit policy was changed.
 * 4720 - A user account was created.
 * 4722 - A user account was enabled.
@@ -45,6 +52,7 @@ The module has transformations for the following event IDs:
 * 4735 - A security-enabled local group was changed.
 * 4737 - A security-enabled global group was changed.
 * 4738 - An user account was changed.
+* 4739 - Domain Policy was changed.
 * 4740 - An user account was locked out.
 * 4741 - A computer account was created.
 * 4742 - A computer account was changed.
@@ -105,6 +113,14 @@ The module has transformations for the following event IDs:
 * 4781 - The name of an account was changed.
 * 4798 - A user's local group membership was enumerated.
 * 4799 - A security-enabled local group membership was enumerated.
+* 4817 - Auditing settings on object were changed.
+* 4902 - The Per-user audit policy table was created.
+* 4904 - An attempt was made to register a security event source.
+* 4905 - An attempt was made to unregister a security event source.
+* 4906 - The CrashOnAuditFail value has changed.
+* 4907 - Auditing settings on object were changed.
+* 4908 - Special Groups Logon table modified.
+* 4912 - Per User Audit Policy was changed.
 * 4964 - Special groups have been assigned to a new logon.
 
 More event IDs will be added.

--- a/x-pack/winlogbeat/module/security/_meta/docs.asciidoc
+++ b/x-pack/winlogbeat/module/security/_meta/docs.asciidoc
@@ -16,6 +16,7 @@ The module has transformations for the following event IDs:
 * 4634 - An account was logged off.
 * 4647 - User initiated logoff (interactive logon types).
 * 4648 - A logon was attempted using explicit credentials.
+* 4670 - Permissions on an object were changed.
 * 4672 - Special privileges assigned to new logon.
 * 4673 - A privileged service was called.
 * 4674 - An operation was attempted on a privileged object.
@@ -27,6 +28,12 @@ The module has transformations for the following event IDs:
 * 4700 - A scheduled task was enabled.
 * 4701 - A scheduled task was disabled.
 * 4702 - A scheduled task was updated.
+* 4706 - A new trust was created to a domain.
+* 4707 - A trust to a domain was removed.
+* 4713 - Kerberos policy was changed.
+* 4716 - Trusted domain information was modified.
+* 4717 - System security access was granted to an account.
+* 4718 - System security access was removed from an account.
 * 4719 - System audit policy was changed.
 * 4720 - A user account was created.
 * 4722 - A user account was enabled.
@@ -45,6 +52,7 @@ The module has transformations for the following event IDs:
 * 4735 - A security-enabled local group was changed.
 * 4737 - A security-enabled global group was changed.
 * 4738 - An user account was changed.
+* 4739 - Domain Policy was changed.
 * 4740 - An user account was locked out.
 * 4741 - A computer account was created.
 * 4742 - A computer account was changed.
@@ -105,6 +113,14 @@ The module has transformations for the following event IDs:
 * 4781 - The name of an account was changed.
 * 4798 - A user's local group membership was enumerated.
 * 4799 - A security-enabled local group membership was enumerated.
+* 4817 - Auditing settings on object were changed.
+* 4902 - The Per-user audit policy table was created.
+* 4904 - An attempt was made to register a security event source.
+* 4905 - An attempt was made to unregister a security event source.
+* 4906 - The CrashOnAuditFail value has changed.
+* 4907 - Auditing settings on object were changed.
+* 4908 - Special Groups Logon table modified.
+* 4912 - Per User Audit Policy was changed.
 * 4964 - Special groups have been assigned to a new logon.
 
 More event IDs will be added.


### PR DESCRIPTION
## What does this PR do?
Add documentation of supported events for winlogbeat's security module
(https://github.com/elastic/beats/pull/20684)
Added missing events in the security,asciidoc file
## Why is it important?
Important for a Complete Documentation of winlogbeat's security module

