### PR TITLE
Set Elastic licence type for APM server Beats update job

### DIFF
--- a/.ci/apm-beats-update.groovy
+++ b/.ci/apm-beats-update.groovy
@@ -127,6 +127,7 @@ def beatsUpdate() {
         git config --global --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
 
         go mod edit -replace github.com/elastic/beats/v7=\${GOPATH}/src/github.com/elastic/beats-local
+        echo '{"name": "\${GOPATH}/src/github.com/elastic/beats-local", "licenceType": "Elastic"}' >> \${GOPATH}/src/github.com/elastic/beats-local/dev-tools/notice/overrides.json
         make update
         git commit -a -m beats-update
 


### PR DESCRIPTION
## What does this PR do?

Adds a new licence override temporarily when testing if Beats can be updated in APM Server.

## Why is it important?

We get the following error in the Beats update job:

```
Failed to detect licences: failed to detect licence type of /var/lib/jenkins/workspace/Beats_apm-beats-update_master/src/github.com/elastic/beats-local from /var/lib/jenkins/workspace/Beats_apm-beats-update_master/src/github.com/elastic/beats-local/LICENSE.txt:
failed to detect licence type of /var/lib/jenkins/workspace/Beats_apm-beats-update_master/src/github.com/elastic/beats-local/LICENSE.txt
```