### PR TITLE
agent: version sub-command exit non-zero on failure

### DIFF
--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
@@ -80,7 +80,7 @@ func NewCommandWithArgs(streams *cli.IOStreams) *cobra.Command {
 					Daemon: daemon,
 				})
 				if err != nil {
-					return fmt.Errorf("failed to render YAML: %s\n", err)
+					return fmt.Errorf("failed to render YAML: %w", err)
 				}
 				fmt.Fprintf(streams.Out, "%s", out)
 				return returnErr

--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
@@ -22,66 +22,81 @@ type Output struct {
 	Daemon *release.VersionInfo `yaml:"daemon,omitempty"`
 }
 
+// queryDaemon gather version information from a running agent
+func queryDaemon() (*release.VersionInfo, error) {
+	c := client.New()
+	err := c.Connect(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	defer c.Disconnect()
+
+	version, err := c.Version(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return &release.VersionInfo{
+		Version:   version.Version,
+		Commit:    version.Commit,
+		BuildTime: version.BuildTime,
+		Snapshot:  version.Snapshot,
+	}, nil
+}
+
 // NewCommandWithArgs returns a new version command.
 func NewCommandWithArgs(streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Display the version of the elastic-agent.",
-		Run: func(cmd *cobra.Command, _ []string) {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// the error returned from this function
+			var returnErr error
+			// prevent RunE from dumping usage on error
+			defer func() {
+				if returnErr != nil {
+					cmd.SilenceErrors = true
+					cmd.SilenceUsage = true
+				}
+			}()
 			var daemon *release.VersionInfo
-			var daemonError error
 
 			binary := release.Info()
 			binaryOnly, _ := cmd.Flags().GetBool("binary-only")
 			if !binaryOnly {
-				c := client.New()
-				daemonError = c.Connect(context.Background())
-				if daemonError == nil {
-					defer c.Disconnect()
-
-					var version client.Version
-					version, daemonError = c.Version(context.Background())
-					if daemonError == nil {
-						daemon = &release.VersionInfo{
-							Version:   version.Version,
-							Commit:    version.Commit,
-							BuildTime: version.BuildTime,
-							Snapshot:  version.Snapshot,
-						}
+				if d, err := queryDaemon(); err != nil {
+					returnErr = fmt.Errorf("failed to communicate with running daemon: %w", err)
+				} else {
+					daemon = d
+					if isMismatch(&binary, daemon) {
+						fmt.Fprintf(streams.Err, "WARN: the running daemon of Elastic Agent does not match this version.\n")
 					}
 				}
-			}
-			if daemonError != nil {
-				fmt.Fprintf(streams.Err, "Failed talking to running daemon: %s\n", daemonError)
 			}
 
 			outputYaml, _ := cmd.Flags().GetBool("yaml")
 			if outputYaml {
-				p := Output{
+				out, err := yaml.Marshal(Output{
 					Binary: &binary,
 					Daemon: daemon,
-				}
-				out, err := yaml.Marshal(p)
+				})
 				if err != nil {
-					fmt.Fprintf(streams.Err, "Failed to render YAML: %s\n", err)
+					return fmt.Errorf("failed to render YAML: %s\n", err)
 				}
 				fmt.Fprintf(streams.Out, "%s", out)
-				return
+				return returnErr
 			}
 
-			if !binaryOnly {
-				mismatch := false
-				str := "<failed to communicate>"
-				if daemon != nil {
-					str = daemon.String()
-					mismatch = isMismatch(&binary, daemon)
-				}
-				if mismatch {
-					fmt.Fprintf(streams.Err, "WARN: Then running daemon of Elastic Agent does not match this version.\n")
-				}
-				fmt.Fprintf(streams.Out, "Daemon: %s\n", str)
-			}
 			fmt.Fprintf(streams.Out, "Binary: %s\n", binary.String())
+			if binaryOnly {
+				return returnErr
+			}
+
+			str := "<failed to communicate>"
+			if daemon != nil {
+				str = daemon.String()
+			}
+			fmt.Fprintf(streams.Out, "Daemon: %s\n", str)
+			return returnErr
 		},
 	}
 

--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd_test.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd_test.go
@@ -25,7 +25,8 @@ func TestCmdBinaryOnly(t *testing.T) {
 	streams, _, out, _ := cli.NewTestingIOStreams()
 	cmd := NewCommandWithArgs(streams)
 	cmd.Flags().Set("binary-only", "true")
-	cmd.Execute()
+	err := cmd.Execute()
+	require.NoError(t, err)
 	version, err := ioutil.ReadAll(out)
 
 	require.NoError(t, err)
@@ -38,7 +39,8 @@ func TestCmdBinaryOnlyYAML(t *testing.T) {
 	cmd := NewCommandWithArgs(streams)
 	cmd.Flags().Set("binary-only", "true")
 	cmd.Flags().Set("yaml", "true")
-	cmd.Execute()
+	err := cmd.Execute()
+	require.NoError(t, err)
 	version, err := ioutil.ReadAll(out)
 
 	require.NoError(t, err)
@@ -58,7 +60,8 @@ func TestCmdDaemon(t *testing.T) {
 
 	streams, _, out, _ := cli.NewTestingIOStreams()
 	cmd := NewCommandWithArgs(streams)
-	cmd.Execute()
+	err := cmd.Execute()
+	require.NoError(t, err)
 	version, err := ioutil.ReadAll(out)
 
 	require.NoError(t, err)
@@ -74,7 +77,8 @@ func TestCmdDaemonYAML(t *testing.T) {
 	streams, _, out, _ := cli.NewTestingIOStreams()
 	cmd := NewCommandWithArgs(streams)
 	cmd.Flags().Set("yaml", "true")
-	cmd.Execute()
+	err := cmd.Execute()
+	require.NoError(t, err)
 	version, err := ioutil.ReadAll(out)
 
 	require.NoError(t, err)
@@ -84,6 +88,37 @@ func TestCmdDaemonYAML(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, release.Info(), *output.Daemon)
+	assert.Equal(t, release.Info(), *output.Binary)
+}
+
+func TestCmdDaemonErr(t *testing.T) {
+	// srv not started
+	streams, _, out, _ := cli.NewTestingIOStreams()
+	cmd := NewCommandWithArgs(streams)
+	err := cmd.Execute()
+	require.Error(t, err)
+	version, err := ioutil.ReadAll(out)
+	require.NoError(t, err)
+
+	assert.True(t, strings.Contains(string(version), "Binary: "))
+	assert.True(t, strings.Contains(string(version), "Daemon: "))
+}
+
+func TestCmdDaemonErrYAML(t *testing.T) {
+	// srv not started
+	streams, _, out, _ := cli.NewTestingIOStreams()
+	cmd := NewCommandWithArgs(streams)
+	cmd.Flags().Set("yaml", "true")
+	err := cmd.Execute()
+	require.Error(t, err)
+	version, err := ioutil.ReadAll(out)
+
+	require.NoError(t, err)
+	var output Output
+	err = yaml.Unmarshal(version, &output)
+	require.NoError(t, err)
+
+	assert.Nil(t, output.Daemon)
 	assert.Equal(t, release.Info(), *output.Binary)
 }
 


### PR DESCRIPTION
also emit warning on version mismatch when outputting yaml.

The original motivation was to enable `elastic-agent version` as a basic liveness healthcheck.

before: return code 0
stdout:
```
Daemon: <failed to communicate>
Binary: 8.0.0 (build: unknown at 0001-01-01 00:00:00 +0000 UTC)
```

stderr:
```
Failed talking to running daemon: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial unix /tmp/elastic-agent-8af6026882fb59b7747005660917dc1750470fd131b1cd0c603bd5856452979b.sock: connect: no such file or directory"
```

after: return code 1
stdout:
```
Binary: 8.0.0 (build: unknown at 0001-01-01 00:00:00 +0000 UTC)
Daemon: <failed to communicate>
```

stderr:
```
failed to communicate with running daemon: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial unix /tmp/elastic-agent-8af6026882fb59b7747005660917dc1750470fd131b1cd0c603bd5856452979b.sock: connect: no such file or directory"
```