### PR TITLE
[CI]: if corrupted installation in workers then install tools

### DIFF
--- a/.ci/scripts/install-docker-compose.sh
+++ b/.ci/scripts/install-docker-compose.sh
@@ -15,6 +15,7 @@ fi
 
 if command -v docker-compose
 then
+    set +e
     echo "Found docker-compose. Checking version.."
     FOUND_DOCKER_COMPOSE_VERSION=$(docker-compose --version|awk '{print $3}'|sed s/\,//)
     if [ $FOUND_DOCKER_COMPOSE_VERSION == $DOCKER_COMPOSE_VERSION ]
@@ -22,6 +23,7 @@ then
         echo "Versions match. No need to install docker-compose. Exiting."
         exit 0
     fi
+    set -e
 fi
 
 echo "UNMET DEP: Installing docker-compose"

--- a/.ci/scripts/install-kind.sh
+++ b/.ci/scripts/install-kind.sh
@@ -9,6 +9,7 @@ KIND_CMD="${HOME}/bin/kind"
 
 if command -v kind
 then
+    set +e
     echo "Found Kind. Checking version.."
     FOUND_KIND_VERSION=$(kind --version 2>&1 >/dev/null | awk '{print $3}')
     if [ "$FOUND_KIND_VERSION" == "$KIND_VERSION" ]
@@ -16,6 +17,7 @@ then
         echo "Versions match. No need to install Kind. Exiting."
         exit 0
     fi
+    set -e
 fi
 
 echo "UNMET DEP: Installing Kind"

--- a/.ci/scripts/install-kubectl.sh
+++ b/.ci/scripts/install-kubectl.sh
@@ -9,6 +9,7 @@ KUBECTL_CMD="${HOME}/bin/kubectl"
 
 if command -v kubectl
 then
+    set +e
     echo "Found kubectl. Checking version.."
     FOUND_KUBECTL_VERSION=$(kubectl version --client --short 2>&1 >/dev/null | awk '{print $3}')
     if [ "${FOUND_KUBECTL_VERSION}" == "${K8S_VERSION}" ]
@@ -16,6 +17,7 @@ then
         echo "Versions match. No need to install kubectl. Exiting."
         exit 0
     fi
+    set -e
 fi
 
 echo "UNMET DEP: Installing kubectl"

--- a/.ci/scripts/install-terraform.sh
+++ b/.ci/scripts/install-terraform.sh
@@ -9,6 +9,7 @@ TERRAFORM_CMD="${HOME}/bin/terraform"
 
 if command -v terraform
 then
+    set +e
     echo "Found Terraform. Checking version.."
     FOUND_TERRAFORM_VERSION=$(terraform --version | awk '{print $2}' | sed s/v//)
     if [ "$FOUND_TERRAFORM_VERSION" == "$TERRAFORM_VERSION" ]
@@ -16,6 +17,7 @@ then
         echo "Versions match. No need to install Terraform. Exiting."
         exit 0
     fi
+    set -e
 fi
 
 echo "UNMET DEP: Installing Terraform"


### PR DESCRIPTION
## What does this PR do?

Defensive programming for CI workers with corrupted installations

## Why is it important?

Fixes

![image](https://user-images.githubusercontent.com/2871786/109432511-70269780-7a03-11eb-80b2-d678b0bd89c3.png)


## Tests

From the CI


![image](https://user-images.githubusercontent.com/2871786/109521927-b7fdfb00-7aa5-11eb-8037-16fcf968a22d.png)
