### PR TITLE
[DOCS] Add note to state App Search module doesn't support Cloud AppSearch Metricbeat monitoring

### DIFF
--- a/metricbeat/docs/modules/appsearch.asciidoc
+++ b/metricbeat/docs/modules/appsearch.asciidoc
@@ -10,7 +10,10 @@ beta[]
 
 This is the App Search module.
 
-
+[NOTE]
+=====
+This module does not support collecting data from App Search running on {ecloud}.
+=====
 
 [float]
 === Example configuration

--- a/x-pack/metricbeat/module/appsearch/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/appsearch/_meta/docs.asciidoc
@@ -1,2 +1,6 @@
 This is the App Search module.
 
+[NOTE]
+=====
+This module does not support collecting data from App Search running on {ecloud}.
+=====


### PR DESCRIPTION
This PR replaces https://github.com/elastic/beats/pull/23532

## Summary

As @InbarShimshon states in https://github.com/elastic/beats/pull/23532

AppSearch starting 7.7.0 was dubbed to Enterprise Search in Cloud that contains both WorkPlace and AppSearch.
From my testing when connecting AppSearch to https://19bb0ad019e54a4c897957779b7ca900.ent-search.eu-central-1.aws.cloud.es.io/api/ent/v1/internal/stats the output is not one supported in https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-metricset-appsearch-stats.html so we should be more explicit in this not being supported for now in cloud where AppSearch falls under the Enterprise Search umbrella.

## What does this PR do?

Clarifies that this module is not supporting Cloud AppSearch Metricbeat monitoring. 

## Why is it important?

Tickets get in support - its a confusing (beta) topic so the clearer we are in the docs the less time it will be for support to test, reproduce open SDHs and take time from Dev to only find out it is not supported.

## HTML preview

Coming soon...