### PR TITLE
[Heartbeat] Remove warning around messages sent outside journeys

### DIFF
--- a/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer.go
@@ -5,10 +5,7 @@
 package synthexec
 
 import (
-	"encoding/json"
-
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
-	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 type ExecMultiplexer struct {
@@ -36,13 +33,9 @@ func (e ExecMultiplexer) writeSynthEvent(se *SynthEvent) {
 		e.currentJourney.Store(false)
 	}
 
-	out, err := json.Marshal(se)
-
 	se.index = e.eventCounter.Inc()
 	if hasCurrentJourney {
 		e.synthEvents <- se
-	} else {
-		logp.Warn("received output from synthetics outside of journey scope: %s %s", out, err)
 	}
 }
 


### PR DESCRIPTION
This removes the annoying and useless warning sent when events are received outside a journey context. This was meant to be a useful invariant catching weird bugs on the synthetics side. In practice, it mostly just doubles the output when errors are received due to a misconfigured environment.

This patch removes this behavior. I don't think there's a strong case to add it back in, it was always a nice-to-have for a hypothetical situation.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
