### PR TITLE
Cherry-pick #24466 to 7.x: Logging to file disabled on enroll 

### DIFF
--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -62,7 +62,8 @@ const defaultLevel = InfoLevel
 // Beat is supposed to be run within.
 func DefaultConfig(environment Environment) Config {
 	return Config{
-		Level: defaultLevel,
+		Level:   defaultLevel,
+		ToFiles: true,
 		Files: FileConfig{
 			MaxSize:         10 * 1024 * 1024,
 			MaxBackups:      7,

--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@
 - Fix windows installer during enroll {pull}[24343]24343
 - Fix failing installation on windows 7 {pull}[24387]24387
 - Fix capabilities resolution in inspect command {pull}[24346]24346
+- Logging to file disabled on enroll {issue}[24173]24173
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -187,6 +187,11 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		}
 	}
 
+	// enroll is invoked either manually or from install with redirected IO
+	// no need to log to file
+	cfg.Settings.LoggingConfig.ToFiles = false
+	cfg.Settings.LoggingConfig.ToStderr = true
+
 	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig)
 	if err != nil {
 		return err

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -54,13 +54,18 @@ func new(name string, cfg *Config) (*Logger, error) {
 	if err != nil {
 		return nil, err
 	}
-	internal, err := makeInternalFileOutput(cfg)
-	if err != nil {
-		return nil, err
+
+	if cfg.ToFiles {
+		internal, err := makeInternalFileOutput(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := configure.LoggingWithOutputs("", commonCfg, internal); err != nil {
+			return nil, fmt.Errorf("error initializing logging: %v", err)
+		}
 	}
-	if err := configure.LoggingWithOutputs("", commonCfg, internal); err != nil {
-		return nil, fmt.Errorf("error initializing logging: %v", err)
-	}
+
 	return logp.NewLogger(name), nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #24466 to 7.x branch. Original message:

## What does this PR do?

The problem here is that enroll runs simultaneously with running service and both try to log into same file. 
Although for enroll there's no need to do that as it is invoked either manually (with std output) or as executed from install command with std redirecting to a caller. 

This PR makes sure to create internal logging file `elastic-agent-json.log` only in case it is really needed.

## Why is it important?

Fixes: #24173

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
