### PR TITLE
Cherry-pick #24336 to 7.12: [Filebeat] httpjson input set Content-Type correctly

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -248,6 +248,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - aws/s3access dataset was populating event.duration using the wrong unit. {pull}23920[23920]
 - Zoom module pipeline failed to ingest some chat_channel events. {pull}23904[23904]
 - Fix aws/vpcflow generating errors for empty logs or unidentified formats. {pull}24167[24167]
+- in httpjson input using encode_as "application/x-www-form-urlencoded" now sets Content-Type correctly {issue}24331[24331] {pull}24336[24336]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -349,7 +349,7 @@ HTTP method to use when making requests. `GET` or `POST` are the options. Defaul
 [float]
 ==== `request.encode_as`
 
-ContentType used for encoding the request body. If set it will force the encoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. By default the requests are sent with `Content-Type: application/json`. Supported values: `application/json` and `application\x-www-form-urlencoded`. `application/x-www-form-encoded` will url encode the `url.params` and set them as the body. It is not set by default.
+ContentType used for encoding the request body. If set it will force the encoding in the specified format regardless of the `Content-Type` header value, otherwise it will honor it if possible or fallback to `application/json`. By default the requests are sent with `Content-Type: application/json`. Supported values: `application/json` and `application/x-www-form-urlencoded`. `application/x-www-form-urlencoded` will url encode the `url.params` and set them as the body. It is not set by default.
 
 [float]
 ==== `request.body`

--- a/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/encoding.go
@@ -91,6 +91,9 @@ func encodeAsJSON(trReq transformable) ([]byte, error) {
 	if len(trReq.body()) == 0 {
 		return nil, nil
 	}
+	header := trReq.header()
+	header.Set("Content-Type", "application/json")
+	trReq.setHeader(header)
 	return json.Marshal(trReq.body())
 }
 
@@ -103,6 +106,9 @@ func encodeAsForm(trReq transformable) ([]byte, error) {
 	body := []byte(url.RawQuery)
 	url.RawQuery = ""
 	trReq.setURL(url)
+	header := trReq.header()
+	header.Set("Content-Type", "application/x-www-form-urlencoded")
+	trReq.setHeader(header)
 	return body, nil
 }
 

--- a/x-pack/filebeat/input/httpjson/internal/v2/encoding_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/encoding_test.go
@@ -61,5 +61,6 @@ func TestEncodeAsForm(t *testing.T) {
 		trReq.setURL(*u)
 		res, err := encodeAsForm(trReq)
 		assert.Equal(t, test.body, string(res))
+		assert.Equal(t, "application/x-www-form-urlencoded", trReq.header().Get("Content-Type"))
 	}
 }


### PR DESCRIPTION
Cherry-pick of PR #24336 to 7.12 branch. Original message: 

## What does this PR do?
when using encode_as "application/x-www-form-urlencoded" option in
httpjson input, the Content-Type is now set correctly to
"application/x-www-form-urlencoded"


## Why is it important?

Content-Type header should match the actual content type

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

```
mage goUnitTest
```

## Related issues

- Closes #24331