### PR TITLE
Change branch to 7.x in generator tests

### DIFF
--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -37,7 +37,7 @@ prepare-test:: mage
 	export NEWBEAT_FULL_NAME="Nicolas Ruflin" ; \
 	export NEWBEAT_TYPE=${BEAT_TYPE} ; \
 	export NEWBEAT_DEV=1 ; \
-	export NEWBEAT_BEATS_REVISION=$(shell git rev-parse origin/master) ; \
+	export NEWBEAT_BEATS_REVISION=$(shell git rev-parse origin/7.x) ; \
 	mage GenerateCustomBeat
 
 # Runs test build for the created beat


### PR DESCRIPTION

## What does this PR do?

Change branch to 7.x in generator tests.

## Why is it important?

This is a temporary fix for #23758.
