### PR TITLE
[Metricbeat] Google Cloud: Do not try to setup region filter on Cloudfunctions metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -508,6 +508,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix ec2 metricset fields.yml and the integration test {pull}23726[23726]
 - Unskip s3_request integration test. {pull}23887[23887]
 - Add system.hostfs configuration option for system module. {pull}23831[23831]
+- Fix GCP not able to request Cloudfunctions metrics if a region filter was set {pull}24218[24218]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/gcp/constants.go
+++ b/x-pack/metricbeat/module/gcp/constants.go
@@ -16,12 +16,12 @@ const (
 
 // Metricsets / GCP services names
 const (
-	ServiceCompute       = "compute"
-	ServicePubsub        = "pubsub"
-	ServiceLoadBalancing = "loadbalancing"
+	ServiceCompute        = "compute"
+	ServicePubsub         = "pubsub"
+	ServiceLoadBalancing  = "loadbalancing"
 	ServiceCloudFunctions = "cloudfunctions"
-	ServiceFirestore     = "firestore"
-	ServiceStorage       = "storage"
+	ServiceFirestore      = "firestore"
+	ServiceStorage        = "storage"
 )
 
 //Paths within the GCP monitoring.TimeSeries response, if converted to JSON, where you can find each ECS field required for the output event

--- a/x-pack/metricbeat/module/gcp/constants.go
+++ b/x-pack/metricbeat/module/gcp/constants.go
@@ -19,6 +19,7 @@ const (
 	ServiceCompute       = "compute"
 	ServicePubsub        = "pubsub"
 	ServiceLoadBalancing = "loadbalancing"
+	ServiceCloudFunctions = "cloudfunctions"
 	ServiceFirestore     = "firestore"
 	ServiceStorage       = "storage"
 )

--- a/x-pack/metricbeat/module/gcp/constants.go
+++ b/x-pack/metricbeat/module/gcp/constants.go
@@ -16,11 +16,10 @@ const (
 
 // Metricsets / GCP services names
 const (
-	ServiceCompute        = "compute"
-	ServicePubsub         = "pubsub"
-	ServiceLoadBalancing  = "loadbalancing"
 	ServiceCloudFunctions = "cloudfunctions"
-	ServiceFirestore      = "firestore"
+	ServiceCompute        = "compute"
+	ServiceLoadBalancing  = "loadbalancing"
+	ServicePubsub         = "pubsub"
 	ServiceStorage        = "storage"
 )
 

--- a/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
@@ -83,7 +83,7 @@ func (r *metricsRequester) Metrics(ctx context.Context, sdc metricsConfig, metri
 		go func(mt string) {
 			defer wg.Done()
 
-			r.logger.Debugf("For metricType %s, metricMeta = %s", mt, metricMeta)
+			r.logger.Debugf("For metricType %s, metricMeta = %d", mt, metricMeta)
 			interval, aligner := getTimeIntervalAligner(metricMeta.ingestDelay, metricMeta.samplePeriod, r.config.period, aligner)
 			ts := r.Metric(ctx, mt, interval, aligner)
 			lock.Lock()
@@ -109,7 +109,7 @@ func (r *metricsRequester) getFilterForMetric(m string) (f string) {
 	service := serviceRegexp.ReplaceAllString(m, "${service}")
 
 	switch service {
-	case gcp.ServicePubsub, gcp.ServiceLoadBalancing:
+	case gcp.ServicePubsub, gcp.ServiceLoadBalancing, gcp.ServiceCloudFunctions:
 		return
 	case gcp.ServiceStorage:
 		if r.config.Region == "" {


### PR DESCRIPTION
## What does this PR do?
This PR solves a bug that appears when setting a `region` parameter in `gcp.yml` only when using CloudFunctions.

Some Google Cloud services fail when you request metrics filtering by `region`. Beats has faced the same situation when requesting PubSub or LoadBalancing metrics from Stackdriver (Stackdriver is the service requested in `metrics` metricset).

Requests to those services must be done explicitly without filtering by region. Unfortunately, this isn't very well documented in GCP docs (or it's well hidden :smile: )

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.