### PR TITLE
Cherry-pick #24123 to 7.x: Add supported versions file in Metricbeat module for Consul

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,7 +71,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use ingress/egress instead of inbound/outbound for system/socket metricset. {pull}22992[22992]
 - Change types of numeric metrics from Kubelet summary api to double so as to cover big numbers. {pull}23335[23335]
 - Add container.image.name and containe.name ECS fields for state_container. {pull}23802[23802]
-- Add support for the MemoryPressure, DiskPressure, OutOfDisk and PIDPressure status conditions in state_node. {pull}[23905]
+- Add support for Consul 1.9. {pull}24123[24123]
+- Add support for the MemoryPressure, DiskPressure, OutOfDisk and PIDPressure status conditions in state_node. {pull}23905[23905]
 - Store `cloudfoundry.container.cpu.pct` in decimal form and as `scaled_float`. {pull}24219[24219]
 
 *Packetbeat*

--- a/metricbeat/docs/modules/consul.asciidoc
+++ b/metricbeat/docs/modules/consul.asciidoc
@@ -12,7 +12,7 @@ This is the https://www.consul.io[Hashicorp's Consul] Metricbeat module. It is s
 [float]
 === Compatibility
 
-The module is being tested with https://github.com/hashicorp/docker-consul/blob/9bd2aa7ecf2414b8712e055f2374699148e8941c/0.X/Dockerfile[1.4.2] version
+The module is being tested with 1.4.2 and 1.9.3 versions of Consul.
 
 [float]
 === Dashboard

--- a/metricbeat/module/consul/_meta/docs.asciidoc
+++ b/metricbeat/module/consul/_meta/docs.asciidoc
@@ -3,7 +3,7 @@ This is the https://www.consul.io[Hashicorp's Consul] Metricbeat module. It is s
 [float]
 === Compatibility
 
-The module is being tested with https://github.com/hashicorp/docker-consul/blob/9bd2aa7ecf2414b8712e055f2374699148e8941c/0.X/Dockerfile[1.4.2] version
+The module is being tested with 1.4.2 and 1.9.3 versions of Consul.
 
 [float]
 === Dashboard

--- a/metricbeat/module/consul/_meta/supported-versions.yml
+++ b/metricbeat/module/consul/_meta/supported-versions.yml
@@ -1,0 +1,3 @@
+variants:
+  - CONSUL_VERSION: 1.4.2
+  - CONSUL_VERSION: 1.9.3

--- a/metricbeat/module/consul/docker-compose.yml
+++ b/metricbeat/module/consul/docker-compose.yml
@@ -2,10 +2,10 @@ version: '2.3'
 
 services:
   consul:
-    image: docker.elastic.co/integrations-ci/beats-consul:${CONSUL_VERSION:-1.4.2}-1
+    image: docker.elastic.co/integrations-ci/beats-consul:${CONSUL_VERSION:-1.9.3}-1
     build:
       context: ./_meta
       args:
-        CONSUL_VERSION: ${CONSUL_VERSION:-1.4.2}
+        CONSUL_VERSION: ${CONSUL_VERSION:-1.9.3}
     ports:
       - 8500

--- a/metricbeat/module/consul/test_consul.py
+++ b/metricbeat/module/consul/test_consul.py
@@ -20,6 +20,7 @@ AGENT_FIELDS = [
 ]
 
 
+@metricbeat.parameterized_with_supported_versions
 class ConsulAgentTest(metricbeat.BaseTest):
 
     COMPOSE_SERVICES = ['consul']


### PR DESCRIPTION
Cherry-pick of PR #24123 to 7.x branch. Original message: 

With the supported versions file, images will be cached, reducing
flakiness in CI.

Added tests with Consul 1.9.3.