### PR TITLE
[CI] resilience when windows workers fail with deleteDir

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -603,10 +603,12 @@ def withBeatsEnv(Map args = [:], Closure body) {
         if (archive) {
           archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)
         }
-        // Tear down the setup for the permamnent workers.
+        // Tear down the setup for the permanent workers.
         catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
           fixPermissions("${WORKSPACE}")
-          deleteDir()
+          dir("${WORKSPACE}") {
+            deleteDir()
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -606,8 +606,12 @@ def withBeatsEnv(Map args = [:], Closure body) {
         // Tear down the setup for the permanent workers.
         catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
           fixPermissions("${WORKSPACE}")
-          dir("${WORKSPACE}") {
-            deleteDir()
+          // TODO: Somehow windows workers got a different opinion regarding removing the workspace
+          // IMPORTANT: windows workers are ephemerals, so this should not really affect us.
+          if (isUnix()) {
+            dir("${WORKSPACE}") {
+              deleteDir()
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -622,6 +622,7 @@ def fixPermissions(location) {
   if(isUnix()) {
     sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
       set +x
+      echo "Cleaning up ${location}"
       source ./dev-tools/common.bash
       docker_setup
       script/fix_permissions.sh ${location}""", returnStatus: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -507,12 +507,16 @@ def target(Map args = [:]) {
 }
 
 /**
-* This method wraps the node call with some latency to avoid the known issue with the scalabitity in gobld.
+* This method wraps the node call for two reasons:
+*  1. with some latency to avoid the known issue with the scalabitity in gobld.
+*  2. allocate a new workspace to workaround the flakiness of windows workers with deleteDir
 */
 def withNode(String label, Closure body) {
   sleep randomNumber(min: 10, max: 200)
   node(label) {
-    body()
+    ws(env.BUILD_TAG) {
+      body()
+    }
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -514,7 +514,7 @@ def target(Map args = [:]) {
 def withNode(String label, Closure body) {
   sleep randomNumber(min: 10, max: 200)
   node(label) {
-    ws(env.BUILD_TAG) {
+    ws("workspace/${JOB_BASE_NAME}-${BUILD_NUMBER}") {
       body()
     }
   }

--- a/script/fix_permissions.sh
+++ b/script/fix_permissions.sh
@@ -13,8 +13,10 @@ else
     DOCKER_IMAGE=alpine:3.4
   fi
   set -e
-  # Change ownership of all files inside the specific folder from root/root to current user/group
+  echo "Change ownership of all files inside the specific folder from root/root to current user/group"
   docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
-  # Change permissions with write access of all files inside the specific folder
-  chmod -R +w "${LOCATION}"
 fi
+
+set -e
+echo "Change permissions with write access of all files inside the specific folder"
+chmod -R +w "${LOCATION}"


### PR DESCRIPTION
## What does this PR do?

Allocate a new workspace with the `ws` step (docs -> https://www.jenkins.io/doc/pipeline/steps/workflow-durable-task-step/#ws-allocate-workspace)

## Why is it important?

Fix environmental issues when the `deleteDir` fails, in ephemeral windows workers, (thouhg it should not happen, maybe they get reused?) 

```
vmartinez@beats-ci-master-green:/var/lib/jenkins/jobs/Beats/jobs/beats/branches/7-12.fare88/builds/25$ tail  log
[2021-03-02T09:27:43.319Z] jenkins.util.io.CompositeIOException: Unable to delete 'C:\Users\jenkins\workspace\Beats_beats_7.12'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts. (Discarded 16173 additional exceptions)
[2021-03-02T09:27:43.319Z] 	at jenkins.util.io.PathRemover.forceRemoveRecursive(PathRemover.java:99)
[2021-03-02T09:27:43.319Z] 	at hudson.Util.deleteRecursive(Util.java:296)
[2021-03-02T09:27:43.319Z] 	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1398)
[2021-03-02T09:27:43.319Z] 	at hudson.FilePath$DeleteRecursive.invoke(FilePath.java:1394)
[2021-03-02T09:27:43.319Z] 	at hudson.FilePath$FileCallableWrapper.call(FilePath.java:3314)
[2021-03-02T09:27:43.319Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
[2021-03-02T09:27:43.319Z] 	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
[2021-03-02T09:27:43.319Z] 	at hudson.remoting.Request$2.run(Request.java:375)
[2021-03-02T09:27:43.319Z] 	at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:73)
[2021-03-02T09:27:43.319Z] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[2021-03-02T09:27:43.319Z] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[2021-03-02T09:27:43.319Z] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[2021-03-02T09:27:43.319Z] 	at hudson.remoting.Engine$1.lambda$newThread$0(Engine.java:118)
[2021-03-02T09:27:43.319Z] 	at java.lang.Thread.run(Thread.java:748)
[2021-03-02T09:27:43.319Z] Finished: FAILURE
```

![image](https://user-images.githubusercontent.com/2871786/109638033-702eb080-7b45-11eb-81b3-c8302a261bba.png)

![image](https://user-images.githubusercontent.com/2871786/109638067-76bd2800-7b45-11eb-96d3-2e139a856f7b.png)

