### PR TITLE
Remove OSS reference for kibana and elasticsearch

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:8.0.0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -25,7 +25,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:8.0.0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -13,6 +13,12 @@ services:
     - "network.host="
     - "transport.host=127.0.0.1"
     - "http.host=0.0.0.0"
+    - "xpack.security.enabled=false"
+    - "indices.id_field_data.enabled=true"
+    - "script.context.template.max_compilations_rate=unlimited"
+    - "script.context.ingest.cache_max_size=2000"
+    - "script.context.processor_conditional.cache_max_size=2000"
+    - "script.context.template.cache_max_size=2000"
 
   logstash:
     image: docker.elastic.co/logstash/logstash-oss:8.0.0-SNAPSHOT


### PR DESCRIPTION
## What does this PR do?

Remove the oss distribution reference for kibana and Elasticsearch

## Why is it important?

`oss` distribution is not anymore available
