### PR TITLE
[Ingest Manager] Move logging defaults to agent

### DIFF
--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -62,8 +62,7 @@ const defaultLevel = InfoLevel
 // Beat is supposed to be run within.
 func DefaultConfig(environment Environment) Config {
 	return Config{
-		Level:   defaultLevel,
-		ToFiles: true,
+		Level: defaultLevel,
 		Files: FileConfig{
 			MaxSize:         10 * 1024 * 1024,
 			MaxBackups:      7,

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -55,17 +55,19 @@ func new(name string, cfg *Config) (*Logger, error) {
 		return nil, err
 	}
 
+	var outputs []zapcore.Core
 	if cfg.ToFiles {
 		internal, err := makeInternalFileOutput(cfg)
 		if err != nil {
 			return nil, err
 		}
 
-		if err := configure.LoggingWithOutputs("", commonCfg, internal); err != nil {
-			return nil, fmt.Errorf("error initializing logging: %v", err)
-		}
+		outputs = append(outputs, internal)
 	}
 
+	if err := configure.LoggingWithOutputs("", commonCfg, outputs...); err != nil {
+		return nil, fmt.Errorf("error initializing logging: %v", err)
+	}
 	return logp.NewLogger(name), nil
 }
 

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -92,6 +92,7 @@ func DefaultLoggingConfig() *Config {
 	cfg := logp.DefaultConfig(logp.DefaultEnvironment)
 	cfg.Beat = agentName
 	cfg.Level = logp.InfoLevel
+	cfg.ToFiles = true
 	cfg.Files.Path = paths.Logs()
 	cfg.Files.Name = fmt.Sprintf("%s.log", agentName)
 


### PR DESCRIPTION
## What does this PR do?

In #24466 i introduced default in libbeat and this PR moves it to agent so other beats are not affected by agent requirements. 

## Why is it important?

Separation

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
