### PR TITLE
Cherry-pick #24055 to 7.x: Fix reloading of log level for services 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@
 - Fixed make status readable in the log. {pull}23849[23849]
 - Fixed Monitoring filebeat and metricbeat not connecting to Agent over GRPC {pull}23843[23843]
 - Windows agent doesn't uninstall with a lowercase `c:` drive in the path {pull}23998[23998]
+- Fix reloading of log level for services {pull}[24055]24055
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic-endpoint-security.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic-endpoint-security.yml
@@ -2,6 +2,7 @@ revision: 5
 fleet:
   agent:
     id: fleet-agent-id
+    logging.level: error
   host:
     id: host-agent-id
   api:

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/endpoint_basic.yml
@@ -3,6 +3,7 @@ name: Endpoint Host
 fleet:
   agent:
     id: fleet-agent-id
+    logging.level: error
   host:
     id: host-agent-id
   access_api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw

--- a/x-pack/elastic-agent/pkg/config/config.go
+++ b/x-pack/elastic-agent/pkg/config/config.go
@@ -116,6 +116,12 @@ func NewConfigFrom(from interface{}, opts ...interface{}) (*Config, error) {
 	}
 	if len(skippedKeys) > 0 {
 		err = cfg.Merge(skippedKeys, ucfg.ResolveNOOP)
+
+		// we modified incoming object
+		// cleanup so skipped keys are not missing
+		for k, v := range skippedKeys {
+			data[k] = v
+		}
 	}
 	return newConfigFrom(cfg), err
 }


### PR DESCRIPTION
Cherry-pick of PR #24055 to 7.x branch. Original message:

## What does this PR do?

This PR fixes 2 things.

First one is an issue introduced in #23886, this caused that `VarSkipKey` removed key from Action which was then stored using Ack and Store. This action was `input`-less so after restart agent was not running anything and it thought it;s ok because preserved state id is same as the one from fleet. 
This one I discovered without filing an issue

Second one is bug described in #23720. The issue here is that agent creates a server with own counter, set to 1. But service already has a config with state counter. So if we change log level and restart an agent counter is 1 which == to the counter in a service and agent thinks everything is up to date. 
Fix is that we take counter from a service and if it's > 0, which means services already retrieved some configuration we force reload of config by incrementing our local counter to `what_service_has + 1`

## Why is it important?

Fixes bugs

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
