### PR TITLE
[docs] Remove release state overrides

### DIFF
--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -18,4 +18,3 @@
 :beat_version_key: agent.version
 :access_role: {beat_default_index_prefix}_reader
 :repo: Beats
-:release-state: released


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/369

## What does this PR do?

Removes release-state override so that download commands do not appear in pre-release docs. 

## Why is it important?

The download commands do not work on pre-release versions. 

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
