### PR TITLE
Cherry-pick #24110 to 7.x: [Filebeat] Document netflow internal_networks and set default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -247,6 +247,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - aws/s3access dataset was populating event.duration using the wrong unit. {pull}23920[23920]
 - Zoom module pipeline failed to ingest some chat_channel events. {pull}23904[23904]
 - Fix aws/vpcflow generating errors for empty logs or unidentified formats. {pull}24167[24167]
+- Fix Netlow module issue with missing `internal_networks` config parameter. {issue}24094[24094] {pull}24110[24110]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -72,6 +72,13 @@ details.
 monitor sequence numbers in the Netflow packets to detect an Exporting Process
 reset. See <<filebeat-input-netflow,netflow input>> for details.
 
+`var.internal_networks`:: A list of CIDR ranges describing the IP addresses that
+you consider internal. This is used in determining the values of
+`source.locality`, `destination.locality`, and `flow.locality`. The values
+can be either a CIDR value or one of the named ranges supported by the
+<<condition-network, `network`>> condition. The default value is `[private]`
+which classifies RFC 1918 (IPv4) and RFC 4193 (IPv6) addresses as internal.
+
 *`var.tags`*::
 
 A list of tags to include in events. Including `forwarded` indicates that the

--- a/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
@@ -120,6 +120,17 @@ cause flow loss until the exporter provides new templates. If set to `false`,
 if the exporter process is reset. This option is only applicable to Netflow V9
 and IPFIX. Default is `true`.
 
+[float]
+[[internal_networks]]
+==== `internal_networks`
+
+A list of CIDR ranges describing the IP addresses that you consider internal.
+This is used in determining the values of `source.locality`,
+`destination.locality`, and `flow.locality`. The values can be either a CIDR
+value or one of the named ranges supported by the
+<<condition-network, `network`>> condition. The default value is `[private]`
+which classifies RFC 1918 (IPv4) and RFC 4193 (IPv6) addresses as internal.
+
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 

--- a/x-pack/filebeat/input/netflow/config.go
+++ b/x-pack/filebeat/input/netflow/config.go
@@ -33,6 +33,7 @@ var defaultConfig = config{
 	ForwarderConfig: harvester.ForwarderConfig{
 		Type: inputName,
 	},
+	InternalNetworks:    []string{"private"},
 	Protocols:           []string{"v5", "v9", "ipfix"},
 	ExpirationTimeout:   time.Minute * 30,
 	PacketQueueSize:     8192,

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -67,6 +67,13 @@ details.
 monitor sequence numbers in the Netflow packets to detect an Exporting Process
 reset. See <<filebeat-input-netflow,netflow input>> for details.
 
+`var.internal_networks`:: A list of CIDR ranges describing the IP addresses that
+you consider internal. This is used in determining the values of
+`source.locality`, `destination.locality`, and `flow.locality`. The values
+can be either a CIDR value or one of the named ranges supported by the
+<<condition-network, `network`>> condition. The default value is `[private]`
+which classifies RFC 1918 (IPv4) and RFC 4193 (IPv6) addresses as internal.
+
 *`var.tags`*::
 
 A list of tags to include in events. Including `forwarded` indicates that the

--- a/x-pack/filebeat/module/netflow/log/config/netflow.yml
+++ b/x-pack/filebeat/module/netflow/log/config/netflow.yml
@@ -6,7 +6,7 @@ expiration_timeout: '{{.expiration_timeout}}'
 queue_size: {{.queue_size}}
 
 {{if .internal_networks}}
-internal_hosts:
+internal_networks:
 {{range .internal_networks}}
 - '{{ . }}'
 {{end}}

--- a/x-pack/filebeat/module/netflow/log/manifest.yml
+++ b/x-pack/filebeat/module/netflow/log/manifest.yml
@@ -17,6 +17,7 @@ var:
   - name: detect_sequence_reset
   - name: tags
     default: [forwarded]
+  - name: internal_networks
 ingest_pipeline: ingest/pipeline.yml
 input: config/netflow.yml
 


### PR DESCRIPTION
Cherry-pick of PR #24110 to 7.x branch. Original message: 

## What does this PR do?

Documentation for the `internal_networks` option of the Netflow input and module was missing.
Also the module's manifest did not declare the option so if it was not set in the module config
it would cause an error.

I did not see where a default was set for the netflow input's internal_networks option so I set that
to `private` to keep the old behavior before this was configurable.

Fixes #24094

## Why is it important?

Existing users of the netflow module are broken after upgrade unless they change their config.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes #24094