### PR TITLE
[Elastic Agent] Fix issues with enrollment key fetching

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	tokenNameStrip = regexp.MustCompile(`\s\([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89AB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\)$`)
+	tokenNameStrip = regexp.MustCompile(`\s\([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\)$`)
 )
 
 func newContainerCommand(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -33,6 +34,10 @@ const (
 
 	requestRetrySleep = 1 * time.Second // sleep 1 sec between retries for HTTP requests
 	maxRequestRetries = 30              // maximum number of retries for HTTP requests
+)
+
+var (
+	tokenNameStrip = regexp.MustCompile(`\s\([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[4][0-9a-fA-F]{3}-[89AB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\)$`)
 )
 
 func newContainerCommand(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
@@ -272,7 +277,12 @@ func kibanaFetchToken(client *kibana.Client, policy *kibanaPolicy, streams *cli.
 	if err != nil {
 		return "", err
 	}
-	return key.APIKey, nil
+	var keyDetail kibanaAPIKeyDetail
+	err = performGET(client, fmt.Sprintf("/api/fleet/enrollment-api-keys/%s", key.ID), &keyDetail, streams.Err, "Kibana fetch token detail")
+	if err != nil {
+		return "", err
+	}
+	return keyDetail.Item.APIKey, nil
 }
 
 func kibanaClient() (*kibana.Client, error) {
@@ -317,7 +327,7 @@ func findPolicy(policies []kibanaPolicy) (*kibanaPolicy, error) {
 func findKey(keys []kibanaAPIKey, policy *kibanaPolicy) (*kibanaAPIKey, error) {
 	tokenName := envWithDefault(defaultTokenName, "FLEET_TOKEN_NAME")
 	for _, key := range keys {
-		name := strings.TrimSpace(strings.Replace(key.Name, fmt.Sprintf(" (%s)", key.ID), "", 1))
+		name := tokenNameStrip.ReplaceAllString(key.Name, "")
 		if name == tokenName && key.PolicyID == policy.ID {
 			return &key, nil
 		}
@@ -424,4 +434,8 @@ type kibanaAPIKey struct {
 
 type kibanaAPIKeys struct {
 	List []kibanaAPIKey `json:"list"`
+}
+
+type kibanaAPIKeyDetail struct {
+	Item kibanaAPIKey `json:"item"`
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -37,6 +37,8 @@ const (
 )
 
 var (
+	// Used to strip the appended ({uuid}) from the name of an enrollment token. This makes much easier for
+	// a container to reference a token by name, without having to know what the generated UUID is for that name.
 	tokenNameStrip = regexp.MustCompile(`\s\([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\)$`)
 )
 
@@ -327,7 +329,7 @@ func findPolicy(policies []kibanaPolicy) (*kibanaPolicy, error) {
 func findKey(keys []kibanaAPIKey, policy *kibanaPolicy) (*kibanaAPIKey, error) {
 	tokenName := envWithDefault(defaultTokenName, "FLEET_TOKEN_NAME")
 	for _, key := range keys {
-		name := tokenNameStrip.ReplaceAllString(key.Name, "")
+		name := strings.TrimSpace(tokenNameStrip.ReplaceAllString(key.Name, ""))
 		if name == tokenName && key.PolicyID == policy.ID {
 			return &key, nil
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes an issue with the new `container` sub-command. It was not handling the naming of the enrollment tokens correctly and when not running without Fleet Server the `api_key` is not returned in the listing, requiring a detailed fetch to retrieve it.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So usage of the Elastic Agent container on 7.13 works.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24310
