### PR TITLE
Cherry-pick #23862 to 7.11: Improve cloudwatch and awsfargate documentation

### DIFF
--- a/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
@@ -100,6 +100,38 @@ several hours. By querying from AWS/Billing namespace every 300 seconds,
 additional costs will occur.
 
 [float]
+==== Example 3
+Depends on the configuration and number of services in the AWS account, the number
+of API calls may get too big to cause high API cost. In order to reduce the number
+of API calls, we recommend users to use this configuration below as an example.
+
+* *metrics.name*: Only collect a sub list of metrics that are useful to your use case.
+* *metrics.statistic*: By default, cloudwatch metricset will make API calls to
+get all stats like average, max, min, sum and etc. If the user knows which
+statistics method is most useful, specify it in the configuration.
+* *metrics.dimensions*: Different AWS services report different dimensions in their
+CloudWatch metrics. For example, https://docs.aws.amazon.com/emr/latest/ManagementGuide/UsingEMR_ViewingMetrics.html[EMR metrics]
+can have either `JobFlowId` dimension or `JobId` dimension. If user knows which
+specific dimension is useful, it can be specified in this configuration option.
+
+[source,yaml]
+----
+- module: aws
+  period: 5m
+  metricsets:
+    - cloudwatch
+  regions: us-east-1
+  metrics:
+    - namespace: AWS/ElasticMapReduce
+      name: ["S3BytesWritten", "S3BytesRead", "HDFSUtilization", "TotalLoad"]
+      resource_type: elasticmapreduce
+      statistic: ["Average"]
+      dimensions:
+        - name: JobId
+          value: "*"
+----
+
+[float]
 === More examples
 With the configuration below, users will be able to collect cloudwatch metrics
 from EBS, ELB and EC2 without tag information.

--- a/x-pack/metricbeat/module/awsfargate/cloudformation.yml
+++ b/x-pack/metricbeat/module/awsfargate/cloudformation.yml
@@ -61,7 +61,7 @@ Resources:
       ExecutionRoleArn: !Ref ExecutionRole
       ContainerDefinitions:
         - Name: metricbeat-container
-          Image: docker.elastic.co/beats/metricbeat:7.11.0-SNAPSHOT
+          Image: docker.elastic.co/beats/metricbeat:8.0.0-SNAPSHOT
           Secrets:
             - Name: ELASTIC_CLOUD_ID
               ValueFrom: !Ref CloudIDArn

--- a/x-pack/metricbeat/module/awsfargate/task_stats/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/awsfargate/task_stats/_meta/docs.asciidoc
@@ -110,7 +110,7 @@ Resources:
       ExecutionRoleArn: !Ref ExecutionRole
       ContainerDefinitions:
         - Name: metricbeat-container
-          Image: docker.elastic.co/beats/metricbeat:7.11.0-SNAPSHOT
+          Image: docker.elastic.co/beats/metricbeat:8.0.0-SNAPSHOT
           Secrets:
             - Name: ELASTIC_CLOUD_ID
               ValueFrom: !Ref CloudIDArn
@@ -158,7 +158,9 @@ Resources:
 
 [float]
 ==== Create CloudFormation Stack
-Once the CloudFormation template is saved locally into `clouformation.yml`, AWS
+When copying the CloudFormation template, please make sure the Metricbeat
+container image is the correct version.
+Once the template is saved locally into `clouformation.yml`, AWS
 CLI can be used to create a stack using one command:
 ----
 aws --region us-east-1 cloudformation create-stack --stack-name <your-stack-name> --template-body file://./cloudformation.yml --capabilities CAPABILITY_NAMED_IAM --parameters ParameterKey=SubnetID,ParameterValue=<subnet-id> ParameterKey=CloudAuthArn,ParameterValue=<cloud-auth-arn> ParameterKey=CloudIDArn,ParameterValue=<cloud-id-arn> ParameterKey=ClusterName,ParameterValue=<cluster-name> ParameterKey=RoleName,ParameterValue=<role-name> ParameterKey=TaskName,ParameterValue=<task-name> ParameterKey=ServiceName,ParameterValue=<service-name> ParameterKey=LogGroupName,ParameterValue=<log-group-name>


### PR DESCRIPTION
Cherry-pick of PR #23862 to 7.11 branch. Original message: 

This PR is to improve `cloudwatch` metricset and `awsfargate` module documentation. 