### PR TITLE
Fix regression with the elastic-agent release

### DIFF
--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -41,7 +41,11 @@ get_go_version() {
 setup_go_root() {
   local version=${1}
   export PROPERTIES_FILE=go_env.properties
-  GO_VERSION="${version}" .ci/scripts/install-go.sh
+
+  # Support cases when the call to this script is done not from the
+  # root folder but from a nested folder.
+  BASEDIR=$(dirname "$(dirname "$0")")
+  GO_VERSION="${version}" "${BASEDIR}"/.ci/scripts/install-go.sh
 
   # Setup GOROOT and add go to the PATH.
   # shellcheck disable=SC1090


### PR DESCRIPTION
## What does this PR do?

Fix regression https://github.com/elastic/beats/pull/23975 since the elastic-agent release process uses some scripting from different locations:

```
      './dev-tools/run_with_go_ver make mage',
      'cd x-pack/elastic-agent',
      './../../dev-tools/run_with_go_ver mage package',
      'cd ../..',
```

Instead the `make release-manager` goals

## Why is it important?

Fix the snapshots


## Tests

From the root folder

```
➜  beats git:(feature/detect-where-dev-tools-is-called-from) ✗ dev-tools/run_with_go_ver mage package        
+ MSG='environment variable missing'
+ GO_VERSION=1.15.8
+ PROPERTIES_FILE=go_env.properties


```

From the elatic-agent location

```
➜  elastic-agent git:(feature/detect-where-dev-tools-is-called-from) ✗ ./../../dev-tools/run_with_go_ver mage package
+ MSG='environment variable missing'
+ GO_VERSION=1.15.8
+ PROPERTIES_FILE=go_env.properties
+ HOME=/Users/vmartinez
++ uname -s


```