### PR TITLE
[CI] docker login for linux only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -877,12 +877,14 @@ def dumpVariables(){
 }
 
 def isDockerInstalled(){
-  if (isUnix()) {
-    // TODO: some issues with macosx if(isInstalled(tool: 'docker', flag: '--version')) {
-    return sh(label: 'check for Docker', script: 'command -v docker', returnStatus: true) == 0
-  } else {
+  if (env?.NODE_LABELS?.toLowerCase().contains('macosx')) {
+    log(level: 'WARN', text: "Macosx workers require some docker-machine context. They are not used for anything related to docker stuff yet.")
     return false
   }
+  if (isUnix()) {
+    return sh(label: 'check for Docker', script: 'command -v docker', returnStatus: true) == 0
+  }
+  return false
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

As a consequence of #23854 then it's required the login for Linux workers to interact with the packaging correctly. But it's not required for other platforms such as `darwin` and `windows`.

## Why is it important?

Docker login in Darwin is not trivial since it requires some docker-machine context, some Darwin workers got no issues regarding the login since it seems the docker-machine context is correct, but some of the CI Darwin workers got some issues.

This should fix the issues of broken builds in the `master` and `7.x` branches regarding those docker login issues.

## Workers

The below workers have been disabled until this fix is not merged for `master` and `7.x` branches.

* https://beats-ci.elastic.co/computer/worker-c07ll940dwyl/
* https://beats-ci.elastic.co/computer/worker-c07y20b4jyvy/
* https://beats-ci.elastic.co/computer/worker-c07y20b6jyvy/