### PR TITLE
Cherry-pick #23998 to 7.x: Windows agent doesn't uninstall with a lowercase `c:` drive in the path

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -32,7 +32,11 @@
 - Fixed nil pointer during unenroll {pull}23609[23609]
 - Fixed reenroll scenario {pull}23686[23686]
 - Fixed make status readable in the log. {pull}23849[23849]
+<<<<<<< HEAD
 - Fixed Monitoring filebeat and metricbeat not connecting to Agent over GRPC {pull}23843[23843]
+=======
+- Windows agent doesn't uninstall with a lowercase `c:` drive in the path {pull}23998[23998]
+>>>>>>> d1e8b253da... [Ingest Manager] Windows agent doesn't uninstall with a lowercase `c:` drive in the path  (#23998)
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -32,11 +32,8 @@
 - Fixed nil pointer during unenroll {pull}23609[23609]
 - Fixed reenroll scenario {pull}23686[23686]
 - Fixed make status readable in the log. {pull}23849[23849]
-<<<<<<< HEAD
 - Fixed Monitoring filebeat and metricbeat not connecting to Agent over GRPC {pull}23843[23843]
-=======
 - Windows agent doesn't uninstall with a lowercase `c:` drive in the path {pull}23998[23998]
->>>>>>> d1e8b253da... [Ingest Manager] Windows agent doesn't uninstall with a lowercase `c:` drive in the path  (#23998)
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/install/installed.go
+++ b/x-pack/elastic-agent/pkg/agent/install/installed.go
@@ -58,7 +58,7 @@ func RunningInstalled() bool {
 		execDir = filepath.Dir(filepath.Dir(execDir))
 		execPath = filepath.Join(execDir, execName)
 	}
-	return expected == execPath
+	return ArePathsEqual(expected, execPath)
 }
 
 // checkService only checks the status of the service.

--- a/x-pack/elastic-agent/pkg/agent/install/paths.go
+++ b/x-pack/elastic-agent/pkg/agent/install/paths.go
@@ -28,3 +28,8 @@ const (
 exec /opt/Elastic/Agent/elastic-agent $@
 `
 )
+
+// ArePathsEqual determines whether paths are equal taking case sensitivity of os into account.
+func ArePathsEqual(expected, actual string) bool {
+	return expected == actual
+}

--- a/x-pack/elastic-agent/pkg/agent/install/paths_darwin.go
+++ b/x-pack/elastic-agent/pkg/agent/install/paths_darwin.go
@@ -27,3 +27,8 @@ const (
 exec /Library/Elastic/Agent/elastic-agent $@
 `
 )
+
+// ArePathsEqual determines whether paths are equal taking case sensitivity of os into account.
+func ArePathsEqual(expected, actual string) bool {
+	return expected == actual
+}

--- a/x-pack/elastic-agent/pkg/agent/install/paths_test.go
+++ b/x-pack/elastic-agent/pkg/agent/install/paths_test.go
@@ -1,0 +1,33 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package install
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqual(t *testing.T) {
+	isWindows := runtime.GOOS == "windows"
+	testCases := []struct {
+		Name        string
+		Expected    string
+		Actual      string
+		ShouldMatch bool
+	}{
+		{"different paths", "/var/path/a", "/var/path/b", false},
+		{"strictly same paths", "/var/path/a", "/var/path/a", true},
+		{"strictly same win paths", `C:\Program Files\Elastic\Agent`, `C:\Program Files\Elastic\Agent`, true},
+		{"case insensitive win paths", `C:\Program Files\Elastic\Agent`, `c:\Program Files\Elastic\Agent`, isWindows},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			assert.Equal(t, tc.ShouldMatch, ArePathsEqual(tc.Expected, tc.Actual))
+		})
+	}
+}

--- a/x-pack/elastic-agent/pkg/agent/install/paths_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/install/paths_windows.go
@@ -6,6 +6,8 @@
 
 package install
 
+import "strings"
+
 const (
 	// BinaryName is the name of the installed binary.
 	BinaryName = "elastic-agent.exe"
@@ -25,3 +27,8 @@ const (
 	// ShellWrapper is the wrapper that is installed.
 	ShellWrapper = "" // no wrapper on Windows
 )
+
+// ArePathsEqual determines whether paths are equal taking case sensitivity of os into account.
+func ArePathsEqual(expected, actual string) bool {
+	return strings.EqualFold(expected, actual)
+}


### PR DESCRIPTION
Cherry-pick of PR #23998 to 7.x branch. Original message:

## What does this PR do?

This PR fixes uninstall check case sensitivity. 
The problem was with windows that paths does not need to match case to work. New Func was added which either check strings for equality(darwin,linux) or checks them in case insensitive way (windows)

## Why is it important?

Fixes #22268 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
