### PR TITLE
Cherry-pick #23966 to 7.11: Skip flaky TestActions on MacOSx

### DIFF
--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -130,10 +130,8 @@ func TestActions(t *testing.T) {
 	}
 
 	// Create some files in first directory
-	go func() {
-		ioutil.WriteFile(createdFilepath, []byte("hello world"), 0600)
-		ioutil.WriteFile(updatedFilepath, []byte("hello world"), 0600)
-	}()
+	ioutil.WriteFile(createdFilepath, []byte("hello world"), 0600)
+	ioutil.WriteFile(updatedFilepath, []byte("hello world"), 0600)
 
 	ms := mbtest.NewPushMetricSetV2(t, getConfig(dir, newDir))
 	events := mbtest.RunPushMetricSetV2(10*time.Second, 5, ms)


### PR DESCRIPTION
Cherry-pick of PR #23966 to 7.11 branch. Original message: 

## What does this PR do?
This PR skips flaky test case reported at https://github.com/elastic/beats/issues/23965.