### PR TITLE
Cherry-pick #24052 to 7.x: Add nodes to filebeat-kubernetes.yaml ClusterRole - fixes #24051

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix parsing issues with nested JSON payloads in Elasticsearch audit log fileset. {pull}22975[22975]
 - Rename `network.direction` values in crowdstrike/falcon to `ingress`/`egress`. {pull}23041[23041]
 - Rename `s3` input to `aws-s3` input. {pull}23469[23469]
+- Add `nodes` to filebeat-kubernetes.yaml ClusterRole. {issue}24051[24051] {pull}24052[24052]
 
 *Heartbeat*
 

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -151,6 +151,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - nodes
   verbs:
   - get
   - watch

--- a/deploy/kubernetes/filebeat/filebeat-role.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - namespaces
   - pods
+  - nodes
   verbs:
   - get
   - watch


### PR DESCRIPTION
Cherry-pick of PR #24052 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds `nodes` to the fileabeat ClusterRole.
Fixes https://github.com/elastic/beats/issues/24051

## Why is it important?

Filebeat will throw an error and be unable to list nodes without this.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally

Deploy Filebeat from the latest manifest in the docs:
https://www.elastic.co/guide/en/beats/filebeat/7.11/running-on-kubernetes.html
curl -L -O https://raw.githubusercontent.com/elastic/beats/7.11/deploy/kubernetes/filebeat-kubernetes.yaml

Use the autodiscover config by doing the following:
    # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:

Filebeat starts up and is unable to list nodes:
>E0215 03:45:32.109053       7 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.4/tools/cache/reflector.go:156: Failed to watch *v1.Node: failed to list *v1.Node: nodes "k3s-01a.spahr.dev" is forbidden: User "system:serviceaccount:bourbontracker:filebeat" cannot list resource "nodes" in API group "" at the cluster scope
>E0215 03:45:33.243209       7 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.4/tools/cache/reflector.go:156: Failed to watch *v1.Node: failed to list *v1.Node: nodes "k3s-01a.spahr.dev" is forbidden: User "system:serviceaccount:bourbontracker:filebeat" cannot list resource "nodes" in API group "" at the cluster scope

This error goes away after adding `nodes` to the ClusterRole.

## Related issues

- Closes #24051

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

Logs without the change:
>E0215 03:45:32.109053       7 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.4/tools/cache/reflector.go:156: Failed to watch *v1.Node: failed to list *v1.Node: nodes "k3s-01a.spahr.dev" is forbidden: User "system:serviceaccount:bourbontracker:filebeat" cannot list resource "nodes" in API group "" at the cluster scope
>E0215 03:45:33.243209       7 reflector.go:127] pkg/mod/k8s.io/client-go@v0.19.4/tools/cache/reflector.go:156: Failed to watch *v1.Node: failed to list *v1.Node: nodes "k3s-01a.spahr.dev" is forbidden: User "system:serviceaccount:bourbontracker:filebeat" cannot list resource "nodes" in API group "" at the cluster scope

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
