### PR TITLE
[CI][static][workers] write access to allow deleteDir

### DIFF
--- a/script/fix_permissions.sh
+++ b/script/fix_permissions.sh
@@ -16,5 +16,5 @@ else
   # Change ownership of all files inside the specific folder from root/root to current user/group
   docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
   # Change permissions with write access of all files inside the specific folder
-  docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -exec chmod -R +w {} \;"
+  chmod -R +w "${LOCATION}"
 fi

--- a/script/fix_permissions.sh
+++ b/script/fix_permissions.sh
@@ -15,4 +15,6 @@ else
   set -e
   # Change ownership of all files inside the specific folder from root/root to current user/group
   docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
+  # Change permissions with write access of all files inside the specific folder
+  docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -exec chmod -R +w {} \;"
 fi


### PR DESCRIPTION
## What does this PR do?

The beats build system somehow create files with read only access and different ownership, this causes issues in the CI when using static workers

## Why is it important?

Ensure the static workers can be tear down correctly.

![image](https://user-images.githubusercontent.com/2871786/109140283-557ac700-7754-11eb-8cab-bad15a57c6da.png)


```
jenkins@worker-0a434dec4bdcd060f:~/workspace/Beats_beats_PR-22662/pkg/mod$ ls -l sigs.k8s.io/structured-merge-diff/v4@v4.0.1/schema/
total 36
-r--r--r-- 1 jenkins jenkins 1178 Feb 24 22:59 doc.go
-r--r--r-- 1 jenkins jenkins 9898 Feb 24 22:59 elements.go
-r--r--r-- 1 jenkins jenkins 3369 Feb 24 22:59 elements_test.go
-r--r--r-- 1 jenkins jenkins 4291 Feb 24 22:59 equals.go
-r--r--r-- 1 jenkins jenkins 3663 Feb 24 22:59 equals_test.go
-r--r--r-- 1 jenkins jenkins 3121 Feb 24 22:59 schemaschema.go
jenkins@worker-0a434dec4bdcd060f:~/workspace/Beats_beats_PR-22662/pkg/mod$ ls -l sigs.k8s.io/structured-merge-diff/v4@v4.0.1/schema/elements_test.go 
-r--r--r-- 1 jenkins jenkins 3369 Feb 24 22:59 sigs.k8s.io/structured-merge-diff/v4@v4.0.1/schema/elements_test.go
```

## Test

![image](https://user-images.githubusercontent.com/2871786/109140429-7f33ee00-7754-11eb-8163-2ea8c5c5a837.png)
