### PR TITLE
Cherry-pick #24172 to 7.x: [Heartbeat] Add sandbox options, defaulted to off

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -584,6 +584,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add mime type detection for http responses. {pull}22976[22976]
 - Bundle synthetics deps with heartbeat docker image. {pull}23274[23274]
+- Add --sandbox option for browser monitor. {pull}24172[24172]
 
 *Heartbeat*
 

--- a/x-pack/heartbeat/monitors/browser/browser.go
+++ b/x-pack/heartbeat/monitors/browser/browser.go
@@ -52,16 +52,21 @@ func create(name string, cfg *common.Config) (p plugin.Plugin, err error) {
 		return plugin.Plugin{}, err
 	}
 
+	extraArgs := []string{}
+	if ss.suiteCfg.Sandbox {
+		extraArgs = append(extraArgs, "--sandbox")
+	}
+
 	var j jobs.Job
 	if src, ok := ss.InlineSource(); ok {
-		j = synthexec.InlineJourneyJob(context.TODO(), src, ss.Params())
+		j = synthexec.InlineJourneyJob(context.TODO(), src, ss.Params(), extraArgs...)
 	} else {
 		j = func(event *beat.Event) ([]jobs.Job, error) {
 			err := ss.Fetch()
 			if err != nil {
 				return nil, fmt.Errorf("could not fetch for suite job: %w", err)
 			}
-			sj, err := synthexec.SuiteJob(context.TODO(), ss.Workdir(), ss.Params())
+			sj, err := synthexec.SuiteJob(context.TODO(), ss.Workdir(), ss.Params(), extraArgs...)
 			if err != nil {
 				return nil, err
 			}

--- a/x-pack/heartbeat/monitors/browser/config.go
+++ b/x-pack/heartbeat/monitors/browser/config.go
@@ -11,6 +11,12 @@ import (
 	"github.com/elastic/beats/v7/x-pack/heartbeat/monitors/browser/source"
 )
 
+func DefaultConfig() *Config {
+	return &Config{
+		Sandbox: false,
+	}
+}
+
 type Config struct {
 	Schedule  string                 `config:"schedule"`
 	Params    map[string]interface{} `config:"params"`
@@ -19,7 +25,8 @@ type Config struct {
 	// Name is optional for lightweight checks but required for browsers
 	Name string `config:"name"`
 	// Id is optional for lightweight checks but required for browsers
-	Id string `config:"id"`
+	Id      string `config:"id"`
+	Sandbox bool   `config:"sandbox"`
 }
 
 var ErrNameRequired = fmt.Errorf("config 'name' must be specified for this monitor")

--- a/x-pack/heartbeat/monitors/browser/suite_runner.go
+++ b/x-pack/heartbeat/monitors/browser/suite_runner.go
@@ -23,7 +23,7 @@ type SyntheticSuite struct {
 func NewSuite(rawCfg *common.Config) (*SyntheticSuite, error) {
 	ss := &SyntheticSuite{
 		rawCfg:   rawCfg,
-		suiteCfg: &Config{},
+		suiteCfg: DefaultConfig(),
 	}
 	err := rawCfg.Unpack(ss.suiteCfg)
 	if err != nil {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -27,10 +27,10 @@ import (
 const debugSelector = "synthexec"
 
 // SuiteJob will run a single journey by name from the given suite.
-func SuiteJob(ctx context.Context, suitePath string, params common.MapStr) (jobs.Job, error) {
+func SuiteJob(ctx context.Context, suitePath string, params common.MapStr, extraArgs ...string) (jobs.Job, error) {
 	// Run the command in the given suitePath, use '.' as the first arg since the command runs
 	// in the correct dir
-	newCmd, err := suiteCommandFactory(suitePath, ".", "--screenshots")
+	newCmd, err := suiteCommandFactory(suitePath, append(extraArgs, ".", "--screenshots")...)
 	if err != nil {
 		return nil, err
 	}
@@ -55,9 +55,9 @@ func suiteCommandFactory(suitePath string, args ...string) (func() *exec.Cmd, er
 }
 
 // InlineJourneyJob returns a job that runs the given source as a single journey.
-func InlineJourneyJob(ctx context.Context, script string, params common.MapStr) jobs.Job {
+func InlineJourneyJob(ctx context.Context, script string, params common.MapStr, extraArgs ...string) jobs.Job {
 	newCmd := func() *exec.Cmd {
-		return exec.Command("elastic-synthetics", "--inline", "--screenshots")
+		return exec.Command("elastic-synthetics", append(extraArgs, "--inline", "--screenshots")...)
 	}
 
 	return startCmdJob(ctx, newCmd, &script, params)


### PR DESCRIPTION
Cherry-pick of PR #24172 to 7.x branch. Original message: 

Fixes https://github.com/elastic/beats/issues/22901

Adds support for the sandbox options in synthetics. I haven't added tests here because we really need E2E tests for this, but those live elsewhere. Given that we're still in experimental, I think it's OK to merge this feature as-is, and circle back to it later if you're OK with it @blakerouse , I can make a placeholder issue.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [x] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
~~- [x] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

You'll need a custom build of https://github.com/elastic/synthetics until a new release is cut. This removes `--no-sandbox` and replaces it with a `--sandbox` flag, flipping the default.