### PR TITLE
Update all Beats to report ECS version 1.8.0

### DIFF
--- a/filebeat/module/apache/access/config/access.yml
+++ b/filebeat/module/apache/access/config/access.yml
@@ -8,4 +8,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/apache/error/config/error.yml
+++ b/filebeat/module/apache/error/config/error.yml
@@ -10,4 +10,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/elasticsearch/audit/config/audit.yml
+++ b/filebeat/module/elasticsearch/audit/config/audit.yml
@@ -10,7 +10,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - if:
       regexp:
         message: "^{"

--- a/filebeat/module/elasticsearch/deprecation/config/log.yml
+++ b/filebeat/module/elasticsearch/deprecation/config/log.yml
@@ -15,4 +15,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.7.0
+      ecs.version: 1.8.0

--- a/filebeat/module/elasticsearch/gc/config/gc.yml
+++ b/filebeat/module/elasticsearch/gc/config/gc.yml
@@ -13,4 +13,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/elasticsearch/server/config/log.yml
+++ b/filebeat/module/elasticsearch/server/config/log.yml
@@ -15,4 +15,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.7.0
+      ecs.version: 1.8.0

--- a/filebeat/module/elasticsearch/slowlog/config/slowlog.yml
+++ b/filebeat/module/elasticsearch/slowlog/config/slowlog.yml
@@ -16,4 +16,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.7.0
+      ecs.version: 1.8.0

--- a/filebeat/module/haproxy/log/config/file.yml
+++ b/filebeat/module/haproxy/log/config/file.yml
@@ -9,4 +9,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/haproxy/log/config/syslog.yml
+++ b/filebeat/module/haproxy/log/config/syslog.yml
@@ -6,4 +6,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/icinga/debug/config/debug.yml
+++ b/filebeat/module/icinga/debug/config/debug.yml
@@ -12,4 +12,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/icinga/main/config/main.yml
+++ b/filebeat/module/icinga/main/config/main.yml
@@ -12,4 +12,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/icinga/startup/config/startup.yml
+++ b/filebeat/module/icinga/startup/config/startup.yml
@@ -12,4 +12,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/iis/access/config/iis-access.yml
+++ b/filebeat/module/iis/access/config/iis-access.yml
@@ -9,4 +9,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/iis/error/config/iis-error.yml
+++ b/filebeat/module/iis/error/config/iis-error.yml
@@ -9,4 +9,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/kafka/log/config/log.yml
+++ b/filebeat/module/kafka/log/config/log.yml
@@ -13,4 +13,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/kibana/log/config/log.yml
+++ b/filebeat/module/kibana/log/config/log.yml
@@ -11,4 +11,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/logstash/log/config/log.yml
+++ b/filebeat/module/logstash/log/config/log.yml
@@ -16,4 +16,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.7.0
+      ecs.version: 1.8.0

--- a/filebeat/module/logstash/slowlog/config/slowlog.yml
+++ b/filebeat/module/logstash/slowlog/config/slowlog.yml
@@ -11,4 +11,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.7.0
+      ecs.version: 1.8.0

--- a/filebeat/module/mongodb/log/config/log.yml
+++ b/filebeat/module/mongodb/log/config/log.yml
@@ -8,4 +8,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/mysql/error/config/error.yml
+++ b/filebeat/module/mysql/error/config/error.yml
@@ -16,4 +16,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/mysql/slowlog/config/slowlog.yml
+++ b/filebeat/module/mysql/slowlog/config/slowlog.yml
@@ -13,4 +13,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/nats/log/config/log.yml
+++ b/filebeat/module/nats/log/config/log.yml
@@ -8,4 +8,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/nginx/access/config/nginx-access.yml
+++ b/filebeat/module/nginx/access/config/nginx-access.yml
@@ -10,4 +10,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/nginx/error/config/nginx-error.yml
+++ b/filebeat/module/nginx/error/config/nginx-error.yml
@@ -14,4 +14,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/nginx/ingress_controller/config/ingress_controller.yml
+++ b/filebeat/module/nginx/ingress_controller/config/ingress_controller.yml
@@ -10,4 +10,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/osquery/result/config/result.yml
+++ b/filebeat/module/osquery/result/config/result.yml
@@ -10,4 +10,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/postgresql/log/config/log.yml
+++ b/filebeat/module/postgresql/log/config/log.yml
@@ -12,4 +12,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/redis/log/config/log.yml
+++ b/filebeat/module/redis/log/config/log.yml
@@ -9,4 +9,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/santa/log/config/file.yml
+++ b/filebeat/module/santa/log/config/file.yml
@@ -8,4 +8,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/system/auth/config/auth.yml
+++ b/filebeat/module/system/auth/config/auth.yml
@@ -12,4 +12,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/system/syslog/config/syslog.yml
+++ b/filebeat/module/system/syslog/config/syslog.yml
@@ -12,4 +12,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/filebeat/module/traefik/access/config/traefik-access.yml
+++ b/filebeat/module/traefik/access/config/traefik-access.yml
@@ -8,4 +8,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/heartbeat/cmd/root.go
+++ b/heartbeat/cmd/root.go
@@ -41,7 +41,7 @@ const (
 	Name = "heartbeat"
 
 	// ecsVersion specifies the version of ECS that this beat is implementing.
-	ecsVersion = "1.7.0"
+	ecsVersion = "1.8.0"
 )
 
 // RootCmd to handle beats cli

--- a/metricbeat/cmd/root.go
+++ b/metricbeat/cmd/root.go
@@ -43,7 +43,7 @@ const (
 	Name = "metricbeat"
 
 	// ecsVersion specifies the version of ECS that this beat is implementing.
-	ecsVersion = "1.7.0"
+	ecsVersion = "1.8.0"
 )
 
 // RootCmd to handle beats cli

--- a/winlogbeat/cmd/root.go
+++ b/winlogbeat/cmd/root.go
@@ -37,7 +37,7 @@ const (
 	Name = "winlogbeat"
 
 	// ecsVersion specifies the version of ECS that Winlogbeat is implementing.
-	ecsVersion = "1.7.0"
+	ecsVersion = "1.8.0"
 )
 
 // withECSVersion is a modifier that adds ecs.version to events.

--- a/x-pack/filebeat/module/activemq/audit/config/audit.yml
+++ b/x-pack/filebeat/module/activemq/audit/config/audit.yml
@@ -9,4 +9,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/activemq/log/config/log.yml
+++ b/x-pack/filebeat/module/activemq/log/config/log.yml
@@ -13,4 +13,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/aws/cloudwatch/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/aws-s3.yml
@@ -52,4 +52,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/aws/cloudwatch/config/file.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/file.yml
@@ -11,4 +11,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/aws/ec2/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/aws-s3.yml
@@ -52,4 +52,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/aws/ec2/config/file.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/file.yml
@@ -11,4 +11,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/aws/elb/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/elb/config/aws-s3.yml
@@ -52,4 +52,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/aws/elb/config/file.yml
+++ b/x-pack/filebeat/module/aws/elb/config/file.yml
@@ -11,4 +11,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/aws/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/config/input.yml
@@ -181,4 +181,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/barracuda/spamfirewall/config/input.yml
+++ b/x-pack/filebeat/module/barracuda/spamfirewall/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/barracuda/waf/config/input.yml
+++ b/x-pack/filebeat/module/barracuda/waf/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/bluecoat/director/config/input.yml
+++ b/x-pack/filebeat/module/bluecoat/director/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/checkpoint/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/config/firewall.yml
@@ -28,7 +28,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
 {{ if .external_zones }}
   - add_fields:
       target: _temp_

--- a/x-pack/filebeat/module/cisco/ios/config/input.yml
+++ b/x-pack/filebeat/module/cisco/ios/config/input.yml
@@ -23,7 +23,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - script:
       lang: javascript
       id: cisco_ios

--- a/x-pack/filebeat/module/cisco/meraki/config/input.yml
+++ b/x-pack/filebeat/module/cisco/meraki/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/cisco/nexus/config/input.yml
+++ b/x-pack/filebeat/module/cisco/nexus/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/coredns/log/config/coredns.yml
+++ b/x-pack/filebeat/module/coredns/log/config/coredns.yml
@@ -9,4 +9,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/cyberark/corepas/config/input.yml
+++ b/x-pack/filebeat/module/cyberark/corepas/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/cylance/protect/config/input.yml
+++ b/x-pack/filebeat/module/cylance/protect/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/envoyproxy/log/config/envoyproxy.yml
+++ b/x-pack/filebeat/module/envoyproxy/log/config/envoyproxy.yml
@@ -9,4 +9,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/f5/bigipafm/config/input.yml
+++ b/x-pack/filebeat/module/f5/bigipafm/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/f5/bigipapm/config/input.yml
+++ b/x-pack/filebeat/module/f5/bigipapm/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/fortinet/clientendpoint/config/input.yml
+++ b/x-pack/filebeat/module/fortinet/clientendpoint/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/fortinet/fortimail/config/input.yml
+++ b/x-pack/filebeat/module/fortinet/fortimail/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/fortinet/fortimanager/config/input.yml
+++ b/x-pack/filebeat/module/fortinet/fortimanager/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/gcp/audit/config/input.yml
+++ b/x-pack/filebeat/module/gcp/audit/config/input.yml
@@ -34,4 +34,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/gcp/firewall/config/input.yml
+++ b/x-pack/filebeat/module/gcp/firewall/config/input.yml
@@ -38,4 +38,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/gcp/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/gcp/vpcflow/config/input.yml
@@ -37,4 +37,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/google_workspace/admin/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/admin/config/config.yml
@@ -45,7 +45,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/x-pack/filebeat/module/google_workspace/drive/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/drive/config/config.yml
@@ -45,7 +45,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/x-pack/filebeat/module/google_workspace/groups/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/groups/config/config.yml
@@ -45,7 +45,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/x-pack/filebeat/module/google_workspace/login/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/login/config/config.yml
@@ -45,7 +45,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/x-pack/filebeat/module/google_workspace/saml/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/saml/config/config.yml
@@ -45,7 +45,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/x-pack/filebeat/module/google_workspace/user_accounts/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/user_accounts/config/config.yml
@@ -45,7 +45,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0
   - script:
       lang: javascript
       id: gworkspace-common

--- a/x-pack/filebeat/module/ibmmq/errorlog/config/errorlog.yml
+++ b/x-pack/filebeat/module/ibmmq/errorlog/config/errorlog.yml
@@ -12,4 +12,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/imperva/securesphere/config/input.yml
+++ b/x-pack/filebeat/module/imperva/securesphere/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/infoblox/nios/config/input.yml
+++ b/x-pack/filebeat/module/infoblox/nios/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/iptables/log/config/input.yml
+++ b/x-pack/filebeat/module/iptables/log/config/input.yml
@@ -55,4 +55,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/juniper/junos/config/input.yml
+++ b/x-pack/filebeat/module/juniper/junos/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/juniper/netscreen/config/input.yml
+++ b/x-pack/filebeat/module/juniper/netscreen/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/microsoft/dhcp/config/input.yml
+++ b/x-pack/filebeat/module/microsoft/dhcp/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/misp/threat/config/input.yml
+++ b/x-pack/filebeat/module/misp/threat/config/input.yml
@@ -56,4 +56,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/mssql/log/config/config.yml
+++ b/x-pack/filebeat/module/mssql/log/config/config.yml
@@ -14,4 +14,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/netflow/log/config/netflow.yml
+++ b/x-pack/filebeat/module/netflow/log/config/netflow.yml
@@ -38,4 +38,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/netscout/sightline/config/input.yml
+++ b/x-pack/filebeat/module/netscout/sightline/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/okta/system/config/input.yml
+++ b/x-pack/filebeat/module/okta/system/config/input.yml
@@ -59,4 +59,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/oracle/database_audit/config/config.yml
+++ b/x-pack/filebeat/module/oracle/database_audit/config/config.yml
@@ -18,4 +18,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/proofpoint/emailsecurity/config/input.yml
+++ b/x-pack/filebeat/module/proofpoint/emailsecurity/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/rabbitmq/log/config/log.yml
+++ b/x-pack/filebeat/module/rabbitmq/log/config/log.yml
@@ -18,4 +18,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/radware/defensepro/config/input.yml
+++ b/x-pack/filebeat/module/radware/defensepro/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/snort/log/config/input.yml
+++ b/x-pack/filebeat/module/snort/log/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/snyk/audit/config/config.yml
+++ b/x-pack/filebeat/module/snyk/audit/config/config.yml
@@ -73,4 +73,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.6.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/snyk/vulnerabilities/config/config.yml
+++ b/x-pack/filebeat/module/snyk/vulnerabilities/config/config.yml
@@ -96,4 +96,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.6.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/sonicwall/firewall/config/input.yml
+++ b/x-pack/filebeat/module/sonicwall/firewall/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/sophos/utm/config/input.yml
+++ b/x-pack/filebeat/module/sophos/utm/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/squid/log/config/input.yml
+++ b/x-pack/filebeat/module/squid/log/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/suricata/eve/config/eve.yml
+++ b/x-pack/filebeat/module/suricata/eve/config/eve.yml
@@ -58,4 +58,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/tomcat/log/config/input.yml
+++ b/x-pack/filebeat/module/tomcat/log/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/zoom/webhook/config/webhook.yml
+++ b/x-pack/filebeat/module/zoom/webhook/config/webhook.yml
@@ -34,4 +34,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/filebeat/module/zscaler/zia/config/input.yml
+++ b/x-pack/filebeat/module/zscaler/zia/config/input.yml
@@ -84,4 +84,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/x-pack/metricbeat/cmd/root.go
+++ b/x-pack/metricbeat/cmd/root.go
@@ -31,7 +31,7 @@ const (
 	Name = "metricbeat"
 
 	// ecsVersion specifies the version of ECS that this beat is implementing.
-	ecsVersion = "1.7.0"
+	ecsVersion = "1.8.0"
 )
 
 // RootCmd to handle beats cli


### PR DESCRIPTION
Updates all Beats to report `ecs.version` field with a value of `1.8.0`.
