### PR TITLE
Cherry-pick to 7.x: [Release] Replace gimme with gvm (#23975)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,8 +210,7 @@ release-manager-snapshot:
 ## release-manager-release : Builds a snapshot release. The Go version defined in .go-version will be installed and used for the build.
 .PHONY: release-manager-release
 release-manager-release:
-	GO_VERSION=$(shell cat ./.go-version) ./.ci/scripts/install-go.sh
-	$(MAKE) release
+	GO_VERSION=$(shell cat ./.go-version) ./dev-tools/run_with_go_ver $(MAKE) release
 
 ## beats-dashboards : Collects dashboards from all Beats and generates a zip file distribution.
 .PHONY: beats-dashboards

--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -34,33 +34,16 @@ get_go_version() {
   fi
 }
 
-# install_gimme
-# Install gimme to HOME/bin.
-install_gimme() {
-  # Install gimme
-  if [ ! -f "${HOME}/bin/gimme" ]; then
-    mkdir -p ${HOME}/bin
-    curl -sL -o ${HOME}/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/v1.1.0/gimme
-    chmod +x ${HOME}/bin/gimme
-  fi
-
-  GIMME="${HOME}/bin/gimme"
-  debug "Gimme version $(${GIMME} version)"
-}
-
 # setup_go_root "version"
 # This configures the Go version being used. It sets GOROOT and adds
 # GOROOT/bin to the PATH. It uses gimme to download the Go version if
 # it does not already exist in the ~/.gimme dir.
 setup_go_root() {
   local version=${1}
-
-  install_gimme
-
-  # Setup GOROOT and add go to the PATH.
-  ${GIMME} "${version}" > /dev/null
-  source "${HOME}/.gimme/envs/go${version}.env" 2> /dev/null
-
+  export PROPERTIES_FILE=go_env.properties
+  GO_VERSION="${version}" .ci/scripts/install-go.sh
+  # shellcheck disable=SC1090
+  source "${PROPERTIES_FILE}" 2> /dev/null
   debug "$(go version)"
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Release] Replace gimme with gvm (#23975)