### PR TITLE
Cherry-pick to 7.x: Dump packages and platforms env variables (#23994)

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -60,6 +60,8 @@ var (
 	XPackDir     = "../x-pack"
 	RaceDetector = false
 	TestCoverage = false
+	PLATFORMS    = EnvOr("PLATFORMS", "")
+	PACKAGES     = EnvOr("PACKAGES", "")
 
 	// CrossBuildMountModcache, if true, mounts $GOPATH/pkg/mod into
 	// the crossbuild images at /go/pkg/mod, read-only.
@@ -160,6 +162,8 @@ func varMap(args ...map[string]interface{}) map[string]interface{} {
 		"GOARCH":          GOARCH,
 		"GOARM":           GOARM,
 		"Platform":        Platform,
+		"PLATFORMS":       PLATFORMS,
+		"PACKAGES":        PACKAGES,
 		"BinaryExt":       BinaryExt,
 		"XPackDir":        XPackDir,
 		"BeatName":        BeatName,
@@ -203,6 +207,8 @@ BeatLicense      = {{.BeatLicense}}
 BeatURL          = {{.BeatURL}}
 BeatUser         = {{.BeatUser}}
 VersionQualifier = {{.Qualifier}}
+PLATFORMS        = {{.PLATFORMS}}
+PACKAGES         = {{.PACKAGES}}
 
 ## Functions
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Dump packages and platforms env variables (#23994)