### PR TITLE
Add undocumented ssl.key_passphrase option to kafka docs.

### DIFF
--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -78,6 +78,9 @@ metricbeat.modules:
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
+
   # SASL authentication
   #username: ""
   #password: ""

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -77,7 +77,7 @@ metricbeat.modules:
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
-
+  
   # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
   #ssl.key_passphrase: "yourKeyPassphrase"
 

--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -77,7 +77,7 @@ metricbeat.modules:
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
-  
+
   # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
   #ssl.key_passphrase: "yourKeyPassphrase"
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -425,6 +425,9 @@ metricbeat.modules:
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
+  
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
 
   # SASL authentication
   #username: ""

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -425,7 +425,7 @@ metricbeat.modules:
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
-  
+
   # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
   #ssl.key_passphrase: "yourKeyPassphrase"
 

--- a/metricbeat/module/kafka/_meta/config.yml
+++ b/metricbeat/module/kafka/_meta/config.yml
@@ -22,7 +22,7 @@
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
-  
+
   # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
   #ssl.key_passphrase: "yourKeyPassphrase"
 

--- a/metricbeat/module/kafka/_meta/config.yml
+++ b/metricbeat/module/kafka/_meta/config.yml
@@ -22,6 +22,9 @@
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
+  
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
 
   # SASL authentication
   #username: ""

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -25,6 +25,9 @@
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
+  
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
 
   # SASL authentication
   #username: ""

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -25,7 +25,7 @@
 
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
-  
+
   # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
   #ssl.key_passphrase: "yourKeyPassphrase"
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -777,6 +777,9 @@ metricbeat.modules:
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
+
   # SASL authentication
   #username: ""
   #password: ""


### PR DESCRIPTION
Replaces #21980 (the branch with the original fix got deleted, so it was easier to create a new PR.

Note that these changes have already been approved in the original PR.