### PR TITLE
Cherry-pick #24120 to 7.x: Add logrotation section on Running Filebeat on k8s

### DIFF
--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -218,3 +218,12 @@ annotations:
     co.elastic.logs.json-logging/json.add_error_key: "true"
     co.elastic.logs.json-logging/json.message_key: "message"
 ------------------------------------------------
+
+[float]
+==== Logrotation
+
+According to https://kubernetes.io/docs/concepts/cluster-administration/logging/#logging-at-the-node-level[kubernetes documentation]
+_Kubernetes is not responsible for rotating logs, but rather a deployment tool should set up a solution to address that_.
+Different logrotation strategies can cause issues that might make Filebeat losing events or even duplicating events.
+Users can find more information about Filebeat's logrotation best practises at Filebeat's
+<<file-log-rotation,log rotation specific documentation>>


### PR DESCRIPTION
Cherry-pick of PR #24120 to 7.x branch. Original message: 

## What does this PR do?
This PR adds logrotation section on docs about `Running Filebeat on Kubernetes`. This is part of [action items](https://github.com/elastic/obs-dc-team/issues/424#issuecomment-781345030) to cover logrotation issues occurring to users running Filebeat on Kubernetes.

## Why is it important?
Users that are not aware of logrotation on their k8s clusters might face issue with lost or duplicate events.

@jsoriano @kvch let me know what you think.