### PR TITLE
Cherry-pick #23716 to 7.x: Add replicasets in k8s clusterrole manifests

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -238,6 +238,10 @@ rules:
   - namespaces
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+    - replicasets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/auditbeat/auditbeat-role.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-role.yaml
@@ -11,3 +11,7 @@ rules:
   - namespaces
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+    - replicasets
+  verbs: ["get", "list", "watch"]

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -155,6 +155,10 @@ rules:
   - get
   - watch
   - list
+- apiGroups: ["apps"]
+  resources:
+    - replicasets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/filebeat/filebeat-role.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-role.yaml
@@ -13,3 +13,7 @@ rules:
   - get
   - watch
   - list
+- apiGroups: ["apps"]
+  resources:
+    - replicasets
+  verbs: ["get", "list", "watch"]

--- a/deploy/kubernetes/heartbeat-kubernetes.yaml
+++ b/deploy/kubernetes/heartbeat-kubernetes.yaml
@@ -148,6 +148,10 @@ rules:
   - namespaces
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+    - replicasets
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/heartbeat/heartbeat-role.yaml
+++ b/deploy/kubernetes/heartbeat/heartbeat-role.yaml
@@ -11,3 +11,7 @@ rules:
   - namespaces
   - pods
   verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+    - replicasets
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Cherry-pick of PR #23716 to 7.x branch. Original message: 

## What does this PR do?
This is follow up PR of https://github.com/elastic/beats/pull/23610 to add `replicasets` resource in clusterroles for `filebeat`, `heartbeat` and `packetbeat` since the addition at https://github.com/elastic/beats/pull/23610 will try to [access ReplicaSets](https://github.com/elastic/beats/blob/2d7e7b4c62f111442a22957fdc92ad12c990b065/libbeat/common/kubernetes/metadata/pod.go#L119) via k8s API for `add_kubernetes_metadata` Pod's autodiscovery.

@jsoriano sorry for forgetting this out from the original PR