### PR TITLE
Cherry-pick #24152 to 7.x: indicator type url is in upper case

### DIFF
--- a/x-pack/filebeat/module/threatintel/otx/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/otx/ingest/pipeline.yml
@@ -89,7 +89,7 @@ processors:
     field: threatintel.otx.indicator
     target_field: threatintel.indicator.url.full
     ignore_missing: true
-    if: "ctx?.threatintel?.otx?.type == 'url' && ctx?.threatintel?.indicator?.url?.original == null"
+    if: "ctx?.threatintel?.otx?.type == 'URL' && ctx?.threatintel?.indicator?.url?.original == null"
 - rename:
     field: threatintel.otx.indicator
     target_field: threatintel.indicator.url.path


### PR DESCRIPTION
Cherry-pick of PR #24152 to 7.x branch. Original message: 

## What does this PR do?

Small fix to OTX url indicators for the new TI module

## Why is it important?

Small fix to OTX url indicators for the new TI module

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

