### PR TITLE
Cherry-pick #23678 to 7.x: [Libbeat][New Processor] XML Decode

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -413,6 +413,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update the baseline version of Sarama (Kafka support library) to 1.27.2. {pull}23595[23595]
 - Add kubernetes.volume.fs.used.pct field. {pull}23564[23564]
 - Add the `enable_krb5_fast` flag to the Kafka output to explicitly opt-in to FAST authentication. {pull}23629[23629]
+- Added new decode_xml processor to libbeat that is available to all beat types. {pull}23678[23678]
 - Add deployment name in pod's meta. {pull}23610[23610]
 
 *Auditbeat*

--- a/libbeat/cmd/instance/imports_common.go
+++ b/libbeat/cmd/instance/imports_common.go
@@ -30,6 +30,7 @@ import (
 	_ "github.com/elastic/beats/v7/libbeat/processors/add_process_metadata"
 	_ "github.com/elastic/beats/v7/libbeat/processors/communityid"
 	_ "github.com/elastic/beats/v7/libbeat/processors/convert"
+	_ "github.com/elastic/beats/v7/libbeat/processors/decode_xml"
 	_ "github.com/elastic/beats/v7/libbeat/processors/dissect"
 	_ "github.com/elastic/beats/v7/libbeat/processors/dns"
 	_ "github.com/elastic/beats/v7/libbeat/processors/extract_array"

--- a/libbeat/common/encoding/xml/decode.go
+++ b/libbeat/common/encoding/xml/decode.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package xml
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"strings"
+)
+
+// A Decoder reads and decodes XML from an input stream.
+type Decoder struct {
+	prependHyphenToAttr bool
+	lowercaseKeys       bool
+	xmlDec              *xml.Decoder
+}
+
+// NewDecoder returns a new decoder that reads from r.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{xmlDec: xml.NewDecoder(r)}
+}
+
+// PrependHyphenToAttr causes the Decoder to prepend a hyphen ('-') to to all
+// XML attribute names.
+func (d *Decoder) PrependHyphenToAttr() { d.prependHyphenToAttr = true }
+
+// LowercaseKeys causes the Decoder to transform all key name to lowercase.
+func (d *Decoder) LowercaseKeys() { d.lowercaseKeys = true }
+
+// Decode reads XML from the input stream and return a map containing the data.
+func (d *Decoder) Decode() (map[string]interface{}, error) {
+	_, m, err := d.decode(nil)
+	return m, err
+}
+
+func (d *Decoder) decode(attrs []xml.Attr) (string, map[string]interface{}, error) {
+	elements := map[string]interface{}{}
+	var cdata string
+
+	for {
+		t, err := d.xmlDec.Token()
+		if err != nil {
+			if err == io.EOF {
+				return "", elements, nil
+			}
+			return "", nil, err
+		}
+
+		switch elem := t.(type) {
+		case xml.StartElement:
+			cdata, subElements, err := d.decode(elem.Attr)
+			if err != nil {
+				return "", nil, err
+			}
+
+			// Combine sub-elements and cdata.
+			var add interface{} = subElements
+			if len(subElements) == 0 {
+				add = cdata
+			} else if len(cdata) > 0 {
+				subElements["#text"] = cdata
+			}
+
+			// Add the data to the current object while taking into account
+			// if the current key already exists (in the case of lists).
+			key := d.key(elem.Name.Local)
+			value := elements[elem.Name.Local]
+			switch v := value.(type) {
+			case nil:
+				elements[key] = add
+			case []interface{}:
+				elements[key] = append(v, add)
+			default:
+				elements[key] = []interface{}{v, add}
+			}
+		case xml.CharData:
+			cdata = string(bytes.TrimSpace(elem.Copy()))
+		case xml.EndElement:
+			d.addAttributes(attrs, elements)
+			return cdata, elements, nil
+		}
+	}
+}
+
+func (d *Decoder) addAttributes(attrs []xml.Attr, m map[string]interface{}) {
+	for _, attr := range attrs {
+		key := d.attrKey(attr.Name.Local)
+		m[key] = attr.Value
+	}
+}
+
+func (d *Decoder) key(in string) string {
+	if d.lowercaseKeys {
+		return strings.ToLower(in)
+	}
+	return in
+}
+
+func (d *Decoder) attrKey(in string) string {
+	if d.prependHyphenToAttr {
+		return d.key("-" + in)
+	}
+	return d.key(in)
+}

--- a/libbeat/common/encoding/xml/decode_test.go
+++ b/libbeat/common/encoding/xml/decode_test.go
@@ -1,0 +1,431 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !integration
+
+package xml
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIncompleteXML(t *testing.T) {
+	const xml = `
+<person>
+  <Name ID="123">John</Name>
+`
+
+	d := NewDecoder(strings.NewReader(xml))
+	out, err := d.Decode()
+	assert.Nil(t, out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected EOF")
+}
+
+func TestLowercaseKeys(t *testing.T) {
+	const xml = `
+<person>
+  <Name ID="123">John</Name>
+</person>
+`
+
+	expected := map[string]interface{}{
+		"person": map[string]interface{}{
+			"name": map[string]interface{}{
+				"#text": "John",
+				"id":    "123",
+			},
+		},
+	}
+
+	d := NewDecoder(strings.NewReader(xml))
+	d.LowercaseKeys()
+	out, err := d.Decode()
+	require.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestPrependHyphenToAttr(t *testing.T) {
+	const xml = `
+<person>
+  <Name ID="123">John</Name>
+</person>
+`
+
+	expected := map[string]interface{}{
+		"person": map[string]interface{}{
+			"Name": map[string]interface{}{
+				"#text": "John",
+				"-ID":   "123",
+			},
+		},
+	}
+
+	d := NewDecoder(strings.NewReader(xml))
+	d.PrependHyphenToAttr()
+	out, err := d.Decode()
+	require.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestDecodeList(t *testing.T) {
+	const xml = `
+<people>
+	<person>
+	  <Name ID="123">John</Name>
+	</person>
+	<person>
+	  <Name ID="456">Jane</Name>
+	</person>
+    <person>Foo</person>
+</people>
+`
+
+	expected := map[string]interface{}{
+		"people": map[string]interface{}{
+			"person": []interface{}{
+				map[string]interface{}{
+					"Name": map[string]interface{}{
+						"#text": "John",
+						"ID":    "123",
+					},
+				},
+				map[string]interface{}{
+					"Name": map[string]interface{}{
+						"#text": "Jane",
+						"ID":    "456",
+					},
+				},
+				"Foo",
+			},
+		},
+	}
+
+	d := NewDecoder(strings.NewReader(xml))
+	out, err := d.Decode()
+	require.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestEmptyElement(t *testing.T) {
+	const xml = `
+<people>
+</people>
+`
+
+	expected := map[string]interface{}{
+		"people": "",
+	}
+
+	d := NewDecoder(strings.NewReader(xml))
+	out, err := d.Decode()
+	require.NoError(t, err)
+	assert.Equal(t, expected, out)
+}
+
+func TestDecode(t *testing.T) {
+	type testCase struct {
+		XML    string
+		Output map[string]interface{}
+	}
+
+	tests := []testCase{
+		{
+			XML: `
+			<catalog>
+				<book seq="1">
+					<author>William H. Gaddis</author>
+					<title>The Recognitions</title>
+					<review>One of the great seminal American novels of the 20th century.</review>
+				</book>
+			</catalog>`,
+			Output: map[string]interface{}{
+				"catalog": map[string]interface{}{
+					"book": map[string]interface{}{
+						"author": "William H. Gaddis",
+						"review": "One of the great seminal American novels of the 20th century.",
+						"seq":    "1",
+						"title":  "The Recognitions"}}},
+		},
+		{
+			XML: `
+			<catalog>
+				<book id="bk101">
+					<author>Gambardella, Matthew</author>
+					<title>XML Developer's Guide</title>
+					<genre>Computer</genre>
+					<price>44.95</price>
+					<publish_date>2000-10-01</publish_date>
+					<description>An in-depth look at creating applications with XML.</description>
+				</book>
+				<book id="bk102">
+					<author>Ralls, Kim</author>
+					<title>Midnight Rain</title>
+					<genre>Fantasy</genre>
+					<price>5.95</price>
+					<publish_date>2000-12-16</publish_date>
+					<description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+				</book>
+			</catalog>`,
+			Output: map[string]interface{}{
+				"catalog": map[string]interface{}{
+					"book": []interface{}{
+						map[string]interface{}{
+							"author":       "Gambardella, Matthew",
+							"description":  "An in-depth look at creating applications with XML.",
+							"genre":        "Computer",
+							"id":           "bk101",
+							"price":        "44.95",
+							"publish_date": "2000-10-01",
+							"title":        "XML Developer's Guide",
+						},
+						map[string]interface{}{
+							"author":       "Ralls, Kim",
+							"description":  "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
+							"genre":        "Fantasy",
+							"id":           "bk102",
+							"price":        "5.95",
+							"publish_date": "2000-12-16",
+							"title":        "Midnight Rain"}}}},
+		},
+		{
+			XML: `
+			<?xml version="1.0"?>
+			<catalog>
+				<book id="bk101">
+					<author>Gambardella, Matthew</author>
+					<title>XML Developer's Guide</title>
+					<genre>Computer</genre>
+					<price>44.95</price>
+					<publish_date>2000-10-01</publish_date>
+					<description>An in-depth look at creating applications with XML.</description>
+				</book>
+				<book id="bk102">
+					<author>Ralls, Kim</author>
+					<title>Midnight Rain</title>
+					<genre>Fantasy</genre>
+					<price>5.95</price>
+					<publish_date>2000-12-16</publish_date>
+					<description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+				</book>
+			</catalog>`,
+			Output: map[string]interface{}{
+				"catalog": map[string]interface{}{
+					"book": []interface{}{
+						map[string]interface{}{
+							"author":       "Gambardella, Matthew",
+							"description":  "An in-depth look at creating applications with XML.",
+							"genre":        "Computer",
+							"id":           "bk101",
+							"price":        "44.95",
+							"publish_date": "2000-10-01",
+							"title":        "XML Developer's Guide"},
+						map[string]interface{}{
+							"author":       "Ralls, Kim",
+							"description":  "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
+							"genre":        "Fantasy",
+							"id":           "bk102",
+							"price":        "5.95",
+							"publish_date": "2000-12-16",
+							"title":        "Midnight Rain"}}}},
+		},
+		{
+			XML: `
+			<?xml version="1.0"?>
+			<catalog>
+				<book id="bk101">
+					<author>Gambardella, Matthew</author>
+					<title>XML Developer's Guide</title>
+					<genre>Computer</genre>
+					<price>44.95</price>
+					<publish_date>2000-10-01</publish_date>
+					<description>An in-depth look at creating applications with XML.</description>
+				</book>
+				<secondcategory>
+					<paper id="bk102">
+						<test2>Ralls, Kim</test2>
+						<description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+					</paper>
+				</secondcategory>
+			</catalog>`,
+			Output: map[string]interface{}{
+				"catalog": map[string]interface{}{
+					"book": map[string]interface{}{
+						"author":       "Gambardella, Matthew",
+						"description":  "An in-depth look at creating applications with XML.",
+						"genre":        "Computer",
+						"id":           "bk101",
+						"price":        "44.95",
+						"publish_date": "2000-10-01",
+						"title":        "XML Developer's Guide"},
+					"secondcategory": map[string]interface{}{
+						"paper": map[string]interface{}{
+							"description": "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
+							"id":          "bk102",
+							"test2":       "Ralls, Kim"}}}},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			d := NewDecoder(strings.NewReader(test.XML))
+			d.LowercaseKeys()
+
+			out, err := d.Decode()
+			require.NoError(t, err)
+			assert.EqualValues(t, test.Output, out)
+		})
+	}
+}
+
+func ExampleDecoder_Decode() {
+	const xml = `
+<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+  <System>
+    <Provider Name="Microsoft-Windows-WinRM" Guid="{a7975c8f-ac13-49f1-87da-5a984a4ab417}" EventSourceName="Service Control Manager"/>
+    <EventID>91</EventID>
+    <Version>1</Version>
+    <Level>4</Level>
+    <Task>9</Task>
+    <Opcode>0</Opcode>
+    <Keywords>0x8020000000000000</Keywords>
+    <TimeCreated SystemTime="2016-01-28T20:33:27.990735300Z"/>
+    <EventRecordID>100</EventRecordID>
+    <Correlation ActivityID="{A066CCF1-8AB3-459B-B62F-F79F957A5036}" RelatedActivityID="{85FC0930-9C49-42DA-804B-A7368104BD1B}" />
+    <Execution ProcessID="920" ThreadID="1152"/>
+    <Channel>Microsoft-Windows-WinRM/Operational</Channel>
+    <Computer>vagrant-2012-r2</Computer>
+    <Security UserID="S-1-5-21-3541430928-2051711210-1391384369-1001"/>
+  </System>
+  <EventData>
+    <Data Name="param1">winlogbeat</Data>
+    <Data Name="param2">running</Data>
+    <Binary>770069006E006C006F00670062006500610074002F0034000000</Binary>
+  </EventData>
+  <UserData>
+    <EventXML xmlns="Event_NS">
+      <ServerName>\\VAGRANT-2012-R2</ServerName>
+      <UserName>vagrant</UserName>
+    </EventXML>
+  </UserData>
+  <ProcessingErrorData>
+    <ErrorCode>15005</ErrorCode>
+    <DataItemName>shellId</DataItemName>
+    <EventPayload>68007400740070003A002F002F0073006300680065006D00610073002E006D006900630072006F0073006F00660074002E0063006F006D002F007700620065006D002F00770073006D0061006E002F0031002F00770069006E0064006F00770073002F007300680065006C006C002F0063006D0064000000</EventPayload>
+  </ProcessingErrorData>
+  <RenderingInfo Culture="en-US">
+    <Message>Creating WSMan shell on server with ResourceUri: %1</Message>
+    <Level>Information</Level>
+    <Task>Request handling</Task>
+    <Opcode>Info</Opcode>
+    <Channel>Microsoft-Windows-WinRM/Operational</Channel>
+    <Provider>Microsoft-Windows-Windows Remote Management</Provider>
+    <Keywords>
+      <Keyword>Server</Keyword>
+    </Keywords>
+  </RenderingInfo>
+</Event>
+}
+`
+	dec := NewDecoder(strings.NewReader(xml))
+	dec.LowercaseKeys()
+	m, err := dec.Decode()
+	if err != nil {
+		return
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err = enc.Encode(m); err != nil {
+		return
+	}
+
+	// Output:
+	// {
+	//   "event": {
+	//     "eventdata": {
+	//       "binary": "770069006E006C006F00670062006500610074002F0034000000",
+	//       "data": {
+	//         "#text": "running",
+	//         "name": "param2"
+	//       }
+	//     },
+	//     "processingerrordata": {
+	//       "dataitemname": "shellId",
+	//       "errorcode": "15005",
+	//       "eventpayload": "68007400740070003A002F002F0073006300680065006D00610073002E006D006900630072006F0073006F00660074002E0063006F006D002F007700620065006D002F00770073006D0061006E002F0031002F00770069006E0064006F00770073002F007300680065006C006C002F0063006D0064000000"
+	//     },
+	//     "renderinginfo": {
+	//       "channel": "Microsoft-Windows-WinRM/Operational",
+	//       "culture": "en-US",
+	//       "keywords": {
+	//         "keyword": "Server"
+	//       },
+	//       "level": "Information",
+	//       "message": "Creating WSMan shell on server with ResourceUri: %1",
+	//       "opcode": "Info",
+	//       "provider": "Microsoft-Windows-Windows Remote Management",
+	//       "task": "Request handling"
+	//     },
+	//     "system": {
+	//       "channel": "Microsoft-Windows-WinRM/Operational",
+	//       "computer": "vagrant-2012-r2",
+	//       "correlation": {
+	//         "activityid": "{A066CCF1-8AB3-459B-B62F-F79F957A5036}",
+	//         "relatedactivityid": "{85FC0930-9C49-42DA-804B-A7368104BD1B}"
+	//       },
+	//       "eventid": "91",
+	//       "eventrecordid": "100",
+	//       "execution": {
+	//         "processid": "920",
+	//         "threadid": "1152"
+	//       },
+	//       "keywords": "0x8020000000000000",
+	//       "level": "4",
+	//       "opcode": "0",
+	//       "provider": {
+	//         "eventsourcename": "Service Control Manager",
+	//         "guid": "{a7975c8f-ac13-49f1-87da-5a984a4ab417}",
+	//         "name": "Microsoft-Windows-WinRM"
+	//       },
+	//       "security": {
+	//         "userid": "S-1-5-21-3541430928-2051711210-1391384369-1001"
+	//       },
+	//       "task": "9",
+	//       "timecreated": {
+	//         "systemtime": "2016-01-28T20:33:27.990735300Z"
+	//       },
+	//       "version": "1"
+	//     },
+	//     "userdata": {
+	//       "eventxml": {
+	//         "servername": "\\\\VAGRANT-2012-R2",
+	//         "username": "vagrant",
+	//         "xmlns": "Event_NS"
+	//       }
+	//     },
+	//     "xmlns": "http://schemas.microsoft.com/win/2004/08/events/event"
+	//   }
+	// }
+}

--- a/libbeat/docs/processors-list.asciidoc
+++ b/libbeat/docs/processors-list.asciidoc
@@ -110,6 +110,9 @@ endif::[]
 ifndef::no_urldecode_processor[]
 * <<urldecode, `urldecode`>>
 endif::[]
+ifndef::no_decode_xml_processor[]
+* <<decode_xml, `decode_xml`>>
+endif::[]
 //# end::processors-list[]
 
 //# tag::processors-include[]
@@ -224,6 +227,9 @@ include::{libbeat-processors-dir}/actions/docs/truncate_fields.asciidoc[]
 endif::[]
 ifndef::no_urldecode_processor[]
 include::{libbeat-processors-dir}/urldecode/docs/urldecode.asciidoc[]
+endif::[]
+ifndef::no_decode_xml_processor[]
+include::{libbeat-processors-dir}/decode_xml/docs/decode_xml.asciidoc[]
 endif::[]
 
 //# end::processors-include[]

--- a/libbeat/processors/decode_xml/config.go
+++ b/libbeat/processors/decode_xml/config.go
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package decode_xml
+
+type decodeXMLConfig struct {
+	Field         string  `config:"field" validate:"required"`
+	Target        *string `config:"target_field"`
+	OverwriteKeys bool    `config:"overwrite_keys"`
+	DocumentID    string  `config:"document_id"`
+	ToLower       bool    `config:"to_lower"`
+	IgnoreMissing bool    `config:"ignore_missing"`
+	IgnoreFailure bool    `config:"ignore_failure"`
+}
+
+func defaultConfig() decodeXMLConfig {
+	return decodeXMLConfig{
+		Field:         "message",
+		OverwriteKeys: true,
+		ToLower:       true,
+	}
+}

--- a/libbeat/processors/decode_xml/decode_xml.go
+++ b/libbeat/processors/decode_xml/decode_xml.go
@@ -1,0 +1,150 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package decode_xml
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/v7/libbeat/common/encoding/xml"
+	"github.com/elastic/beats/v7/libbeat/common/jsontransform"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/libbeat/processors/checks"
+	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
+)
+
+type decodeXML struct {
+	decodeXMLConfig
+	log *logp.Logger
+}
+
+var (
+	errFieldIsNotString = errors.New("field value is not a string")
+)
+
+const (
+	procName = "decode_xml"
+	logName  = "processor." + procName
+)
+
+func init() {
+	processors.RegisterPlugin(procName,
+		checks.ConfigChecked(New,
+			checks.RequireFields("fields"),
+			checks.AllowedFields("fields", "overwrite_keys", "add_error_key", "target", "document_id")))
+	jsprocessor.RegisterPlugin(procName, New)
+}
+
+// New constructs a new decode_xml processor.
+func New(c *common.Config) (processors.Processor, error) {
+	config := defaultConfig()
+
+	if err := c.Unpack(&config); err != nil {
+		return nil, fmt.Errorf("fail to unpack the "+procName+" processor configuration: %s", err)
+	}
+
+	return newDecodeXML(config)
+}
+
+func newDecodeXML(config decodeXMLConfig) (processors.Processor, error) {
+	cfgwarn.Experimental("The " + procName + " processor is experimental.")
+
+	// Default target to overwriting field.
+	if config.Target == nil {
+		config.Target = &config.Field
+	}
+
+	return &decodeXML{
+		decodeXMLConfig: config,
+		log:             logp.NewLogger(logName),
+	}, nil
+}
+
+func (x *decodeXML) Run(event *beat.Event) (*beat.Event, error) {
+	if err := x.run(event); err != nil && !x.IgnoreFailure {
+		err = fmt.Errorf("failed in decode_xml on the %q field: %w", x.Field, err)
+		event.PutValue("error.message", err.Error())
+		return event, err
+	}
+	return event, nil
+}
+
+func (x *decodeXML) run(event *beat.Event) error {
+	data, err := event.GetValue(x.Field)
+	if err != nil {
+		if x.IgnoreMissing && err == common.ErrKeyNotFound {
+			return nil
+		}
+		return err
+	}
+
+	text, ok := data.(string)
+	if !ok {
+		return errFieldIsNotString
+	}
+
+	xmlOutput, err := x.decodeField(text)
+	if err != nil {
+		return err
+	}
+
+	var id string
+	if tmp, err := common.MapStr(xmlOutput).GetValue(x.DocumentID); err == nil {
+		if v, ok := tmp.(string); ok {
+			id = v
+			common.MapStr(xmlOutput).Delete(x.DocumentID)
+		}
+	}
+
+	if *x.Target != "" {
+		if _, err = event.PutValue(*x.Target, xmlOutput); err != nil {
+			return fmt.Errorf("failed to put value %v into field %q: %w", xmlOutput, *x.Target, err)
+		}
+	} else {
+		jsontransform.WriteJSONKeys(event, xmlOutput, false, x.OverwriteKeys, !x.IgnoreFailure)
+	}
+
+	if id != "" {
+		event.SetID(id)
+	}
+	return nil
+}
+
+func (x *decodeXML) decodeField(data string) (decodedData map[string]interface{}, err error) {
+	dec := xml.NewDecoder(strings.NewReader(data))
+	if x.ToLower {
+		dec.LowercaseKeys()
+	}
+
+	out, err := dec.Decode()
+	if err != nil {
+		return nil, fmt.Errorf("error decoding XML field: %w", err)
+	}
+	return out, nil
+}
+
+func (x *decodeXML) String() string {
+	json, _ := json.Marshal(x.decodeXMLConfig)
+	return procName + "=" + string(json)
+}

--- a/libbeat/processors/decode_xml/decode_xml_test.go
+++ b/libbeat/processors/decode_xml/decode_xml_test.go
@@ -1,0 +1,467 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package decode_xml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+var (
+	testXMLTargetField  = "xml"
+	testRootTargetField = ""
+)
+
+func TestDecodeXML(t *testing.T) {
+	var testCases = []struct {
+		description  string
+		config       decodeXMLConfig
+		Input        common.MapStr
+		Output       common.MapStr
+		error        bool
+		errorMessage string
+	}{
+		{
+			description: "Simple xml decode with target field set",
+			config: decodeXMLConfig{
+				Field:  "message",
+				Target: &testXMLTargetField,
+			},
+			Input: common.MapStr{
+				"message": `<catalog>
+					<book seq="1">
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+				</catalog>`,
+			},
+			Output: common.MapStr{
+				"xml": map[string]interface{}{
+					"catalog": map[string]interface{}{
+						"book": map[string]interface{}{
+							"author": "William H. Gaddis",
+							"review": "One of the great seminal American novels of the 20th century.",
+							"seq":    "1",
+							"title":  "The Recognitions",
+						},
+					},
+				},
+				"message": `<catalog>
+					<book seq="1">
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+				</catalog>`,
+			},
+		},
+		{
+			description: "Test with target set to root",
+			config: decodeXMLConfig{
+				Field:  "message",
+				Target: &testRootTargetField,
+			},
+			Input: common.MapStr{
+				"message": `<catalog>
+					<book seq="1">
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+				</catalog>`,
+			},
+			Output: common.MapStr{
+				"catalog": common.MapStr{
+					"book": map[string]interface{}{
+						"author": "William H. Gaddis",
+						"review": "One of the great seminal American novels of the 20th century.",
+						"seq":    "1",
+						"title":  "The Recognitions",
+					},
+				},
+				"message": `<catalog>
+					<book seq="1">
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+				</catalog>`,
+			},
+		},
+		{
+			description: "Simple xml decode with xml string to same field name when Target is null",
+			config: decodeXMLConfig{
+				Field: "message",
+			},
+			Input: common.MapStr{
+				"message": `<?xml version="1.0"?>
+				<catalog>
+					<book seq="1">
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+				</catalog>`,
+			},
+			Output: common.MapStr{
+				"message": map[string]interface{}{
+					"catalog": map[string]interface{}{
+						"book": map[string]interface{}{
+							"author": "William H. Gaddis",
+							"review": "One of the great seminal American novels of the 20th century.",
+							"seq":    "1",
+							"title":  "The Recognitions",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Decoding with array input",
+			config: decodeXMLConfig{
+				Field: "message",
+			},
+			Input: common.MapStr{
+				"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+					<book>
+						<author>Ralls, Kim</author>
+						<title>Midnight Rain</title>
+						<review>Some review.</review>
+					</book>
+				</catalog>`,
+			},
+			Output: common.MapStr{
+				"message": map[string]interface{}{
+					"catalog": map[string]interface{}{
+						"book": []interface{}{
+							map[string]interface{}{
+								"author": "William H. Gaddis",
+								"review": "One of the great seminal American novels of the 20th century.",
+								"title":  "The Recognitions",
+							},
+							map[string]interface{}{
+								"author": "Ralls, Kim",
+								"review": "Some review.",
+								"title":  "Midnight Rain",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Decoding with multiple xml objects",
+			config: decodeXMLConfig{
+				Field: "message",
+			},
+			Input: common.MapStr{
+				"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+					<author>William H. Gaddis</author>
+					<title>The Recognitions</title>
+					<review>One of the great seminal American novels of the 20th century.</review>
+				</book>
+				<book>
+					<author>Ralls, Kim</author>
+					<title>Midnight Rain</title>
+					<review>Some review.</review>
+				</book>
+				<secondcategory>
+					<paper id="bk102">
+						<test2>Ralls, Kim</test2>
+						<description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+					</paper>
+				</secondcategory>
+				</catalog>`,
+			},
+			Output: common.MapStr{
+				"message": map[string]interface{}{
+					"catalog": map[string]interface{}{
+						"book": []interface{}{
+							map[string]interface{}{
+								"author": "William H. Gaddis",
+								"review": "One of the great seminal American novels of the 20th century.",
+								"title":  "The Recognitions",
+							},
+							map[string]interface{}{
+								"author": "Ralls, Kim",
+								"review": "Some review.",
+								"title":  "Midnight Rain",
+							},
+						},
+						"secondcategory": map[string]interface{}{
+							"paper": map[string]interface{}{
+								"description": "A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.",
+								"id":          "bk102",
+								"test2":       "Ralls, Kim",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "Decoding with broken XML format, with IgnoreFailure false",
+			config: decodeXMLConfig{
+				Field:         "message",
+				IgnoreFailure: false,
+			},
+			Input: common.MapStr{
+				"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+				</ook>
+				catalog>`,
+			},
+			Output: common.MapStr{
+				"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+				</ook>
+				catalog>`,
+				"error": common.MapStr{"message": "failed in decode_xml on the \"message\" field: error decoding XML field: XML syntax error on line 7: element <book> closed by </ook>"},
+			},
+			error:        true,
+			errorMessage: "error decoding XML field:",
+		},
+		{
+			description: "Decoding with broken XML format, with IgnoreFailure true",
+			config: decodeXMLConfig{
+				Field:         "message",
+				IgnoreFailure: true,
+			},
+			Input: common.MapStr{
+				"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+				</ook>
+				catalog>`,
+			},
+			Output: common.MapStr{
+				"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+				</ook>
+				catalog>`,
+			},
+		},
+		{
+			description: "Test when the XML field is empty, IgnoreMissing false",
+			config: decodeXMLConfig{
+				Field:         "message2",
+				IgnoreMissing: false,
+			},
+			Input: common.MapStr{
+				"message": "testing message",
+			},
+			Output: common.MapStr{
+				"message": "testing message",
+				"error":   common.MapStr{"message": "failed in decode_xml on the \"message2\" field: key not found"},
+			},
+			error:        true,
+			errorMessage: "key not found",
+		},
+		{
+			description: "Test when the XML field is empty IgnoreMissing true",
+			config: decodeXMLConfig{
+				Field:         "message2",
+				IgnoreMissing: true,
+			},
+			Input: common.MapStr{
+				"message": "testing message",
+			},
+			Output: common.MapStr{
+				"message": "testing message",
+			},
+		},
+		{
+			description: "Test when the XML field not a string, IgnoreFailure false",
+			config: decodeXMLConfig{
+				Field:         "message",
+				IgnoreFailure: false,
+			},
+			Input: common.MapStr{
+				"message": 1,
+			},
+			Output: common.MapStr{
+				"message": 1,
+				"error":   common.MapStr{"message": "failed in decode_xml on the \"message\" field: field value is not a string"},
+			},
+			error:        true,
+			errorMessage: "field value is not a string",
+		},
+		{
+			description: "Test when the XML field not a string, IgnoreFailure true",
+			config: decodeXMLConfig{
+				Field:         "message",
+				IgnoreFailure: true,
+			},
+			Input: common.MapStr{
+				"message": 1,
+			},
+			Output: common.MapStr{
+				"message": 1,
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
+			f, err := newDecodeXML(test.config)
+			require.NoError(t, err)
+
+			event := &beat.Event{
+				Fields: test.Input,
+			}
+			newEvent, err := f.Run(event)
+			if !test.error {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), test.errorMessage)
+				}
+			}
+			assert.Equal(t, test.Output, newEvent.Fields)
+		})
+	}
+}
+
+func BenchmarkProcessor_Run(b *testing.B) {
+	c := defaultConfig()
+	target := "xml"
+	c.Target = &target
+	p, err := newDecodeXML(c)
+	require.NoError(b, err)
+
+	b.Run("single_object", func(b *testing.B) {
+		evt := &beat.Event{Fields: map[string]interface{}{
+			"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+					<author>William H. Gaddis</author>
+					<title>The Recognitions</title>
+					<review>One of the great seminal American novels of the 20th century.</review>
+				</book>
+				</catalog>`,
+		}}
+
+		for i := 0; i < b.N; i++ {
+			_, err = p.Run(evt)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("nested_and_array_object", func(b *testing.B) {
+		evt := &beat.Event{Fields: map[string]interface{}{
+			"message": `<?xml version="1.0"?>
+				<catalog>
+					<book>
+					<author>William H. Gaddis</author>
+					<title>The Recognitions</title>
+					<review>One of the great seminal American novels of the 20th century.</review>
+				</book>
+				<book>
+					<author>Ralls, Kim</author>
+					<title>Midnight Rain</title>
+					<review>Some review.</review>
+				</book>
+				<secondcategory>
+					<paper id="bk102">
+						<test2>Ralls, Kim</test2>
+						<description>A former architect battles corporate zombies, an evil sorceress, and her own childhood to become queen of the world.</description>
+					</paper>
+				</secondcategory>
+				</catalog>`,
+		}}
+
+		for i := 0; i < b.N; i++ {
+			_, err = p.Run(evt)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func TestXMLToDocumentID(t *testing.T) {
+	p, err := newDecodeXML(decodeXMLConfig{
+		Field:      "message",
+		DocumentID: "catalog.book.seq",
+	})
+	require.NoError(t, err)
+
+	input := common.MapStr{
+		"message": `<catalog>
+						<book seq="10">
+							<author>William H. Gaddis</author>
+							<title>The Recognitions</title>
+							<review>One of the great seminal American novels of the 20th century.</review>
+						</book>
+					</catalog>`,
+	}
+	actual, err := p.Run(&beat.Event{Fields: input})
+	require.NoError(t, err)
+
+	wantFields := common.MapStr{
+		"message": map[string]interface{}{
+			"catalog": map[string]interface{}{
+				"book": map[string]interface{}{
+					"author": "William H. Gaddis",
+					"review": "One of the great seminal American novels of the 20th century.",
+					"title":  "The Recognitions",
+				},
+			},
+		},
+	}
+	wantMeta := common.MapStr{
+		"_id": "10",
+	}
+
+	assert.Equal(t, wantFields, actual.Fields)
+	assert.Equal(t, wantMeta, actual.Meta)
+}

--- a/libbeat/processors/decode_xml/docs/decode_xml.asciidoc
+++ b/libbeat/processors/decode_xml/docs/decode_xml.asciidoc
@@ -1,0 +1,115 @@
+[[decode_xml]]
+=== Decode XML
+
+++++
+<titleabbrev>decode_xml</titleabbrev>
+++++
+
+experimental[]
+
+The `decode_xml` processor decodes XML data that is stored under the `field`
+key. It outputs the result into the `target_field`.
+
+This example demonstrates how to decode an XML string contained in the `message`
+field and write the resulting fields into the root of the document. Any fields
+that already exist will be overwritten.
+
+[source,yaml]
+-------
+processors:
+  - decode_xml:
+      field: message
+      target_field: ""
+      overwrite_keys: true
+-------
+
+By default any decoding errors that occur will stop the processing chain and the
+error will be added to `error.message` field. To ignore all errors and continue
+to the next processor you can set `ignore_failure: true`. To specifically
+ignore failures caused by `field` not existing use `ignore_missing`.
+
+[source,yaml]
+-------
+processors:
+  - decode_xml:
+      field: example
+      target_field: xml
+      ignore_missing: true
+      ignore_failure: true
+-------
+
+By default all keys converted from XML will have the names converted to
+lowercase. If there is a need to disable this behavior it is possible to use the
+below example:
+
+[source,yaml]
+-------
+processors:
+  - decode_xml:
+      field: message
+      target_field: xml
+      to_lower: false
+-------
+
+Example XML input:
+
+[source,xml]
+-------------------------------------------------------------------------------
+{
+  <catalog>
+    <book seq="1">
+      <author>William H. Gaddis</author>
+      <title>The Recognitions</title>
+      <review>One of the great seminal American novels of the 20th century.</review>
+    </book>
+  </catalog>
+}
+-------------------------------------------------------------------------------
+
+Will produce the following output:
+
+[source,json]
+-------------------------------------------------------------------------------
+{
+	"xml": {
+		"catalog": {
+			"book": {
+				"author": "William H. Gaddis",
+				"review": "One of the great seminal American novels of the 20th century.",
+				"seq": "1",
+				"title": "The Recognitions"
+			}
+		}
+	}
+}
+-------------------------------------------------------------------------------
+
+
+The supported configuration options are:
+
+`field`:: (Required) Source field containing the XML. Defaults to `message`.
+
+`target_field`:: (Optional) The field under which the decoded XML will be
+written. By default the decoded XML object replaces the field from which it was
+read. To merge the decoded XML fields into the root of the event specify
+`target_field` with an empty string (`target_field: ""`). Note that the `null`
+value (`target_field:`) is treated as if the field was not set at all.
+
+`overwrite_keys`:: (Optional) A boolean that specifies whether keys that already
+exist in the event are overwritten by keys from the decoded XML object. The
+default value is false.
+
+`to_lower`:: (Optional) Converts all keys to lowercase. Accepts either true or
+false. The default value is true.
+
+`document_id`:: (Optional) XML key to use as the document ID. If configured, the
+field will be removed from the original XML document and stored in
+`@metadata._id`.
+
+`ignore_missing`:: (Optional) If `true` the processor will not return an error
+when a specified field does not exist. Defaults to `false`.
+
+`ignore_failure`:: (Optional) Ignore all errors produced by the processor.
+Defaults to `false`.
+
+See <<conditions>> for a list of supported conditions.


### PR DESCRIPTION
Cherry-pick of PR #23678 to 7.x branch. Original message: 

## What does this PR do?

This PR adds 2 components to `Libbeat`.
1. It adds a small XML Unmarshal helper function to the `common` folder in `Libbeat`, the reason this is added is so that not only processors can utilize it if/when needed, but also inputs. For example I plan to reuse this in `http_endpoint` to add XML support there as well. Other beats/inputs that would benefit from this is `Winlogbeat`.
The helper function expects a `[]byte` with valid XML object(s), and will return it as a struct reusing the names of the XML object(s).
It supports lists, arrays, nested fields, object identifiers (for example `<book seq="1">`).
If the XML is not valid it will return a proper error message describing why it failed.
For more information on supported formats, please see the included unit test files.

2. Second component is a `decode_xml` processor, **this is the first processor I made, so please review it carefully**. I have used `urldecode`, `mime_type` and the `decode_json_fields` processor as a guideline for this one.
For the supported objects and more information on supported formats, please see the included unit test files.

## Why is it important?

This adds the possibility to read XML files for file/log input, or decoding XML strings in existing message fields, for example XML strings in existing JSON fields.
Implements an easy helper function for other parts of beats to reuse if they want to Unmarshal XML into a struct.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #23366 
