### PR TITLE
Cherry-pick #24264 to 7.x: support defining metrics_filters for prometheus module in annotations

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -665,6 +665,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Enrich events of `state_service` metricset with kubernetes services' metadata. {pull}23730[23730]
 - Add support for Darwin/arm M1. {pull}24019[24019]
 - Check fields are documented in aws metricsets. {pull}23887[23887]
+- Add support for defining metrics_filters for prometheus module in hints. {pull}24264[24264]
 
 *Packetbeat*
 

--- a/metricbeat/autodiscover/builder/hints/metrics.go
+++ b/metricbeat/autodiscover/builder/hints/metrics.go
@@ -38,16 +38,17 @@ func init() {
 }
 
 const (
-	module      = "module"
-	namespace   = "namespace"
-	hosts       = "hosts"
-	metricsets  = "metricsets"
-	period      = "period"
-	timeout     = "timeout"
-	ssl         = "ssl"
-	metricspath = "metrics_path"
-	username    = "username"
-	password    = "password"
+	module         = "module"
+	namespace      = "namespace"
+	hosts          = "hosts"
+	metricsets     = "metricsets"
+	period         = "period"
+	timeout        = "timeout"
+	ssl            = "ssl"
+	metricsfilters = "metrics_filters"
+	metricspath    = "metrics_path"
+	username       = "username"
+	password       = "password"
 
 	defaultTimeout = "3s"
 	defaultPeriod  = "1m"
@@ -138,6 +139,10 @@ func (m *metricHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*c
 			"enabled":    true,
 			"ssl":        sslConf,
 			"processors": procs,
+		}
+
+		if mod == "prometheus" {
+			moduleConfig[metricsfilters] = m.getMetricsFilters(hint)
 		}
 
 		if ns != "" {
@@ -298,6 +303,14 @@ func (m *metricHints) getTimeout(hints common.MapStr) string {
 
 func (m *metricHints) getSSLConfig(hints common.MapStr) common.MapStr {
 	return builder.GetHintMapStr(hints, m.Key, ssl)
+}
+
+func (m *metricHints) getMetricsFilters(hints common.MapStr) common.MapStr {
+	mf := common.MapStr{}
+	for k := range builder.GetHintMapStr(hints, m.Key, metricsfilters) {
+		mf[k] = builder.GetHintAsList(hints, m.Key, metricsfilters+"."+k)
+	}
+	return mf
 }
 
 func (m *metricHints) getModuleConfigs(hints common.MapStr) []common.MapStr {

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -57,6 +57,18 @@ can make use of Kuberentes Secrets as described in <<kubernetes-secrets>>.
 SSL parameters, as seen in <<configuration-ssl>>.
 
 [float]
+===== `co.elastic.metrics/metrics_filters.*`
+
+Metrics filters (for prometheus module only).
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+co.elastic.metrics/module: prometheus
+co.elastic.metrics/metrics_filters.include: node_filesystem_*
+co.elastic.metrics/metrics_filters.exclude: node_filesystem_device_foo,node_filesystem_device_bar
+-------------------------------------------------------------------------------------
+
+[float]
 ===== `co.elastic.metrics/raw`
 When an entire module configuration needs to be completely set the `raw` hint can be used. You can provide a
 stringified JSON of the input configuration. `raw` overrides every other hint and can be used to create both a single or


### PR DESCRIPTION
Cherry-pick of PR #24264 to 7.x branch. Original message: 

Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement

## What does this PR do?

support defining metrics_filters for prometheus module in annotations

## Why is it important?

support metrics_filters in annotations

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] 

## How to test this PR locally

run test case

Or:

1. Run Metricbeat with hints based autodiscover:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      node: ${NODE_NAME}
      hints.enabled: true
```
2. Deploy a Prometheus sample:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: prom-deployment8
  namespace: kube-system
spec:
  selector:
    matchLabels:
      app: prometheus
  replicas: 1 
  template:
    metadata:
      labels:
        app: prometheus
      annotations:
        co.elastic.metrics/module: prometheus
        co.elastic.metrics/hosts: '${data.host}:${data.port}'
        co.elastic.metrics/metrics_path: '/metrics'
        co.elastic.metrics/period: 1m
        co.elastic.metrics/metrics_filters.include: prometheus_http_*
        co.elastic.metrics/metrics_filters.exclude: ^prometheus_http_response_size_bytes$
    spec:
      containers:
      - name: prometheus
        image: prom/prometheus
        ports:
        - containerPort: 9090
```
3. Verify that filters work properly and only `prometheus_http_*` metrics are collected while `prometheus_http_response_size_bytes` are excluded .

## Related issues

- Closes #23430

## Use cases

annotate pod to add metrics filters without defining all of them in `/raw`

## Screenshots


## Logs

```
2021-03-01T11:09:03.154+0800    DEBUG   [autodiscover.pod]      kubernetes/pod.go:224   Generated builder event map[container:{"id":"3cee712678e78de090ef1f734cede27065dcbd47d8e4393b8fba7801b185ca68","image":"quay.io/freshtracks.io/avalanche","name":"metrics-exporter","runtime":"containerd"} hints:{"metrics":{"hosts":"${data.host}:9001/metrics","metrics_filters":{"exclude":"foo,bar","include":"xxx,yyy"},"module":"prometheus"}} host:10.1.94.211 kubernetes:{"annotations":{"co":{"elastic":{"metrics/hosts":"${data.host}:9001/metrics","metrics/metrics_filters":{"exclude":"foo,bar","include":"xxx,yyy"},"metrics/module":"prometheus"}}},"container":{"id":"3cee712678e78de090ef1f734cede27065dcbd47d8e4393b8fba7801b185ca68","image":"quay.io/freshtracks.io/avalanche","name":"metrics-exporter","runtime":"containerd"},"deployment":{"name":"metrics-exporter"},"labels":{"run":"metrics-exporter"},"namespace":"testing","namespace_uid":"d8707747-d485-492c-8ba6-7746d9a4f0c3","node":{"hostname":"yundeng-ubuntu-3533991","labels":null,"name":"yundeng-ubuntu-3533991","uid":"00828e39-da73-47d7-a826-280e11f5ed04"},"pod":{"name":"metrics-exporter-bc8cfdbc6-f29pr","uid":"cfd69c76-b7b2-4a5d-a7d6-4c715f99ef92"},"replicaset":{"name":"metrics-exporter-bc8cfdbc6"}} port:9001]
2021-03-01T11:09:03.154+0800    DEBUG   [autodiscover]  autodiscover/autodiscover.go:172        Got a start event: map[config:[0xc000995620] host:10.1.94.211 id:cfd69c76-b7b2-4a5d-a7d6-4c715f99ef92 kubernetes:{"annotations":{"co":{"elastic":{"metrics/hosts":"${data.host}:9001/metrics","metrics/metrics_filters":{"exclude":"foo,bar","include":"xxx,yyy"},"metrics/module":"prometheus"}}},"deployment":{"name":"metrics-exporter"},"labels":{"run":"metrics-exporter"},"namespace":"testing","namespace_uid":"d8707747-d485-492c-8ba6-7746d9a4f0c3","node":{"hostname":"yundeng-ubuntu-3533991","labels":null,"name":"yundeng-ubuntu-3533991","uid":"00828e39-da73-47d7-a826-280e11f5ed04"},"pod":{"name":"metrics-exporter-bc8cfdbc6-f29pr","uid":"cfd69c76-b7b2-4a5d-a7d6-4c715f99ef92"},"replicaset":{"name":"metrics-exporter-bc8cfdbc6"}} meta:{"kubernetes":{"deployment":{"name":"metrics-exporter"},"labels":{"run":"metrics-exporter"},"namespace":"testing","namespace_uid":"d8707747-d485-492c-8ba6-7746d9a4f0c3","node":{"hostname":"yundeng-ubuntu-3533991","labels":null,"name":"yundeng-ubuntu-3533991","uid":"00828e39-da73-47d7-a826-280e11f5ed04"},"pod":{"name":"metrics-exporter-bc8cfdbc6-f29pr","uid":"cfd69c76-b7b2-4a5d-a7d6-4c715f99ef92"},"replicaset":{"name":"metrics-exporter-bc8cfdbc6"}}} ports:{"":9001} provider:99997848-4871-4f9e-bbdd-337f6e680a58 start:true]
2021-03-01T11:09:03.154+0800    DEBUG   [registry.lightmodules] mb/lightmodules.go:262  Light modules directory '%!d(string=/private/var/folders/db/rczwwf5j2l553fv9kf_b27j0394k87/T/module)' doesn't exist
2021-03-01T11:09:03.154+0800    DEBUG   [hints.builder] hints/metrics.go:171    generated config: {"enabled":true,"hosts":"xxxxx","metrics_filters":{"exclude":["foo","bar"],"include":["xxx","yyy"]},"metricsets":["collector"],"module":"prometheus","period":"1m","processors":null,"ssl":{},"timeout":"3s"}
2021-03-01T11:09:03.154+0800    DEBUG   [autodiscover]  autodiscover/autodiscover.go:193        Generated config: {
  "enabled": true,
  "hosts": [
    "xxxxx"
  ],
  "metrics_filters": {
    "exclude": [
      "foo",
      "bar"
    ],
    "include": [
      "xxx",
      "yyy"
    ]
  },
  "metricsets": [
    "collector"
  ],
  "module": "prometheus",
  "period": "1m",
  "timeout": "3s"
}

```