### PR TITLE
Cherry-pick to 7.x: chore: comment out the E2E (#24109)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -247,6 +247,7 @@ pipeline {
             }
           }
         }
+        /*
         stage('Run E2E Tests for Packages'){
           agent { label 'ubuntu-18 && immutable' }
           options { skipDefaultCheckout() }
@@ -254,6 +255,7 @@ pipeline {
             runE2ETests()
           }
         }
+        */
       }
       post {
         success {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore: comment out the E2E (#24109)