### PR TITLE
Add tests and support for truncated files in filestream input

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -59,6 +59,9 @@ type fileScanner struct {
 type fileWatcherConfig struct {
 	// Interval is the time between two scans.
 	Interval time.Duration `config:"check_interval"`
+	// ResendOnModTime  if a file has been changed according to modtime but the size is the same
+	// it is still considered truncation.
+	ResendOnModTime bool `config:"resend_on_touch"`
 	// Scanner is the configuration of the scanner.
 	Scanner fileScannerConfig `config:",inline"`
 }
@@ -66,11 +69,12 @@ type fileWatcherConfig struct {
 // fileWatcher gets the list of files from a FSWatcher and creates events by
 // comparing the files between its last two runs.
 type fileWatcher struct {
-	interval time.Duration
-	prev     map[string]os.FileInfo
-	scanner  loginp.FSScanner
-	log      *logp.Logger
-	events   chan loginp.FSEvent
+	interval        time.Duration
+	resendOnModTime bool
+	prev            map[string]os.FileInfo
+	scanner         loginp.FSScanner
+	log             *logp.Logger
+	events          chan loginp.FSEvent
 }
 
 func newFileWatcher(paths []string, ns *common.ConfigNamespace) (loginp.FSWatcher, error) {
@@ -98,18 +102,20 @@ func newScannerWatcher(paths []string, c *common.Config) (loginp.FSWatcher, erro
 		return nil, err
 	}
 	return &fileWatcher{
-		log:      logp.NewLogger(watcherDebugKey),
-		interval: config.Interval,
-		prev:     make(map[string]os.FileInfo, 0),
-		scanner:  scanner,
-		events:   make(chan loginp.FSEvent),
+		log:             logp.NewLogger(watcherDebugKey),
+		interval:        config.Interval,
+		resendOnModTime: config.ResendOnModTime,
+		prev:            make(map[string]os.FileInfo, 0),
+		scanner:         scanner,
+		events:          make(chan loginp.FSEvent),
 	}, nil
 }
 
 func defaultFileWatcherConfig() fileWatcherConfig {
 	return fileWatcherConfig{
-		Interval: 10 * time.Second,
-		Scanner:  defaultFileScannerConfig(),
+		Interval:        10 * time.Second,
+		ResendOnModTime: false,
+		Scanner:         defaultFileScannerConfig(),
 	}
 }
 
@@ -142,10 +148,18 @@ func (w *fileWatcher) watch(ctx unison.Canceler) {
 		}
 
 		if prevInfo.ModTime() != info.ModTime() {
-			select {
-			case <-ctx.Done():
-				return
-			case w.events <- writeEvent(path, info):
+			if prevInfo.Size() > info.Size() || w.resendOnModTime && prevInfo.Size() == info.Size() {
+				select {
+				case <-ctx.Done():
+					return
+				case w.events <- truncateEvent(path, info):
+				}
+			} else {
+				select {
+				case <-ctx.Done():
+					return
+				case w.events <- writeEvent(path, info):
+				}
 			}
 		}
 
@@ -196,6 +210,10 @@ func createEvent(path string, fi os.FileInfo) loginp.FSEvent {
 
 func writeEvent(path string, fi os.FileInfo) loginp.FSEvent {
 	return loginp.FSEvent{Op: loginp.OpWrite, OldPath: path, NewPath: path, Info: fi}
+}
+
+func truncateEvent(path string, fi os.FileInfo) loginp.FSEvent {
+	return loginp.FSEvent{Op: loginp.OpTruncate, OldPath: path, NewPath: path, Info: fi}
 }
 
 func renamedEvent(oldPath, path string, fi os.FileInfo) loginp.FSEvent {

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -60,9 +60,10 @@ type fileIdentifier interface {
 // fileSource implements the Source interface
 // It is required to identify and manage file sources.
 type fileSource struct {
-	info    os.FileInfo
-	newPath string
-	oldPath string
+	info      os.FileInfo
+	newPath   string
+	oldPath   string
+	truncated bool
 
 	name                string
 	identifierGenerator string
@@ -103,6 +104,7 @@ func (i *inodeDeviceIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                i.name + identitySep + file.GetOSState(e.Info).String(),
 		identifierGenerator: i.name,
 	}
@@ -140,6 +142,7 @@ func (p *pathIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                p.name + identitySep + path,
 		identifierGenerator: p.name,
 	}

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -98,6 +98,7 @@ func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                i.name + identitySep + osstate.InodeString() + "-" + i.markerContents(),
 		identifierGenerator: i.name,
 	}

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -225,19 +225,19 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, path stri
 // is returned and the harvester is closed. The file will be picked up again the next time
 // the file system is scanned
 func (inp *filestream) openFile(log *logp.Logger, path string, offset int64) (*os.File, error) {
-	fi, err := os.Stat(path)
+	f, err := os.OpenFile(path, os.O_RDONLY, os.FileMode(0))
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat source file %s: %v", path, err)
+		return nil, fmt.Errorf("failed opening %s: %s", path, err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat source file %s: %s", path, err)
 	}
 
 	err = checkFileBeforeOpening(fi)
 	if err != nil {
 		return nil, err
-	}
-
-	f, err := os.OpenFile(path, os.O_RDONLY, os.FileMode(0))
-	if err != nil {
-		return nil, fmt.Errorf("failed opening %s: %s", path, err)
 	}
 
 	if fi.Size() < offset {

--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/encoding"
@@ -513,6 +514,224 @@ func TestFilestreamCloseAfterIntervalRotatedAndNewRemoved(t *testing.T) {
 	env.mustRemoveFile(newFileName)
 
 	env.waitUntilHarvesterIsDone()
+
+	cancelInput()
+	env.waitUntilInputStops()
+}
+
+// test_truncated_file_open from test_harvester.py
+func TestFilestreamTruncatedFileOpen(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.mustTruncateFile(testlogName, 0)
+	time.Sleep(5 * time.Millisecond)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+	env.waitUntilEventCount(4)
+
+	cancelInput()
+	env.waitUntilInputStops()
+	env.requireOffsetInRegistry(testlogName, len(truncatedTestLines))
+}
+
+// test_truncated_file_closed from test_harvester.py
+func TestFilestreamTruncatedFileClosed(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+		"close.reader.on_eof":                "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.waitUntilHarvesterIsDone()
+
+	env.mustTruncateFile(testlogName, 0)
+	time.Sleep(5 * time.Millisecond)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+	env.waitUntilEventCount(4)
+
+	cancelInput()
+	env.waitUntilInputStops()
+	env.requireOffsetInRegistry(testlogName, len(truncatedTestLines))
+}
+
+// test_truncate from test_harvester.py
+func TestFilestreamTruncateWithSymlink(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(testlogName),
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+		"prospector.scanner.symlinks":        "true",
+	})
+
+	lines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, lines)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(3)
+
+	env.requireOffsetInRegistry(testlogName, len(lines))
+
+	// remove symlink
+	env.mustRemoveFile(symlinkName)
+	env.mustTruncateFile(testlogName, 0)
+	env.waitUntilOffsetInRegistry(testlogName, 0)
+
+	moreLines := []byte("forth line\nfifth line\n")
+	env.mustWriteLinesToFile(testlogName, moreLines)
+
+	env.waitUntilEventCount(5)
+	env.requireOffsetInRegistry(testlogName, len(moreLines))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(1)
+}
+
+func TestFilestreamTruncateBigScannerInterval(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "5s",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.mustTruncateFile(testlogName, 0)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+
+	env.waitUntilEventCount(3)
+
+	cancelInput()
+	env.waitUntilInputStops()
+}
+
+func TestFilestreamTruncateCheckOffset(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.mustTruncateFile(testlogName, 0)
+
+	env.waitUntilOffsetInRegistry(testlogName, 0)
+
+	cancelInput()
+	env.waitUntilInputStops()
+}
+
+func TestFilestreamTruncateBlockedOutput(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+	env.pipeline = &mockPipelineConnector{blocking: true}
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	testlines := []byte("first line\nsecond line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	for env.pipeline.clientsCount() != 1 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	env.pipeline.clients[0].waitUntilPublishingHasStarted()
+	env.pipeline.clients[0].canceler()
+
+	env.waitUntilEventCount(2)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	// extra lines are appended after first line is processed
+	// so it can interfere with the truncation of the file
+	env.mustAppendLinesToFile(testlogName, []byte("third line\n"))
+
+	env.mustTruncateFile(testlogName, 0)
+
+	env.waitUntilOffsetInRegistry(testlogName, 0)
+
+	// all newly started client has to be cancelled so events can be processed
+	env.pipeline.cancelAllClients()
+	// if a new client shows up, it should not block
+	env.pipeline.invertBlocking()
+
+	truncatedTestLines := []byte("truncated line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+
+	env.waitUntilEventCount(3)
+	env.waitUntilOffsetInRegistry(testlogName, len(truncatedTestLines))
 
 	cancelInput()
 	env.waitUntilInputStops()

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -29,6 +29,7 @@ const (
 	OpWrite
 	OpDelete
 	OpRename
+	OpTruncate
 )
 
 // Operation describes what happened to a file.

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -152,7 +152,6 @@ func (hg *defaultHarvesterGroup) Restart(ctx input.Context, s Source) {
 	ctx.Logger = ctx.Logger.With("source", sourceName)
 	ctx.Logger.Debug("Restarting harvester for file")
 
-	// we are waiting for five seconds so harvester has enough time to shut down
 	hg.tg.Go(startHarvester(ctx, hg, s, true))
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -117,6 +117,8 @@ func (r *readerGroup) hasID(id string) bool {
 type HarvesterGroup interface {
 	// Start starts a Harvester and adds it to the readers list.
 	Start(input.Context, Source)
+	// Restart starts a Harvester if it might be already running.
+	Restart(input.Context, Source)
 	// Stop cancels the reader of a given Source.
 	Stop(Source)
 	// StopGroup cancels all running Harvesters.
@@ -139,25 +141,49 @@ func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
 	ctx.Logger = ctx.Logger.With("source", sourceName)
 	ctx.Logger.Debug("Starting harvester for file")
 
-	hg.tg.Go(func(canceler unison.Canceler) error {
+	hg.tg.Go(startHarvester(ctx, hg, s, false))
+}
+
+// Restart starts the Harvester for a Source if a Harvester is already running it waits for it
+// to shut down for a specified timeout. It does not block.
+func (hg *defaultHarvesterGroup) Restart(ctx input.Context, s Source) {
+	sourceName := hg.identifier.ID(s)
+
+	ctx.Logger = ctx.Logger.With("source", sourceName)
+	ctx.Logger.Debug("Restarting harvester for file")
+
+	// we are waiting for five seconds so harvester has enough time to shut down
+	hg.tg.Go(startHarvester(ctx, hg, s, true))
+}
+
+func startHarvester(ctx input.Context, hg *defaultHarvesterGroup, s Source, restart bool) func(canceler unison.Canceler) error {
+	srcID := hg.identifier.ID(s)
+
+	return func(canceler unison.Canceler) error {
 		defer func() {
 			if v := recover(); v != nil {
 				err := fmt.Errorf("harvester panic with: %+v\n%s", v, debug.Stack())
 				ctx.Logger.Errorf("Harvester crashed with: %+v", err)
+				hg.readers.remove(srcID)
 			}
 		}()
+
+		if restart {
+			// stop previous harvester
+			hg.readers.remove(srcID)
+		}
 		defer ctx.Logger.Debug("Stopped harvester for file")
 
-		harvesterCtx, cancelHarvester, err := hg.readers.newContext(sourceName, canceler)
+		harvesterCtx, cancelHarvester, err := hg.readers.newContext(srcID, canceler)
 		if err != nil {
 			return fmt.Errorf("error while adding new reader to the bookkeeper %v", err)
 		}
 		ctx.Cancelation = harvesterCtx
 		defer cancelHarvester()
-		defer hg.readers.remove(sourceName)
 
-		resource, err := lock(ctx, hg.store, sourceName)
+		resource, err := lock(ctx, hg.store, srcID)
 		if err != nil {
+			hg.readers.remove(srcID)
 			return fmt.Errorf("error while locking resource: %v", err)
 		}
 		defer releaseResource(resource)
@@ -167,6 +193,7 @@ func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
 			ACKHandler: newInputACKHandler(ctx.Logger),
 		})
 		if err != nil {
+			hg.readers.remove(srcID)
 			return fmt.Errorf("error while connecting to output with pipeline: %v", err)
 		}
 		defer client.Close()
@@ -177,10 +204,18 @@ func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
 
 		err = hg.harvester.Run(ctx, s, cursor, publisher)
 		if err != nil && err != context.Canceled {
+			hg.readers.remove(srcID)
 			return fmt.Errorf("error while running harvester: %v", err)
 		}
+		// If the context was not cancelled it means that the Harvester is stopping because of
+		// some internal decision, not due to outside interaction.
+		// If it is stopping itself, it must clean up the bookkeeper.
+		if ctx.Cancelation.Err() != context.Canceled {
+			hg.readers.remove(srcID)
+		}
+
 		return nil
-	})
+	}
 }
 
 // Stop stops the running Harvester for a given Source.
@@ -205,6 +240,11 @@ func lock(ctx input.Context, store *store, key string) (*resource, error) {
 		resource.Release()
 		return nil, err
 	}
+
+	resource.stateMutex.Lock()
+	resource.lockedVersion = resource.version
+	resource.stateMutex.Unlock()
+
 	return resource, nil
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -43,6 +43,9 @@ type StateMetadataUpdater interface {
 	UpdateMetadata(s Source, v interface{}) error
 	// Remove marks a state for deletion of a given Source.
 	Remove(s Source) error
+	// ResetCursor resets the cursor in the registry and drops previous state
+	// updates that are not yet ACKed.
+	ResetCursor(s Source, cur interface{}) error
 }
 
 // ProspectorCleaner cleans the state store before it starts running.

--- a/filebeat/input/filestream/internal/input-logfile/publish.go
+++ b/filebeat/input/filestream/internal/input-logfile/publish.go
@@ -124,11 +124,15 @@ func (op *updateOp) done(n uint) {
 // Execute updates the persistent store with the scheduled changes and releases the resource.
 func (op *updateOp) Execute(n uint) {
 	resource := op.resource
-	defer op.done(n)
 
 	resource.stateMutex.Lock()
 	defer resource.stateMutex.Unlock()
 
+	if resource.lockedVersion != op.resource.version {
+		return
+	}
+
+	defer op.done(n)
 	resource.activeCursorOperations -= n
 	if resource.activeCursorOperations == 0 {
 		resource.cursor = resource.pendingCursor

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -75,6 +75,10 @@ type resource struct {
 	// as long as pending is > 0 the resource is in used and must not be garbage collected.
 	pending atomic.Uint64
 
+	// current identity version when updated stateMutex must be locked.
+	// Pending updates will be discarded if it is increased.
+	version, lockedVersion uint
+
 	// lock guarantees only one input create updates for this entry
 	lock unison.Mutex
 
@@ -84,7 +88,7 @@ type resource struct {
 	// stateMutex is used to lock the resource when it is update/read from
 	// multiple go-routines like the ACK handler or the input publishing an
 	// event.
-	// stateMutex is used to access the fields 'stored', 'state' and 'internalInSync'
+	// stateMutex is used to access the fields 'stored', 'state', 'internalInSync' and 'version'.
 	stateMutex sync.Mutex
 
 	// stored indicates that the state is available in the registry file. It is false for new entries.
@@ -179,6 +183,11 @@ func (s *sourceStore) UpdateMetadata(src Source, v interface{}) error {
 func (s *sourceStore) Remove(src Source) error {
 	key := s.identifier.ID(src)
 	return s.store.remove(key)
+}
+
+func (s *sourceStore) ResetCursor(src Source, cur interface{}) error {
+	key := s.identifier.ID(src)
+	return s.store.resetCursor(key, cur)
 }
 
 // CleanIf sets the TTL of a resource if the predicate return true.
@@ -292,6 +301,29 @@ func (s *store) writeState(r *resource) {
 		r.stored = true
 		r.internalInSync = true
 	}
+}
+
+// resetCursor sets the cursor to the value in cur in the persistent store and
+// drops all pending cursor operations.
+func (s *store) resetCursor(key string, cur interface{}) error {
+	r := s.ephemeralStore.Find(key, false)
+	if r == nil {
+		return fmt.Errorf("resource '%s' not found", key)
+	}
+	defer r.Release()
+
+	r.stateMutex.Lock()
+	defer r.stateMutex.Unlock()
+
+	r.version++
+	r.UpdatesReleaseN(r.activeCursorOperations)
+	r.activeCursorOperations = 0
+	r.pendingCursor = nil
+	typeconv.Convert(&r.cursor, cur)
+
+	s.writeState(r)
+
+	return nil
 }
 
 // Removes marks an entry for removal by setting its TTL to zero.

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
@@ -224,6 +225,98 @@ func TestStore_UpdateTTL(t *testing.T) {
 		checkEqualStoreState(t, map[string]state{"test::key": wantMemoryState}, storeMemorySnapshot(store))
 		checkEqualStoreState(t, map[string]state{"test::key": wantInSyncState}, storeInSyncSnapshot(store))
 		checkEqualStoreState(t, map[string]state{"test::key": wantInSyncState}, backend.snapshot())
+	})
+}
+
+func TestStore_ResetCursor(t *testing.T) {
+	type cur struct {
+		Offset int
+	}
+	t.Run("reset cursor empty and lock it", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL: 60 * time.Second,
+			},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		require.Equal(t, uint(0), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, nil, res.cursor)
+		require.Equal(t, nil, res.pendingCursor)
+
+		store.resetCursor("test::key", cur{Offset: 10})
+
+		res = store.Get("test::key")
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, map[string]interface{}{"offset": int64(10)}, res.cursor)
+
+		res, err := lock(input.Context{}, store, "test::key")
+		require.NoError(t, err)
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(1), res.lockedVersion)
+	})
+
+	t.Run("reset cursor with no pending updates", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL:    60 * time.Second,
+				Cursor: cur{Offset: 6},
+			},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		require.Equal(t, uint(0), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, map[string]interface{}{"offset": int64(6)}, res.cursor)
+		require.Equal(t, nil, res.pendingCursor)
+
+		store.resetCursor("test::key", cur{Offset: 0})
+
+		res = store.Get("test::key")
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, map[string]interface{}{"offset": int64(0)}, res.cursor)
+
+		res, err := lock(input.Context{}, store, "test::key")
+		require.NoError(t, err)
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(1), res.lockedVersion)
+	})
+
+	t.Run("reset cursor with pending updates", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL:    60 * time.Second,
+				Cursor: cur{Offset: 6},
+			},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+
+		// lock before creating a new update operation
+		res, err := lock(input.Context{}, store, "test::key")
+		require.NoError(t, err)
+		op, err := createUpdateOp(store, res, cur{Offset: 42})
+		require.NoError(t, err)
+
+		store.resetCursor("test::key", cur{Offset: 0})
+
+		// try to update cursor after it has been reset
+		op.Execute(1)
+		releaseResource(res)
+
+		res = store.Get("test::key")
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, uint(0), res.activeCursorOperations)
+		require.Equal(t, map[string]interface{}{"offset": int64(0)}, res.cursor)
+		require.Equal(t, nil, res.pendingCursor)
+
 	})
 }
 

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -130,8 +130,13 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 						break
 					}
 				}
-
 				hg.Start(ctx, src)
+
+			case loginp.OpTruncate:
+				log.Debugf("File %s has been truncated", fe.NewPath)
+
+				s.ResetCursor(src, state{Offset: 0})
+				hg.Restart(ctx, src)
 
 			case loginp.OpDelete:
 				log.Debugf("File %s has been removed", fe.OldPath)


### PR DESCRIPTION
## What does this PR do?

Add support for truncated files and adds migrates related tests from `test_harvester.py`. It also adds more tests to cover the following cases:

* truncation is detected only by the `Prospector`
* truncation is detected first by the `Harvester` then by the `Prospector`
* truncation is detected first by the `Prospector` then by the `Harvester`
* file gets truncated when the output is not able to accept events

## Why is it important?

The support for stopping reading from truncated files was already implemented. However, `filestream` input could not start reading it from the beginning.

A new file system event is added called `OpTruncate`. When the size of a file has shrinked compared to the last time the scanner has encountered it, an `OpTruncate` event is emitted. When the prospector gets this event, the `HarvesterGroup` is restarting the `Harvester` of the file. Restarting basically means that the new `Harvester` cancels the previous reader and starts a new one.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~