### PR TITLE
Cherry-pick #24022 to 7.x: [Filebeat] httpjson split strings on delimiter

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -523,6 +523,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added `application/x-ndjson` as decode option for httpjson input {pull}23521[23521]
 - Added `application/x-www-form-urlencoded` as encode option for httpjson input {pull}23521[23521]
 - Move aws-s3 input to GA. {pull}23631[23631]
+- Added string splitting for httpjson input {pull}24022[24022]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -499,7 +499,7 @@ filebeat.inputs:
 [float]
 ==== `response.split`
 
-Split operation to apply to the response once it is received. A split can convert a map or an array into multiple events.
+Split operation to apply to the response once it is received. A split can convert a map, array, or string into multiple events.
 
 [float]
 ==== `response.split[].target`
@@ -509,7 +509,7 @@ Defines the target field upon the split operation will be performed.
 [float]
 ==== `response.split[].type`
 
-Defines the field type of the target. Allowed values: `array`, `map`. Default: `array`.
+Defines the field type of the target. Allowed values: `array`, `map`, `string`. `string` requires the use of the `delimiter` options to specify what characters to split the string on.  `delimiter` always behaves as if `keep_parent` is set to `true`. Default: `array`.
 
 [float]
 ==== `response.split[].transforms`
@@ -528,6 +528,11 @@ NOTE: in this context, `body.*` will be the result of all the previous transform
 ==== `response.split[].keep_parent`
 
 If set to true, the fields from the parent document (at the same level as `target`) will be kept. Otherwise a new document will be created using `target` as the root. Default: `false`.
+
+[float]
+==== `response.split[].delimiter`
+
+Required if using split type of `string`.  This is the sub string used to split the string.  For example if `delimiter` was "\n" and the string was "line 1\nline 2", then the split would result in "line 1" and "line 2".
 
 [float]
 ==== `response.split[].key_field`
@@ -800,6 +805,56 @@ This will output:
   {
     "something": "something 2",
     "new": "will be added for each"
+  }
+]
+----
+
+- We have a response with a keys whose value is a string.  We want the string to be split on a delimiter and a document for each sub strings.
+
++
+["source","json",subs="attributes"]
+----
+{
+  "this": "is kept",
+  "lines": "Line 1\nLine 2\nLine 3"
+}
+----
+
++
+The config will look like:
+
++
+["source","yaml",subs="attributes"]
+----
+filebeat.inputs:
+- type: httpjson
+  config_version: 2
+  interval: 1m
+  request.url: https://example.com
+  response.split:
+    target: body.lines
+    type: string
+    delimiter: "\n"
+----
+
++
+This will output:
+
++
+["source","json",subs="attributes"]
+----
+[
+  {
+    "this": "is kept",
+    "lines": "Line 1"
+  },
+  {
+    "this": "is kept",
+    "lines": "Line 2"
+  },
+  {
+    "this": "is kept",
+    "lines": "Line 3"
   }
 ]
 ----

--- a/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	splitTypeArr = "array"
-	splitTypeMap = "map"
+	splitTypeArr    = "array"
+	splitTypeMap    = "map"
+	splitTypeString = "string"
 )
 
 type responseConfig struct {
@@ -23,12 +24,13 @@ type responseConfig struct {
 }
 
 type splitConfig struct {
-	Target     string           `config:"target" validation:"required"`
-	Type       string           `config:"type"`
-	Transforms transformsConfig `config:"transforms"`
-	Split      *splitConfig     `config:"split"`
-	KeepParent bool             `config:"keep_parent"`
-	KeyField   string           `config:"key_field"`
+	Target          string           `config:"target" validation:"required"`
+	Type            string           `config:"type"`
+	Transforms      transformsConfig `config:"transforms"`
+	Split           *splitConfig     `config:"split"`
+	KeepParent      bool             `config:"keep_parent"`
+	KeyField        string           `config:"key_field"`
+	DelimiterString string           `config:"delimiter"`
 }
 
 func (c *responseConfig) Validate() error {
@@ -58,6 +60,10 @@ func (c *splitConfig) Validate() error {
 			return fmt.Errorf("key_field can only be used with a %s split type", splitTypeMap)
 		}
 	case splitTypeMap:
+	case splitTypeString:
+		if c.DelimiterString == "" {
+			return fmt.Errorf("delimiter required for split type %s", splitTypeString)
+		}
 	default:
 		return fmt.Errorf("invalid split type: %s", c.Type)
 	}

--- a/x-pack/filebeat/input/httpjson/internal/v2/split_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/split_test.go
@@ -334,6 +334,26 @@ func TestSplit(t *testing.T) {
 				{"baz": "buzz", "splitHere": common.MapStr{"splitMore": common.MapStr{"deepest2": "data"}}},
 			},
 		},
+		{
+			name: "Split string",
+			config: &splitConfig{
+				Target:          "body.items",
+				Type:            "string",
+				DelimiterString: "\n",
+			},
+			ctx: emptyTransformContext(),
+			resp: transformable{
+				"body": common.MapStr{
+					"@timestamp": "1234567890",
+					"items":      "Line 1\nLine 2\nLine 3",
+				},
+			},
+			expectedMessages: []common.MapStr{
+				{"@timestamp": "1234567890", "items": "Line 1"},
+				{"@timestamp": "1234567890", "items": "Line 2"},
+				{"@timestamp": "1234567890", "items": "Line 3"},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Cherry-pick of PR #24022 to 7.x branch. Original message: 

## What does this PR do?

Adds a new split type to httpjson input, so you can split on strings
inside the response body.

- adds new split type "string"
- adds new split config option "delimiter", to specify what to split on

## Why is it important?

Necessary if a string field contains information that should be spit
into multiple events

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

``` bash
mage goUnitTest
```