### PR TITLE
[Auditbeat] btmp offset check

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -262,6 +262,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/socket: Having some CPUs unavailable to Auditbeat could cause startup errors or event loss. {pull}22827[22827]
 - Note incompatibility of system/socket on ARM. {pull}23381[23381]
 - system/login: Fixed offset reset on inode reuse. {pull}24414[24414]
+- system/login: Add additional offset check for utmp files. {pull}24515[24515]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/login/utmp.go
+++ b/x-pack/auditbeat/module/system/login/utmp.go
@@ -221,7 +221,7 @@ func (r *UtmpFileReader) readNewInFile(loginRecordC chan<- LoginRecord, errorC c
 
 		// This will be the usual case, but we do not want to seek with the stored offset
 		// if the saved size is smaller than the current one.
-		if size >= oldSize {
+		if size >= oldSize && utmpFile.Offset <= size {
 			_, err = f.Seek(utmpFile.Offset, 0)
 			if err != nil {
 				errorC <- errors.Wrapf(err, "error setting offset %d for file %v", utmpFile.Offset, utmpFile.Path)
@@ -230,7 +230,7 @@ func (r *UtmpFileReader) readNewInFile(loginRecordC chan<- LoginRecord, errorC c
 
 		// If the saved size is smaller than the current one, or the previous Seek failed,
 		// we retry one more time, this time resetting to the beginning of the file.
-		if size < oldSize || err != nil {
+		if size < oldSize || utmpFile.Offset > size || err != nil {
 			_, err = f.Seek(0, 0)
 			if err != nil {
 				errorC <- errors.Wrapf(err, "error setting offset 0 for file %v", utmpFile.Path)

--- a/x-pack/auditbeat/module/system/login/utmp.go
+++ b/x-pack/auditbeat/module/system/login/utmp.go
@@ -181,14 +181,14 @@ func (r *UtmpFileReader) readNewInFile(loginRecordC chan<- LoginRecord, errorC c
 
 	size := utmpFile.Size
 	oldSize := savedUtmpFile.Size
-	if size < oldSize {
+	if size < oldSize || utmpFile.Offset > size {
 		// UTMP files are append-only and so this is weird. It might be a sign of
 		// a highly unlikely inode reuse - or of something more nefarious.
 		// Setting isKnownFile to false so we read the whole file from the beginning.
 		isKnownFile = false
 
-		r.log.Warnf("Unexpectedly, the file %v is smaller than before (new: %v, old: %v) - reading whole file.",
-			utmpFile.Path, size, oldSize)
+		r.log.Warnf("saved size or offset illogical (new=%+v, saved=%+v) - reading whole file.",
+			utmpFile, savedUtmpFile)
 	}
 
 	if !isKnownFile && size == 0 {


### PR DESCRIPTION
## What does this PR do?

Adds check that saved offset is not larger than the current file size.

## Why is it important?

This prevents seeking past the end of the file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Relates #24414


## Logs

Bug report contained logs like:

```
  2021-03-01T10:58:05.161+0100	DEBUG	[login]	login/utmp.go:204	Reading file /var/log/btmp (utmpFile={Inode:1704287 Path:/var/log/btmp Size:1536 Offset:10752 Type:1})
```