### PR TITLE
Increase the fleet server client timeout to 10 minutes

### DIFF
--- a/x-pack/elastic-agent/pkg/kibana/config.go
+++ b/x-pack/elastic-agent/pkg/kibana/config.go
@@ -53,8 +53,9 @@ func DefaultClientConfig() *Config {
 		SpaceID:  "",
 		Username: "",
 		Password: "",
-		Timeout:  5 * time.Minute,
-		TLS:      nil,
+		// Default timeout 10 minutes, expecting Fleet Server to control the long poll with default timeout of 5 minutes
+		Timeout: 10 * time.Minute,
+		TLS:     nil,
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

* Fixes a timeout error when the client and Fleet Server both have 5 mins
  timeout and client times out before the server request.
  The Fleet server should drive the request timeout for long poll. The client request timeout should be longer.

Addresses https://github.com/elastic/fleet-server/issues/83

Open to other suggestions.
