### PR TITLE
Cherry-pick to 7.12: Fix admonition tag to render text correctly (#24258)

### DIFF
--- a/filebeat/docs/inputs/input-log.asciidoc
+++ b/filebeat/docs/inputs/input-log.asciidoc
@@ -60,7 +60,7 @@ because this can lead to unexpected behaviour.
 [[file-identity]]
 ==== Reading files on network shares and cloud providers
 
-:WARNING: Filebeat does not support reading from network shares and cloud providers.
+WARNING: Filebeat does not support reading from network shares and cloud providers.
 
 However, one of the limitations of these data sources can be mitigated
 if you configure Filebeat adequately.


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Fix admonition tag to render text correctly (#24258)