### PR TITLE
fix processors/script documentation

### DIFF
--- a/libbeat/processors/script/docs/script.asciidoc
+++ b/libbeat/processors/script/docs/script.asciidoc
@@ -70,6 +70,7 @@ function process(event) {
     if (event.Get("event.code") === 1102) {
         event.Put("event.action", "cleared");
     }
+    return event;
 }
 
 function test() {


### PR DESCRIPTION
process() should return event object, otherwise test() fails with "failed in test() function: TypeError: Cannot read property 'Get' of undefined at test"

## What does this PR do?

Fixes mistake in test example of script processor documentation

## Why is it important?

The provided example isn't valid

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Logs

```
Mar 12 19:02:46 localhost filebeat: 2021-03-12T19:02:46.862+0100#011INFO#011instance/beat.go:386#011filebeat stopped.
Mar 12 19:02:46 localhost filebeat: 2021-03-12T19:02:46.862+0100#011ERROR#011instance/beat.go:971#011Exiting: error initializing processors: failed in processor.javascript: failed in test() function: TypeError: Cannot read property 'Get' of undefined at test (inline.js:9:9(19))
Mar 12 19:02:46 localhost filebeat: Exiting: error initializing processors: failed in processor.javascript: failed in test() function: TypeError: Cannot read property 'Get' of undefined at test (inline.js:9:9(19))
Mar 12 19:02:46 localhost systemd: filebeat.service: main process exited, code=exited, status=1/FAILURE
Mar 12 19:02:46 localhost systemd: Unit filebeat.service entered failed state.
```