### PR TITLE
Adjust the position of the architecture name in Dockerlogbeat tarball

### DIFF
--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -320,7 +320,7 @@ func Export() error {
 
 	for _, plat := range devtools.Platforms {
 		arch := plat.GOARCH()
-		tarballName := fmt.Sprintf("%s-%s-%s-%s.tar.gz", logDriverName, version, arch, "docker-plugin")
+		tarballName := fmt.Sprintf("%s-%s-%s-%s.tar.gz", logDriverName, version, "docker-plugin", arch)
 
 		outpath := filepath.Join("../..", packageEndDir, tarballName)
 


### PR DESCRIPTION
## What does this PR do?

Previously the Dockerlogbeat tarball produced by `mage package` contained the architecture information in the wrong position. Thus, the release manager could not find the build artifact.

Expected name by RM: `elastic-logging-plugin-8.0.0-SNAPSHOT-docker-plugin-amd64.tar.gz`

## Why is it important?

Release job of beats is failing.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
