### PR TITLE
[CI] enable one shoot workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -212,7 +212,7 @@ def generateStages(Map args = [:]) {
 }
 
 def cloud(Map args = [:]) {
-  withNode(args.label) {
+  withNode(labels: args.label, sleepMin: 30, sleepMax: 200, forceWorkspace: true){
     startCloudTestEnv(name: args.directory, dirs: args.dirs)
   }
   withCloudTestEnv() {
@@ -227,7 +227,7 @@ def cloud(Map args = [:]) {
 def k8sTest(Map args = [:]) {
   def versions = args.versions
   versions.each{ v ->
-    withNode(args.label) {
+    withNode(labels: args.label, sleepMin: 30, sleepMax: 200, forceWorkspace: true){
       stage("${args.context} ${v}"){
         withEnv(["K8S_VERSION=${v}", "KIND_VERSION=v0.7.0", "KUBECONFIG=${env.WORKSPACE}/kubecfg"]){
           withGithubNotify(context: "${args.context} ${v}") {
@@ -479,7 +479,7 @@ def target(Map args = [:]) {
   def isE2E = args.e2e?.get('enabled', false)
   def isPackaging = args.get('package', false)
   def dockerArch = args.get('dockerArch', 'amd64')
-  withNode(args.label) {
+  withNode(labels: args.label, sleepMin: 30, sleepMax: 200, forceWorkspace: true){
     withGithubNotify(context: "${context}") {
       withBeatsEnv(archive: true, withModule: withModule, directory: directory, id: args.id) {
         dumpVariables()
@@ -502,33 +502,6 @@ def target(Map args = [:]) {
           pushCIDockerImages(beatsFolder: "${directory}", arch: dockerArch)
         }
       }
-    }
-  }
-}
-
-/**
-* If a static worker given the labels.
-* TODO: as soon as ARM and MacOS are ephemerals then we need to change this method
-*/
-def isStaticWorker(label) {
-  return (label?.contains('arm') || label?.contains('macosx') || label?.contains('metal'))
-}
-
-/**
-* This method wraps the node call for two reasons:
-*  1. with some latency to avoid the known issue with the scalabitity in gobld.
-*  2. allocate a new workspace to workaround the flakiness of windows workers with deleteDir.
-*  3. enforce one shoot ephemeral workers with the extra/uuid label that gobld provides.
-*/
-def withNode(String label, Closure body) {
-  sleep randomNumber(min: 10, max: 200)
-  // this should workaround the existing issue with reusing workers with the Gobld
-  def uuid = UUID.randomUUID().toString()
-  def labels = isStaticWorker(label) ? label : (label?.trim() ? "${label} && extra/${uuid}" : "extra/${uuid}")
-  log(level: 'INFO', text: "Allocating a worker with the labels '${labels}'.")
-  node("${labels}") {
-    ws("workspace/${JOB_BASE_NAME}-${BUILD_NUMBER}-${uuid}") {
-      body()
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Force one-shot ephemeral workers approach

## Why is it important?

Reduce environmental issues with the provisioner

## Issues

Similar to https://github.com/elastic/beats/pull/22588 and https://github.com/elastic/beats/pull/22626