### PR TITLE
[elastic-agent] fix: cpu cgroup values

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -100,5 +100,10 @@ USER {{ .user }}
 EXPOSE {{ $port }}
 {{- end }}
 
+# When running under Docker, we must ensure libbeat monitoring pulls cgroup
+# metrics from /sys/fs/cgroup/<subsystem>/, ignoring any paths found in
+# /proc/self/cgroup.
+ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
+
 WORKDIR {{ $beatHome }}
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint"]

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -410,7 +410,7 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 							},
 							// Cgroup reporting
 							{
-								"from": "http.agent.beat.cgrgit loup",
+								"from": "http.agent.beat.cgroup",
 								"to":   "system.process.cgroup",
 							},
 						},


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Minor fix for collecting `cgroup` based metrics. 

follow up of https://github.com/elastic/beats/pull/22793
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

cgroups metrics are not reported due to a typo

## How to test
* create elastic agent docker image, e.g. `DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 TYPES=docker mage package` 
* run image and pass some quota, e.g. `--cpu-period=100000 --cpu-quota=50000` 
* run load against APM Server, e.g. by using [this testapp](https://gist.github.com/simitt/7ece7a741ed8fb35c59447659f88cbba#file-testapp-go)
* check metrics indexed to ES and ensure `cgroup` values are set
```
GET *metric*/_search
{
  "_source": ["system.process.cgroup"],
  "query": {
    "exists": {
      "field": "system.process.cgroup"
    }
  }
}
```
