### PR TITLE
Check fields are documented for aws metricsets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -500,6 +500,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add stack monitoring section to elasticsearch module documentation {pull}#23286[23286]
 - Fix metric grouping for windows/perfmon module {issue}23489[23489] {pull}23505[23505]
 - Add check for iis/application_pool metricset for nil worker process id values. {issue}23605[23605] {pull}23647[23647]
+- Unskip s3_request integration test. {pull}23887[23887]
 
 *Packetbeat*
 
@@ -967,6 +968,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Apache: convert status.total_kbytes to status.total_bytes in fleet mode. {pull}23022[23022]
 - Release MSSQL as GA {pull}23146[23146]
 - Enrich events of `state_service` metricset with kubernetes services' metadata. {pull}23730[23730]
+- Check fields are documented in aws metricsets. {pull}23887[23887]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
@@ -27,6 +27,7 @@ func TestFetch(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, events)
+	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
 }
 
 func TestData(t *testing.T) {

--- a/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
+++ b/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
@@ -26,24 +26,7 @@ func TestFetch(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, events)
-
-	for _, event := range events {
-		t.Logf("%s/%s event: %+v", metricSet.Module().Name(), metricSet.Name(), event)
-
-		// RootField
-		mtest.CheckEventField("service.name", "string", event, t)
-		mtest.CheckEventField("cloud.provider", "string", event, t)
-		mtest.CheckEventField("cloud.provider", "string", event, t)
-		mtest.CheckEventField("cloud.region", "string", event, t)
-		mtest.CheckEventField("cloud.availability_zone", "string", event, t)
-
-		// MetricSetField
-		mtest.CheckEventField("db_instance.arn", "string", event, t)
-		mtest.CheckEventField("db_instance.class", "string", event, t)
-		mtest.CheckEventField("queries", "float", event, t)
-		mtest.CheckEventField("latency.select", "float", event, t)
-		mtest.CheckEventField("login_failures", "float", event, t)
-	}
+	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
 }
 
 func TestData(t *testing.T) {

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
@@ -27,14 +27,7 @@ func TestFetch(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, events)
-
-	for _, event := range events {
-		mtest.CheckEventField("cloud.region", "string", event, t)
-		mtest.CheckEventField("aws.dimensions.BucketName", "string", event, t)
-		mtest.CheckEventField("aws.dimensions.StorageType", "string", event, t)
-		mtest.CheckEventField("aws.s3.metrics.BucketSizeBytes.avg", "float", event, t)
-		mtest.CheckEventField("aws.s3.metrics.NumberOfObjects.avg", "float", event, t)
-	}
+	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
 }
 
 func TestData(t *testing.T) {

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/21826")
 	config := mtest.GetConfigForTest(t, "s3_request", "60s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
@@ -28,28 +27,7 @@ func TestFetch(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, events)
-
-	for _, event := range events {
-		mtest.CheckEventField("cloud.region", "string", event, t)
-		mtest.CheckEventField("aws.dimensions.BucketName", "string", event, t)
-		mtest.CheckEventField("aws.dimensions.StorageType", "string", event, t)
-		mtest.CheckEventField("s3.metrics.AllRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.GetRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.PutRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.DeleteRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.HeadRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.PostRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.SelectRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.SelectScannedBytes.avg", "float", event, t)
-		mtest.CheckEventField("s3.metrics.SelectReturnedBytes.avg", "float", event, t)
-		mtest.CheckEventField("s3.metrics.ListRequests.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.BytesDownloaded.avg", "float", event, t)
-		mtest.CheckEventField("s3.metrics.BytesUploaded.avg", "float", event, t)
-		mtest.CheckEventField("s3.metrics.4xxErrors.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.5xxErrors.avg", "int", event, t)
-		mtest.CheckEventField("s3.metrics.FirstByteLatency.avg", "float", event, t)
-		mtest.CheckEventField("s3.metrics.TotalRequestLatency.avg", "float", event, t)
-	}
+	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
 }
 
 func TestData(t *testing.T) {

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -27,23 +27,7 @@ func TestFetch(t *testing.T) {
 	}
 
 	assert.NotEmpty(t, events)
-
-	for _, event := range events {
-		// RootField
-		mtest.CheckEventField("service.name", "string", event, t)
-		mtest.CheckEventField("cloud.region", "string", event, t)
-		// MetricSetField
-		mtest.CheckEventField("empty_receives", "float", event, t)
-		mtest.CheckEventField("messages.delayed", "float", event, t)
-		mtest.CheckEventField("messages.deleted", "float", event, t)
-		mtest.CheckEventField("messages.not_visible", "float", event, t)
-		mtest.CheckEventField("messages.received", "float", event, t)
-		mtest.CheckEventField("messages.sent", "float", event, t)
-		mtest.CheckEventField("messages.visible", "float", event, t)
-		mtest.CheckEventField("oldest_message_age.sec", "float", event, t)
-		mtest.CheckEventField("sent_message_size", "float", event, t)
-		mtest.CheckEventField("queue.name", "string", event, t)
-	}
+	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
 }
 
 func TestData(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to unskip flaky test in `s3_request` metricset and add check on fields to see if they are documented: https://github.com/elastic/beats/issues/21826

This PR also add `TestMetricsetFieldsDocumented` for fields from `rds`, `s3_daily_storage`, `s3_request`, `sqs` and `cloudwatch` metricsets: https://github.com/elastic/beats/pull/23887

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.