### PR TITLE
Cherry-pick to 7.x: [CI] resilience when windows workers fail with deleteDir (#24289)

### DIFF
--- a/script/fix_permissions.sh
+++ b/script/fix_permissions.sh
@@ -13,8 +13,10 @@ else
     DOCKER_IMAGE=alpine:3.4
   fi
   set -e
-  # Change ownership of all files inside the specific folder from root/root to current user/group
+  echo "Change ownership of all files inside the specific folder from root/root to current user/group"
   docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
-  # Change permissions with write access of all files inside the specific folder
-  chmod -R +w "${LOCATION}"
 fi
+
+set -e
+echo "Change permissions with write access of all files inside the specific folder"
+chmod -R +w "${LOCATION}"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] resilience when windows workers fail with deleteDir (#24289)