### PR TITLE
Cherry-pick #24346 to 7.x: Fix capabilities resolution in inspect command 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 - Fix reloading of log level for services {pull}[24055]24055
 - Fix: Successfully installed and enrolled agent running standalone{pull}[24128]24128
 - Make installer atomic on windows {pull}[24253]24253
+- Fix capabilities resolution in inspect command {pull}[24346]24346
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/capabilities/input.go
+++ b/x-pack/elastic-agent/pkg/capabilities/input.go
@@ -92,11 +92,23 @@ func inputsMap(cfgInputs interface{}, l *logger.Logger) []map[string]interface{}
 
 	inputsMap := make([]map[string]interface{}, 0, len(inputsSet))
 	for _, s := range inputsSet {
-		mm, ok := s.(map[string]interface{})
-		if !ok {
+		switch mm := s.(type) {
+		case map[string]interface{}:
+			inputsMap = append(inputsMap, mm)
+		case map[interface{}]interface{}:
+			newMap := make(map[string]interface{})
+			for k, v := range mm {
+				key, ok := k.(string)
+				if !ok {
+					continue
+				}
+
+				newMap[key] = v
+			}
+			inputsMap = append(inputsMap, newMap)
+		default:
 			continue
 		}
-		inputsMap = append(inputsMap, mm)
 	}
 
 	return inputsMap
@@ -188,7 +200,7 @@ func (c *multiInputsCapability) Apply(in interface{}) (interface{}, error) {
 
 	inputsMap, err = c.cleanupInput(inputsMap)
 	if err != nil {
-		c.log.Errorf("cleaning up config object failed for capability 'multi-outputs': %v", err)
+		c.log.Errorf("cleaning up config object failed for capability 'multi-inputs': %v", err)
 		return in, nil
 	}
 

--- a/x-pack/elastic-agent/pkg/capabilities/output.go
+++ b/x-pack/elastic-agent/pkg/capabilities/output.go
@@ -182,11 +182,21 @@ func (c *multiOutputsCapability) cleanupOutput(cfgMap map[string]interface{}) (m
 		return cfgMap, nil
 	}
 
-	outputsMap, ok := outputsIface.(map[string]interface{})
-	if !ok {
+	switch outputsMap := outputsIface.(type) {
+	case map[string]interface{}:
+		handleOutputMapStr(outputsMap)
+		cfgMap[outputKey] = outputsMap
+	case map[interface{}]interface{}:
+		handleOutputMapIface(outputsMap)
+		cfgMap[outputKey] = outputsMap
+	default:
 		return nil, fmt.Errorf("outputs must be a map")
 	}
 
+	return cfgMap, nil
+}
+
+func handleOutputMapStr(outputsMap map[string]interface{}) {
 	for outputName, outputIface := range outputsMap {
 		acceptValue := true
 
@@ -208,7 +218,28 @@ func (c *multiOutputsCapability) cleanupOutput(cfgMap map[string]interface{}) (m
 
 		delete(outputMap, conditionKey)
 	}
+}
 
-	cfgMap[outputKey] = outputsMap
-	return cfgMap, nil
+func handleOutputMapIface(outputsMap map[interface{}]interface{}) {
+	for outputName, outputIface := range outputsMap {
+		acceptValue := true
+
+		outputMap, ok := outputIface.(map[interface{}]interface{})
+		if ok {
+			conditionIface, found := outputMap[conditionKey]
+			if found {
+				conditionVal, ok := conditionIface.(bool)
+				if ok {
+					acceptValue = conditionVal
+				}
+			}
+		}
+
+		if !acceptValue {
+			delete(outputsMap, outputName)
+			continue
+		}
+
+		delete(outputMap, conditionKey)
+	}
 }

--- a/x-pack/elastic-agent/pkg/capabilities/upgrade.go
+++ b/x-pack/elastic-agent/pkg/capabilities/upgrade.go
@@ -147,7 +147,7 @@ type multiUpgradeCapability struct {
 func (c *multiUpgradeCapability) Apply(in interface{}) (interface{}, error) {
 	upgradeMap := upgradeObject(in)
 	if upgradeMap == nil {
-		c.log.Warnf("expecting map config object but got nil for capability 'multi-outputs'")
+		c.log.Warnf("expecting map config object but got nil for capability 'multi-upgrade'")
 		// not an upgrade we don't alter origin
 		return in, nil
 	}


### PR DESCRIPTION
Cherry-pick of PR #24343 to 7.x branch. Original message:

## What does this PR do?

This one was reported by @faec during testing.

When using inspect command type of object is resolved as `map[interface{}]interface{}` instead of usual `map[string]interface{}`
This PR allows capabilities handle this type as well. 

## Why is it important?

Resolve same config in pipeline and inspect

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.