### PR TITLE
Cherry-pick to 7.x: Remove release state override (#23866)

### DIFF
--- a/libbeat/docs/shared-beats-attributes.asciidoc
+++ b/libbeat/docs/shared-beats-attributes.asciidoc
@@ -18,4 +18,3 @@
 :beat_version_key: agent.version
 :access_role: {beat_default_index_prefix}_reader
 :repo: Beats
-:release-state: released


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove release state override (#23866)