### PR TITLE
Add unit tests for harvester.go of input-logfile package

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	HarvesterAlreadyRunning = errors.New("harvester is already running for file")
+	ErrHarvesterAlreadyRunning = errors.New("harvester is already running for file")
 )
 
 // Harvester is the reader which collects the lines from
@@ -71,7 +71,7 @@ func (r *readerGroup) newContext(id string, cancelation v2.Canceler) (context.Co
 	defer r.mu.Unlock()
 
 	if _, ok := r.table[id]; ok {
-		return nil, nil, HarvesterAlreadyRunning
+		return nil, nil, ErrHarvesterAlreadyRunning
 	}
 
 	ctx, cancel := context.WithCancel(ctxtool.FromCanceller(cancelation))

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -93,6 +93,14 @@ func (r *readerGroup) remove(id string) {
 	delete(r.table, id)
 }
 
+func (r *readerGroup) isIDAdded(id string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, ok := r.table[id]
+	return ok
+}
+
 // HarvesterGroup is responsible for running the
 // Harvesters started by the Prospector.
 type HarvesterGroup interface {

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -19,6 +19,7 @@ package input_logfile
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime/debug"
 	"sync"
@@ -30,6 +31,10 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-concert/ctxtool"
 	"github.com/elastic/go-concert/unison"
+)
+
+var (
+	HarvesterAlreadyRunning = errors.New("harvester is already running for file")
 )
 
 // Harvester is the reader which collects the lines from
@@ -66,7 +71,7 @@ func (r *readerGroup) newContext(id string, cancelation v2.Canceler) (context.Co
 	defer r.mu.Unlock()
 
 	if _, ok := r.table[id]; ok {
-		return nil, nil, fmt.Errorf("harvester is already running for file")
+		return nil, nil, HarvesterAlreadyRunning
 	}
 
 	ctx, cancel := context.WithCancel(ctxtool.FromCanceller(cancelation))

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -93,7 +93,7 @@ func (r *readerGroup) remove(id string) {
 	delete(r.table, id)
 }
 
-func (r *readerGroup) isIDAdded(id string) bool {
+func (r *readerGroup) hasID(id string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/libbeat/tests/resources/goroutines.go
+++ b/libbeat/tests/resources/goroutines.go
@@ -90,16 +90,8 @@ func (c GoroutinesChecker) WaitUntilOriginalCount() int {
 	return after
 }
 
-func (c *GoroutinesChecker) RunFuncWhenNewGoroutinesAreStarted(f func()) {
-	for runtime.NumGoroutine() == c.before {
-		time.Sleep(10 * time.Millisecond)
-	}
-	f()
-}
-
 func (c *GoroutinesChecker) WaitUntilIncreased(n int) {
 	for runtime.NumGoroutine() < c.before+n {
-		fmt.Println("before", c.before+n, "now", runtime.NumGoroutine())
 		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/libbeat/tests/resources/goroutines.go
+++ b/libbeat/tests/resources/goroutines.go
@@ -94,6 +94,12 @@ func (c *GoroutinesChecker) RunFuncWhenNewGoroutinesAreStarted(f func()) {
 	for runtime.NumGoroutine() == c.before {
 		time.Sleep(10 * time.Millisecond)
 	}
-	fmt.Println("vege")
 	f()
+}
+
+func (c *GoroutinesChecker) WaitUntilIncreased(n int) {
+	for runtime.NumGoroutine() < c.before+n {
+		fmt.Println("before", c.before+n, "now", runtime.NumGoroutine())
+		time.Sleep(10 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds unit tests for `readerGroup` and `defaultHarvesterGroup` of the `filestream` input.

It also creates a separate error for if a Harvester is already running for a source.

## Why is it important?

Test coverage for `harvester.go` is increased from 0% to 98.4%.

Overall coverage of `github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile`  is increased from 47.4% to 64.8%.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~