### PR TITLE
Fix jolokia downloads in 6.8

### DIFF
--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -20,8 +20,6 @@ stages:
           make check-no-changes;
     build:
         make: "RACE_DETECTOR=1 make -C metricbeat check testsuite integration-tests-environment"
-        when:
-            disabled: true     ## Disabled since Integration Testing is broken. See https://github.com/elastic/beats/issues/21961
     crosscompile:
         make: "make -C metricbeat crosscompile"
     windows:

--- a/metricbeat/module/jolokia/_meta/Dockerfile
+++ b/metricbeat/module/jolokia/_meta/Dockerfile
@@ -5,22 +5,22 @@ ENV TOMCAT_VERSION 7.0.86
 ENV TC apache-tomcat-${TOMCAT_VERSION}
 ENV JOLOKIA_VERSION 1.5.0
 
-RUN apk update;\
-    apk add curl
+RUN apk update && \
+    apk add curl openssl ca-certificates
 
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f localhost:8778/jolokia/
 EXPOSE 8778
 
 # Prepare a server where jolokia runs in proxy mode
-RUN wget http://archive.apache.org/dist/tomcat/tomcat-7/v${TOMCAT_VERSION}/bin/${TC}.tar.gz;\
-    tar xzf ${TC}.tar.gz -C /usr;\
-    rm ${TC}.tar.gz;\
-    sed -i -e 's/Connector port="8080"/Connector port="8778"/g' /usr/${TC}/conf/server.xml;\
-    wget http://central.maven.org/maven2/org/jolokia/jolokia-war/${JOLOKIA_VERSION}/jolokia-war-${JOLOKIA_VERSION}.war -O /usr/${TC}/webapps/jolokia.war
+RUN wget http://archive.apache.org/dist/tomcat/tomcat-7/v${TOMCAT_VERSION}/bin/${TC}.tar.gz && \
+    tar xzf ${TC}.tar.gz -C /usr && \
+    rm ${TC}.tar.gz && \
+    sed -i -e 's/Connector port="8080"/Connector port="8778"/g' /usr/${TC}/conf/server.xml && \
+    wget https://oss.sonatype.org/content/repositories/releases/org/jolokia/jolokia-war/${JOLOKIA_VERSION}/jolokia-war-${JOLOKIA_VERSION}.war -O /usr/${TC}/webapps/jolokia.war
 
 # JMX setting to request authentication with remote connection
-RUN echo "monitorRole QED" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/management/jmxremote.password;\
-    echo "controlRole R&D" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/management/jmxremote.password;\
+RUN echo "monitorRole QED" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/management/jmxremote.password && \
+    echo "controlRole R&D" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/management/jmxremote.password && \
     chmod 600 /usr/lib/jvm/java-1.8-openjdk/jre/lib/management/jmxremote.password
 
 ADD jolokia.xml /usr/${TC}/conf/Catalina/localhost/jolokia.xml

--- a/metricbeat/module/jolokia/_meta/Dockerfile
+++ b/metricbeat/module/jolokia/_meta/Dockerfile
@@ -6,7 +6,7 @@ ENV TC apache-tomcat-${TOMCAT_VERSION}
 ENV JOLOKIA_VERSION 1.5.0
 
 RUN apk update && \
-    apk add curl openssl ca-certificates
+    apk add curl openssl ca-certificates bash
 
 HEALTHCHECK --interval=1s --retries=90 CMD curl -f localhost:8778/jolokia/
 EXPOSE 8778
@@ -16,7 +16,9 @@ RUN wget http://archive.apache.org/dist/tomcat/tomcat-7/v${TOMCAT_VERSION}/bin/$
     tar xzf ${TC}.tar.gz -C /usr && \
     rm ${TC}.tar.gz && \
     sed -i -e 's/Connector port="8080"/Connector port="8778"/g' /usr/${TC}/conf/server.xml && \
-    wget https://oss.sonatype.org/content/repositories/releases/org/jolokia/jolokia-war/${JOLOKIA_VERSION}/jolokia-war-${JOLOKIA_VERSION}.war -O /usr/${TC}/webapps/jolokia.war
+    curl -J -L -s -f -o - https://github.com/kadwanev/retry/releases/download/1.0.1/retry-1.0.1.tar.gz | tar xfz - -C /usr/local/bin && \
+    retry --min 1 --max 180 -- curl -J -L -s -f --show-error -o /usr/${TC}/webapps/jolokia.war \
+        "https://oss.sonatype.org/content/repositories/releases/org/jolokia/jolokia-war/${JOLOKIA_VERSION}/jolokia-war-${JOLOKIA_VERSION}.war"
 
 # JMX setting to request authentication with remote connection
 RUN echo "monitorRole QED" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/management/jmxremote.password && \


### PR DESCRIPTION
Backports #12707 and #13201 to fix build of jolokia docker image in 6.8.

Fixes #21961.