### PR TITLE
Cherry-pick #23240 to 7.12: libbeat/template: duplicate entries in fields.yml leads to repeated dynamic templates

### DIFF
--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -317,7 +317,6 @@ func TestProcessor(t *testing.T) {
 }
 
 func TestDynamicTemplates(t *testing.T) {
-	p := &Processor{}
 	tests := []struct {
 		field    mapping.Field
 		expected []common.MapStr
@@ -493,9 +492,10 @@ func TestDynamicTemplates(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		dynamicTemplates = nil
+		p := &Processor{}
 		p.object(&test.field)
-		assert.Equal(t, test.expected, dynamicTemplates)
+		p.object(&test.field) // should not be added twice
+		assert.Equal(t, test.expected, p.dynamicTemplates)
 	}
 }
 

--- a/libbeat/template/template.go
+++ b/libbeat/template/template.go
@@ -37,9 +37,6 @@ var (
 	defaultNumberOfRoutingShards   = 30
 	defaultMaxDocvalueFieldsSearch = 200
 
-	// Array to store dynamicTemplate parts in
-	dynamicTemplates []common.MapStr
-
 	defaultFields []string
 )
 
@@ -147,7 +144,6 @@ func (t *Template) load(fields mapping.Fields) (common.MapStr, error) {
 	t.Lock()
 	defer t.Unlock()
 
-	dynamicTemplates = nil
 	defaultFields = nil
 
 	var err error
@@ -164,7 +160,8 @@ func (t *Template) load(fields mapping.Fields) (common.MapStr, error) {
 	if err := processor.Process(fields, nil, properties); err != nil {
 		return nil, err
 	}
-	output := t.Generate(properties, dynamicTemplates)
+
+	output := t.Generate(properties, processor.dynamicTemplates)
 
 	return output, nil
 }
@@ -255,17 +252,16 @@ func (t *Template) GetPattern() string {
 func (t *Template) Generate(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
 	switch t.templateType {
 	case IndexTemplateLegacy:
-		return t.generateLegacy(properties)
+		return t.generateLegacy(properties, dynamicTemplates)
 	case IndexTemplateComponent:
-		return t.generateComponent(properties)
+		return t.generateComponent(properties, dynamicTemplates)
 	case IndexTemplateIndex:
-		return t.generateIndex(properties)
-	default:
+		return t.generateIndex(properties, dynamicTemplates)
 	}
 	return nil
 }
 
-func (t *Template) generateLegacy(properties common.MapStr) common.MapStr {
+func (t *Template) generateLegacy(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
 	keyPattern, patterns := buildPatternSettings(t.esVersion, t.GetPattern())
 	return common.MapStr{
 		keyPattern: patterns,
@@ -284,7 +280,7 @@ func (t *Template) generateLegacy(properties common.MapStr) common.MapStr {
 	}
 }
 
-func (t *Template) generateComponent(properties common.MapStr) common.MapStr {
+func (t *Template) generateComponent(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
 	return common.MapStr{
 		"template": common.MapStr{
 			"mappings": buildMappings(
@@ -302,8 +298,8 @@ func (t *Template) generateComponent(properties common.MapStr) common.MapStr {
 	}
 }
 
-func (t *Template) generateIndex(properties common.MapStr) common.MapStr {
-	tmpl := t.generateComponent(properties)
+func (t *Template) generateIndex(properties common.MapStr, dynamicTemplates []common.MapStr) common.MapStr {
+	tmpl := t.generateComponent(properties, dynamicTemplates)
 	tmpl["priority"] = t.priority
 	keyPattern, patterns := buildPatternSettings(t.esVersion, t.GetPattern())
 	tmpl[keyPattern] = patterns


### PR DESCRIPTION
Cherry-pick of PR #23240 to 7.12 branch. Original message: 

## What does this PR do?

In case of duplicate fields, do not generate duplicate dynamic_template items. We already deduplicate field mappings because there we update a map.

There's some light refactoring here to stop using a global list of dynamic templates, and instead maintain a map of dynamic templates on the processor.

## Why is it important?

As part of APM Server's migration to Fleet and data streams, we now duplicate fields for each data stream. We still need to generate legacy templates for 7.x, so we gather all of these data stream fields.yml files together to generate docs, templates, etc. The combined fields.yml will therefore have duplicate entries.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

N/A

## Related issues

https://github.com/elastic/apm-server/issues/4576