### PR TITLE
Finish porting all tests from Python to Golang from test_harvester.py

### DIFF
--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -30,7 +30,7 @@ import (
 
 // Config stores the options of a file stream.
 type config struct {
-	readerConfig
+	ReaderConfig `config:",inline"`
 
 	Paths          []string                `config:"paths"`
 	Close          closerConfig            `config:"close"`
@@ -59,7 +59,7 @@ type stateChangeCloserConfig struct {
 	Renamed       bool          `config:"renamed"`
 }
 
-type readerConfig struct {
+type ReaderConfig struct {
 	Backoff        backoffConfig           `config:"backoff"`
 	BufferSize     int                     `config:"buffer_size"`
 	Encoding       string                  `config:"encoding"`
@@ -79,7 +79,7 @@ type backoffConfig struct {
 
 func defaultConfig() config {
 	return config{
-		readerConfig:   defaultReaderConfig(),
+		ReaderConfig:   defaultReaderConfig(),
 		Paths:          []string{},
 		Close:          defaultCloserConfig(),
 		CleanInactive:  0,
@@ -104,8 +104,8 @@ func defaultCloserConfig() closerConfig {
 	}
 }
 
-func defaultReaderConfig() readerConfig {
-	return readerConfig{
+func defaultReaderConfig() ReaderConfig {
+	return ReaderConfig{
 		Backoff: backoffConfig{
 			Init: 1 * time.Second,
 			Max:  10 * time.Second,

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -134,8 +134,38 @@ func (e *inputTestingEnvironment) mustRemoveFile(filename string) {
 	}
 }
 
+func (e *inputTestingEnvironment) mustSymlink(filename, symlinkname string) {
+	err := os.Symlink(e.abspath(filename), e.abspath(symlinkname))
+	if err != nil {
+		e.t.Fatalf("failed to create symlink to file '%s': %+v", filename, err)
+	}
+}
+
+func (e *inputTestingEnvironment) mustTruncateFile(filename string, size int64) {
+	path := e.abspath(filename)
+	err := os.Truncate(path, size)
+	if err != nil {
+		e.t.Fatalf("failed to truncate file '%s': %+v", path, err)
+	}
+}
+
 func (e *inputTestingEnvironment) abspath(filename string) string {
 	return filepath.Join(e.workingDir, filename)
+}
+
+func (e *inputTestingEnvironment) requireRegistryEntryCount(expectedCount int) {
+	inputStore, _ := e.stateStore.Access()
+
+	actual := 0
+	err := inputStore.Each(func(_ string, _ statestore.ValueDecoder) (bool, error) {
+		actual += 1
+		return true, nil
+	})
+	if err != nil {
+		e.t.Fatalf("error while iterating through registry: %+v", err)
+	}
+
+	require.Equal(e.t, actual, expectedCount)
 }
 
 // requireOffsetInRegistry checks if the expected offset is set for a file.
@@ -205,12 +235,23 @@ func (e *inputTestingEnvironment) waitUntilEventCount(count int) {
 	}
 }
 
+// waitUntilHarvesterIsDone detects Harvester stop by checking if the last client has been closed
+// as when a Harvester stops the client is closed.
+func (e *inputTestingEnvironment) waitUntilHarvesterIsDone() {
+	for !e.pipeline.clients[len(e.pipeline.clients)-1].closed {
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // requireEventReceived requires that the list of messages has made it into the output.
 func (e *inputTestingEnvironment) requireEventsReceived(events []string) {
 	foundEvents := make([]bool, len(events))
 	checkedEventCount := 0
 	for _, c := range e.pipeline.clients {
 		for _, evt := range c.GetEvents() {
+			if len(events) == checkedEventCount {
+				e.t.Fatalf("not enough expected elements")
+			}
 			message := evt.Fields["message"].(string)
 			if message == events[checkedEventCount] {
 				foundEvents[checkedEventCount] = true
@@ -227,6 +268,16 @@ func (e *inputTestingEnvironment) requireEventsReceived(events []string) {
 	}
 
 	require.Equal(e.t, 0, len(missingEvents), "following events are missing: %+v", missingEvents)
+}
+
+func (e *inputTestingEnvironment) getOutputMessages() []string {
+	messages := make([]string, 0)
+	for _, c := range e.pipeline.clients {
+		for _, evt := range c.GetEvents() {
+			messages = append(messages, evt.Fields["message"].(string))
+		}
+	}
+	return messages
 }
 
 type testInputStore struct {

--- a/filebeat/input/filestream/filestream.go
+++ b/filebeat/input/filestream/filestream.go
@@ -63,7 +63,7 @@ func newFileReader(
 	log *logp.Logger,
 	canceler input.Canceler,
 	f *os.File,
-	config readerConfig,
+	config ReaderConfig,
 	closerConfig closerConfig,
 ) (*logFile, error) {
 	offset, err := f.Seek(0, os.SEEK_CUR)

--- a/filebeat/input/filestream/filestream_test.go
+++ b/filebeat/input/filestream/filestream_test.go
@@ -63,7 +63,7 @@ func TestLogFileTimedClosing(t *testing.T) {
 				logp.L(),
 				context.TODO(),
 				f,
-				readerConfig{},
+				ReaderConfig{},
 				closerConfig{
 					OnStateChange: stateChangeCloserConfig{
 						CheckInterval: 1 * time.Second,
@@ -91,7 +91,7 @@ func TestLogFileTruncated(t *testing.T) {
 	defer f.Close()
 	defer os.Remove(f.Name())
 
-	reader, err := newFileReader(logp.L(), context.TODO(), f, readerConfig{}, closerConfig{})
+	reader, err := newFileReader(logp.L(), context.TODO(), f, ReaderConfig{}, closerConfig{})
 	if err != nil {
 		t.Fatalf("error while creating logReader: %+v", err)
 	}

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -76,7 +76,7 @@ func TestFileScanner(t *testing.T) {
 		test := test
 
 		t.Run(name, func(t *testing.T) {
-			cfg := fileScannerConfig{
+			cfg := FileScannerConfig{
 				ExcludedFiles: test.excludedFiles,
 				Symlinks:      test.symlinks,
 				RecursiveGlob: false,

--- a/filebeat/input/filestream/fswatch_test_non_windows.go
+++ b/filebeat/input/filestream/fswatch_test_non_windows.go
@@ -82,7 +82,7 @@ func TestFileScannerSymlinks(t *testing.T) {
 		test := test
 
 		t.Run(name, func(t *testing.T) {
-			cfg := fileScannerConfig{
+			cfg := FileScannerConfig{
 				ExcludedFiles: test.excludedFiles,
 				Symlinks:      true,
 				RecursiveGlob: false,
@@ -115,7 +115,7 @@ func TestFileWatcherRenamedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := fileScannerConfig{
+	cfg := FileScannerConfig{
 		ExcludedFiles: nil,
 		Symlinks:      false,
 		RecursiveGlob: false,

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -60,9 +60,10 @@ type fileIdentifier interface {
 // fileSource implements the Source interface
 // It is required to identify and manage file sources.
 type fileSource struct {
-	info    os.FileInfo
-	newPath string
-	oldPath string
+	info      os.FileInfo
+	newPath   string
+	oldPath   string
+	truncated bool
 
 	name                string
 	identifierGenerator string
@@ -103,6 +104,7 @@ func (i *inodeDeviceIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                i.name + identitySep + file.GetOSState(e.Info).String(),
 		identifierGenerator: i.name,
 	}
@@ -140,6 +142,7 @@ func (p *pathIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                p.name + identitySep + path,
 		identifierGenerator: p.name,
 	}

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -98,6 +98,7 @@ func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                i.name + identitySep + osstate.InodeString() + "-" + i.markerContents(),
 		identifierGenerator: i.name,
 	}

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -52,7 +52,7 @@ type fileMeta struct {
 // filestream is the input for reading from files which
 // are actively written by other applications.
 type filestream struct {
-	readerConfig    readerConfig
+	readerConfig    ReaderConfig
 	bufferSize      int
 	tailFile        bool // TODO
 	encodingFactory encoding.EncodingFactory
@@ -111,7 +111,7 @@ func configure(cfg *common.Config) (loginp.Prospector, loginp.Harvester, error) 
 	}
 
 	filestream := &filestream{
-		readerConfig:    config.readerConfig,
+		readerConfig:    config.ReaderConfig,
 		bufferSize:      config.BufferSize,
 		encodingFactory: encodingFactory,
 		lineTerminator:  config.LineTerminator,
@@ -173,7 +173,7 @@ func (inp *filestream) Run(
 
 func initState(log *logp.Logger, c loginp.Cursor, s fileSource) state {
 	var state state
-	if c.IsNew() {
+	if c.IsNew() || s.truncated {
 		return state
 	}
 
@@ -236,7 +236,7 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, path stri
 // is returned and the harvester is closed. The file will be picked up again the next time
 // the file system is scanned
 func (inp *filestream) openFile(path string, offset int64) (*os.File, error) {
-	err := inp.checkFileBeforeOpening(path)
+	err := inp.checkFileBeforeOpening(path, &offset)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (inp *filestream) openFile(path string, offset int64) (*os.File, error) {
 	return f, nil
 }
 
-func (inp *filestream) checkFileBeforeOpening(path string) error {
+func (inp *filestream) checkFileBeforeOpening(path string, offset *int64) error {
 	fi, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("failed to stat source file %s: %v", path, err)
@@ -276,6 +276,11 @@ func (inp *filestream) checkFileBeforeOpening(path string) error {
 
 	if fi.Mode()&os.ModeNamedPipe != 0 {
 		return fmt.Errorf("failed to open file %s, named pipes are not supported", path)
+	}
+
+	// file was truncated
+	if fi.Size() < *offset {
+		*offset = 0
 	}
 
 	return nil
@@ -306,7 +311,6 @@ func (inp *filestream) readFromSource(
 			switch err {
 			case ErrFileTruncate:
 				log.Info("File was truncated. Begin reading file from offset 0.")
-				s.Offset = 0
 			case ErrClosed:
 				log.Info("Reader was closed. Closing.")
 			case reader.ErrLineUnparsable:

--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -20,10 +20,17 @@
 package filestream
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"runtime"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 )
@@ -227,4 +234,342 @@ func TestFilestreamExceedBuffer(t *testing.T) {
 	env.waitUntilInputStops()
 
 	env.requireOffsetInRegistry(testlogName, expectedOffset)
+}
+
+// test_truncated_file_open from test_harvester.py
+func TestFilestreamTruncatedFileOpen(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                             []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval": "1ms",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.mustTruncateFile(testlogName, 0)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+	env.waitUntilEventCount(4)
+
+	cancelInput()
+	env.waitUntilInputStops()
+	env.requireOffsetInRegistry(testlogName, len(truncatedTestLines))
+}
+
+// test_truncated_file_closed from test_harvester.py
+func TestFilestreamTruncatedFileClosed(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                                []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":    "1ms",
+		"close.on_state_change.check_interval": "1ms",
+		"close.on_state_change.inactive":       "50ms",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.waitUntilHarvesterIsDone()
+
+	env.mustTruncateFile(testlogName, 0)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+	env.waitUntilEventCount(4)
+
+	cancelInput()
+	env.waitUntilInputStops()
+	env.requireOffsetInRegistry(testlogName, len(truncatedTestLines))
+}
+
+// test_truncated_file_closed from test_harvester.py
+func TestFilestreamCloseTimeout(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                                []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":    "24h",
+		"close.on_state_change.check_interval": "100ms",
+		"close.reader.after_interval":          "500ms",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(1)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+	env.waitUntilHarvesterIsDone()
+
+	env.mustWriteLinesToFile(testlogName, []byte("first line\nsecond log line\n"))
+
+	env.waitUntilEventCount(1)
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+}
+
+// test_bom_utf8 from test_harvester.py
+func TestFilestreamBOMUTF8(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{env.abspath(testlogName)},
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	// BOM: 0xEF,0xBB,0xBF
+	lines := append([]byte{0xEF, 0xBB, 0xBF}, []byte(`#Software: Microsoft Exchange Server
+#Version: 14.0.0.0
+#Log-type: Message Tracking Log
+#Date: 2016-04-05T00:00:02.052Z
+#Fields: date-time,client-ip,client-hostname,server-ip,server-hostname,source-context,connector-id,source,event-id,internal-message-id,message-id,recipient-address,recipient-status,total-bytes,recipient-count,related-recipient-address,reference,message-subject,sender-address,return-path,message-info,directionality,tenant-id,original-client-ip,original-server-ip,custom-data
+2016-04-05T00:00:02.052Z,,,,,"MDB:61914740-3f1b-4ddb-94e0-557196870cfa, Mailbox:279f077c-216f-4323-a9ee-48e50ffd3cad, Event:269492708, MessageClass:IPM.Note.StorageQuotaWarning.Warning, CreationTime:2016-04-05T00:00:01.022Z, ClientType:System",,STOREDRIVER,NOTIFYMAPI,,,,,,,,,,,,,,,,,S:ItemEntryId=00-00-00-00-37-DB-F9-F9-B5-F2-42-4F-86-62-E6-5D-FC-0C-A1-41-07-00-0E-D6-03-16-80-DC-8C-44-9D-30-07-23-ED-71-B7-F7-00-00-1F-D4-B5-0E-00-00-2E-EF-F2-59-0E-E8-2D-46-BC-31-02-85-0D-67-98-43-00-00-37-4A-A3-B3-00-00
+2016-04-05T00:00:02.145Z,,,,,"MDB:61914740-3f1b-4ddb-94e0-557196870cfa, Mailbox:49cb09c6-5b76-415d-a085-da0ad9079682, Event:269492711, MessageClass:IPM.Note.StorageQuotaWarning.Warning, CreationTime:2016-04-05T00:00:01.038Z, ClientType:System",,STOREDRIVER,NOTIFYMAPI,,,,,,,,,,,,,,,,,S:ItemEntryId=00-00-00-00-97-8F-07-43-51-44-61-4A-AD-BD-29-D4-97-4E-20-A0-07-00-0E-D6-03-16-80-DC-8C-44-9D-30-07-23-ED-71-B7-F7-00-8E-8F-BD-EB-57-00-00-3D-FB-CE-26-A4-8D-46-4C-A4-35-0F-A7-9B-FA-D7-B9-00-00-37-44-2F-CA-00-00
+`)...)
+	env.mustWriteLinesToFile(testlogName, lines)
+
+	env.waitUntilEventCount(7)
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	messages := env.getOutputMessages()
+	require.Equal(t, messages[0], "#Software: Microsoft Exchange Server")
+}
+
+// test_boms from test_harvester.py
+func TestFilestreamUTF16BOMs(t *testing.T) {
+	encodings := map[string]encoding.Encoding{
+		"utf-16be-bom": unicode.UTF16(unicode.BigEndian, unicode.UseBOM),
+		"utf-16le-bom": unicode.UTF16(unicode.LittleEndian, unicode.UseBOM),
+	}
+
+	for name, enc := range encodings {
+		name := name
+		encoder := enc.NewEncoder()
+		t.Run(name, func(t *testing.T) {
+			env := newInputTestingEnvironment(t)
+
+			testlogName := "test.log"
+			inp := env.mustCreateInput(map[string]interface{}{
+				"paths":    []string{env.abspath(testlogName)},
+				"encoding": name,
+			})
+
+			ctx, cancelInput := context.WithCancel(context.Background())
+			env.startInput(ctx, inp)
+
+			line := []byte("first line\n")
+			buf := bytes.NewBuffer(nil)
+			writer := transform.NewWriter(buf, encoder)
+			writer.Write(line)
+			writer.Close()
+
+			env.mustWriteLinesToFile(testlogName, buf.Bytes())
+
+			env.waitUntilEventCount(1)
+
+			env.requireEventsReceived([]string{"first line"})
+
+			cancelInput()
+			env.waitUntilInputStops()
+		})
+	}
+}
+
+// test_symlinks_enabled from test_harvester.py
+func TestFilestreamSymlinksEnabled(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(testlogName),
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.symlinks": "true",
+	})
+
+	testlines := []byte("first line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(1)
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+	env.requireOffsetInRegistry(symlinkName, len(testlines))
+}
+
+// test_symlink_rotated from test_harvester.py
+func TestFilestreamSymlinkRotated(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	firstTestlogName := "test1.log"
+	secondTestlogName := "test2.log"
+	symlinkName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(firstTestlogName),
+			env.abspath(secondTestlogName),
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.check_interval": "1ms",
+		"prospector.scanner.symlinks":       "true",
+		"close.on_state_change.removed":     "false",
+		"clean_removed":                     "false",
+	})
+
+	commonLine := "first line in file "
+	for i, path := range []string{firstTestlogName, secondTestlogName} {
+		env.mustWriteLinesToFile(path, []byte(commonLine+strconv.Itoa(i)+"\n"))
+	}
+
+	env.mustSymlink(firstTestlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(2)
+
+	expectedOffset := len(commonLine) + 2
+	env.requireOffsetInRegistry(firstTestlogName, expectedOffset)
+	env.requireOffsetInRegistry(secondTestlogName, expectedOffset)
+
+	// rotate symlink
+	env.mustRemoveFile(symlinkName)
+	env.mustSymlink(secondTestlogName, symlinkName)
+
+	moreLines := "second line in file 2\nthird line in file 2\n"
+	env.mustAppendLinesToFile(secondTestlogName, []byte(moreLines))
+
+	env.waitUntilEventCount(4)
+	env.requireOffsetInRegistry(firstTestlogName, expectedOffset)
+	env.requireOffsetInRegistry(secondTestlogName, expectedOffset+len(moreLines))
+	env.requireOffsetInRegistry(symlinkName, expectedOffset+len(moreLines))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(2)
+}
+
+// test_symlink_removed from test_harvester.py
+func TestFilestreamSymlinkRemoved(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(testlogName),
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.check_interval": "1ms",
+		"prospector.scanner.symlinks":       "true",
+		"close.on_state_change.removed":     "false",
+		"clean_removed":                     "false",
+	})
+
+	line := []byte("first line\n")
+	env.mustWriteLinesToFile(testlogName, line)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(1)
+
+	env.requireOffsetInRegistry(testlogName, len(line))
+
+	// remove symlink
+	env.mustRemoveFile(symlinkName)
+
+	env.mustAppendLinesToFile(testlogName, line)
+
+	env.waitUntilEventCount(2)
+	env.requireOffsetInRegistry(testlogName, 2*len(line))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(1)
+}
+
+// test_truncate from test_harvester.py
+func TestFilestreamTruncate(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(testlogName),
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.check_interval": "1ms",
+		"prospector.scanner.symlinks":       "true",
+	})
+
+	lines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, lines)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(3)
+
+	env.requireOffsetInRegistry(testlogName, len(lines))
+
+	// remove symlink
+	env.mustRemoveFile(symlinkName)
+	env.mustTruncateFile(testlogName, 0)
+
+	moreLines := []byte("forth line\nfifth line\n")
+	env.mustWriteLinesToFile(testlogName, moreLines)
+
+	env.waitUntilEventCount(5)
+	env.requireOffsetInRegistry(testlogName, len(moreLines))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(1)
 }

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -29,6 +29,7 @@ const (
 	OpWrite
 	OpDelete
 	OpRename
+	OpTruncate
 )
 
 // Operation describes what happened to a file.

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -124,8 +124,12 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 						break
 					}
 				}
-
 				hg.Start(ctx, src)
+
+			case loginp.OpTruncate:
+				log.Debugf("File %s has been truncated", fe.NewPath)
+
+				hg.Restart(ctx, src)
 
 			case loginp.OpDelete:
 				log.Debugf("File %s has been removed", fe.OldPath)

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -381,6 +381,10 @@ type harvesterStart string
 
 func (h harvesterStart) String() string { return string(h) }
 
+type harvesterRestart string
+
+func (h harvesterRestart) String() string { return string(h) }
+
 type harvesterStop string
 
 func (h harvesterStop) String() string { return string(h) }
@@ -399,6 +403,10 @@ func newTestHarvesterGroup() *testHarvesterGroup {
 
 func (t *testHarvesterGroup) Start(_ input.Context, s loginp.Source) {
 	t.events = append(t.events, harvesterStart(s.Name()))
+}
+
+func (t *testHarvesterGroup) Restart(_ input.Context, s loginp.Source) {
+	t.events = append(t.events, harvesterRestart(s.Name()))
 }
 
 func (t *testHarvesterGroup) Stop(s loginp.Source) {


### PR DESCRIPTION
## What does this PR do?

This PR finishes porting tests from `test_harvester.py`. It is based on #24250.

## Why is it important?

Two problems were discovered while porting tests:

1. lack of support of trucated files

    The support for stopping reading from truncated files was already implemented. However, `filestream` input could not start reading it from the beginning.

    A new file system event is added called `OpTruncate`. When the size of a file has shrinked compared to the last time the scanner has encountered it, an `OpTruncate` event is emitted. When the prospector gets this event, the `HarvesterGroup` is restarting the `Harvester` of the file. Restarting basically means that the new `Harvester` waits for the previous one to finish and then starts reading the file from the beginning. The wait has a predefined timeout which is not the best solution, but I did not want to introduce waiting indefinitely until the context is cancelled for a Harvester. Although, this might be the right approach...

2. encoding configuration

    Encoding configuration could not be parsed from the configuration. After fixing this, there was not any new problems because most of the underlying code is already covered by unit tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

