### PR TITLE
Cherry-pick #24167 to 7.12: [Filebeat][AWS] Fix vpcflow pipeline exception: Cannot invoke "Object.getClass()" because "receiver" is null

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -245,6 +245,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Logstash module handling of logstash.log.log_event.action field. {issue}20709[20709]
 - aws/s3access dataset was populating event.duration using the wrong unit. {pull}23920[23920]
 - Zoom module pipeline failed to ingest some chat_channel events. {pull}23904[23904]
+- Fix aws/vpcflow generating errors for empty logs or unidentified formats. {pull}24167[24167]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/aws/vpcflow/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/ingest/pipeline.yml
@@ -119,7 +119,7 @@ processors:
       ignore_empty_value: true
 
   - set:
-      if: "ctx.aws.vpcflow.instance_id != '-'"
+      if: "ctx.aws?.vpcflow?.instance_id != null && ctx.aws.vpcflow.instance_id != '-'"
       field: cloud.instance.id
       value: "{{aws.vpcflow.instance_id}}"
       ignore_empty_value: true
@@ -131,11 +131,9 @@ processors:
   - script:
       lang: painless
       ignore_failure: true
+      if: "ctx.aws?.vpcflow?.tcp_flags != null"
       source: |
-        if (ctx?.aws?.vpcflow?.tcp_flags == null)
-          return;
-
-        if (ctx?.aws?.vpcflow?.tcp_flags_array == null) {
+        if (ctx.aws.vpcflow.tcp_flags_array == null) {
           ArrayList al = new ArrayList();
           ctx.aws.vpcflow.put("tcp_flags_array", al);
         }

--- a/x-pack/filebeat/module/aws/vpcflow/test/bad.log
+++ b/x-pack/filebeat/module/aws/vpcflow/test/bad.log
@@ -1,0 +1,1 @@
+Phony unsupported log format.

--- a/x-pack/filebeat/module/aws/vpcflow/test/bad.log-expected.json
+++ b/x-pack/filebeat/module/aws/vpcflow/test/bad.log-expected.json
@@ -1,0 +1,18 @@
+[
+    {
+        "cloud.provider": "aws",
+        "event.category": "network_traffic",
+        "event.dataset": "aws.vpcflow",
+        "event.kind": "event",
+        "event.module": "aws",
+        "event.original": "Phony unsupported log format.",
+        "event.type": "flow",
+        "fileset.name": "vpcflow",
+        "input.type": "log",
+        "log.offset": 0,
+        "service.type": "aws",
+        "tags": [
+            "forwarded"
+        ]
+    }
+]


### PR DESCRIPTION
Cherry-pick of PR #24167 to 7.12 branch. Original message: 

## What does this PR do?

Fixes Filebeat's `aws/vpcflow` ingest pipeline to avoid painless exceptions when `aws.vpcflow` fields are missing in the ingested document. This happens for empty lines in text logs, or any lines that don't conform to the expected format.

## Why is it important?

The fileset was generating documents with the following error.message:
> Cannot invoke "Object.getClass()" because "receiver" is null
 
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
