### PR TITLE
Cherry-pick #23747 to 7.x: Enable windows-7 32-bit jobs for Metricbeat

### DIFF
--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -75,7 +75,7 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
-#    windows-7-32:
-#        mage: "mage build unitTest"
-#        platforms:             ## override default labels in this specific stage.
-#            - "windows-7-32-bit"
+    windows-7-32:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-7-32-bit"

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -9,9 +9,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 	metricbeat "github.com/elastic/beats/v7/metricbeat/scripts/mage"
@@ -21,8 +25,6 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
 	// mage:import
-	"github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
-	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 	// mage:import
 	_ "github.com/elastic/beats/v7/metricbeat/scripts/mage/target/metricset"
@@ -30,7 +32,6 @@ import (
 
 func init() {
 	common.RegisterCheckDeps(Update)
-	unittest.RegisterPythonTestDeps(Fields)
 	test.RegisterDeps(IntegTest)
 
 	devtools.BeatDescription = "Metricbeat is a lightweight shipper for metrics."
@@ -39,13 +40,23 @@ func init() {
 
 // Build builds the Beat binary.
 func Build() error {
-	return devtools.Build(devtools.DefaultBuildArgs())
+	args := devtools.DefaultBuildArgs()
+	// On Windows 7 32-bit we run out of memory if we enable DWARF
+	if isWindows32bitRunner() {
+		args.LDFlags = append(args.LDFlags, "-w")
+	}
+	return devtools.Build(args)
 }
 
 // GolangCrossBuild build the Beat binary inside of the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
-	return devtools.GolangCrossBuild(devtools.DefaultGolangCrossBuildArgs())
+	args := devtools.DefaultGolangCrossBuildArgs()
+	// On Windows 7 32-bit we run out of memory if we enable DWARF
+	if isWindows32bitRunner() {
+		args.LDFlags = append(args.LDFlags, "-w")
+	}
+	return devtools.GolangCrossBuild(args)
 }
 
 // CrossBuild cross-builds the beat for all target platforms.
@@ -61,6 +72,64 @@ func BuildGoDaemon() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// UnitTest executes the unit tests (Go and Python).
+func UnitTest() {
+	mg.SerialDeps(GoUnitTest, PythonUnitTest)
+}
+
+// GoUnitTest executes the Go unit tests.
+// Use TEST_COVERAGE=true to enable code coverage profiling.
+// Use RACE_DETECTOR=true to enable the race detector.
+func GoUnitTest(ctx context.Context) error {
+	args := devtools.DefaultGoTestUnitArgs()
+	// On Windows 7 32-bit we run out of memory if we enable DWARF
+	if isWindows32bitRunner() {
+		args.ExtraFlags = append(args.ExtraFlags, "-ldflags=-w")
+	}
+	return devtools.GoTest(ctx, args)
+}
+
+// PythonUnitTest executes the python system tests.
+func PythonUnitTest() error {
+	mg.SerialDeps(Fields)
+	mg.Deps(BuildSystemTestBinary)
+
+	args := devtools.DefaultPythonTestUnitArgs()
+	// On Windows 32-bit converage is not enabled.
+	if isWindows32bitRunner() {
+		args.Env["TEST_COVERAGE"] = "false"
+	}
+	return devtools.PythonTest(args)
+}
+
+// BuildSystemTestBinary build a system test binary depending on the runner.
+func BuildSystemTestBinary() error {
+	binArgs := devtools.DefaultTestBinaryArgs()
+	args := []string{
+		"test", "-c",
+		"-o", binArgs.Name + ".test",
+	}
+
+	// On Windows 7 32-bit we run out of memory if we enable coverage and DWARF
+	isWin32Runner := isWindows32bitRunner()
+	if isWin32Runner {
+		args = append(args, "-ldflags=-w")
+	}
+	if devtools.TestCoverage && !isWin32Runner {
+		args = append(args, "-coverpkg", "./...")
+	}
+
+	if len(binArgs.InputFiles) > 0 {
+		args = append(args, binArgs.InputFiles...)
+	}
+
+	start := time.Now()
+	defer func() {
+		log.Printf("BuildSystemTestGoBinary (go %v) took %v.", strings.Join(args, " "), time.Since(start))
+	}()
+	return sh.RunV("go", args...)
 }
 
 // Package packages the Beat for distribution.
@@ -132,7 +201,7 @@ func IntegTest() {
 }
 
 // GoIntegTest executes the Go integration tests.
-// Use TEST_COVERAGE=true to enable code coverage profiling.
+// Use TEST_COVERAGE=true to enable code coverage profiling if not running on Windows 7 32bit.
 // Use RACE_DETECTOR=true to enable the race detector.
 // Use TEST_TAGS=tag1,tag2 to add additional build tags.
 // Use MODULE=module to run only tests for `module`.
@@ -157,7 +226,16 @@ func PythonIntegTest(ctx context.Context) error {
 		return err
 	}
 	return runner.Test("pythonIntegTest", func() error {
-		mg.Deps(devtools.BuildSystemTestBinary)
-		return devtools.PythonTest(devtools.DefaultPythonTestIntegrationArgs())
+		mg.Deps(BuildSystemTestBinary)
+		args := devtools.DefaultPythonTestIntegrationArgs()
+		// On Windows 32-bit converage is not enabled.
+		if isWindows32bitRunner() {
+			args.Env["TEST_COVERAGE"] = "false"
+		}
+		return devtools.PythonTest(args)
 	})
+}
+
+func isWindows32bitRunner() bool {
+	return runtime.GOOS == "windows" && runtime.GOARCH == "386"
 }


### PR DESCRIPTION
Cherry-pick of PR #23747 to 7.x branch. Original message: 

## What does this PR do?

This PR enabled the job `x-pack/metricbeat-windows-7-32-windows-7-32-bit` which had to be turned off temporarily when introducing Golang 1.15.

When x-pack/metricbeat jobs run on a 32-bit Windows, coverage and DWARF are disabled, so do not run out of memory.

## Why is it important?

Tests for x-pack/metricbeat on Windows 7 32bit version were disabled. Now they are available again.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~