### PR TITLE
[Filebeat] Fix Zoom module config for url and basic auth

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -377,6 +377,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Simplify regex for organization custom prefix in AWS/CloudTrail fileset. {issue}23203[23203] {pull}23204[23204]
 - Fix syslog header parsing in infoblox module. {issue}23272[23272] {pull}23273[23273]
 - Fix concurrent modification exception in Suricata ingest node pipeline. {pull}23534[23534]
+- Fix Zoom module parameters for basic auth and url path. {pull}23779[23779]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/zoom/webhook/config/webhook.yml
+++ b/x-pack/filebeat/module/zoom/webhook/config/webhook.yml
@@ -3,10 +3,11 @@
 type: http_endpoint
 listen_address: {{ .listen_address }}
 listen_port: {{ .listen_port }}
+{{ if .url }}url: {{ .url}}{{ end }}
 prefix: {{ .prefix }}
 basic_auth: {{ .basic_auth }}
 username: {{ .username }}
-username: {{ .password }}
+password: {{ .password }}
 content_type: "{{ .content_type }}"
 secret: {{ .secret | tojson }}
 ssl: {{ .ssl | tojson }}


### PR DESCRIPTION
## What does this PR do?

The basic auth username and password options were broken. And the `url` parameter was
missing from the config despite being defined in the manifest.

## Why is it important?

The option to host the webhook callback as a prefix other than `/` is not possible.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

