### PR TITLE
[RELEASE] populate Go environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage.out
 .python-version
 beat.db
 *.keystore
+go_env.properties
 mage_output_file.go
 x-pack/functionbeat/*/fields.yml
 x-pack/functionbeat/provider/*/functionbeat-*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,6 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
-            sh(label: "Test Release snapshot", script: 'make release-manager-snapshot')
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
+            sh(label: "Test Release snapshot", script: 'make release-manager-snapshot')
           }
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ release-manager-snapshot:
 .PHONY: release-manager-release
 release-manager-release:
 	GO_VERSION=$(shell cat ./.go-version) ./.ci/scripts/install-go.sh
-	eval $(shell cat ./go_env.properties) ; make release
+	eval $(shell cat ./go_env.properties) ; $(MAKE) release
 
 ## beats-dashboards : Collects dashboards from all Beats and generates a zip file distribution.
 .PHONY: beats-dashboards

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ release-manager-snapshot:
 .PHONY: release-manager-release
 release-manager-release:
 	GO_VERSION=$(shell cat ./.go-version) ./.ci/scripts/install-go.sh
-	$(MAKE) release
+	eval $(shell cat ./go_env.properties) ; make release
 
 ## beats-dashboards : Collects dashboards from all Beats and generates a zip file distribution.
 .PHONY: beats-dashboards


### PR DESCRIPTION
## What does this PR do?

Use install-go.sh and populate the environment within the make release goal.

## Why is it important?

Unblock the release for ARM

## Test


AS far as I see the tests I run in the CI were able to load the gvm context using the properties file:

```
[2021-02-10T16:32:17.522Z] ++ gvm 1.15.7
[2021-02-10T16:32:17.522Z] + eval export 'GOROOT="/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64"' export 'PATH="/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64/bin:$PATH"'
[2021-02-10T16:32:17.522Z] ++ export GOROOT=/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64 export PATH=/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
[2021-02-10T16:32:17.522Z] ++ GOROOT=/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64
[2021-02-10T16:32:17.522Z] ++ PATH=/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
[2021-02-10T16:32:17.522Z] eval GOROOT=/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64 PATH=/var/lib/jenkins/workspace/Beats_beats_PR-23974/.gvm/versions/go1.15.7.linux.amd64/bin:$PATH ; make release
[2021-02-10T16:32:17.522Z] make[2]: Entering directory '/var/lib/jenkins/workspace/Beats_beats_PR-23974/src/github.com/elastic/beats'
[2021-02-10T16:32:17.522Z] Installing mage v1.11.0.
[2021-02-10T16:32:18.461Z] go: downloading github.com/magefile/mage v1.11.0
[2021-02-10T16:32:19.427Z] make[2]: mage: Command not found
[2021-02-10T16:32:19.427Z] dev-tools/make/mage-install.mk:9: recipe for target 'mage' failed
```

It failed when installing the mage, but I assume the Release process is something that it does take care to configure

