### PR TITLE
[Release] Replace gimme with gvm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
+            sh 'make release-manager-snapshot'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,6 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
-            sh 'make release-manager-snapshot'
           }
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -210,8 +210,7 @@ release-manager-snapshot:
 ## release-manager-release : Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 .PHONY: release-manager-release
 release-manager-release:
-	GO_VERSION=$(shell cat ./.go-version) ./.ci/scripts/install-go.sh
-	$(MAKE) release
+	GO_VERSION=$(shell cat ./.go-version) ./dev-tools/run_with_go_ver $(MAKE) release
 
 ## beats-dashboards : Collects dashboards from all Beats and generates a zip file distribution.
 .PHONY: beats-dashboards

--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -34,33 +34,16 @@ get_go_version() {
   fi
 }
 
-# install_gimme
-# Install gimme to HOME/bin.
-install_gimme() {
-  # Install gimme
-  if [ ! -f "${HOME}/bin/gimme" ]; then
-    mkdir -p ${HOME}/bin
-    curl -sL -o ${HOME}/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.1.0/gimme
-    chmod +x ${HOME}/bin/gimme
-  fi
-
-  GIMME="${HOME}/bin/gimme"
-  debug "Gimme version $(${GIMME} version)"
-}
-
 # setup_go_root "version"
 # This configures the Go version being used. It sets GOROOT and adds
 # GOROOT/bin to the PATH. It uses gimme to download the Go version if
 # it does not already exist in the ~/.gimme dir.
 setup_go_root() {
   local version=${1}
-
-  install_gimme
-
-  # Setup GOROOT and add go to the PATH.
-  ${GIMME} "${version}" > /dev/null
-  source "${HOME}/.gimme/envs/go${version}.env" 2> /dev/null
-
+  export PROPERTIES_FILE=go_env.properties
+  GO_VERSION="${version}" .ci/scripts/install-go.sh
+  # shellcheck disable=SC1090
+  source "${PROPERTIES_FILE}" 2> /dev/null
   debug "$(go version)"
 }
 


### PR DESCRIPTION
## What does this PR do?

Use the `./dev-tools/run_with_go_ver` wrapper that configures the go environment as used to be with gimme but using `gvm`

This is the way it was done for the previous releases, then we won't need to change anything in the Release Manager process since the environment will be automatically configued with the `run_with_go_ver` wrapper

## Why is it important?

Releases