### PR TITLE
Add system level logs for Agent on k8s

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
@@ -109,7 +109,49 @@ data:
       node: ${NODE_NAME}
       scope: node
     inputs:
-      - name: log-1
+      - name: system-logs
+        type: logfile
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.10.7
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              dataset: system.auth
+              type: logs
+            paths:
+              - /var/log/auth.log*
+              - /var/log/secure*
+            exclude_files:
+              - .gz$
+            multiline:
+              pattern: ^\s
+              match: after
+            processors:
+              - add_fields:
+                  target: ''
+                  fields:
+                    ecs.version: 1.5.0
+          - data_stream:
+              dataset: system.syslog
+              type: logs
+            paths:
+              - /var/log/messages*
+              - /var/log/syslog*
+            exclude_files:
+              - .gz$
+            multiline:
+              pattern: ^\s
+              match: after
+            processors:
+              - add_fields:
+                  target: ''
+                  fields:
+                    ecs.version: 1.5.0
+      - name: container-log
         type: logfile
         use_output: default
         meta:
@@ -124,7 +166,7 @@ data:
             symlinks: true
             paths:
               - /var/log/containers/*${kubernetes.container.id}.log
-      - name: system-3
+      - name: system-metrics
         type: system/metrics
         use_output: default
         meta:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -25,7 +25,49 @@ data:
       node: ${NODE_NAME}
       scope: node
     inputs:
-      - name: log-1
+      - name: system-logs
+        type: logfile
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.10.7
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              dataset: system.auth
+              type: logs
+            paths:
+              - /var/log/auth.log*
+              - /var/log/secure*
+            exclude_files:
+              - .gz$
+            multiline:
+              pattern: ^\s
+              match: after
+            processors:
+              - add_fields:
+                  target: ''
+                  fields:
+                    ecs.version: 1.5.0
+          - data_stream:
+              dataset: system.syslog
+              type: logs
+            paths:
+              - /var/log/messages*
+              - /var/log/syslog*
+            exclude_files:
+              - .gz$
+            multiline:
+              pattern: ^\s
+              match: after
+            processors:
+              - add_fields:
+                  target: ''
+                  fields:
+                    ecs.version: 1.5.0
+      - name: container-log
         type: logfile
         use_output: default
         meta:
@@ -40,7 +82,7 @@ data:
             symlinks: true
             paths:
               - /var/log/containers/*${kubernetes.container.id}.log
-      - name: system-3
+      - name: system-metrics
         type: system/metrics
         use_output: default
         meta:


### PR DESCRIPTION
## What does this PR do?

This PR adds system integration to collect system level logs from k8s nodes:
```
- var/log/auth.log*
- /var/log/secure*
- /var/log/messages*
- /var/log/syslog*
```
Tested on GKE (ubuntu based nodes) but manual installation of `rsyslog` is required since it's not there by default:
`sudo apt-get -y install rsyslog && sudo service rsyslog start`

## Why is it important?

So as to collect system level logs from k8s nodes on which Agent runs as Pod.


## Related issues

- Relates https://github.com/elastic/beats/issues/23613


## Screenshots

<img width="1258" alt="Screenshot 2021-02-23 at 2 37 16 PM" src="https://user-images.githubusercontent.com/11754898/108844320-a4095380-75e4-11eb-9542-77f853cc1b38.png">

