### PR TITLE
Cherry-pick to 7.x: Add breaking changes file for 7.11 (#23943)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.11.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.11.asciidoc
@@ -1,0 +1,29 @@
+[[breaking-changes-7.11]]
+
+=== Breaking changes in 7.11
+++++
+<titleabbrev>7.11</titleabbrev>
+++++
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+
+[float]
+==== Field changes
+
+The following field changes are potentially breaking for anything that relies
+on these fields:
+
+* In {filebeat}, the `suricata.eve.timestamp` alias field has been removed from
+the Suricata module. 
+
+* In {auditbeat}, the file integrity dataset no longer includes a leading dot
+in `file.extension` values. For example, it will report `png` instead of `.png`
+to comply with Elastic Common Schema (ECS). 
+
+// end::notable-breaking-changes[]
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.11>>
+
 * <<breaking-changes-7.10>>
 
 * <<breaking-changes-7.9>>
@@ -32,6 +34,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.11.asciidoc[]
 
 include::breaking-7.10.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add breaking changes file for 7.11 (#23943)