### PR TITLE
Cherry-pick #23631 to 7.x: Move aws-s3 input to GA

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -522,6 +522,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added RFC6587 framing option for tcp and unix inputs {issue}23663[23663] {pull}23724[23724]
 - Added `application/x-ndjson` as decode option for httpjson input {pull}23521[23521]
 - Added `application/x-www-form-urlencoded` as encode option for httpjson input {pull}23521[23521]
+- Move aws-s3 input to GA. {pull}23631[23631]
+- Populate `source.mac` and `destination.mac` for Suricata EVE events. {issue}23706[23706] {pull}23721[23721]
+- Added RFC6587 framing option for tcp and unix inputs {issue}23663[23663] {pull}23724[23724]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -523,8 +523,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added `application/x-ndjson` as decode option for httpjson input {pull}23521[23521]
 - Added `application/x-www-form-urlencoded` as encode option for httpjson input {pull}23521[23521]
 - Move aws-s3 input to GA. {pull}23631[23631]
-- Populate `source.mac` and `destination.mac` for Suricata EVE events. {issue}23706[23706] {pull}23721[23721]
-- Added RFC6587 framing option for tcp and unix inputs {issue}23663[23663] {pull}23724[23724]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/awss3/_meta/fields.yml
+++ b/x-pack/filebeat/input/awss3/_meta/fields.yml
@@ -2,7 +2,7 @@
   title: "s3"
   description: >
     S3 fields from s3 input.
-  release: beta
+  release: ga
   fields:
     - name: bucket_name
       type: keyword

--- a/x-pack/filebeat/input/awss3/fields.go
+++ b/x-pack/filebeat/input/awss3/fields.go
@@ -19,5 +19,5 @@ func init() {
 // AssetAwss3 returns asset data.
 // This is the base64 encoded gzipped contents of input/awss3.
 func AssetAwss3() string {
-	return "eJykjjGugzAQRHufYkQPjTsX/wi/+QdABg8fB4ORvSTi9pGBJlKkFNlipZ3dnTc1Ju4GWStAvAQaVFlXCnDMffKr+LgY/CgA+NMYPIPLGFKckTX8sm7SKCAx0GYadBSrcN2Z463GYuey2vqJ0pbh0AHZV5qS4BGTu7Q33FK/dibiABlZcpxekNGW5jNC/EeiJM873ZGveYHH7sZe2on71+zT6gP7GQAA//+k2GkG"
+	return "eJykjrFuhDAQRHt/xYgeGncu8glp8gHI4AEcDEb2koi/PxloTjrpittipR3tzJsaMw+DrBUgXgINqqwrBTjmPvlNfFwNvhQA/GgMnsFlDCkuyBp+3XZpFJAYaDMNRqtwf5nTVGO1Cw26vZ8pbTlOHZBjoyn8/5jcrb2glvm2CxEHyMTS4sqCTLYsnxHiiERJnn90Z7vmCR67X/bSzjw+Zl9Rb9iPAAAA//+ahmgy"
 }

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -25,7 +25,7 @@ const inputName = "aws-s3"
 func Plugin() v2.Plugin {
 	return v2.Plugin{
 		Name:       inputName,
-		Stability:  feature.Beta,
+		Stability:  feature.Stable,
 		Deprecated: false,
 		Info:       "Collect logs from s3",
 		Manager:    v2.ConfigureWith(configure),


### PR DESCRIPTION
Cherry-pick of PR #23631 to 7.x branch. Original message: 

This PR is to move `aws-s3` input in Filebeat from beta to GA.

closes https://github.com/elastic/integrations/issues/489