### PR TITLE
[Filebeat] change httpjson logging

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -381,6 +381,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use rfc6587 framing for fortinet firewall and clientendpoint filesets when transferring over tcp. {pull}23837[23837]
 - Fix goroutines leak with some inputs in autodiscover. {pull}23722[23722]
 - Fix various processing errors in the Suricata module. {pull}23236[23236]
+- Fix httpjson input logging so it doesn't conflict with ECS. {pull}23972[23972]
 
 *Heartbeat*
 

--- a/filebeat/input/v2/input-cursor/input.go
+++ b/filebeat/input/v2/input-cursor/input.go
@@ -117,7 +117,7 @@ func (inp *managedInput) Run(
 			// refine per worker context
 			inpCtx := ctx
 			inpCtx.ID = ctx.ID + "::" + source.Name()
-			inpCtx.Logger = ctx.Logger.With("source", source.Name())
+			inpCtx.Logger = ctx.Logger.With("input_source", source.Name())
 
 			if err = inp.runSource(inpCtx, inp.manager.store, source, pipeline); err != nil {
 				cancel()

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -125,7 +125,7 @@ func run(
 	publisher cursor.Publisher,
 	cursor *cursor.Cursor,
 ) error {
-	log := ctx.Logger.With("url", config.URL)
+	log := ctx.Logger.With("input_url", config.URL)
 
 	stdCtx := ctxtool.FromCanceller(ctx.Cancelation)
 

--- a/x-pack/filebeat/input/httpjson/internal/v2/input.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/input.go
@@ -104,7 +104,7 @@ func run(
 	publisher inputcursor.Publisher,
 	cursor *inputcursor.Cursor,
 ) error {
-	log := ctx.Logger.With("url", config.Request.URL)
+	log := ctx.Logger.With("input_url", config.Request.URL)
 
 	stdCtx := ctxtool.FromCanceller(ctx.Cancelation)
 


### PR DESCRIPTION
## What does this PR do?

Changes key values for httpjson input that conflicted with ECS fields

- change "source" key to "input_source"
- change "url" key to "input_url"

## Why is it important?

You get illegal argument exception when you try to ingest json
filebeat logs and other data source that sets "url.*" or "source.*"
fields from ECS

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.