### PR TITLE
Cherry-pick #24387 to 7.x: Fix failing installation on windows 7

### DIFF
--- a/libbeat/common/backoff/exponential.go
+++ b/libbeat/common/backoff/exponential.go
@@ -21,8 +21,8 @@ import (
 	"time"
 )
 
-// ExpBackoff exponential backoff, will wait an initial time and exponentialy
-// increases the wait time up to a predefined maximun. Resetting Backoff will reset the next sleep
+// ExpBackoff exponential backoff, will wait an initial time and exponentially
+// increases the wait time up to a predefined maximum. Resetting Backoff will reset the next sleep
 // timer to the initial backoff duration.
 type ExpBackoff struct {
 	duration time.Duration

--- a/libbeat/common/file/helper_windows.go
+++ b/libbeat/common/file/helper_windows.go
@@ -19,6 +19,7 @@ package file
 
 import (
 	"os"
+	"path/filepath"
 )
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
@@ -40,5 +41,13 @@ func SafeFileRotate(path, tempfile string) error {
 	if e = os.Rename(tempfile, path); e != nil {
 		return e
 	}
+
+	// sync all files
+	parent := filepath.Dir(path)
+	if f, err := os.OpenFile(parent, os.O_SYNC|os.O_RDWR, 0755); err == nil {
+		f.Sync()
+		f.Close()
+	}
+
 	return nil
 }

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@
 - Fix reloading of log level for services {pull}[24055]24055
 - Fix: Successfully installed and enrolled agent running standalone{pull}[24128]24128
 - Make installer atomic on windows {pull}[24253]24253
+- Fix failing installation on windows 7 {pull}[24387]24387
 - Fix capabilities resolution in inspect command {pull}[24346]24346
 
 ==== New features

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -15,13 +15,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
-
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/v7/libbeat/common/backoff"
-
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filelock"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/client"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/proto"
@@ -29,15 +27,17 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/storage"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/authority"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/kibana"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
 const (
-	waitingForAgent        = "waiting for Elastic Agent to start"
-	waitingForFleetServer  = "waiting for Elastic Agent to start Fleet Server"
-	defaultFleetServerPort = 8220
+	maxRetriesstoreAgentInfo = 5
+	waitingForAgent          = "waiting for Elastic Agent to start"
+	waitingForFleetServer    = "waiting for Elastic Agent to start Fleet Server"
+	defaultFleetServerPort   = 8220
 )
 
 var (
@@ -233,8 +233,9 @@ func (c *EnrollCmd) fleetServerBootstrap(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := c.configStore.Save(reader); err != nil {
-		return errors.New(err, "could not save fleet server bootstrap information", errors.TypeFilesystem)
+
+	if err := safelyStoreAgentInfo(c.configStore, reader); err != nil {
+		return err
 	}
 
 	if agentRunning {
@@ -404,11 +405,7 @@ func (c *EnrollCmd) enroll(ctx context.Context) error {
 		return err
 	}
 
-	if err := c.configStore.Save(reader); err != nil {
-		return errors.New(err, "could not save enrollment information", errors.TypeFilesystem)
-	}
-
-	if _, err := info.NewAgentInfo(); err != nil {
+	if err := safelyStoreAgentInfo(c.configStore, reader); err != nil {
 		return err
 	}
 
@@ -554,5 +551,36 @@ func getAppFromStatus(status *client.AgentStatus, name string) *client.Applicati
 			return app
 		}
 	}
+	return nil
+}
+
+func safelyStoreAgentInfo(s store, reader io.Reader) error {
+	var err error
+	signal := make(chan struct{})
+	backExp := backoff.NewExpBackoff(signal, 100*time.Millisecond, 3*time.Second)
+
+	for i := 0; i <= maxRetriesstoreAgentInfo; i++ {
+		backExp.Wait()
+		err = storeAgentInfo(s, reader)
+		if err != filelock.ErrAppAlreadyRunning {
+			break
+		}
+	}
+
+	close(signal)
+	return err
+}
+
+func storeAgentInfo(s store, reader io.Reader) error {
+	fileLock := info.AgentConfigFileLock()
+	if err := fileLock.TryLock(); err != nil {
+		return err
+	}
+	defer fileLock.Unlock()
+
+	if err := s.Save(reader); err != nil {
+		return errors.New(err, "could not save enrollment information", errors.TypeFilesystem)
+	}
+
 	return nil
 }

--- a/x-pack/elastic-agent/pkg/agent/application/filelock/locker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filelock/locker.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package application
+package filelock
 
 import (
 	"fmt"

--- a/x-pack/elastic-agent/pkg/agent/application/filelock/locker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filelock/locker_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-package application
+package filelock
 
 import (
 	"io/ioutil"

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_info.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_info.go
@@ -21,7 +21,7 @@ type AgentInfo struct {
 // If agent config file does not exist it gets created.
 // Initiates log level to predefined value.
 func NewAgentInfoWithLog(level string) (*AgentInfo, error) {
-	agentInfo, err := loadAgentInfo(false, level)
+	agentInfo, err := loadAgentInfoWithBackoff(false, level)
 	if err != nil {
 		return nil, err
 	}
@@ -48,6 +48,16 @@ func (i *AgentInfo) LogLevel(level string) error {
 	}
 
 	i.logLevel = level
+	return nil
+}
+
+// ReloadID reloads agent info ID from configuration file.
+func (i *AgentInfo) ReloadID() error {
+	newInfo, err := NewAgentInfoWithLog(i.logLevel)
+	if err != nil {
+		return err
+	}
+	i.agentID = newInfo.agentID
 	return nil
 }
 

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -280,6 +280,11 @@ func (m *Managed) Start() error {
 		return nil
 	}
 
+	// reload ID because of win7 sync issue
+	if err := m.agentInfo.ReloadID(); err != nil {
+		return err
+	}
+
 	err := m.upgrader.Ack(m.bgContext)
 	if err != nil {
 		m.log.Warnf("failed to ack update %v", err)

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -9,12 +9,11 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
-
 	"github.com/spf13/cobra"
 
 	c "github.com/elastic/beats/v7/libbeat/common/cli"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filelock"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/install"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/warn"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
@@ -58,9 +57,9 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, 
 	}
 
 	// check the lock to ensure that elastic-agent is not already running in this directory
-	locker := application.NewAppLocker(paths.Data(), agentLockFileName)
+	locker := filelock.NewAppLocker(paths.Data(), agentLockFileName)
 	if err := locker.TryLock(); err != nil {
-		if err == application.ErrAppAlreadyRunning {
+		if err == filelock.ErrAppAlreadyRunning {
 			return fmt.Errorf("cannot perform installation as Elastic Agent is already running from this directory")
 		}
 		return err

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/beats/v7/libbeat/service"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filelock"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/reexec"
@@ -63,7 +64,7 @@ func run(flags *globalFlags, streams *cli.IOStreams) error { // Windows: Mark se
 	// This must be the first deferred cleanup task (last to execute).
 	defer service.NotifyTermination()
 
-	locker := application.NewAppLocker(paths.Data(), agentLockFileName)
+	locker := filelock.NewAppLocker(paths.Data(), agentLockFileName)
 	if err := locker.TryLock(); err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/agent/cmd/watch.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/watch.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filelock"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/upgrade"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
@@ -67,9 +67,9 @@ func watchCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, ar
 		return nil
 	}
 
-	locker := application.NewAppLocker(paths.Top(), watcherLockFile)
+	locker := filelock.NewAppLocker(paths.Top(), watcherLockFile)
 	if err := locker.TryLock(); err != nil {
-		if err == application.ErrAppAlreadyRunning {
+		if err == filelock.ErrAppAlreadyRunning {
 			log.Debugf("exiting, lock already exists")
 			return nil
 		}


### PR DESCRIPTION
Cherry-pick of PR #24387 to 7.x branch. Original message:

## What does this PR do?

Issue described here: #24327 
there was a race between enrollment process and restarting service, FS playing part as well. 
The thing was that when agent was restarted only on windows 7 it loaded standalone ID, even though it was already replaced by enrollment process. 
Then when agent retrieved hosts from fleet it even overwrote updated ID with stale one. 

This fix adds a lock which prevents simultaneous write in between these two processes and a forced Reload in case of fleet managed agent later in the cycle. 
Another thing is FSync after file rotation which was missing for windows. 

These seems to fix the issue, tested on win 7 VM on cloud

## Why is it important?

Fixes #24327

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
