### PR TITLE
[kubernetes][metricbeat]correct args system.hostfs

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -151,7 +151,7 @@ spec:
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
-          "-system.hostfs=/hostfs",
+          "--system.hostfs=/hostfs",
         ]
         env:
         - name: ELASTICSEARCH_HOST


### PR DESCRIPTION
Error on args system.hostfs, second - is missing

## What does this PR do?

This is a fix for  #23267.
In current kubernetes deployment, yaml file for metricbeat forget a second -

## Why is it important?

Without that, args system.hostfs not use

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

-  #23267
