### PR TITLE
Cherry-pick to 7.x: Fix typo in mqtt input docs (#24509)

### DIFF
--- a/filebeat/docs/inputs/input-mqtt.asciidoc
+++ b/filebeat/docs/inputs/input-mqtt.asciidoc
@@ -29,7 +29,7 @@ Example configuration:
 
 <1> `hosts` are required.
 
-<2> `paths` are required.
+<2> `topics` are required.
 
 All other settings are optional.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix typo in mqtt input docs (#24509)