### PR TITLE
[Elastic Agent] Fix fleet-server insecure flag

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -216,7 +216,7 @@ func buildEnrollArgs(token string, policyID string) ([]string, error) {
 			args = append(args, "--fleet-server-cert-key", certKey)
 		}
 		if envBool("FLEET_SERVER_INSECURE_HTTP") {
-			args = append(args, "--fleet-server--insecure-http")
+			args = append(args, "--fleet-server-insecure-http")
 			args = append(args, "--insecure")
 		}
 	} else {


### PR DESCRIPTION
When using FLEET_SERVER_INSECURE_HTTP=1 it tried to set the flag `--fleet-server--insecure-http` which does not exist. Instead it should be `--fleet-server-insecure-http`.
