### PR TITLE
Add system.hostfs configuration option for system module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -496,6 +496,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add stack monitoring section to elasticsearch module documentation {pull}#23286[23286]
 - Fix metric grouping for windows/perfmon module {issue}23489[23489] {pull}23505[23505]
 - Add check for iis/application_pool metricset for nil worker process id values. {issue}23605[23605] {pull}23647[23647]
+- Add system.hostfs configuration option for system module. {pull}23831[23831]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -177,6 +177,9 @@ metricbeat.modules:
   period: 10s
   processes: ['.*']
 
+  # Configure the mount point of the host’s filesystem for use in monitoring a host from within a container
+  #system.hostfs: "/hostfs"
+
   # Configure the metric types that are included by these metricsets.
   cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -79,6 +79,9 @@ metricbeat.modules:
   period: 10s
   processes: ['.*']
 
+  # Configure the mount point of the host’s filesystem for use in monitoring a host from within a container
+  #system.hostfs: "/hostfs"
+
   # Configure the metric types that are included by these metricsets.
   cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.

--- a/metricbeat/module/system/_meta/config.reference.yml
+++ b/metricbeat/module/system/_meta/config.reference.yml
@@ -19,6 +19,9 @@
   period: 10s
   processes: ['.*']
 
+  # Configure the mount point of the host’s filesystem for use in monitoring a host from within a container
+  #system.hostfs: "/hostfs"
+
   # Configure the metric types that are included by these metricsets.
   cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.

--- a/metricbeat/module/system/_meta/config.yml
+++ b/metricbeat/module/system/_meta/config.yml
@@ -17,6 +17,8 @@
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU
     by_memory: 5   # include top 5 processes by memory
+  # Configure the mount point of the host’s filesystem for use in monitoring a host from within a container
+  #system.hostfs: "/hostfs"
 
 - module: system
   period: 1m

--- a/metricbeat/module/system/system.go
+++ b/metricbeat/module/system/system.go
@@ -42,7 +42,7 @@ func init() {
 
 // Config for the system module.
 type Config struct {
-	HostFS string `config:"system.hostfs"`      // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
+	HostFS string `config:"system.hostfs"` // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
 }
 
 // Module represents the system module

--- a/metricbeat/module/system/system.go
+++ b/metricbeat/module/system/system.go
@@ -54,10 +54,6 @@ type Module struct {
 
 // NewModule instatiates the system module
 func NewModule(base mb.BaseModule) (mb.Module, error) {
-	// This only needs to be configured once for all system modules.
-	once.Do(func() {
-		initModule()
-	})
 
 	config := Config{
 		HostFS: "",
@@ -69,6 +65,11 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 	if *HostFS != "" {
 		config.HostFS = *HostFS
 	}
+
+	// This only needs to be configured once for all system modules.
+	once.Do(func() {
+		initModule(config)
+	})
 
 	return &Module{BaseModule: base, HostFS: config.HostFS, IsAgent: fleetmode.Enabled()}, nil
 }

--- a/metricbeat/module/system/system.go
+++ b/metricbeat/module/system/system.go
@@ -26,6 +26,7 @@ import (
 )
 
 var (
+	// TODO: remove this flag in 8.0 since it should be replaced by system.hostfs configuration option (config.HostFS)
 	// HostFS is an alternate mountpoint for the filesytem root, for when metricbeat is running inside a container.
 	HostFS = flag.String("system.hostfs", "", "mountpoint of the host's filesystem for use in monitoring a host from within a container")
 )
@@ -37,6 +38,11 @@ func init() {
 	if err := mb.Registry.AddModule("system", NewModule); err != nil {
 		panic(err)
 	}
+}
+
+// Config for the system module.
+type Config struct {
+	HostFS string `config:"system.hostfs"`      // Specifies the mount point of the host’s filesystem for use in monitoring a host from within a container.
 }
 
 // Module represents the system module
@@ -53,5 +59,16 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 		initModule()
 	})
 
-	return &Module{BaseModule: base, HostFS: *HostFS, IsAgent: fleetmode.Enabled()}, nil
+	config := Config{
+		HostFS: "",
+	}
+	err := base.UnpackConfig(&config)
+	if err != nil {
+		return nil, err
+	}
+	if *HostFS != "" {
+		config.HostFS = *HostFS
+	}
+
+	return &Module{BaseModule: base, HostFS: config.HostFS, IsAgent: fleetmode.Enabled()}, nil
 }

--- a/metricbeat/module/system/system.go
+++ b/metricbeat/module/system/system.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/elastic/beats/v7/libbeat/common/fleetmode"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
 
@@ -63,6 +64,9 @@ func NewModule(base mb.BaseModule) (mb.Module, error) {
 		return nil, err
 	}
 	if *HostFS != "" {
+		if config.HostFS != "" {
+			logp.Warn("-system.hostfs flag is set and will override configuration setting")
+		}
 		config.HostFS = *HostFS
 	}
 

--- a/metricbeat/module/system/system_linux.go
+++ b/metricbeat/module/system/system_linux.go
@@ -24,12 +24,12 @@ import (
 	"github.com/elastic/gosigar"
 )
 
-func initModule() {
-	configureHostFS()
+func initModule(config Config) {
+	configureHostFS(config)
 }
 
-func configureHostFS() {
-	dir := *HostFS
+func configureHostFS(config Config) {
+	dir := config.HostFS
 	if dir == "" {
 		dir = "/"
 	}

--- a/metricbeat/module/system/system_other.go
+++ b/metricbeat/module/system/system_other.go
@@ -19,6 +19,6 @@
 
 package system
 
-func initModule() {
+func initModule(config Config) {
 	// Stub method for non-linux.
 }

--- a/metricbeat/module/system/system_windows.go
+++ b/metricbeat/module/system/system_windows.go
@@ -22,7 +22,7 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/helper"
 )
 
-func initModule() {
+func initModule(config Config) {
 	if err := helper.CheckAndEnableSeDebugPrivilege(); err != nil {
 		logp.Warn("%v", err)
 	}

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -20,6 +20,8 @@
   process.include_top_n:
     by_cpu: 5      # include top 5 processes by CPU
     by_memory: 5   # include top 5 processes by memory
+  # Configure the mount point of the host’s filesystem for use in monitoring a host from within a container
+  #system.hostfs: "/hostfs"
 
 - module: system
   period: 1m

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -79,6 +79,9 @@ metricbeat.modules:
   period: 10s
   processes: ['.*']
 
+  # Configure the mount point of the host’s filesystem for use in monitoring a host from within a container
+  #system.hostfs: "/hostfs"
+
   # Configure the metric types that are included by these metricsets.
   cpu.metrics:  ["percentages","normalized_percentages"]  # The other available option is ticks.
   core.metrics: ["percentages"]  # The other available option is ticks.


### PR DESCRIPTION
## What does this PR do?
This PR adds `system.hostfs` configuration option for system module. 
It will be used instead of the flag `-system.hostfs=/hostfs` where adding a flag is not possible ie in Agent. Using the `-system.hostfs` will still be available until we completely remove it in 8.0

## Why is it important?
In some cases setting the `proc` filesystem using the `-system.hostfs` is not possible like when running with Agent, see https://github.com/elastic/beats/issues/22915. A configuration option should be used instead.


## How to test this PR manually

1. Build Metricbeat: `GOOS=linux GOARCH=amd64 go build`
2. Prepare a configuration file `vim system.yml`:
```
- module: system
  period: 10s
  metricsets:
    - process
  # Configure the mount point of the host’s filesystem for use in monitoring a host from within a container
  system.hostfs: "/hostfs"
```
3. Use the following Dockerfile.debug to build a custom image locally:
```
FROM docker.elastic.co/beats/metricbeat:7.10.2
COPY metricbeat.yml /usr/share/metricbeat/metricbeat.yml
COPY metricbeat /usr/share/metricbeat/metricbeat
COPY system.yml /usr/share/metricbeat/modules.d/system.yml
USER root
RUN chown root:metricbeat /usr/share/metricbeat/metricbeat.yml
USER metricbeat
```
4. Build the image: `docker build -f Dockefile.debug . -t metricbeat-hostfs`
5. Run Metricbeat and verify that `process` metricset collects data:
```
docker run --mount type=bind,source=/proc,target=/hostfs/proc,readonly --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly --mount type=bind,source=/,target=/hostfs,readonly --net=host metricbeat-hostfs -e -d "*" 
```
6. Try to break Metricbeat by adding a random hostpath flag: `-system.hostfs=/hostfs45`

## Related issues

- Closes https://github.com/elastic/beats/issues/22915
- Relates https://github.com/elastic/beats/issues/23613


cc: @blakerouse 