### PR TITLE
Cherry-pick #23970 to 7.12: Rewrite check for admin

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -37,6 +37,7 @@
 - Fix issue of missing log messages from filebeat monitor {pull}23514[23514]
 - Increase checkin grace period to 30 seconds {pull}23568[23568]
 - Fix libbeat from reporting back degraded on config update {pull}23537[23537]
+- Rewrite check if agent is running with admin rights on Windows {pull}23970[23970]
 - Fix issues with dynamic inputs and conditions {pull}23886[23886]
 - Select default agent policy if no enrollment token provided. {pull}23973[23973]
 - Fix bad substitution of API key. {pull}24036[24036]

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -44,8 +44,11 @@ would like the Agent to operate.
 }
 
 func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
-	var err error
-	if !install.HasRoot() {
+	isAdmin, err := install.HasRoot()
+	if err != nil {
+		return fmt.Errorf("unable to perform install command while checking for administrator rights, %v", err)
+	}
+	if !isAdmin {
 		return fmt.Errorf("unable to perform install command, not executed with %s permissions", install.PermissionUser)
 	}
 	status, reason := install.Status()

--- a/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
@@ -37,8 +37,12 @@ Unless -f is used this command will ask confirmation before performing removal.
 }
 
 func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
-	if !install.HasRoot() {
-		return fmt.Errorf("unable to perform uninstall command, not executed with %s permissions", install.PermissionUser)
+	isAdmin, err := install.HasRoot()
+	if err != nil {
+		return fmt.Errorf("unable to perform command while checking for administrator rights, %v", err)
+	}
+	if !isAdmin {
+		return fmt.Errorf("unable to perform command, not executed with %s permissions", install.PermissionUser)
 	}
 	status, reason := install.Status()
 	if status == install.NotInstalled {
@@ -72,7 +76,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags
 		}
 	}
 
-	err := install.Uninstall()
+	err = install.Uninstall()
 	if err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/agent/install/root_unix.go
+++ b/x-pack/elastic-agent/pkg/agent/install/root_unix.go
@@ -14,6 +14,7 @@ const (
 )
 
 // HasRoot returns true if the user has root permissions.
-func HasRoot() bool {
-	return os.Getegid() == 0
+// Added extra `nil` value to return since the HasRoot for windows will return an error as well
+func HasRoot() (bool, error) {
+	return os.Getegid() == 0, nil
 }

--- a/x-pack/elastic-agent/pkg/agent/install/root_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/install/root_windows.go
@@ -7,7 +7,8 @@
 package install
 
 import (
-	"os"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -16,12 +17,26 @@ const (
 )
 
 // HasRoot returns true if the user has Administrator/SYSTEM permissions.
-func HasRoot() bool {
-	// only valid rights can open the physical drive
-	f, err := os.Open("\\\\.\\PHYSICALDRIVE0")
+func HasRoot() (bool, error) {
+	var sid *windows.SID
+	// See https://docs.microsoft.com/en-us/windows/desktop/api/securitybaseapi/nf-securitybaseapi-checktokenmembership for more on the api
+	err := windows.AllocateAndInitializeSid(
+		&windows.SECURITY_NT_AUTHORITY,
+		2,
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&sid)
 	if err != nil {
-		return false
+		return false, errors.Errorf("sid error: %s", err)
 	}
-	defer f.Close()
-	return true
+
+	token := windows.Token(0)
+
+	member, err := token.IsMember(sid)
+	if err != nil {
+		return false, errors.Errorf("token membership error: %s", err)
+	}
+
+	return member, nil
 }

--- a/x-pack/elastic-agent/pkg/agent/install/root_windows_test.go
+++ b/x-pack/elastic-agent/pkg/agent/install/root_windows_test.go
@@ -1,0 +1,20 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build windows
+
+package install
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasRoot(t *testing.T) {
+	t.Run("check if user is admin", func(t *testing.T) {
+		_, err := HasRoot()
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Cherry-pick of PR #23970 to 7.12 branch. Original message: 

## What does this PR do?

Re writes the HasRoot function.
The token.IsMember(sid) returns TRUE if the caller's process is a member of the Administrators local group. Caller is NOT
expected to be impersonating anyone and is expected to be able to open its own process and process token. In order for the process to "Run as administrator" the user must be in the BUILTIN\Administrators Group.


## Why is it important?

In order to install the elastic agent we are checking for Admin by  accessing "\\.\PHYSICALDRIVE0".
This will not work on all setups since the physical drive might be missing, ex testing with windows containers,  kubelet startup.



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


