### PR TITLE
Fix typo in PostgreSQL metricbeat module docs

### DIFF
--- a/metricbeat/docs/modules/postgresql.asciidoc
+++ b/metricbeat/docs/modules/postgresql.asciidoc
@@ -14,7 +14,7 @@ Default metricsets are `activity`, `bgwriter` and `database`.
 [float]
 === Dashboard
 
-The PostgreSQL module comes with a predefined dashboard showing databse related metrics. For example:
+The PostgreSQL module comes with a predefined dashboard showing database related metrics. For example:
 
 image::./images/metricbeat-postgresql-overview.png[]
 


### PR DESCRIPTION
Fix a typo: databse => datab***a***se