### PR TITLE
[Ingest Manager] Elastic Agent - Endpoint e2e test fix

### DIFF
--- a/x-pack/elastic-agent/pkg/core/authority/ca.go
+++ b/x-pack/elastic-agent/pkg/core/authority/ca.go
@@ -42,6 +42,7 @@ func NewCA() (*CertificateAuthority, error) {
 		SerialNumber: big.NewInt(1653),
 		Subject: pkix.Name{
 			Organization: []string{"elastic-fleet"},
+			CommonName:   "localhost",
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(10, 0, 0),
@@ -108,6 +109,7 @@ func (c *CertificateAuthority) GeneratePairWithName(name string) (*Pair, error) 
 		DNSNames:     []string{name},
 		Subject: pkix.Name{
 			Organization: []string{"elastic-fleet"},
+			CommonName:   name,
 		},
 		NotBefore:   time.Now(),
 		NotAfter:    time.Now().AddDate(10, 0, 0),


### PR DESCRIPTION
## What does this PR do?

This PR uses CN together with DNSName, 
in nightly test we see that when agent is assigned an Endpoint Security integration it wont show up in Security App.
I was not able to get more info from Endpoint so far but what i see is a message `AgentComms.cpp:628 Waiting for GRPC connection to be READY` for. really long period of time.

Agent wise we are not experiencing any errors,
Creds endpoint created a LISTENING
I see endpoint connecting to Creds endpoint and not issues there server side.

But when i change generated cert to have CN as addition to DNSNames, endpoint is ready in 20s and Endpoint reported green, showing up in security tabs. I did multiple runs, mutiple build always same behavior. 
I suspect gdpr library to do some checks on CN so while golang stopped supporting CN and we moved to DNSNames we probably need to keep CN for a while

## Why is it important?

#23693

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
