### PR TITLE
Cherry-pick to 7.11: [CI] install docker-compose with retry (#24069)

### DIFF
--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -9,5 +9,12 @@ DC_CMD="${HOME}/bin/docker-compose"
 
 mkdir -p "${HOME}/bin"
 
-curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
-chmod +x "${DC_CMD}"
+if curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" ; then
+    chmod +x "${DC_CMD}"
+else
+    echo "Something bad with the download, let's delete the corrupted binary"
+    if [ -e "${DC_CMD}" ] ; then
+        rm "${DC_CMD}"
+    fi
+    exit 1
+fi


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [CI] install docker-compose with retry (#24069)