### PR TITLE
Cherry-pick to 7.x: [elastic-agent] fix: cpu cgroup values (#23714)

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -102,5 +102,10 @@ USER {{ .user }}
 EXPOSE {{ $port }}
 {{- end }}
 
+# When running under Docker, we must ensure libbeat monitoring pulls cgroup
+# metrics from /sys/fs/cgroup/<subsystem>/, ignoring any paths found in
+# /proc/self/cgroup.
+ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
+
 WORKDIR {{ $beatHome }}
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint"]

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -410,7 +410,7 @@ func (o *Operator) getMonitoringMetricbeatConfig(output interface{}) (map[string
 							},
 							// Cgroup reporting
 							{
-								"from": "http.agent.beat.cgrgit loup",
+								"from": "http.agent.beat.cgroup",
 								"to":   "system.process.cgroup",
 							},
 						},


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [elastic-agent] fix: cpu cgroup values (#23714)