### PR TITLE
Cherry-pick #23610 to 7.x: Add deployment name in pod's meta

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -410,6 +410,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update the baseline version of Sarama (Kafka support library) to 1.27.2. {pull}23595[23595]
 - Add kubernetes.volume.fs.used.pct field. {pull}23564[23564]
 - Add the `enable_krb5_fast` flag to the Kafka output to explicitly opt-in to FAST authentication. {pull}23629[23629]
+- Add deployment name in pod's meta. {pull}23610[23610]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/pod_test.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod_test.go
@@ -1497,7 +1497,7 @@ func TestEmitEvent(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			metaGen := metadata.NewPodMetadataGenerator(common.NewConfig(), nil, nil, nil)
+			metaGen := metadata.NewPodMetadataGenerator(common.NewConfig(), nil, nil, nil, nil)
 			p := &Provider{
 				config:    defaultConfig(),
 				bus:       bus.New(logp.NewLogger("bus"), "test"),

--- a/libbeat/common/kubernetes/metadata/metadata.go
+++ b/libbeat/common/kubernetes/metadata/metadata.go
@@ -67,7 +67,7 @@ func GetPodMetaGen(
 	if namespaceWatcher != nil && metaConf.Namespace.Enabled() {
 		namespaceMetaGen = NewNamespaceMetadataGenerator(metaConf.Namespace, namespaceWatcher.Store())
 	}
-	metaGen := NewPodMetadataGenerator(cfg, podWatcher.Store(), nodeMetaGen, namespaceMetaGen)
+	metaGen := NewPodMetadataGenerator(cfg, podWatcher.Store(), podWatcher.Client(), nodeMetaGen, namespaceMetaGen)
 
 	return metaGen
 }

--- a/libbeat/common/kubernetes/metadata/pod_test.go
+++ b/libbeat/common/kubernetes/metadata/pod_test.go
@@ -18,15 +18,18 @@
 package metadata
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -34,10 +37,61 @@ import (
 )
 
 func TestPod_Generate(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
 	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
 	namespace := "default"
 	name := "obj"
 	boolean := true
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx-rs",
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps",
+					Kind:       "Deployment",
+					Name:       "nginx-deployment",
+					UID:        "005f3b90-4b9d-12f8-acf0-31020a840144",
+					Controller: &boolean,
+				},
+			},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "demo",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "demo",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "nginx",
+							Image: "nginx:1.12",
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "http",
+									Protocol:      v1.ProtocolTCP,
+									ContainerPort: 80,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := client.AppsV1().ReplicaSets(namespace).Create(context.Background(), rs, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create k8s deployment: %v", err)
+	}
+
 	tests := []struct {
 		input  kubernetes.Resource
 		output common.MapStr
@@ -133,6 +187,60 @@ func TestPod_Generate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test object with owner reference to replicaset",
+			input: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					UID:       types.UID(uid),
+					Namespace: namespace,
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"app": "production",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps",
+							Kind:       "ReplicaSet",
+							Name:       "nginx-rs",
+							UID:        "005f3b90-4b9d-12f8-acf0-31020a8409087",
+							Controller: &boolean,
+						},
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+				},
+			},
+			output: common.MapStr{
+				"pod": common.MapStr{
+					"name": "obj",
+					"uid":  uid,
+				},
+				"namespace": "default",
+				"deployment": common.MapStr{
+					"name": "nginx-deployment",
+				},
+				"replicaset": common.MapStr{
+					"name": "nginx-rs",
+				},
+				"node": common.MapStr{
+					"name": "testnode",
+				},
+				"labels": common.MapStr{
+					"foo": "bar",
+				},
+				"annotations": common.MapStr{
+					"app": "production",
+				},
+			},
+		},
 	}
 
 	config, err := common.NewConfigFrom(map[string]interface{}{
@@ -140,7 +248,7 @@ func TestPod_Generate(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	metagen := NewPodMetadataGenerator(config, nil, nil, nil)
+	metagen := NewPodMetadataGenerator(config, nil, client, nil, nil)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.Generate(test.input))
@@ -257,7 +365,7 @@ func TestPod_GenerateFromName(t *testing.T) {
 		assert.Nil(t, err)
 		pods := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		pods.Add(test.input)
-		metagen := NewPodMetadataGenerator(config, pods, nil, nil)
+		metagen := NewPodMetadataGenerator(config, pods, nil, nil, nil)
 
 		accessor, err := meta.Accessor(test.input)
 		require.Nil(t, err)
@@ -376,7 +484,7 @@ func TestPod_GenerateWithNodeNamespace(t *testing.T) {
 		namespaces.Add(test.namespace)
 		nsMeta := NewNamespaceMetadataGenerator(config, namespaces)
 
-		metagen := NewPodMetadataGenerator(config, pods, nodeMeta, nsMeta)
+		metagen := NewPodMetadataGenerator(config, pods, nil, nodeMeta, nsMeta)
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.Generate(test.input))
 		})

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -56,6 +56,9 @@ type Watcher interface {
 
 	// Store returns the store object for the watcher
 	Store() cache.Store
+
+	// Client returns the kubernetes client object used by the watcher
+	Client() kubernetes.Interface
 }
 
 // WatchOptions controls watch behaviors
@@ -163,6 +166,11 @@ func (w *watcher) AddEventHandler(h ResourceEventHandler) {
 // Store returns the store object for the resource that is being watched
 func (w *watcher) Store() cache.Store {
 	return w.store
+}
+
+// Client returns the kubernetes client object used by the watcher
+func (w *watcher) Client() kubernetes.Interface {
+	return w.client
 }
 
 // Start watching pods

--- a/libbeat/processors/add_kubernetes_metadata/indexers_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/indexers_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
 )
 
-var metagen = metadata.NewPodMetadataGenerator(common.NewConfig(), nil, nil, nil)
+var metagen = metadata.NewPodMetadataGenerator(common.NewConfig(), nil, nil, nil, nil)
 
 func TestPodIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
@@ -86,7 +86,7 @@ func TestPodIndexer(t *testing.T) {
 func TestPodUIDIndexer(t *testing.T) {
 	var testConfig = common.NewConfig()
 
-	metaGenWithPodUID := metadata.NewPodMetadataGenerator(common.NewConfig(), nil, nil, nil)
+	metaGenWithPodUID := metadata.NewPodMetadataGenerator(common.NewConfig(), nil, nil, nil, nil)
 
 	podUIDIndexer, err := NewPodUIDIndexer(*testConfig, metaGenWithPodUID)
 	assert.Nil(t, err)
@@ -287,7 +287,7 @@ func TestFilteredGenMeta(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	filteredGen := metadata.NewPodMetadataGenerator(config, nil, nil, nil)
+	filteredGen := metadata.NewPodMetadataGenerator(config, nil, nil, nil, nil)
 
 	podIndexer, err = NewPodNameIndexer(*testConfig, filteredGen)
 	assert.Nil(t, err)
@@ -324,7 +324,7 @@ func TestFilteredGenMetaExclusion(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	filteredGen := metadata.NewPodMetadataGenerator(config, nil, nil, nil)
+	filteredGen := metadata.NewPodMetadataGenerator(config, nil, nil, nil, nil)
 
 	podIndexer, err := NewPodNameIndexer(*testConfig, filteredGen)
 	assert.Nil(t, err)

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -129,7 +129,7 @@ func NewResourceMetadataEnricher(
 	cfg, _ := common.NewConfigFrom(&metaConfig)
 
 	metaGen := metadata.NewResourceMetadataGenerator(cfg)
-	podMetaGen := metadata.NewPodMetadataGenerator(cfg, nil, nil, nil)
+	podMetaGen := metadata.NewPodMetadataGenerator(cfg, nil, watcher.Client(), nil, nil)
 	enricher := buildMetadataEnricher(watcher,
 		// update
 		func(m map[string]common.MapStr, r kubernetes.Resource) {
@@ -213,7 +213,7 @@ func NewContainerMetadataEnricher(
 
 	cfg, _ := common.NewConfigFrom(&metaConfig)
 
-	metaGen := metadata.NewPodMetadataGenerator(cfg, nil, nil, nil)
+	metaGen := metadata.NewPodMetadataGenerator(cfg, nil, watcher.Client(), nil, nil)
 	enricher := buildMetadataEnricher(watcher,
 		// update
 		func(m map[string]common.MapStr, r kubernetes.Resource) {

--- a/metricbeat/module/kubernetes/util/kubernetes_test.go
+++ b/metricbeat/module/kubernetes/util/kubernetes_test.go
@@ -20,6 +20,7 @@ package util
 import (
 	"testing"
 
+	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/stretchr/testify/assert"
@@ -155,5 +156,9 @@ func (m *mockWatcher) AddEventHandler(r kubernetes.ResourceEventHandler) {
 }
 
 func (m *mockWatcher) Store() cache.Store {
+	return nil
+}
+
+func (m *mockWatcher) Client() k8s.Interface {
 	return nil
 }


### PR DESCRIPTION
Cherry-pick of PR #23610 to 7.x branch. Original message: 

## What does this PR do?
This PR adds `kubernetes.deployment.name` in Pods' metadata. Right now we only add `kubernetes.replicaset.name` when a Pod is handled by a Deployment since a Deployment controls the Pod through a ReplicaSet and the ReplicaSet is considered as the direct owner of the Pod in k8s API. In this we need an extra step check to retrieve the owner of the ReplicaSet if possible.


## Why is it important?
So as to correlate Pods with Deployments controlling them.


## How to test this PR locally
1. Deploy a sample Deployment on k8s: `kubectl apply -f https://k8s.io/examples/controllers/nginx-deployment.yaml `
2. Deploy Metricbeat ([instructions](https://github.com/elastic/observability-dev/blob/master/docs/dc/testing/k8s.md)) on k8s and verify that events shiped by `pod` and `state_pod` metricset include `kubernetes.deployment.name` when `kubernetes.replicaset.name` exists. As an example see screenshots below.

Extra: Verify that `add_kubernetes_metadata` adds `kubernetes.deployment.name` when `kubernetes.replicaset.name` exists, using the following configuration with Filebeat on k8s:
```
filebeat.inputs:
- type: container
  paths:
    - /var/log/containers/*.log
  processors:
    - add_kubernetes_metadata:
        host: ${NODE_NAME}
        matchers:
        - logs_path:
            logs_path: "/var/log/containers/"
```

## Related issues
- Closes https://github.com/elastic/beats/issues/20991


## Screenshots
![Screenshot 2021-01-21 at 11 29 37 AM](https://user-images.githubusercontent.com/11754898/105334202-447fe880-5bdf-11eb-8118-affe0b50d699.png)
![Screenshot 2021-01-21 at 11 06 15 AM](https://user-images.githubusercontent.com/11754898/105334207-46e24280-5bdf-11eb-8092-e9c8bdf36485.png)

