### PR TITLE
Cherry-pick #23628 to 7.x: [Elastic Log Driver] Change hosts config flag

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -316,6 +316,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Functionbeat*
 
+*Elastic Logging Plugin*
+- Fix out of date CLI flags on docs. {pull}23628[23628]
+
 
 ==== Added
 

--- a/x-pack/dockerlogbeat/docs/configuration.asciidoc
+++ b/x-pack/dockerlogbeat/docs/configuration.asciidoc
@@ -152,7 +152,7 @@ The local log also supports the `max-file`, `max-size` and `compress` options th
 ["source","sh",subs="attributes"]
 ----
 docker run --log-driver=elastic/{log-driver-alias}:{version} \
-           --log-opt endpoint="myhost:9200" \
+           --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
            --log-opt max-file=10 \

--- a/x-pack/dockerlogbeat/docs/install.asciidoc
+++ b/x-pack/dockerlogbeat/docs/install.asciidoc
@@ -80,7 +80,7 @@ example:
 ["source","sh",subs="attributes"]
 ----
 docker run --log-driver=elastic/{log-driver-alias}:{version} \
-           --log-opt endpoint="https://myhost:9200" \
+           --log-opt hosts="https://myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
            -it debian:jessie /bin/bash
@@ -98,7 +98,7 @@ example:
 {
   "log-driver" : "elastic/{log-driver-alias}:{version}",
   "log-opts" : {
-    "endpoint" : "https://myhost:9200",
+    "hosts" : "https://myhost:9200",
     "user" : "myusername",
     "password" : "mypassword"
   }

--- a/x-pack/dockerlogbeat/docs/usage.asciidoc
+++ b/x-pack/dockerlogbeat/docs/usage.asciidoc
@@ -16,7 +16,7 @@ The following examples show common configurations for the {log-driver}.
 ["source","sh",subs="attributes"]
 ----
 docker run --log-driver=elastic/{log-driver-alias}:{version} \
-           --log-opt endpoint="myhost:9200" \
+           --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
            -it debian:jessie /bin/bash
@@ -29,7 +29,7 @@ docker run --log-driver=elastic/{log-driver-alias}:{version} \
 {
   "log-driver" : "elastic/{log-driver-alias}:{version}",
   "log-opts" : {
-    "endpoint" : "myhost:9200",
+    "hosts" : "myhost:9200",
     "user" : "myusername",
     "password" : "mypassword",
   }
@@ -71,7 +71,7 @@ docker run --log-driver=elastic/{log-driver-alias}:{version} \
 ["source","sh",subs="attributes"]
 ----
 docker run --log-driver=elastic/{log-driver-alias}:{version} \
-           --log-opt endpoint="myhost:9200" \
+           --log-opt hosts="myhost:9200" \
            --log-opt user="myusername" \
            --log-opt password="mypassword" \
            --log-opt index="eld-%{[agent.version]}-%{+yyyy.MM.dd}" \
@@ -85,7 +85,7 @@ docker run --log-driver=elastic/{log-driver-alias}:{version} \
 {
   "log-driver" : "elastic/{log-driver-alias}:{version}",
   "log-opts" : {
-    "endpoint" : "myhost:9200",
+    "hosts" : "myhost:9200",
     "user" : "myusername",
     "index" : "eld-%{[agent.version]}-%{+yyyy.MM.dd}",
     "password" : "mypassword",


### PR DESCRIPTION
Cherry-pick of PR #23628 to 7.x branch. Original message: 

## What does this PR do?

When we switched over the CLI for the Elastic Log Driver a while ago, it looks like we missed a few sections of documentation. We need to update that now.

## Why is it important?

Docs are incorrect.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

