### PR TITLE
Ensure k8s secrets do not enable access by default

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -238,16 +238,16 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-    - nodes
-    - namespaces
-    - events
-    - pods
-    - services
+  - nodes
+  - namespaces
+  - events
+  - pods
+  - services
   verbs: ["get", "list", "watch"]
 # Enable this rule only if planing to use Kubernetes keystore
 #- apiGroups: [""]
 #  resources:
-#    - secrets
+#  - secrets
 #  verbs: ["get"]
 - apiGroups: ["extensions"]
   resources:

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -238,13 +238,17 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - nodes
-  - namespaces
-  - events
-  - pods
-  - secrets
-  - services
+    - nodes
+    - namespaces
+    - events
+    - pods
+    - services
   verbs: ["get", "list", "watch"]
+# Enable this rule only if planing to use Kubernetes keystore
+#- apiGroups: [""]
+#  resources:
+#    - secrets
+#  verbs: ["get"]
 - apiGroups: ["extensions"]
   resources:
   - replicasets

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -7,16 +7,16 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-    - nodes
-    - namespaces
-    - events
-    - pods
-    - services
+  - nodes
+  - namespaces
+  - events
+  - pods
+  - services
   verbs: ["get", "list", "watch"]
 # Enable this rule only if planing to use Kubernetes keystore
 #- apiGroups: [""]
 #  resources:
-#    - secrets
+#  - secrets
 #  verbs: ["get"]
 - apiGroups: ["extensions"]
   resources:

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -7,13 +7,17 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - nodes
-  - namespaces
-  - events
-  - pods
-  - secrets
-  - services
+    - nodes
+    - namespaces
+    - events
+    - pods
+    - services
   verbs: ["get", "list", "watch"]
+# Enable this rule only if planing to use Kubernetes keystore
+#- apiGroups: [""]
+#  resources:
+#    - secrets
+#  verbs: ["get"]
 - apiGroups: ["extensions"]
   resources:
   - replicasets

--- a/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
+++ b/libbeat/common/kubernetes/k8skeystore/kubernetes_keystore.go
@@ -111,15 +111,6 @@ func (k *KubernetesSecretsKeystore) Retrieve(key string) (*keystore.SecureString
 	}
 	secretIntefrace := k.client.CoreV1().Secrets(ns)
 	ctx := context.TODO()
-	secrets, err := secretIntefrace.List(ctx, metav1.ListOptions{})
-	if err != nil {
-		k.logger.Errorf("Could not retrieve secrets from k8s API: %v", err)
-		return nil, keystore.ErrKeyDoesntExists
-	}
-	if len(secrets.Items) == 0 {
-		k.logger.Debugf("no secrets found for namespace: %v", ns)
-		return nil, keystore.ErrKeyDoesntExists
-	}
 	secret, err := secretIntefrace.Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		k.logger.Errorf("Could not retrieve secret from k8s API: %v", err)

--- a/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -67,7 +67,22 @@ where `REDIS_PASSWORD` is a key stored in local keystore of Metricbeat.
 [float]
 ===== Kubernetes Secrets
 Metricbeat autodiscover supports leveraging https://kubernetes.io/docs/concepts/configuration/secret/[Kubernetes secrets]
-in order to retrieve sensitive data like passwords.
+in order to retrieve sensitive data like passwords. In order to enable this future add the following section
+in Metricbeat's `ClusterRole` rules:
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+- apiGroups: [""]
+  resources:
+    - secrets
+  verbs: ["get"]
+-------------------------------------------------------------------------------------
+
+CAUTION: The above rule will give permission to Metricbeat Pod to access Kubernetes Secrets API.
+This means that anyone who have access to Metricbeat Pod (`kubectl exec` for example) will be able to access
+Kubernetes Secrets API and get a specific secret no matter which namespace it belongs to. In this,
+this option should be carefully considered, specially when used with hints.
+
 Here is an example of how a configuration using Kubernetes secrets would look like:
 
 ["source","yaml",subs="attributes"]

--- a/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/metricbeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -83,6 +83,25 @@ This means that anyone who have access to Metricbeat Pod (`kubectl exec` for exa
 Kubernetes Secrets API and get a specific secret no matter which namespace it belongs to. In this,
 this option should be carefully considered, specially when used with hints.
 
+One option to give permissions only for one namespace, and not cluster-scoped, is to use
+a specific Role for a targeted namespace so as to better control access:
+
+["source","yaml",subs="attributes"]
+-------------------------------------------------------------------------------------
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: marketing-team
+  name: secret-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["secrets"]
+  verbs: ["get"]
+-------------------------------------------------------------------------------------
+
+One can find more info about Role and ClusterRole in the official Kubernetes
+https://kubernetes.io/docs/reference/access-authn-authz/rbac/[documentation].
+
 Here is an example of how a configuration using Kubernetes secrets would look like:
 
 ["source","yaml",subs="attributes"]


### PR DESCRIPTION
## What does this PR do?
This PR [makes sure that access to k8s secrets](https://github.com/elastic/obs-dc-team/issues/478) are not provided by default with the following:
 - [ ] Explictly separate the rule to give access to secrets.
 - [ ] Give permissions only to `get` (not to `list` or `watch`), so the name of the secret needs to be known in order of get it.
 - [ ] Comment it out by default, mention it in the Keystore docs and comments.

## Why is it important?
To make sure we don't enable access to k8s Secrets API through Metricbeat Pod without actually want it.


## How to test this PR locally

1. Deploy Metricbeat with the proper clusterRole rule added in the manifest:
```
- apiGroups: [""]
  resources:
    - secrets
  verbs: ["get"]
```
2. Enable hints based autodiscover:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      node: ${NODE_NAME}
      hints.enabled: true
```
3. Create secret:
```
cat << EOF | kubectl apply -f -
apiVersion: v1
kind: Secret
metadata:
  name: somesecret
type: Opaque
data:
  value: $(echo -n "passpass" | base64)
EOF
```
4. Deploy Redis target:
```
apiVersion: v1
kind: Service
metadata:
  name: redis
  labels:
    app: redis
spec:
  clusterIP: None
  ports:
  - name: web
    port: 6379
    protocol: TCP
  selector:
    app: redis
  type: ClusterIP
---
apiVersion: v1
kind: Pod
metadata:
  name: redis
  namespace: default
  labels:
    role: main
    app: redis
  annotations:
    co.elastic.metrics.redis/module: redis
    co.elastic.metrics.redis/hosts: '${data.host}:6379'
    co.elastic.metrics.redis/password: "${kubernetes.default.somesecret.value}"
    co.elastic.metrics.redis/period: 10s
spec:
  containers:
    - name: redis
      image: redis:latest
      command:
        - redis-server
        - "--requirepass 'passpass'"
      ports:
        - name: web
          containerPort: 6379
          protocol: TCP
```
5. Verify data flow in.

Extra: try to remove different pieces and verify that the feature blocks access to Redis.
