### PR TITLE
Fixed monitoring filebeat and metricbeat not connecting to Agent over GRPC

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -31,6 +31,7 @@
 - Fix refresh of monitoring configuration {pull}23619[23619]
 - Fixed nil pointer during unenroll {pull}23609[23609]
 - Fixed reenroll scenario {pull}23686[23686]
+- Fixed Monitoring filebeat and metricbeat not connecting to Agent over GRPC {pull}23843[23843]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -138,13 +138,9 @@ func (o *Operator) generateMonitoringSteps(version string, output interface{}) [
 			stepID = configrequest.StepRemove
 		}
 		filebeatStep := configrequest.Step{
-			ID:      stepID,
-			Version: version,
-			ProgramSpec: program.Spec{
-				Name:     logsProcessName,
-				Cmd:      logsProcessName,
-				Artifact: fmt.Sprintf("%s/%s", artifactPrefix, logsProcessName),
-			},
+			ID:          stepID,
+			Version:     version,
+			ProgramSpec: loadSpecFromSupported(logsProcessName),
 			Meta: map[string]interface{}{
 				configrequest.MetaConfigKey: fbConfig,
 			},
@@ -160,13 +156,9 @@ func (o *Operator) generateMonitoringSteps(version string, output interface{}) [
 		}
 
 		metricbeatStep := configrequest.Step{
-			ID:      stepID,
-			Version: version,
-			ProgramSpec: program.Spec{
-				Name:     metricsProcessName,
-				Cmd:      metricsProcessName,
-				Artifact: fmt.Sprintf("%s/%s", artifactPrefix, metricsProcessName),
-			},
+			ID:          stepID,
+			Version:     version,
+			ProgramSpec: loadSpecFromSupported(metricsProcessName),
 			Meta: map[string]interface{}{
 				configrequest.MetaConfigKey: mbConfig,
 			},
@@ -176,6 +168,18 @@ func (o *Operator) generateMonitoringSteps(version string, output interface{}) [
 	}
 
 	return steps
+}
+
+func loadSpecFromSupported(processName string) program.Spec {
+	if loadedSpec, found := program.SupportedMap[strings.ToLower(processName)]; found {
+		return loadedSpec
+	}
+
+	return program.Spec{
+		Name:     processName,
+		Cmd:      processName,
+		Artifact: fmt.Sprintf("%s/%s", artifactPrefix, processName),
+	}
 }
 
 func (o *Operator) getMonitoringFilebeatConfig(output interface{}) (map[string]interface{}, bool) {


### PR DESCRIPTION
## What does this PR do?

In PR #23736 there was a populate method remove which in case spec is not complete reloaded it from the spec file. 

Spec was indeed in some cases incomplete it depends where the request came from. If it was normal one from emitter it was complete and beat was stable.

If it was from monitoring injector it was just a naked spec with only cmdName to run, this one was populated, in a removed populate func.
Having naked spec means no args are passed into the beat and beat does not know it is agent-managed, so it wont event try to connect back. It just runs with the default configuration until agent restarts it.

This change goes from generating naked spec file to loading it from spec definition at the time of injecting monitoring. which means only complete specs comes to the place where populate func was before and correct Args are passed to process.  

## Why is it important?

Fixes #23833

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
