### PR TITLE
Cherry-pick #22351 to 7.x: Fix build of Packetbeat test under windows/386

### DIFF
--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -77,7 +77,7 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
-    #windows-7-32:  See https://github.com/elastic/beats/issues/22303
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7-32-bit"
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"

--- a/packetbeat/procs/procs_windows_test.go
+++ b/packetbeat/procs/procs_windows_test.go
@@ -33,6 +33,7 @@ func TestParseTableRaw(t *testing.T) {
 	IPv4 := extractTCPRowOwnerPID
 	IPv6 := extractTCP6RowOwnerPID
 
+	pid := uint32(0xCCCCCCCC)
 	for idx, testCase := range []struct {
 		name     string
 		factory  extractorFactory
@@ -52,7 +53,7 @@ func TestParseTableRaw(t *testing.T) {
 			"01000000" +
 				"77777777AAAAAAAA12340000BBBBBBBBFFFF0000CCCCCCCC",
 			[]portProcMapping{
-				{endpoint: endpoint{address: "170.170.170.170", port: 0x1234}, pid: 0xCCCCCCCC},
+				{endpoint: endpoint{address: "170.170.170.170", port: 0x1234}, pid: int(pid)},
 			}, false},
 		{"Two entries (IPv6)", IPv6,
 			"02000000" +


### PR DESCRIPTION
Cherry-pick of PR #22351 to 7.x branch. Original message: 

Fixes a constant overflow under 32-bit OS and re-enables testing under Windows 7 32bits.

Closes #22303 