### PR TITLE
Cherry-pick to 7.x: Add undocumented ssl.key_passphrase option to kafka docs. (#23826)

### DIFF
--- a/metricbeat/docs/modules/kafka.asciidoc
+++ b/metricbeat/docs/modules/kafka.asciidoc
@@ -78,6 +78,9 @@ metricbeat.modules:
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
+
   # SASL authentication
   #username: ""
   #password: ""

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -426,6 +426,9 @@ metricbeat.modules:
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
+
   # SASL authentication
   #username: ""
   #password: ""

--- a/metricbeat/module/kafka/_meta/config.yml
+++ b/metricbeat/module/kafka/_meta/config.yml
@@ -23,6 +23,9 @@
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
+
   # SASL authentication
   #username: ""
   #password: ""

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -26,6 +26,9 @@
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
+
   # SASL authentication
   #username: ""
   #password: ""

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -778,6 +778,9 @@ metricbeat.modules:
   # Client Certificate Key
   #ssl.key: "/etc/pki/client/cert.key"
 
+  # Client Certificate Passphrase (in case your Client Certificate Key is encrypted)
+  #ssl.key_passphrase: "yourKeyPassphrase"
+
   # SASL authentication
   #username: ""
   #password: ""


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add undocumented ssl.key_passphrase option to kafka docs. (#23826)