### PR TITLE
fix(partition.go): fix kafka get negative partition when hash value e…

### DIFF
--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -276,7 +276,12 @@ func hash2Partition(hash uint32, numPartitions int32) (int32, error) {
 	if p < 0 {
 		p = -p
 	}
-	return p % numPartitions, nil
+
+	r := p % numPartitions
+	if r < 0 {
+		r = -r
+	}
+	return r, nil
 }
 
 func hashFieldValue(h hash.Hash32, event common.MapStr, field string) error {


### PR DESCRIPTION
## What does this PR do?

Fix [bug 24157](https://github.com/elastic/beats/issues/24175), which cause Kafka Output Stuck, when `partition.hash.hash` get a negative `partition`.

## Why is it important?

Beat, such as Filebeat, may stcuk forever without any error.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] check Int32 MIN_VALUE
- [x] check Int32 positive
- [x] check Int32 negative

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
When use partition.hash.hash, use `2304669687` as input.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates [24175](https://github.com/elastic/beats/issues/24175)

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
Compared to `& 0x7fffffff`, this may be the minimal chage, even though it can't avoid affect rolling upgrade when user fixed it himself.