### PR TITLE
Cherry-pick #24359 to 7.x: Convert postgresql.statement.query.id to number

### DIFF
--- a/metricbeat/module/postgresql/statement/_meta/data.json
+++ b/metricbeat/module/postgresql/statement/_meta/data.json
@@ -1,16 +1,13 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "agent": {
-        "hostname": "host.example.com",
-        "name": "host.example.com"
-    },
     "event": {
         "dataset": "postgresql.statement",
         "duration": 115000,
         "module": "postgresql"
     },
     "metricset": {
-        "name": "statement"
+        "name": "statement",
+        "period": 10000
     },
     "postgresql": {
         "statement": {
@@ -19,7 +16,7 @@
             },
             "query": {
                 "calls": 2,
-                "id": "1592910677",
+                "id": 1592910677,
                 "memory": {
                     "local": {
                         "dirtied": 0,
@@ -42,19 +39,19 @@
                 "text": "SELECT * FROM pg_stat_statements",
                 "time": {
                     "max": {
-                        "ms": 0.388
+                        "ms": 0.161
                     },
                     "mean": {
-                        "ms": 0.235
+                        "ms": 0.1595
                     },
                     "min": {
-                        "ms": 0.082
+                        "ms": 0.158
                     },
                     "stddev": {
-                        "ms": 0.153
+                        "ms": 0.0015000000000000013
                     },
                     "total": {
-                        "ms": 0.47000000000000003
+                        "ms": 0.319
                     }
                 }
             },
@@ -64,7 +61,7 @@
         }
     },
     "service": {
-        "address": "172.26.0.2:5432",
+        "address": "192.168.144.2:5432",
         "type": "postgresql"
     }
 }

--- a/metricbeat/module/postgresql/statement/data.go
+++ b/metricbeat/module/postgresql/statement/data.go
@@ -22,7 +22,7 @@ import (
 	c "github.com/elastic/beats/v7/libbeat/common/schema/mapstrstr"
 )
 
-// Based on: https://www.postgresql.org/docs/9.2/static/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW
+// Based on: https://www.postgresql.org/docs/9.6/pgstatstatements.html
 var schema = s.Schema{
 	"user": s.Object{
 		"id": c.Int("userid"),
@@ -31,7 +31,7 @@ var schema = s.Schema{
 		"oid": c.Int("dbid"),
 	},
 	"query": s.Object{
-		"id":    c.Str("queryid"),
+		"id":    c.Int("queryid"),
 		"text":  c.Str("query"),
 		"calls": c.Int("calls"),
 		"rows":  c.Int("rows"),


### PR DESCRIPTION
Cherry-pick of PR #24359 to 7.x branch. Original message: 

## What does this PR do?

Send `postgresql.statement.query.id` as number.

## Why is it important?

Found while migrating to package. This field is a number, and defined as number in `fields.yml`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~ It doesn't change anything for users.

## Related issues

- Found in https://github.com/elastic/integrations/pull/747