### PR TITLE
Cherry-pick #24174 to 7.x: Allow credential_profile_name and shared_credential_file with role_arn

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -145,6 +145,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix CPU usage metrics on VMs with dynamic CPU config {pull}23154[23154]
 - Fix panic due to unhandled DeletedFinalStateUnknown in k8s OnDelete {pull}23419[23419]
 - Fix error loop with runaway CPU use when the Kafka output encounters some connection errors {pull}23484[23484]
+- Allow configuring credential_profile_name and shared_credential_file when using role_arn. {pull}24174[24174]
 - Fix issue discovering docker containers and metadata after reconnections {pull}24318[24318]
 
 

--- a/metricbeat/docs/aws-credentials-examples.asciidoc
+++ b/metricbeat/docs/aws-credentials-examples.asciidoc
@@ -49,3 +49,17 @@ metricbeat.modules:
     - ec2
   credential_profile_name: test-mb
 ----
+
+* Use IAM role ARN with shared AWS credentials file
++
+[source,yaml]
+----
+metricbeat.modules:
+- module: aws
+  period: 5m
+  role_arn: arn:aws:iam::123456789012:role/test-mb
+  shared_credential_file: /Users/mb/.aws/credentials_backup
+  credential_profile_name: test
+  metricsets:
+    - ec2
+----

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -78,6 +78,13 @@ the home path depends on the user that manages the service, so the `shared_crede
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/create-shared-credentials-file.html[Create Shared Credentials File]
 for more details.
 
+* Use `role_arn`
+
+If `access_key_id` and `secret_access_key`, `credential_profile_name` and/or
+`shared_credential_file` are not given, then {beatname_lc} will check for
+`role_arn`. `role_arn` is used to specify which AWS IAM role to assume
+for generating temporary credentials.
+
 If running on Docker, the credential file needs to be provided via a volume
 mount. For example, with Metricbeat:
 
@@ -135,6 +142,83 @@ A role does not have standard long-term credentials such as a password or access
 Instead, when you assume a role, it provides you with temporary security credentials for your role session.
 IAM role Amazon Resource Name (ARN) can be used to specify which AWS IAM role to assume to generate temporary credentials.
 Please see https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html[AssumeRole API documentation] for more details.
+
+Here are the steps to set up IAM role using AWS CLI for Metricbeat. Please replace
+`123456789012` with your own account ID.
+
+Step 1. Create `example-policy.json` file to include all permissions:
+[source,yaml]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "sqs:ReceiveMessage"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "sqs:ChangeMessageVisibility",
+            "Resource": "arn:aws:sqs:us-east-1:123456789012:test-fb-ks"
+        },
+        {
+            "Sid": "VisualEditor2",
+            "Effect": "Allow",
+            "Action": "sqs:DeleteMessage",
+            "Resource": "arn:aws:sqs:us-east-1:123456789012:test-fb-ks"
+        },
+        {
+            "Sid": "VisualEditor3",
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole",
+                "sqs:ListQueues",
+                "tag:GetResources",
+                "ec2:DescribeInstances",
+                "cloudwatch:GetMetricData",
+                "ec2:DescribeRegions",
+                "iam:ListAccountAliases",
+                "sts:GetCallerIdentity",
+                "cloudwatch:ListMetrics"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+----
+
+Step 2. Create IAM policy using the `aws iam create-policy` command:
+----
+$ aws iam create-policy --policy-name example-policy --policy-document file://example-policy.json
+----
+
+Step 3. Create the JSON file `example-role-trust-policy.json` that defines the trust relationship of the IAM role
+[source,yaml]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": {
+        "Effect": "Allow",
+        "Principal": { "AWS": "arn:aws:iam::123456789012:root" },
+        "Action": "sts:AssumeRole"
+    }
+}
+----
+
+Step 4. Create the IAM role and attach the policy:
+----
+$ aws iam create-role --role-name example-role --assume-role-policy-document file://example-role-trust-policy.json
+$ aws iam attach-role-policy --role-name example-role --policy-arn "arn:aws:iam::123456789012:policy/example-policy"
+----
+
+After these steps are done, IAM role ARN can be used for authentication in Metricbeat
+`aws` module.
 
 * Temporary security credentials
 


### PR DESCRIPTION
Cherry-pick of PR #24174 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to revisit the `role_arn` config parameter for AWS and add support for `role_arn` to be used with 
`credential_profile_name` and `shared_credential_file`.

## Why is it important?

Sometimes, the default credential profile might not be at the location that AWS SDK thinks is. So user should be able to specify that instead of only relying on the default location and default profile name.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Setup role ARN following the steps updated in the documentation.
2. Enable aws module and the config below should work
```
- module: aws
  period: 5m
  role_arn: arn:aws:iam::123456789012:role/example-role
  shared_credential_file: /Users/kaiyansheng/.aws/credentials_backup
  credential_profile_name: test
  metricsets:
    - ec2
```

## Related issues

- Relates https://github.com/elastic/integrations/issues/738