### PR TITLE
Cherry-pick to 7.12: [CI] Use MacOS for x86_64 arch (#24362)

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -40,7 +40,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test auditbeat for macos"

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -39,7 +39,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test filebeat for macos"

--- a/generator/Jenkinsfile.yml
+++ b/generator/Jenkinsfile.yml
@@ -22,7 +22,7 @@ stages:
     macos-metricbeat:
         make: "make -C generator/_templates/metricbeat test"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test generator for macos"
@@ -35,7 +35,7 @@ stages:
     macos-beat:
         make: "make -C generator/_templates/beat test"
         platforms:             ## override default label in this specific stage.
-            - "macosx"
+            - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test generator for macos"

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -38,7 +38,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test heartbeat for macos"

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -33,7 +33,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test metricbeat for macos"

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -39,7 +39,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test packetbeat for macos"

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -39,7 +39,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/auditbeat for macos"

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -36,7 +36,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-            - "macosx"
+            - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/elastic-agent for macos"

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -39,7 +39,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/filebeat for macos"

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -34,7 +34,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/functionbeat for macos"

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -25,7 +25,7 @@ stages:
     macos:
         mage: "mage build test"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/heartbeat for macos"

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -37,7 +37,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/metricbeat for macos"

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -39,7 +39,7 @@ stages:
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "macosx"
+          - "macosx&&x86_64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/packetbeat for macos"


### PR DESCRIPTION
Backports the following commits to 7.12:
 - [CI] Use MacOS for x86_64 arch (#24362)