### PR TITLE
Cherry-pick #23592 to 7.x: Add support for ARM64 Docker images for all Beats

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -92,6 +92,7 @@ func GolangCrossBuild(params BuildArgs) error {
 	}
 
 	defer DockerChown(filepath.Join(params.OutputDir, params.Name+binaryExtension(GOOS)))
+	defer DockerChown(filepath.Join(params.OutputDir))
 	return Build(params)
 }
 

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -45,13 +45,23 @@ func Package() error {
 	var tasks []interface{}
 	for _, target := range Platforms {
 		for _, pkg := range Packages {
-			if pkg.OS != target.GOOS() {
+			if pkg.OS != target.GOOS() || pkg.Arch != "" && pkg.Arch != target.Arch() {
 				continue
 			}
 
 			for _, pkgType := range pkg.Types {
+				if !isPackageTypeSelected(pkgType) {
+					log.Printf("Skipping %s package type because it is not selected", pkgType)
+					continue
+				}
+
 				if pkgType == DMG && runtime.GOOS != "darwin" {
 					log.Printf("Skipping DMG package type because build host isn't darwin")
+					continue
+				}
+
+				if target.Name == "linux/arm64" && pkgType == Docker && runtime.GOARCH != "arm64" {
+					log.Printf("Skipping Docker package type because build host isn't arm")
 					continue
 				}
 
@@ -104,6 +114,19 @@ func Package() error {
 
 	Parallel(tasks...)
 	return nil
+}
+
+func isPackageTypeSelected(pkgType PackageType) bool {
+	if SelectedPackageTypes != nil {
+		selected := false
+		for _, t := range SelectedPackageTypes {
+			if t == pkgType {
+				selected = true
+			}
+		}
+		return selected
+	}
+	return true
 }
 
 type packageBuilder struct {

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -68,6 +68,7 @@ const (
 // system using the contained PackageSpec.
 type OSPackageArgs struct {
 	OS    string        `yaml:"os"`
+	Arch  string        `yaml:"arch,omitempty"`
 	Types []PackageType `yaml:"types"`
 	Spec  PackageSpec   `yaml:"spec"`
 }
@@ -172,6 +173,7 @@ var OSArchNames = map[string]map[PackageType]map[string]string{
 		},
 		Docker: map[string]string{
 			"amd64": "amd64",
+			"arm64": "arm64",
 		},
 	},
 }

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -305,6 +305,12 @@ shared:
           {{ commit }}
         mode: 0644
 
+  - &agent_docker_arm_spec
+    <<: *agent_docker_spec
+    extra_vars:
+      from: 'arm64v8/centos:7'
+      buildFrom: 'arm64v8/centos:7'
+
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec
     <<: *common
@@ -459,10 +465,21 @@ shared:
         mode: 0600
         config: true
 
+  - &docker_arm_spec
+    <<: *docker_spec
+    extra_vars:
+      from: 'arm64v8/centos:7'
+      buildFrom: 'arm64v8/centos:7'
+
   - &docker_ubi_spec
     extra_vars:
       image_name: '{{.BeatName}}-ubi8'
       from: 'docker.elastic.co/ubi8/ubi-minimal'
+
+  - &docker_arm_ubi_spec
+    extra_vars:
+      image_name: '{{.BeatName}}-ubi8'
+      from: 'registry.access.redhat.com/ubi8/ubi-minimal:8.2'
 
   - &elastic_docker_spec
     extra_vars:
@@ -627,17 +644,20 @@ specs:
         <<: *elastic_license_for_deb_rpm
 
     - os: linux
-      types: [docker]
-      spec:
-        <<: *docker_spec
-        <<: *elastic_docker_spec
-        <<: *elastic_license_for_binaries
-
-    - os: linux
+      arch: amd64
       types: [docker]
       spec:
         <<: *docker_spec
         <<: *docker_ubi_spec
+        <<: *elastic_docker_spec
+        <<: *elastic_license_for_binaries
+
+    - os: linux
+      arch: arm64
+      types: [docker]
+      spec:
+        <<: *docker_arm_spec
+        <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
 
@@ -716,9 +736,11 @@ specs:
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
+      arch: amd64
       types: [docker]
       spec:
         <<: *docker_spec
+        <<: *docker_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
@@ -726,10 +748,11 @@ specs:
             source: ./{{.XPackDir}}/{{.BeatName}}/build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
+      arch: arm64
       types: [docker]
       spec:
-        <<: *docker_spec
-        <<: *docker_ubi_spec
+        <<: *docker_arm_spec
+        <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
@@ -795,9 +818,11 @@ specs:
             mode: 0755
 
     - os: linux
+      arch: amd64
       types: [docker]
       spec:
         <<: *agent_docker_spec
+        <<: *docker_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:
@@ -805,10 +830,11 @@ specs:
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: linux
+      arch: arm64
       types: [docker]
       spec:
-        <<: *agent_docker_spec
-        <<: *docker_ubi_spec
+        <<: *agent_docker_arm_spec
+        <<: *docker_arm_ubi_spec
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         files:

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -28,9 +28,7 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
 FROM {{ .from }}
 
 {{- if contains .from "ubi-minimal" }}
-RUN for iter in {1..10}; do microdnf update -y && microdnf install -y shadow-utils &&  microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
-RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/local/bin/jq && \
-    chmod +x /usr/local/bin/jq
+RUN for iter in {1..10}; do microdnf update -y && microdnf install -y shadow-utils jq &&  microdnf clean all && exit_code=0 && break || exit_code=$? && echo "microdnf error: retry $iter in 10s" && sleep 10; done; (exit $exit_code)
 {{- else }}
 # Installing jq needs to be installed after epel-release and cannot be in the same yum install command.
 RUN yum -y --setopt=tsflags=nodocs update && \
@@ -71,9 +69,22 @@ ENV GODEBUG="madvdontneed=1"
 
 # Add an init process, check the checksum to make sure it's a match
 RUN set -e ; \
-  TINI_VERSION='v0.19.0' ; \
-  TINI_BIN='tini-amd64' ; \
-  TINI_SHA256='93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c' ; \
+  TINI_BIN=""; \
+  TINI_SHA256=""; \
+  TINI_VERSION="v0.19.0"; \
+  case "$(arch)" in \
+    x86_64) \
+        TINI_BIN="tini-amd64"; \
+        TINI_SHA256="93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c"; \
+        ;; \
+    aarch64) \
+        TINI_BIN="tini-arm64"; \
+        TINI_SHA256="07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81"; \
+        ;; \
+    *) \
+        echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+        ;; \
+  esac ; \
   curl --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}" ; \
   echo "${TINI_SHA256} ${TINI_BIN}" | sha256sum -c - ; \
   mv "${TINI_BIN}" /usr/bin/tini ; \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -31,10 +31,10 @@ RUN microdnf -y --setopt=tsflags=nodocs update && \
 RUN yum -y --setopt=tsflags=nodocs update \
   {{- if (eq .BeatName "heartbeat") }}
     && yum -y install epel-release \
-    && yum -y install atk cups gtk gdk xrandr pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 \
-	  libXext.x86_64 libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 \
-	  alsa-lib.x86_64 atk.x86_64 gtk3.x86_64 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
-	  xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
+    && yum -y install atk cups gtk gdk xrandr pango libXcomposite libXcursor libXdamage \
+        libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 \
+        alsa-lib atk gtk3 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
+        xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
   {{- end }}
   && yum clean all && rm -rf /var/cache/yum
   # See https://access.redhat.com/discussions/3195102 for why rm is needed
@@ -83,9 +83,22 @@ ENV GODEBUG="madvdontneed=1"
 
 # Add an init process, check the checksum to make sure it's a match
 RUN set -e ; \
-  TINI_VERSION='v0.19.0' ; \
-  TINI_BIN='tini-amd64' ; \
-  TINI_SHA256='93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c' ; \
+  TINI_BIN=""; \
+  TINI_SHA256=""; \
+  TINI_VERSION="v0.19.0"; \
+  case "$(arch)" in \
+    x86_64) \
+        TINI_BIN="tini-amd64"; \
+        TINI_SHA256="93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c"; \
+        ;; \
+    aarch64) \
+        TINI_BIN="tini-arm64"; \
+        TINI_SHA256="07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81"; \
+        ;; \
+    *) \
+        echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+        ;; \
+  esac ; \
   curl --retry 8 -S -L -O "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_BIN}" ; \
   echo "${TINI_SHA256} ${TINI_BIN}" | sha256sum -c - ; \
   mv "${TINI_BIN}" /usr/bin/tini ; \
@@ -119,8 +132,20 @@ ENV PATH="$NODE_PATH/node/bin:$PATH"
 # cached node_modules, heartbeat then calls the global executable to run test suites
 # Setup node
 RUN cd /usr/share/heartbeat/.node \
+  && NODE_DOWNLOAD_URL="" \
+  && case "$(arch)" in \
+       x86_64) \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
+           ;; \
+       aarch64) \
+           NODE_DOWNLOAD_URL=https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-arm64.tar.xz \
+           ;; \
+       *) \
+           echo >&2 ; echo >&2 "Unsupported architecture \$(arch)" ; echo >&2 ; exit 1 ; \
+           ;; \
+     esac \
   && mkdir -p node \
-  && curl https://nodejs.org/dist/v12.18.4/node-v12.18.4-linux-x64.tar.xz | tar -xJ --strip 1 -C node \
+  && curl ${NODE_DOWNLOAD_URL} | tar -xJ --strip 1 -C node \
   && chmod ug+rwX -R $NODE_PATH \
   && npm i -g -f @elastic/synthetics && chmod ug+rwX -R $NODE_PATH
 {{- end }}

--- a/journalbeat/magefile.go
+++ b/journalbeat/magefile.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"time"
 
@@ -138,6 +139,9 @@ func selectImage(platform string) (string, error) {
 	switch {
 	case strings.HasPrefix(platform, "linux/arm"):
 		tagSuffix = "arm"
+		if runtime.GOARCH == "arm64" {
+			tagSuffix = "base-arm-debian9"
+		}
 	case strings.HasPrefix(platform, "linux/mips"):
 		tagSuffix = "mips"
 	case strings.HasPrefix(platform, "linux/ppc"):

--- a/script/fix_permissions.sh
+++ b/script/fix_permissions.sh
@@ -5,7 +5,14 @@ readonly LOCATION="${1?Please define the path where the fix permissions should r
 if ! docker version ; then
   echo "It requires Docker daemon to be installed and running"
 else
+  ## Detect architecture to support ARM specific docker images.
+  ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+  if [ "${ARCH}" == "aarch64" ] ; then
+    DOCKER_IMAGE=arm64v8/alpine:3
+  else
+    DOCKER_IMAGE=alpine:3.4
+  fi
   set -e
   # Change ownership of all files inside the specific folder from root/root to current user/group
-  docker run -v ${LOCATION}:/beat alpine:3.4 sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
+  docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
 fi

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -578,6 +578,9 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
 				cmd.Env = append(os.Environ(), fmt.Sprintf("PWD=%s", pwd), "AGENT_PACKAGING=on")
+				if envVar := selectedPackageTypes(); envVar != "" {
+					cmd.Env = append(cmd.Env, envVar)
+				}
 
 				if err := cmd.Run(); err != nil {
 					panic(err)
@@ -598,6 +601,22 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 	mg.Deps(Update)
 	mg.Deps(CrossBuild, CrossBuildGoDaemon)
 	mg.SerialDeps(devtools.Package, TestPackages)
+}
+
+func selectedPackageTypes() string {
+	if len(devtools.SelectedPackageTypes) == 0 {
+		return ""
+	}
+
+	envVar := "PACKAGES="
+	for _, p := range devtools.SelectedPackageTypes {
+		if p == devtools.Docker {
+			envVar += "targz,"
+		} else {
+			envVar += p.String() + ","
+		}
+	}
+	return envVar[:len(envVar)-1]
 }
 
 func copyAll(from, to string) error {


### PR DESCRIPTION
Cherry-pick of PR #23592 to 7.x branch. Original message: 

This PR adds support for building ARM64 Docker images for all Beats on ARM64 machines.

To limit what packages should be built I have added the new environment variable named `PACKAGES`. It expects a comma-separated list of packages types. Available options: rpm, deb, tgz, dmg, docker, zip. If nothing is specified all available package types are built for the given platform.

This PR relies on the newly added crossbuild image with the suffix `base-arm-debian9`. This image is automatically selected if the runtime of the builder machine is ARM64.

A possible enhancement to this solution is described in #23775.

