### PR TITLE
[CI] googleStorageUploadExt step

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@feature/override-google-storage-step') _
+@Library('apm@current') _
 
 import groovy.transform.Field
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@feature/override-google-storage-step') _
 
 import groovy.transform.Field
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -448,14 +448,11 @@ def publishPackages(baseDir){
   uploadPackages("${bucketUri}/${beatsFolderName}", baseDir)
 }
 
-def uploadPackages(bucketUri, baseDir){
-  googleStorageUpload(bucket: bucketUri,
+def uploadPackages(bucketUri, beatsFolder){
+  googleStorageUploadExt(bucket: bucketUri,
     credentialsId: "${JOB_GCS_CREDENTIALS}",
-    pathPrefix: "${baseDir}/build/distributions/",
-    pattern: "${baseDir}/build/distributions/**/*",
-    sharedPublicly: true,
-    showInline: true
-  )
+    pattern: "${beatsFolder}/build/distributions/**/*",
+    sharedPublicly: true)
 }
 
 /**

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -17,6 +17,7 @@ pipeline {
     JOB_GCS_BUCKET = 'beats-ci-artifacts'
     JOB_GCS_BUCKET_STASH = 'beats-ci-temp'
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
+    JOB_GCS_EXT_CREDENTIALS = 'beats-ci-gcs-plugin-file-credentials'
     DOCKERELASTIC_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     GITHUB_CHECK_E2E_TESTS_NAME = 'E2E Tests'
@@ -450,7 +451,7 @@ def publishPackages(baseDir){
 
 def uploadPackages(bucketUri, beatsFolder){
   googleStorageUploadExt(bucket: bucketUri,
-    credentialsId: "${JOB_GCS_CREDENTIALS}",
+    credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
     pattern: "${beatsFolder}/build/distributions/**/*",
     sharedPublicly: true)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -311,7 +311,7 @@ def publishPackages(beatsFolder){
 * @param beatsFolder the beats folder.
 */
 def uploadPackages(bucketUri, beatsFolder){
-  googleStorageUploadExt(bucket: bucket: bucketUri,
+  googleStorageUploadExt(bucket: bucketUri,
     credentialsId: "${JOB_GCS_CREDENTIALS}",
     pattern: "${beatsFolder}/build/distributions/**/*",
     sharedPublicly: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -311,13 +311,10 @@ def publishPackages(beatsFolder){
 * @param beatsFolder the beats folder.
 */
 def uploadPackages(bucketUri, beatsFolder){
-  googleStorageUpload(bucket: bucketUri,
+  googleStorageUploadExt(bucket: bucket: bucketUri,
     credentialsId: "${JOB_GCS_CREDENTIALS}",
-    pathPrefix: "${beatsFolder}/build/distributions/",
     pattern: "${beatsFolder}/build/distributions/**/*",
-    sharedPublicly: true,
-    showInline: true
-  )
+    sharedPublicly: true)
 }
 
 /**
@@ -693,11 +690,10 @@ def archiveTestOutput(Map args = [:]) {
 */
 def tarAndUploadArtifacts(Map args = [:]) {
   tar(file: args.file, dir: args.location, archive: false, allowMissing: true)
-  googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
-                      credentialsId: "${JOB_GCS_CREDENTIALS}",
-                      pattern: "${args.file}",
-                      sharedPublicly: true,
-                      showInline: true)
+  googleStorageUploadExt(bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
+                         credentialsId: "${JOB_GCS_CREDENTIALS}",
+                         pattern: "${args.file}",
+                         sharedPublicly: true)
 }
 
 /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@feature/override-google-storage-step') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     JOB_GCS_BUCKET = 'beats-ci-temp'
     JOB_GCS_CREDENTIALS = 'beats-ci-gcs-plugin'
+    JOB_GCS_EXT_CREDENTIALS = 'beats-ci-gcs-plugin-file-credentials'
     OSS_MODULE_PATTERN = '^[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
     PIPELINE_LOG_LEVEL = 'INFO'
     PYTEST_ADDOPTS = "${params.PYTEST_ADDOPTS}"
@@ -312,7 +313,7 @@ def publishPackages(beatsFolder){
 */
 def uploadPackages(bucketUri, beatsFolder){
   googleStorageUploadExt(bucket: bucketUri,
-    credentialsId: "${JOB_GCS_CREDENTIALS}",
+    credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
     pattern: "${beatsFolder}/build/distributions/**/*",
     sharedPublicly: true)
 }
@@ -691,7 +692,7 @@ def archiveTestOutput(Map args = [:]) {
 def tarAndUploadArtifacts(Map args = [:]) {
   tar(file: args.file, dir: args.location, archive: false, allowMissing: true)
   googleStorageUploadExt(bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
-                         credentialsId: "${JOB_GCS_CREDENTIALS}",
+                         credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
                          pattern: "${args.file}",
                          sharedPublicly: true)
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@feature/override-google-storage-step') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }


### PR DESCRIPTION
## What does this PR do?

Use the customised step to upload artifacts to Google Storage

## Why is it important?

Known bug already in the built-in step provided by the Google Storage plugin

## Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/867