### PR TITLE
Cherry-pick #24128 to 7.12: Fix: Successfully installed and enrolled agent running standalone

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@
 - Fixed Monitoring filebeat and metricbeat not connecting to Agent over GRPC {pull}23843[23843]
 - Windows agent doesn't uninstall with a lowercase `c:` drive in the path {pull}23998[23998]
 - Fix reloading of log level for services {pull}[24055]24055
+- Fix: Successfully installed and enrolled agent running standalone{pull}[24128]24128
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -84,7 +84,6 @@ type EnrollCmdOption struct {
 	Staging              string
 	FleetServerConnStr   string
 	FleetServerPolicyID  string
-	NoRestart            bool
 }
 
 func (e *EnrollCmdOption) kibanaConfig() (*kibana.Config, error) {
@@ -178,16 +177,11 @@ func (c *EnrollCmd) Execute(ctx context.Context) error {
 		// enroll should use localhost as fleet-server is now running
 		// it must also restart
 		c.options.URL = "http://localhost:8000"
-		c.options.NoRestart = false
 	}
 
 	err := c.enrollWithBackoff(ctx)
 	if err != nil {
 		return errors.New(err, "fail to enroll")
-	}
-
-	if c.options.NoRestart {
-		return nil
 	}
 
 	if c.daemonReload(ctx) != nil {

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -38,7 +38,6 @@ func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStr
 
 	addEnrollFlags(cmd)
 	cmd.Flags().BoolP("force", "f", false, "Force overwrite the current and do not prompt for confirmation")
-	cmd.Flags().Bool("no-restart", false, "Skip restarting the currently running daemon")
 
 	// used by install command
 	cmd.Flags().BoolP("from-install", "", false, "Set by install command to signal this was executed from install")
@@ -141,11 +140,9 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		}
 	}
 
-	noRestart, _ := cmd.Flags().GetBool("no-restart")
 	force, _ := cmd.Flags().GetBool("force")
 	if fromInstall {
 		force = true
-		noRestart = true
 	}
 
 	// prompt only when it is not forced and is already enrolled
@@ -192,7 +189,6 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		Staging:              staging,
 		FleetServerConnStr:   fServer,
 		FleetServerPolicyID:  fPolicy,
-		NoRestart:            noRestart,
 	}
 
 	c, err := application.NewEnrollCmd(


### PR DESCRIPTION
Cherry-pick of PR #24128 to 7.12 branch. Original message:

## What does this PR do?

In #23865 there was a change in order of starting a service and enrollment itself.
Installation procedure first enrolled agent and then started a service.

With the change introduced we first start a service in standalone mode and then enroll to fleet/fleet-server if needed. 
This lead into race which either did not manifest or manifested as agent with fleet config in it's directory running standalone 

During enrollment there was a check if it originates in `install` command and if so restart is not performed. This check is no longer needed and restart needs to be performed every time.

Manifested as what we thought of as flaky-ness in e2e

## Why is it important?

Successfully installed and enrolled agent running standalone

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
