### PR TITLE
Cherry-pick #24295 to 7.x: netflow: Use internal and external for locality fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -48,6 +48,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix parsing issues with nested JSON payloads in Elasticsearch audit log fileset. {pull}22975[22975]
 - Rename `network.direction` values in crowdstrike/falcon to `ingress`/`egress`. {pull}23041[23041]
 - Rename `s3` input to `aws-s3` input. {pull}23469[23469]
+- Possible values for Netflow's locality fields (source.locality, destination.locality and flow.locality) are now `internal` and `external`, instead of `private` and `public`. {issue}24272[24272] {pull}24295[24295]
 
 *Heartbeat*
 - Adds negative body match. {pull}20728[20728]

--- a/x-pack/filebeat/input/netflow/convert.go
+++ b/x-pack/filebeat/input/netflow/convert.go
@@ -375,16 +375,20 @@ func fixMacAddresses(dict map[string]interface{}) {
 	}
 }
 
+// Locality is an enum representing the locality of a network address.
 type Locality uint8
 
 const (
-	LocalityPrivate Locality = iota + 1
-	LocalityPublic
+	// LocalityInternal identifies addresses that are internal to the organization.
+	LocalityInternal Locality = iota + 1
+
+	// LocalityExternal identifies addresses that are outside of the organization.
+	LocalityExternal
 )
 
 var localityNames = map[Locality]string{
-	LocalityPrivate: "private",
-	LocalityPublic:  "public",
+	LocalityInternal: "internal",
+	LocalityExternal: "external",
 }
 
 func (l Locality) String() string {
@@ -408,14 +412,14 @@ func getIPLocality(internalNetworks []string, ips ...net.IP) Locality {
 	for _, ip := range ips {
 		contains, err := conditions.NetworkContains(ip, internalNetworks...)
 		if err != nil {
-			return LocalityPublic
+			return LocalityExternal
 		}
 		// always consider loopback/link-local private
 		if !contains && !isLocal(ip) {
-			return LocalityPublic
+			return LocalityExternal
 		}
 	}
-	return LocalityPrivate
+	return LocalityInternal
 }
 
 // TODO: create table from https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-extended-uniflow-template-256.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "64.235.151.76",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -24,7 +24,7 @@
         },
         "flow": {
           "id": "kSpZ1WuBhjc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "audit_counter": 4157725,
@@ -84,7 +84,7 @@
         "source": {
           "bytes": 0,
           "ip": "10.236.5.4",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:b9:26:46",
           "packets": 0,
           "port": 51917
@@ -99,7 +99,7 @@
       "Fields": {
         "destination": {
           "ip": "10.236.5.4",
-          "locality": "private",
+          "locality": "internal",
           "port": 51917
         },
         "event": {
@@ -116,7 +116,7 @@
         },
         "flow": {
           "id": "kSpZ1WuBhjc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "audit_counter": 4157725,
@@ -176,7 +176,7 @@
         "source": {
           "bytes": 0,
           "ip": "64.235.151.76",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:00:00:00:00:00",
           "packets": 0,
           "port": 443

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Barracuda-firewall.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.99.252.50",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -24,7 +24,7 @@
         },
         "flow": {
           "id": "2vFIarATx_4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.99.252.50",
@@ -72,7 +72,7 @@
         "source": {
           "bytes": 0,
           "ip": "10.99.130.239",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 0,
           "port": 65105
@@ -87,7 +87,7 @@
       "Fields": {
         "destination": {
           "ip": "10.99.130.239",
-          "locality": "private",
+          "locality": "internal",
           "port": 65105
         },
         "event": {
@@ -104,7 +104,7 @@
         },
         "flow": {
           "id": "2vFIarATx_4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.99.130.239",
@@ -152,7 +152,7 @@
         "source": {
           "bytes": 81,
           "ip": "10.99.252.50",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 1,
           "port": 53
@@ -167,7 +167,7 @@
       "Fields": {
         "destination": {
           "ip": "10.98.243.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -184,7 +184,7 @@
         },
         "flow": {
           "id": "wU3G8idsscw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.98.243.20",
@@ -232,7 +232,7 @@
         "source": {
           "bytes": 0,
           "ip": "10.99.130.239",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 0,
           "port": 65105
@@ -247,7 +247,7 @@
       "Fields": {
         "destination": {
           "ip": "10.99.130.239",
-          "locality": "private",
+          "locality": "internal",
           "port": 65105
         },
         "event": {
@@ -264,7 +264,7 @@
         },
         "flow": {
           "id": "wU3G8idsscw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.99.130.239",
@@ -312,7 +312,7 @@
         "source": {
           "bytes": 81,
           "ip": "10.98.243.20",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 1,
           "port": 53
@@ -327,7 +327,7 @@
       "Fields": {
         "destination": {
           "ip": "10.98.243.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -344,7 +344,7 @@
         },
         "flow": {
           "id": "rOmj8EdZ2dc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.98.243.20",
@@ -392,7 +392,7 @@
         "source": {
           "bytes": 0,
           "ip": "10.99.168.140",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 0,
           "port": 52344
@@ -407,7 +407,7 @@
       "Fields": {
         "destination": {
           "ip": "10.99.168.140",
-          "locality": "private",
+          "locality": "internal",
           "port": 52344
         },
         "event": {
@@ -424,7 +424,7 @@
         },
         "flow": {
           "id": "rOmj8EdZ2dc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.99.168.140",
@@ -472,7 +472,7 @@
         "source": {
           "bytes": 113,
           "ip": "10.98.243.20",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 1,
           "port": 53
@@ -487,7 +487,7 @@
       "Fields": {
         "destination": {
           "ip": "10.98.243.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -504,7 +504,7 @@
         },
         "flow": {
           "id": "JE7pThaMwJY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.98.243.20",
@@ -552,7 +552,7 @@
         "source": {
           "bytes": 0,
           "ip": "10.99.168.140",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 0,
           "port": 50294
@@ -567,7 +567,7 @@
       "Fields": {
         "destination": {
           "ip": "10.99.168.140",
-          "locality": "private",
+          "locality": "internal",
           "port": 50294
         },
         "event": {
@@ -584,7 +584,7 @@
         },
         "flow": {
           "id": "JE7pThaMwJY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.99.168.140",
@@ -632,7 +632,7 @@
         "source": {
           "bytes": 113,
           "ip": "10.98.243.20",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:00:00:00:00:00",
           "packets": 1,
           "port": 53

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Mikrotik-RouterOS-6.39.2.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.128.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "1SREAwMSn_Y",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.128.17",
@@ -71,7 +71,7 @@
         "source": {
           "bytes": 152,
           "ip": "10.10.8.197",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 123
         }
@@ -85,7 +85,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.230.216",
-          "locality": "private",
+          "locality": "internal",
           "port": 82
         },
         "event": {
@@ -101,7 +101,7 @@
         },
         "flow": {
           "id": "-1ecQ0Y-YzY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.230.216",
@@ -149,7 +149,7 @@
         "source": {
           "bytes": 502,
           "ip": "192.168.35.143",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 46518
         }
@@ -163,7 +163,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.35.143",
-          "locality": "private",
+          "locality": "internal",
           "port": 46518
         },
         "event": {
@@ -179,7 +179,7 @@
         },
         "flow": {
           "id": "_ztnBsqvzw4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.35.143",
@@ -227,7 +227,7 @@
         "source": {
           "bytes": 2233,
           "ip": "10.10.6.11",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 80
         }
@@ -241,7 +241,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.230.216",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -257,7 +257,7 @@
         },
         "flow": {
           "id": "83jerlRbQig",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.230.216",
@@ -305,7 +305,7 @@
         "source": {
           "bytes": 152,
           "ip": "192.168.128.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 123
         }
@@ -319,7 +319,7 @@
       "Fields": {
         "destination": {
           "ip": "172.20.5.191",
-          "locality": "private",
+          "locality": "internal",
           "port": 42502
         },
         "event": {
@@ -335,7 +335,7 @@
         },
         "flow": {
           "id": "r6DcuKSlKG8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.20.5.191",
@@ -383,7 +383,7 @@
         "source": {
           "bytes": 79724,
           "ip": "10.10.8.220",
-          "locality": "private",
+          "locality": "internal",
           "packets": 57,
           "port": 80
         }
@@ -397,7 +397,7 @@
       "Fields": {
         "destination": {
           "ip": "172.20.4.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -413,7 +413,7 @@
         },
         "flow": {
           "id": "MJV4se1d1EY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.20.4.1",
@@ -461,7 +461,7 @@
         "source": {
           "bytes": 161,
           "ip": "172.20.4.199",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 10240
         }
@@ -475,7 +475,7 @@
       "Fields": {
         "destination": {
           "ip": "172.20.4.199",
-          "locality": "private",
+          "locality": "internal",
           "port": 10240
         },
         "event": {
@@ -491,7 +491,7 @@
         },
         "flow": {
           "id": "MJV4se1d1EY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.20.4.199",
@@ -539,7 +539,7 @@
         "source": {
           "bytes": 245,
           "ip": "172.20.4.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 53
         }
@@ -553,7 +553,7 @@
       "Fields": {
         "destination": {
           "ip": "10.10.8.34",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -569,7 +569,7 @@
         },
         "flow": {
           "id": "Md4y9RxWsu0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.10.8.34",
@@ -617,7 +617,7 @@
         "source": {
           "bytes": 504,
           "ip": "172.20.4.30",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 0
         }
@@ -631,7 +631,7 @@
       "Fields": {
         "destination": {
           "ip": "172.20.4.30",
-          "locality": "private",
+          "locality": "internal",
           "port": 59571
         },
         "event": {
@@ -647,7 +647,7 @@
         },
         "flow": {
           "id": "_XZysP4InTc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.20.4.30",
@@ -695,7 +695,7 @@
         "source": {
           "bytes": 784,
           "ip": "10.10.8.105",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 22
         }
@@ -709,7 +709,7 @@
       "Fields": {
         "destination": {
           "ip": "10.10.8.105",
-          "locality": "private",
+          "locality": "internal",
           "port": 22
         },
         "event": {
@@ -725,7 +725,7 @@
         },
         "flow": {
           "id": "_XZysP4InTc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.10.8.105",
@@ -773,7 +773,7 @@
         "source": {
           "bytes": 433,
           "ip": "172.20.4.30",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 59571
         }
@@ -787,7 +787,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.183.199",
-          "locality": "private",
+          "locality": "internal",
           "port": 6667
         },
         "event": {
@@ -803,7 +803,7 @@
         },
         "flow": {
           "id": "5stvUzTWY8c",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.183.199",
@@ -851,7 +851,7 @@
         "source": {
           "bytes": 196,
           "ip": "10.10.7.11",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 48378
         }
@@ -865,7 +865,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.230.216",
-          "locality": "private",
+          "locality": "internal",
           "port": 48378
         },
         "event": {
@@ -881,7 +881,7 @@
         },
         "flow": {
           "id": "VdPCBSYnnS0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.230.216",
@@ -929,7 +929,7 @@
         "source": {
           "bytes": 206,
           "ip": "192.168.183.199",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 6667
         }
@@ -943,7 +943,7 @@
       "Fields": {
         "destination": {
           "ip": "172.20.4.30",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -959,7 +959,7 @@
         },
         "flow": {
           "id": "asoP1PL3Pao",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.20.4.30",
@@ -1007,7 +1007,7 @@
         "source": {
           "bytes": 504,
           "ip": "10.10.8.34",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 0
         }
@@ -1021,7 +1021,7 @@
       "Fields": {
         "destination": {
           "ip": "10.10.8.220",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1037,7 +1037,7 @@
         },
         "flow": {
           "id": "r6DcuKSlKG8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.10.8.220",
@@ -1085,7 +1085,7 @@
         "source": {
           "bytes": 3539,
           "ip": "172.20.5.191",
-          "locality": "private",
+          "locality": "internal",
           "packets": 58,
           "port": 42502
         }
@@ -1099,7 +1099,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1115,7 +1115,7 @@
         },
         "flow": {
           "id": "4AA5ETLDkm0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1163,7 +1163,7 @@
         "source": {
           "bytes": 495,
           "ip": "172.20.4.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 33332
         }
@@ -1177,7 +1177,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1193,7 +1193,7 @@
         },
         "flow": {
           "id": "4AA5ETLDkm0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1241,7 +1241,7 @@
         "source": {
           "bytes": 330,
           "ip": "172.20.4.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 33332
         }
@@ -1255,7 +1255,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1271,7 +1271,7 @@
         },
         "flow": {
           "id": "BaTGW6h8V9s",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1319,7 +1319,7 @@
         "source": {
           "bytes": 435,
           "ip": "172.30.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 53298
         }
@@ -1333,7 +1333,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1349,7 +1349,7 @@
         },
         "flow": {
           "id": "BaTGW6h8V9s",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1397,7 +1397,7 @@
         "source": {
           "bytes": 290,
           "ip": "172.30.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 53298
         }
@@ -1411,7 +1411,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1427,7 +1427,7 @@
         },
         "flow": {
           "id": "a0peNOTOYXA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1475,7 +1475,7 @@
         "source": {
           "bytes": 495,
           "ip": "10.10.6.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 48172
         }
@@ -1489,7 +1489,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1505,7 +1505,7 @@
         },
         "flow": {
           "id": "a0peNOTOYXA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1553,7 +1553,7 @@
         "source": {
           "bytes": 330,
           "ip": "10.10.6.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 48172
         }
@@ -1567,7 +1567,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1583,7 +1583,7 @@
         },
         "flow": {
           "id": "rX81_0wnl4c",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1631,7 +1631,7 @@
         "source": {
           "bytes": 495,
           "ip": "10.10.7.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 48935
         }
@@ -1645,7 +1645,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1661,7 +1661,7 @@
         },
         "flow": {
           "id": "rX81_0wnl4c",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1709,7 +1709,7 @@
         "source": {
           "bytes": 330,
           "ip": "10.10.7.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 48935
         }
@@ -1723,7 +1723,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1739,7 +1739,7 @@
         },
         "flow": {
           "id": "7EW3D8kjT4Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1787,7 +1787,7 @@
         "source": {
           "bytes": 495,
           "ip": "10.10.8.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 51931
         }
@@ -1801,7 +1801,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1817,7 +1817,7 @@
         },
         "flow": {
           "id": "7EW3D8kjT4Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1865,7 +1865,7 @@
         "source": {
           "bytes": 330,
           "ip": "10.10.8.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 51931
         }
@@ -1879,7 +1879,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1895,7 +1895,7 @@
         },
         "flow": {
           "id": "JacJ1_FgpYg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -1943,7 +1943,7 @@
         "source": {
           "bytes": 495,
           "ip": "10.20.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 43454
         }
@@ -1957,7 +1957,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -1973,7 +1973,7 @@
         },
         "flow": {
           "id": "JacJ1_FgpYg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -2021,7 +2021,7 @@
         "source": {
           "bytes": 330,
           "ip": "10.20.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 43454
         }
@@ -2035,7 +2035,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -2051,7 +2051,7 @@
         },
         "flow": {
           "id": "38frmBtEgfI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -2099,7 +2099,7 @@
         "source": {
           "bytes": 495,
           "ip": "10.10.10.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 52837
         }
@@ -2113,7 +2113,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 5678
         },
         "event": {
@@ -2129,7 +2129,7 @@
         },
         "flow": {
           "id": "38frmBtEgfI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "255.255.255.255",
@@ -2177,7 +2177,7 @@
         "source": {
           "bytes": 330,
           "ip": "10.10.10.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 52837
         }
@@ -2205,7 +2205,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:401",
@@ -2271,7 +2271,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:401",
@@ -2337,7 +2337,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:501",
@@ -2403,7 +2403,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:501",
@@ -2469,7 +2469,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:601",
@@ -2535,7 +2535,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:601",
@@ -2601,7 +2601,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:701",
@@ -2667,7 +2667,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:701",
@@ -2733,7 +2733,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:801",
@@ -2799,7 +2799,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:801",
@@ -2865,7 +2865,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:901",
@@ -2931,7 +2931,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:901",
@@ -2997,7 +2997,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:1001",
@@ -3063,7 +3063,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:1001",
@@ -3129,7 +3129,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:1101",
@@ -3195,7 +3195,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:1101",
@@ -3261,7 +3261,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:1201",
@@ -3327,7 +3327,7 @@
         },
         "flow": {
           "id": "RlrAo_U1Y14",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "fe80::ff:fe00:1201",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Netscaler-with-variable-length-fields.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "8wXIKNz6u_8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.0.0.1",
@@ -94,7 +94,7 @@
         "source": {
           "bytes": 40,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 51053
         }
@@ -108,7 +108,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 51053
         },
         "event": {
@@ -124,7 +124,7 @@
         },
         "flow": {
           "id": "8wXIKNz6u_8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -183,7 +183,7 @@
         "source": {
           "bytes": 1525,
           "ip": "10.0.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 443
         }
@@ -197,7 +197,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -213,7 +213,7 @@
         },
         "flow": {
           "id": "8wXIKNz6u_8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.0.0.1",
@@ -284,7 +284,7 @@
         "source": {
           "bytes": 1541,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 51053
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Nokia-BRAS.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.0.34",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "aVnWxMM8qxI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.0.0.34",
@@ -63,7 +63,7 @@
         },
         "source": {
           "ip": "10.0.1.228",
-          "locality": "private",
+          "locality": "internal",
           "port": 5878
         }
       },

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-OpenBSD-pflow.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "_dzJqQAoWYk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -67,7 +67,7 @@
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 64020
         }
@@ -81,7 +81,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64020
         },
         "event": {
@@ -97,7 +97,7 @@
         },
         "flow": {
           "id": "_dzJqQAoWYk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -141,7 +141,7 @@
         "source": {
           "bytes": 6634,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 80
         }
@@ -155,7 +155,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -171,7 +171,7 @@
         },
         "flow": {
           "id": "iSYE82PBcbQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -215,7 +215,7 @@
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 9,
           "port": 64021
         }
@@ -229,7 +229,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64021
         },
         "event": {
@@ -245,7 +245,7 @@
         },
         "flow": {
           "id": "iSYE82PBcbQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -289,7 +289,7 @@
         "source": {
           "bytes": 10893,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 11,
           "port": 80
         }
@@ -303,7 +303,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -319,7 +319,7 @@
         },
         "flow": {
           "id": "iSYE82PBcbQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -363,7 +363,7 @@
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 9,
           "port": 64021
         }
@@ -377,7 +377,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64021
         },
         "event": {
@@ -393,7 +393,7 @@
         },
         "flow": {
           "id": "iSYE82PBcbQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -437,7 +437,7 @@
         "source": {
           "bytes": 10893,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 11,
           "port": 80
         }
@@ -451,7 +451,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -467,7 +467,7 @@
         },
         "flow": {
           "id": "L_N7tNeOZwc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -511,7 +511,7 @@
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 64022
         }
@@ -525,7 +525,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64022
         },
         "event": {
@@ -541,7 +541,7 @@
         },
         "flow": {
           "id": "L_N7tNeOZwc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -585,7 +585,7 @@
         "source": {
           "bytes": 6780,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 80
         }
@@ -599,7 +599,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -615,7 +615,7 @@
         },
         "flow": {
           "id": "L_N7tNeOZwc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -659,7 +659,7 @@
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 64022
         }
@@ -673,7 +673,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64022
         },
         "event": {
@@ -689,7 +689,7 @@
         },
         "flow": {
           "id": "L_N7tNeOZwc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -733,7 +733,7 @@
         "source": {
           "bytes": 6780,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 80
         }
@@ -747,7 +747,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -763,7 +763,7 @@
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -807,7 +807,7 @@
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 64023
         }
@@ -821,7 +821,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64023
         },
         "event": {
@@ -837,7 +837,7 @@
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -881,7 +881,7 @@
         "source": {
           "bytes": 7319,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 9,
           "port": 80
         }
@@ -895,7 +895,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -911,7 +911,7 @@
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -955,7 +955,7 @@
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 64023
         }
@@ -969,7 +969,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64023
         },
         "event": {
@@ -985,7 +985,7 @@
         },
         "flow": {
           "id": "Dsp4RZAzcPQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1029,7 +1029,7 @@
         "source": {
           "bytes": 7319,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 9,
           "port": 80
         }
@@ -1043,7 +1043,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1059,7 +1059,7 @@
         },
         "flow": {
           "id": "B9Jsqhany8Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -1103,7 +1103,7 @@
         "source": {
           "bytes": 333,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 64024
         }
@@ -1117,7 +1117,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64024
         },
         "event": {
@@ -1133,7 +1133,7 @@
         },
         "flow": {
           "id": "B9Jsqhany8Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1177,7 +1177,7 @@
         "source": {
           "bytes": 1833,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 80
         }
@@ -1191,7 +1191,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1207,7 +1207,7 @@
         },
         "flow": {
           "id": "B9Jsqhany8Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -1251,7 +1251,7 @@
         "source": {
           "bytes": 333,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 64024
         }
@@ -1265,7 +1265,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64024
         },
         "event": {
@@ -1281,7 +1281,7 @@
         },
         "flow": {
           "id": "B9Jsqhany8Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1325,7 +1325,7 @@
         "source": {
           "bytes": 1833,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 80
         }
@@ -1339,7 +1339,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1355,7 +1355,7 @@
         },
         "flow": {
           "id": "O7k79Py4ef0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -1399,7 +1399,7 @@
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 9,
           "port": 64025
         }
@@ -1413,7 +1413,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64025
         },
         "event": {
@@ -1429,7 +1429,7 @@
         },
         "flow": {
           "id": "O7k79Py4ef0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1473,7 +1473,7 @@
         "source": {
           "bytes": 10550,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 11,
           "port": 80
         }
@@ -1487,7 +1487,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1503,7 +1503,7 @@
         },
         "flow": {
           "id": "O7k79Py4ef0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -1547,7 +1547,7 @@
         "source": {
           "bytes": 453,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 9,
           "port": 64025
         }
@@ -1561,7 +1561,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64025
         },
         "event": {
@@ -1577,7 +1577,7 @@
         },
         "flow": {
           "id": "O7k79Py4ef0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1621,7 +1621,7 @@
         "source": {
           "bytes": 10550,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 11,
           "port": 80
         }
@@ -1635,7 +1635,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1651,7 +1651,7 @@
         },
         "flow": {
           "id": "T1etbJ4WSI0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -1695,7 +1695,7 @@
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 64026
         }
@@ -1709,7 +1709,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64026
         },
         "event": {
@@ -1725,7 +1725,7 @@
         },
         "flow": {
           "id": "T1etbJ4WSI0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1769,7 +1769,7 @@
         "source": {
           "bytes": 6425,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 80
         }
@@ -1783,7 +1783,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1799,7 +1799,7 @@
         },
         "flow": {
           "id": "T1etbJ4WSI0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -1843,7 +1843,7 @@
         "source": {
           "bytes": 373,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 64026
         }
@@ -1857,7 +1857,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 64026
         },
         "event": {
@@ -1873,7 +1873,7 @@
         },
         "flow": {
           "id": "T1etbJ4WSI0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1917,7 +1917,7 @@
         "source": {
           "bytes": 6425,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 80
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-Procera.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "138.44.161.14",
-          "locality": "public",
+          "locality": "external",
           "port": 47838
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "gEodlN50y4w",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "bgp_destination_as_number": 7575,
@@ -75,7 +75,7 @@
         },
         "source": {
           "ip": "181.214.87.71",
-          "locality": "public",
+          "locality": "external",
           "port": 53787
         }
       },
@@ -88,7 +88,7 @@
       "Fields": {
         "destination": {
           "ip": "0.0.0.0",
-          "locality": "private",
+          "locality": "internal",
           "port": 135
         },
         "event": {
@@ -104,7 +104,7 @@
         },
         "flow": {
           "id": "GYmhjYyvaAI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -156,7 +156,7 @@
         },
         "source": {
           "ip": "0.0.0.0",
-          "locality": "private",
+          "locality": "internal",
           "port": 136
         }
       },
@@ -169,7 +169,7 @@
       "Fields": {
         "destination": {
           "ip": "138.44.161.14",
-          "locality": "public",
+          "locality": "external",
           "port": 22252
         },
         "event": {
@@ -185,7 +185,7 @@
         },
         "flow": {
           "id": "qSSNfC38l0c",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "bgp_destination_as_number": 7575,
@@ -237,7 +237,7 @@
         },
         "source": {
           "ip": "5.188.11.35",
-          "locality": "public",
+          "locality": "external",
           "port": 44155
         }
       },
@@ -250,7 +250,7 @@
       "Fields": {
         "destination": {
           "ip": "138.44.161.14",
-          "locality": "public",
+          "locality": "external",
           "port": 8
         },
         "event": {
@@ -266,7 +266,7 @@
         },
         "flow": {
           "id": "Tv1jmZy2vn4",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "bgp_destination_as_number": 7575,
@@ -318,7 +318,7 @@
         },
         "source": {
           "ip": "206.117.25.89",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         }
       },
@@ -331,7 +331,7 @@
       "Fields": {
         "destination": {
           "ip": "0.0.0.0",
-          "locality": "private",
+          "locality": "internal",
           "port": 135
         },
         "event": {
@@ -347,7 +347,7 @@
         },
         "flow": {
           "id": "GYmhjYyvaAI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -399,7 +399,7 @@
         },
         "source": {
           "ip": "0.0.0.0",
-          "locality": "private",
+          "locality": "internal",
           "port": 136
         }
       },
@@ -412,7 +412,7 @@
       "Fields": {
         "destination": {
           "ip": "138.44.161.14",
-          "locality": "public",
+          "locality": "external",
           "port": 7451
         },
         "event": {
@@ -428,7 +428,7 @@
         },
         "flow": {
           "id": "JhEHWMX5XwI",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "bgp_destination_as_number": 7575,
@@ -480,7 +480,7 @@
         },
         "source": {
           "ip": "185.232.29.199",
-          "locality": "public",
+          "locality": "external",
           "port": 55869
         }
       },
@@ -493,7 +493,7 @@
       "Fields": {
         "destination": {
           "ip": "138.44.161.14",
-          "locality": "public",
+          "locality": "external",
           "port": 2000
         },
         "event": {
@@ -509,7 +509,7 @@
         },
         "flow": {
           "id": "Q_zyIhDZuIo",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "bgp_destination_as_number": 7575,
@@ -561,7 +561,7 @@
         },
         "source": {
           "ip": "177.188.228.137",
-          "locality": "public",
+          "locality": "external",
           "port": 9430
         }
       },
@@ -574,7 +574,7 @@
       "Fields": {
         "destination": {
           "ip": "138.44.161.13",
-          "locality": "public",
+          "locality": "external",
           "port": 179
         },
         "event": {
@@ -590,7 +590,7 @@
         },
         "flow": {
           "id": "pNMKY7O9aVc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "bgp_destination_as_number": 7575,
@@ -642,7 +642,7 @@
         },
         "source": {
           "ip": "138.44.161.14",
-          "locality": "public",
+          "locality": "external",
           "port": 33689
         }
       },

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-VMware-virtual-distributed-switch.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "172.18.65.211",
-          "locality": "private",
+          "locality": "internal",
           "port": 5985
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "-Sv1di8xiKE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.18.65.211",
@@ -76,7 +76,7 @@
         "source": {
           "bytes": 100,
           "ip": "172.18.65.21",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 61209
         }
@@ -90,7 +90,7 @@
       "Fields": {
         "destination": {
           "ip": "172.18.65.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 138
         },
         "event": {
@@ -106,7 +106,7 @@
         },
         "flow": {
           "id": "OQCLJ5IN83c",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.18.65.255",
@@ -159,7 +159,7 @@
         "source": {
           "bytes": 229,
           "ip": "172.18.65.91",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 138
         }
@@ -173,7 +173,7 @@
       "Fields": {
         "destination": {
           "ip": "172.18.65.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 138
         },
         "event": {
@@ -189,7 +189,7 @@
         },
         "flow": {
           "id": "OQCLJ5IN83c",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.18.65.255",
@@ -242,7 +242,7 @@
         "source": {
           "bytes": 229,
           "ip": "172.18.65.91",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 138
         }
@@ -256,7 +256,7 @@
       "Fields": {
         "destination": {
           "ip": "224.0.0.252",
-          "locality": "private",
+          "locality": "internal",
           "port": 5355
         },
         "event": {
@@ -272,7 +272,7 @@
         },
         "flow": {
           "id": "xcyYrM-QBl0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "224.0.0.252",
@@ -325,7 +325,7 @@
         "source": {
           "bytes": 104,
           "ip": "172.18.65.21",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 61329
         }
@@ -353,7 +353,7 @@
         },
         "flow": {
           "id": "y_Vml2vPNtw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "ff02::1:3",

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-YAF-basic-with-applabel.golden.json
@@ -8,7 +8,7 @@
         "destination": {
           "bytes": 200,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 53
         },
@@ -25,7 +25,7 @@
         },
         "flow": {
           "id": "QMH_S2K9KdI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -77,7 +77,7 @@
         "source": {
           "bytes": 132,
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 46086
         }
@@ -92,7 +92,7 @@
         "destination": {
           "bytes": 92,
           "ip": "172.16.32.215",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 9997
         },
@@ -109,7 +109,7 @@
         },
         "flow": {
           "id": "YlvEOsG0NHc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.215",
@@ -167,7 +167,7 @@
         "source": {
           "bytes": 172,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 4,
           "port": 63499
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-configured-with-include_flowset_id.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "8wXIKNz6u_8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.0.0.1",
@@ -94,7 +94,7 @@
         "source": {
           "bytes": 40,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 51053
         }
@@ -108,7 +108,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 51053
         },
         "event": {
@@ -124,7 +124,7 @@
         },
         "flow": {
           "id": "8wXIKNz6u_8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.1",
@@ -183,7 +183,7 @@
         "source": {
           "bytes": 1525,
           "ip": "10.0.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 443
         }
@@ -197,7 +197,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -213,7 +213,7 @@
         },
         "flow": {
           "id": "8wXIKNz6u_8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.0.0.1",
@@ -284,7 +284,7 @@
         "source": {
           "bytes": 1541,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 51053
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX-vIPtela-with-VPN-id.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.21.27",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "dO-Anbp9xpw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.21.27",
@@ -79,7 +79,7 @@
         "source": {
           "bytes": 775,
           "ip": "10.113.7.54",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 41717
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/IPFIX.golden.json
@@ -45,7 +45,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.128",
-          "locality": "private",
+          "locality": "internal",
           "port": 22
         },
         "event": {
@@ -61,7 +61,7 @@
         },
         "flow": {
           "id": "ofdVXz7_x6E",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.128",
@@ -109,7 +109,7 @@
         "source": {
           "bytes": 260,
           "ip": "192.168.253.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 60560
         }
@@ -123,7 +123,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 60560
         },
         "event": {
@@ -139,7 +139,7 @@
         },
         "flow": {
           "id": "ofdVXz7_x6E",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.1",
@@ -187,7 +187,7 @@
         "source": {
           "bytes": 1000,
           "ip": "192.168.253.128",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 22
         }
@@ -201,7 +201,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.132",
-          "locality": "private",
+          "locality": "internal",
           "port": 35262
         },
         "event": {
@@ -217,7 +217,7 @@
         },
         "flow": {
           "id": "ztL93_3GZNs",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.132",
@@ -265,7 +265,7 @@
         "source": {
           "bytes": 601,
           "ip": "192.168.253.2",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 53
         }
@@ -279,7 +279,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -295,7 +295,7 @@
         },
         "flow": {
           "id": "ztL93_3GZNs",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.2",
@@ -343,7 +343,7 @@
         "source": {
           "bytes": 148,
           "ip": "192.168.253.132",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 35262
         }
@@ -357,7 +357,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.132",
-          "locality": "private",
+          "locality": "internal",
           "port": 49935
         },
         "event": {
@@ -373,7 +373,7 @@
         },
         "flow": {
           "id": "VANFUe1rklc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.132",
@@ -421,7 +421,7 @@
         "source": {
           "bytes": 5946,
           "ip": "54.214.9.161",
-          "locality": "public",
+          "locality": "external",
           "packets": 14,
           "port": 443
         }
@@ -435,7 +435,7 @@
       "Fields": {
         "destination": {
           "ip": "54.214.9.161",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -451,7 +451,7 @@
         },
         "flow": {
           "id": "VANFUe1rklc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "54.214.9.161",
@@ -499,7 +499,7 @@
         "source": {
           "bytes": 2608,
           "ip": "192.168.253.132",
-          "locality": "private",
+          "locality": "internal",
           "packets": 13,
           "port": 49935
         }
@@ -513,7 +513,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.36.64",
-          "locality": "private",
+          "locality": "internal",
           "port": 9200
         },
         "event": {
@@ -529,7 +529,7 @@
         },
         "flow": {
           "id": "iDHwMSG6faQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.4.36.64",
@@ -577,7 +577,7 @@
         "source": {
           "bytes": 60,
           "ip": "192.168.253.130",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 38254
         }
@@ -591,7 +591,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.128",
-          "locality": "private",
+          "locality": "internal",
           "port": 22
         },
         "event": {
@@ -607,7 +607,7 @@
         },
         "flow": {
           "id": "ofdVXz7_x6E",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.128",
@@ -655,7 +655,7 @@
         "source": {
           "bytes": 256,
           "ip": "192.168.253.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 4,
           "port": 60560
         }
@@ -669,7 +669,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 60560
         },
         "event": {
@@ -685,7 +685,7 @@
         },
         "flow": {
           "id": "ofdVXz7_x6E",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.1",
@@ -733,7 +733,7 @@
         "source": {
           "bytes": 1916,
           "ip": "192.168.253.128",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 22
         }
@@ -747,7 +747,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.128",
-          "locality": "private",
+          "locality": "internal",
           "port": 22
         },
         "event": {
@@ -763,7 +763,7 @@
         },
         "flow": {
           "id": "WgPN9s2D0jg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.128",
@@ -811,7 +811,7 @@
         "source": {
           "bytes": 168,
           "ip": "192.168.253.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 65308
         }
@@ -825,7 +825,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.253.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 65308
         },
         "event": {
@@ -841,7 +841,7 @@
         },
         "flow": {
           "id": "WgPN9s2D0jg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.253.1",
@@ -889,7 +889,7 @@
         "source": {
           "bytes": 84,
           "ip": "192.168.253.128",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 22
         }
@@ -903,7 +903,7 @@
       "Fields": {
         "destination": {
           "ip": "224.0.0.251",
-          "locality": "private",
+          "locality": "internal",
           "port": 5353
         },
         "event": {
@@ -919,7 +919,7 @@
         },
         "flow": {
           "id": "PSMPOofjjVU",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "224.0.0.251",
@@ -967,7 +967,7 @@
         "source": {
           "bytes": 232,
           "ip": "192.168.253.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 5353
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-1941-K9-release-15.1.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "62.217.193.1",
-          "locality": "public",
+          "locality": "external",
           "port": 53
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "BPlkuHwo9sU",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -70,7 +70,7 @@
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
-          "locality": "private",
+          "locality": "internal",
           "mac": "ec:1f:72:11:9f:c1",
           "packets": 1,
           "port": 37301
@@ -85,7 +85,7 @@
       "Fields": {
         "destination": {
           "ip": "62.217.193.65",
-          "locality": "public",
+          "locality": "external",
           "port": 53
         },
         "event": {
@@ -101,7 +101,7 @@
         },
         "flow": {
           "id": "-PhJhHv5gvE",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -148,7 +148,7 @@
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
-          "locality": "private",
+          "locality": "internal",
           "mac": "ec:1f:72:11:9f:c1",
           "packets": 1,
           "port": 58411
@@ -163,7 +163,7 @@
       "Fields": {
         "destination": {
           "ip": "62.217.193.1",
-          "locality": "public",
+          "locality": "external",
           "port": 53
         },
         "event": {
@@ -179,7 +179,7 @@
         },
         "flow": {
           "id": "zTrEnrxMnjo",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -226,7 +226,7 @@
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
-          "locality": "private",
+          "locality": "internal",
           "mac": "ec:1f:72:11:9f:c1",
           "packets": 1,
           "port": 37661
@@ -241,7 +241,7 @@
       "Fields": {
         "destination": {
           "ip": "62.217.193.65",
-          "locality": "public",
+          "locality": "external",
           "port": 53
         },
         "event": {
@@ -257,7 +257,7 @@
         },
         "flow": {
           "id": "G4AVpSxBAVo",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAASA==",
@@ -304,7 +304,7 @@
         "source": {
           "bytes": 75,
           "ip": "192.168.0.111",
-          "locality": "private",
+          "locality": "internal",
           "mac": "ec:1f:72:11:9f:c1",
           "packets": 1,
           "port": 60212
@@ -319,7 +319,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.3.142",
-          "locality": "private",
+          "locality": "internal",
           "port": 37450
         },
         "event": {
@@ -335,7 +335,7 @@
         },
         "flow": {
           "id": "2nQmjOOzSH0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -382,7 +382,7 @@
         "source": {
           "bytes": 964,
           "ip": "158.85.58.115",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 10,
           "port": 5222
@@ -397,7 +397,7 @@
       "Fields": {
         "destination": {
           "ip": "216.58.212.195",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -413,7 +413,7 @@
         },
         "flow": {
           "id": "z7uHiA5SrD0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAQg==",
@@ -460,7 +460,7 @@
         "source": {
           "bytes": 2748,
           "ip": "192.168.0.88",
-          "locality": "private",
+          "locality": "internal",
           "mac": "a4:d1:8c:e9:30:2c",
           "packets": 8,
           "port": 61490
@@ -475,7 +475,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.88",
-          "locality": "private",
+          "locality": "internal",
           "port": 61490
         },
         "event": {
@@ -491,7 +491,7 @@
         },
         "flow": {
           "id": "z7uHiA5SrD0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -538,7 +538,7 @@
         "source": {
           "bytes": 2023,
           "ip": "216.58.212.195",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 9,
           "port": 443
@@ -553,7 +553,7 @@
       "Fields": {
         "destination": {
           "ip": "216.58.201.106",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -569,7 +569,7 @@
         },
         "flow": {
           "id": "eyNcUtWu34I",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -616,7 +616,7 @@
         "source": {
           "bytes": 2180,
           "ip": "192.168.1.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "98:01:a7:9f:8d:5f",
           "packets": 9,
           "port": 50299
@@ -631,7 +631,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.1.201",
-          "locality": "private",
+          "locality": "internal",
           "port": 50299
         },
         "event": {
@@ -647,7 +647,7 @@
         },
         "flow": {
           "id": "eyNcUtWu34I",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -694,7 +694,7 @@
         "source": {
           "bytes": 700,
           "ip": "216.58.201.106",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 9,
           "port": 443
@@ -709,7 +709,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.2.118",
-          "locality": "private",
+          "locality": "internal",
           "port": 61353
         },
         "event": {
@@ -725,7 +725,7 @@
         },
         "flow": {
           "id": "i7e4W23LBGg",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -772,7 +772,7 @@
         "source": {
           "bytes": 161,
           "ip": "52.236.33.163",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 2,
           "port": 443
@@ -787,7 +787,7 @@
       "Fields": {
         "destination": {
           "ip": "52.216.130.237",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -803,7 +803,7 @@
         },
         "flow": {
           "id": "ALOJ32qLh_s",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -850,7 +850,7 @@
         "source": {
           "bytes": 1764,
           "ip": "192.168.3.34",
-          "locality": "private",
+          "locality": "internal",
           "mac": "1c:5c:f2:07:0f:2a",
           "packets": 21,
           "port": 61674
@@ -865,7 +865,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.3.34",
-          "locality": "private",
+          "locality": "internal",
           "port": 61672
         },
         "event": {
@@ -881,7 +881,7 @@
         },
         "flow": {
           "id": "h9s7TXaoMZw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -928,7 +928,7 @@
         "source": {
           "bytes": 13811,
           "ip": "209.197.3.19",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 30,
           "port": 443
@@ -943,7 +943,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.3.34",
-          "locality": "private",
+          "locality": "internal",
           "port": 61674
         },
         "event": {
@@ -959,7 +959,7 @@
         },
         "flow": {
           "id": "ALOJ32qLh_s",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1006,7 +1006,7 @@
         "source": {
           "bytes": 4717,
           "ip": "52.216.130.237",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 16,
           "port": 443
@@ -1021,7 +1021,7 @@
       "Fields": {
         "destination": {
           "ip": "172.217.23.232",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -1037,7 +1037,7 @@
         },
         "flow": {
           "id": "2GPS5gJiF8g",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1084,7 +1084,7 @@
         "source": {
           "bytes": 2419,
           "ip": "192.168.0.157",
-          "locality": "private",
+          "locality": "internal",
           "mac": "b0:34:95:0d:d2:5d",
           "packets": 13,
           "port": 51209
@@ -1099,7 +1099,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.157",
-          "locality": "private",
+          "locality": "internal",
           "port": 51209
         },
         "event": {
@@ -1115,7 +1115,7 @@
         },
         "flow": {
           "id": "2GPS5gJiF8g",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1162,7 +1162,7 @@
         "source": {
           "bytes": 5551,
           "ip": "172.217.23.232",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 10,
           "port": 443
@@ -1177,7 +1177,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.3.178",
-          "locality": "private",
+          "locality": "internal",
           "port": 45584
         },
         "event": {
@@ -1193,7 +1193,7 @@
         },
         "flow": {
           "id": "ughO0a0lrBw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1240,7 +1240,7 @@
         "source": {
           "bytes": 187,
           "ip": "107.21.232.174",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 3,
           "port": 443
@@ -1255,7 +1255,7 @@
       "Fields": {
         "destination": {
           "ip": "107.21.232.174",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -1271,7 +1271,7 @@
         },
         "flow": {
           "id": "ughO0a0lrBw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1318,7 +1318,7 @@
         "source": {
           "bytes": 104,
           "ip": "192.168.3.178",
-          "locality": "private",
+          "locality": "internal",
           "mac": "dc:ef:ca:4c:da:57",
           "packets": 2,
           "port": 45584
@@ -1333,7 +1333,7 @@
       "Fields": {
         "destination": {
           "ip": "95.0.145.242",
-          "locality": "public",
+          "locality": "external",
           "port": 2222
         },
         "event": {
@@ -1349,7 +1349,7 @@
         },
         "flow": {
           "id": "Ie4W_7Snl8w",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -1396,7 +1396,7 @@
         "source": {
           "bytes": 4050,
           "ip": "192.168.2.118",
-          "locality": "private",
+          "locality": "internal",
           "mac": "70:18:8b:5c:c9:b5",
           "packets": 72,
           "port": 64233
@@ -1411,7 +1411,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.2.118",
-          "locality": "private",
+          "locality": "internal",
           "port": 64233
         },
         "event": {
@@ -1427,7 +1427,7 @@
         },
         "flow": {
           "id": "Ie4W_7Snl8w",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -1474,7 +1474,7 @@
         "source": {
           "bytes": 3719,
           "ip": "95.0.145.242",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 72,
           "port": 2222
@@ -1489,7 +1489,7 @@
       "Fields": {
         "destination": {
           "ip": "23.5.100.66",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -1505,7 +1505,7 @@
         },
         "flow": {
           "id": "yokq763qB0U",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1552,7 +1552,7 @@
         "source": {
           "bytes": 1402,
           "ip": "192.168.0.79",
-          "locality": "private",
+          "locality": "internal",
           "mac": "8c:29:37:7a:28:c0",
           "packets": 16,
           "port": 54275
@@ -1567,7 +1567,7 @@
       "Fields": {
         "destination": {
           "ip": "23.5.100.66",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -1583,7 +1583,7 @@
         },
         "flow": {
           "id": "DCY-5ocv9ik",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1630,7 +1630,7 @@
         "source": {
           "bytes": 1538,
           "ip": "192.168.0.79",
-          "locality": "private",
+          "locality": "internal",
           "mac": "8c:29:37:7a:28:c0",
           "packets": 17,
           "port": 54276
@@ -1645,7 +1645,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.79",
-          "locality": "private",
+          "locality": "internal",
           "port": 54276
         },
         "event": {
@@ -1661,7 +1661,7 @@
         },
         "flow": {
           "id": "DCY-5ocv9ik",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1708,7 +1708,7 @@
         "source": {
           "bytes": 13002,
           "ip": "23.5.100.66",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 14,
           "port": 443
@@ -1723,7 +1723,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.61",
-          "locality": "private",
+          "locality": "internal",
           "port": 57007
         },
         "event": {
@@ -1739,7 +1739,7 @@
         },
         "flow": {
           "id": "B7rjR_940zU",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1786,7 +1786,7 @@
         "source": {
           "bytes": 1194,
           "ip": "170.251.180.15",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 4,
           "port": 443
@@ -1801,7 +1801,7 @@
       "Fields": {
         "destination": {
           "ip": "170.251.180.15",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -1817,7 +1817,7 @@
         },
         "flow": {
           "id": "B7rjR_940zU",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1864,7 +1864,7 @@
         "source": {
           "bytes": 682,
           "ip": "192.168.0.61",
-          "locality": "private",
+          "locality": "internal",
           "mac": "90:61:ae:76:e5:e9",
           "packets": 2,
           "port": 57007
@@ -1879,7 +1879,7 @@
       "Fields": {
         "destination": {
           "ip": "74.119.119.84",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -1895,7 +1895,7 @@
         },
         "flow": {
           "id": "0RrmR_QtH34",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -1942,7 +1942,7 @@
         "source": {
           "bytes": 1804,
           "ip": "192.168.3.34",
-          "locality": "private",
+          "locality": "internal",
           "mac": "1c:5c:f2:07:0f:2a",
           "packets": 11,
           "port": 61694
@@ -1957,7 +1957,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.3.142",
-          "locality": "private",
+          "locality": "internal",
           "port": 59459
         },
         "event": {
@@ -1973,7 +1973,7 @@
         },
         "flow": {
           "id": "O1-Y9rjVH2A",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -2020,7 +2020,7 @@
         "source": {
           "bytes": 4774,
           "ip": "185.60.218.19",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 9,
           "port": 443
@@ -2035,7 +2035,7 @@
       "Fields": {
         "destination": {
           "ip": "185.60.218.15",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -2051,7 +2051,7 @@
         },
         "flow": {
           "id": "CtFBGbTcLpg",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -2098,7 +2098,7 @@
         "source": {
           "bytes": 135,
           "ip": "192.168.3.200",
-          "locality": "private",
+          "locality": "internal",
           "mac": "18:20:32:bb:1d:62",
           "packets": 2,
           "port": 64493
@@ -2113,7 +2113,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.3.200",
-          "locality": "private",
+          "locality": "internal",
           "port": 64493
         },
         "event": {
@@ -2129,7 +2129,7 @@
         },
         "flow": {
           "id": "CtFBGbTcLpg",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAEA==",
@@ -2176,7 +2176,7 @@
         "source": {
           "bytes": 135,
           "ip": "185.60.218.15",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:23:04:18:ef:40",
           "packets": 2,
           "port": 443
@@ -2191,7 +2191,7 @@
       "Fields": {
         "destination": {
           "ip": "169.45.214.246",
-          "locality": "public",
+          "locality": "external",
           "port": 5222
         },
         "event": {
@@ -2207,7 +2207,7 @@
         },
         "flow": {
           "id": "lT_guTKc7y4",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "BQAAAQ==",
@@ -2254,7 +2254,7 @@
         "source": {
           "bytes": 194,
           "ip": "192.168.0.95",
-          "locality": "private",
+          "locality": "internal",
           "mac": "a0:39:f7:4d:49:d5",
           "packets": 3,
           "port": 35053

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA-2.golden.json
@@ -8,7 +8,7 @@
         "destination": {
           "bytes": 763,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -24,7 +24,7 @@
         },
         "flow": {
           "id": "UTkRrDbrhnI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -75,7 +75,7 @@
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61775
         }
       },
@@ -89,7 +89,7 @@
         "destination": {
           "bytes": 6207,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -105,7 +105,7 @@
         },
         "flow": {
           "id": "WQVc0v7217I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -156,7 +156,7 @@
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61776
         }
       },
@@ -170,7 +170,7 @@
         "destination": {
           "bytes": 6207,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -186,7 +186,7 @@
         },
         "flow": {
           "id": "WQVc0v7217I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -237,7 +237,7 @@
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61776
         }
       },
@@ -251,7 +251,7 @@
         "destination": {
           "bytes": 9075,
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -267,7 +267,7 @@
         },
         "flow": {
           "id": "Nle5z0FLBjA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.18",
@@ -318,7 +318,7 @@
         "source": {
           "bytes": 81,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56635
         }
       },
@@ -332,7 +332,7 @@
         "destination": {
           "bytes": 9075,
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -348,7 +348,7 @@
         },
         "flow": {
           "id": "Nle5z0FLBjA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.18",
@@ -399,7 +399,7 @@
         "source": {
           "bytes": 81,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56635
         }
       },
@@ -413,7 +413,7 @@
         "destination": {
           "bytes": 5536,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -429,7 +429,7 @@
         },
         "flow": {
           "id": "lfYzCmoZgqo",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -480,7 +480,7 @@
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61773
         }
       },
@@ -494,7 +494,7 @@
         "destination": {
           "bytes": 5536,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -510,7 +510,7 @@
         },
         "flow": {
           "id": "lfYzCmoZgqo",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -561,7 +561,7 @@
         "source": {
           "bytes": 81,
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61773
         }
       },
@@ -574,7 +574,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -590,7 +590,7 @@
         },
         "flow": {
           "id": "_9ahEyFsD94",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "asa_username": "",
@@ -640,7 +640,7 @@
         },
         "source": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56649
         }
       },
@@ -654,7 +654,7 @@
         "destination": {
           "bytes": 14179,
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -670,7 +670,7 @@
         },
         "flow": {
           "id": "_9ahEyFsD94",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.18",
@@ -721,7 +721,7 @@
         "source": {
           "bytes": 69,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56649
         }
       },
@@ -735,7 +735,7 @@
         "destination": {
           "bytes": 14179,
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -751,7 +751,7 @@
         },
         "flow": {
           "id": "_9ahEyFsD94",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.18",
@@ -802,7 +802,7 @@
         "source": {
           "bytes": 69,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56649
         }
       },
@@ -815,7 +815,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -831,7 +831,7 @@
         },
         "flow": {
           "id": "bnG6S7DUlEE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "asa_username": "",
@@ -881,7 +881,7 @@
         },
         "source": {
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61777
         }
       },
@@ -895,7 +895,7 @@
         "destination": {
           "bytes": 14178,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -911,7 +911,7 @@
         },
         "flow": {
           "id": "bnG6S7DUlEE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -962,7 +962,7 @@
         "source": {
           "bytes": 69,
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61777
         }
       },
@@ -976,7 +976,7 @@
         "destination": {
           "bytes": 14178,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -992,7 +992,7 @@
         },
         "flow": {
           "id": "bnG6S7DUlEE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1043,7 +1043,7 @@
         "source": {
           "bytes": 69,
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 61777
         }
       },
@@ -1056,7 +1056,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1072,7 +1072,7 @@
         },
         "flow": {
           "id": "wuMbsS0oTj4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "asa_username": "",
@@ -1122,7 +1122,7 @@
         },
         "source": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56650
         }
       },
@@ -1136,7 +1136,7 @@
         "destination": {
           "bytes": 881,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1152,7 +1152,7 @@
         },
         "flow": {
           "id": "wuMbsS0oTj4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1203,7 +1203,7 @@
         "source": {
           "bytes": 75,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56650
         }
       },
@@ -1217,7 +1217,7 @@
         "destination": {
           "bytes": 881,
           "ip": "192.168.0.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1233,7 +1233,7 @@
         },
         "flow": {
           "id": "wuMbsS0oTj4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.17",
@@ -1284,7 +1284,7 @@
         "source": {
           "bytes": 75,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56650
         }
       },
@@ -1297,7 +1297,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1313,7 +1313,7 @@
         },
         "flow": {
           "id": "geQD5O-NWw8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "asa_username": "",
@@ -1363,7 +1363,7 @@
         },
         "source": {
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56651
         }
       },
@@ -1377,7 +1377,7 @@
         "destination": {
           "bytes": 14178,
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1393,7 +1393,7 @@
         },
         "flow": {
           "id": "geQD5O-NWw8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.18",
@@ -1444,7 +1444,7 @@
         "source": {
           "bytes": 69,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56651
         }
       },
@@ -1458,7 +1458,7 @@
         "destination": {
           "bytes": 14178,
           "ip": "192.168.0.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1474,7 +1474,7 @@
         },
         "flow": {
           "id": "geQD5O-NWw8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.18",
@@ -1525,7 +1525,7 @@
         "source": {
           "bytes": 69,
           "ip": "192.168.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 56651
         }
       },

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASA.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "2.2.2.11",
-          "locality": "public",
+          "locality": "external",
           "port": 17549
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "5JpExP8VeSU",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -76,7 +76,7 @@
         "source": {
           "bytes": 56,
           "ip": "192.168.14.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         }
       },
@@ -89,7 +89,7 @@
       "Fields": {
         "destination": {
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -105,7 +105,7 @@
         },
         "flow": {
           "id": "MSQgezzAYh0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -158,7 +158,7 @@
         "source": {
           "bytes": 56,
           "ip": "192.168.23.22",
-          "locality": "private",
+          "locality": "internal",
           "port": 17549
         }
       },
@@ -171,7 +171,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.23.22",
-          "locality": "private",
+          "locality": "internal",
           "port": 17549
         },
         "event": {
@@ -187,7 +187,7 @@
         },
         "flow": {
           "id": "MSQgezzAYh0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -240,7 +240,7 @@
         "source": {
           "bytes": 56,
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         }
       },
@@ -253,7 +253,7 @@
       "Fields": {
         "destination": {
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -269,7 +269,7 @@
         },
         "flow": {
           "id": "ioGVEAJtaEQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -322,7 +322,7 @@
         "source": {
           "bytes": 56,
           "ip": "192.168.23.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 17805
         }
       },
@@ -335,7 +335,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.23.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 17805
         },
         "event": {
@@ -351,7 +351,7 @@
         },
         "flow": {
           "id": "ioGVEAJtaEQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -404,7 +404,7 @@
         "source": {
           "bytes": 56,
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         }
       },
@@ -417,7 +417,7 @@
       "Fields": {
         "destination": {
           "ip": "2.2.2.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -433,7 +433,7 @@
         },
         "flow": {
           "id": "0xqELVtMeog",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -486,7 +486,7 @@
         "source": {
           "bytes": 56,
           "ip": "192.168.14.11",
-          "locality": "private",
+          "locality": "internal",
           "port": 17805
         }
       },
@@ -499,7 +499,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.14.11",
-          "locality": "private",
+          "locality": "internal",
           "port": 17805
         },
         "event": {
@@ -515,7 +515,7 @@
         },
         "flow": {
           "id": "0xqELVtMeog",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -568,7 +568,7 @@
         "source": {
           "bytes": 56,
           "ip": "2.2.2.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         }
       },
@@ -581,7 +581,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.14.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -597,7 +597,7 @@
         },
         "flow": {
           "id": "LA3WpK17LAw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -650,7 +650,7 @@
         "source": {
           "bytes": 56,
           "ip": "2.2.2.11",
-          "locality": "public",
+          "locality": "external",
           "port": 17805
         }
       },
@@ -663,7 +663,7 @@
       "Fields": {
         "destination": {
           "ip": "2.2.2.11",
-          "locality": "public",
+          "locality": "external",
           "port": 17805
         },
         "event": {
@@ -679,7 +679,7 @@
         },
         "flow": {
           "id": "LA3WpK17LAw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -732,7 +732,7 @@
         "source": {
           "bytes": 56,
           "ip": "192.168.14.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         }
       },
@@ -745,7 +745,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.23.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -761,7 +761,7 @@
         },
         "flow": {
           "id": "tBFZO1WrQyk",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -814,7 +814,7 @@
         "source": {
           "bytes": 160,
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         }
       },
@@ -827,7 +827,7 @@
       "Fields": {
         "destination": {
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -843,7 +843,7 @@
         },
         "flow": {
           "id": "oil2JqFPSyE",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -896,7 +896,7 @@
         "source": {
           "bytes": 56,
           "ip": "192.168.23.22",
-          "locality": "private",
+          "locality": "internal",
           "port": 18061
         }
       },
@@ -909,7 +909,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.23.22",
-          "locality": "private",
+          "locality": "internal",
           "port": 18061
         },
         "event": {
@@ -925,7 +925,7 @@
         },
         "flow": {
           "id": "oil2JqFPSyE",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -978,7 +978,7 @@
         "source": {
           "bytes": 56,
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         }
       },
@@ -991,7 +991,7 @@
       "Fields": {
         "destination": {
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -1007,7 +1007,7 @@
         },
         "flow": {
           "id": "Pbk_o-xetL4",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -1060,7 +1060,7 @@
         "source": {
           "bytes": 56,
           "ip": "192.168.23.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 18061
         }
       },
@@ -1073,7 +1073,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.23.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 18061
         },
         "event": {
@@ -1089,7 +1089,7 @@
         },
         "flow": {
           "id": "Pbk_o-xetL4",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "asa_fw_event": 2,
@@ -1142,7 +1142,7 @@
         "source": {
           "bytes": 56,
           "ip": "164.164.37.11",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         }
       },

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR-9000-series-template-260.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.31.81",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "kkhtKjgAywQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64496,
@@ -80,7 +80,7 @@
         "source": {
           "bytes": 40,
           "ip": "10.0.9.146",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 54017
         }
@@ -94,7 +94,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.35.4",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -113,7 +113,7 @@
         },
         "flow": {
           "id": "4su7p2nlyno",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64496,
@@ -167,7 +167,7 @@
         "source": {
           "bytes": 104,
           "ip": "10.0.17.42",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 36484
         }
@@ -181,7 +181,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.34.141",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -200,7 +200,7 @@
         },
         "flow": {
           "id": "mfb1_zWayo4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64496,
@@ -254,7 +254,7 @@
         "source": {
           "bytes": 52,
           "ip": "10.0.22.111",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 16814
         }
@@ -268,7 +268,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.36.170",
-          "locality": "private",
+          "locality": "internal",
           "port": 64812
         },
         "event": {
@@ -287,7 +287,7 @@
         },
         "flow": {
           "id": "jKhffDbQq0o",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64497,
@@ -341,7 +341,7 @@
         "source": {
           "bytes": 435,
           "ip": "10.0.23.59",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 53
         }
@@ -355,7 +355,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.20.242",
-          "locality": "private",
+          "locality": "internal",
           "port": 2013
         },
         "event": {
@@ -374,7 +374,7 @@
         },
         "flow": {
           "id": "5siGD7iCzo4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 65442,
@@ -428,7 +428,7 @@
         "source": {
           "bytes": 969,
           "ip": "10.0.34.71",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 443
         }
@@ -442,7 +442,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.30.102",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -461,7 +461,7 @@
         },
         "flow": {
           "id": "IyuegsSri_U",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64496,
@@ -515,7 +515,7 @@
         "source": {
           "bytes": 104,
           "ip": "10.0.10.133",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 35273
         }
@@ -529,7 +529,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.6.24",
-          "locality": "private",
+          "locality": "internal",
           "port": 56771
         },
         "event": {
@@ -548,7 +548,7 @@
         },
         "flow": {
           "id": "9JGzjsOdNi4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 65431,
@@ -602,7 +602,7 @@
         "source": {
           "bytes": 52,
           "ip": "10.0.37.29",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 80
         }
@@ -616,7 +616,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.11.113",
-          "locality": "private",
+          "locality": "internal",
           "port": 56830
         },
         "event": {
@@ -635,7 +635,7 @@
         },
         "flow": {
           "id": "Y3aiAEAjjys",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 65432,
@@ -689,7 +689,7 @@
         "source": {
           "bytes": 614,
           "ip": "10.0.32.176",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 443
         }
@@ -703,7 +703,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.15.38",
-          "locality": "private",
+          "locality": "internal",
           "port": 40078
         },
         "event": {
@@ -722,7 +722,7 @@
         },
         "flow": {
           "id": "sC3kzwxISec",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64498,
@@ -776,7 +776,7 @@
         "source": {
           "bytes": 4350,
           "ip": "10.0.12.21",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 443
         }
@@ -790,7 +790,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.3.110",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -809,7 +809,7 @@
         },
         "flow": {
           "id": "dTmlxL48EoA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 70,
@@ -863,7 +863,7 @@
         "source": {
           "bytes": 533,
           "ip": "10.0.4.212",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 50691
         }
@@ -877,7 +877,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.1.136",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -896,7 +896,7 @@
         },
         "flow": {
           "id": "oMLDxCSgNuA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -950,7 +950,7 @@
         "source": {
           "bytes": 13660,
           "ip": "10.0.33.122",
-          "locality": "private",
+          "locality": "internal",
           "packets": 325,
           "port": 58814
         }
@@ -964,7 +964,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.34.71",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -983,7 +983,7 @@
         },
         "flow": {
           "id": "5siGD7iCzo4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64496,
@@ -1037,7 +1037,7 @@
         "source": {
           "bytes": 89,
           "ip": "10.0.20.242",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 2013
         }
@@ -1051,7 +1051,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.15.38",
-          "locality": "private",
+          "locality": "internal",
           "port": 51621
         },
         "event": {
@@ -1070,7 +1070,7 @@
         },
         "flow": {
           "id": "-IcTJfcRi8w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64498,
@@ -1124,7 +1124,7 @@
         "source": {
           "bytes": 833,
           "ip": "10.0.13.25",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 443
         }
@@ -1138,7 +1138,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.2.18",
-          "locality": "private",
+          "locality": "internal",
           "port": 62464
         },
         "event": {
@@ -1157,7 +1157,7 @@
         },
         "flow": {
           "id": "tyf0jfEIDwM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 65437,
@@ -1211,7 +1211,7 @@
         "source": {
           "bytes": 1625,
           "ip": "10.0.25.59",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 443
         }
@@ -1225,7 +1225,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.27.168",
-          "locality": "private",
+          "locality": "internal",
           "port": 465
         },
         "event": {
@@ -1244,7 +1244,7 @@
         },
         "flow": {
           "id": "OYKOBQNKdF4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64496,
@@ -1298,7 +1298,7 @@
         "source": {
           "bytes": 142184,
           "ip": "10.0.7.73",
-          "locality": "private",
+          "locality": "internal",
           "packets": 97,
           "port": 60312
         }
@@ -1312,7 +1312,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.27.169",
-          "locality": "private",
+          "locality": "internal",
           "port": 995
         },
         "event": {
@@ -1331,7 +1331,7 @@
         },
         "flow": {
           "id": "fC6tFjsdK54",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64496,
@@ -1385,7 +1385,7 @@
         "source": {
           "bytes": 3016,
           "ip": "10.0.19.50",
-          "locality": "private",
+          "locality": "internal",
           "packets": 58,
           "port": 34452
         }
@@ -1399,7 +1399,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.24.13",
-          "locality": "private",
+          "locality": "internal",
           "port": 49917
         },
         "event": {
@@ -1418,7 +1418,7 @@
         },
         "flow": {
           "id": "Kk4bVU4hDRk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -1472,7 +1472,7 @@
         "source": {
           "bytes": 31500,
           "ip": "10.0.28.150",
-          "locality": "private",
+          "locality": "internal",
           "packets": 21,
           "port": 443
         }
@@ -1486,7 +1486,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.21.200",
-          "locality": "private",
+          "locality": "internal",
           "port": 50254
         },
         "event": {
@@ -1505,7 +1505,7 @@
         },
         "flow": {
           "id": "_Fk2ywvptGE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -1559,7 +1559,7 @@
         "source": {
           "bytes": 2919,
           "ip": "10.0.26.188",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 993
         }
@@ -1573,7 +1573,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.15.38",
-          "locality": "private",
+          "locality": "internal",
           "port": 35983
         },
         "event": {
@@ -1592,7 +1592,7 @@
         },
         "flow": {
           "id": "MrTF7IZhOrg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64498,
@@ -1646,7 +1646,7 @@
         "source": {
           "bytes": 4514,
           "ip": "10.0.29.34",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 443
         }
@@ -1660,7 +1660,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.5.224",
-          "locality": "private",
+          "locality": "internal",
           "port": 51671
         },
         "event": {
@@ -1679,7 +1679,7 @@
         },
         "flow": {
           "id": "hUKUTbBVmIY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 65431,
@@ -1733,7 +1733,7 @@
         "source": {
           "bytes": 326,
           "ip": "10.0.8.200",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 23128
         }
@@ -1747,7 +1747,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.15.38",
-          "locality": "private",
+          "locality": "internal",
           "port": 52364
         },
         "event": {
@@ -1766,7 +1766,7 @@
         },
         "flow": {
           "id": "IoEUbnBqGXE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 64498,
@@ -1820,7 +1820,7 @@
         "source": {
           "bytes": 112,
           "ip": "10.0.29.46",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 443
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-ASR1001--X.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.12.100.13",
-          "locality": "private",
+          "locality": "internal",
           "port": 53218
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "_qSyv-Xe8IM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAFHg==",
@@ -70,7 +70,7 @@
         "source": {
           "bytes": 965,
           "ip": "10.111.111.242",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 52444
         }
@@ -84,7 +84,7 @@
       "Fields": {
         "destination": {
           "ip": "10.100.105.85",
-          "locality": "private",
+          "locality": "internal",
           "port": 41746
         },
         "event": {
@@ -100,7 +100,7 @@
         },
         "flow": {
           "id": "7s_4xBb69Y0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAoQ==",
@@ -147,7 +147,7 @@
         "source": {
           "bytes": 284,
           "ip": "10.10.4.29",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 161
         }
@@ -161,7 +161,7 @@
       "Fields": {
         "destination": {
           "ip": "10.111.111.242",
-          "locality": "private",
+          "locality": "internal",
           "port": 52444
         },
         "event": {
@@ -177,7 +177,7 @@
         },
         "flow": {
           "id": "_qSyv-Xe8IM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAFHg==",
@@ -224,7 +224,7 @@
         "source": {
           "bytes": 670,
           "ip": "10.12.100.13",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 53218
         }
@@ -238,7 +238,7 @@
       "Fields": {
         "destination": {
           "ip": "10.10.11.21",
-          "locality": "private",
+          "locality": "internal",
           "port": 61440
         },
         "event": {
@@ -254,7 +254,7 @@
         },
         "flow": {
           "id": "jk1T8-P2OHM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAQA==",
@@ -301,7 +301,7 @@
         "source": {
           "bytes": 80,
           "ip": "10.12.104.239",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 1720
         }
@@ -315,7 +315,7 @@
       "Fields": {
         "destination": {
           "ip": "10.12.104.239",
-          "locality": "private",
+          "locality": "internal",
           "port": 1720
         },
         "event": {
@@ -331,7 +331,7 @@
         },
         "flow": {
           "id": "jk1T8-P2OHM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAQA==",
@@ -378,7 +378,7 @@
         "source": {
           "bytes": 80,
           "ip": "10.10.11.21",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 61440
         }
@@ -392,7 +392,7 @@
       "Fields": {
         "destination": {
           "ip": "10.15.131.98",
-          "locality": "private",
+          "locality": "internal",
           "port": 64400
         },
         "event": {
@@ -408,7 +408,7 @@
         },
         "flow": {
           "id": "6AEj_wlzQm4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAANQ==",
@@ -455,7 +455,7 @@
         "source": {
           "bytes": 101,
           "ip": "10.100.101.45",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 53
         }
@@ -469,7 +469,7 @@
       "Fields": {
         "destination": {
           "ip": "10.12.105.23",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -485,7 +485,7 @@
         },
         "flow": {
           "id": "MtCuD-nvBTY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAHFA==",
@@ -532,7 +532,7 @@
         "source": {
           "bytes": 1134,
           "ip": "10.100.101.43",
-          "locality": "private",
+          "locality": "internal",
           "packets": 14,
           "port": 0
         }
@@ -546,7 +546,7 @@
       "Fields": {
         "destination": {
           "ip": "10.11.31.108",
-          "locality": "private",
+          "locality": "internal",
           "port": 51708
         },
         "event": {
@@ -562,7 +562,7 @@
         },
         "flow": {
           "id": "8zAXung0YbA",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "DQACBg==",
@@ -609,7 +609,7 @@
         "source": {
           "bytes": 237,
           "ip": "31.13.71.7",
-          "locality": "public",
+          "locality": "external",
           "packets": 4,
           "port": 443
         }
@@ -623,7 +623,7 @@
       "Fields": {
         "destination": {
           "ip": "10.100.105.86",
-          "locality": "private",
+          "locality": "internal",
           "port": 58842
         },
         "event": {
@@ -639,7 +639,7 @@
         },
         "flow": {
           "id": "5LxKkXX5FfM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAoQ==",
@@ -686,7 +686,7 @@
         "source": {
           "bytes": 91,
           "ip": "10.11.21.60",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 161
         }
@@ -700,7 +700,7 @@
       "Fields": {
         "destination": {
           "ip": "172.217.11.5",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -716,7 +716,7 @@
         },
         "flow": {
           "id": "MnDMft-qZjs",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "DQABzg==",
@@ -763,7 +763,7 @@
         "source": {
           "bytes": 41,
           "ip": "10.12.92.102",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 50766
         }
@@ -777,7 +777,7 @@
       "Fields": {
         "destination": {
           "ip": "10.11.21.60",
-          "locality": "private",
+          "locality": "internal",
           "port": 161
         },
         "event": {
@@ -793,7 +793,7 @@
         },
         "flow": {
           "id": "Ddy-Ii-ZDDI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAoQ==",
@@ -840,7 +840,7 @@
         "source": {
           "bytes": 111,
           "ip": "10.100.105.86",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 58843
         }
@@ -854,7 +854,7 @@
       "Fields": {
         "destination": {
           "ip": "10.100.105.85",
-          "locality": "private",
+          "locality": "internal",
           "port": 41351
         },
         "event": {
@@ -870,7 +870,7 @@
         },
         "flow": {
           "id": "Hiy-Ti0eVlY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAoQ==",
@@ -917,7 +917,7 @@
         "source": {
           "bytes": 1164,
           "ip": "10.10.4.234",
-          "locality": "private",
+          "locality": "internal",
           "packets": 4,
           "port": 161
         }
@@ -931,7 +931,7 @@
       "Fields": {
         "destination": {
           "ip": "10.10.11.21",
-          "locality": "private",
+          "locality": "internal",
           "port": 61440
         },
         "event": {
@@ -947,7 +947,7 @@
         },
         "flow": {
           "id": "7iMintjCsaw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAQA==",
@@ -994,7 +994,7 @@
         "source": {
           "bytes": 80,
           "ip": "10.12.106.83",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 1720
         }
@@ -1008,7 +1008,7 @@
       "Fields": {
         "destination": {
           "ip": "10.12.92.102",
-          "locality": "private",
+          "locality": "internal",
           "port": 50766
         },
         "event": {
@@ -1024,7 +1024,7 @@
         },
         "flow": {
           "id": "MnDMft-qZjs",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "DQABzg==",
@@ -1071,7 +1071,7 @@
         "source": {
           "bytes": 52,
           "ip": "172.217.11.5",
-          "locality": "public",
+          "locality": "external",
           "packets": 1,
           "port": 443
         }
@@ -1085,7 +1085,7 @@
       "Fields": {
         "destination": {
           "ip": "10.12.106.83",
-          "locality": "private",
+          "locality": "internal",
           "port": 1720
         },
         "event": {
@@ -1101,7 +1101,7 @@
         },
         "flow": {
           "id": "7iMintjCsaw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAQA==",
@@ -1148,7 +1148,7 @@
         "source": {
           "bytes": 80,
           "ip": "10.10.11.21",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 61440
         }
@@ -1162,7 +1162,7 @@
       "Fields": {
         "destination": {
           "ip": "74.201.129.29",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -1178,7 +1178,7 @@
         },
         "flow": {
           "id": "hphBugBrKPY",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -1225,7 +1225,7 @@
         "source": {
           "bytes": 3088,
           "ip": "10.12.81.86",
-          "locality": "private",
+          "locality": "internal",
           "packets": 10,
           "port": 58657
         }
@@ -1239,7 +1239,7 @@
       "Fields": {
         "destination": {
           "ip": "10.12.100.13",
-          "locality": "private",
+          "locality": "internal",
           "port": 389
         },
         "event": {
@@ -1255,7 +1255,7 @@
         },
         "flow": {
           "id": "gJ7Z20zGGk8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAB2Q==",
@@ -1302,7 +1302,7 @@
         "source": {
           "bytes": 5306,
           "ip": "10.14.121.98",
-          "locality": "private",
+          "locality": "internal",
           "packets": 24,
           "port": 50174
         }
@@ -1316,7 +1316,7 @@
       "Fields": {
         "destination": {
           "ip": "10.100.105.86",
-          "locality": "private",
+          "locality": "internal",
           "port": 58843
         },
         "event": {
@@ -1332,7 +1332,7 @@
         },
         "flow": {
           "id": "Ddy-Ii-ZDDI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAoQ==",
@@ -1379,7 +1379,7 @@
         "source": {
           "bytes": 116,
           "ip": "10.11.21.60",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 161
         }
@@ -1393,7 +1393,7 @@
       "Fields": {
         "destination": {
           "ip": "10.14.121.98",
-          "locality": "private",
+          "locality": "internal",
           "port": 50174
         },
         "event": {
@@ -1409,7 +1409,7 @@
         },
         "flow": {
           "id": "gJ7Z20zGGk8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAB2Q==",
@@ -1456,7 +1456,7 @@
         "source": {
           "bytes": 22764,
           "ip": "10.12.100.13",
-          "locality": "private",
+          "locality": "internal",
           "packets": 30,
           "port": 389
         }
@@ -1470,7 +1470,7 @@
       "Fields": {
         "destination": {
           "ip": "10.10.11.21",
-          "locality": "private",
+          "locality": "internal",
           "port": 61443
         },
         "event": {
@@ -1486,7 +1486,7 @@
         },
         "flow": {
           "id": "LZaFrMI9jg0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAQA==",
@@ -1533,7 +1533,7 @@
         "source": {
           "bytes": 80,
           "ip": "10.12.102.125",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 1720
         }
@@ -1547,7 +1547,7 @@
       "Fields": {
         "destination": {
           "ip": "10.11.21.60",
-          "locality": "private",
+          "locality": "internal",
           "port": 161
         },
         "event": {
@@ -1563,7 +1563,7 @@
         },
         "flow": {
           "id": "f6pXcQQIzpU",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAoQ==",
@@ -1610,7 +1610,7 @@
         "source": {
           "bytes": 75,
           "ip": "10.100.105.86",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 58844
         }
@@ -1624,7 +1624,7 @@
       "Fields": {
         "destination": {
           "ip": "10.12.102.125",
-          "locality": "private",
+          "locality": "internal",
           "port": 1720
         },
         "event": {
@@ -1640,7 +1640,7 @@
         },
         "flow": {
           "id": "LZaFrMI9jg0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAQA==",
@@ -1687,7 +1687,7 @@
         "source": {
           "bytes": 80,
           "ip": "10.10.11.21",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 61443
         }
@@ -1701,7 +1701,7 @@
       "Fields": {
         "destination": {
           "ip": "10.10.4.151",
-          "locality": "private",
+          "locality": "internal",
           "port": 161
         },
         "event": {
@@ -1717,7 +1717,7 @@
         },
         "flow": {
           "id": "gQGJtHjUcB8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAoQ==",
@@ -1764,7 +1764,7 @@
         "source": {
           "bytes": 160,
           "ip": "10.100.105.85",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 37265
         }
@@ -1778,7 +1778,7 @@
       "Fields": {
         "destination": {
           "ip": "17.253.24.253",
-          "locality": "public",
+          "locality": "external",
           "port": 123
         },
         "event": {
@@ -1794,7 +1794,7 @@
         },
         "flow": {
           "id": "UHiF_w4I6zM",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "AwAAew==",
@@ -1841,7 +1841,7 @@
         "source": {
           "bytes": 76,
           "ip": "10.14.25.80",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 62427
         }
@@ -1855,7 +1855,7 @@
       "Fields": {
         "destination": {
           "ip": "10.100.101.43",
-          "locality": "private",
+          "locality": "internal",
           "port": 49156
         },
         "event": {
@@ -1871,7 +1871,7 @@
         },
         "flow": {
           "id": "czsFrOKrayM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAB2Q==",
@@ -1918,7 +1918,7 @@
         "source": {
           "bytes": 1340,
           "ip": "10.12.150.13",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 61792
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-NBAR-flowset-262.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.30.19.180",
-          "locality": "private",
+          "locality": "internal",
           "mac": "1c:df:0f:7e:c3:58",
           "port": 2048
         },
@@ -27,7 +27,7 @@
         },
         "flow": {
           "id": "Bk-2FcuOyCU",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AQAAAQ==",
@@ -84,7 +84,7 @@
         "source": {
           "bytes": 44,
           "ip": "10.30.18.62",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:91:56:86",
           "packets": 1,
           "port": 0
@@ -99,7 +99,7 @@
       "Fields": {
         "destination": {
           "ip": "10.30.19.180",
-          "locality": "private",
+          "locality": "internal",
           "mac": "1c:df:0f:7e:c3:58",
           "port": 161
         },
@@ -119,7 +119,7 @@
         },
         "flow": {
           "id": "4Xk8GtQfUAo",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "BQAAJg==",
@@ -176,7 +176,7 @@
         "source": {
           "bytes": 106,
           "ip": "10.30.18.62",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:91:56:86",
           "packets": 1,
           "port": 34220
@@ -191,7 +191,7 @@
       "Fields": {
         "destination": {
           "ip": "10.30.19.180",
-          "locality": "private",
+          "locality": "internal",
           "mac": "1c:df:0f:7e:c3:58",
           "port": 2048
         },
@@ -211,7 +211,7 @@
         },
         "flow": {
           "id": "tfLRXnB6AOA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AQAAAQ==",
@@ -268,7 +268,7 @@
         "source": {
           "bytes": 44,
           "ip": "10.10.172.60",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:18:19:9e:6c:01",
           "packets": 1,
           "port": 0
@@ -283,7 +283,7 @@
       "Fields": {
         "destination": {
           "ip": "10.30.19.180",
-          "locality": "private",
+          "locality": "internal",
           "mac": "1c:df:0f:7e:c3:58",
           "port": 123
         },
@@ -303,7 +303,7 @@
         },
         "flow": {
           "id": "1mfP23NPuB8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAew==",
@@ -360,7 +360,7 @@
         "source": {
           "bytes": 76,
           "ip": "10.10.172.60",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:18:19:9e:6c:01",
           "packets": 1,
           "port": 123
@@ -375,7 +375,7 @@
       "Fields": {
         "destination": {
           "ip": "10.30.19.180",
-          "locality": "private",
+          "locality": "internal",
           "mac": "1c:df:0f:7e:c3:58",
           "port": 161
         },
@@ -395,7 +395,7 @@
         },
         "flow": {
           "id": "g6a7KlISbtM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "BQAAJg==",
@@ -452,7 +452,7 @@
         "source": {
           "bytes": 2794,
           "ip": "10.10.172.60",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:18:19:9e:6c:01",
           "packets": 36,
           "port": 45269

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Cisco-WLC.golden.json
@@ -21,7 +21,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAB3w==",
@@ -56,7 +56,7 @@
         "source": {
           "bytes": 3320,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 83
         }
@@ -70,7 +70,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -86,7 +86,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAB3w==",
@@ -147,7 +147,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAANQ==",
@@ -182,7 +182,7 @@
         "source": {
           "bytes": 7760,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 69
         }
@@ -196,7 +196,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -212,7 +212,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAANQ==",
@@ -273,7 +273,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAig==",
@@ -308,7 +308,7 @@
         "source": {
           "bytes": 215,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 1
         }
@@ -336,7 +336,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAAQ==",
@@ -371,7 +371,7 @@
         "source": {
           "bytes": 40854,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 225
         }
@@ -385,7 +385,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -401,7 +401,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAAQ==",
@@ -462,7 +462,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -497,7 +497,7 @@
         "source": {
           "bytes": 12279,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 63
         }
@@ -511,7 +511,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -527,7 +527,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -588,7 +588,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -623,7 +623,7 @@
         "source": {
           "bytes": 147145,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 773
         }
@@ -637,7 +637,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -653,7 +653,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -714,7 +714,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACCA==",
@@ -749,7 +749,7 @@
         "source": {
           "bytes": 6777,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 26
         }
@@ -763,7 +763,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -779,7 +779,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACCA==",
@@ -840,7 +840,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwABuw==",
@@ -875,7 +875,7 @@
         "source": {
           "bytes": 2433001,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 20434
         }
@@ -889,7 +889,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -905,7 +905,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwABuw==",
@@ -966,7 +966,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AQAAAQ==",
@@ -1001,7 +1001,7 @@
         "source": {
           "bytes": 1658,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 15
         }
@@ -1015,7 +1015,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -1031,7 +1031,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AQAAAQ==",
@@ -1092,7 +1092,7 @@
         },
         "flow": {
           "id": "lTcFptYSabQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABrw==",
@@ -1127,7 +1127,7 @@
         "source": {
           "bytes": 1495567,
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51",
           "packets": 16145
         }
@@ -1141,7 +1141,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.20.121",
-          "locality": "private",
+          "locality": "internal",
           "mac": "34:02:86:75:c0:51"
         },
         "event": {
@@ -1157,7 +1157,7 @@
         },
         "flow": {
           "id": "Q1JIGzkHw0I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABrw==",

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-5.2.1.golden.json
@@ -48,7 +48,7 @@
       "Fields": {
         "destination": {
           "ip": "31.13.87.36",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -64,7 +64,7 @@
         },
         "flow": {
           "id": "SKsZNpZob60",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "31.13.87.36",
@@ -109,7 +109,7 @@
         "source": {
           "bytes": 152,
           "ip": "192.168.99.7",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 61910
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Fortigate-FortiOS-54x-appid.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "182.50.136.239",
-          "locality": "public",
+          "locality": "external",
           "port": 80
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "FfT-8jRRvok",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAI80",
@@ -78,7 +78,7 @@
         "source": {
           "bytes": 748,
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 45380
         }
@@ -92,7 +92,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "port": 44778
         },
         "event": {
@@ -111,7 +111,7 @@
         },
         "flow": {
           "id": "bZjTG4EkhLs",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAJ54",
@@ -163,7 +163,7 @@
         "source": {
           "bytes": 6948,
           "ip": "208.100.17.187",
-          "locality": "public",
+          "locality": "external",
           "packets": 10,
           "port": 443
         }
@@ -177,7 +177,7 @@
       "Fields": {
         "destination": {
           "ip": "208.100.17.187",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -196,7 +196,7 @@
         },
         "flow": {
           "id": "bZjTG4EkhLs",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAJ54",
@@ -248,7 +248,7 @@
         "source": {
           "bytes": 1584,
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "packets": 14,
           "port": 44778
         }
@@ -262,7 +262,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "port": 50618
         },
         "event": {
@@ -281,7 +281,7 @@
         },
         "flow": {
           "id": "kZjCeMUhjqE",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAJ54",
@@ -333,7 +333,7 @@
         "source": {
           "bytes": 8201,
           "ip": "208.100.17.189",
-          "locality": "public",
+          "locality": "external",
           "packets": 11,
           "port": 443
         }
@@ -347,7 +347,7 @@
       "Fields": {
         "destination": {
           "ip": "208.100.17.189",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -366,7 +366,7 @@
         },
         "flow": {
           "id": "kZjCeMUhjqE",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAJ54",
@@ -418,7 +418,7 @@
         "source": {
           "bytes": 1729,
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "packets": 15,
           "port": 50618
         }
@@ -432,7 +432,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "port": 33660
         },
         "event": {
@@ -451,7 +451,7 @@
         },
         "flow": {
           "id": "8PR91KFjFKw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAGTz",
@@ -503,7 +503,7 @@
         "source": {
           "bytes": 1122,
           "ip": "178.255.83.1",
-          "locality": "public",
+          "locality": "external",
           "packets": 5,
           "port": 80
         }
@@ -517,7 +517,7 @@
       "Fields": {
         "destination": {
           "ip": "178.255.83.1",
-          "locality": "public",
+          "locality": "external",
           "port": 80
         },
         "event": {
@@ -536,7 +536,7 @@
         },
         "flow": {
           "id": "8PR91KFjFKw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAGTz",
@@ -588,7 +588,7 @@
         "source": {
           "bytes": 705,
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 33660
         }
@@ -602,7 +602,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "port": 33646
         },
         "event": {
@@ -621,7 +621,7 @@
         },
         "flow": {
           "id": "O5vacJG8mLQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAGTz",
@@ -673,7 +673,7 @@
         "source": {
           "bytes": 1123,
           "ip": "178.255.83.1",
-          "locality": "public",
+          "locality": "external",
           "packets": 5,
           "port": 80
         }
@@ -687,7 +687,7 @@
       "Fields": {
         "destination": {
           "ip": "178.255.83.1",
-          "locality": "public",
+          "locality": "external",
           "port": 80
         },
         "event": {
@@ -706,7 +706,7 @@
         },
         "flow": {
           "id": "O5vacJG8mLQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "application_id": "FAAAMEQAAGTz",
@@ -758,7 +758,7 @@
         "source": {
           "bytes": 706,
           "ip": "192.168.100.151",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 33646
         }
@@ -772,7 +772,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "port": 52970
         },
         "event": {
@@ -791,7 +791,7 @@
         },
         "flow": {
           "id": "wdz94oax40U",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -839,7 +839,7 @@
         "source": {
           "bytes": 74,
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 53
         }
@@ -853,7 +853,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -872,7 +872,7 @@
         },
         "flow": {
           "id": "wdz94oax40U",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -920,7 +920,7 @@
         "source": {
           "bytes": 58,
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 52970
         }
@@ -934,7 +934,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "port": 49311
         },
         "event": {
@@ -953,7 +953,7 @@
         },
         "flow": {
           "id": "KvZZ7LW-Qdc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -1001,7 +1001,7 @@
         "source": {
           "bytes": 74,
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 53
         }
@@ -1015,7 +1015,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -1034,7 +1034,7 @@
         },
         "flow": {
           "id": "KvZZ7LW-Qdc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -1082,7 +1082,7 @@
         "source": {
           "bytes": 58,
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 49311
         }
@@ -1096,7 +1096,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "port": 51746
         },
         "event": {
@@ -1115,7 +1115,7 @@
         },
         "flow": {
           "id": "PC3a5T13Dpw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -1163,7 +1163,7 @@
         "source": {
           "bytes": 1071,
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 80
         }
@@ -1177,7 +1177,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1196,7 +1196,7 @@
         },
         "flow": {
           "id": "PC3a5T13Dpw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -1244,7 +1244,7 @@
         "source": {
           "bytes": 1147,
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 51746
         }
@@ -1258,7 +1258,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "port": 51745
         },
         "event": {
@@ -1277,7 +1277,7 @@
         },
         "flow": {
           "id": "zdGWMwGlfsg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -1325,7 +1325,7 @@
         "source": {
           "bytes": 1980,
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 80
         }
@@ -1339,7 +1339,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.100.111",
-          "locality": "private",
+          "locality": "internal",
           "port": 80
         },
         "event": {
@@ -1358,7 +1358,7 @@
         },
         "flow": {
           "id": "zdGWMwGlfsg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "FAAAMEQAAAAA",
@@ -1406,7 +1406,7 @@
         "source": {
           "bytes": 2164,
           "ip": "192.168.100.150",
-          "locality": "private",
+          "locality": "internal",
           "packets": 8,
           "port": 51745
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C-Netstream-with-varstring.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "20.20.255.255",
-          "locality": "public",
+          "locality": "external",
           "port": 137
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "dK1E5m-O-ns",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -84,7 +84,7 @@
         "source": {
           "bytes": 702,
           "ip": "20.20.20.20",
-          "locality": "public",
+          "locality": "external",
           "packets": 9,
           "port": 137
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-H3C.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.22.163.21",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "6gDDasxO-4o",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -83,7 +83,7 @@
         "source": {
           "bytes": 1027087,
           "ip": "10.22.166.30",
-          "locality": "private",
+          "locality": "internal",
           "packets": 697,
           "port": 0
         }
@@ -97,7 +97,7 @@
       "Fields": {
         "destination": {
           "ip": "10.21.3.172",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -116,7 +116,7 @@
         },
         "flow": {
           "id": "RJbWY0zxttI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -173,7 +173,7 @@
         "source": {
           "bytes": 6200,
           "ip": "10.22.166.12",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 0
         }
@@ -187,7 +187,7 @@
       "Fields": {
         "destination": {
           "ip": "10.22.178.37",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -206,7 +206,7 @@
         },
         "flow": {
           "id": "MfdYhUDA3Y4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -263,7 +263,7 @@
         "source": {
           "bytes": 11896,
           "ip": "10.22.166.33",
-          "locality": "private",
+          "locality": "internal",
           "packets": 21,
           "port": 0
         }
@@ -277,7 +277,7 @@
       "Fields": {
         "destination": {
           "ip": "10.20.100.253",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -296,7 +296,7 @@
         },
         "flow": {
           "id": "_QFogYw9xiY",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -353,7 +353,7 @@
         "source": {
           "bytes": 1041,
           "ip": "10.22.166.35",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 0
         }
@@ -367,7 +367,7 @@
       "Fields": {
         "destination": {
           "ip": "10.20.136.36",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -386,7 +386,7 @@
         },
         "flow": {
           "id": "-O7eEnuq5LI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -443,7 +443,7 @@
         "source": {
           "bytes": 1740,
           "ip": "10.22.166.36",
-          "locality": "private",
+          "locality": "internal",
           "packets": 20,
           "port": 0
         }
@@ -457,7 +457,7 @@
       "Fields": {
         "destination": {
           "ip": "10.20.147.28",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -476,7 +476,7 @@
         },
         "flow": {
           "id": "pcgnaJ3iCvI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -533,7 +533,7 @@
         "source": {
           "bytes": 2998,
           "ip": "10.22.166.36",
-          "locality": "private",
+          "locality": "internal",
           "packets": 16,
           "port": 0
         }
@@ -547,7 +547,7 @@
       "Fields": {
         "destination": {
           "ip": "10.20.141.16",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -566,7 +566,7 @@
         },
         "flow": {
           "id": "_gbuwRW4AVE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -623,7 +623,7 @@
         "source": {
           "bytes": 55773,
           "ip": "10.22.166.28",
-          "locality": "private",
+          "locality": "internal",
           "packets": 37,
           "port": 0
         }
@@ -637,7 +637,7 @@
       "Fields": {
         "destination": {
           "ip": "10.20.162.17",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -656,7 +656,7 @@
         },
         "flow": {
           "id": "VOe0rUor-cg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -713,7 +713,7 @@
         "source": {
           "bytes": 3239438,
           "ip": "10.22.166.35",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2135,
           "port": 0
         }
@@ -727,7 +727,7 @@
       "Fields": {
         "destination": {
           "ip": "10.20.171.36",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -746,7 +746,7 @@
         },
         "flow": {
           "id": "nkp7tr2MVcs",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -803,7 +803,7 @@
         "source": {
           "bytes": 5701,
           "ip": "10.22.166.15",
-          "locality": "private",
+          "locality": "internal",
           "packets": 20,
           "port": 0
         }
@@ -817,7 +817,7 @@
       "Fields": {
         "destination": {
           "ip": "10.22.208.12",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -836,7 +836,7 @@
         },
         "flow": {
           "id": "WxCFEmsTIh0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -893,7 +893,7 @@
         "source": {
           "bytes": 4255012,
           "ip": "10.22.166.2",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2804,
           "port": 0
         }
@@ -907,7 +907,7 @@
       "Fields": {
         "destination": {
           "ip": "10.22.196.21",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -926,7 +926,7 @@
         },
         "flow": {
           "id": "rAIv2psXy74",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -983,7 +983,7 @@
         "source": {
           "bytes": 37557,
           "ip": "10.22.166.28",
-          "locality": "private",
+          "locality": "internal",
           "packets": 25,
           "port": 0
         }
@@ -997,7 +997,7 @@
       "Fields": {
         "destination": {
           "ip": "10.22.202.15",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -1016,7 +1016,7 @@
         },
         "flow": {
           "id": "lR18K-eSVNM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -1073,7 +1073,7 @@
         "source": {
           "bytes": 23676,
           "ip": "10.22.166.25",
-          "locality": "private",
+          "locality": "internal",
           "packets": 68,
           "port": 0
         }
@@ -1087,7 +1087,7 @@
       "Fields": {
         "destination": {
           "ip": "10.20.166.26",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -1106,7 +1106,7 @@
         },
         "flow": {
           "id": "1XCFo-Jv19g",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -1163,7 +1163,7 @@
         "source": {
           "bytes": 22821,
           "ip": "10.22.166.25",
-          "locality": "private",
+          "locality": "internal",
           "packets": 30,
           "port": 0
         }
@@ -1177,7 +1177,7 @@
       "Fields": {
         "destination": {
           "ip": "10.21.3.117",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -1196,7 +1196,7 @@
         },
         "flow": {
           "id": "DkV-9Meb8W8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -1253,7 +1253,7 @@
         "source": {
           "bytes": 526,
           "ip": "10.22.166.12",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 0
         }
@@ -1267,7 +1267,7 @@
       "Fields": {
         "destination": {
           "ip": "10.22.145.26",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -1286,7 +1286,7 @@
         },
         "flow": {
           "id": "v1m_MeAqdL4",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -1343,7 +1343,7 @@
         "source": {
           "bytes": 33129,
           "ip": "10.22.166.17",
-          "locality": "private",
+          "locality": "internal",
           "packets": 220,
           "port": 0
         }
@@ -1357,7 +1357,7 @@
       "Fields": {
         "destination": {
           "ip": "10.21.75.38",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -1376,7 +1376,7 @@
         },
         "flow": {
           "id": "ru0mPvG-tKw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -1433,7 +1433,7 @@
         "source": {
           "bytes": 5092,
           "ip": "10.22.166.36",
-          "locality": "private",
+          "locality": "internal",
           "packets": 9,
           "port": 0
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Huawei-Netstream.golden.json
@@ -8,7 +8,7 @@
         "destination": {
           "bytes": 0,
           "ip": "10.111.112.204",
-          "locality": "private",
+          "locality": "internal",
           "port": 2598
         },
         "event": {
@@ -27,7 +27,7 @@
         },
         "flow": {
           "id": "d-FUjj8eKi8",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -84,7 +84,7 @@
         "source": {
           "bytes": 200,
           "ip": "10.108.219.53",
-          "locality": "private",
+          "locality": "internal",
           "packets": 4,
           "port": 45587
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-IE150-IE151.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.2",
-          "locality": "private",
+          "locality": "internal",
           "port": 137
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "X6k2SQeAX5c",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.2",
@@ -70,7 +70,7 @@
         "source": {
           "bytes": 78,
           "ip": "192.168.0.3",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 137
         }
@@ -84,7 +84,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.0.5",
-          "locality": "private",
+          "locality": "internal",
           "port": 6343
         },
         "event": {
@@ -100,7 +100,7 @@
         },
         "flow": {
           "id": "XEzNKvE_H1k",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.0.5",
@@ -147,7 +147,7 @@
         "source": {
           "bytes": 232,
           "ip": "192.168.0.4",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 58130
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-1-flowset-in-large-zero-filled-packet.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "134.220.1.156",
-          "locality": "public",
+          "locality": "external",
           "port": 50234
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "A-NpGXd6eh4",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "134.220.1.156",
@@ -76,7 +76,7 @@
         "source": {
           "bytes": 363,
           "ip": "134.220.2.6",
-          "locality": "public",
+          "locality": "external",
           "packets": 3,
           "port": 88
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Palo-Alto-PAN--OS-with-app--id.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.32.91.205",
-          "locality": "private",
+          "locality": "internal",
           "port": 49519
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "0HZ2F4aNlps",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.32.91.205",
@@ -76,7 +76,7 @@
         "source": {
           "bytes": 70,
           "ip": "23.35.171.27",
-          "locality": "public",
+          "locality": "external",
           "packets": 1,
           "port": 80
         }
@@ -90,7 +90,7 @@
       "Fields": {
         "destination": {
           "ip": "162.115.24.30",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -109,7 +109,7 @@
         },
         "flow": {
           "id": "GTu1zsDt3yw",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "162.115.24.30",
@@ -159,7 +159,7 @@
         "source": {
           "bytes": 111,
           "ip": "10.32.105.103",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 39702
         }
@@ -173,7 +173,7 @@
       "Fields": {
         "destination": {
           "ip": "34.202.173.126",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -192,7 +192,7 @@
         },
         "flow": {
           "id": "nUCuFEB8z_c",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "34.202.173.126",
@@ -242,7 +242,7 @@
         "source": {
           "bytes": 70,
           "ip": "10.32.144.145",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 52069
         }
@@ -256,7 +256,7 @@
       "Fields": {
         "destination": {
           "ip": "10.130.145.44",
-          "locality": "private",
+          "locality": "internal",
           "port": 49449
         },
         "event": {
@@ -275,7 +275,7 @@
         },
         "flow": {
           "id": "inYZm0Y9EVM",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.130.145.44",
@@ -325,7 +325,7 @@
         "source": {
           "bytes": 70,
           "ip": "23.209.52.99",
-          "locality": "public",
+          "locality": "external",
           "packets": 1,
           "port": 443
         }
@@ -339,7 +339,7 @@
       "Fields": {
         "destination": {
           "ip": "10.50.96.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 5432
         },
         "event": {
@@ -358,7 +358,7 @@
         },
         "flow": {
           "id": "6vds_sLxXqE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.50.96.20",
@@ -408,7 +408,7 @@
         "source": {
           "bytes": 78,
           "ip": "10.50.97.57",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 55481
         }
@@ -422,7 +422,7 @@
       "Fields": {
         "destination": {
           "ip": "10.50.97.57",
-          "locality": "private",
+          "locality": "internal",
           "port": 55481
         },
         "event": {
@@ -441,7 +441,7 @@
         },
         "flow": {
           "id": "6vds_sLxXqE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.50.97.57",
@@ -491,7 +491,7 @@
         "source": {
           "bytes": 78,
           "ip": "10.50.96.20",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 5432
         }
@@ -505,7 +505,7 @@
       "Fields": {
         "destination": {
           "ip": "10.48.208.209",
-          "locality": "private",
+          "locality": "internal",
           "port": 60068
         },
         "event": {
@@ -524,7 +524,7 @@
         },
         "flow": {
           "id": "v3XVGdLaIe4",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.48.208.209",
@@ -574,7 +574,7 @@
         "source": {
           "bytes": 70,
           "ip": "34.234.173.147",
-          "locality": "public",
+          "locality": "external",
           "packets": 1,
           "port": 443
         }
@@ -588,7 +588,7 @@
       "Fields": {
         "destination": {
           "ip": "65.52.108.254",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -607,7 +607,7 @@
         },
         "flow": {
           "id": "aenMB9Z5Tzc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "65.52.108.254",
@@ -657,7 +657,7 @@
         "source": {
           "bytes": 70,
           "ip": "10.130.167.43",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 62196
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Streamcore.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.231.128.150",
-          "locality": "private",
+          "locality": "internal",
           "port": 50073
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "wdxUeEaOBho",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.231.128.150",
@@ -71,7 +71,7 @@
         "source": {
           "bytes": 128,
           "ip": "100.78.40.201",
-          "locality": "public",
+          "locality": "external",
           "packets": 3,
           "port": 8080
         }
@@ -85,7 +85,7 @@
       "Fields": {
         "destination": {
           "ip": "100.78.40.201",
-          "locality": "public",
+          "locality": "external",
           "port": 8080
         },
         "event": {
@@ -104,7 +104,7 @@
         },
         "flow": {
           "id": "wdxUeEaOBho",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "100.78.40.201",
@@ -149,7 +149,7 @@
         "source": {
           "bytes": 172,
           "ip": "10.231.128.150",
-          "locality": "private",
+          "locality": "internal",
           "packets": 4,
           "port": 50073
         }
@@ -163,7 +163,7 @@
       "Fields": {
         "destination": {
           "ip": "10.27.8.20",
-          "locality": "private",
+          "locality": "internal",
           "port": 53483
         },
         "event": {
@@ -182,7 +182,7 @@
         },
         "flow": {
           "id": "6_Ia6lqx2cg",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.27.8.20",
@@ -227,7 +227,7 @@
         "source": {
           "bytes": 3943,
           "ip": "100.78.40.201",
-          "locality": "public",
+          "locality": "external",
           "packets": 10,
           "port": 8080
         }
@@ -241,7 +241,7 @@
       "Fields": {
         "destination": {
           "ip": "100.78.40.201",
-          "locality": "public",
+          "locality": "external",
           "port": 8080
         },
         "event": {
@@ -260,7 +260,7 @@
         },
         "flow": {
           "id": "6_Ia6lqx2cg",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "100.78.40.201",
@@ -305,7 +305,7 @@
         "source": {
           "bytes": 3052,
           "ip": "10.27.8.20",
-          "locality": "private",
+          "locality": "internal",
           "packets": 11,
           "port": 53483
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-Ubiquiti-Edgerouter-with-MPLS-labels.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 17232
         },
@@ -27,7 +27,7 @@
         },
         "flow": {
           "id": "KYJ6RiyA5YM",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -79,7 +79,7 @@
         "source": {
           "bytes": 174,
           "ip": "10.1.0.135",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 2,
           "port": 53
@@ -94,7 +94,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 17232
         },
@@ -114,7 +114,7 @@
         },
         "flow": {
           "id": "4GHcyowN7sg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -166,7 +166,7 @@
         "source": {
           "bytes": 87,
           "ip": "10.1.0.136",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 1,
           "port": 53
@@ -181,7 +181,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 51369
         },
@@ -201,7 +201,7 @@
         },
         "flow": {
           "id": "GRn2z1Rao3c",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -253,7 +253,7 @@
         "source": {
           "bytes": 1920,
           "ip": "10.1.0.232",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 15,
           "port": 443
@@ -268,7 +268,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 51370
         },
@@ -288,7 +288,7 @@
         },
         "flow": {
           "id": "iHA6jdIkqjA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -340,7 +340,7 @@
         "source": {
           "bytes": 610,
           "ip": "10.1.0.232",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 8,
           "port": 443
@@ -355,7 +355,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 44006
         },
@@ -375,7 +375,7 @@
         },
         "flow": {
           "id": "cBjtKefzGos",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -427,7 +427,7 @@
         "source": {
           "bytes": 2420,
           "ip": "10.5.0.91",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 21,
           "port": 443
@@ -442,7 +442,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 33282
         },
@@ -462,7 +462,7 @@
         },
         "flow": {
           "id": "EzT0lQWYBRw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -514,7 +514,7 @@
         "source": {
           "bytes": 10204,
           "ip": "10.1.0.30",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 30,
           "port": 443
@@ -529,7 +529,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 64642
         },
@@ -549,7 +549,7 @@
         },
         "flow": {
           "id": "TROGwofkmJA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -601,7 +601,7 @@
         "source": {
           "bytes": 216,
           "ip": "10.3.0.100",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 4,
           "port": 443
@@ -616,7 +616,7 @@
       "Fields": {
         "destination": {
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "mac": "44:d9:e7:be:ef:89",
           "port": 9497
         },
@@ -636,7 +636,7 @@
         },
         "flow": {
           "id": "wLclDbADA9s",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -688,7 +688,7 @@
         "source": {
           "bytes": 152,
           "ip": "10.1.0.135",
-          "locality": "private",
+          "locality": "internal",
           "mac": "06:be:ef:be:ef:4f",
           "packets": 1,
           "port": 53
@@ -703,7 +703,7 @@
       "Fields": {
         "destination": {
           "ip": "10.0.0.73",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -722,7 +722,7 @@
         },
         "flow": {
           "id": "LpdyE0SSB-o",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -774,7 +774,7 @@
         "source": {
           "bytes": 260,
           "ip": "192.168.1.98",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 55105
         }
@@ -788,7 +788,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 10001
         },
         "event": {
@@ -807,7 +807,7 @@
         },
         "flow": {
           "id": "32P6av-L8P0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -859,7 +859,7 @@
         "source": {
           "bytes": 32,
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 42506
         }
@@ -873,7 +873,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 37868
         },
         "event": {
@@ -892,7 +892,7 @@
         },
         "flow": {
           "id": "ft_m5C7Hgpo",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -944,7 +944,7 @@
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 40295
         }
@@ -958,7 +958,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 56911
         },
         "event": {
@@ -977,7 +977,7 @@
         },
         "flow": {
           "id": "bVX88Ii80AQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -1029,7 +1029,7 @@
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 36071
         }
@@ -1043,7 +1043,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 56327
         },
         "event": {
@@ -1062,7 +1062,7 @@
         },
         "flow": {
           "id": "bA4nBN4veuI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -1114,7 +1114,7 @@
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 49829
         }
@@ -1128,7 +1128,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 56239
         },
         "event": {
@@ -1147,7 +1147,7 @@
         },
         "flow": {
           "id": "lY5yfRKXE3s",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -1199,7 +1199,7 @@
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 35059
         }
@@ -1213,7 +1213,7 @@
       "Fields": {
         "destination": {
           "ip": "255.255.255.255",
-          "locality": "private",
+          "locality": "internal",
           "port": 39832
         },
         "event": {
@@ -1232,7 +1232,7 @@
         },
         "flow": {
           "id": "x3GfEtY3zCQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -1284,7 +1284,7 @@
         "source": {
           "bytes": 135,
           "ip": "10.4.0.251",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 38231
         }
@@ -1298,7 +1298,7 @@
       "Fields": {
         "destination": {
           "ip": "10.2.0.95",
-          "locality": "private",
+          "locality": "internal",
           "port": 443
         },
         "event": {
@@ -1317,7 +1317,7 @@
         },
         "flow": {
           "id": "bfT831bq5AI",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -1369,7 +1369,7 @@
         "source": {
           "bytes": 3668,
           "ip": "192.168.1.102",
-          "locality": "private",
+          "locality": "internal",
           "packets": 21,
           "port": 47690
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-field-layer2segmentid.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "80.82.237.40",
-          "locality": "public",
+          "locality": "external",
           "port": 445
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "tS3zN7t_rFg",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "80.82.237.40",
@@ -75,7 +75,7 @@
         "source": {
           "bytes": 52,
           "ip": "192.168.200.136",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 61926
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-ipt_netflow-reduced-size-encoding.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "193.151.198.166",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dd",
           "port": 36025
         },
@@ -27,7 +27,7 @@
         },
         "flow": {
           "id": "XLC-7u3wi0U",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "193.151.198.166",
@@ -79,7 +79,7 @@
         "source": {
           "bytes": 156,
           "ip": "37.122.1.226",
-          "locality": "public",
+          "locality": "external",
           "mac": "90:e2:ba:23:09:fc",
           "packets": 3,
           "port": 27622
@@ -94,7 +94,7 @@
       "Fields": {
         "destination": {
           "ip": "193.151.199.69",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dd",
           "port": 29598
         },
@@ -114,7 +114,7 @@
         },
         "flow": {
           "id": "2mdiEm9z6pA",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "193.151.199.69",
@@ -166,7 +166,7 @@
         "source": {
           "bytes": 48,
           "ip": "5.141.231.166",
-          "locality": "public",
+          "locality": "external",
           "mac": "90:e2:ba:23:09:fc",
           "packets": 1,
           "port": 31178
@@ -181,7 +181,7 @@
       "Fields": {
         "destination": {
           "ip": "212.224.113.74",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dc",
           "port": 443
         },
@@ -201,7 +201,7 @@
         },
         "flow": {
           "id": "IKsDJxZK5UA",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "212.224.113.74",
@@ -253,7 +253,7 @@
         "source": {
           "bytes": 584,
           "ip": "10.233.128.4",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:04:96:97:b8:cd",
           "packets": 11,
           "port": 53688
@@ -268,7 +268,7 @@
       "Fields": {
         "destination": {
           "ip": "10.236.8.4",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:1b:21:bc:24:dc",
           "port": 51549
         },
@@ -288,7 +288,7 @@
         },
         "flow": {
           "id": "lfpS1KL7LwI",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.236.8.4",
@@ -340,7 +340,7 @@
         "source": {
           "bytes": 577,
           "ip": "193.151.192.46",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1a:4a:16:01:81",
           "packets": 4,
           "port": 80
@@ -355,7 +355,7 @@
       "Fields": {
         "destination": {
           "ip": "62.221.115.205",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dc",
           "port": 1024
         },
@@ -375,7 +375,7 @@
         },
         "flow": {
           "id": "HRyho8QOr5M",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "62.221.115.205",
@@ -427,7 +427,7 @@
         "source": {
           "bytes": 152,
           "ip": "10.235.197.6",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:04:96:97:b8:cd",
           "packets": 3,
           "port": 57505
@@ -442,7 +442,7 @@
       "Fields": {
         "destination": {
           "ip": "37.146.125.64",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dc",
           "port": 3237
         },
@@ -462,7 +462,7 @@
         },
         "flow": {
           "id": "jbL3H_oK7ok",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "37.146.125.64",
@@ -514,7 +514,7 @@
         "source": {
           "bytes": 152,
           "ip": "10.236.31.7",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:04:96:97:b8:cd",
           "packets": 3,
           "port": 61471
@@ -529,7 +529,7 @@
       "Fields": {
         "destination": {
           "ip": "52.198.214.72",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dc",
           "port": 443
         },
@@ -549,7 +549,7 @@
         },
         "flow": {
           "id": "ayKjfr1z0QU",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "52.198.214.72",
@@ -601,7 +601,7 @@
         "source": {
           "bytes": 1809,
           "ip": "10.233.151.8",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:04:96:97:b8:cd",
           "packets": 15,
           "port": 58044
@@ -616,7 +616,7 @@
       "Fields": {
         "destination": {
           "ip": "64.233.161.188",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dc",
           "port": 5228
         },
@@ -636,7 +636,7 @@
         },
         "flow": {
           "id": "B15R8wv_tVI",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "64.233.161.188",
@@ -688,7 +688,7 @@
         "source": {
           "bytes": 234,
           "ip": "10.234.22.4",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:04:96:97:b8:cd",
           "packets": 3,
           "port": 60583
@@ -703,7 +703,7 @@
       "Fields": {
         "destination": {
           "ip": "185.209.20.240",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dc",
           "port": 80
         },
@@ -723,7 +723,7 @@
         },
         "flow": {
           "id": "oYN-uwp504w",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "185.209.20.240",
@@ -775,7 +775,7 @@
         "source": {
           "bytes": 1681,
           "ip": "10.233.36.7",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:04:96:97:b8:cd",
           "packets": 22,
           "port": 51399
@@ -790,7 +790,7 @@
       "Fields": {
         "destination": {
           "ip": "84.39.245.175",
-          "locality": "public",
+          "locality": "external",
           "mac": "00:1b:21:bc:24:dc",
           "port": 18580
         },
@@ -810,7 +810,7 @@
         },
         "flow": {
           "id": "MUPum_LUoxk",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "84.39.245.175",
@@ -862,7 +862,7 @@
         "source": {
           "bytes": 152,
           "ip": "10.233.200.7",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:04:96:97:b8:cd",
           "packets": 3,
           "port": 61820
@@ -877,7 +877,7 @@
       "Fields": {
         "destination": {
           "ip": "10.232.8.45",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:1b:21:bc:24:dd",
           "port": 56257
         },
@@ -897,7 +897,7 @@
         },
         "flow": {
           "id": "YStkNP0pV1E",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.232.8.45",
@@ -949,7 +949,7 @@
         "source": {
           "bytes": 1866,
           "ip": "23.43.139.27",
-          "locality": "public",
+          "locality": "external",
           "mac": "90:e2:ba:23:09:fc",
           "packets": 3,
           "port": 80
@@ -964,7 +964,7 @@
       "Fields": {
         "destination": {
           "ip": "10.233.150.21",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:1b:21:bc:24:dd",
           "port": 38164
         },
@@ -984,7 +984,7 @@
         },
         "flow": {
           "id": "nkastJ_vPI4",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.233.150.21",
@@ -1036,7 +1036,7 @@
         "source": {
           "bytes": 187,
           "ip": "2.17.140.47",
-          "locality": "public",
+          "locality": "external",
           "mac": "90:e2:ba:23:09:fc",
           "packets": 3,
           "port": 443

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-macaddress.golden.json
@@ -43,7 +43,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 22
         },
@@ -60,7 +60,7 @@
         },
         "flow": {
           "id": "zQfsdfKgh-o",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -96,7 +96,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 65058
         }
@@ -110,7 +110,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:8d:af:c3",
           "port": 123
         },
@@ -127,7 +127,7 @@
         },
         "flow": {
           "id": "Tw1iOKJ-dfE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -163,7 +163,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 123
         }
@@ -177,7 +177,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 123
         },
@@ -194,7 +194,7 @@
         },
         "flow": {
           "id": "NF1W3jyrHAA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -230,7 +230,7 @@
         },
         "source": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:8d:af:c3",
           "port": 123
         }
@@ -244,7 +244,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 80
         },
@@ -261,7 +261,7 @@
         },
         "flow": {
           "id": "B-_-kE8PEgA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -297,7 +297,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59157
         }
@@ -311,7 +311,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59157
         },
@@ -328,7 +328,7 @@
         },
         "flow": {
           "id": "B-_-kE8PEgA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -364,7 +364,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 80
         }
@@ -378,7 +378,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 443
         },
@@ -395,7 +395,7 @@
         },
         "flow": {
           "id": "q6jss8DvXWE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -431,7 +431,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59158
         }
@@ -445,7 +445,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59158
         },
@@ -462,7 +462,7 @@
         },
         "flow": {
           "id": "q6jss8DvXWE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -498,7 +498,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 443
         }
@@ -512,7 +512,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 139
         },
@@ -529,7 +529,7 @@
         },
         "flow": {
           "id": "3TmuMjQR8Mk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -565,7 +565,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59159
         }
@@ -579,7 +579,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59159
         },
@@ -596,7 +596,7 @@
         },
         "flow": {
           "id": "3TmuMjQR8Mk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -632,7 +632,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 139
         }
@@ -646,7 +646,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 23
         },
@@ -663,7 +663,7 @@
         },
         "flow": {
           "id": "2KDgFVtVKGg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -699,7 +699,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59160
         }
@@ -713,7 +713,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59160
         },
@@ -730,7 +730,7 @@
         },
         "flow": {
           "id": "2KDgFVtVKGg",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -766,7 +766,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 23
         }
@@ -780,7 +780,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 995
         },
@@ -797,7 +797,7 @@
         },
         "flow": {
           "id": "vwr6dNcr6FE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -833,7 +833,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59161
         }
@@ -847,7 +847,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59161
         },
@@ -864,7 +864,7 @@
         },
         "flow": {
           "id": "vwr6dNcr6FE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -900,7 +900,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 995
         }
@@ -914,7 +914,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 443
         },
@@ -931,7 +931,7 @@
         },
         "flow": {
           "id": "tmgCubSF_CU",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -967,7 +967,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59162
         }
@@ -981,7 +981,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59162
         },
@@ -998,7 +998,7 @@
         },
         "flow": {
           "id": "tmgCubSF_CU",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1034,7 +1034,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 443
         }
@@ -1048,7 +1048,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 135
         },
@@ -1065,7 +1065,7 @@
         },
         "flow": {
           "id": "Agzgga7RAr0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -1101,7 +1101,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59163
         }
@@ -1115,7 +1115,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59163
         },
@@ -1132,7 +1132,7 @@
         },
         "flow": {
           "id": "Agzgga7RAr0",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1168,7 +1168,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 135
         }
@@ -1182,7 +1182,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 110
         },
@@ -1199,7 +1199,7 @@
         },
         "flow": {
           "id": "-cqFlm16mLc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -1235,7 +1235,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59164
         }
@@ -1249,7 +1249,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59164
         },
@@ -1266,7 +1266,7 @@
         },
         "flow": {
           "id": "-cqFlm16mLc",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1302,7 +1302,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 110
         }
@@ -1316,7 +1316,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 111
         },
@@ -1333,7 +1333,7 @@
         },
         "flow": {
           "id": "Txfldw7-948",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -1369,7 +1369,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59165
         }
@@ -1383,7 +1383,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59165
         },
@@ -1400,7 +1400,7 @@
         },
         "flow": {
           "id": "Txfldw7-948",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1436,7 +1436,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 111
         }
@@ -1450,7 +1450,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 143
         },
@@ -1467,7 +1467,7 @@
         },
         "flow": {
           "id": "iaXg6w051Ho",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -1503,7 +1503,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59166
         }
@@ -1517,7 +1517,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59166
         },
@@ -1534,7 +1534,7 @@
         },
         "flow": {
           "id": "iaXg6w051Ho",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1570,7 +1570,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 143
         }
@@ -1584,7 +1584,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 3389
         },
@@ -1601,7 +1601,7 @@
         },
         "flow": {
           "id": "cEvEMCFhKJk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -1637,7 +1637,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59167
         }
@@ -1651,7 +1651,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59167
         },
@@ -1668,7 +1668,7 @@
         },
         "flow": {
           "id": "cEvEMCFhKJk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1704,7 +1704,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 3389
         }
@@ -1718,7 +1718,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 80
         },
@@ -1735,7 +1735,7 @@
         },
         "flow": {
           "id": "DnN0kX-gR3Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -1771,7 +1771,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59168
         }
@@ -1785,7 +1785,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59168
         },
@@ -1802,7 +1802,7 @@
         },
         "flow": {
           "id": "DnN0kX-gR3Q",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1838,7 +1838,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 80
         }
@@ -1852,7 +1852,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 25
         },
@@ -1869,7 +1869,7 @@
         },
         "flow": {
           "id": "-kLcuxmRzgk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -1905,7 +1905,7 @@
         },
         "source": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59169
         }
@@ -1919,7 +1919,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:50:56:c0:00:01",
           "port": 59169
         },
@@ -1936,7 +1936,7 @@
         },
         "flow": {
           "id": "-kLcuxmRzgk",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.1",
@@ -1972,7 +1972,7 @@
         },
         "source": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "mac": "00:0c:29:70:86:09",
           "port": 25
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-multiple-netflow-exporters.golden.json
@@ -43,7 +43,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.248",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -62,7 +62,7 @@
         },
         "flow": {
           "id": "1E-M5OJg_go",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.248",
@@ -108,7 +108,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -122,7 +122,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -141,7 +141,7 @@
         },
         "flow": {
           "id": "yMxFd8CW_Ok",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -187,7 +187,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.248",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -201,7 +201,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -220,7 +220,7 @@
         },
         "flow": {
           "id": "NF1W3jyrHAA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -266,7 +266,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -280,7 +280,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -299,7 +299,7 @@
         },
         "flow": {
           "id": "Tw1iOKJ-dfE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -345,7 +345,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -359,7 +359,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.202",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -378,7 +378,7 @@
         },
         "flow": {
           "id": "sNF38-obC7k",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.202",
@@ -424,7 +424,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -438,7 +438,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -457,7 +457,7 @@
         },
         "flow": {
           "id": "458D6voFu3E",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -503,7 +503,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.202",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -534,7 +534,7 @@
         },
         "flow": {
           "id": "tYpw8DU5u10",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "ff02::1",
@@ -586,7 +586,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 65058
         },
         "event": {
@@ -605,7 +605,7 @@
         },
         "flow": {
           "id": "zQfsdfKgh-o",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "bgp_destination_as_number": 0,
@@ -655,7 +655,7 @@
         "source": {
           "bytes": 200,
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "packets": 2,
           "port": 22
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-nprobe-DPI-L7.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "0.0.0.0",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "oFN7CMNpOLQ",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AAAAUg==",
@@ -66,7 +66,7 @@
         "source": {
           "bytes": 82,
           "ip": "0.0.0.0",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 0
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-template-with-0-length-fields.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.1.80",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "BSsjrf_TZnk",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.1.80",
@@ -76,7 +76,7 @@
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "packets": 0,
           "port": 0
         }
@@ -90,7 +90,7 @@
       "Fields": {
         "destination": {
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -109,7 +109,7 @@
         },
         "flow": {
           "id": "R1Sjz_ITbgo",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -159,7 +159,7 @@
         "source": {
           "bytes": 0,
           "ip": "192.168.1.80",
-          "locality": "private",
+          "locality": "internal",
           "packets": 0,
           "port": 0
         }
@@ -173,7 +173,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.1.95",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -192,7 +192,7 @@
         },
         "flow": {
           "id": "FpUgB2PIhjQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.1.95",
@@ -242,7 +242,7 @@
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "packets": 0,
           "port": 0
         }
@@ -256,7 +256,7 @@
       "Fields": {
         "destination": {
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -275,7 +275,7 @@
         },
         "flow": {
           "id": "qN8iQExOvkc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -325,7 +325,7 @@
         "source": {
           "bytes": 32,
           "ip": "192.168.1.95",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 0
         }
@@ -339,7 +339,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.1.95",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -358,7 +358,7 @@
         },
         "flow": {
           "id": "FpUgB2PIhjQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.1.95",
@@ -408,7 +408,7 @@
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "packets": 0,
           "port": 0
         }
@@ -422,7 +422,7 @@
       "Fields": {
         "destination": {
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -441,7 +441,7 @@
         },
         "flow": {
           "id": "qN8iQExOvkc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -491,7 +491,7 @@
         "source": {
           "bytes": 0,
           "ip": "192.168.1.95",
-          "locality": "private",
+          "locality": "internal",
           "packets": 0,
           "port": 0
         }
@@ -505,7 +505,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.1.33",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -524,7 +524,7 @@
         },
         "flow": {
           "id": "WuFpyBG1Gt0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.1.33",
@@ -574,7 +574,7 @@
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "packets": 0,
           "port": 0
         }
@@ -588,7 +588,7 @@
       "Fields": {
         "destination": {
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -607,7 +607,7 @@
         },
         "flow": {
           "id": "1aysHUs7BpA",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -657,7 +657,7 @@
         "source": {
           "bytes": 32,
           "ip": "192.168.1.33",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 0
         }
@@ -671,7 +671,7 @@
       "Fields": {
         "destination": {
           "ip": "192.168.1.33",
-          "locality": "private",
+          "locality": "internal",
           "port": 0
         },
         "event": {
@@ -690,7 +690,7 @@
         },
         "flow": {
           "id": "WuFpyBG1Gt0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "192.168.1.33",
@@ -740,7 +740,7 @@
         "source": {
           "bytes": 0,
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "packets": 0,
           "port": 0
         }
@@ -754,7 +754,7 @@
       "Fields": {
         "destination": {
           "ip": "239.255.255.250",
-          "locality": "public",
+          "locality": "external",
           "port": 0
         },
         "event": {
@@ -773,7 +773,7 @@
         },
         "flow": {
           "id": "1aysHUs7BpA",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "239.255.255.250",
@@ -823,7 +823,7 @@
         "source": {
           "bytes": 0,
           "ip": "192.168.1.33",
-          "locality": "private",
+          "locality": "internal",
           "packets": 0,
           "port": 0
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/Netflow-9-valid-01.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.248",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "1E-M5OJg_go",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.248",
@@ -72,7 +72,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -86,7 +86,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -105,7 +105,7 @@
         },
         "flow": {
           "id": "yMxFd8CW_Ok",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -151,7 +151,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.248",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -165,7 +165,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -184,7 +184,7 @@
         },
         "flow": {
           "id": "NF1W3jyrHAA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.201",
@@ -230,7 +230,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -244,7 +244,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -263,7 +263,7 @@
         },
         "flow": {
           "id": "Tw1iOKJ-dfE",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -309,7 +309,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.201",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -323,7 +323,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.202",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -342,7 +342,7 @@
         },
         "flow": {
           "id": "sNF38-obC7k",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.202",
@@ -388,7 +388,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -402,7 +402,7 @@
       "Fields": {
         "destination": {
           "ip": "172.16.32.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 123
         },
         "event": {
@@ -421,7 +421,7 @@
         },
         "flow": {
           "id": "458D6voFu3E",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "172.16.32.100",
@@ -467,7 +467,7 @@
         "source": {
           "bytes": 76,
           "ip": "172.16.32.202",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 123
         }
@@ -498,7 +498,7 @@
         },
         "flow": {
           "id": "tYpw8DU5u10",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv6_address": "ff02::1",

--- a/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/ipfix_cisco.pcap.golden.json
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -110,7 +110,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -197,7 +197,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACCA==",
@@ -284,7 +284,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -371,7 +371,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -458,7 +458,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -545,7 +545,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -632,7 +632,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -719,7 +719,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACYw==",
@@ -806,7 +806,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAMQ==",
@@ -893,7 +893,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -980,7 +980,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACYw==",
@@ -1067,7 +1067,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACCA==",
@@ -1154,7 +1154,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -1241,7 +1241,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -1328,7 +1328,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQAAAQ==",
@@ -1415,7 +1415,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -1502,7 +1502,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -1589,7 +1589,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -1676,7 +1676,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACZg==",
@@ -1763,7 +1763,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACYw==",
@@ -1850,7 +1850,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAFmQ==",
@@ -1937,7 +1937,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAAUA==",
@@ -2024,7 +2024,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -2111,7 +2111,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "AwAFmQ==",
@@ -2198,7 +2198,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -2285,7 +2285,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -2372,7 +2372,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQABxQ==",
@@ -2459,7 +2459,7 @@
         },
         "flow": {
           "id": "Vhs9T5k296w",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "application_id": "DQACYw==",

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_e10s_4_7byte_pad.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_e10s_4_7byte_pad.pcap.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "10.36.236.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 54594
         },
         "event": {
@@ -23,7 +23,7 @@
         },
         "flow": {
           "id": "6mUV1nPVG80",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.36.236.100",
@@ -68,7 +68,7 @@
         "source": {
           "bytes": 1855,
           "ip": "10.127.32.11",
-          "locality": "private",
+          "locality": "internal",
           "packets": 5,
           "port": 53
         }
@@ -82,7 +82,7 @@
       "Fields": {
         "destination": {
           "ip": "10.36.237.22",
-          "locality": "private",
+          "locality": "internal",
           "port": 52058
         },
         "event": {
@@ -98,7 +98,7 @@
         },
         "flow": {
           "id": "3BTOVt9gp8I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.36.237.22",
@@ -143,7 +143,7 @@
         "source": {
           "bytes": 217,
           "ip": "10.36.228.103",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 8000
         }
@@ -157,7 +157,7 @@
       "Fields": {
         "destination": {
           "ip": "10.127.32.11",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -173,7 +173,7 @@
         },
         "flow": {
           "id": "6mUV1nPVG80",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.127.32.11",
@@ -218,7 +218,7 @@
         "source": {
           "bytes": 547,
           "ip": "10.36.236.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 7,
           "port": 54594
         }
@@ -232,7 +232,7 @@
       "Fields": {
         "destination": {
           "ip": "10.36.236.100",
-          "locality": "private",
+          "locality": "internal",
           "port": 49180
         },
         "event": {
@@ -248,7 +248,7 @@
         },
         "flow": {
           "id": "HVg4SttTufc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "10.36.236.100",
@@ -293,7 +293,7 @@
         "source": {
           "bytes": 7158,
           "ip": "52.206.251.4",
-          "locality": "public",
+          "locality": "external",
           "packets": 10,
           "port": 443
         }
@@ -307,7 +307,7 @@
       "Fields": {
         "destination": {
           "ip": "52.206.251.4",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -323,7 +323,7 @@
         },
         "flow": {
           "id": "HVg4SttTufc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "destination_ipv4_address": "52.206.251.4",
@@ -368,7 +368,7 @@
         "source": {
           "bytes": 1538,
           "ip": "10.36.236.100",
-          "locality": "private",
+          "locality": "internal",
           "packets": 11,
           "port": 49180
         }
@@ -382,7 +382,7 @@
       "Fields": {
         "destination": {
           "ip": "10.36.228.103",
-          "locality": "private",
+          "locality": "internal",
           "port": 8000
         },
         "event": {
@@ -398,7 +398,7 @@
         },
         "flow": {
           "id": "3BTOVt9gp8I",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "destination_ipv4_address": "10.36.228.103",
@@ -443,7 +443,7 @@
         "source": {
           "bytes": 217,
           "ip": "10.36.237.22",
-          "locality": "private",
+          "locality": "internal",
           "packets": 3,
           "port": 52058
         }

--- a/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
+++ b/x-pack/filebeat/input/netflow/testdata/golden/netflow9_ubiquiti_edgerouter.pcap.golden.json
@@ -7,7 +7,7 @@
       "Fields": {
         "destination": {
           "ip": "159.65.125.168",
-          "locality": "public",
+          "locality": "external",
           "port": 80
         },
         "event": {
@@ -26,7 +26,7 @@
         },
         "flow": {
           "id": "NPZRWU1oZKQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -78,7 +78,7 @@
         "source": {
           "bytes": 421,
           "ip": "10.100.5.2",
-          "locality": "private",
+          "locality": "internal",
           "packets": 6,
           "port": 43376
         }
@@ -92,7 +92,7 @@
       "Fields": {
         "destination": {
           "ip": "13.32.251.125",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -111,7 +111,7 @@
         },
         "flow": {
           "id": "wMmxEUF-2Sk",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -163,7 +163,7 @@
         "source": {
           "bytes": 7621,
           "ip": "10.100.6.93",
-          "locality": "private",
+          "locality": "internal",
           "packets": 131,
           "port": 54520
         }
@@ -177,7 +177,7 @@
       "Fields": {
         "destination": {
           "ip": "10.100.6.80",
-          "locality": "private",
+          "locality": "internal",
           "port": 62323
         },
         "event": {
@@ -196,7 +196,7 @@
         },
         "flow": {
           "id": "2NG48p7EGpw",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -248,7 +248,7 @@
         "source": {
           "bytes": 95,
           "ip": "10.100.4.1",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 53
         }
@@ -262,7 +262,7 @@
       "Fields": {
         "destination": {
           "ip": "13.32.251.8",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -281,7 +281,7 @@
         },
         "flow": {
           "id": "f0LYEiUntL0",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -333,7 +333,7 @@
         "source": {
           "bytes": 3162,
           "ip": "10.100.6.93",
-          "locality": "private",
+          "locality": "internal",
           "packets": 30,
           "port": 54497
         }
@@ -347,7 +347,7 @@
       "Fields": {
         "destination": {
           "ip": "52.22.76.61",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -366,7 +366,7 @@
         },
         "flow": {
           "id": "9ATz0HlBbIQ",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -418,7 +418,7 @@
         "source": {
           "bytes": 2711,
           "ip": "10.100.6.80",
-          "locality": "private",
+          "locality": "internal",
           "packets": 13,
           "port": 50030
         }
@@ -432,7 +432,7 @@
       "Fields": {
         "destination": {
           "ip": "13.32.251.125",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -451,7 +451,7 @@
         },
         "flow": {
           "id": "vueGG5QVS_M",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -503,7 +503,7 @@
         "source": {
           "bytes": 20855,
           "ip": "10.100.6.93",
-          "locality": "private",
+          "locality": "internal",
           "packets": 346,
           "port": 54517
         }
@@ -517,7 +517,7 @@
       "Fields": {
         "destination": {
           "ip": "13.32.251.125",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -536,7 +536,7 @@
         },
         "flow": {
           "id": "rJySLUBW94Y",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -588,7 +588,7 @@
         "source": {
           "bytes": 7495,
           "ip": "10.100.6.93",
-          "locality": "private",
+          "locality": "internal",
           "packets": 129,
           "port": 54518
         }
@@ -602,7 +602,7 @@
       "Fields": {
         "destination": {
           "ip": "13.32.251.125",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -621,7 +621,7 @@
         },
         "flow": {
           "id": "pWQ3ZWUMRfU",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -673,7 +673,7 @@
         "source": {
           "bytes": 7049,
           "ip": "10.100.6.93",
-          "locality": "private",
+          "locality": "internal",
           "packets": 119,
           "port": 54519
         }
@@ -687,7 +687,7 @@
       "Fields": {
         "destination": {
           "ip": "13.32.251.126",
-          "locality": "public",
+          "locality": "external",
           "port": 443
         },
         "event": {
@@ -706,7 +706,7 @@
         },
         "flow": {
           "id": "M0l00u11bWc",
-          "locality": "public"
+          "locality": "external"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -758,7 +758,7 @@
         "source": {
           "bytes": 1348,
           "ip": "10.100.6.93",
-          "locality": "private",
+          "locality": "internal",
           "packets": 13,
           "port": 54521
         }
@@ -772,7 +772,7 @@
       "Fields": {
         "destination": {
           "ip": "10.100.0.1",
-          "locality": "private",
+          "locality": "internal",
           "port": 53
         },
         "event": {
@@ -791,7 +791,7 @@
         },
         "flow": {
           "id": "lzKTutEyrKA",
-          "locality": "private"
+          "locality": "internal"
         },
         "netflow": {
           "delta_flow_count": 0,
@@ -843,7 +843,7 @@
         "source": {
           "bytes": 82,
           "ip": "192.168.1.4",
-          "locality": "private",
+          "locality": "internal",
           "packets": 1,
           "port": 57253
         }


### PR DESCRIPTION
Cherry-pick of PR #24295 to 7.x branch. Original message: 

## What does this PR do?

Changes netflow input to use `internal` and `external` for locality fields:
- source.locality
- destination.locality
- flow.locality

Previously it was using `public` and `private`.

## Why is it important?

There was a mismatch between the output values and the values expected by the ingest pipeline used by the Netflow module. Also the new values make more sense from a locality perspective.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #24272