### PR TITLE
Cherry-pick to 7.11: [lint][CI] fix linting for x-pack/packetbeat and x-pack/journalbeat (#23729)

### DIFF
--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -17,8 +17,6 @@ stages:
         make: |
           make -C journalbeat check;
           make -C journalbeat update;
-          make -C x-pack/journalbeat check;
-          make -C x-pack/journalbeat update;
           make check-no-changes;
     arm:
         mage: "mage build unitTest"

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -17,9 +17,10 @@ stages:
         make: |
           make -C packetbeat check;
           make -C packetbeat update;
-          make -C x-pack/packetbeat check;
-          make -C x-pack/packetbeat update;
           make check-no-changes;
+          cd x-pack/packetbeat;
+          mage check;
+          mage update;
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -15,8 +15,9 @@ platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     Lint:
         mage: |
-          mage -C x-pack/packetbeat check;
-          mage -C x-pack/packetbeat update;
+          mage check;
+          mage update;
+        make: |
           make -C packetbeat check;
           make -C packetbeat update;
           make check-no-changes;


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [lint][CI] fix linting for x-pack/packetbeat and x-pack/journalbeat (#23729)