### PR TITLE
Cherry-pick to 7.11: Move example to the correct location in reference docs (#24455)

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -45,6 +45,15 @@ call will be interrupted.
 The default AWS API call timeout for a message is 120 seconds. The minimum
 is 0 seconds. The maximum is half of the visibility timeout value.
 
+[float]
+==== `expand_event_list_from_field`
+
+If the fileset using this input expects to receive multiple messages bundled
+under a specific field then the config option expand_event_list_from_field value
+can be assigned the name of the field. This setting will be able to split the
+messages under the group value into separate events. For example, CloudTrail logs
+are in JSON format and events are found under the JSON object "Records".
+
 ["source","json"]
 ----
 {
@@ -65,16 +74,7 @@ is 0 seconds. The maximum is half of the visibility timeout value.
 }
 ----
 
-[float]
-==== `expand_event_list_from_field`
-
-If the fileset using this input expects to receive multiple messages bundled
-under a specific field then the config option expand_event_list_from_field value
-can be assigned the name of the field. This setting will be able to split the
-messages under the group value into separate events. For example, CloudTrail logs
-are in JSON format and events are found under the JSON object "Records".
-
-Note: When `expand_event_list_from_field` parameter is given in the config, s3
+Note: When `expand_event_list_from_field` parameter is given in the config, aws-s3
 input will assume the logs are in JSON format and decode them as JSON. Content
 type will not be checked.
 If a file has "application/json" content-type, `expand_event_list_from_field`


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Move example to the correct location in reference docs (#24455)