### PR TITLE
Cherry-pick #23837 to 7.x: [Filebeat] rfc6587 framing for fortinet firewall

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -229,6 +229,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
   to be consistent with ECS. {pull}23094[23094]
 - Fix Zoom module parameters for basic auth and url path. {pull}23779[23779]
 - Fix handling of ModifiedProperties field in Office 365. {pull}23777[23777]
+- Use rfc6587 framing for fortinet firewall and clientendpoint filesets when transferring over tcp. {pull}23837[23837]
 - Fix goroutines leak with some inputs in autodiscover. {pull}23722[23722]
 - Fix various processing errors in the Suricata module. {pull}23236[23236]
 

--- a/x-pack/filebeat/module/fortinet/clientendpoint/config/input.yml
+++ b/x-pack/filebeat/module/fortinet/clientendpoint/config/input.yml
@@ -7,7 +7,13 @@ paths:
   {{ end }}
 exclude_files: [".gz$"]
 
-{{ else }}
+{{ else  if eq .input "tcp" }}
+
+type: {{.input}}
+host: "{{.syslog_host}}:{{.syslog_port}}"
+framing: rfc6587
+
+{{ else  if eq .input "udp" }}
 
 type: {{.input}}
 host: "{{.syslog_host}}:{{.syslog_port}}"

--- a/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
@@ -2,6 +2,7 @@
 
 type: tcp
 host: "{{.syslog_host}}:{{.syslog_port}}"
+framing: rfc6587
 
 {{ else if eq .input "udp" }}
 


### PR DESCRIPTION
Cherry-pick of PR #23837 to 7.x branch. Original message: 

## What does this PR do?

Changes fortinet firewall & clientendpoint filesets to use rfc6587
framing when transferring logs via syslog over TCP

## Why is it important?

This is necessary to support syslog messages inside TLS and over TCP
if octet counting is used.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Use pysyslogclient or other syslog client that can send using octet counting.