### PR TITLE
[Elastic Agent] Add the ability to provide custom CA's inside of docker.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -75,3 +75,4 @@
 - Add support for enrollment with local bootstrap of Fleet Server {pull}23865[23865]
 - Add TLS support for Fleet Server {pull}24142[24142]
 - Add support for Fleet Server running under Elastic Agent {pull}24220[24220]
+- Add CA support to Elastic Agent docker image {pull}24486[24486]

--- a/x-pack/elastic-agent/pkg/agent/application/config.go
+++ b/x-pack/elastic-agent/pkg/agent/application/config.go
@@ -28,10 +28,15 @@ func createFleetConfigFromEnroll(accessAPIKey string, kbn *kibana.Config) (*conf
 	return cfg, nil
 }
 
-func createFleetServerBootstrapConfig(connStr string, policyID string, host string, port uint16, cert string, key string) (*configuration.FleetAgentConfig, error) {
+func createFleetServerBootstrapConfig(connStr string, policyID string, host string, port uint16, cert string, key string, esCA string) (*configuration.FleetAgentConfig, error) {
 	es, err := configuration.ElasticsearchFromConnStr(connStr)
 	if err != nil {
 		return nil, err
+	}
+	if esCA != "" {
+		es.TLS = &tlscommon.Config{
+			CAs: []string{esCA},
+		}
 	}
 	cfg := configuration.DefaultFleetAgentConfig()
 	cfg.Enabled = true

--- a/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/enroll_cmd.go
@@ -81,14 +81,15 @@ type EnrollCmd struct {
 
 // EnrollCmdFleetServerOption define all the supported enrollment options for bootstrapping with Fleet Server.
 type EnrollCmdFleetServerOption struct {
-	ConnStr    string
-	PolicyID   string
-	Host       string
-	Port       uint16
-	Cert       string
-	CertKey    string
-	Insecure   bool
-	SpawnAgent bool
+	ConnStr         string
+	ElasticsearchCA string
+	PolicyID        string
+	Host            string
+	Port            uint16
+	Cert            string
+	CertKey         string
+	Insecure        bool
+	SpawnAgent      bool
 }
 
 // EnrollCmdOption define all the supported enrollment option.
@@ -227,7 +228,7 @@ func (c *EnrollCmd) fleetServerBootstrap(ctx context.Context) error {
 	fleetConfig, err := createFleetServerBootstrapConfig(
 		c.options.FleetServer.ConnStr, c.options.FleetServer.PolicyID,
 		c.options.FleetServer.Host, c.options.FleetServer.Port,
-		c.options.FleetServer.Cert, c.options.FleetServer.CertKey)
+		c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA)
 	configToStore := map[string]interface{}{
 		"fleet": fleetConfig,
 	}
@@ -388,7 +389,7 @@ func (c *EnrollCmd) enroll(ctx context.Context) error {
 		serverConfig, err := createFleetServerBootstrapConfig(
 			c.options.FleetServer.ConnStr, c.options.FleetServer.PolicyID,
 			c.options.FleetServer.Host, c.options.FleetServer.Port,
-			c.options.FleetServer.Cert, c.options.FleetServer.CertKey)
+			c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA)
 		if err != nil {
 			return err
 		}

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -52,6 +52,7 @@ func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("kibana-url", "k", "", "URL of Kibana to enroll Agent into Fleet")
 	cmd.Flags().StringP("enrollment-token", "t", "", "Enrollment token to use to enroll Agent into Fleet")
 	cmd.Flags().StringP("fleet-server", "", "", "Start and run a Fleet Server along side this Elastic Agent")
+	cmd.Flags().StringP("fleet-server-elasticsearch-ca", "", "", "Path to certificate authority to use with communicate with elasticsearch")
 	cmd.Flags().StringP("fleet-server-policy", "", "", "Start and run a Fleet Server on this specific policy")
 	cmd.Flags().StringP("fleet-server-host", "", "", "Fleet Server HTTP binding host (overrides the policy)")
 	cmd.Flags().Uint16P("fleet-server-port", "", 0, "Fleet Server HTTP binding port (overrides the policy)")
@@ -75,6 +76,7 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 		token, _ = cmd.Flags().GetString("enrollment-token")
 	}
 	fServer, _ := cmd.Flags().GetString("fleet-server")
+	fElasticSearchCA, _ := cmd.Flags().GetString("fleet-server-elasticsearch-ca")
 	fPolicy, _ := cmd.Flags().GetString("fleet-server-policy")
 	fHost, _ := cmd.Flags().GetString("fleet-server-host")
 	fPort, _ := cmd.Flags().GetUint16("fleet-server-port")
@@ -98,6 +100,10 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 	if fServer != "" {
 		args = append(args, "--fleet-server")
 		args = append(args, fServer)
+	}
+	if fElasticSearchCA != "" {
+		args = append(args, "--fleet-server-elasticsearch-ca")
+		args = append(args, fElasticSearchCA)
 	}
 	if fPolicy != "" {
 		args = append(args, "--fleet-server-policy")
@@ -199,6 +205,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 	}
 	enrollmentToken, _ := cmd.Flags().GetString("enrollment-token")
 	fServer, _ := cmd.Flags().GetString("fleet-server")
+	fElasticSearchCA, _ := cmd.Flags().GetString("fleet-server-elasticsearch-ca")
 	fPolicy, _ := cmd.Flags().GetString("fleet-server-policy")
 	fHost, _ := cmd.Flags().GetString("fleet-server-host")
 	fPort, _ := cmd.Flags().GetUint16("fleet-server-port")
@@ -223,14 +230,15 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args
 		UserProvidedMetadata: make(map[string]interface{}),
 		Staging:              staging,
 		FleetServer: application.EnrollCmdFleetServerOption{
-			ConnStr:    fServer,
-			PolicyID:   fPolicy,
-			Host:       fHost,
-			Port:       fPort,
-			Cert:       fCert,
-			CertKey:    fCertKey,
-			Insecure:   fInsecure,
-			SpawnAgent: !fromInstall,
+			ConnStr:         fServer,
+			ElasticsearchCA: fElasticSearchCA,
+			PolicyID:        fPolicy,
+			Host:            fHost,
+			Port:            fPort,
+			Cert:            fCert,
+			CertKey:         fCertKey,
+			Insecure:        fInsecure,
+			SpawnAgent:      !fromInstall,
 		},
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds environment variables for the `container` sub-command (aka. Docker) to reference custom CA's. Without this it was not possible to use self-generated certificates.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So self-generated certificates could be used.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24484 
