### PR TITLE
[Release] Configure GOPATH=$HOME otherwise GOPATH=GOROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ coverage.out
 .python-version
 beat.db
 *.keystore
+go_env.properties
 mage_output_file.go
 x-pack/functionbeat/*/fields.yml
 x-pack/functionbeat/provider/*/functionbeat-*

--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -42,8 +42,18 @@ setup_go_root() {
   local version=${1}
   export PROPERTIES_FILE=go_env.properties
   GO_VERSION="${version}" .ci/scripts/install-go.sh
+
+  # Setup GOROOT and add go to the PATH.
   # shellcheck disable=SC1090
   source "${PROPERTIES_FILE}" 2> /dev/null
+
+  # Setup GOPATH and add GOPATH/bin to the PATH.
+  if [ -d "${HOME}" ] ; then
+    setup_go_path "${HOME}"
+  else
+    setup_go_path "${GOROOT}"
+  fi
+
   debug "$(go version)"
 }
 


### PR DESCRIPTION
## What does this PR do?

Configure GOPATH to be able to use the `mage` command

## Why is it important?

Fix the issues with the latest changes to support ARM

## Issues

Leftover from https://github.com/elastic/beats/pull/23975

## Test

```bash
$ make release-manager-snapshot
GO_VERSION=1.15.7 ./dev-tools/run_with_go_ver /Library/Developer/CommandLineTools/usr/bin/make release
+ MSG='environment variable missing'
+ GO_VERSION=1.15.7
+ PROPERTIES_FILE=go_env.properties
+ HOME=/Users/vmartinez
++ uname -s
++ tr '[:upper:]' '[:lower:]'
+ OS=darwin
++ uname -m
++ tr '[:upper:]' '[:lower:]'
+ ARCH=x86_64
+ GVM_CMD=/Users/vmartinez/bin/gvm
+ command -v go
/usr/local/bin/go
+ echo 'Found Go. Checking version..'
Found Go. Checking version..
++ go version
++ awk '{print $3}'
++ sed s/go//
+ FOUND_GO_VERSION=1.15.7
+ '[' 1.15.7 == 1.15.7 ']'
+ echo 'Versions match. No need to install Go. Exiting.'
Versions match. No need to install Go. Exiting.
+ exit 0
Installing mage v1.11.0.
go: downloading github.com/magefile/mage v1.11.0
/Users/vmartinez/.magefile cleaned
Generating NOTICE

$ ls -l ~/bin                            
total 31560
-rwxr-xr-x  1 vmartinez  staff  11190648 10 Feb 21:37 gvm
-rwxr-xr-x  1 vmartinez  staff   4557104 10 Feb 21:31 mage
```