### PR TITLE
[CI] install docker-compose with retry

### DIFF
--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -23,11 +23,12 @@ DC_CMD="${HOME}/bin/docker-compose"
 
 mkdir -p "${HOME}/bin"
 
-if ! curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" ; then
+if curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" ; then
+    chmod +x "${DC_CMD}"
+else
+    echo "Something bad with the download, let's delete the corrupted binary"
     if [ -e "${DC_CMD}" ] ; then
         rm "${DC_CMD}"
     fi
     exit 1
-else
-    chmod +x "${DC_CMD}"
 fi

--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -23,5 +23,11 @@ DC_CMD="${HOME}/bin/docker-compose"
 
 mkdir -p "${HOME}/bin"
 
-curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
-chmod +x "${DC_CMD}"
+if ! curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" ; then
+    if [ -e "${DC_CMD}" ] ; then
+        rm "${DC_CMD}"
+    fi
+    exit 1
+else
+    chmod +x "${DC_CMD}"
+fi


### PR DESCRIPTION
## What does this PR do?

Remove corrupted binary if it failed to download it.

## Why is it important?

When installing `docker-compose` if it failed the very first attempt then the binary it might be corrupted and the retries will fail over and over

## Fixes

```
[2021-02-16T14:17:03.541Z] + echo 'Found docker-compose. Checking version..'
[2021-02-16T14:17:03.541Z] Found docker-compose. Checking version..
[2021-02-16T14:17:03.541Z] ++ docker-compose --version
[2021-02-16T14:17:03.541Z] ++ awk '{print $3}'
[2021-02-16T14:17:03.541Z] ++ sed s/,//
[2021-02-16T14:17:03.541Z] [2802] Cannot open self /var/lib/jenkins/workspace/Beats_beats_PR-24041/bin/docker-compose or archive /var/lib/jenkins/workspace/Beats_beats_PR-24041/bin/docker-compose.pkg
[2021-02-16T14:17:03.541Z] + FOUND_DOCKER_COMPOSE_VERSION=
script returned exit code 255

```

![image](https://user-images.githubusercontent.com/2871786/108102575-9dc52580-7080-11eb-95a2-0505c999a343.png)
