### PR TITLE
[Heartbeat] Enable x-pack tests in magefile

### DIFF
--- a/x-pack/heartbeat/magefile.go
+++ b/x-pack/heartbeat/magefile.go
@@ -23,6 +23,8 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest/notests"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"


### PR DESCRIPTION
`mage test` hasn't ever worked in `x-pack/heartbeat` this should fix that.

Fixes https://github.com/elastic/beats/issues/23915#issuecomment-775594065
