### PR TITLE
Cherry-pick #24489 to 7.x: [Elastic Agent] Add verification check when updating communication to Kibana.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -43,6 +43,7 @@
 - Fix bad substitution of API key. {pull}24036[24036]
 - Fix docker enrollment issue related to Fleet Server change. {pull}24155[24155]
 - Improve log on failure of Endpoint Security installation. {pull}24429[24429]
+- Verify communication to Kibana before updating Fleet client. {pull}24489[24489]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/fleet_gateway.go
+++ b/x-pack/elastic-agent/pkg/agent/application/fleet_gateway.go
@@ -186,14 +186,20 @@ func (f *fleetGateway) worker() {
 				actions[idx] = a
 			}
 
+			var errMsg string
 			if err := f.dispatcher.Dispatch(f.acker, actions...); err != nil {
-				msg := fmt.Sprintf("failed to dispatch actions, error: %s", err)
-				f.log.Error(msg)
-				f.statusReporter.Update(state.Degraded, msg)
+				errMsg = fmt.Sprintf("failed to dispatch actions, error: %s", err)
+				f.log.Error(errMsg)
+				f.statusReporter.Update(state.Failed, errMsg)
 			}
 
 			f.log.Debugf("FleetGateway is sleeping, next update in %s", f.settings.Duration)
-			f.statusReporter.Update(state.Healthy, "")
+			if errMsg != "" {
+				f.statusReporter.Update(state.Failed, errMsg)
+			} else {
+				f.statusReporter.Update(state.Healthy, "")
+			}
+
 		case <-f.bgContext.Done():
 			f.stop()
 			return

--- a/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_change.go
+++ b/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_change.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"time"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 
@@ -22,6 +23,10 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/kibana"
+)
+
+const (
+	apiStatusTimeout = 15 * time.Second
 )
 
 type clientSetter interface {
@@ -50,7 +55,7 @@ func (h *handlerPolicyChange) Handle(ctx context.Context, a action, acker fleetA
 	}
 
 	h.log.Debugf("handlerPolicyChange: emit configuration for action %+v", a)
-	err = h.handleKibanaHosts(c)
+	err = h.handleKibanaHosts(ctx, c)
 	if err != nil {
 		return err
 	}
@@ -61,7 +66,7 @@ func (h *handlerPolicyChange) Handle(ctx context.Context, a action, acker fleetA
 	return acker.Ack(ctx, action)
 }
 
-func (h *handlerPolicyChange) handleKibanaHosts(c *config.Config) (err error) {
+func (h *handlerPolicyChange) handleKibanaHosts(ctx context.Context, c *config.Config) (err error) {
 	// do not update kibana host from policy; no setters provided with local Fleet Server
 	if len(h.setters) == 0 {
 		return nil
@@ -97,6 +102,14 @@ func (h *handlerPolicyChange) handleKibanaHosts(c *config.Config) (err error) {
 	if err != nil {
 		return errors.New(
 			err, "fail to create API client with updated hosts",
+			errors.TypeNetwork, errors.M("hosts", h.config.Fleet.Kibana.Hosts))
+	}
+	ctx, cancel := context.WithTimeout(ctx, apiStatusTimeout)
+	defer cancel()
+	_, err = client.Send(ctx, "GET", "/api/status", nil, nil, nil)
+	if err != nil {
+		return errors.New(
+			err, "fail to communicate with updated API client hosts",
 			errors.TypeNetwork, errors.M("hosts", h.config.Fleet.Kibana.Hosts))
 	}
 	reader, err := fleetToReader(h.agentInfo, h.config)


### PR DESCRIPTION
Cherry-pick of PR #24489 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a verification check when updating how the Elastic Agent communicates with Kibana. Ensures that the Elastic Agent reports Failed when an error occurs dispatching action.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently if the user has the global Kibana connection information wrong in the policies Elastic Agent will update the client and then fail to checkin. This ensures that before updating to a new client that the new client can actually communicate with Kibana. In the case that it cannot communicate it updates the Elastic Agent as failed and reports back to the original client that the action of updating the policy failed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24485
