### PR TITLE
[DOCS] Minor updates to Kubernetes and Heartbeat docs

### DIFF
--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -62,8 +62,8 @@ Heartbeat currently provides monitors for ICMP, TCP, and HTTP (see
 
 You configure each monitor individually. In +{beatname_lc}.yml+, specify the
 list of monitors that you want to enable. Each item in the list begins with a
-dash (-). The following example configures Heartbeat to use two monitors, an
-`icmp` monitor and a `tcp` monitor:
+dash (-). The following example configures Heartbeat to use three monitors: an
+`icmp` monitor, a `tcp` monitor, and an `http` monitor.
 
 [source,yaml]
 ----------------------------------------------------------------------

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -26,9 +26,9 @@ Kubernetes module is a bit complex as its internal metricsets require access to 
 This section highlights and introduces some groups of metricsets with similar endpoint access needs. For more details on the metricsets see `configuration example` and the `metricsets` sections below.
 
 [float]
-==== node / system / pod / container / module
+==== container / node / pod / system / volume
 
-The default metricsets `container`, `node`, `pod`, `system` and `volume` require access to the `kubelet endpoint` in each of the Kubernetes nodes, hence it's recommended to include them as part of a `Metricbeat DaemonSet` or standalone Metricbeats running on the hosts.
+The default metricsets `container`, `node`, `pod`, `system`, and `volume` require access to the `kubelet endpoint` in each of the Kubernetes nodes, hence it's recommended to include them as part of a `Metricbeat DaemonSet` or standalone Metricbeats running on the hosts.
 
 Depending on the version and configuration of Kubernetes nodes, `kubelet` might provide a read only http port (typically 10255), which is used in some configuration examples. But in general, and lately, this endpoint requires SSL (`https`) access (to port 10250 by default) and token based authentication.
 

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -19,9 +19,9 @@ Kubernetes module is a bit complex as its internal metricsets require access to 
 This section highlights and introduces some groups of metricsets with similar endpoint access needs. For more details on the metricsets see `configuration example` and the `metricsets` sections below.
 
 [float]
-==== node / system / pod / container / module
+==== container / node / pod / system / volume
 
-The default metricsets `container`, `node`, `pod`, `system` and `volume` require access to the `kubelet endpoint` in each of the Kubernetes nodes, hence it's recommended to include them as part of a `Metricbeat DaemonSet` or standalone Metricbeats running on the hosts.
+The default metricsets `container`, `node`, `pod`, `system`, and `volume` require access to the `kubelet endpoint` in each of the Kubernetes nodes, hence it's recommended to include them as part of a `Metricbeat DaemonSet` or standalone Metricbeats running on the hosts.
 
 Depending on the version and configuration of Kubernetes nodes, `kubelet` might provide a read only http port (typically 10255), which is used in some configuration examples. But in general, and lately, this endpoint requires SSL (`https`) access (to port 10250 by default) and token based authentication.
 


### PR DESCRIPTION
### Summary

This PR contains two minor updates to the Metricbeat Kubernetes module doc and the Heartbeat Getting Started doc.

### HTML Preview

- **Metricbeat**: https://beats_23712.docs-preview.app.elstc.co/guide/en/beats/metricbeat/master/metricbeat-module-kubernetes.html#_container_node_pod_system_volume
- **Heartbeat**: https://beats_23712.docs-preview.app.elstc.co/guide/en/beats/heartbeat/master/heartbeat-installation-configuration.html#configuration

**NOTE**: Running `mage fmt update` to update the Kubernetes doc didn't work for me. I ran `make clean` and then `make update`, which seemed to work fine.

 