### PR TITLE
Cherry-pick #22351 to 7.11: Fix build of Packetbeat test under windows/386

### DIFF
--- a/packetbeat/procs/procs_windows_test.go
+++ b/packetbeat/procs/procs_windows_test.go
@@ -33,6 +33,7 @@ func TestParseTableRaw(t *testing.T) {
 	IPv4 := extractTCPRowOwnerPID
 	IPv6 := extractTCP6RowOwnerPID
 
+	pid := uint32(0xCCCCCCCC)
 	for idx, testCase := range []struct {
 		name     string
 		factory  extractorFactory
@@ -52,7 +53,7 @@ func TestParseTableRaw(t *testing.T) {
 			"01000000" +
 				"77777777AAAAAAAA12340000BBBBBBBBFFFF0000CCCCCCCC",
 			[]portProcMapping{
-				{endpoint: endpoint{address: "170.170.170.170", port: 0x1234}, pid: 0xCCCCCCCC},
+				{endpoint: endpoint{address: "170.170.170.170", port: 0x1234}, pid: int(pid)},
 			}, false},
 		{"Two entries (IPv6)", IPv6,
 			"02000000" +


### PR DESCRIPTION
Cherry-pick of PR #22351 to 7.11 branch. Original message: 

Fixes a constant overflow under 32-bit OS and re-enables testing under Windows 7 32bits.

Closes #22303 