### PR TITLE
Cherry-pick to master: fix truncate_fields example (#23796)

### DIFF
--- a/libbeat/processors/actions/docs/truncate_fields.asciidoc
+++ b/libbeat/processors/actions/docs/truncate_fields.asciidoc
@@ -24,9 +24,9 @@ For example, this configuration truncates the field named `message` to 5 charact
 ------------------------------------------------------------------------------
 processors:
   - truncate_fields:
-    fields:
-    - message
-    max_characters: 5
-    fail_on_error: false
-    ignore_missing: true
+      fields:
+        - message
+      max_characters: 5
+      fail_on_error: false
+      ignore_missing: true
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Backports the following commits to master:
 - fixed indentation in the example (#23796)