### PR TITLE
Cherry-pick to 7.x: Update system.asciidoc (#23322)

### DIFF
--- a/metricbeat/docs/modules/system.asciidoc
+++ b/metricbeat/docs/modules/system.asciidoc
@@ -8,10 +8,11 @@ This file is generated! See scripts/mage/docs_collector.go
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
-`process_summary`. To disable a default metricset, comment it out in the
-`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
-and the System module is enabled, {beatname_uc} uses the default metricsets.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`,
+`process_summary`, `socket_summary`, `filesystem`, `fsstat`, and `uptime`. 
+To disable a default metricset, comment it out in the `modules.d/system.yml` 
+configuration file. If _all_ metricsets are commented out and the System module 
+is enabled, {beatname_uc} uses the default metricsets.
 
 Note that certain metricsets may access `/proc` to gather process information,
 and the resulting `ptrace_may_access()` call by the kernel to check for

--- a/metricbeat/module/system/_meta/docs.asciidoc
+++ b/metricbeat/module/system/_meta/docs.asciidoc
@@ -1,10 +1,11 @@
 The System module allows you to monitor your servers. Because the System module
 always applies to the local server, the `hosts` config option is not needed.
 
-The default metricsets are `cpu`, `load`, `memory`, `network`, `process`, and
-`process_summary`. To disable a default metricset, comment it out in the
-`modules.d/system.yml` configuration file. If _all_ metricsets are commented out
-and the System module is enabled, {beatname_uc} uses the default metricsets.
+The default metricsets are `cpu`, `load`, `memory`, `network`, `process`,
+`process_summary`, `socket_summary`, `filesystem`, `fsstat`, and `uptime`. 
+To disable a default metricset, comment it out in the `modules.d/system.yml` 
+configuration file. If _all_ metricsets are commented out and the System module 
+is enabled, {beatname_uc} uses the default metricsets.
 
 Note that certain metricsets may access `/proc` to gather process information,
 and the resulting `ptrace_may_access()` call by the kernel to check for


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update system.asciidoc (#23322)