### PR TITLE
Cherry-pick #23956 to 7.x: Pass GO_VERSION to install-go command in make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,8 @@ release-manager-snapshot:
 ## release-manager-release : Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 .PHONY: release-manager-release
 release-manager-release:
-	./dev-tools/run_with_go_ver $(MAKE) release
+	GO_VERSION=$(shell cat ./.go-version) ./.ci/scripts/install-go.sh
+	$(MAKE) release
 
 ## beats-dashboards : Collects dashboards from all Beats and generates a zip file distribution.
 .PHONY: beats-dashboards


### PR DESCRIPTION
Cherry-pick of PR #23956 to 7.x branch. Original message: 

