### PR TITLE
[Ingest Manager] Sync on rename on windows

### DIFF
--- a/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
@@ -55,15 +55,8 @@ func (i *Installer) Install(ctx context.Context, spec program.Spec, version, ins
 	// on windows rename is not atomic, let's force it to flush the cache
 	defer func() {
 		if runtime.GOOS == "windows" {
-			if f, err := os.OpenFile(installDir, os.O_RDWR, 0777); err == nil {
-				f.Sync()
-				f.Close()
-			}
-
-			if f, err := os.OpenFile(tempInstallDir, os.O_RDWR, 0777); err == nil {
-				f.Sync()
-				f.Close()
-			}
+			syncDir(installDir)
+			syncDir(tempInstallDir)
 		}
 	}()
 
@@ -86,4 +79,11 @@ func (i *Installer) Install(ctx context.Context, spec program.Spec, version, ins
 	}
 
 	return nil
+}
+
+func syncDir(dir string) {
+	if f, err := os.OpenFile(dir, os.O_RDWR, 0777); err == nil {
+		f.Sync()
+		f.Close()
+	}
 }

--- a/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/zip/zip_installer.go
@@ -61,9 +61,13 @@ func (i *Installer) Install(ctx context.Context, spec program.Spec, version, ins
 	// if root directory is not the same as desired directory rename
 	// e.g contains `-windows-` or  `-SNAPSHOT-`
 	if rootDir != installDir {
+		defer syncDir(rootDir)
+		defer syncDir(installDir)
+
 		if err := os.Rename(rootDir, installDir); err != nil {
 			return errors.New(err, errors.TypeFilesystem, errors.M(errors.MetaKeyPath, installDir))
 		}
+
 	}
 
 	return nil
@@ -154,4 +158,11 @@ func (i *Installer) getRootDir(zipPath string) (dir string, err error) {
 	}
 
 	return rootDir, nil
+}
+
+func syncDir(dir string) {
+	if f, err := os.OpenFile(dir, os.O_RDWR, 0777); err == nil {
+		f.Sync()
+		f.Close()
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Adds one more sync in rename when unpacking zip archive

## Why is it important?

FS issues also may e related to #24477

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
