### PR TITLE
Cherry-pick #23830 to 7.11: Try to improve test_syslog_udp

### DIFF
--- a/filebeat/tests/system/test_syslog.py
+++ b/filebeat/tests/system/test_syslog.py
@@ -117,21 +117,17 @@ class Test(BaseTest):
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)  # TCP
 
-        for n in range(0, 2):
+        for n in range(0, 50):
             m = "<13>Oct 11 22:14:15 wopr.mymachine.co postfix/smtpd[2000]:" \
                 " 'su root' failed for lonvick on /dev/pts/8 {}\n"
             m = m.format(n)
             sock.sendto(m.encode("utf-8"), (host, port))
 
-        self.wait_until(lambda: self.output_count(lambda x: x >= 2))
-
+        self.wait_until(lambda: self.output_count(lambda x: x >= 1))
         filebeat.check_kill_and_wait()
-
         sock.close()
 
         output = self.read_output()
-
-        assert len(output) == 2
         self.assert_syslog(output[0])
 
     # AF_UNIX support in python isn't available until


### PR DESCRIPTION
Cherry-pick of PR #23830 to 7.11 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Flaky Test

## What does this PR do?

On windows the test can be quite flaky due to message actually being
dropped if the Beat was not ready yet, or does not read fast enough.

In order to "improve" the test we will attempt to send 50 syslog
messages, but require at minimum 1 message to be published by Filebeat.

## Why is it important?

Try to stabilize flaky test without skipping.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.``

