### PR TITLE
Cherry-pick #24021 to 7.x: Syslog system tests: be more forgiving

### DIFF
--- a/filebeat/tests/system/test_syslog.py
+++ b/filebeat/tests/system/test_syslog.py
@@ -254,7 +254,7 @@ class Test(BaseTest):
         assert syslog["event.severity"] == 5
         assert syslog["hostname"] == "wopr.mymachine.co"
         assert syslog["input.type"] == "syslog"
-        assert syslog["message"] == "'su root' failed for lonvick on /dev/pts/8 0"
+        assert syslog["message"].startswith("'su root' failed for lonvick on /dev/pts/8")
         assert syslog["process.pid"] == 2000
         assert syslog["process.program"] == "postfix/smtpd"
         assert syslog["syslog.facility"] == 1


### PR DESCRIPTION
Cherry-pick of PR #24021 to 7.x branch. Original message: 

- Fix Flaky Test

## What does this PR do?

Update the syslog system tests in filebeat to check for a message prefix only.

## Why is it important?

The assert function did require the message ID "0" to be added. The syslog tests increase counter per message. Due asserting the message ID we did require the UDP test to never drop the first message, but drop as many other message as is possible. By checking for the prefix only the test succeeds if at least a single UDP message will be received improving the chance of the test to succeed.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
