### PR TITLE
dev-tools/mage: pin pip

### DIFF
--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -225,7 +225,7 @@ func PythonVirtualenv() (string, error) {
 	}
 
 	// Ensure we are using the latest pip version.
-	if err = pipUpgrade("pip"); err != nil {
+	if err = pipUpgrade("pip==20.3.4"); err != nil {
 		fmt.Printf("warn: failed to upgrade pip (ignoring): %v", err)
 	}
 


### PR DESCRIPTION
## What does this PR do?

Pin the version of `pip` used for setting up venv, as used for builds and tests.

## Why is it important?

The 7.11 release builds are using an older version of Python which does not respect the Python version constraint in pypi, causing it to upgrade pip to something too new.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

In apm-server: `make build/ve/linux/bin`. Check that the installed version of pip is 20.3.4.

## Related issues

None.