### PR TITLE
Cherry-pick #23926 to 7.x: Use install-ci.sh during release-manager-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,8 @@ release-manager-snapshot:
 ## release-manager-release : Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 .PHONY: release-manager-release
 release-manager-release:
-	./dev-tools/run_with_go_ver $(MAKE) release
+	./.ci/scripts/install-go.sh
+	$(MAKE) release
 
 ## beats-dashboards : Collects dashboards from all Beats and generates a zip file distribution.
 .PHONY: beats-dashboards


### PR DESCRIPTION
Cherry-pick of PR #23926 to 7.x branch. Original message: 

## What does this PR do?

This PR uses the `install-go.sh` to install Golang for releasing Beats on the release manager.

## Why is it important?

We cannot install Golang with the previous method.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
