### PR TITLE
Cherry-pick to 7.x: Indicate in docs that stack monitoring uses a different index (#23916)

### DIFF
--- a/metricbeat/docs/modules/beat.asciidoc
+++ b/metricbeat/docs/modules/beat.asciidoc
@@ -13,13 +13,17 @@ The `beat` module collects metrics about any Beat or other software based on lib
 The `beat` module works with {beats} 7.3.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Usage for {stack} Monitoring
 
-The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `beat` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
 `metricbeat modules enable beat-xpack`.
 
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].
 
 [float]
 === Example configuration

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -13,12 +13,17 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Usage for {stack} Monitoring
 
-The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `elasticsearch` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
 `metricbeat modules enable elasticsearch-xpack`.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].
 
 [float]
 === Module-specific configuration notes

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -13,12 +13,17 @@ The `kibana` module collects metrics about {kib}.
 The `kibana` module works with {kib} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Usage for {stack} Monitoring
 
-The `kibana` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `kibana` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable kibana` and
 `metricbeat modules enable kibana-xpack`.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].
 
 
 [float]

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -15,10 +15,15 @@ The `logstash` module works with {ls} 7.3.0 and later.
 [float]
 === Usage for Stack Monitoring
 
-The `logstash` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `logstash` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable logstash` and
 `metricbeat modules enable logstash-xpack`.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].
 
 
 [float]

--- a/metricbeat/module/beat/_meta/docs.asciidoc
+++ b/metricbeat/module/beat/_meta/docs.asciidoc
@@ -6,9 +6,14 @@ The `beat` module collects metrics about any Beat or other software based on lib
 The `beat` module works with {beats} 7.3.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Usage for {stack} Monitoring
 
-The `beat` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `beat` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable beat` and
 `metricbeat modules enable beat-xpack`.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -6,12 +6,17 @@ The `elasticsearch` module collects metrics about {es}.
 The `elasticsearch` module works with {es} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Usage for {stack} Monitoring
 
-The `elasticsearch` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `elasticsearch` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable elasticsearch` and
 `metricbeat modules enable elasticsearch-xpack`.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].
 
 [float]
 === Module-specific configuration notes

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -6,9 +6,14 @@ The `kibana` module collects metrics about {kib}.
 The `kibana` module works with {kib} 6.7.0 and later.
 
 [float]
-=== Usage for Stack Monitoring
+=== Usage for {stack} Monitoring
 
-The `kibana` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `kibana` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable kibana` and
 `metricbeat modules enable kibana-xpack`.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].

--- a/metricbeat/module/logstash/_meta/docs.asciidoc
+++ b/metricbeat/module/logstash/_meta/docs.asciidoc
@@ -8,7 +8,12 @@ The `logstash` module works with {ls} 7.3.0 and later.
 [float]
 === Usage for Stack Monitoring
 
-The `logstash` module can be used to collect metrics shown in our {stack} {monitor-features}
+The `logstash` module can be used to collect metrics shown in our {stack-monitor-app}
 UI in {kib}. To enable this usage, set `xpack.enabled: true` and remove any `metricsets`
 from the module's configuration. Alternatively, run `metricbeat modules disable logstash` and
 `metricbeat modules enable logstash-xpack`.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Indicate in docs that stack monitoring uses a different index (#23916)