### PR TITLE
Cherry-pick #23229 to 7.x: [Heartbeat] Enable script processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -675,6 +675,10 @@ port. {pull}19209[19209]
 - Provide more ways to set AWS credentials. {issue}12464[12464] {pull}23344[23344]
 - Add support for multiple regions {pull}21065[21065]
 
+*Heartbeat*
+
+- Add support for script processor. {pull}23229[23229]
+
 *Winlogbeat*
 
 - Set process.command_line and process.parent.command_line from Sysmon Event ID 1. {pull}17327[17327]

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -36,6 +36,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/management"
+
+	_ "github.com/elastic/beats/v7/libbeat/processors/script"
 )
 
 // Heartbeat represents the root datastructure of this beat.

--- a/heartbeat/docs/index.asciidoc
+++ b/heartbeat/docs/index.asciidoc
@@ -24,7 +24,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :no_dashboards:
 :no_decode_cef_processor:
 :no_decode_csv_fields_processor:
-:no_script_processor:
 :no_timestamp_processor:
 
 include::{libbeat-dir}/shared-beats-attributes.asciidoc[]


### PR DESCRIPTION
Cherry-pick of PR #23229 to 7.x branch. Original message: 

Enables the script processor for heartbeat. This is an opt-in processor, but there's really never been a concrete need for that. This fixes https://github.com/elastic/beats/issues/22788 .

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Add a script section to the processors block, it will work!

## Use cases

Mostly useful for situations where people want to apply novel complex logic. See https://github.com/elastic/beats/issues/22788

