### PR TITLE
Cherry-pick to 7.12: Reuse configuration from the workers and bump terraform (#24184) (#24214)

### DIFF
--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -2,14 +2,35 @@
 
 set -exuo pipefail
 
-MSG="parameter missing."
+MSG="environment variable missing: DOCKER_COMPOSE_VERSION."
 DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:?$MSG}
 HOME=${HOME:?$MSG}
+
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+if [ "${ARCH}" == "aarch64" ] ; then
+    echo "docker-compose distribution for ARM is not supported yet. See https://github.com/docker/compose/issues/6831."
+    echo "Let's use the installed docker-compose version"
+    exit 0
+fi
+
+if command -v docker-compose
+then
+    echo "Found docker-compose. Checking version.."
+    FOUND_DOCKER_COMPOSE_VERSION=$(docker-compose --version|awk '{print $3}'|sed s/\,//)
+    if [ $FOUND_DOCKER_COMPOSE_VERSION == $DOCKER_COMPOSE_VERSION ]
+    then
+        echo "Versions match. No need to install docker-compose. Exiting."
+        exit 0
+    fi
+fi
+
+echo "UNMET DEP: Installing docker-compose"
+
 DC_CMD="${HOME}/bin/docker-compose"
 
 mkdir -p "${HOME}/bin"
 
-if curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" ; then
+if curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"; then
     chmod +x "${DC_CMD}"
 else
     echo "Something bad with the download, let's delete the corrupted binary"

--- a/.ci/scripts/install-kind.sh
+++ b/.ci/scripts/install-kind.sh
@@ -7,7 +7,35 @@ KIND_VERSION=${KIND_VERSION:?$MSG}
 HOME=${HOME:?$DEFAULT_HOME}
 KIND_CMD="${HOME}/bin/kind"
 
+if command -v kind
+then
+    echo "Found Kind. Checking version.."
+    FOUND_KIND_VERSION=$(kind --version 2>&1 >/dev/null | awk '{print $3}')
+    if [ "$FOUND_KIND_VERSION" == "$KIND_VERSION" ]
+    then
+        echo "Versions match. No need to install Kind. Exiting."
+        exit 0
+    fi
+fi
+
+echo "UNMET DEP: Installing Kind"
+
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+if [ "${ARCH}" == "aarch64" ] ; then
+    ARCH_SUFFIX=arm64
+else
+    ARCH_SUFFIX=amd64
+fi
+
 mkdir -p "${HOME}/bin"
 
-curl -sSLo "${KIND_CMD}" "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
-chmod +x "${KIND_CMD}"
+if curl -sSLo "${KIND_CMD}" "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-${OS}-${ARCH_SUFFIX}" ; then
+    chmod +x "${KIND_CMD}"
+else
+    echo "Something bad with the download, let's delete the corrupted binary"
+    if [ -e "${KIND_CMD}" ] ; then
+        rm "${KIND_CMD}"
+    fi
+    exit 1
+fi

--- a/.ci/scripts/install-kubectl.sh
+++ b/.ci/scripts/install-kubectl.sh
@@ -7,8 +7,36 @@ K8S_VERSION=${K8S_VERSION:?$MSG}
 HOME=${HOME:?$DEFAULT_HOME}
 KUBECTL_CMD="${HOME}/bin/kubectl"
 
+if command -v kubectl
+then
+    echo "Found kubectl. Checking version.."
+    FOUND_KUBECTL_VERSION=$(kubectl version --client --short 2>&1 >/dev/null | awk '{print $3}')
+    if [ "${FOUND_KUBECTL_VERSION}" == "${K8S_VERSION}" ]
+    then
+        echo "Versions match. No need to install kubectl. Exiting."
+        exit 0
+    fi
+fi
+
+echo "UNMET DEP: Installing kubectl"
+
 mkdir -p "${HOME}/bin"
 
-curl -sSLo "${KUBECTL_CMD}" "https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl"
-chmod +x "${KUBECTL_CMD}"
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+if [ "${ARCH}" == "aarch64" ] ; then
+    ARCH_SUFFIX=arm64
+else
+    ARCH_SUFFIX=amd64
+fi
+
+if curl -sSLo "${KUBECTL_CMD}" "https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/${OS}/${ARCH_SUFFIX}/kubectl" ; then
+    chmod +x "${KUBECTL_CMD}"
+else
+    echo "Something bad with the download, let's delete the corrupted binary"
+    if [ -e "${KUBECTL_CMD}" ] ; then
+        rm "${KUBECTL_CMD}"
+    fi
+    exit 1
+fi
 

--- a/.ci/scripts/install-terraform.sh
+++ b/.ci/scripts/install-terraform.sh
@@ -7,12 +7,42 @@ TERRAFORM_VERSION=${TERRAFORM_VERSION:?$MSG}
 HOME=${HOME:?$MSG}
 TERRAFORM_CMD="${HOME}/bin/terraform"
 
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+if command -v terraform
+then
+    echo "Found Terraform. Checking version.."
+    FOUND_TERRAFORM_VERSION=$(terraform --version | awk '{print $2}' | sed s/v//)
+    if [ "$FOUND_TERRAFORM_VERSION" == "$TERRAFORM_VERSION" ]
+    then
+        echo "Versions match. No need to install Terraform. Exiting."
+        exit 0
+    fi
+fi
+
+echo "UNMET DEP: Installing Terraform"
 
 mkdir -p "${HOME}/bin"
 
-curl -sSLo - "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_amd64.zip" > ${TERRAFORM_CMD}.zip
-unzip -o ${TERRAFORM_CMD}.zip -d $(dirname ${TERRAFORM_CMD})
-rm ${TERRAFORM_CMD}.zip
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+if [ "${ARCH}" == "aarch64" ] ; then
+    ARCH_SUFFIX=arm64
+elif [ "${ARCH}" == "x86_64" ] ; then
+    ARCH_SUFFIX=amd64
+elif [ "${ARCH}" == "i686" ] ; then
+    ARCH_SUFFIX=386
+else
+    ARCH_SUFFIX=arm
+fi
 
-chmod +x "${TERRAFORM_CMD}"
+if curl -sSLo - "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_${ARCH_SUFFIX}.zip" > "${TERRAFORM_CMD}.zip" ; then
+    unzip -o "${TERRAFORM_CMD}".zip -d "$(dirname ${TERRAFORM_CMD})"
+    rm "${TERRAFORM_CMD}".zip
+
+    chmod +x "${TERRAFORM_CMD}"
+else
+    echo "Something bad with the download, let's delete the corrupted binary"
+    if [ -e "${TERRAFORM_CMD}" ] ; then
+        rm "${TERRAFORM_CMD}"
+    fi
+    exit 1
+fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     RUNBLD_DISABLE_NOTIFICATIONS = 'true'
     SLACK_CHANNEL = "#beats-build"
     SNAPSHOT = 'true'
-    TERRAFORM_VERSION = "0.12.24"
+    TERRAFORM_VERSION = "0.12.30"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
   }
   options {


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [CI] reuse configuration from the workers if possible (#24184)
 - Bump terraform dependency with arm64 support (#24214)

Merge conflict solved since https://github.com/elastic/beats/pull/20349 was not backported

Requires https://github.com/elastic/beats/pull/24214