### PR TITLE
Fix admonition tag to render text correctly

### DIFF
--- a/filebeat/docs/inputs/input-log.asciidoc
+++ b/filebeat/docs/inputs/input-log.asciidoc
@@ -60,7 +60,7 @@ because this can lead to unexpected behaviour.
 [[file-identity]]
 ==== Reading files on network shares and cloud providers
 
-:WARNING: Filebeat does not support reading from network shares and cloud providers.
+WARNING: Filebeat does not support reading from network shares and cloud providers.
 
 However, one of the limitations of these data sources can be mitigated
 if you configure Filebeat adequately.


### PR DESCRIPTION
The leading colon was causing asciidoc to interpret the warning as an attribute.