### PR TITLE
Cherry-pick to 7.x: Add syntax for multiple selector logging (#24207)

### DIFF
--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -156,6 +156,12 @@ To see which selectors are available, run {beatname_uc} in debug mode
 after the log level and is enclosed in brackets.
 =====
 
+To configure multiple selectors, use the following {beats-ref}/config-file-format.html[YAML list syntax]:
+["source","yaml",subs="attributes"]
+----
+logging.selectors: [ harvester, input ]
+----
+
 ifndef::serverless[]
 To override selectors at the command line, use the `-d` global flag (`-d` also
 sets the debug log level). For more information, see <<command-line-options>>.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add syntax for multiple selector logging (#24207)