### PR TITLE
Bump terraform dependency with arm64 support

### DIFF
--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -6,6 +6,13 @@ MSG="environment variable missing: DOCKER_COMPOSE_VERSION."
 DOCKER_COMPOSE_VERSION=${DOCKER_COMPOSE_VERSION:?$MSG}
 HOME=${HOME:?$MSG}
 
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+if [ "${ARCH}" == "aarch64" ] ; then
+    echo "docker-compose distribution for ARM is not supported yet. See https://github.com/docker/compose/issues/6831."
+    echo "Let's use the installed docker-compose version"
+    exit 0
+fi
+
 if command -v docker-compose
 then
     echo "Found docker-compose. Checking version.."
@@ -23,7 +30,7 @@ DC_CMD="${HOME}/bin/docker-compose"
 
 mkdir -p "${HOME}/bin"
 
-if curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" ; then
+if curl -sSLo "${DC_CMD}" "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"; then
     chmod +x "${DC_CMD}"
 else
     echo "Something bad with the download, let's delete the corrupted binary"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
     RUNBLD_DISABLE_NOTIFICATIONS = 'true'
     SLACK_CHANNEL = "#beats-build"
     SNAPSHOT = 'true'
-    TERRAFORM_VERSION = "0.12.24"
+    TERRAFORM_VERSION = "0.12.30"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
   }
   options {


### PR DESCRIPTION
## What does this PR do?

Bump the terraform version that got support for arm64

Otherwise 

![image](https://user-images.githubusercontent.com/2871786/109023706-eb5f1500-76b4-11eb-9f18-c854d82dbf80.png)


![image](https://user-images.githubusercontent.com/2871786/109024226-6d4f3e00-76b5-11eb-9d70-1ffa58414d8c.png)

