### PR TITLE
Empty configuration options generate `<no value>` string for azure-eventhub input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -281,6 +281,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change the `event.created` in Netflow events to be the time the event was created by Filebeat
   to be consistent with ECS. {pull}23094[23094]
 - Update `filestream` reader offset when a line is skipped. {pull}23417[23417]
+- Add check for empty values in azure module. {pull}24156[24156]
 
 *Filebeat*
 

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -33,7 +33,7 @@ func (conf *azureInputConfig) Validate() error {
 		return errors.New("no event hub name configured")
 	}
 	if conf.SAName == "" || conf.SAKey == "" {
-		return errors.New("missing storage account information")
+		return errors.New("no storage account or storage account key configured")
 	}
 	if conf.SAContainer == "" {
 		conf.SAContainer = fmt.Sprintf("%s-%s", ephContainerName, conf.EventHubName)

--- a/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
@@ -1,11 +1,29 @@
 type: azure-eventhub
-connection_string: {{ .connection_string }}
+{{ if .eventhub }}
 eventhub: {{ .eventhub }}
-consumer_group: {{ .consumer_group }}
-storage_account: {{ .storage_account }}
-storage_account_key: {{ .storage_account_key }}
-resource_manager_endpoint: {{ .resource_manager_endpoint }}
 storage_account_container: filebeat-activitylogs-{{ .eventhub }}
+{{ end }}
+
+{{ if .connection_string }}
+connection_string: {{ .connection_string }}
+{{ end }}
+
+{{ if .consumer_group }}
+consumer_group: {{ .consumer_group }}
+{{ end }}
+
+{{ if .storage_account }}
+storage_account: {{ .storage_account }}
+{{ end }}
+
+{{ if .storage_account_key }}
+storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .resource_manager_endpoint }}
+resource_manager_endpoint: {{ .resource_manager_endpoint }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
@@ -1,11 +1,29 @@
 type: azure-eventhub
-connection_string: {{ .connection_string }}
+{{ if .eventhub }}
 eventhub: {{ .eventhub }}
-consumer_group: {{ .consumer_group }}
-storage_account: {{ .storage_account }}
-storage_account_key: {{ .storage_account_key }}
-resource_manager_endpoint: {{ .resource_manager_endpoint }}
 storage_account_container: filebeat-auditlogs-{{ .eventhub }}
+{{ end }}
+
+{{ if .connection_string }}
+connection_string: {{ .connection_string }}
+{{ end }}
+
+{{ if .consumer_group }}
+consumer_group: {{ .consumer_group }}
+{{ end }}
+
+{{ if .storage_account }}
+storage_account: {{ .storage_account }}
+{{ end }}
+
+{{ if .storage_account_key }}
+storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .resource_manager_endpoint }}
+resource_manager_endpoint: {{ .resource_manager_endpoint }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 processors:

--- a/x-pack/filebeat/module/azure/platformlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/platformlogs/config/azure-eventhub.yml
@@ -1,11 +1,29 @@
 type: azure-eventhub
-connection_string: {{ .connection_string }}
+{{ if .eventhub }}
 eventhub: {{ .eventhub }}
-consumer_group: {{ .consumer_group }}
-storage_account: {{ .storage_account }}
-storage_account_key: {{ .storage_account_key }}
-resource_manager_endpoint: {{ .resource_manager_endpoint }}
 storage_account_container: filebeat-platformlogs-{{ .eventhub }}
+{{ end }}
+
+{{ if .connection_string }}
+connection_string: {{ .connection_string }}
+{{ end }}
+
+{{ if .consumer_group }}
+consumer_group: {{ .consumer_group }}
+{{ end }}
+
+{{ if .storage_account }}
+storage_account: {{ .storage_account }}
+{{ end }}
+
+{{ if .storage_account_key }}
+storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .resource_manager_endpoint }}
+resource_manager_endpoint: {{ .resource_manager_endpoint }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
@@ -1,11 +1,29 @@
 type: azure-eventhub
-connection_string: {{ .connection_string }}
+{{ if .eventhub }}
 eventhub: {{ .eventhub }}
-consumer_group: {{ .consumer_group }}
-storage_account: {{ .storage_account }}
-storage_account_key: {{ .storage_account_key }}
-resource_manager_endpoint: {{ .resource_manager_endpoint }}
 storage_account_container: filebeat-signinlogs-{{ .eventhub }}
+{{ end }}
+
+{{ if .connection_string }}
+connection_string: {{ .connection_string }}
+{{ end }}
+
+{{ if .consumer_group }}
+consumer_group: {{ .consumer_group }}
+{{ end }}
+
+{{ if .storage_account }}
+storage_account: {{ .storage_account }}
+{{ end }}
+
+{{ if .storage_account_key }}
+storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .resource_manager_endpoint }}
+resource_manager_endpoint: {{ .resource_manager_endpoint }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 processors:


### PR DESCRIPTION
## What does this PR do?

makes sure to provide empty string values when input configuration is validated

## Why is it important?

`<no value>` string is sent instead of empty value and sometimes passes required validation

## Checklist

<!-- Mandatory

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

