### PR TITLE
Move example to the correct location in reference docs

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -45,6 +45,15 @@ call will be interrupted.
 The default AWS API call timeout for a message is 120 seconds. The minimum
 is 0 seconds. The maximum is half of the visibility timeout value.
 
+[float]
+==== `expand_event_list_from_field`
+
+If the fileset using this input expects to receive multiple messages bundled
+under a specific field then the config option expand_event_list_from_field value
+can be assigned the name of the field. This setting will be able to split the
+messages under the group value into separate events. For example, CloudTrail logs
+are in JSON format and events are found under the JSON object "Records".
+
 ["source","json"]
 ----
 {
@@ -64,15 +73,6 @@ is 0 seconds. The maximum is half of the visibility timeout value.
     ]
 }
 ----
-
-[float]
-==== `expand_event_list_from_field`
-
-If the fileset using this input expects to receive multiple messages bundled
-under a specific field then the config option expand_event_list_from_field value
-can be assigned the name of the field. This setting will be able to split the
-messages under the group value into separate events. For example, CloudTrail logs
-are in JSON format and events are found under the JSON object "Records".
 
 Note: When `expand_event_list_from_field` parameter is given in the config, aws-s3
 input will assume the logs are in JSON format and decode them as JSON. Content


### PR DESCRIPTION
Looks like someone inserted a new field description in the wrong place.

No changes to the existing text. (I'm making edits as I create config docs for standalone agent, but I don't have time to make the edits in both places.)