### PR TITLE
Cherry-pick #24036 to 7.x: Fix: bad substitution of API key

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -41,7 +41,7 @@ function enroll(){
       local apikeyId=$(echo $enrollResp | jq -r '.list[] | select((.name | startswith("Default ")) and (.active == true)) | .id')
       echo $apikeyId
 
-      if [[ -z "${$apikeyId}" ]]; then
+      if [[ -z "${apikeyId}" ]]; then
         echo "Default agent policy was not found. Please consider using own enrollment token (FLEET_ENROLLMENT_TOKEN)."
         exit 1
       fi

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -39,6 +39,7 @@
 - Fix libbeat from reporting back degraded on config update {pull}23537[23537]
 - Fix issues with dynamic inputs and conditions {pull}23886[23886]
 - Select default agent policy if no enrollment token provided. {pull}23973[23973]
+- Fix bad substitution of API key. {pull}24036[24036]
 
 ==== New features
 


### PR DESCRIPTION
Cherry-pick of PR #24036 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes the bad substitution (typo), spotted in https://beats-ci.elastic.co/job/Ingest-manager/job/elastic-package/job/PR-246/45/artifact/build/elastic-stack-dump/stack/logs/elastic-agent.log .

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Create new custom policy in the Kibana UI.
2. Start new Docker container with Elastic Agent, don't provide the enrollment token.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-  https://github.com/elastic/elastic-package/pull/246