### PR TITLE
Cherry-pick #24414 to 7.11: [fix][auditbeat] Reset file offset when re-reading from the beginning

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -122,6 +122,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033] {pull}19764[19764]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
+- system/login: Fixed offset reset on inode reuse. {pull}24414[24414]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/login/utmp.go
+++ b/x-pack/auditbeat/module/system/login/utmp.go
@@ -219,11 +219,18 @@ func (r *UtmpFileReader) readNewInFile(loginRecordC chan<- LoginRecord, errorC c
 			f.Close()
 		}()
 
-		_, err = f.Seek(utmpFile.Offset, 0)
-		if err != nil {
-			errorC <- errors.Wrapf(err, "error setting offset for file %v", utmpFile.Path)
+		// This will be the usual case, but we do not want to seek with the stored offset
+		// if the saved size is smaller than the current one.
+		if size >= oldSize {
+			_, err = f.Seek(utmpFile.Offset, 0)
+			if err != nil {
+				errorC <- errors.Wrapf(err, "error setting offset %d for file %v", utmpFile.Offset, utmpFile.Path)
+			}
+		}
 
-			// Try one more time, this time resetting to the beginning of the file.
+		// If the saved size is smaller than the current one, or the previous Seek failed,
+		// we retry one more time, this time resetting to the beginning of the file.
+		if size < oldSize || err != nil {
 			_, err = f.Seek(0, 0)
 			if err != nil {
 				errorC <- errors.Wrapf(err, "error setting offset 0 for file %v", utmpFile.Path)


### PR DESCRIPTION
Cherry-pick of PR #24414 to 7.11 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When a `utmp` file is read and its size is smaller than before (which can be caused by an inode reuse, for example), we have to reset its offset, also, otherwise it will ignore any new events in that file until the size is bigger than its previous value.
 
## Why is it important?

We were missing events in some edge cases.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## Logs

The logs of the bug:

```
2021-03-01T17:16:07.665+1000	WARN	[login]	login/utmp.go:190	Unexpectedly, the file /var/log/wtmp is smaller than before (new: 35712, old: 39552) - reading whole file.
2021-03-01T17:16:07.665+1000	DEBUG	[login]	login/utmp.go:204	Reading file /var/log/wtmp (utmpFile={Inode:14 Path:/var/log/wtmp Size:35712 Offset:39552 Type:0})
2021-03-01T17:16:07.665+1000	DEBUG	[login]	login/utmp.go:279	Saving UTMP file record ({Inode:14 Path:/var/log/wtmp Size:35712 Offset:39552 Type:0})
```

As you can see, it is reading from an invalid offset and saving it.

```
2021-03-01T17:16:17.666+1000	DEBUG	[login]	login/utmp.go:204	Reading file /var/log/wtmp (utmpFile={Inode:14 Path:/var/log/wtmp Size:36096 Offset:39552 Type:0})
2021-03-01T17:16:17.666+1000	DEBUG	[login]	login/utmp.go:279	Saving UTMP file record ({Inode:14 Path:/var/log/wtmp Size:36096 Offset:39552 Type:0})
2021-03-01T17:16:17.666+1000	DEBUG	[login]	login/login.go:130	0 new login records.
```

Subsequent calls still ignore new events even if the size has grown.
