### PR TITLE
Cherry-pick to 7.11: docs: add missing bracket in test function (#23917)

### DIFF
--- a/libbeat/processors/script/docs/script.asciidoc
+++ b/libbeat/processors/script/docs/script.asciidoc
@@ -73,7 +73,7 @@ function process(event) {
 }
 
 function test() {
-    var event = process(new Event({event: {code: 1102}));
+    var event = process(new Event({event: {code: 1102}}));
     if (event.Get("event.action") !== "cleared") {
         throw "expected event.action === cleared";
     }


### PR DESCRIPTION
Backports the following commits to 7.11:
 - docs: add missing bracket in test function (#23917)