### PR TITLE
Cherry-pick #23724 to 7.x: [Filebeat] add RFC6587 framing support

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -567,6 +567,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added `alternative_host` option to google pubsub input {pull}23215[23215]
 - Added username parsing from Cisco ASA message 302013. {pull}21196[21196]
 - Added `encode_as` and `decode_as` options to httpjson along with pluggable encoders/decoders {pull}23478[23478]
+- Added RFC6587 framing option for tcp and unix inputs {issue}23663[23663] {pull}23724[23724]
 
 *Heartbeat*
 

--- a/filebeat/docs/inputs/input-common-tcp-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-tcp-options.asciidoc
@@ -17,6 +17,17 @@ The maximum size of the message received over TCP. The default is `20MiB`.
 The host and TCP port to listen on for event streams.
 
 [float]
+[id="{beatname_lc}-input-{type}-tcp-framing"]
+==== `framing`
+
+Specify the framing used to split incoming events.  Can be one of
+`delimiter` or `rfc6587`.  `delimiter` uses the characters specified
+in `line_delimiter` to split the incoming events.  `rfc6587` supports
+octet counting and non-transparent framing as described in
+https://tools.ietf.org/html/rfc6587[RFC6587].  `line_delimiter` is
+used to split the events in non-transparent framing.  The default is `delimiter`.
+
+[float]
 [id="{beatname_lc}-input-{type}-tcp-line-delimiter"]
 ==== `line_delimiter`
 

--- a/filebeat/docs/inputs/input-common-unix-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-unix-options.asciidoc
@@ -40,6 +40,17 @@ expected to be a file mode as an octal string. The default value is the system
 default (generally `0755`).
 
 [float]
+[id="{beatname_lc}-input-{type}-unix-framing"]
+==== `framing`
+
+Specify the framing used to split incoming events.  Can be one of
+`delimiter` or `rfc6587`.  `delimiter` uses the characters specified
+in `line_delimiter` to split the incoming events.  `rfc6587` supports
+octet counting and non-transparent framing as described in
+https://tools.ietf.org/html/rfc6587[RFC6587].  `line_delimiter` is
+used to split the events in non-transparent framing.  The default is `delimiter`.
+
+[float]
 [id="{beatname_lc}-input-{type}-unix-line-delimiter"]
 ==== `line_delimiter`
 

--- a/filebeat/input/syslog/config.go
+++ b/filebeat/input/syslog/config.go
@@ -47,7 +47,8 @@ var defaultConfig = config{
 
 type syslogTCP struct {
 	tcp.Config    `config:",inline"`
-	LineDelimiter string `config:"line_delimiter" validate:"nonzero"`
+	LineDelimiter string                `config:"line_delimiter" validate:"nonzero"`
+	Framing       streaming.FramingType `config:"framing"`
 }
 
 var defaultTCP = syslogTCP{
@@ -90,9 +91,9 @@ func factory(
 			return nil, err
 		}
 
-		splitFunc := streaming.SplitFunc([]byte(config.LineDelimiter))
-		if splitFunc == nil {
-			return nil, fmt.Errorf("error creating splitFunc from delimiter %s", config.LineDelimiter)
+		splitFunc, err := streaming.SplitFunc(config.Framing, []byte(config.LineDelimiter))
+		if err != nil {
+			return nil, err
 		}
 
 		logger := logp.NewLogger("input.syslog.tcp").With("address", config.Config.Host)

--- a/filebeat/input/tcp/config.go
+++ b/filebeat/input/tcp/config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dustin/go-humanize"
 
 	"github.com/elastic/beats/v7/filebeat/harvester"
+	"github.com/elastic/beats/v7/filebeat/inputsource/common/streaming"
 	"github.com/elastic/beats/v7/filebeat/inputsource/tcp"
 )
 
@@ -30,7 +31,8 @@ type config struct {
 	tcp.Config                `config:",inline"`
 	harvester.ForwarderConfig `config:",inline"`
 
-	LineDelimiter string `config:"line_delimiter" validate:"nonzero"`
+	LineDelimiter string                `config:"line_delimiter" validate:"nonzero"`
+	Framing       streaming.FramingType `config:"framing"`
 }
 
 var defaultConfig = config{

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -18,7 +18,6 @@
 package tcp
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -75,9 +74,9 @@ func NewInput(
 		forwarder.Send(event)
 	}
 
-	splitFunc := streaming.SplitFunc([]byte(config.LineDelimiter))
-	if splitFunc == nil {
-		return nil, fmt.Errorf("unable to create splitFunc for delimiter %s", config.LineDelimiter)
+	splitFunc, err := streaming.SplitFunc(config.Framing, []byte(config.LineDelimiter))
+	if err != nil {
+		return nil, err
 	}
 
 	logger := logp.NewLogger("input.tcp").With("address", config.Config.Host)

--- a/filebeat/inputsource/common/streaming/listener.go
+++ b/filebeat/inputsource/common/streaming/listener.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"sync"
 
@@ -46,6 +47,21 @@ type Listener struct {
 	handlerFactory  HandlerFactory
 	listenerFactory ListenerFactory
 }
+
+// FramingType are supported framing options for the SplitFunc
+type FramingType int
+
+const (
+	FramingDelimiter = iota
+	FramingRFC6587
+)
+
+var (
+	framingTypes = map[string]FramingType{
+		"delimiter": FramingDelimiter,
+		"rfc6587":   FramingRFC6587,
+	}
+)
 
 // NewListener creates a new Listener
 func NewListener(family inputsource.Family, location string, handlerFactory HandlerFactory, listenerFactory ListenerFactory, config *ListenerConfig) *Listener {
@@ -176,18 +192,43 @@ func (l *Listener) unregisterHandler() {
 	l.clientsCount.Dec()
 }
 
-// SplitFunc allows to create a `bufio.SplitFunc` based on a delimiter provided.
-func SplitFunc(lineDelimiter []byte) bufio.SplitFunc {
+// SplitFunc allows to create a `bufio.SplitFunc` based on a framing &
+// delimiter provided.
+func SplitFunc(framing FramingType, lineDelimiter []byte) (bufio.SplitFunc, error) {
 	if len(lineDelimiter) == 0 {
-		return nil
+		return nil, fmt.Errorf("line delimiter required")
+	}
+	switch framing {
+	case FramingDelimiter:
+		// This will work for most usecases and will also
+		// strip \r if present.  CustomDelimiter, need to
+		// match completely and the delimiter will be
+		// completely removed from the returned byte slice
+		if bytes.Equal(lineDelimiter, []byte("\n")) {
+			return bufio.ScanLines, nil
+		}
+		return FactoryDelimiter(lineDelimiter), nil
+	case FramingRFC6587:
+		return FactoryRFC6587Framing(lineDelimiter), nil
+	default:
+		return nil, fmt.Errorf("unknown SplitFunc for framing %d and line delimiter %s", framing, string(lineDelimiter))
 	}
 
-	ld := []byte(lineDelimiter)
-	if bytes.Equal(ld, []byte("\n")) {
-		// This will work for most usecases and will also strip \r if present.
-		// CustomDelimiter, need to match completely and the delimiter will be completely removed from
-		// the returned byte slice
-		return bufio.ScanLines
+}
+
+// Unpack for config
+func (f *FramingType) Unpack(value string) error {
+	ft, ok := framingTypes[value]
+	if !ok {
+		availableTypes := make([]string, len(framingTypes))
+		i := 0
+		for t := range framingTypes {
+			availableTypes[i] = t
+			i++
+		}
+		return fmt.Errorf("invalid framing type '%s', supported types: %v", value, availableTypes)
+
 	}
-	return FactoryDelimiter(ld)
+	*f = ft
+	return nil
 }

--- a/filebeat/inputsource/unix/config.go
+++ b/filebeat/inputsource/unix/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/v7/filebeat/inputsource/common/streaming"
 	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
 )
 
@@ -45,14 +46,15 @@ var socketTypes = map[string]SocketType{
 
 // Config exposes the unix configuration.
 type Config struct {
-	Path           string           `config:"path"`
-	Group          *string          `config:"group"`
-	Mode           *string          `config:"mode"`
-	Timeout        time.Duration    `config:"timeout" validate:"nonzero,positive"`
-	MaxMessageSize cfgtype.ByteSize `config:"max_message_size" validate:"nonzero,positive"`
-	MaxConnections int              `config:"max_connections"`
-	LineDelimiter  string           `config:"line_delimiter"`
-	SocketType     SocketType       `config:"socket_type"`
+	Path           string                `config:"path"`
+	Group          *string               `config:"group"`
+	Mode           *string               `config:"mode"`
+	Timeout        time.Duration         `config:"timeout" validate:"nonzero,positive"`
+	MaxMessageSize cfgtype.ByteSize      `config:"max_message_size" validate:"nonzero,positive"`
+	MaxConnections int                   `config:"max_connections"`
+	LineDelimiter  string                `config:"line_delimiter"`
+	Framing        streaming.FramingType `config:"framing"`
+	SocketType     SocketType            `config:"socket_type"`
 }
 
 // Validate validates the Config option for the unix input.

--- a/filebeat/inputsource/unix/server.go
+++ b/filebeat/inputsource/unix/server.go
@@ -52,9 +52,9 @@ type datagramServer struct {
 func New(log *logp.Logger, config *Config, nf inputsource.NetworkFunc) (Server, error) {
 	switch config.SocketType {
 	case StreamSocket:
-		splitFunc := streaming.SplitFunc([]byte(config.LineDelimiter))
-		if splitFunc == nil {
-			return nil, fmt.Errorf("unable to create splitFunc for delimiter %s", config.LineDelimiter)
+		splitFunc, err := streaming.SplitFunc(config.Framing, []byte(config.LineDelimiter))
+		if err != nil {
+			return nil, err
 		}
 		factory := streaming.SplitHandlerFactory(inputsource.FamilyUnix, log, MetadataCallback, nf, splitFunc)
 		server := &streamServer{config: config}

--- a/filebeat/tests/system/test_tcp.py
+++ b/filebeat/tests/system/test_tcp.py
@@ -25,6 +25,18 @@ class Test(BaseTest):
         """
         self.send_events_with_delimiter("<END>")
 
+    def test_tcp_with_rfc6587_non_transparent(self):
+        """
+        Test TCP input with rfc6587 non_transparent framing
+        """
+        self.send_events_with_rfc6587_framing("non-transparent")
+
+    def test_tcp_with_rfc6587_octet(self):
+        """
+        Test TCP input with rfc6587 octet counting framing
+        """
+        self.send_events_with_rfc6587_framing("octet")
+
     def send_events_with_delimiter(self, delimiter):
         host = "127.0.0.1"
         port = 8080
@@ -54,6 +66,50 @@ class Test(BaseTest):
 
         for n in range(0, 2):
             sock.send(bytes("Hello World: " + str(n) + delimiter, "utf-8"))
+
+        self.wait_until(lambda: self.output_count(lambda x: x >= 2))
+
+        filebeat.check_kill_and_wait()
+
+        output = self.read_output()
+
+        assert len(output) == 2
+        assert output[0]["input.type"] == "tcp"
+
+        sock.close()
+
+    def send_events_with_rfc6587_framing(self, framing):
+        host = "127.0.0.1"
+        port = 8080
+        delimiter = "\n"
+        input_raw = """
+- type: tcp
+  host: "{}:{}"
+  enabled: true
+  framing: rfc6587
+"""
+
+        input_raw += "\n  line_delimiter: {}".format(delimiter)
+
+        input_raw = input_raw.format(host, port)
+
+        self.render_config_template(
+            input_raw=input_raw,
+            inputs=False,
+        )
+
+        filebeat = self.start_beat()
+
+        self.wait_until(lambda: self.log_contains("Started listening for TCP connection"))
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # TCP
+        sock.connect((host, port))
+
+        for n in range(0, 2):
+            if framing == "non-transparent":
+                sock.send(bytes("Hello World: " + str(n) + "\n", "utf-8"))
+            if framing == "octet":
+                sock.send(bytes("14 Hello World: " + str(n), "utf-8"))
 
         self.wait_until(lambda: self.output_count(lambda x: x >= 2))
 

--- a/filebeat/tests/system/test_tcp_tls.py
+++ b/filebeat/tests/system/test_tcp_tls.py
@@ -284,3 +284,62 @@ class Test(BaseTest):
     def assert_output(self, output):
         assert len(output) == 2
         assert output[0]["input.type"] == "tcp"
+
+    def test_tcp_over_tls_mutual_auth_rfc6587_framing(self):
+        """
+        Test filebeat TCP with TLS when enforcing client auth with good client certificates and rfc6587 framing.
+        """
+        input_raw = """
+- type: tcp
+  host: "{host}:{port}"
+  enabled: true
+  framing: rfc6587
+  ssl.certificate_authorities: {cacert}
+  ssl.certificate: {certificate}
+  ssl.key: {key}
+  ssl.client_authentication: required
+"""
+        config = {
+            "host": "127.0.0.1",
+            "port": 8080,
+            "cacert": CACERT,
+            "certificate": CLIENT1,
+            "key": CLIENTKEY1,
+        }
+
+        input_raw = input_raw.format(**config)
+
+        self.render_config_template(
+            input_raw=input_raw,
+            inputs=False,
+        )
+
+        filebeat = self.start_beat()
+
+        self.wait_until(lambda: self.log_contains(
+            "Started listening for TCP connection"))
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.load_verify_locations(CACERT)
+        context.load_cert_chain(certfile=CLIENT2, keyfile=CLIENTKEY2)
+
+        tls = context.wrap_socket(sock, server_side=False)
+
+        tls.connect((config.get('host'), config.get('port')))
+
+        for n in range(0, NUMBER_OF_EVENTS):
+            tls.send(bytes("14 Hello World: " + str(n), "utf-8"))
+
+        self.wait_until(lambda: self.output_count(
+            lambda x: x >= NUMBER_OF_EVENTS))
+
+        filebeat.check_kill_and_wait()
+
+        output = self.read_output()
+
+        self.assert_output(output)
+
+        sock.close()


### PR DESCRIPTION
Cherry-pick of PR #23724 to 7.x branch. Original message: 

## What does this PR do?

Adds support for RFC6587 framing.

- Adds new config option "framing" for tcp & unix inputs
- supported options are "delimiter" & rfc6587
- delimiter is current option of newline or custom character(s)
  delimiter
- rfc6587 adds support for octet counting and non-transparent framing
  as described in RFC6587
- rfc6587 supports changing of framing on a frame by frame basis
- Default is "delimiter"

## Why is it important?

- Required for Syslog inside TLS
- Required for some RFC6587 compliant Syslog clients

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
mage test
```

## Related issues

- Closes #23663