### PR TITLE
[Filebeat] Remove TCP input from fortinet fileset

### DIFF
--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -53,7 +53,7 @@ include::../include/var-paths.asciidoc[]
 
 *`var.input`*::
 
-The input to use, can be either the value `tcp`, `udp` or `file`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
@@ -81,11 +81,11 @@ NOTE: This was converted from RSA NetWitness log parser XML "forticlientendpoint
 
 *`var.input`*::
 
-The input from which messages are read. One of `file`, `tcp` or `udp`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
-The address to listen to UDP or TCP based syslog traffic.
+The address to listen to for UDP based syslog traffic.
 Defaults to `localhost`.
 Set to `0.0.0.0` to bind to all available interfaces.
 
@@ -126,11 +126,11 @@ NOTE: This was converted from RSA NetWitness log parser XML "fortinetfortimail" 
 
 *`var.input`*::
 
-The input from which messages are read. One of `file`, `tcp` or `udp`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
-The address to listen to UDP or TCP based syslog traffic.
+The address to listen to for UDP based syslog traffic.
 Defaults to `localhost`.
 Set to `0.0.0.0` to bind to all available interfaces.
 
@@ -171,11 +171,11 @@ NOTE: This was converted from RSA NetWitness log parser XML "fortinetmgr" device
 
 *`var.input`*::
 
-The input from which messages are read. One of `file`, `tcp` or `udp`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
-The address to listen to UDP or TCP based syslog traffic.
+The address to listen to for UDP based syslog traffic.
 Defaults to `localhost`.
 Set to `0.0.0.0` to bind to all available interfaces.
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -767,7 +767,7 @@ filebeat.modules:
   firewall:
     enabled: true
 
-    # Set which input to use between tcp, udp (default) or file.
+    # Set which input to use between udp (default) or file.
     #var.input: udp
 
     # The interface to listen to syslog traffic. Defaults to
@@ -790,7 +790,7 @@ filebeat.modules:
   clientendpoint:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9510
@@ -809,7 +809,7 @@ filebeat.modules:
   fortimail:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9529
@@ -828,7 +828,7 @@ filebeat.modules:
   fortimanager:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9530

--- a/x-pack/filebeat/module/fortinet/_meta/config.yml
+++ b/x-pack/filebeat/module/fortinet/_meta/config.yml
@@ -2,7 +2,7 @@
   firewall:
     enabled: true
 
-    # Set which input to use between tcp, udp (default) or file.
+    # Set which input to use between udp (default) or file.
     #var.input: udp
 
     # The interface to listen to syslog traffic. Defaults to
@@ -25,7 +25,7 @@
   clientendpoint:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9510
@@ -44,7 +44,7 @@
   fortimail:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9529
@@ -63,7 +63,7 @@
   fortimanager:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9530

--- a/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
@@ -48,7 +48,7 @@ include::../include/var-paths.asciidoc[]
 
 *`var.input`*::
 
-The input to use, can be either the value `tcp`, `udp` or `file`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
@@ -76,11 +76,11 @@ NOTE: This was converted from RSA NetWitness log parser XML "forticlientendpoint
 
 *`var.input`*::
 
-The input from which messages are read. One of `file`, `tcp` or `udp`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
-The address to listen to UDP or TCP based syslog traffic.
+The address to listen to for UDP based syslog traffic.
 Defaults to `localhost`.
 Set to `0.0.0.0` to bind to all available interfaces.
 
@@ -121,11 +121,11 @@ NOTE: This was converted from RSA NetWitness log parser XML "fortinetfortimail" 
 
 *`var.input`*::
 
-The input from which messages are read. One of `file`, `tcp` or `udp`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
-The address to listen to UDP or TCP based syslog traffic.
+The address to listen to for UDP based syslog traffic.
 Defaults to `localhost`.
 Set to `0.0.0.0` to bind to all available interfaces.
 
@@ -166,11 +166,11 @@ NOTE: This was converted from RSA NetWitness log parser XML "fortinetmgr" device
 
 *`var.input`*::
 
-The input from which messages are read. One of `file`, `tcp` or `udp`.
+The input to use, can be either the value `udp` or `file`.
 
 *`var.syslog_host`*::
 
-The address to listen to UDP or TCP based syslog traffic.
+The address to listen to for UDP based syslog traffic.
 Defaults to `localhost`.
 Set to `0.0.0.0` to bind to all available interfaces.
 

--- a/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
@@ -1,9 +1,4 @@
-{{ if eq .input "tcp" }}
-
-type: tcp
-host: "{{.syslog_host}}:{{.syslog_port}}"
-
-{{ else if eq .input "udp" }}
+{{ if eq .input "udp" }}
 
 type: udp
 host: "{{.syslog_host}}:{{.syslog_port}}"

--- a/x-pack/filebeat/modules.d/fortinet.yml.disabled
+++ b/x-pack/filebeat/modules.d/fortinet.yml.disabled
@@ -5,7 +5,7 @@
   firewall:
     enabled: true
 
-    # Set which input to use between tcp, udp (default) or file.
+    # Set which input to use between udp (default) or file.
     #var.input: udp
 
     # The interface to listen to syslog traffic. Defaults to
@@ -28,7 +28,7 @@
   clientendpoint:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9510
@@ -47,7 +47,7 @@
   fortimail:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9529
@@ -66,7 +66,7 @@
   fortimanager:
     enabled: true
 
-    # Set which input to use between udp (default), tcp or file.
+    # Set which input to use between udp (default) or file.
     # var.input: udp
     # var.syslog_host: localhost
     # var.syslog_port: 9530


### PR DESCRIPTION
## What does this PR do?

Removes TCP input from fortinet fileset.  Filebeat doesn't currently
support necessary options to receive TCP syslog from Fortinet systems.


## Why is it important?

Document correct behavior.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~