### PR TITLE
[CI] Run if manual build for the apm-beats-update

### DIFF
--- a/.ci/apm-beats-update.groovy
+++ b/.ci/apm-beats-update.groovy
@@ -86,10 +86,9 @@ pipeline {
               branch "v\\d?"
               tag "v\\d+\\.\\d+\\.\\d+*"
               allOf {
-                expression { return env.BEATS_UPDATED != "false" || isCommentTrigger() }
+                expression { return env.BEATS_UPDATED != "false" || isCommentTrigger() || isUserTrigger() }
                 changeRequest()
               }
-
             }
           }
           steps {


### PR DESCRIPTION
## What does this PR do?

Exclude UI interactions when running the `apm-beats-update` pipeline

## Why is it important?

It did not trigger the required stage :/

![image](https://user-images.githubusercontent.com/2871786/108403061-3640de80-7216-11eb-9935-83e77a79fce9.png)
