### PR TITLE
Cherry-pick #24248 to 7.x: Use `timed.Periodic` when running the periodic scans of filestream

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/go-concert/timed"
 	"github.com/elastic/go-concert/unison"
 )
 
@@ -115,16 +116,14 @@ func defaultFileWatcherConfig() fileWatcherConfig {
 func (w *fileWatcher) Run(ctx unison.Canceler) {
 	defer close(w.events)
 
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			w.watch(ctx)
-		}
-	}
+	// run initial scan before starting regular
+	w.watch(ctx)
+
+	timed.Periodic(ctx, w.interval, func() error {
+		w.watch(ctx)
+
+		return nil
+	})
 }
 
 func (w *fileWatcher) watch(ctx unison.Canceler) {


### PR DESCRIPTION
Cherry-pick of PR #24248 to 7.x branch. Original message: 

## What does this PR do?

This PR changes the existing cancellation check to the `timed.Periodic` function of `go-concert` to make sure scanning does not ignore cancellation if a scan phase takes longer than the interval configured in `prospector.scanner.check_interval`.

## Why is it important?

We leak a goroutine if cancellation is not detected properly.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
