### PR TITLE
Cherry-pick #24194 to 7.x: [Heartbeat] Report first synth error on summary

### DIFF
--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -30,6 +30,11 @@ func TestJourneyEnricher(t *testing.T) {
 		Name:    "my-errname",
 		Stack:   "my\nerr\nstack",
 	}
+	otherErr := &SynthError{
+		Message: "last-errmsg",
+		Name:    "last-errname",
+		Stack:   "last\nerr\nstack",
+	}
 	journeyStart := &SynthEvent{
 		Type:                 "journey/start",
 		TimestampEpochMicros: 1000,
@@ -66,7 +71,7 @@ func TestJourneyEnricher(t *testing.T) {
 		makeStepEvent("step/start", 21, "Step2", 1, "", nil),
 		makeStepEvent("step/end", 30, "Step2", 1, url2, syntherr),
 		makeStepEvent("step/start", 31, "Step3", 1, "", nil),
-		makeStepEvent("step/end", 40, "Step3", 1, url3, nil),
+		makeStepEvent("step/end", 40, "Step3", 1, url3, otherErr),
 		journeyEnd,
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #24194 to 7.x branch. Original message: 

Fixes https://github.com/elastic/kibana/issues/92066

Prior to this for the summary.error field for browser events we'd report the last encountered error. We now report the first. This
prevents the issue where on a failing run the synthetics library considers an exit status of 1 to be an error. This will always be the
case when a step fails, meaning that the last error will always be a status code error stepping on the actual step error.

No changelog required because this bug should only be present in 7.12

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

Run synthetics with a failing test against this branch. In the Uptime UI, on the monitor overview page, the error shown should be the first failing step.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
