### PR TITLE
Cherry-pick #24253 to 7.x: Make installer atomic on windows

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -36,6 +36,8 @@
 - Windows agent doesn't uninstall with a lowercase `c:` drive in the path {pull}23998[23998]
 - Fix reloading of log level for services {pull}[24055]24055
 - Fix: Successfully installed and enrolled agent running standalone{pull}[24128]24128
+- Make installer atomic on windows {pull}[24253]24253
+- Remove installed services on agent uninstall {pull}[24151]24151
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,7 +37,6 @@
 - Fix reloading of log level for services {pull}[24055]24055
 - Fix: Successfully installed and enrolled agent running standalone{pull}[24128]24128
 - Make installer atomic on windows {pull}[24253]24253
-- Remove installed services on agent uninstall {pull}[24151]24151
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/artifact/install/awaitable/awaitable_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/awaitable/awaitable_installer.go
@@ -1,0 +1,57 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awaitable
+
+import (
+	"context"
+	"sync"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/program"
+)
+
+type embeddedInstaller interface {
+	Install(ctx context.Context, spec program.Spec, version, installDir string) error
+}
+
+type embeddedChecker interface {
+	Check(ctx context.Context, spec program.Spec, version, installDir string) error
+}
+
+// Installer installs into temporary destination and moves to correct one after
+// successful finish.
+type Installer struct {
+	installer embeddedInstaller
+	checker   embeddedChecker
+	wg        sync.WaitGroup
+}
+
+// NewInstaller creates a new AtomicInstaller
+func NewInstaller(i embeddedInstaller, ch embeddedChecker) (*Installer, error) {
+	return &Installer{
+		installer: i,
+		checker:   ch,
+	}, nil
+}
+
+// Wait allows caller to wait for install to be finished
+func (i *Installer) Wait() {
+	i.wg.Wait()
+}
+
+// Install performs installation of program in a specific version.
+func (i *Installer) Install(ctx context.Context, spec program.Spec, version, installDir string) error {
+	i.wg.Add(1)
+	defer i.wg.Done()
+
+	return i.installer.Install(ctx, spec, version, installDir)
+}
+
+// Check performs installation checks
+func (i *Installer) Check(ctx context.Context, spec program.Spec, version, installDir string) error {
+	i.wg.Add(1)
+	defer i.wg.Done()
+
+	return i.checker.Check(ctx, spec, version, installDir)
+}


### PR DESCRIPTION
Cherry-pick of PR #24253 to 7.x branch. Original message:

## What does this PR do?

PR fixes issue on windows when on restart while installing beats we end up with partial data. 
awaitable installler was introduced which forces app wait for installer finish its job 

and 

sync is forced for windows after rename is called during install. 

## Why is it important?

Fixes #24180

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
