### PR TITLE
Cherry-pick #24343 to 7.12: Fix windows installer during enroll 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 - Fix reloading of log level for services {pull}[24055]24055
 - Fix: Successfully installed and enrolled agent running standalone{pull}[24128]24128
 - Make installer atomic on windows {pull}[24253]24253
+- Fix windows installer during enroll {pull}[24343]24343
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
@@ -69,7 +69,7 @@ func (i *Installer) Install(ctx context.Context, spec program.Spec, version, ins
 	return nil
 }
 
-func (i *Installer) unzip(ctx context.Context, artifactPath string) error {
+func (i *Installer) unzip(_ context.Context, artifactPath string) error {
 	r, err := zip.OpenReader(artifactPath)
 	if err != nil {
 		return err
@@ -120,11 +120,6 @@ func (i *Installer) unzip(ctx context.Context, artifactPath string) error {
 	}
 
 	for _, f := range r.File {
-		// if we were cancelled in between
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
 		if err := unpackFile(f); err != nil {
 			return err
 		}


### PR DESCRIPTION
Cherry-pick of PR #24343 to 7.21 branch. Original message:

## What does this PR do?

after #24253 issue still occurred on some systems.
the problem really is with rename and sync after unzip which is skipped in case ctx is cancelled.  
my first option was to make agent rename rootDir even if zip is not fully unpacked and sync directories all rootDir, installDir and temp directories.
this complicated code to the form I did not like, so many conditions there. but it was working 5/5

i went with a code-cleaner way _(especially with change in mind @blakerouse suggested that we should remove it before start)_ and i let unzip finish, rename rootDir to correct tmp install path, sync paths and then let awaitable installer wait for whole installation to finish. we lose tiny amount of time, but cleaner code is worth small perf impact especially in this edge case scenario.

## Why is it important?

Fixes #24317

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
