### PR TITLE
Cherry-pick to 7.x: [CI] enable x-pack/heartbeat in the CI (#23873)

### DIFF
--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -13,6 +13,63 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
+    Lint:
+        make: |
+          make -C x-pack/heartbeat check;
+          make -C x-pack/heartbeat update;
+          make -C heartbeat check;
+          make -C heartbeat update;
+          make check-no-changes;
+    build:
+        mage: "mage build test"
+    macos:
+        mage: "mage build test"
+        platforms:             ## override default label in this specific stage.
+          - "macosx"
+        when:                  ## Override the top-level when.
+            comments:
+                - "/test x-pack/heartbeat for macos"
+            labels:
+                - "macOS"
+            parameters:
+                - "macosTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
+# TODO: there are windows test failures already reported
+# https://github.com/elastic/beats/issues/23957 and https://github.com/elastic/beats/issues/23958
+# waiting for being fixed.
+#    windows:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-2019"
+#    windows-2016:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-2016"
+#    windows-2012:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-2012-r2"
+#    windows-10:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-10"
+#    windows-2008:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-2008-r2"
+#    windows-8:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-8"
+#    windows-7:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-7"
+#    windows-7-32:
+#        mage: "mage build test"
+#        platforms:             ## override default labels in this specific stage.
+#            - "windows-7-32-bit"
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/x-pack/heartbeat/magefile.go
+++ b/x-pack/heartbeat/magefile.go
@@ -23,6 +23,8 @@ import (
 	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
+	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/integtest/notests"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] enable x-pack/heartbeat in the CI (#23873)