### PR TITLE
Cherry-pick #23802 to 7.x: Add container image and container name ECS fields for state_container

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -84,6 +84,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename googlecloud module to gcp module. {pull}22246[22246]
 - Use ingress/egress instead of inbound/outbound for system/socket metricset. {pull}22992[22992]
 - Change types of numeric metrics from Kubelet summary api to double so as to cover big numbers. {pull}23335[23335]
+- Add container.image.name and containe.name ECS fields for state_container. {pull}23802[23802]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/state_container/_meta/test/ksm.v1.3.0.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/ksm.v1.3.0.expected
@@ -2,7 +2,11 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "4beb9aab887ca162c9cb3534c4826156636241052cd548153eaa2a170b6d102f",
+				"id": "ab382dbe8f8265f88ee9fec7de142f778da4a5fd9fe0334e3bdb6fe851124c08",
+				"image": {
+					"name": "k8s.gcr.io/kube-addon-manager:v8.6"
+				},
+				"name": "kube-addon-manager",
 				"runtime": "docker"
 			}
 		},
@@ -12,18 +16,23 @@
 				"name": "minikube"
 			},
 			"pod": {
-				"name": "kube-controller-manager-minikube"
+				"name": "kube-addon-manager-minikube"
 			}
 		},
 		"MetricSetFields": {
 			"cpu": {
 				"request": {
-					"cores": 0.2
+					"cores": 0.005
 				}
 			},
-			"id": "docker://4beb9aab887ca162c9cb3534c4826156636241052cd548153eaa2a170b6d102f",
-			"image": "gcr.io/google_containers/kube-controller-manager-amd64:v1.9.7",
-			"name": "kube-controller-manager",
+			"id": "docker://ab382dbe8f8265f88ee9fec7de142f778da4a5fd9fe0334e3bdb6fe851124c08",
+			"image": "k8s.gcr.io/kube-addon-manager:v8.6",
+			"memory": {
+				"request": {
+					"bytes": 52428800
+				}
+			},
+			"name": "kube-addon-manager",
 			"status": {
 				"phase": "running",
 				"ready": true,
@@ -44,7 +53,11 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "c46bc2164edcb5972be6fc9174155e61179cb04314c4f6da5d25d3a76acadee6",
+				"id": "76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
+				"image": {
+					"name": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7"
+				},
+				"name": "kube-proxy",
 				"runtime": "docker"
 			}
 		},
@@ -54,13 +67,105 @@
 				"name": "minikube"
 			},
 			"pod": {
-				"name": "kubernetes-dashboard-77d8b98585-vqtzm"
+				"name": "kube-proxy-znhg6"
 			}
 		},
 		"MetricSetFields": {
-			"id": "docker://c46bc2164edcb5972be6fc9174155e61179cb04314c4f6da5d25d3a76acadee6",
-			"image": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
-			"name": "kubernetes-dashboard",
+			"id": "docker://76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
+			"image": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7",
+			"name": "kube-proxy",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
+				"image": {
+					"name": "gcr.io/google_containers/kube-apiserver-amd64:v1.9.7"
+				},
+				"name": "kube-apiserver",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-apiserver-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.25
+				}
+			},
+			"id": "docker://e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
+			"image": "gcr.io/google_containers/kube-apiserver-amd64:v1.9.7",
+			"name": "kube-apiserver",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
+				"image": {
+					"name": "gcr.io/google_containers/kube-scheduler-amd64:v1.9.7"
+				},
+				"name": "kube-scheduler",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-scheduler-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
+			"image": "gcr.io/google_containers/kube-scheduler-amd64:v1.9.7",
+			"name": "kube-scheduler",
 			"status": {
 				"phase": "running",
 				"ready": true,
@@ -82,6 +187,10 @@
 		"RootFields": {
 			"container": {
 				"id": "88951e0178ea5131fa3e2d7cafacb3a7e63700795dd6fa0d40ed2e4ac1f52f9c",
+				"image": {
+					"name": "quay.io/coreos/kube-state-metrics:v1.3.0"
+				},
+				"name": "kube-state-metrics",
 				"runtime": "docker"
 			}
 		},
@@ -134,7 +243,297 @@
 	{
 		"RootFields": {
 			"container": {
+				"id": "1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
+				"image": {
+					"name": "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7"
+				},
+				"name": "kubedns",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
+			"image": "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7",
+			"memory": {
+				"limit": {
+					"bytes": 178257920
+				},
+				"request": {
+					"bytes": 73400320
+				}
+			},
+			"name": "kubedns",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
+				"image": {
+					"name": "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7"
+				},
+				"name": "sidecar",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.01
+				}
+			},
+			"id": "docker://aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
+			"image": "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7",
+			"memory": {
+				"request": {
+					"bytes": 20971520
+				}
+			},
+			"name": "sidecar",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"reason": "OOMKilled",
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "c46bc2164edcb5972be6fc9174155e61179cb04314c4f6da5d25d3a76acadee6",
+				"image": {
+					"name": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1"
+				},
+				"name": "kubernetes-dashboard",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kubernetes-dashboard-77d8b98585-vqtzm"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://c46bc2164edcb5972be6fc9174155e61179cb04314c4f6da5d25d3a76acadee6",
+			"image": "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.1",
+			"name": "kubernetes-dashboard",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "4beb9aab887ca162c9cb3534c4826156636241052cd548153eaa2a170b6d102f",
+				"image": {
+					"name": "gcr.io/google_containers/kube-controller-manager-amd64:v1.9.7"
+				},
+				"name": "kube-controller-manager",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-controller-manager-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.2
+				}
+			},
+			"id": "docker://4beb9aab887ca162c9cb3534c4826156636241052cd548153eaa2a170b6d102f",
+			"image": "gcr.io/google_containers/kube-controller-manager-amd64:v1.9.7",
+			"name": "kube-controller-manager",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
+				"image": {
+					"name": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1"
+				},
+				"name": "storage-provisioner",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "storage-provisioner"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
+			"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
+			"name": "storage-provisioner",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"reason": "ImagePullBackOff",
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
+				"image": {
+					"name": "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7"
+				},
+				"name": "dnsmasq",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-dns-6f4fd4bdf-wlmht"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.15
+				}
+			},
+			"id": "docker://e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
+			"image": "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7",
+			"memory": {
+				"request": {
+					"bytes": 20971520
+				}
+			},
+			"name": "dnsmasq",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
 				"id": "948c4ebd8ca4fdf352e7fbf7f5c5d381af7e615ced435dc42fde0c1d25851320",
+				"image": {
+					"name": "k8s.gcr.io/addon-resizer:1.7"
+				},
+				"name": "addon-resizer",
 				"runtime": "docker"
 			}
 		},
@@ -187,216 +586,11 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-6f4fd4bdf-wlmht"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "docker://1958e71d048065d38ce83dafda567c5fa9d0c1278cd7292d55b9f1d80b0a67f9",
-			"image": "gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7",
-			"memory": {
-				"limit": {
-					"bytes": 178257920
-				},
-				"request": {
-					"bytes": 73400320
-				}
-			},
-			"name": "kubedns",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-proxy-znhg6"
-			}
-		},
-		"MetricSetFields": {
-			"id": "docker://76c260259ddfd0267b5acb4e514465215ef1ebfa93a4057d592828772e6b39f5",
-			"image": "gcr.io/google_containers/kube-proxy-amd64:v1.9.7",
-			"name": "kube-proxy",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "storage-provisioner"
-			}
-		},
-		"MetricSetFields": {
-			"id": "docker://f4cc07b8e7ee5952738c69a0bff0c7b331c10af66faa541197684127d393b760",
-			"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
-			"name": "storage-provisioner",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"reason": "ImagePullBackOff",
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-apiserver-minikube"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.25
-				}
-			},
-			"id": "docker://e9568dfef1dd249cabac4bf09e6bf4a239fe738ae20eba072b6516676fce4bf6",
-			"image": "gcr.io/google_containers/kube-apiserver-amd64:v1.9.7",
-			"name": "kube-apiserver",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-scheduler-minikube"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "docker://eadcbd54ba914dff6475ae64805887967cfb973aeb9b07364c94372658a71d11",
-			"image": "gcr.io/google_containers/kube-scheduler-amd64:v1.9.7",
-			"name": "kube-scheduler",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
 				"id": "6e96fd8a687409b2314dcc01f209bb0c813c2fb08b8f75ad1695e120d41e1a2a",
+				"image": {
+					"name": "gcr.io/google_containers/etcd-amd64:3.1.11"
+				},
+				"name": "etcd",
 				"runtime": "docker"
 			}
 		},
@@ -413,148 +607,6 @@
 			"id": "docker://6e96fd8a687409b2314dcc01f209bb0c813c2fb08b8f75ad1695e120d41e1a2a",
 			"image": "gcr.io/google_containers/etcd-amd64:3.1.11",
 			"name": "etcd",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "ab382dbe8f8265f88ee9fec7de142f778da4a5fd9fe0334e3bdb6fe851124c08",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-addon-manager-minikube"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.005
-				}
-			},
-			"id": "docker://ab382dbe8f8265f88ee9fec7de142f778da4a5fd9fe0334e3bdb6fe851124c08",
-			"image": "k8s.gcr.io/kube-addon-manager:v8.6",
-			"memory": {
-				"request": {
-					"bytes": 52428800
-				}
-			},
-			"name": "kube-addon-manager",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-6f4fd4bdf-wlmht"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.01
-				}
-			},
-			"id": "docker://aad0addd205dc72dc7abc8f9d02a1b429a2f2e1df3acc60431ca6b79746c093b",
-			"image": "gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7",
-			"memory": {
-				"request": {
-					"bytes": 20971520
-				}
-			},
-			"name": "sidecar",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"reason": "OOMKilled",
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-dns-6f4fd4bdf-wlmht"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.15
-				}
-			},
-			"id": "docker://e9560bbace13ca19de4b3771023198e8568f6b5ed6af3a949f10a5b8137b5be9",
-			"image": "gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7",
-			"memory": {
-				"request": {
-					"bytes": 20971520
-				}
-			},
-			"name": "dnsmasq",
 			"status": {
 				"phase": "running",
 				"ready": true,

--- a/metricbeat/module/kubernetes/state_container/_meta/test/ksm.v1.8.0.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/ksm.v1.8.0.expected
@@ -2,44 +2,11 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "c152296116c064db311061cf6c39cff2de8d66339c954505cb68816464cf4a03",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-proxy-dwg6l"
-			}
-		},
-		"MetricSetFields": {
-			"id": "docker://c152296116c064db311061cf6c39cff2de8d66339c954505cb68816464cf4a03",
-			"image": "k8s.gcr.io/kube-proxy:v1.16.2",
-			"name": "kube-proxy",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
 				"id": "cdaefb4df2f2add498f884fdc717a6ca8d2681c1636934747de600e6427e0c0d",
+				"image": {
+					"name": "k8s.gcr.io/kube-apiserver:v1.16.2"
+				},
+				"name": "kube-apiserver",
 				"runtime": "docker"
 			}
 		},
@@ -81,7 +48,236 @@
 	{
 		"RootFields": {
 			"container": {
+				"id": "f13c53a3ed0f3626b33b3c588d6913257320f65714eff28f25ead8f7663dc93b",
+				"image": {
+					"name": "k8s.gcr.io/kube-addon-manager:v9.0.2"
+				},
+				"name": "kube-addon-manager",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-addon-manager-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.005
+				}
+			},
+			"id": "docker://f13c53a3ed0f3626b33b3c588d6913257320f65714eff28f25ead8f7663dc93b",
+			"image": "k8s.gcr.io/kube-addon-manager:v9.0.2",
+			"memory": {
+				"request": {
+					"bytes": 52428800
+				}
+			},
+			"name": "kube-addon-manager",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "0ea0cef8a79c7643474a736e5da14c254d9411d87167028fa07c96d09748c83a",
+				"image": {
+					"name": "k8s.gcr.io/kube-scheduler:v1.16.2"
+				},
+				"name": "kube-scheduler",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-scheduler-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "docker://0ea0cef8a79c7643474a736e5da14c254d9411d87167028fa07c96d09748c83a",
+			"image": "k8s.gcr.io/kube-scheduler:v1.16.2",
+			"name": "kube-scheduler",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "a4cec783af3614b137f4b449eebf3ac61eaf0a8661cb2f4847741be5a24de0bf",
+				"image": {
+					"name": "k8s.gcr.io/nginx-slim:0.8"
+				},
+				"name": "nginx",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "default",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "web-0"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://a4cec783af3614b137f4b449eebf3ac61eaf0a8661cb2f4847741be5a24de0bf",
+			"image": "k8s.gcr.io/nginx-slim:0.8",
+			"name": "nginx",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "842fbd62a0ab71b9ed9139edce3db502e9d81e545b9646daa3cde09f9986ab06",
+				"image": {
+					"name": "k8s.gcr.io/etcd:3.3.15-0"
+				},
+				"name": "etcd",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "etcd-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://842fbd62a0ab71b9ed9139edce3db502e9d81e545b9646daa3cde09f9986ab06",
+			"image": "k8s.gcr.io/etcd:3.3.15-0",
+			"name": "etcd",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "465ebffafd7fc238a2fa2e764255efcbff88d5513f4c68f57d70932985428d12",
+				"image": {
+					"name": "k8s.gcr.io/kube-controller-manager:v1.16.2"
+				},
+				"name": "kube-controller-manager",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "kube-controller-manager-minikube"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.2
+				}
+			},
+			"id": "docker://465ebffafd7fc238a2fa2e764255efcbff88d5513f4c68f57d70932985428d12",
+			"image": "k8s.gcr.io/kube-controller-manager:v1.16.2",
+			"name": "kube-controller-manager",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
 				"id": "2e0519a3fcd62acea8f4253b994ce53356d89171c0eb0920a13fe58b637d8cdb",
+				"image": {
+					"name": "quay.io/coreos/kube-state-metrics:v1.8.0"
+				},
+				"name": "kube-state-metrics",
 				"runtime": "docker"
 			}
 		},
@@ -119,6 +315,10 @@
 		"RootFields": {
 			"container": {
 				"id": "15ada7864628d1c8007c01420e5887a501590d3bc9c25628a4770172ad615112",
+				"image": {
+					"name": "k8s.gcr.io/coredns:1.6.2"
+				},
+				"name": "coredns",
 				"runtime": "docker"
 			}
 		},
@@ -168,23 +368,27 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "669cc415d86b872450deaada60c73cca387ca23a7b0f21c5b146467b95cf1f76",
+				"id": "c152296116c064db311061cf6c39cff2de8d66339c954505cb68816464cf4a03",
+				"image": {
+					"name": "k8s.gcr.io/kube-proxy:v1.16.2"
+				},
+				"name": "kube-proxy",
 				"runtime": "docker"
 			}
 		},
 		"ModuleFields": {
-			"namespace": "default",
+			"namespace": "kube-system",
 			"node": {
 				"name": "minikube"
 			},
 			"pod": {
-				"name": "web-1"
+				"name": "kube-proxy-dwg6l"
 			}
 		},
 		"MetricSetFields": {
-			"id": "docker://669cc415d86b872450deaada60c73cca387ca23a7b0f21c5b146467b95cf1f76",
-			"image": "k8s.gcr.io/nginx-slim:0.8",
-			"name": "nginx",
+			"id": "docker://c152296116c064db311061cf6c39cff2de8d66339c954505cb68816464cf4a03",
+			"image": "k8s.gcr.io/kube-proxy:v1.16.2",
+			"name": "kube-proxy",
 			"status": {
 				"phase": "running",
 				"ready": true,
@@ -205,7 +409,53 @@
 	{
 		"RootFields": {
 			"container": {
+				"id": "30216f9823ca7d3454987075dd7256b665b14b2333c9a6762b127b6378516609",
+				"image": {
+					"name": "busybox:latest"
+				},
+				"name": "hello",
+				"runtime": "docker"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "default",
+			"node": {
+				"name": "minikube"
+			},
+			"pod": {
+				"name": "hello-1578512100-vr7wj"
+			}
+		},
+		"MetricSetFields": {
+			"id": "docker://30216f9823ca7d3454987075dd7256b665b14b2333c9a6762b127b6378516609",
+			"image": "busybox:latest",
+			"name": "hello",
+			"status": {
+				"phase": "terminated",
+				"ready": false,
+				"reason": "Completed",
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
 				"id": "f8fe5be1dbb1931d702c89235c79965730cbcced7b0ced9895f6c54c1ae8e5c3",
+				"image": {
+					"name": "k8s.gcr.io/coredns:1.6.2"
+				},
+				"name": "coredns",
 				"runtime": "docker"
 			}
 		},
@@ -255,133 +505,11 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "f13c53a3ed0f3626b33b3c588d6913257320f65714eff28f25ead8f7663dc93b",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-addon-manager-minikube"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.005
-				}
-			},
-			"id": "docker://f13c53a3ed0f3626b33b3c588d6913257320f65714eff28f25ead8f7663dc93b",
-			"image": "k8s.gcr.io/kube-addon-manager:v9.0.2",
-			"memory": {
-				"request": {
-					"bytes": 52428800
-				}
-			},
-			"name": "kube-addon-manager",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "842fbd62a0ab71b9ed9139edce3db502e9d81e545b9646daa3cde09f9986ab06",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "etcd-minikube"
-			}
-		},
-		"MetricSetFields": {
-			"id": "docker://842fbd62a0ab71b9ed9139edce3db502e9d81e545b9646daa3cde09f9986ab06",
-			"image": "k8s.gcr.io/etcd:3.3.15-0",
-			"name": "etcd",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "465ebffafd7fc238a2fa2e764255efcbff88d5513f4c68f57d70932985428d12",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-controller-manager-minikube"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.2
-				}
-			},
-			"id": "docker://465ebffafd7fc238a2fa2e764255efcbff88d5513f4c68f57d70932985428d12",
-			"image": "k8s.gcr.io/kube-controller-manager:v1.16.2",
-			"name": "kube-controller-manager",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "a4cec783af3614b137f4b449eebf3ac61eaf0a8661cb2f4847741be5a24de0bf",
+				"id": "669cc415d86b872450deaada60c73cca387ca23a7b0f21c5b146467b95cf1f76",
+				"image": {
+					"name": "k8s.gcr.io/nginx-slim:0.8"
+				},
+				"name": "nginx",
 				"runtime": "docker"
 			}
 		},
@@ -391,11 +519,11 @@
 				"name": "minikube"
 			},
 			"pod": {
-				"name": "web-0"
+				"name": "web-1"
 			}
 		},
 		"MetricSetFields": {
-			"id": "docker://a4cec783af3614b137f4b449eebf3ac61eaf0a8661cb2f4847741be5a24de0bf",
+			"id": "docker://669cc415d86b872450deaada60c73cca387ca23a7b0f21c5b146467b95cf1f76",
 			"image": "k8s.gcr.io/nginx-slim:0.8",
 			"name": "nginx",
 			"status": {
@@ -419,6 +547,10 @@
 		"RootFields": {
 			"container": {
 				"id": "e0b05fcb32abf937c395942e0234b5dfc834206149bbb95afa585c51693650f3",
+				"image": {
+					"name": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1"
+				},
+				"name": "storage-provisioner",
 				"runtime": "docker"
 			}
 		},
@@ -435,86 +567,6 @@
 			"id": "docker://e0b05fcb32abf937c395942e0234b5dfc834206149bbb95afa585c51693650f3",
 			"image": "gcr.io/k8s-minikube/storage-provisioner:v1.8.1",
 			"name": "storage-provisioner",
-			"status": {
-				"phase": "running",
-				"ready": true,
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "30216f9823ca7d3454987075dd7256b665b14b2333c9a6762b127b6378516609",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "default",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "hello-1578512100-vr7wj"
-			}
-		},
-		"MetricSetFields": {
-			"id": "docker://30216f9823ca7d3454987075dd7256b665b14b2333c9a6762b127b6378516609",
-			"image": "busybox:latest",
-			"name": "hello",
-			"status": {
-				"phase": "terminated",
-				"ready": false,
-				"reason": "Completed",
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "0ea0cef8a79c7643474a736e5da14c254d9411d87167028fa07c96d09748c83a",
-				"runtime": "docker"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "minikube"
-			},
-			"pod": {
-				"name": "kube-scheduler-minikube"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "docker://0ea0cef8a79c7643474a736e5da14c254d9411d87167028fa07c96d09748c83a",
-			"image": "k8s.gcr.io/kube-scheduler:v1.16.2",
-			"name": "kube-scheduler",
 			"status": {
 				"phase": "running",
 				"ready": true,

--- a/metricbeat/module/kubernetes/state_container/_meta/testdata/ksm-v1_3_0.plain-expected.json
+++ b/metricbeat/module/kubernetes/state_container/_meta/testdata/ksm-v1_3_0.plain-expected.json
@@ -1,5 +1,13 @@
 [
     {
+        "container": {
+            "id": "e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
+            "image": {
+                "name": "jenkinsci/jenkins:2.46.1"
+            },
+            "name": "wise-lynx-jenkins",
+            "runtime": "docker"
+        },
         "event": {
             "dataset": "kubernetes.container",
             "duration": 115000,
@@ -8,26 +16,211 @@
         "kubernetes": {
             "container": {
                 "cpu": {
-                    "limit": {
+                    "request": {
                         "cores": 0.2
-                    },
+                    }
+                },
+                "id": "docker://e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
+                "image": "jenkinsci/jenkins:2.46.1",
+                "memory": {
+                    "request": {
+                        "bytes": 268435456
+                    }
+                },
+                "name": "wise-lynx-jenkins",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 1
+                }
+            },
+            "namespace": "jenkins",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "wise-lynx-jenkins-1616735317-svn6k"
+            }
+        },
+        "metricset": {
+            "name": "state_container",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "container": {
+            "id": "3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
+            "image": {
+                "name": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1"
+            },
+            "name": "kubernetes-dashboard",
+            "runtime": "docker"
+        },
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
+                "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
+                "name": "kubernetes-dashboard",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kubernetes-dashboard-vw0l6"
+            }
+        },
+        "metricset": {
+            "name": "state_container",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "container": {
+            "id": "469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
+            "image": {
+                "name": "gcr.io/kubernetes-helm/tiller:v2.3.1"
+            },
+            "name": "tiller",
+            "runtime": "docker"
+        },
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "id": "docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
+                "image": "gcr.io/kubernetes-helm/tiller:v2.3.1",
+                "name": "tiller",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 1
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "tiller-deploy-3067024529-9lpmb"
+            }
+        },
+        "metricset": {
+            "name": "state_container",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "container": {
+            "id": "9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
+            "image": {
+                "name": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4"
+            },
+            "name": "dnsmasq",
+            "runtime": "docker"
+        },
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
+                "image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
+                "name": "dnsmasq",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
+            },
+            "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
+            "pod": {
+                "name": "kube-dns-v20-5g5cb"
+            }
+        },
+        "metricset": {
+            "name": "state_container",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "container": {
+            "id": "fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
+            "image": {
+                "name": "gcr.io/google_containers/kubedns-amd64:1.9"
+            },
+            "name": "kubedns",
+            "runtime": "docker"
+        },
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
                     "request": {
                         "cores": 0.1
                     }
                 },
+                "id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
+                "image": "gcr.io/google_containers/kubedns-amd64:1.9",
                 "memory": {
                     "limit": {
-                        "bytes": 52428800
+                        "bytes": 178257920
                     },
                     "request": {
-                        "bytes": 31457280
+                        "bytes": 73400320
                     }
                 },
-                "name": "kube-state-metrics"
+                "name": "kubedns",
+                "status": {
+                    "phase": "running",
+                    "ready": true,
+                    "restarts": 2
+                }
             },
             "namespace": "kube-system",
+            "node": {
+                "name": "minikube"
+            },
             "pod": {
-                "name": "kube-state-metrics-1303537707-mnzbp"
+                "name": "kube-dns-v20-5g5cb"
             }
         },
         "metricset": {
@@ -42,6 +235,10 @@
     {
         "container": {
             "id": "4fa227874ee68536bf902394fb662f07b99099798ca9cd5c1506b79075acc065",
+            "image": {
+                "name": "bitnami/redis:3.2.8-r2"
+            },
+            "name": "jumpy-owl-redis",
             "runtime": "docker"
         },
         "event": {
@@ -89,45 +286,11 @@
     },
     {
         "container": {
-            "id": "9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
-            "runtime": "docker"
-        },
-        "event": {
-            "dataset": "kubernetes.container",
-            "duration": 115000,
-            "module": "kubernetes"
-        },
-        "kubernetes": {
-            "container": {
-                "id": "docker://9a4c9462cd078d7be4f0a9b94bcfeb69d5fdd76bff67142df3f58367ac7e8d61",
-                "image": "gcr.io/google_containers/kube-dnsmasq-amd64:1.4",
-                "name": "dnsmasq",
-                "status": {
-                    "phase": "running",
-                    "ready": true,
-                    "restarts": 2
-                }
-            },
-            "namespace": "kube-system",
-            "node": {
-                "name": "minikube"
-            },
-            "pod": {
-                "name": "kube-dns-v20-5g5cb"
-            }
-        },
-        "metricset": {
-            "name": "state_container",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "kubernetes"
-        }
-    },
-    {
-        "container": {
             "id": "973cbe45982c5126a5caf8c58d964c0ab1d5bb2c165ccc59715fcc1ebd58ab3d",
+            "image": {
+                "name": "gcr.io/google_containers/kube-state-metrics:v0.4.1"
+            },
+            "name": "kube-state-metrics",
             "runtime": "docker"
         },
         "event": {
@@ -181,243 +344,11 @@
     },
     {
         "container": {
-            "id": "fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
-            "runtime": "docker"
-        },
-        "event": {
-            "dataset": "kubernetes.container",
-            "duration": 115000,
-            "module": "kubernetes"
-        },
-        "kubernetes": {
-            "container": {
-                "cpu": {
-                    "request": {
-                        "cores": 0.1
-                    }
-                },
-                "id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62",
-                "image": "gcr.io/google_containers/kubedns-amd64:1.9",
-                "memory": {
-                    "limit": {
-                        "bytes": 178257920
-                    },
-                    "request": {
-                        "bytes": 73400320
-                    }
-                },
-                "name": "kubedns",
-                "status": {
-                    "phase": "running",
-                    "ready": true,
-                    "restarts": 2
-                }
-            },
-            "namespace": "kube-system",
-            "node": {
-                "name": "minikube"
-            },
-            "pod": {
-                "name": "kube-dns-v20-5g5cb"
-            }
-        },
-        "metricset": {
-            "name": "state_container",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "kubernetes"
-        }
-    },
-    {
-        "container": {
-            "id": "e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
-            "runtime": "docker"
-        },
-        "event": {
-            "dataset": "kubernetes.container",
-            "duration": 115000,
-            "module": "kubernetes"
-        },
-        "kubernetes": {
-            "container": {
-                "cpu": {
-                    "request": {
-                        "cores": 0.2
-                    }
-                },
-                "id": "docker://e2ee1c2c7b8d4e5fd8c834b83cba8377d6b0e39da18157688ccc1a06b7c53117",
-                "image": "jenkinsci/jenkins:2.46.1",
-                "memory": {
-                    "request": {
-                        "bytes": 268435456
-                    }
-                },
-                "name": "wise-lynx-jenkins",
-                "status": {
-                    "phase": "running",
-                    "ready": true,
-                    "restarts": 1
-                }
-            },
-            "namespace": "jenkins",
-            "node": {
-                "name": "minikube"
-            },
-            "pod": {
-                "name": "wise-lynx-jenkins-1616735317-svn6k"
-            }
-        },
-        "metricset": {
-            "name": "state_container",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "kubernetes"
-        }
-    },
-    {
-        "container": {
-            "id": "91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
-            "runtime": "docker"
-        },
-        "event": {
-            "dataset": "kubernetes.container",
-            "duration": 115000,
-            "module": "kubernetes"
-        },
-        "kubernetes": {
-            "container": {
-                "cpu": {
-                    "request": {
-                        "cores": 0.005
-                    }
-                },
-                "id": "docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
-                "image": "gcr.io/google-containers/kube-addon-manager:v6.3",
-                "memory": {
-                    "request": {
-                        "bytes": 52428800
-                    }
-                },
-                "name": "kube-addon-manager",
-                "status": {
-                    "phase": "running",
-                    "ready": true,
-                    "restarts": 2
-                }
-            },
-            "namespace": "kube-system",
-            "node": {
-                "name": "minikube"
-            },
-            "pod": {
-                "name": "kube-addon-manager-minikube"
-            }
-        },
-        "metricset": {
-            "name": "state_container",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "kubernetes"
-        }
-    },
-    {
-        "container": {
-            "id": "3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
-            "runtime": "docker"
-        },
-        "event": {
-            "dataset": "kubernetes.container",
-            "duration": 115000,
-            "module": "kubernetes"
-        },
-        "kubernetes": {
-            "container": {
-                "id": "docker://3aaee8bdd311c015240e99fa2a5a5f2f26b11b51236a683b39d8c1902e423978",
-                "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1",
-                "name": "kubernetes-dashboard",
-                "status": {
-                    "phase": "running",
-                    "ready": true,
-                    "restarts": 2
-                }
-            },
-            "namespace": "kube-system",
-            "node": {
-                "name": "minikube"
-            },
-            "pod": {
-                "name": "kubernetes-dashboard-vw0l6"
-            }
-        },
-        "metricset": {
-            "name": "state_container",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "kubernetes"
-        }
-    },
-    {
-        "container": {
-            "id": "fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
-            "runtime": "docker"
-        },
-        "event": {
-            "dataset": "kubernetes.container",
-            "duration": 115000,
-            "module": "kubernetes"
-        },
-        "kubernetes": {
-            "container": {
-                "cpu": {
-                    "request": {
-                        "cores": 0.2
-                    }
-                },
-                "id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
-                "image": "gcr.io/google_containers/kubedns-amd64:1.9-test",
-                "memory": {
-                    "limit": {
-                        "bytes": 278257920
-                    },
-                    "request": {
-                        "bytes": 83400320
-                    }
-                },
-                "name": "kubedns",
-                "status": {
-                    "phase": "terminated",
-                    "ready": false,
-                    "restarts": 3
-                }
-            },
-            "namespace": "test",
-            "node": {
-                "name": "minikube-test"
-            },
-            "pod": {
-                "name": "kube-dns-v20-5g5cb-test"
-            }
-        },
-        "metricset": {
-            "name": "state_container",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "kubernetes"
-        }
-    },
-    {
-        "container": {
             "id": "52fa55e051dc5b68e44c027588685b7edd85aaa03b07f7216d399249ff4fc821",
+            "image": {
+                "name": "gcr.io/google_containers/exechealthz-amd64:1.2"
+            },
+            "name": "healthz",
             "runtime": "docker"
         },
         "event": {
@@ -468,7 +399,11 @@
     },
     {
         "container": {
-            "id": "469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
+            "id": "91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
+            "image": {
+                "name": "gcr.io/google-containers/kube-addon-manager:v6.3"
+            },
+            "name": "kube-addon-manager",
             "runtime": "docker"
         },
         "event": {
@@ -478,13 +413,23 @@
         },
         "kubernetes": {
             "container": {
-                "id": "docker://469f5d2b7854eb52e5d13dc0cd3e664c1b682b157aabaf596ffe4984f1516902",
-                "image": "gcr.io/kubernetes-helm/tiller:v2.3.1",
-                "name": "tiller",
+                "cpu": {
+                    "request": {
+                        "cores": 0.005
+                    }
+                },
+                "id": "docker://91fdd43f6b1b4c3dd133cfca53e0b1210bc557c2ae56006026b5ccdb5f52826f",
+                "image": "gcr.io/google-containers/kube-addon-manager:v6.3",
+                "memory": {
+                    "request": {
+                        "bytes": 52428800
+                    }
+                },
+                "name": "kube-addon-manager",
                 "status": {
                     "phase": "running",
                     "ready": true,
-                    "restarts": 1
+                    "restarts": 2
                 }
             },
             "namespace": "kube-system",
@@ -492,7 +437,105 @@
                 "name": "minikube"
             },
             "pod": {
-                "name": "tiller-deploy-3067024529-9lpmb"
+                "name": "kube-addon-manager-minikube"
+            }
+        },
+        "metricset": {
+            "name": "state_container",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "container": {
+            "id": "fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
+            "image": {
+                "name": "gcr.io/google_containers/kubedns-amd64:1.9-test"
+            },
+            "name": "kubedns",
+            "runtime": "docker"
+        },
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "request": {
+                        "cores": 0.2
+                    }
+                },
+                "id": "docker://fa3d83f648de42492b38fa3e8501d109376f391c50f2bd210c895c8477ae4b62-test",
+                "image": "gcr.io/google_containers/kubedns-amd64:1.9-test",
+                "memory": {
+                    "limit": {
+                        "bytes": 278257920
+                    },
+                    "request": {
+                        "bytes": 83400320
+                    }
+                },
+                "name": "kubedns",
+                "status": {
+                    "phase": "terminated",
+                    "ready": false,
+                    "restarts": 3
+                }
+            },
+            "namespace": "test",
+            "node": {
+                "name": "minikube-test"
+            },
+            "pod": {
+                "name": "kube-dns-v20-5g5cb-test"
+            }
+        },
+        "metricset": {
+            "name": "state_container",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "kubernetes"
+        }
+    },
+    {
+        "container": {
+            "name": "kube-state-metrics"
+        },
+        "event": {
+            "dataset": "kubernetes.container",
+            "duration": 115000,
+            "module": "kubernetes"
+        },
+        "kubernetes": {
+            "container": {
+                "cpu": {
+                    "limit": {
+                        "cores": 0.2
+                    },
+                    "request": {
+                        "cores": 0.1
+                    }
+                },
+                "memory": {
+                    "limit": {
+                        "bytes": 52428800
+                    },
+                    "request": {
+                        "bytes": 31457280
+                    }
+                },
+                "name": "kube-state-metrics"
+            },
+            "namespace": "kube-system",
+            "pod": {
+                "name": "kube-state-metrics-1303537707-mnzbp"
             }
         },
         "metricset": {


### PR DESCRIPTION
Cherry-pick of PR #23802 to 7.x branch. Original message: 

## What does this PR do?
Most probably this was not caught at https://github.com/elastic/beats/pull/13884.
With this PR `kubernetes.container.name` is being copied to `container.name` and `kubernetes.container.name` is being copied to `container.image.name` based on [container ECS](https://www.elastic.co/guide/en/ecs/current/ecs-container.html).

`kubernetes.container.*` fields will not be removed until 8.0 elastic stack release.

Related to https://github.com/elastic/beats/issues/23585