### PR TITLE
Cherry-pick #24104 to 7.x: [Metricbeat] Update Cockroachdb Overview and add SQL dashboard

### DIFF
--- a/x-pack/metricbeat/module/cockroachdb/_meta/kibana/7/dashboard/Metricbeat-cockroachdb-overview.json
+++ b/x-pack/metricbeat/module/cockroachdb/_meta/kibana/7/dashboard/Metricbeat-cockroachdb-overview.json
@@ -19,21 +19,25 @@
         },
         "panelsJSON": [
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "enhancements": {}
+            },
             "gridData": {
               "h": 11,
               "i": "1",
-              "w": 24,
-              "x": 0,
+              "w": 19,
+              "x": 5,
               "y": 0
             },
             "panelIndex": "1",
             "panelRefName": "panel_0",
             "title": "Number of SQL connections",
-            "version": "7.1.0"
+            "version": "7.11.1"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "enhancements": {}
+            },
             "gridData": {
               "h": 11,
               "i": "2",
@@ -44,10 +48,12 @@
             "panelIndex": "2",
             "panelRefName": "panel_1",
             "title": "SQL queries",
-            "version": "7.1.0"
+            "version": "7.11.1"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "enhancements": {}
+            },
             "gridData": {
               "h": 9,
               "i": "3",
@@ -58,10 +64,12 @@
             "panelIndex": "3",
             "panelRefName": "panel_2",
             "title": "Replicas per Store",
-            "version": "7.1.0"
+            "version": "7.11.1"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "enhancements": {}
+            },
             "gridData": {
               "h": 9,
               "i": "4",
@@ -72,10 +80,12 @@
             "panelIndex": "4",
             "panelRefName": "panel_3",
             "title": "Replica leaseholders",
-            "version": "7.1.0"
+            "version": "7.11.1"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "enhancements": {}
+            },
             "gridData": {
               "h": 9,
               "i": "5",
@@ -86,10 +96,12 @@
             "panelIndex": "5",
             "panelRefName": "panel_4",
             "title": "Ranges",
-            "version": "7.1.0"
+            "version": "7.11.1"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "enhancements": {}
+            },
             "gridData": {
               "h": 10,
               "i": "6",
@@ -100,10 +112,12 @@
             "panelIndex": "6",
             "panelRefName": "panel_5",
             "title": "Average log commit latency",
-            "version": "7.1.0"
+            "version": "7.11.1"
           },
           {
-            "embeddableConfig": {},
+            "embeddableConfig": {
+              "enhancements": {}
+            },
             "gridData": {
               "h": 10,
               "i": "7",
@@ -114,17 +128,117 @@
             "panelIndex": "7",
             "panelRefName": "panel_6",
             "title": "Average command commit latency",
-            "version": "7.1.0"
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {},
+              "hidePanelTitles": false
+            },
+            "gridData": {
+              "h": 11,
+              "i": "b9cf2afd-ae8b-409b-93f2-b69ba1e1f064",
+              "w": 5,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "b9cf2afd-ae8b-409b-93f2-b69ba1e1f064",
+            "panelRefName": "panel_7",
+            "title": "Dashboards Navigation",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {}
+            },
+            "gridData": {
+              "h": 10,
+              "i": "3b2a916c-213c-4179-93f6-067224d1f741",
+              "w": 24,
+              "x": 0,
+              "y": 30
+            },
+            "panelIndex": "3b2a916c-213c-4179-93f6-067224d1f741",
+            "panelRefName": "panel_8",
+            "title": "Live Nodes",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {}
+            },
+            "gridData": {
+              "h": 10,
+              "i": "725c9437-5d36-48bd-9328-e08637e42ac7",
+              "w": 24,
+              "x": 24,
+              "y": 30
+            },
+            "panelIndex": "725c9437-5d36-48bd-9328-e08637e42ac7",
+            "panelRefName": "panel_9",
+            "title": "Process Uptime",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {}
+            },
+            "gridData": {
+              "h": 10,
+              "i": "7d37508a-3614-4c51-b8e1-84d9101a233b",
+              "w": 24,
+              "x": 0,
+              "y": 40
+            },
+            "panelIndex": "7d37508a-3614-4c51-b8e1-84d9101a233b",
+            "panelRefName": "panel_10",
+            "title": "Capacity Usage",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {}
+            },
+            "gridData": {
+              "h": 10,
+              "i": "3b319d88-1798-433b-9ab8-783c53d24423",
+              "w": 24,
+              "x": 24,
+              "y": 40
+            },
+            "panelIndex": "3b319d88-1798-433b-9ab8-783c53d24423",
+            "panelRefName": "panel_11",
+            "title": "Disk Metrics",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {}
+            },
+            "gridData": {
+              "h": 10,
+              "i": "7cf99937-570d-4132-ab15-204a547bd986",
+              "w": 24,
+              "x": 0,
+              "y": 50
+            },
+            "panelIndex": "7cf99937-570d-4132-ab15-204a547bd986",
+            "panelRefName": "panel_12",
+            "title": "Node Clock Offset",
+            "version": "7.11.1"
           }
         ],
         "timeRestore": false,
         "title": "[Metricbeat CockroachDB] Overview",
         "version": 1
       },
-      "id": "e3ba0c30-9766-11e9-9eea-6f554992ec1f",
+      "id": "04b595b0-c1fc-11ea-8a94-61b423d19ae7",
       "migrationVersion": {
-        "dashboard": "7.0.0"
+        "dashboard": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [
         {
           "id": "79691920-9766-11e9-9eea-6f554992ec1f",
@@ -160,23 +274,47 @@
           "id": "b5ab45b0-9771-11e9-9eea-6f554992ec1f",
           "name": "panel_6",
           "type": "visualization"
+        },
+        {
+          "id": "d4177d60-75e2-11eb-b955-29bfd5c9e2dd",
+          "name": "panel_7",
+          "type": "visualization"
+        },
+        {
+          "id": "643353f0-c202-11ea-8a94-61b423d19ae7",
+          "name": "panel_8",
+          "type": "visualization"
+        },
+        {
+          "id": "bbd18b20-ccf4-11ea-8a94-61b423d19ae7",
+          "name": "panel_9",
+          "type": "visualization"
+        },
+        {
+          "id": "57939a70-ec63-11ea-b088-6f3c0066a551",
+          "name": "panel_10",
+          "type": "visualization"
+        },
+        {
+          "id": "020f6a20-ec68-11ea-b088-6f3c0066a551",
+          "name": "panel_11",
+          "type": "visualization"
+        },
+        {
+          "id": "f2d065e0-ee11-11ea-b088-6f3c0066a551",
+          "name": "panel_12",
+          "type": "visualization"
         }
       ],
       "type": "dashboard",
-      "updated_at": "2019-06-25T19:17:43.667Z",
-      "version": "WzU0LDFd"
+      "updated_at": "2021-02-23T18:01:10.249Z",
+      "version": "WzQwNzIsMl0="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Number of SQL connections [Metricbeat CockroachDB]",
         "uiStateJSON": {},
@@ -229,24 +367,21 @@
       },
       "id": "79691920-9766-11e9-9eea-6f554992ec1f",
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-06-25T19:10:30.316Z",
-      "version": "WzUxLDFd"
+      "updated_at": "2021-02-23T13:34:56.700Z",
+      "version": "WzEzOTQsMV0="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "SQL queries [Metricbeat CockroachDB]",
         "uiStateJSON": {},
@@ -259,9 +394,11 @@
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "metricbeat-*",
-            "interval": "auto",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -282,7 +419,7 @@
                     "field": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
                     "id": "658d2990-9762-11e9-b3d5-07b0ab7d6354",
                     "type": "derivative",
-                    "unit": ""
+                    "unit": "1s"
                   },
                   {
                     "field": "658d2990-9762-11e9-b3d5-07b0ab7d6354",
@@ -294,10 +431,12 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "stacked",
                 "terms_field": "service.address",
-                "terms_order_by": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354"
+                "terms_order_by": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                "type": "timeseries"
               },
               {
                 "axis_position": "right",
@@ -319,7 +458,7 @@
                     "field": "02d89101-9761-11e9-b3d5-07b0ab7d6354",
                     "id": "74eba420-9762-11e9-b3d5-07b0ab7d6354",
                     "type": "derivative",
-                    "unit": ""
+                    "unit": "1s"
                   },
                   {
                     "field": "74eba420-9762-11e9-b3d5-07b0ab7d6354",
@@ -330,8 +469,10 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
-                "stacked": "stacked"
+                "stacked": "stacked",
+                "type": "timeseries"
               },
               {
                 "axis_position": "right",
@@ -353,7 +494,7 @@
                     "field": "61ca57f2-469d-11e7-af02-69e470af7417",
                     "id": "9aa7ace0-9762-11e9-b3d5-07b0ab7d6354",
                     "type": "derivative",
-                    "unit": ""
+                    "unit": "1s"
                   },
                   {
                     "field": "9aa7ace0-9762-11e9-b3d5-07b0ab7d6354",
@@ -364,9 +505,11 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "stacked",
-                "terms_field": "service.address"
+                "terms_field": "service.address",
+                "type": "timeseries"
               },
               {
                 "axis_position": "right",
@@ -388,7 +531,7 @@
                     "field": "03f6d241-9761-11e9-b3d5-07b0ab7d6354",
                     "id": "a3ed7c30-9762-11e9-b3d5-07b0ab7d6354",
                     "type": "derivative",
-                    "unit": ""
+                    "unit": "1s"
                   },
                   {
                     "field": "a3ed7c30-9762-11e9-b3d5-07b0ab7d6354",
@@ -399,13 +542,16 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
-                "stacked": "stacked"
+                "stacked": "stacked",
+                "type": "timeseries"
               }
             ],
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
             "type": "timeseries"
           },
           "title": "SQL queries [Metricbeat CockroachDB]",
@@ -414,24 +560,21 @@
       },
       "id": "5073ed20-9760-11e9-9eea-6f554992ec1f",
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-06-25T18:41:34.934Z",
-      "version": "WzQ0LDFd"
+      "updated_at": "2021-02-23T13:36:58.294Z",
+      "version": "WzE5MjQsMV0="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Replicas per Store [Metricbeat CockroachDB]",
         "uiStateJSON": {},
@@ -443,9 +586,11 @@
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "metricbeat-*",
-            "interval": "auto",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -476,6 +621,7 @@
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
             "type": "timeseries"
           },
           "title": "Replicas per Store [Metricbeat CockroachDB]",
@@ -484,24 +630,21 @@
       },
       "id": "bad285b0-9769-11e9-9eea-6f554992ec1f",
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-06-25T19:06:30.737Z",
-      "version": "WzQ4LDFd"
+      "updated_at": "2021-02-23T13:36:58.294Z",
+      "version": "WzE5MjYsMV0="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Replica leaseholders [Metricbeat CockroachDB]",
         "uiStateJSON": {},
@@ -513,9 +656,11 @@
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "metricbeat-*",
-            "interval": "auto",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -544,6 +689,7 @@
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
             "type": "timeseries"
           },
           "title": "Replica leaseholders [Metricbeat CockroachDB]",
@@ -552,24 +698,21 @@
       },
       "id": "8add0960-976a-11e9-9eea-6f554992ec1f",
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-06-25T18:34:03.281Z",
-      "version": "WzQwLDFd"
+      "updated_at": "2021-02-23T13:36:58.294Z",
+      "version": "WzE5MjcsMV0="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Ranges [Metricbeat CockroachDB]",
         "uiStateJSON": {},
@@ -581,9 +724,11 @@
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "metricbeat-*",
-            "interval": "auto",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -603,6 +748,7 @@
                 ],
                 "point_size": "2",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "terms_field": null
@@ -625,6 +771,7 @@
                 ],
                 "point_size": "2",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "terms_field": null
@@ -647,6 +794,7 @@
                 ],
                 "point_size": "2",
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "terms_field": null
@@ -669,6 +817,7 @@
                 ],
                 "point_size": 1,
                 "separate_axis": 0,
+                "split_color_mode": "gradient",
                 "split_mode": "everything",
                 "stacked": "none",
                 "terms_field": null
@@ -677,6 +826,7 @@
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
             "type": "timeseries"
           },
           "title": "Ranges [Metricbeat CockroachDB]",
@@ -685,24 +835,21 @@
       },
       "id": "2af19b90-976c-11e9-9eea-6f554992ec1f",
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-06-25T18:38:28.645Z",
-      "version": "WzQyLDFd"
+      "updated_at": "2021-02-23T13:36:58.294Z",
+      "version": "WzE5MjgsMV0="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Log commit latency [Metricbeat CockroachDB]",
         "uiStateJSON": {},
@@ -714,9 +861,11 @@
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "metricbeat-*",
-            "interval": "auto",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -785,6 +934,7 @@
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
             "type": "timeseries"
           },
           "title": "Log commit latency [Metricbeat CockroachDB]",
@@ -793,24 +943,21 @@
       },
       "id": "74cf44b0-9771-11e9-9eea-6f554992ec1f",
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-06-25T19:08:05.279Z",
-      "version": "WzQ5LDFd"
+      "updated_at": "2021-02-23T13:36:58.294Z",
+      "version": "WzE5MjksMV0="
     },
     {
       "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-          "searchSourceJSON": {
-            "filter": [],
-            "query": {
-              "language": "kuery",
-              "query": ""
-            }
-          }
+          "searchSourceJSON": {}
         },
         "title": "Command commit latency [Metricbeat CockroachDB]",
         "uiStateJSON": {},
@@ -822,9 +969,11 @@
             "axis_position": "left",
             "axis_scale": "normal",
             "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
             "id": "61ca57f0-469d-11e7-af02-69e470af7417",
             "index_pattern": "metricbeat-*",
-            "interval": "auto",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
             "series": [
               {
                 "axis_position": "right",
@@ -893,6 +1042,7 @@
             "show_grid": 1,
             "show_legend": 1,
             "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
             "type": "timeseries"
           },
           "title": "Command commit latency [Metricbeat CockroachDB]",
@@ -901,13 +1051,598 @@
       },
       "id": "b5ab45b0-9771-11e9-9eea-6f554992ec1f",
       "migrationVersion": {
-        "visualization": "7.0.1"
+        "visualization": "7.11.0"
       },
+      "namespaces": [
+        "default"
+      ],
       "references": [],
       "type": "visualization",
-      "updated_at": "2019-06-25T19:08:47.407Z",
-      "version": "WzUwLDFd"
+      "updated_at": "2021-02-23T13:36:58.294Z",
+      "version": "WzE5MzAsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Navigation [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "fontSize": 12,
+            "markdown": "[Overview](#/dashboard/04b595b0-c1fc-11ea-8a94-61b423d19ae7) | [SQL](#/dashboard/3975ad70-c761-11ea-8a94-61b423d19ae7)\n",
+            "openLinksInNewTab": false
+          },
+          "title": "Navigation [Metricbeat CockroachDB]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4177d60-75e2-11eb-b955-29bfd5c9e2dd",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-24T14:44:24.373Z",
+      "version": "WzQyMTUsM10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Live Nodes [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "4e4d6390-c1fe-11ea-bd96-b595ac63d5e9"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "59bbdf40-c1fe-11ea-bd96-b595ac63d5e9"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "gauge_color_rules": [
+              {
+                "id": "f1642eb0-c1fe-11ea-bd96-b595ac63d5e9"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": "0.5",
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Live Nodes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "prometheus.metrics.node_id",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Live Nodes [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "643353f0-c202-11ea-8a94-61b423d19ae7",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:53:25.710Z",
+      "version": "WzIwMjYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Process Uptime [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "s,h,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Cockroach Process Uptime",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "type": "timeseries",
+                "value_template": "{{value}} h"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Process Uptime [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "bbd18b20-ccf4-11ea-8a94-61b423d19ae7",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:54:51.798Z",
+      "version": "WzIxMDYsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Capacity Usage [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "background_color_rules": [
+              {
+                "id": "68be3790-ec65-11ea-8a63-93b9b48262dc"
+              }
+            ],
+            "bar_color_rules": [
+              {
+                "id": "6eabb420-ec65-11ea-8a63-93b9b48262dc"
+              }
+            ],
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "gauge_color_rules": [
+              {
+                "id": "71a5ba40-ec65-11ea-8a63-93b9b48262dc"
+              }
+            ],
+            "gauge_inner_width": 10,
+            "gauge_style": "half",
+            "gauge_width": 10,
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "hidden": false,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Total Capacity",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_filters": [
+                  {
+                    "color": "#68BC00",
+                    "filter": {
+                      "language": "kuery",
+                      "query": ""
+                    },
+                    "id": "0464ddc0-ec66-11ea-8a63-93b9b48262dc"
+                  }
+                ],
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_direction": "desc",
+                "terms_field": "service.address",
+                "terms_order_by": "_count",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "775782d0-ec64-11ea-8a63-93b9b48262dc",
+                "label": "Capacity Available",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "775782d1-ec64-11ea-8a63-93b9b48262dc",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_direction": "desc",
+                "terms_field": "service.address",
+                "terms_order_by": "_count",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": 0.5,
+                "formatter": "bytes",
+                "id": "78322b60-ec64-11ea-8a63-93b9b48262dc",
+                "label": "Capacity Used",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "78322b61-ec64-11ea-8a63-93b9b48262dc",
+                    "type": "sum"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_direction": "desc",
+                "terms_field": "service.address",
+                "terms_order_by": "_count",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Capacity Usage [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "57939a70-ec63-11ea-b088-6f3c0066a551",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:53:40.881Z",
+      "version": "WzIwNDcsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Disk Metrics [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(254,146,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "e4489e50-976b-11e9-b3d5-07b0ab7d6354",
+                "label": "Disk IOPS in Progress",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "e4489e51-976b-11e9-b3d5-07b0ab7d6354",
+                    "type": "max",
+                    "unit": "1s"
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "none",
+                "terms_field": "host.name",
+                "terms_size": "100",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "c938f9c0-976b-11e9-b3d5-07b0ab7d6354",
+                "label": "Disk Read Ops",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "c938f9c1-976b-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "b5a57e90-ec67-11ea-8a63-93b9b48262dc",
+                    "type": "series_agg"
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_size": "100",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": "0",
+                "formatter": "number",
+                "id": "0ed1bf80-976c-11e9-b3d5-07b0ab7d6354",
+                "label": "Disk Write Ops",
+                "line_width": "2",
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "0ed1bf81-976c-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "d6fb6e10-ec67-11ea-8a63-93b9b48262dc",
+                    "type": "series_agg"
+                  }
+                ],
+                "point_size": "2",
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_order_by": "_key",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Disk Metrics [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "020f6a20-ec68-11ea-b088-6f3c0066a551",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:53:59.248Z",
+      "version": "WzIwNjIsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Clock Offset [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "annotations": [],
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(84,179,153,1)",
+                "fill": 0.5,
+                "formatter": "ns,ms,3",
+                "id": "88d6bda0-9760-11e9-b3d5-07b0ab7d6354",
+                "label": "Clock Offsets",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_field": null,
+                "terms_order_by": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                "type": "timeseries",
+                "value_template": "{{value}} ms"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Clock Offset [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "f2d065e0-ee11-11ea-b088-6f3c0066a551",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:54:14.540Z",
+      "version": "WzIwNzYsMV0="
     }
   ],
-  "version": "7.1.0"
+  "version": "7.11.1"
 }

--- a/x-pack/metricbeat/module/cockroachdb/_meta/kibana/7/dashboard/Metricbeat-cockroachdb-sql.json
+++ b/x-pack/metricbeat/module/cockroachdb/_meta/kibana/7/dashboard/Metricbeat-cockroachdb-sql.json
@@ -1,0 +1,981 @@
+{
+  "objects": [
+    {
+      "attributes": {
+        "description": "CockroachDB SQL Performance",
+        "hits": 0,
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "optionsJSON": {
+          "hidePanelTitles": false,
+          "useMargins": true
+        },
+        "panelsJSON": [
+          {
+            "embeddableConfig": {
+              "enhancements": {}
+            },
+            "gridData": {
+              "h": 11,
+              "i": "1",
+              "w": 19,
+              "x": 5,
+              "y": 0
+            },
+            "panelIndex": "1",
+            "panelRefName": "panel_0",
+            "title": "Number of SQL connections",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {},
+              "hidePanelTitles": false
+            },
+            "gridData": {
+              "h": 11,
+              "i": "2f29ec8c-d61d-4b27-94e7-7c9437e5abda",
+              "w": 5,
+              "x": 0,
+              "y": 0
+            },
+            "panelIndex": "2f29ec8c-d61d-4b27-94e7-7c9437e5abda",
+            "panelRefName": "panel_1",
+            "title": "Dashboard Navigation",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {},
+              "hidePanelTitles": false
+            },
+            "gridData": {
+              "h": 11,
+              "i": "d5e26270-2ebe-45c2-9697-f7e24dcd8492",
+              "w": 24,
+              "x": 24,
+              "y": 0
+            },
+            "panelIndex": "d5e26270-2ebe-45c2-9697-f7e24dcd8492",
+            "panelRefName": "panel_2",
+            "title": "SQL queries",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {},
+              "hidePanelTitles": false
+            },
+            "gridData": {
+              "h": 15,
+              "i": "a63ed7f8-f4ea-411a-98d5-14427bf3237e",
+              "w": 24,
+              "x": 0,
+              "y": 11
+            },
+            "panelIndex": "a63ed7f8-f4ea-411a-98d5-14427bf3237e",
+            "panelRefName": "panel_3",
+            "title": "Average Exec latency",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {},
+              "hidePanelTitles": false
+            },
+            "gridData": {
+              "h": 15,
+              "i": "6660f8f4-c3af-4b56-9ecf-fffd8210a302",
+              "w": 24,
+              "x": 24,
+              "y": 11
+            },
+            "panelIndex": "6660f8f4-c3af-4b56-9ecf-fffd8210a302",
+            "panelRefName": "panel_4",
+            "title": "Transactions",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {},
+              "hidePanelTitles": false
+            },
+            "gridData": {
+              "h": 15,
+              "i": "98d6be7f-9aba-4181-a1a1-2152be085550",
+              "w": 24,
+              "x": 0,
+              "y": 26
+            },
+            "panelIndex": "98d6be7f-9aba-4181-a1a1-2152be085550",
+            "panelRefName": "panel_5",
+            "title": "SQL Bytes",
+            "version": "7.11.1"
+          },
+          {
+            "embeddableConfig": {
+              "enhancements": {},
+              "hidePanelTitles": false
+            },
+            "gridData": {
+              "h": 15,
+              "i": "f4c38787-07a3-431a-8b1e-df12214c5bec",
+              "w": 24,
+              "x": 24,
+              "y": 26
+            },
+            "panelIndex": "f4c38787-07a3-431a-8b1e-df12214c5bec",
+            "panelRefName": "panel_6",
+            "title": "Schema Changes",
+            "version": "7.11.1"
+          }
+        ],
+        "timeRestore": false,
+        "title": "[Metricbeat CockroachDB] SQL",
+        "version": 1
+      },
+      "id": "3975ad70-c761-11ea-8a94-61b423d19ae7",
+      "migrationVersion": {
+        "dashboard": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [
+        {
+          "id": "79691920-9766-11e9-9eea-6f554992ec1f",
+          "name": "panel_0",
+          "type": "visualization"
+        },
+        {
+          "id": "d4177d60-75e2-11eb-b955-29bfd5c9e2dd",
+          "name": "panel_1",
+          "type": "visualization"
+        },
+        {
+          "id": "5073ed20-9760-11e9-9eea-6f554992ec1f",
+          "name": "panel_2",
+          "type": "visualization"
+        },
+        {
+          "id": "89e96120-fe7a-11ea-a589-8d7d9f58c8fd",
+          "name": "panel_3",
+          "type": "visualization"
+        },
+        {
+          "id": "61999c30-c766-11ea-8a94-61b423d19ae7",
+          "name": "panel_4",
+          "type": "visualization"
+        },
+        {
+          "id": "7d13f0d0-c763-11ea-8a94-61b423d19ae7",
+          "name": "panel_5",
+          "type": "visualization"
+        },
+        {
+          "id": "6fdbdbe0-c767-11ea-8a94-61b423d19ae7",
+          "name": "panel_6",
+          "type": "visualization"
+        }
+      ],
+      "type": "dashboard",
+      "updated_at": "2021-02-23T18:06:08.236Z",
+      "version": "WzQyMDIsMl0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "Number of SQL connections [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "auto",
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Number of connections",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_conns",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "max"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "stacked",
+                "terms_direction": "desc",
+                "terms_field": "service.address",
+                "terms_order_by": "_count"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "type": "timeseries"
+          },
+          "title": "Number of SQL connections [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "79691920-9766-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:34:56.700Z",
+      "version": "WzEzOTQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Navigation [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "fontSize": 12,
+            "markdown": "[Overview](#/dashboard/04b595b0-c1fc-11ea-8a94-61b423d19ae7) | [SQL](#/dashboard/3975ad70-c761-11ea-8a94-61b423d19ae7)\n",
+            "openLinksInNewTab": false
+          },
+          "title": "Navigation [Metricbeat CockroachDB]",
+          "type": "markdown"
+        }
+      },
+      "id": "d4177d60-75e2-11eb-b955-29bfd5c9e2dd",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-24T14:44:24.373Z",
+      "version": "WzQyMTUsM10="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {}
+        },
+        "title": "SQL queries [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "annotations": [],
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "88d6bda0-9760-11e9-b3d5-07b0ab7d6354",
+                "label": "Selects",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_select_count",
+                    "id": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                    "id": "658d2990-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "658d2990-9762-11e9-b3d5-07b0ab7d6354",
+                    "function": "sum",
+                    "id": "ec698bc0-9762-11e9-b3d5-07b0ab7d6354",
+                    "sigma": "",
+                    "type": "positive_only"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "stacked",
+                "terms_field": "service.address",
+                "terms_order_by": "88d70bc0-9760-11e9-b3d5-07b0ab7d6354",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "02d89100-9761-11e9-b3d5-07b0ab7d6354",
+                "label": "Inserts",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_insert_count",
+                    "id": "02d89101-9761-11e9-b3d5-07b0ab7d6354",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "02d89101-9761-11e9-b3d5-07b0ab7d6354",
+                    "id": "74eba420-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "74eba420-9762-11e9-b3d5-07b0ab7d6354",
+                    "id": "54cb8aa0-9764-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "stacked",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Updates",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_update_count",
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "9aa7ace0-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "9aa7ace0-9762-11e9-b3d5-07b0ab7d6354",
+                    "id": "939af2c0-9764-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "stacked",
+                "terms_field": "service.address",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(115,216,255,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "hidden": false,
+                "id": "03f6d240-9761-11e9-b3d5-07b0ab7d6354",
+                "label": "Deletes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": "prometheus.metrics.sql_delete_count",
+                    "id": "03f6d241-9761-11e9-b3d5-07b0ab7d6354",
+                    "type": "sum"
+                  },
+                  {
+                    "field": "03f6d241-9761-11e9-b3d5-07b0ab7d6354",
+                    "id": "a3ed7c30-9762-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": "1s"
+                  },
+                  {
+                    "field": "a3ed7c30-9762-11e9-b3d5-07b0ab7d6354",
+                    "id": "a13994e0-9764-11e9-b3d5-07b0ab7d6354",
+                    "type": "positive_only",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "gradient",
+                "split_mode": "everything",
+                "stacked": "stacked",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "SQL queries [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "5073ed20-9760-11e9-9eea-6f554992ec1f",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:36:58.294Z",
+      "version": "WzE5MjQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "Average SQL execution latency",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Average Exec latency [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(104,188,0,1)",
+                "fill": 0.5,
+                "filter": "",
+                "formatter": "ns,ms,2",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Average log commit latency",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "agg_with": "avg",
+                    "field": null,
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "order": "desc",
+                    "size": 1,
+                    "type": "max"
+                  },
+                  {
+                    "field": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "id": "4346d3b0-976f-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "field": null,
+                    "id": "4a430120-976f-11e9-b3d5-07b0ab7d6354",
+                    "type": "max",
+                    "unit": ""
+                  },
+                  {
+                    "field": "4a430120-976f-11e9-b3d5-07b0ab7d6354",
+                    "id": "581519e0-9770-11e9-b3d5-07b0ab7d6354",
+                    "type": "derivative",
+                    "unit": ""
+                  },
+                  {
+                    "id": "6574b730-9770-11e9-b3d5-07b0ab7d6354",
+                    "script": "params.sum / params.count",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "581519e0-9770-11e9-b3d5-07b0ab7d6354",
+                        "id": "6fbb54b0-9770-11e9-b3d5-07b0ab7d6354",
+                        "name": "sum"
+                      },
+                      {
+                        "field": "4346d3b0-976f-11e9-b3d5-07b0ab7d6354",
+                        "id": "76cc90c0-9770-11e9-b3d5-07b0ab7d6354",
+                        "name": "count"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "rainbow",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "type": "timeseries",
+                "value_template": "{{value}}ms"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Average Exec latency [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "89e96120-fe7a-11ea-a589-8d7d9f58c8fd",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:54:28.905Z",
+      "version": "WzIwOTEsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Transactions [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Transactions Begins",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "6db52340-2067-11eb-96da-17d67bb2d46d",
+                    "type": "series_agg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_size": "50",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(164,221,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "1c074fc0-ccf0-11ea-8da4-c95c019bd9d5",
+                "label": "Transaction Commits",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "1c074fc1-ccf0-11ea-8da4-c95c019bd9d5",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "9241d3c0-2067-11eb-96da-17d67bb2d46d",
+                    "type": "series_agg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_size": "50",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(252,220,0,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "84ac4080-ccf0-11ea-8da4-c95c019bd9d5",
+                "label": "Transaction Rollbacks",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "84ac4081-ccf0-11ea-8da4-c95c019bd9d5",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "a9b7afc0-2067-11eb-96da-17d67bb2d46d",
+                    "type": "series_agg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_size": "50",
+                "type": "timeseries"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(244,78,59,1)",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "9701db00-ccf0-11ea-8da4-c95c019bd9d5",
+                "label": "Transaction Aborts",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "9701db01-ccf0-11ea-8da4-c95c019bd9d5",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "bc1fc0d0-2067-11eb-96da-17d67bb2d46d",
+                    "type": "series_agg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_size": "50",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Transactions [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "61999c30-c766-11ea-8a94-61b423d19ae7",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:58:36.680Z",
+      "version": "WzIzNzQsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "SQL Bytes [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(84,179,153,1)",
+                "fill": "0.5",
+                "formatter": "bytes",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Bytes In",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "e37c46b0-cd03-11ea-90ab-5112cd60bde7",
+                    "type": "series_agg"
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_size": "50",
+                "type": "timeseries",
+                "value_template": "{{value}}/s"
+              },
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "rgba(96,146,192,1)",
+                "fill": "0.5",
+                "formatter": "bytes",
+                "id": "15553390-cd04-11ea-90ab-5112cd60bde7",
+                "label": "Bytes Out",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "15553391-cd04-11ea-90ab-5112cd60bde7",
+                    "type": "positive_rate",
+                    "unit": "1s"
+                  },
+                  {
+                    "function": "sum",
+                    "id": "6bc01490-2068-11eb-96da-17d67bb2d46d",
+                    "type": "series_agg"
+                  },
+                  {
+                    "id": "789ffa90-2068-11eb-96da-17d67bb2d46d",
+                    "script": "params.rate != null \u0026\u0026 params.rate \u003e 0 ? params.rate * -1 : null",
+                    "type": "calculation",
+                    "variables": [
+                      {
+                        "field": "15553391-cd04-11ea-90ab-5112cd60bde7",
+                        "id": "7ff173f0-2068-11eb-96da-17d67bb2d46d",
+                        "name": "rate"
+                      }
+                    ]
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "terms",
+                "stacked": "none",
+                "terms_field": null,
+                "terms_size": "100",
+                "type": "timeseries",
+                "value_template": "{{value}}/s"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "SQL Bytes [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "7d13f0d0-c763-11ea-8a94-61b423d19ae7",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:58:59.377Z",
+      "version": "WzIzOTMsMV0="
+    },
+    {
+      "attributes": {
+        "description": "",
+        "kibanaSavedObjectMeta": {
+          "searchSourceJSON": {
+            "filter": [],
+            "query": {
+              "language": "kuery",
+              "query": ""
+            }
+          }
+        },
+        "title": "Schema Changes [Metricbeat CockroachDB]",
+        "uiStateJSON": {},
+        "version": 1,
+        "visState": {
+          "aggs": [],
+          "params": {
+            "axis_formatter": "number",
+            "axis_position": "left",
+            "axis_scale": "normal",
+            "default_index_pattern": "metricbeat-*",
+            "default_timefield": "@timestamp",
+            "id": "61ca57f0-469d-11e7-af02-69e470af7417",
+            "index_pattern": "metricbeat-*",
+            "interval": "\u003e=10s",
+            "isModelInvalid": false,
+            "series": [
+              {
+                "axis_position": "right",
+                "chart_type": "line",
+                "color": "#68BC00",
+                "fill": 0.5,
+                "formatter": "number",
+                "id": "61ca57f1-469d-11e7-af02-69e470af7417",
+                "label": "Schema Changes",
+                "line_width": 1,
+                "metrics": [
+                  {
+                    "field": null,
+                    "id": "61ca57f2-469d-11e7-af02-69e470af7417",
+                    "type": "positive_rate",
+                    "unit": ""
+                  }
+                ],
+                "point_size": 1,
+                "separate_axis": 0,
+                "split_color_mode": "kibana",
+                "split_mode": "everything",
+                "stacked": "none",
+                "type": "timeseries"
+              }
+            ],
+            "show_grid": 1,
+            "show_legend": 1,
+            "time_field": "@timestamp",
+            "tooltip_mode": "show_all",
+            "type": "timeseries"
+          },
+          "title": "Schema Changes [Metricbeat CockroachDB]",
+          "type": "metrics"
+        }
+      },
+      "id": "6fdbdbe0-c767-11ea-8a94-61b423d19ae7",
+      "migrationVersion": {
+        "visualization": "7.11.0"
+      },
+      "namespaces": [
+        "default"
+      ],
+      "references": [],
+      "type": "visualization",
+      "updated_at": "2021-02-23T13:58:47.503Z",
+      "version": "WzIzODMsMV0="
+    }
+  ],
+  "version": "7.11.1"
+}


### PR DESCRIPTION
Cherry-pick of PR #24104 to 7.x branch. Original message: 

## What does this PR do?

In CockroachDB Metricbeat module:

- Clean / Improve visualization titles in "Overall" dashboard.
- Create new "SQL" dashboard
- Remove Cluster filter that wasn't often used.

Checks:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- ~~[x] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

@sorantis you might want to quickly take a look at the screenshots

- [x] Confirm that the filter is removed as expected.
- [ ] Confirm that overall look is the expected.

## Related issues

- Closes https://github.com/elastic/beats/issues/22981

## Screenshots
### Overview
![image](https://user-images.githubusercontent.com/4249331/108887101-16405f00-760a-11eb-80f9-259f86968e80.png)


### SQL
![image](https://user-images.githubusercontent.com/4249331/108887214-3a03a500-760a-11eb-9c4c-573eae6aa3f7.png)



