### PR TITLE
Cherry-pick #24139 to 7.x: Add running aws module on docker doc

### DIFF
--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -26,6 +26,36 @@ Users can either put the credentials into metricbeat module configuration or use
 environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN` instead.
 
+If running on Docker, these environment variables should be added as a part of
+the docker command. For example, with Metricbeat:
+
+----
+$ docker run -e AWS_ACCESS_KEY_ID=abcd -e AWS_SECRET_ACCESS_KEY=abcd -d --name=metricbeat --user=root --volume="$(pwd)/metricbeat.aws.yml:/usr/share/metricbeat/metricbeat.yml:ro" docker.elastic.co/beats/metricbeat:7.11.1 metricbeat -e -E cloud.auth=elastic:1234 -E cloud.id=test-aws:1234
+----
+
+Sample `metricbeat.aws.yml` looks like:
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 5m
+  access_key_id: ${AWS_ACCESS_KEY_ID}
+  secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+  session_token: ${AWS_SESSION_TOKEN}
+  metricsets:
+    - ec2
+----
+
+Environment variables can also be added through a file. For example:
+
+----
+$ cat env.list
+AWS_ACCESS_KEY_ID=abcd
+AWS_SECRET_ACCESS_KEY=abcd
+
+$ docker run --env-file env.list -d --name=metricbeat --user=root --volume="$(pwd)/metricbeat.aws.yml:/usr/share/metricbeat/metricbeat.yml:ro" docker.elastic.co/beats/metricbeat:7.11.1 metricbeat -e -E cloud.auth=elastic:1234 -E cloud.id=test-aws:1234
+----
+
 * Use `role_arn`
 
 If `access_key_id` and `secret_access_key` are not given, then {beatname_lc} will
@@ -47,6 +77,25 @@ For Linux, macOS or Unix, the file is located at `~/.aws/credentials`. When runn
 the home path depends on the user that manages the service, so the `shared_credential_file` parameter can be used to avoid ambiguity. Please see
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
 for more details.
+
+If running on Docker, the credential file needs to be provided via a volume
+mount. For example, with Metricbeat:
+
+----
+docker run -d --name=metricbeat --user=root --volume="$(pwd)/metricbeat.aws.yml:/usr/share/metricbeat/metricbeat.yml:ro" --volume="/Users/foo/.aws/credentials:/usr/share/metricbeat/credentials:ro" docker.elastic.co/beats/metricbeat:7.11.1 metricbeat -e -E cloud.auth=elastic:1234 -E cloud.id=test-aws:1234
+----
+
+Sample `metricbeat.aws.yml` looks like:
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 5m
+  credential_profile_name: elastic-beats
+  shared_credential_file: /usr/share/metricbeat/credentials
+  metricsets:
+    - ec2
+----
 
 ifeval::["{beatname_lc}"=="filebeat"]
 include::../../../filebeat/docs/aws-credentials-examples.asciidoc[]


### PR DESCRIPTION
Cherry-pick of PR #24139 to 7.x branch. Original message: 

This PR is to improve documentation on running aws module on docker.

closes: https://github.com/elastic/beats/issues/24073