### PR TITLE
[Heartbeat] Add retry logic for http check

### DIFF
--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	ProxyURL     string         `config:"proxy_url"`
 	Timeout      time.Duration  `config:"timeout"`
 	MaxRedirects int            `config:"max_redirects"`
+	MaxRetries   int            `config:"max_retries"`
 	Response     responseConfig `config:"response"`
 
 	Mode monitors.IPSettings `config:",inline"`
@@ -93,6 +94,7 @@ type compressionConfig struct {
 var defaultConfig = Config{
 	Timeout:      16 * time.Second,
 	MaxRedirects: 0,
+	MaxRetries:   0,
 	Response: responseConfig{
 		IncludeBody:         "on_error",
 		IncludeBodyMaxBytes: 2048,

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -232,11 +232,12 @@ func execPing(
 	responseConfig responseConfig,
 ) (start, end time.Time, err reason.Reason) {
 	var (
-		ctx       context.Context
-		cancel    context.CancelFunc
-		errReason reason.Reason
-		retries   int
+		ctx     context.Context
+		cancel  context.CancelFunc
+		retries int
 	)
+	// initial start
+	start = time.Now()
 	// default retries is 0, that means there's no retry by default
 	if maxRetries <= 0 {
 		retries = 0
@@ -279,6 +280,8 @@ func execPing(
 		}
 
 		bodyFields, mimeType, errReason := processBody(resp, responseConfig, validator)
+		// overwrite the func scope err with errReason, that can return the real err
+		err = errReason
 
 		responseFields := common.MapStr{
 			"status_code": resp.StatusCode,
@@ -329,7 +332,9 @@ func execPing(
 	if cancel != nil {
 		cancel()
 	}
-	return start, end, errReason
+	// initial end
+	end = time.Now()
+	return start, end, err
 }
 
 func attachRequestBody(ctx *context.Context, req *http.Request, body []byte) *http.Request {


### PR DESCRIPTION
## What does this PR do?

Add new parameter `max_retries` the same level as `max_redirects` to support retry logic for http check.

## Why is it important?
Currently, there's no retry logic for http check in Heartbeat.
However, there could be some http check failures happen if only a single http check in case:

the number of http check targets is huge;
there's a network jitter;
the target is not ready in the first round check.

## Checklist

- [*] My code follows the style guidelines of this project
- [*] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [*] I have made corresponding change to the default configuration files
- [*] I have added tests that prove my fix is effective or that my feature works
- [] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
https://github.com/elastic/beats/issues/24148

## Use cases

1. by default, the `max_retries` will be 0, like `max_redirects`, that means there's only a single http check happening without retries by default.
2. Heartbeat will try only 1 time if the target `http://127.0.0.1:80` is reachable whereas HB will try 3 times by total when the target is unreachable and `max_retries` is 2 from HB config like the following:
```
- type: http
  schedule: 36 * * * * * *
  hosts:
    - http://127.0.0.1:80
  check.request:
    method: GET
  check.response:
    status:
    - 200
    - 201
  timeout: 10s
  max_redirects: 2
  max_retries: 3
```