### PR TITLE
Add state_service in metricsets that are enabled in k8s manifests

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -36,6 +36,7 @@ data:
                     - state_cronjob
                     - state_resourcequota
                     - state_statefulset
+                    - state_service
                 - module: kubernetes
                   metricsets:
                     - apiserver

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -36,6 +36,7 @@ data:
                     - state_cronjob
                     - state_resourcequota
                     - state_statefulset
+                    - state_service
                 - module: kubernetes
                   metricsets:
                     - apiserver


### PR DESCRIPTION
## What does this PR do?
Adds `state_service` in metricsets that are enabled in k8s manifests.

## Why is it important?
To collect service metrics by default after deploying the manifests.