### PR TITLE
CI: add resilience when ephemeral windows workers are reused

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -513,8 +513,10 @@ def target(Map args = [:]) {
 */
 def withNode(String label, Closure body) {
   sleep randomNumber(min: 10, max: 200)
+  // this should workaround the existing issue with reusing workers with the Gobld
+  def uuid = UUID.randomUUID().toString()
   node(label) {
-    ws("workspace/${JOB_BASE_NAME}-${BUILD_NUMBER}") {
+    ws("workspace/${JOB_BASE_NAME}-${BUILD_NUMBER}-${uuid}") {
       body()
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -621,6 +621,7 @@ def withBeatsEnv(Map args = [:], Closure body) {
 */
 def tearDown() {
   catchError(buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
+    cmd(label: 'Remove the entire module cache', script: 'go clean -modcache', returnStatus: true)
     fixPermissions("${WORKSPACE}")
     // IMPORTANT: Somehow windows workers got a different opinion regarding removing the workspace.
     //            Windows workers are ephemerals, so this should not really affect us.


### PR DESCRIPTION
## What does this PR do?

- Skip deleteDir for windows since those workers are ephemeral.
- Create a unique workspace

## Why is it important?

* As long as the provisioner does not resolve the issue with reusing workspace we need to put some self-defense code in place
* As long as the build system does not change the permissions to write only we are affected by the above reused workers.

## Issues

https://github.com/elastic/beats/issues/24284