### PR TITLE
[lint][CI] fix linting for x-pack/packetbeat and x-pack/journalbeat

### DIFF
--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -18,9 +18,6 @@ stages:
           make -C journalbeat check;
           make -C journalbeat update;
           make check-no-changes;
-          cd x-pack/journalbeat;
-          mage check;
-          mage update;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -17,9 +17,10 @@ stages:
         make: |
           make -C journalbeat check;
           make -C journalbeat update;
-          make -C x-pack/journalbeat check;
-          make -C x-pack/journalbeat update;
           make check-no-changes;
+          cd x-pack/journalbeat;
+          mage check;
+          mage update;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -17,9 +17,10 @@ stages:
         make: |
           make -C packetbeat check;
           make -C packetbeat update;
-          make -C x-pack/packetbeat check;
-          make -C x-pack/packetbeat update;
           make check-no-changes;
+          cd x-pack/packetbeat;
+          mage check;
+          mage update;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -15,8 +15,9 @@ platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     Lint:
         mage: |
-          mage -C x-pack/packetbeat check;
-          mage -C x-pack/packetbeat update;
+          mage check;
+          mage update;
+        make: |
           make -C packetbeat check;
           make -C packetbeat update;
           make check-no-changes;


### PR DESCRIPTION
## What does this PR do?

Some beats don't use. `make check` but `mage check` so let's fix those beats:
- x-pack/journalbeat <--- does not have any build go files so its cross-linting is not supported.
- x-pack/packetbeat

## Why is it important?

Run cross-linting correctly

## Issue

Regression from https://github.com/elastic/beats/pull/23695