### PR TITLE
Cherry-pick #23801 to 7.x: [Filebeat][Cisco Umbrella] Updating manifest file for fileset.

### DIFF
--- a/x-pack/filebeat/module/cisco/umbrella/manifest.yml
+++ b/x-pack/filebeat/module/cisco/umbrella/manifest.yml
@@ -8,7 +8,14 @@ var:
   - name: api_timeout
     default: 120
   - name: input
-    default: s3
+    default: aws-s3
+  - name: queue_url
+  - name: access_key_id
+  - name: secret_access_key
+  - name: visibility_timeout
+    default: 300s
+  - name: api_timeout
+    default: 120s
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/input.yml


### PR DESCRIPTION
Cherry-pick of PR #23801 to 7.x branch. Original message: 

## What does this PR do?

This adds some default manifest variables for configuration items, in case they might be commented out, and also updates the input type to the new aws-s3 name.

## Why is it important?

Makes the user experience easier, if the umbrella fileset is enabled, but the configuration items not filled in it will break.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes #23795 

