### PR TITLE
Cherry-pick #23722 to 7.10: Fix leak caused by input runners created when checking their configuration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033] {pull}19764[19764]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
+- Fix goroutines leak with some inputs in autodiscover. {pull}23722[23722]
 
 *Filebeat*
 

--- a/filebeat/input/container/input_test.go
+++ b/filebeat/input/container/input_test.go
@@ -15,41 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package tcp
+// +build !integration
+
+package container
 
 import (
-	"net"
+	"os"
+	"path"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/v7/filebeat/input/inputtest"
-	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestCreateEvent(t *testing.T) {
-	hello := "hello world"
-	ip := "127.0.0.1"
-	parsedIP := net.ParseIP(ip)
-	addr := &net.IPAddr{IP: parsedIP, Zone: ""}
-
-	message := []byte(hello)
-	mt := inputsource.NetworkMetadata{RemoteAddr: addr}
-
-	event := createEvent(message, mt)
-
-	m, err := event.GetValue("message")
-	assert.NoError(t, err)
-	assert.Equal(t, string(message), m)
-
-	from, _ := event.GetValue("log.source.address")
-	assert.Equal(t, ip, from)
-}
-
 func TestNewInputDone(t *testing.T) {
 	config := common.MapStr{
-		"host": ":0",
+		"paths": path.Join(os.TempDir(), "logs", "*.log"),
 	}
 	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }

--- a/filebeat/input/docker/input_test.go
+++ b/filebeat/input/docker/input_test.go
@@ -15,41 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package tcp
+// +build !integration
+
+package docker
 
 import (
-	"net"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/v7/filebeat/input/inputtest"
-	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestCreateEvent(t *testing.T) {
-	hello := "hello world"
-	ip := "127.0.0.1"
-	parsedIP := net.ParseIP(ip)
-	addr := &net.IPAddr{IP: parsedIP, Zone: ""}
-
-	message := []byte(hello)
-	mt := inputsource.NetworkMetadata{RemoteAddr: addr}
-
-	event := createEvent(message, mt)
-
-	m, err := event.GetValue("message")
-	assert.NoError(t, err)
-	assert.Equal(t, string(message), m)
-
-	from, _ := event.GetValue("log.source.address")
-	assert.Equal(t, ip, from)
-}
-
 func TestNewInputDone(t *testing.T) {
 	config := common.MapStr{
-		"host": ":0",
+		"containers.ids": "fad130edd3d2",
 	}
 	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }

--- a/filebeat/input/inputtest/input.go
+++ b/filebeat/input/inputtest/input.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package inputtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/filebeat/channel"
+	"github.com/elastic/beats/v7/filebeat/input"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/tests/resources"
+)
+
+// Outlet is an empty outlet for testing.
+type Outlet struct{}
+
+func (o Outlet) OnEvent(event beat.Event) bool { return true }
+func (o Outlet) Close() error                  { return nil }
+func (o Outlet) Done() <-chan struct{}         { return nil }
+
+// Connector is a connector to a test empty outlet.
+var Connector = channel.ConnectorFunc(
+	func(_ *common.Config, _ beat.ClientConfig) (channel.Outleter, error) {
+		return Outlet{}, nil
+	},
+)
+
+// AssertNotStartedInputCanBeDone checks that the context of an input can be
+// done before starting the input, and it doesn't leak goroutines. This is
+// important to confirm that leaks don't happen with CheckConfig.
+func AssertNotStartedInputCanBeDone(t *testing.T, factory input.Factory, configMap *common.MapStr) {
+	goroutines := resources.NewGoroutinesChecker()
+	defer goroutines.Check(t)
+
+	config, err := common.NewConfigFrom(configMap)
+	require.NoError(t, err)
+
+	context := input.Context{
+		Done: make(chan struct{}),
+	}
+
+	_, err = factory(config, Connector, context)
+	assert.NoError(t, err)
+
+	close(context.Done)
+}

--- a/filebeat/input/kafka/input_test.go
+++ b/filebeat/input/kafka/input_test.go
@@ -15,41 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package tcp
+// +build !integration
+
+package kafka
 
 import (
-	"net"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/v7/filebeat/input/inputtest"
-	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestCreateEvent(t *testing.T) {
-	hello := "hello world"
-	ip := "127.0.0.1"
-	parsedIP := net.ParseIP(ip)
-	addr := &net.IPAddr{IP: parsedIP, Zone: ""}
-
-	message := []byte(hello)
-	mt := inputsource.NetworkMetadata{RemoteAddr: addr}
-
-	event := createEvent(message, mt)
-
-	m, err := event.GetValue("message")
-	assert.NoError(t, err)
-	assert.Equal(t, string(message), m)
-
-	from, _ := event.GetValue("log.source.address")
-	assert.Equal(t, ip, from)
-}
-
 func TestNewInputDone(t *testing.T) {
 	config := common.MapStr{
-		"host": ":0",
+		"hosts":    "localhost:9092",
+		"topics":   "messages",
+		"group_id": "filebeat",
 	}
 	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }

--- a/filebeat/input/log/input_other_test.go
+++ b/filebeat/input/log/input_other_test.go
@@ -22,10 +22,11 @@ package log
 import (
 	"testing"
 
-	"github.com/elastic/beats/v7/filebeat/input/file"
-	"github.com/elastic/beats/v7/libbeat/common/match"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/filebeat/input/file"
+	"github.com/elastic/beats/v7/filebeat/input/inputtest"
+	"github.com/elastic/beats/v7/libbeat/common/match"
 )
 
 var matchTests = []struct {
@@ -148,7 +149,7 @@ func TestInit(t *testing.T) {
 				Paths: test.paths,
 			},
 			states:              file.NewStates(),
-			outlet:              TestOutlet{},
+			outlet:              inputtest.Outlet{},
 			fileStateIdentifier: &file.MockIdentifier{},
 		}
 

--- a/filebeat/input/mqtt/input_test.go
+++ b/filebeat/input/mqtt/input_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	finput "github.com/elastic/beats/v7/filebeat/input"
+	"github.com/elastic/beats/v7/filebeat/input/inputtest"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/backoff"
@@ -320,6 +321,13 @@ func TestOnCreateHandler_SubscribeMultiple_BackoffSignalDone(t *testing.T) {
 
 	require.Equal(t, 2, client.subscribeMultipleCount)
 	require.Equal(t, 1, mockedBackoff.resetCount)
+}
+
+func TestNewInputDone(t *testing.T) {
+	config := common.MapStr{
+		"hosts": "tcp://:0",
+	}
+	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }
 
 func assertEventMatches(t *testing.T, expected mockedMessage, got beat.Event) {

--- a/filebeat/input/redis/input_test.go
+++ b/filebeat/input/redis/input_test.go
@@ -15,41 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package tcp
+// +build !integration
+
+package redis
 
 import (
-	"net"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/v7/filebeat/input/inputtest"
-	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestCreateEvent(t *testing.T) {
-	hello := "hello world"
-	ip := "127.0.0.1"
-	parsedIP := net.ParseIP(ip)
-	addr := &net.IPAddr{IP: parsedIP, Zone: ""}
-
-	message := []byte(hello)
-	mt := inputsource.NetworkMetadata{RemoteAddr: addr}
-
-	event := createEvent(message, mt)
-
-	m, err := event.GetValue("message")
-	assert.NoError(t, err)
-	assert.Equal(t, string(message), m)
-
-	from, _ := event.GetValue("log.source.address")
-	assert.Equal(t, ip, from)
-}
-
 func TestNewInputDone(t *testing.T) {
 	config := common.MapStr{
-		"host": ":0",
+		"hosts": "localhost:3679",
 	}
 	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }

--- a/filebeat/input/runnerfactory.go
+++ b/filebeat/input/runnerfactory.go
@@ -58,10 +58,14 @@ func (r *RunnerFactory) Create(
 }
 
 func (r *RunnerFactory) CheckConfig(cfg *common.Config) error {
-	_, err := r.Create(pipeline.NewNilPipeline(), cfg)
+	runner, err := r.Create(pipeline.NewNilPipeline(), cfg)
 	if _, ok := err.(*common.ErrInputNotFinished); ok {
 		// error is related to state, and hence config can be considered valid
 		return nil
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	runner.Stop()
+	return nil
 }

--- a/filebeat/input/stdin/input_test.go
+++ b/filebeat/input/stdin/input_test.go
@@ -15,41 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package tcp
+// +build !integration
+
+package stdin
 
 import (
-	"net"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/v7/filebeat/input/inputtest"
-	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestCreateEvent(t *testing.T) {
-	hello := "hello world"
-	ip := "127.0.0.1"
-	parsedIP := net.ParseIP(ip)
-	addr := &net.IPAddr{IP: parsedIP, Zone: ""}
-
-	message := []byte(hello)
-	mt := inputsource.NetworkMetadata{RemoteAddr: addr}
-
-	event := createEvent(message, mt)
-
-	m, err := event.GetValue("message")
-	assert.NoError(t, err)
-	assert.Equal(t, string(message), m)
-
-	from, _ := event.GetValue("log.source.address")
-	assert.Equal(t, ip, from)
-}
-
 func TestNewInputDone(t *testing.T) {
 	config := common.MapStr{
-		"host": ":0",
+		"paths": "-",
 	}
 	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }

--- a/filebeat/input/syslog/input_test.go
+++ b/filebeat/input/syslog/input_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/v7/filebeat/input/inputtest"
 	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -243,6 +244,13 @@ func TestParseAndCreateEvent(t *testing.T) {
 			assert.Equal(t, metadata.Truncated, event.Meta["truncated"])
 		})
 	}
+}
+
+func TestNewInputDone(t *testing.T) {
+	config := common.MapStr{
+		"protocol.tcp.host": "localhost:9000",
+	}
+	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }
 
 func dummyMetadata() inputsource.NetworkMetadata {

--- a/filebeat/input/udp/input_test.go
+++ b/filebeat/input/udp/input_test.go
@@ -15,41 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package tcp
+// +build !integration
+
+package udp
 
 import (
-	"net"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/v7/filebeat/input/inputtest"
-	"github.com/elastic/beats/v7/filebeat/inputsource"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestCreateEvent(t *testing.T) {
-	hello := "hello world"
-	ip := "127.0.0.1"
-	parsedIP := net.ParseIP(ip)
-	addr := &net.IPAddr{IP: parsedIP, Zone: ""}
-
-	message := []byte(hello)
-	mt := inputsource.NetworkMetadata{RemoteAddr: addr}
-
-	event := createEvent(message, mt)
-
-	m, err := event.GetValue("message")
-	assert.NoError(t, err)
-	assert.Equal(t, string(message), m)
-
-	from, _ := event.GetValue("log.source.address")
-	assert.Equal(t, ip, from)
-}
-
 func TestNewInputDone(t *testing.T) {
 	config := common.MapStr{
-		"host": ":0",
+		"hosts": ":0",
 	}
 	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }

--- a/x-pack/filebeat/input/awscloudwatch/input_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/input_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/cloudwatchlogsiface"
 
+	"github.com/elastic/beats/v7/filebeat/input/inputtest"
 	"github.com/elastic/beats/v7/libbeat/common"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetStartPosition(t *testing.T) {
@@ -153,4 +154,12 @@ func TestParseARN(t *testing.T) {
 	assert.Equal(t, "test", logGroup)
 	assert.Equal(t, "us-east-1", regionName)
 	assert.NoError(t, err)
+}
+
+func TestNewInputDone(t *testing.T) {
+	config := common.MapStr{
+		"log_group_name": "some-group",
+		"region_name":    "eu-west-1",
+	}
+	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }

--- a/x-pack/filebeat/input/azureeventhub/input_test.go
+++ b/x-pack/filebeat/input/azureeventhub/input_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
+	"github.com/elastic/beats/v7/filebeat/input/inputtest"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
@@ -107,6 +108,16 @@ func TestParseMultipleMessages(t *testing.T) {
 	for _, ms := range messages {
 		assert.Contains(t, msgs, ms)
 	}
+}
+
+func TestNewInputDone(t *testing.T) {
+	config := common.MapStr{
+		"connection_string":   "Endpoint=sb://something",
+		"eventhub":            "insights-operational-logs",
+		"storage_account":     "someaccount",
+		"storage_account_key": "secret",
+	}
+	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
 }
 
 type stubOutleter struct {

--- a/x-pack/filebeat/input/googlepubsub/input_test.go
+++ b/x-pack/filebeat/input/googlepubsub/input_test.go
@@ -1,0 +1,27 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build !integration
+
+package googlepubsub
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/filebeat/input/inputtest"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestNewInputDone(t *testing.T) {
+	config := common.MapStr{
+		"project_id":        "some-project",
+		"topic":             "sometopic",
+		"subscription.name": "subscription",
+
+		// Provide some credentials to avoid trying to query GCP for them,
+		// what creates HTTP-related goroutines.
+		"credentials_json": "{}",
+	}
+	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
+}

--- a/x-pack/filebeat/input/netflow/input_test.go
+++ b/x-pack/filebeat/input/netflow/input_test.go
@@ -1,0 +1,19 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build !integration
+
+package netflow
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/filebeat/input/inputtest"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestNewInputDone(t *testing.T) {
+	config := common.MapStr{}
+	inputtest.AssertNotStartedInputCanBeDone(t, NewInput, &config)
+}


### PR DESCRIPTION
Cherry-pick of PR #23722 to 7.10 branch. Original message: 

## What does this PR do?

Stop input v1 runners created to check config.

`CheckConfig` for v1 inputs actually calls the constructors of the inputs. In some cases, as in the `log` input, the constructor creates resources that are never released unless the runner is stopped. This causes goroutines leaks with autodiscover or other dynamic configurations.

As discovered in #23658, this started to cause leaks since 7.8.0 (specifically since #16715), but I am not sure why this was not an issue before as config checkers were moved there but not really changed. Perhaps before this change input configs were not actually checked.

### Considered alternatives

* Avoid creating goroutines in v1 input builders. I may give a try to this option, but the problem I see is that ~~`Start()`~~ `Run()` doesn't return errors, and it may be too late to do some checks expected now in the builder.
* Add a runner builder that creates a runner using fake contexts and connectors that can be controlled from `CheckConfig`. Not sure if this would be very different at the end, and we would need to rely on inputs releasing their resources if the context is done.
* Migrate all inputs to v2. Long term is the best solution, but it can be a big effort to be done now, and we would still need a fix to backport to released branches.
* Do nothing on `CheckConfig` for inputs. A feature would be lost.

## Why is it important?

Avoid goroutines and other possible leaks with autodiscover in Filebeat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works.
  - Not easy to add a test for this. It needs at least the module loader, the autodiscover process, and a v1 input. Doing it as system test would be flaky because there are several other goroutines.
  - Added tests to check that v1 inputs don't leak goroutines if their context is stopped after being created.
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Confirm that all v1 inputs can be stopped without being started before.

## How to test this PR locally

- Start filebeat with docker (or kubernetes) autodiscover and `-httpprof :6060`.
- Collect a base profile (`curl http://localhost:6060/debug/pprof/goroutine -o /tmp/goroutines-base.prof`).
- Start a container, and check that filebeat starts collecting its logs.
- Check with pprof that new goroutines have been started
  - `go tool pprof -top -base /tmp/goroutines-base.prof http://localhost:6060/debug/pprof/goroutine`
  - Look for goroutines like `CloseOnSignal` or `SubOutlets`.
- Stop the container.
- Confirm that eventually (~after `cleanup_timeout`) the started goroutines are not in pprof anymore.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
-->

- Fix #23658.