### PR TITLE
[Ingest Manager] Fixed reenroll scenario

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@
 - Fix incorrect hash when upgrading agent {pull}22322[22322]
 - Fix refresh of monitoring configuration {pull}23619[23619]
 - Fixed nil pointer during unenroll {pull}23609[23609]
+- Fixed reenroll scenario {pull}23686[23686]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -209,6 +209,12 @@ func (c *EnrollCmd) Execute() error {
 		return err
 	}
 
+	// clear action store
+	// fail only if file exists and there was a failure
+	if err := os.Remove(info.AgentStateStoreFile()); !os.IsNotExist(err) {
+		return err
+	}
+
 	return nil
 }
 

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -247,19 +247,26 @@ func rollbackInstall(ctx context.Context, hash string) {
 }
 
 func copyActionStore(newHash string) error {
-	currentActionStorePath := info.AgentActionStoreFile()
+	storePaths := []string{info.AgentActionStoreFile(), info.AgentStateStoreFile()}
 
-	newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
-	newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))
+	for _, currentActionStorePath := range storePaths {
 
-	currentActionStore, err := ioutil.ReadFile(currentActionStorePath)
-	if os.IsNotExist(err) {
-		// nothing to copy
-		return nil
+		newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
+		newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))
+
+		currentActionStore, err := ioutil.ReadFile(currentActionStorePath)
+		if os.IsNotExist(err) {
+			// nothing to copy
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if err := ioutil.WriteFile(newActionStorePath, currentActionStore, 0600); err != nil {
+			return err
+		}
 	}
-	if err != nil {
-		return err
-	}
 
-	return ioutil.WriteFile(newActionStorePath, currentActionStore, 0600)
+	return nil
 }

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -250,14 +250,13 @@ func copyActionStore(newHash string) error {
 	storePaths := []string{info.AgentActionStoreFile(), info.AgentStateStoreFile()}
 
 	for _, currentActionStorePath := range storePaths {
-
 		newHome := filepath.Join(filepath.Dir(paths.Home()), fmt.Sprintf("%s-%s", agentName, newHash))
 		newActionStorePath := filepath.Join(newHome, filepath.Base(currentActionStorePath))
 
 		currentActionStore, err := ioutil.ReadFile(currentActionStorePath)
 		if os.IsNotExist(err) {
 			// nothing to copy
-			return nil
+			continue
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
## What does this PR do?

Continuation of #23569 on enroll we need to cleanup state otherwise when agent starts it will report unenrolled and fails to proceed with configuration check.

## Why is it important?

Reenroll scenario when agent is unenrolled and enrolled later at the time

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
