### PR TITLE
Cherry-pick to 7.11: Update input-http-endpoint.asciidoc (#24490)

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -101,7 +101,7 @@ If `basic_auth` is enabled, this is the username used for authentication against
 [float]
 ==== `password`
 
-If `basic_auth` is eanbled, this is the password used for authentication against the HTTP listener. Requires `username` to also be set.
+If `basic_auth` is enabled, this is the password used for authentication against the HTTP listener. Requires `username` to also be set.
 
 [float]
 ==== `secret.header`
@@ -117,7 +117,7 @@ The secret stored in the header name specified by `secret.header`. Certain webho
 ==== `content_type`
 
 By default the input expects the incoming POST to include a Content-Type of `application/json` to try to enforce the incoming data to be valid JSON.
-In certain scenarios when the source of the request is not able to do that, it can be overwritten with another value or set to null
+In certain scenarios when the source of the request is not able to do that, it can be overwritten with another value or set to null.
 
 [float]
 ==== `response_code`


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Update input-http-endpoint.asciidoc (#24490)