### PR TITLE
docs: Add application logging to FB quickstart

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -44,10 +44,10 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 ==== Other installation options
 
 * <<setup-repositories,APT or YUM>>
-* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page] 
+* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 * <<running-on-docker,Docker>>
-* <<running-on-kubernetes,Kubernetes>> 
-* <<running-on-cloudfoundry,Cloud Foundry>> 
+* <<running-on-kubernetes,Kubernetes>>
+* <<running-on-cloudfoundry,Cloud Foundry>>
 
 [float]
 [[set-connection]]
@@ -56,10 +56,20 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 include::{libbeat-dir}/shared/connecting-to-es.asciidoc[]
 
 [float]
-[[enable-modules]]
-=== Step 3: Enable and configure data collection modules
+[[collect-log-data]]
+=== Step 3: Collect log data
 
-{beatname_uc} uses modules to collect and parse log data.
+There are three ways to collect log data with {beatname_uc}:
+
+* Data collection modules -- simplify the collection, parsing,
+and visualization of common log formats
+* {ecs-logging-ref}/intro.html[ECS loggers] -- plugins that structure and format
+application logs into ECS-compatible JSON
+* Manual {beatname_uc} configuration
+
+[float]
+[[enable-modules]]
+==== Enable and configure data collection modules
 
 . Identify the modules you need to enable. To see a list of available
 <<filebeat-modules,modules>>, run:
@@ -67,9 +77,6 @@ include::{libbeat-dir}/shared/connecting-to-es.asciidoc[]
 --
 include::{libbeat-dir}/tab-widgets/list-modules-widget.asciidoc[]
 --
-+
-Can't find a module for your file type? Skip this section and
-<<configuration-filebeat-options,configure the input>> manually.
 
 . From the installation directory, enable one or more modules. For example, the
 following command enables the `system`, `nginx`, and `mysql` module
@@ -90,7 +97,7 @@ default locations, set the `paths` variable:
 ----
 - module: nginx
   access:
-    var.paths: ["/var/log/nginx/access.log*"] <1> 
+    var.paths: ["/var/log/nginx/access.log*"] <1>
 ----
 --
 
@@ -100,27 +107,25 @@ To see the full list of variables for a module, see the documentation under
 include::{libbeat-dir}/shared/config-check.asciidoc[]
 
 [float]
-[[setup-application-logs]]
-=== Step 4: Ingest application logs
+[[collect-application-logs]]
+==== Enable and configure ECS loggers for application log collection
 
-This section is about best practices for ingesting logs from your own applications,
-as well as for off-the-shelf applications for which we don't have suitable built-in modules.
+While {beatname_uc} can be used to ingest raw, plain-text application logs,
+we recommend structuring your logs at ingest time. This lets you extract fields,
+like log level and exception stack traces.
 
-Although you can ingest raw plain-text logs, we recommend you structure
-your logs at ingest time.
-This lets you extract fields such as log level and exception stack traces.
+Elastic simplifies this process by providing application log formatters in a variety
+of popular programming languages. These plugins format your logs into ECS compatible JSON,
+which removes the need to manually parse logs.
 
-If you can change your application's log output,
-we recommend configuring your application to use the log formatters
-provided by {ecs-logging-ref}/intro.html[ECS logging].
-These plugins format your logs into ECS-compatible JSON.
-This simplifies configuration by removing the need to manually parse logs.
+See {ecs-logging-ref}/intro.html[ECS loggers] to get started.
 
-If you can't change your application's log output or if
-there is no appropriate ECS logging plugin for your language or preferred
-logging framework, you will need to manually your logs using an
-<<configuring-ingest-node,ingest node processors>>.
+[float]
+[[manual-configuration]]
+==== Manual configuration
 
+If you're unable to find a module for your file type, or can't change your application's
+log output, see <<configuration-filebeat-options,configure the input>> manually.
 
 [float]
 [[setup-assets]]

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -59,11 +59,11 @@ include::{libbeat-dir}/shared/connecting-to-es.asciidoc[]
 [[collect-log-data]]
 === Step 3: Collect log data
 
-There are three ways to collect log data with {beatname_uc}:
+There are several ways to collect log data with {beatname_uc}:
 
 * Data collection modules -- simplify the collection, parsing,
 and visualization of common log formats
-* ECS loggers -- plugins that structure and format
+* ECS loggers -- structure and format
 application logs into ECS-compatible JSON
 * Manual {beatname_uc} configuration
 
@@ -115,14 +115,14 @@ we recommend structuring your logs at ingest time. This lets you extract fields,
 like log level and exception stack traces.
 
 Elastic simplifies this process by providing application log formatters in a variety
-of popular programming languages. These plugins format your logs into ECS compatible JSON,
+of popular programming languages. These plugins format your logs into ECS-compatible JSON,
 which removes the need to manually parse logs.
 
 See {ecs-logging-ref}/intro.html[ECS loggers] to get started.
 
 [float]
 [[manual-configuration]]
-==== Manual configuration
+==== Configure {beatname_uc} manually
 
 If you're unable to find a module for your file type, or can't change your application's
 log output, see <<configuration-filebeat-options,configure the input>> manually.

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -106,21 +106,20 @@ include::{libbeat-dir}/shared/config-check.asciidoc[]
 This section is about best practices for ingesting logs from your own applications,
 as well as for off-the-shelf applications for which we don't have suitable built-in modules.
 
-Although you can ingest raw plain-text logs, we recommend you to structure
-your logs on ingest time.
-This lets you extract fields such as the log level and exception stack traces.
+Although you can ingest raw plain-text logs, we recommend you structure
+your logs at ingest time.
+This lets you extract fields such as log level and exception stack traces.
 
-If you can change the log output of your application,
+If you can change your application's log output,
 we recommend configuring your application to use the log formatters
 provided by {ecs-logging-ref}/intro.html[ECS logging].
 These plugins format your logs into ECS-compatible JSON.
-This makes the configuration particularly easy as you don't have to
-manually parse your logs.
+This simplifies configuration by removing the need to manually parse logs.
 
-If it is not possible to configure the logging for your application or if
+If you can't change your application's log output or if
 there is no appropriate ECS logging plugin for your language or preferred
-logging framework, you will need to manually
-<<configuring-ingest-node, parse the logs using ingest node processors>>.
+logging framework, you will need to manually your logs using an
+<<configuring-ingest-node,ingest node processors>>.
 
 
 [float]

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -129,7 +129,7 @@ log output, see <<configuration-filebeat-options,configure the input>> manually.
 
 [float]
 [[setup-assets]]
-=== Step 5: Set up assets
+=== Step 4: Set up assets
 
 {beatname_uc} comes with predefined assets for parsing, indexing, and
 visualizing your data. To load these assets:

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -100,8 +100,32 @@ To see the full list of variables for a module, see the documentation under
 include::{libbeat-dir}/shared/config-check.asciidoc[]
 
 [float]
+[[setup-application-logs]]
+=== Step 4: Ingest application logs
+
+This section is about best practices for ingesting logs from your own applications,
+as well as for off-the-shelf applications for which we don't have suitable built-in modules.
+
+Although you can ingest raw plain-text logs, we recommend you to structure
+your logs on ingest time.
+This lets you extract fields such as the log level and exception stack traces.
+
+If you can change the log output of your application,
+we recommend configuring your application to use the log formatters
+provided by {ecs-logging-ref}/intro.html[ECS logging].
+These plugins format your logs into ECS-compatible JSON.
+This makes the configuration particularly easy as you don't have to
+manually parse your logs.
+
+If it is not possible to configure the logging for your application or if
+there is no appropriate ECS logging plugin for your language or preferred
+logging framework, you will need to manually
+<<configuring-ingest-node, parse the logs using ingest node processors>>.
+
+
+[float]
 [[setup-assets]]
-=== Step 4: Set up assets
+=== Step 5: Set up assets
 
 {beatname_uc} comes with predefined assets for parsing, indexing, and
 visualizing your data. To load these assets:

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -63,7 +63,7 @@ There are three ways to collect log data with {beatname_uc}:
 
 * Data collection modules -- simplify the collection, parsing,
 and visualization of common log formats
-* {ecs-logging-ref}/intro.html[ECS loggers] -- plugins that structure and format
+* ECS loggers -- plugins that structure and format
 application logs into ECS-compatible JSON
 * Manual {beatname_uc} configuration
 


### PR DESCRIPTION
Adds a reference to application logging with ECS loggers to the Filebeat quickstart guide.

Replaces https://github.com/elastic/beats/pull/23116.