### PR TITLE
Filebeat check if processor is supported

### DIFF
--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -409,7 +409,3 @@ func modifyAppendProcessor(esVersion common.Version, pipelineID string, content 
 	}
 	return nil
 }
-
-func removeProcessor(processors []interface{}, processor int) []interface{} {
-	return append(processors[:processor], processors[processor+1:]...)
-}

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -162,38 +162,6 @@ func setECSProcessors(esVersion common.Version, pipelineID string, content map[s
 	}
 
 	minUserAgentVersion := common.MustNewVersion("6.7.0")
-	for _, p := range processors {
-		processor, ok := p.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if options, ok := processor["user_agent"].(map[string]interface{}); ok {
-			if esVersion.LessThan(minUserAgentVersion) {
-				return fmt.Errorf("user_agent processor requires option 'ecs: true', but Elasticsearch %v does not support this option (Elasticsearch %v or newer is required)", esVersion, minUserAgentVersion)
-			}
-			logp.Debug("modules", "Setting 'ecs: true' option in user_agent processor for field '%v' in pipeline '%s'", options["field"], pipelineID)
-			options["ecs"] = true
-		}
-	}
-	return nil
-}
-
-func checkProcessorMinVersion(esVersion common.Version, pipelineID string, content map[string]interface{}) error {
-	ecsVersion := common.MustNewVersion("7.0.0")
-	if !esVersion.LessThan(ecsVersion) {
-		return nil
-	}
-
-	p, ok := content["processors"]
-	if !ok {
-		return nil
-	}
-	processors, ok := p.([]interface{})
-	if !ok {
-		return fmt.Errorf("'processors' in pipeline '%s' expected to be a list, found %T", pipelineID, p)
-	}
-
-	minUserAgentVersion := common.MustNewVersion("6.7.0")
 	minURIPartsVersion := common.MustNewVersion("7.12")
 	newProcessors := make([]interface{}, len(processors))
 	for i, p := range processors {
@@ -216,7 +184,6 @@ func checkProcessorMinVersion(esVersion common.Version, pipelineID string, conte
 
 		}
 		newProcessors = append(newProcessors, processors[i])
-
 	}
 	content["processors"] = newProcessors
 	return nil


### PR DESCRIPTION
## What does this PR do?

Certain processors are only available in newer versions of Elasticsearch, this adds checks for uri_parts for minimum version 7.12

This PR is a blocker for certain new modules that would like to use this processor.

This only extends a function that already exists for a similar usecase, it might be better to create a whole new function that just takes a list of processor names and minimum versions.
WDYT?

## Why is it important?

Allows modules to work for older versions even when including processors that is supported by newer versions.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

