### PR TITLE
[CI] Explicit linting stages for OSS and x-pack

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -2,7 +2,6 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^auditbeat/.*"
-        - "^x-pack/auditbeat/.*"  ## when changes in the x-pack/auditbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -19,6 +18,11 @@ stages:
           make -C auditbeat check;
           make -C auditbeat update;
           make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/auditbeat check;
+          make -C x-pack/auditbeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -34,16 +38,8 @@ stages:
             tags: true         ## for all the tags
     build:
         mage: "mage build test"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     crosscompile:
         make: "make -C auditbeat crosscompile"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -63,42 +59,22 @@ stages:
             - "windows-2019"
             #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19831
             #- "windows-2008-r2" https://github.com/elastic/beats/issues/19799
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     #windows-7:  See https://github.com/elastic/beats/issues/19831
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.

--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C auditbeat check;
           make -C auditbeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/auditbeat check;
           make -C x-pack/auditbeat update;
           make check-no-changes;

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C filebeat check;
           make -C filebeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/filebeat check;
           make -C x-pack/filebeat update;
           make check-no-changes;

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -2,7 +2,6 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^filebeat/.*"
-        - "^x-pack/filebeat/.*"  ## when changes in the x-pack/filebeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -18,6 +17,11 @@ stages:
         make: |
           make -C filebeat check;
           make -C filebeat update;
+          make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/filebeat check;
+          make -C x-pack/filebeat update;
           make check-no-changes;
     arm:
         mage: "mage build unitTest"
@@ -35,10 +39,6 @@ stages:
     build:
         mage: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -57,34 +57,18 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19795
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     #windows-7:  See https://github.com/elastic/beats/issues/22317
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.
@@ -100,7 +84,3 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C heartbeat check;
           make -C heartbeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/heartbeat check;
           make -C x-pack/heartbeat update;
           make check-no-changes;

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -2,7 +2,6 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^heartbeat/.*"
-        - "^x-pack/heartbeat/.*"  ## when changes in the x-pack/heartbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -19,6 +18,11 @@ stages:
           make -C heartbeat check;
           make -C heartbeat update;
           make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/heartbeat check;
+          make -C x-pack/heartbeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -34,10 +38,6 @@ stages:
             tags: true         ## for all the tags
     build:
         mage: "mage build test"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -55,63 +55,31 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C journalbeat check;
           make -C journalbeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/journalbeat check;
           make -C x-pack/journalbeat update;
           make check-no-changes;

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -2,7 +2,6 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^journalbeat/.*"
-        - "^x-pack/journalbeat/.*"  ## when changes in the x-pack/journalbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -19,6 +18,11 @@ stages:
           make -C journalbeat check;
           make -C journalbeat update;
           make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/journalbeat check;
+          make -C x-pack/journalbeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -34,7 +38,3 @@ stages:
             tags: true         ## for all the tags
     unitTest:
         mage: "mage build unitTest"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -16,9 +16,6 @@ stages:
         make: |
           make -C libbeat check;
           make -C libbeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/libbeat check;
           make -C x-pack/libbeat update;
           make check-no-changes;

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -1,7 +1,6 @@
 when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
-        - "^x-pack/libbeat/.*" ## when changes in the x-pack/libbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -18,6 +17,11 @@ stages:
           make -C libbeat check;
           make -C libbeat update;
           make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/libbeat check;
+          make -C x-pack/libbeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -31,19 +35,7 @@ stages:
                 - "armTest"
     build:
         mage: "mage build test"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     crosscompile:
         make: "make -C libbeat crosscompile"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     stress-tests:
         make: "make STRESS_TEST_OPTIONS='-timeout=20m -race -v -parallel 1' -C libbeat stress-tests"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C metricbeat check;
           make -C metricbeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
           make check-no-changes;

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -2,7 +2,6 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^metricbeat/.*"
-        - "^x-pack/metricbeat/.*"  ## when changes in the x-pack/metricbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -19,32 +18,21 @@ stages:
           make -C metricbeat check;
           make -C metricbeat update;
           make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/metricbeat check;
+          make -C x-pack/metricbeat update;
+          make check-no-changes;
     unitTest:
         mage: "mage build unitTest"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     goIntegTest:
         mage: "mage goIntegTest"
         withModule: true
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     pythonIntegTest:
         mage: "mage pythonIntegTest"
         withModule: true
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     crosscompile:
         make: "make -C metricbeat crosscompile"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -62,63 +50,31 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -2,7 +2,6 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^packetbeat/.*"
-        - "^x-pack/packetbeat/.*"  ## when changes in the x-pack/packetbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -19,6 +18,11 @@ stages:
           make -C packetbeat check;
           make -C packetbeat update;
           make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/packetbeat check;
+          make -C x-pack/packetbeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -34,10 +38,6 @@ stages:
             tags: true         ## for all the tags
     build:
         mage: "mage build test"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -55,63 +55,31 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C packetbeat check;
           make -C packetbeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/packetbeat check;
           make -C x-pack/packetbeat update;
           make check-no-changes;

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C winlogbeat check;
           make -C winlogbeat update;
-          make check-no-changes;
-    Lint-Xpack:
-        make: |
           make -C x-pack/winlogbeat check;
           make -C x-pack/winlogbeat update;
           make check-no-changes;

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -2,7 +2,6 @@ when:
     branches: true             ## for all the branches
     changeset:                 ## when PR contains any of those entries in the changeset
         - "^winlogbeat/.*"
-        - "^x-pack/winlogbeat/.*"  ## when changes in the x-pack/winlogbeat
         - "@ci"                ## special token regarding the changeset for the ci
         - "@oss"               ## special token regarding the changeset for the oss
     comments:                  ## when PR comment contains any of those entries
@@ -19,66 +18,39 @@ stages:
           make -C winlogbeat check;
           make -C winlogbeat update;
           make check-no-changes;
+    Lint-Xpack:
+        make: |
+          make -C x-pack/winlogbeat check;
+          make -C x-pack/winlogbeat update;
+          make check-no-changes;
     crosscompile:
         make: "make -C winlogbeat crosscompile"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
             - "windows-2008-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
-        when:                  ## Override the top-level when.
-            not_changeset_full_match: "^x-pack/.*" ## Disable the stage if ONLY changes for the x-pack
-            branches: true                         ## for all the branches
-            tags: true                             ## for all the tags

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C x-pack/auditbeat check;
           make -C x-pack/auditbeat update;
-          make check-no-changes;
-    Lint-OSS:
-        make: |
           make -C auditbeat check;
           make -C auditbeat update;
           make check-no-changes;

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -18,6 +18,11 @@ stages:
           make -C x-pack/auditbeat check;
           make -C x-pack/auditbeat update;
           make check-no-changes;
+    Lint-OSS:
+        make: |
+          make -C auditbeat check;
+          make -C auditbeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C x-pack/filebeat check;
           make -C x-pack/filebeat update;
-          make check-no-changes;
-    Lint-OSS:
-        make: |
           make -C filebeat check;
           make -C filebeat update;
           make check-no-changes;

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -18,6 +18,11 @@ stages:
           make -C x-pack/filebeat check;
           make -C x-pack/filebeat update;
           make check-no-changes;
+    Lint-OSS:
+        make: |
+          make -C filebeat check;
+          make -C filebeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         make: |
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
-          make check-no-changes;
-    Lint-OSS:
-        make: |
           make -C metricbeat check;
           make -C metricbeat update;
           make check-no-changes;

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -18,6 +18,11 @@ stages:
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
           make check-no-changes;
+    Lint-OSS:
+        make: |
+          make -C metricbeat check;
+          make -C metricbeat update;
+          make check-no-changes;
     unitTest:
         mage: "mage build unitTest"
     cloud:

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -15,9 +15,14 @@ platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     Lint:
         mage: |
-          mage check;
-          mage update;
-        make: "make check-no-changes"
+          mage -C x-pack/packetbeat check;
+          mage -C x-pack/packetbeat update;
+          make check-no-changes;
+    Lint-OSS:
+        make: |
+          make -C packetbeat check;
+          make -C packetbeat update;
+          make check-no-changes;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -17,9 +17,6 @@ stages:
         mage: |
           mage -C x-pack/packetbeat check;
           mage -C x-pack/packetbeat update;
-          make check-no-changes;
-    Lint-OSS:
-        make: |
           make -C packetbeat check;
           make -C packetbeat update;
           make check-no-changes;

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -20,6 +20,13 @@ stages:
           make check-no-changes;
         platforms:             ## override default labels in this specific stage.
             - "immutable && ubuntu-18"
+    Lint-OSS:
+        make: |
+          make -C winlogbeat check;
+          make -C winlogbeat update;
+          make check-no-changes;
+        platforms:             ## override default labels in this specific stage.
+            - "immutable && ubuntu-18"
     build:
         mage: "mage build unitTest"
         withModule: true

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -17,11 +17,6 @@ stages:
         make: |
           make -C x-pack/winlogbeat check;
           make -C x-pack/winlogbeat update;
-          make check-no-changes;
-        platforms:             ## override default labels in this specific stage.
-            - "immutable && ubuntu-18"
-    Lint-OSS:
-        make: |
           make -C winlogbeat check;
           make -C winlogbeat update;
           make check-no-changes;


### PR DESCRIPTION
## What does this PR do?

This might produce duplicated stages but it reduces the complexity of the when conditions.

## Why is it important?

Run cross-linting between x-pack and OSS beats.

## Issues

Supersedes https://github.com/elastic/beats/pull/23655 and https://github.com/elastic/beats/pull/23378