### PR TITLE
Cherry-pick #18992 to 7.x: Fix typo in netflow module docs

### DIFF
--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -44,7 +44,7 @@ traffic from network devices.
       netflow_port: 2055
 -----
 
-`var.netflow_host`:: Address to find to. Defaults to `localhost`.
+`var.netflow_host`:: Address to bind to. Defaults to `localhost`.
 
 `var.netflow_port`:: Port to listen on. Defaults to `2055`.
 

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -39,7 +39,7 @@ traffic from network devices.
       netflow_port: 2055
 -----
 
-`var.netflow_host`:: Address to find to. Defaults to `localhost`.
+`var.netflow_host`:: Address to bind to. Defaults to `localhost`.
 
 `var.netflow_port`:: Port to listen on. Defaults to `2055`.
 


### PR DESCRIPTION
Cherry-pick of PR #18992 to 7.x branch. Original message: 

## What does this PR do?

Fixes typo in netflow config documentation (s/find/bind/).

## Why is it important?

Sloppy spelling gives bad impression for Elastic.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.