### PR TITLE
Add Agent  example input autodiscover config for standalone k8s

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
@@ -313,6 +313,31 @@ data:
               - 'https://${env.NODE_NAME}:10250'
             period: 10s
             ssl.verification_mode: none
+      # Add extra input blocks here, based on conditions
+      # so as to automatically identify targeted Pods and start monitoring them
+      # using a predefined integration. For instance:
+      #- name: redis
+      #  type: redis/metrics
+      #  use_output: default
+      #  meta:
+      #    package:
+      #      name: redis
+      #      version: 0.3.6
+      #  data_stream:
+      #    namespace: default
+      #  streams:
+      #    - data_stream:
+      #        dataset: redis.info
+      #        type: metrics
+      #      metricsets:
+      #        - info
+      #      hosts:
+      #        - '${kubernetes.pod.ip}:6379'
+      #      idle_timeout: 20s
+      #      maxconn: 10
+      #      network: tcp
+      #      period: 10s
+      #      condition: ${kubernetes.pod.labels.app} == 'redis'
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -229,3 +229,28 @@ data:
               - 'https://${env.NODE_NAME}:10250'
             period: 10s
             ssl.verification_mode: none
+      # Add extra input blocks here, based on conditions
+      # so as to automatically identify targeted Pods and start monitoring them
+      # using a predefined integration. For instance:
+      #- name: redis
+      #  type: redis/metrics
+      #  use_output: default
+      #  meta:
+      #    package:
+      #      name: redis
+      #      version: 0.3.6
+      #  data_stream:
+      #    namespace: default
+      #  streams:
+      #    - data_stream:
+      #        dataset: redis.info
+      #        type: metrics
+      #      metricsets:
+      #        - info
+      #      hosts:
+      #        - '${kubernetes.pod.ip}:6379'
+      #      idle_timeout: 20s
+      #      maxconn: 10
+      #      network: tcp
+      #      period: 10s
+      #      condition: ${kubernetes.pod.labels.app} == 'redis'


### PR DESCRIPTION
## What does this PR do?
This PR is a follow up of https://github.com/elastic/beats/pull/23938 to add a commented out section within the k8s manifest as an example for enabling autodiscover for specific target based on dynamic inputs and k8s provider.

It comes along with https://github.com/elastic/observability-docs/pull/401.

Part of https://github.com/elastic/beats/issues/23613

## Why is it important?
So as to provide an easy way for the users to define their own autodiscover condition based inputs.

## How to test this PR locally
1. Uncoment the added section
2. Deploy Agent on k8s: `kubectl apply -f elastic-agent-standalone-kubernetes.yml `
3. Deploy a target Redis Pod: 
```
apiVersion: v1
kind: Service
metadata:
  name: redis
  labels:
    app: redis
spec:
  clusterIP: None
  ports:
  - name: web
    port: 6379
    protocol: TCP
  selector:
    app: redis
  type: ClusterIP
---
apiVersion: v1
kind: Pod
metadata:
  name: redis
  labels:
    role: main
    app: redis
spec:
  containers:
    - name: redis
      image: redis
```
4. Verify that redis integration start collecting redis metrics from the Pod. In Kibana discover filter on `redis.info` for `event.dataset` and expect to events arriving looking like the one below in`Screenshots` part.

## Screenshots

Sample event:
```json
{
  "_index": ".ds-metrics-redis.info-default-2021.02.22-000001",
  "_type": "_doc",
  "_id": "m_cZyncB1P74KB3B7J-v",
  "_version": 1,
  "_score": null,
  "_source": {
    "@timestamp": "2021-02-22T14:16:55.832Z",
    "service": {
      "version": "6.0.10",
      "address": "redis://10.244.1.8:6379",
      "type": "redis"
    },
    "os": {
      "full": "Linux 4.9.184-linuxkit x86_64"
    },
    "redis": {
      "info": {
        "stats": {
          "latest_fork_usec": 0,
          "keyspace": {
            "hits": 0,
            "misses": 0
          },
          "active_defrag": {
            "key_hits": 0,
            "key_misses": 0,
            "hits": 0,
            "misses": 0
          },
          "pubsub": {
            "patterns": 0,
            "channels": 0
          },
          "connections": {
            "received": 1,
            "rejected": 0
          },
          "keys": {
            "expired": 0,
            "evicted": 0
          },
          "commands_processed": 18,
          "sync": {
            "full": 0,
            "partial": {
              "err": 0,
              "ok": 0
            }
          },
          "instantaneous": {
            "input_kbps": 0,
            "output_kbps": 0,
            "ops_per_sec": 0
          },
          "migrate_cached_sockets": 0,
          "slave_expires_tracked_keys": 0,
          "net": {
            "input": {
              "bytes": 504
            },
            "output": {
              "bytes": 32651
            }
          }
        },
        "cluster": {
          "enabled": false
        },
        "clients": {
          "blocked": 0,
          "connected": 1,
          "longest_output_list": 0,
          "biggest_input_buf": 8,
          "max_output_buffer": 0,
          "max_input_buffer": 8
        },
        "persistence": {
          "loading": false,
          "rdb": {
            "bgsave": {
              "in_progress": false,
              "last_time": {
                "sec": -1
              },
              "current_time": {
                "sec": -1
              },
              "last_status": "ok"
            },
            "copy_on_write": {
              "last_size": 0
            },
            "last_save": {
              "changes_since": 0,
              "time": 1614003324
            }
          },
          "aof": {
            "fsync": {},
            "enabled": false,
            "rewrite": {
              "last_time": {
                "sec": -1
              },
              "current_time": {
                "sec": -1
              },
              "buffer": {},
              "in_progress": false,
              "scheduled": false
            },
            "bgrewrite": {
              "last_status": "ok"
            },
            "write": {
              "last_status": "ok"
            },
            "copy_on_write": {
              "last_size": 0
            },
            "buffer": {},
            "size": {}
          }
        },
        "replication": {
          "slave": {},
          "role": "master",
          "connected_slaves": 0,
          "master_offset": 0,
          "backlog": {
            "size": 1048576,
            "first_byte_offset": 0,
            "histlen": 0,
            "active": 0
          },
          "master": {
            "sync": {},
            "offset": 0,
            "second_offset": -1
          }
        },
        "memory": {
          "max": {
            "value": 0,
            "policy": "noeviction"
          },
          "fragmentation": {
            "ratio": 9.53,
            "bytes": 7031992
          },
          "active_defrag": {
            "is_running": false
          },
          "allocator": "jemalloc-5.1.0",
          "allocator_stats": {
            "allocated": 1135544,
            "active": 1355776,
            "resident": 4169728,
            "fragmentation": {
              "ratio": 1.19,
              "bytes": 220232
            },
            "rss": {
              "bytes": 2813952,
              "ratio": 3.08
            }
          },
          "used": {
            "rss": 7856128,
            "peak": 866680,
            "lua": 37888,
            "dataset": 43008,
            "value": 866680
          }
        },
        "cpu": {
          "used": {
            "sys_children": 0,
            "user_children": 0,
            "sys": 0.07,
            "user": 0.07
          }
        },
        "server": {
          "mode": "standalone",
          "run_id": "fa112bef9093d2ac5ccff855be0ae270375ad0f6",
          "lru_clock": 3390679,
          "hz": 10,
          "gcc_version": "8.3.0",
          "build_id": "1c3aed2f9fd88f03",
          "config_file": "",
          "git_dirty": "0",
          "uptime": 91,
          "tcp_port": 6379,
          "arch_bits": "64",
          "multiplexing_api": "epoll",
          "git_sha1": "00000000"
        },
        "slowlog": {
          "count": 0
        }
      }
    },
    "data_stream": {
      "type": "metrics",
      "dataset": "redis.info",
      "namespace": "default"
    },
    "elastic_agent": {
      "id": "9392caf0-cdfc-4abf-981b-f98cb6b9edad",
      "snapshot": true,
      "version": "8.0.0"
    },
    "host": {
      "hostname": "kind-worker",
      "architecture": "x86_64",
      "os": {
        "family": "redhat",
        "name": "CentOS Linux",
        "kernel": "4.9.184-linuxkit",
        "codename": "Core",
        "platform": "centos",
        "version": "7 (Core)"
      },
      "id": "17af4efd6a5716fb64a196f3cd53c4f8",
      "containerized": true,
      "name": "kind-worker",
      "ip": [
        "10.244.1.1",
        "10.244.1.1",
        "10.244.1.1",
        "172.18.0.2",
        "fc00:f853:ccd:e793::2",
        "fe80::42:acff:fe12:2"
      ],
      "mac": [
        "ba:4a:a1:a2:9a:81",
        "9a:80:f1:73:34:7a",
        "2e:0a:1c:40:46:f8",
        "02:42:ac:12:00:02"
      ]
    },
    "process": {
      "pid": 1
    },
    "event": {
      "module": "redis",
      "duration": 666897,
      "dataset": "redis.info"
    },
    "metricset": {
      "name": "info",
      "period": 10000
    },
    "kubernetes": {
      "namespace": "default",
      "pod": {
        "labels": {
          "role": "main",
          "app": "redis"
        },
        "name": "redis",
        "uid": "150148b5-b0a0-4237-b1ea-b2c2634fba59",
        "ip": "10.244.1.8"
      }
    },
    "agent": {
      "ephemeral_id": "7b49f72c-73c2-49be-99c9-b09d55fcd7b9",
      "id": "22e06d3f-a7cb-464c-b813-dee4302ca78a",
      "name": "kind-worker",
      "type": "metricbeat",
      "version": "8.0.0"
    },
    "ecs": {
      "version": "1.7.0"
    }
  },
  "fields": {
    "@timestamp": [
      "2021-02-22T14:16:55.832Z"
    ]
  },
  "highlight": {
    "event.dataset": [
      "@kibana-highlighted-field@redis.info@/kibana-highlighted-field@"
    ]
  },
  "sort": [
    1614003415832
  ]
}
```
