### PR TITLE
[Heartbeat] Produce error rather than panic on missing source

### DIFF
--- a/x-pack/heartbeat/monitors/browser/config.go
+++ b/x-pack/heartbeat/monitors/browser/config.go
@@ -31,6 +31,7 @@ type Config struct {
 
 var ErrNameRequired = fmt.Errorf("config 'name' must be specified for this monitor")
 var ErrIdRequired = fmt.Errorf("config 'id' must be specified for this monitor")
+var ErrSourceRequired = fmt.Errorf("config 'source' must be specified for this monitor, if upgrading from a previous experimental version please see our new config docs")
 
 func (c *Config) Validate() error {
 	if c.Name == "" {
@@ -38,6 +39,10 @@ func (c *Config) Validate() error {
 	}
 	if c.Id == "" {
 		return ErrIdRequired
+	}
+
+	if c.Source == nil {
+		return ErrSourceRequired
 	}
 
 	return nil

--- a/x-pack/heartbeat/monitors/browser/config_test.go
+++ b/x-pack/heartbeat/monitors/browser/config_test.go
@@ -1,0 +1,55 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package browser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/x-pack/heartbeat/monitors/browser/source"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	testSource := source.Source{Inline: &source.InlineSource{Script: "//something"}}
+
+	tests := []struct {
+		name    string
+		cfg     *Config
+		wantErr error
+	}{
+		{
+			"no error",
+			&Config{Id: "myid", Name: "myname", Source: &testSource},
+			nil,
+		},
+		{
+			"no id",
+			&Config{Name: "myname", Source: &testSource},
+			ErrIdRequired,
+		},
+		{
+			"no name",
+			&Config{Id: "myid", Source: &testSource},
+			ErrNameRequired,
+		},
+		{
+			"no source",
+			&Config{Id: "myid", Name: "myname"},
+			ErrSourceRequired,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+
+			if tt.wantErr != nil {
+				require.Equal(t, tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x-pack/heartbeat/monitors/browser/source/inline.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline.go
@@ -14,9 +14,11 @@ type InlineSource struct {
 	BaseSource
 }
 
+var ErrNoInlineScript = fmt.Errorf("no 'script' value specified for inline source")
+
 func (s *InlineSource) Validate() error {
 	if !regexp.MustCompile("\\S").MatchString(s.Script) {
-		return fmt.Errorf("no 'script' value specified for inline source")
+		return ErrNoInlineScript
 	}
 
 	return nil

--- a/x-pack/heartbeat/monitors/browser/source/inline_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline_test.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInlineSourceValidation(t *testing.T) {
+	type testCase struct {
+		name    string
+		source  *InlineSource
+		wantErr error
+	}
+	testCases := []testCase{
+		{
+			"no error",
+			&InlineSource{Script: "a script"},
+			nil,
+		},
+		{
+			"no script",
+			&InlineSource{},
+			ErrNoInlineScript,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.source.Validate()
+			if tt.wantErr != nil {
+				require.Equal(t, tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x-pack/heartbeat/monitors/browser/source/source.go
+++ b/x-pack/heartbeat/monitors/browser/source/source.go
@@ -28,7 +28,7 @@ func (s *Source) Active() ISource {
 	return s.ActiveMemo
 }
 
-var ErrInvalidSource = fmt.Errorf("no or unknown source type specified for synthetic monitor")
+var ErrInvalidSource = fmt.Errorf("no or unknown source type specified for synthetic monitor.")
 
 func (s *Source) Validate() error {
 	if s.Active() == nil {

--- a/x-pack/heartbeat/monitors/browser/source/source_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/source_test.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package source
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceValidation(t *testing.T) {
+	type testCase struct {
+		name    string
+		source  Source
+		wantErr error
+	}
+	testCases := []testCase{
+		{
+			"no error",
+			Source{Inline: &InlineSource{}},
+			nil,
+		},
+		{
+			"no concrete source",
+			Source{},
+			ErrInvalidSource,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.source.Validate()
+			if tt.wantErr != nil {
+				require.Equal(t, tt.wantErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #24403.

With the changes to the heartbeat config syntax in 7.12 the `source` field is now required. Our config validation code didn't actually check for this field's presence, which caused an NPE.

This PR adds a validation checking for that config's presence. It also adds tests for the validation code for config sub-fields. There were no defects found in the validations for source.inline, or source.browser, but a few tests were missing.

Instead of the panic seen in #24403 users will now get the error seen below.

```
2021-03-05T15:41:40.146-0600	ERROR	instance/beat.go:952	Exiting: could not create monitor: job err could not parse suite config: config 'source' must be specified for this monitor, if upgrading from a previous experimental version please see our new config docs accessing 'heartbeat.monitors.0' (source:'sample-synthetics-config/heartbeat.yml')
Exiting: could not create monitor: job err could not parse suite config: config 'source' must be specified for this monitor, if upgrading from a previous experimental version please see our new config docs accessing 'heartbeat.monitors.0' (source:'sample-synthetics-config/heartbeat.yml')
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

Build and run heartbeat in the `x-pack/heartbeat` folder using a modified version of the config file in `sample-syntheticsconfig/heartbeat.yml`. Simply delete the `source` attribute for the top monitor. The correct error mentioned above should appear.
