### PR TITLE
Cherry-pick #24332 to 7.x: Do not drop errors when checking for templates

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -98,6 +98,12 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Fix templates being overwritten if there was an error when check for the template existance. {pull}24332[24332]
+- Fix Kubernetes autodiscovery provider to correctly handle pod states and avoid missing event data {pull}17223[17223]
+- Fix `add_cloud_metadata` to better support modifying sub-fields with other processors. {pull}13808[13808]
+- TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
+- Fix panics that could result from invalid TLS certificates. This can affect Beats that connect over TLS, or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
+- Fix panic in the Logstash output when trying to send events to closed connection. {pull}15568[15568]
 - Fix a race condition with the Kafka pipeline client, it is possible that `Close()` get called before `Connect()` . {issue}11945[11945]
 - Allow users to configure only `cluster_uuid` setting under `monitoring` namespace. {pull}14338[14338]
 - Update replicaset group to apps/v1 {pull}15854[15802]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,11 +99,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - Fix templates being overwritten if there was an error when check for the template existance. {pull}24332[24332]
-- Fix Kubernetes autodiscovery provider to correctly handle pod states and avoid missing event data {pull}17223[17223]
-- Fix `add_cloud_metadata` to better support modifying sub-fields with other processors. {pull}13808[13808]
-- TLS or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
-- Fix panics that could result from invalid TLS certificates. This can affect Beats that connect over TLS, or Beats that accept connections over TLS and validate client certificates. {pull}14146[14146]
-- Fix panic in the Logstash output when trying to send events to closed connection. {pull}15568[15568]
 - Fix a race condition with the Kafka pipeline client, it is possible that `Close()` get called before `Connect()` . {issue}11945[11945]
 - Allow users to configure only `cluster_uuid` setting under `monitoring` namespace. {pull}14338[14338]
 - Update replicaset group to apps/v1 {pull}15854[15802]

--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -66,13 +66,25 @@ func newTestSetup(t *testing.T, cfg TemplateConfig) *testSetup {
 	}
 	s := testSetup{t: t, client: client, loader: NewESLoader(client), config: cfg}
 	client.Request("DELETE", templateLoaderPath[cfg.Type]+cfg.Name, "", nil, nil)
-	require.False(t, s.loader.templateExists(cfg.Name, cfg.Type))
+	s.requireTemplateDoesNotExist("")
 	return &s
 }
+
+func (ts *testSetup) mustLoadTemplate(body map[string]interface{}) {
+	err := ts.loader.loadTemplate(ts.config.Name, ts.config.Type, body)
+	require.NoError(ts.t, err)
+	ts.requireTemplateExists("")
+}
+
 func (ts *testSetup) loadFromFile(fileElems []string) error {
 	ts.config.Fields = path(ts.t, fileElems)
 	beatInfo := beat.Info{Version: version.GetDefaultVersion()}
 	return ts.loader.Load(ts.config, beatInfo, nil, false)
+}
+
+func (ts *testSetup) mustLoadFromFile(fileElems []string) {
+	require.NoError(ts.t, ts.loadFromFile(fileElems))
+	ts.requireTemplateExists("")
 }
 
 func (ts *testSetup) load(fields []byte) error {
@@ -82,7 +94,25 @@ func (ts *testSetup) load(fields []byte) error {
 
 func (ts *testSetup) mustLoad(fields []byte) {
 	require.NoError(ts.t, ts.load(fields))
-	require.True(ts.t, ts.loader.templateExists(ts.config.Name, ts.config.Type))
+	ts.requireTemplateExists("")
+}
+
+func (ts *testSetup) requireTemplateExists(name string) {
+	if name == "" {
+		name = ts.config.Name
+	}
+	exists, err := ts.loader.templateExists(name, ts.config.Type)
+	require.NoError(ts.t, err, "failed to query template status")
+	require.True(ts.t, exists, "template must exist")
+}
+
+func (ts *testSetup) requireTemplateDoesNotExist(name string) {
+	if name == "" {
+		name = ts.config.Name
+	}
+	exists, err := ts.loader.templateExists(name, ts.config.Type)
+	require.NoError(ts.t, err, "failed to query template status")
+	require.False(ts.t, exists, "template must not exist")
 }
 
 func TestESLoader_Load(t *testing.T) {
@@ -91,7 +121,7 @@ func TestESLoader_Load(t *testing.T) {
 			setup := newTestSetup(t, TemplateConfig{Enabled: false})
 
 			setup.load(nil)
-			assert.False(t, setup.loader.templateExists(setup.config.Name, setup.config.Type))
+			setup.requireTemplateDoesNotExist("")
 		})
 
 		t.Run("invalid version", func(t *testing.T) {
@@ -99,9 +129,8 @@ func TestESLoader_Load(t *testing.T) {
 
 			beatInfo := beat.Info{Version: "invalid"}
 			err := setup.loader.Load(setup.config, beatInfo, nil, false)
-			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), "version is not semver")
-			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "version is not semver")
 		})
 	})
 
@@ -140,7 +169,7 @@ func TestESLoader_Load(t *testing.T) {
 			Name    string `config:"name"`
 		}{Enabled: true, Path: path(t, []string{"testdata", "fields.json"}), Name: nameJSON}
 		setup.load(nil)
-		assert.True(t, setup.loader.templateExists(nameJSON, setup.config.Type))
+		setup.requireTemplateExists(nameJSON)
 	})
 
 	t.Run("load template successful", func(t *testing.T) {
@@ -211,8 +240,7 @@ func TestESLoader_Load(t *testing.T) {
 
 func TestTemplate_LoadFile(t *testing.T) {
 	setup := newTestSetup(t, TemplateConfig{Enabled: true})
-	assert.NoError(t, setup.loadFromFile([]string{"..", "fields.yml"}))
-	assert.True(t, setup.loader.templateExists(setup.config.Name, setup.config.Type))
+	setup.mustLoadFromFile([]string{"..", "fields.yml"})
 }
 
 func TestLoadInvalidTemplate(t *testing.T) {
@@ -222,7 +250,7 @@ func TestLoadInvalidTemplate(t *testing.T) {
 	template := map[string]interface{}{"json": "invalid"}
 	err := setup.loader.loadTemplate(setup.config.Name, setup.config.Type, template)
 	assert.Error(t, err)
-	assert.False(t, setup.loader.templateExists(setup.config.Name, setup.config.Type))
+	setup.requireTemplateDoesNotExist("")
 }
 
 // Tests loading the templates for each beat
@@ -233,8 +261,7 @@ func TestLoadBeatsTemplate_fromFile(t *testing.T) {
 
 	for _, beat := range beats {
 		setup := newTestSetup(t, TemplateConfig{Name: beat, Enabled: true})
-		assert.NoError(t, setup.loadFromFile([]string{"..", "..", beat, "fields.yml"}))
-		assert.True(t, setup.loader.templateExists(setup.config.Name, setup.config.Type))
+		setup.mustLoadFromFile([]string{"..", "..", beat, "fields.yml"})
 	}
 }
 
@@ -244,7 +271,7 @@ func TestTemplateSettings(t *testing.T) {
 		Source: common.MapStr{"enabled": false},
 	}
 	setup := newTestSetup(t, TemplateConfig{Settings: settings, Enabled: true})
-	require.NoError(t, setup.loadFromFile([]string{"..", "fields.yml"}))
+	setup.mustLoadFromFile([]string{"..", "fields.yml"})
 
 	// Check that it contains the mapping
 	templateJSON := getTemplate(t, setup.client, setup.config.Name, setup.config.Type)
@@ -297,8 +324,8 @@ var dataTests = []struct {
 // Tests if data can be loaded into elasticsearch with right types
 func TestTemplateWithData(t *testing.T) {
 	setup := newTestSetup(t, TemplateConfig{Enabled: true})
-	require.NoError(t, setup.loadFromFile([]string{"testdata", "fields.yml"}))
-	require.True(t, setup.loader.templateExists(setup.config.Name, setup.config.Type))
+	setup.mustLoadFromFile([]string{"testdata", "fields.yml"})
+
 	esClient := setup.client.(*eslegclient.Connection)
 	for _, test := range dataTests {
 		_, _, err := esClient.Index(setup.config.Name, "_doc", "", nil, test.data)


### PR DESCRIPTION
Cherry-pick of PR #24332 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Bug

## What does this PR do?

Return an error when the HTTP request to check if a template is installed failed due to IO or in case the status code indicates that ES is not stable.

## Why is it important?

When connecting to Elasticsearch Beats do check if a template exists and attempt to create the template if that is not the case. If there is an error while checking for the template, the error should be handled. By not handling the error the Beat might attempt to install the template, even if it was already installed. This can lead to issues like Beats overwriting an already existing and modified index with settings that are not supposed to be applied. Plus if Elasticsearch is currently unstable (return code 429 or 5xx), we might trigger a thundering herd problem with hundreds of Beats attempting to overwrite templates in an unstable cluster. By returning early on error, the output will back off exponentially (with random jitter), potentially reducing the chance of breaking the existing template or finally bringing Elasticsearch down to its knees.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24144
