### PR TITLE
Cherry-pick #23546 to 7.11: Remove dimension TAGS from aws metricbeat module documentation for billing

### DIFF
--- a/x-pack/metricbeat/module/aws/billing/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/billing/_meta/docs.asciidoc
@@ -49,8 +49,6 @@ different groups, either dimensions, tag keys, or both. Right now we support
 group by type dimension and type tag with separate config parameters:
 
 * *group_by_dimension_keys*: A list of keys used in Cost Explorer to group by
-dimensions. Valid values are AZ, INSTANCE_TYPE, LEGAL_ENTITY_NAME,
-LINKED_ACCOUNT, OPERATION, PLATFORM, PURCHASE_TYPE, SERVICE, TAGS, TENANCY, and
-USAGE_TYPE.
+dimensions. Valid values are AZ, INSTANCE_TYPE, LINKED_ACCOUNT, OPERATION, PURCHASE_TYPE, REGION, SERVICE, USAGE_TYPE, USAGE_TYPE_GROUP, RECORD_TYPE, OPERATING_SYSTEM, TENANCY, SCOPE, PLATFORM, SUBSCRIPTION_ID, LEGAL_ENTITY_NAME, DEPLOYMENT_OPTION, DATABASE_ENGINE, CACHE_ENGINE, INSTANCE_TYPE_FAMILY, BILLING_ENTITY and RESERVATION_ID.
 
 * *group_by_tag_keys*: A list of keys used in Cost Explorer to group by tags.


### PR DESCRIPTION
Cherry-pick of PR #23546 to 7.11 branch. Original message: 

https://github.com/elastic/beats/blob/7.11/x-pack/metricbeat/module/aws/billing/billing.go#L34-L42 :
```
	// This list is from https://github.com/aws/aws-sdk-go-v2/blob/master/service/costexplorer/api_enums.go#L60-L90
	supportedDimensionKeys = []string{
		"AZ", "INSTANCE_TYPE", "LINKED_ACCOUNT", "OPERATION", "PURCHASE_TYPE",
		"REGION", "SERVICE", "USAGE_TYPE", "USAGE_TYPE_GROUP", "RECORD_TYPE",
		"OPERATING_SYSTEM", "TENANCY", "SCOPE", "PLATFORM", "SUBSCRIPTION_ID",
		"LEGAL_ENTITY_NAME", "DEPLOYMENT_OPTION", "DATABASE_ENGINE",
		"CACHE_ENGINE", "INSTANCE_TYPE_FAMILY", "BILLING_ENTITY",
		"RESERVATION_ID",
	}
```

https://github.com/elastic/beats/blob/master/x-pack/metricbeat/module/aws/billing/_meta/docs.asciidoc mentions `TAGS` :
> group_by_dimension_keys: A list of keys used in Cost Explorer to group by dimensions. Valid values are AZ, INSTANCE_TYPE, LEGAL_ENTITY_NAME, LINKED_ACCOUNT, OPERATION, PLATFORM, PURCHASE_TYPE, SERVICE, **TAGS,** TENANCY, and USAGE_TYPE.

https://github.com/aws/aws-sdk-go-v2/blob/main/service/costexplorer/types/enums.go#L171-L203 :
```
func (Dimension) Values() []Dimension {
	return []Dimension{
		"AZ",
		"INSTANCE_TYPE",
		"LINKED_ACCOUNT",
		"LINKED_ACCOUNT_NAME",
		"OPERATION",
		"PURCHASE_TYPE",
		"REGION",
		"SERVICE",
		"SERVICE_CODE",
		"USAGE_TYPE",
		"USAGE_TYPE_GROUP",
		"RECORD_TYPE",
		"OPERATING_SYSTEM",
		"TENANCY",
		"SCOPE",
		"PLATFORM",
		"SUBSCRIPTION_ID",
		"LEGAL_ENTITY_NAME",
		"DEPLOYMENT_OPTION",
		"DATABASE_ENGINE",
		"CACHE_ENGINE",
		"INSTANCE_TYPE_FAMILY",
		"BILLING_ENTITY",
		"RESERVATION_ID",
		"RESOURCE_ID",
		"RIGHTSIZING_TYPE",
		"SAVINGS_PLANS_TYPE",
		"SAVINGS_PLAN_ARN",
		"PAYMENT_OPTION",
	}
}
```

I think we just need to remove TAGS from the documentation, when used metricbeat won't start with this error
```
ERROR  instance/beat.go:956  Exiting: 1 error: error unpack raw module config using UnpackConfig: costexplorer GetCostAndUsageRequest does not support dimension key: TAGS accessing '0.cost_explorer_config' (source:'/usr/share/metricbeat/modules.d/aws.yml')
```
