### PR TITLE
Cherry-pick #23999 to 7.x: Crossbuilding of Lambda functions only supported on AMD64

### DIFF
--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/magefile/mage/mg"
@@ -89,6 +90,7 @@ func BuildGoDaemon() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
+
 	// Building functionbeat manager
 	err := devtools.CrossBuild()
 	if err != nil {
@@ -105,6 +107,11 @@ func CrossBuild() error {
 	for _, provider := range selectedProviders {
 		if !provider.Buildable {
 			continue
+		}
+
+		if runtime.GOARCH != "amd64" {
+			fmt.Println("Crossbuilding functions only works on amd64 architecture.")
+			return nil
 		}
 
 		err := devtools.CrossBuild(devtools.AddPlatforms("linux/amd64"), devtools.InDir("x-pack", "functionbeat", "provider", provider.Name))


### PR DESCRIPTION
Cherry-pick of PR #23999 to 7.x branch. Original message: 

## What does this PR do?

This PR disables building Lambda function on ARM64.

## Why is it important?

Functionbeat manager can be built on ARM64, however, the crossbuilding only supported on linux/amd64 as this is the only platform we support for Lambda functions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~