### PR TITLE
[Fleet] support log level warning for beat

### DIFF
--- a/x-pack/elastic-agent/pkg/core/plugin/process/start.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/start.go
@@ -140,6 +140,8 @@ func injectLogLevel(logLevel string, args []string) []string {
 		level = "info"
 	case "debug":
 		level = "debug"
+	case "warning":
+		level = "warning"
 	case "error":
 		level = "error"
 	}


### PR DESCRIPTION
## Description

Resolve https://github.com/elastic/beats/issues/23243

Setting the log level to "warning" via an action was reporting metricbeat and filebeat logs as `debug` due to a missing case.

That PR should fix it 