### PR TITLE
Cherry-pick to 7.x: chore(ci): use beat_version instead of PR version (#24446)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -429,13 +429,11 @@ def triggerE2ETests(String suite) {
     booleanParam(name: 'notifyOnGreenBuilds', value: !isPR()),
     booleanParam(name: 'BEATS_USE_CI_SNAPSHOTS', value: true),
     string(name: 'runTestsSuites', value: suite),
+    string(name: 'BEAT_VERSION', value: env.BEAT_VERSION),
     string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_E2E_TESTS_NAME),
     string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
     string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT),
   ]
-  if (isPR()) {
-    parameters.push(string(name: 'BEAT_VERSION', value: "pr-${env.CHANGE_ID}"))
-  }
 
   build(job: "${e2eTestsPipeline}",
     parameters: parameters,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - chore(ci): use beat_version instead of PR version (#24446)