### PR TITLE
Cherry-pick #24247 to 7.x: [Heartbeat] Remove extraneous factory log

### DIFF
--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -26,7 +26,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/fmtstr"
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/add_formatted_index"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipetool"
@@ -114,8 +113,6 @@ func newCommonPublishConfigs(info beat.Info, cfg *common.Config) (pipetool.Confi
 	}
 
 	return func(clientCfg beat.ClientConfig) (beat.ClientConfig, error) {
-		logp.Info("Client connection with: %#v", clientCfg)
-
 		fields := clientCfg.Processing.Fields.Clone()
 		fields.Put("event.dataset", dataset)
 


### PR DESCRIPTION
Cherry-pick of PR #24247 to 7.x branch. Original message: 

In 61eaf3bf58b a logging statement that was probably just for debugging
was introduced. This looks pretty ugly on the CLI and I assume was not
intended for release.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Logs

Sample log

```
2021-02-25T14:28:49.978Z        INFO    monitors/factory.go:117 Client connection with: beat.ClientConfig{PublishMode:0x0, Processing:beat.ProcessingConfig{EventMetadata:common.EventMetadata{Fields:null, FieldsUnderRoot:false, Tags:[]string(nil)}, Meta:null, Fields:null, DynamicFields:(*common.MapStrPointer)(nil), Processor:beat.ProcessorList(nil), KeepNull:false, DisableHost:false, Private:interface {}(nil)}, CloseRef:beat.CloseRef(nil), WaitClose:0, ACKHandler:beat.ACKer(nil), Events:beat.ClientEventer(nil)}
```

