### PR TITLE
Release: dump the environment context

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,8 +60,8 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
+            cmd(label: "make release-manager-snapshot", script: "make release-manager-snapshot")
           }
-          cmd(label: "make release-manager-snapshot", script: "make release-manager-snapshot")
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,6 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
-            cmd(label: "make release-manager-snapshot", script: "make release-manager-snapshot")
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
           }
+          cmd(label: "make release-manager-snapshot", script: "make release-manager-snapshot")
         }
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,7 @@ snapshot:
 ## release : Builds a release.
 .PHONY: release
 release: beats-dashboards
+	@mage dumpVariables
 	@$(foreach var,$(BEATS) $(PROJECTS_XPACK_PKG),$(MAKE) -C $(var) release || exit 1;)
 	@$(foreach var,$(BEATS) $(PROJECTS_XPACK_PKG), \
       test -d $(var)/build/distributions && test -n "$$(ls $(var)/build/distributions)" || exit 0; \


### PR DESCRIPTION
## What does this PR do?

Release process in the release manager context for ARM somehow is using the linux/amd64 platform, so let's add some debug traces regarding what's the current context when a release/snapshot is triggered with the release manager

