### PR TITLE
[Metricbeat] Add an example to MySQL Query docs

### DIFF
--- a/metricbeat/module/mysql/query/_meta/docs.asciidoc
+++ b/metricbeat/module/mysql/query/_meta/docs.asciidoc
@@ -1,1 +1,25 @@
 `query` metricset allows for custom execution of metric related queries in MySQL
+
+
+[source,yaml]
+----
+- module: mysql
+  metricsets:
+    - query
+  period: 10s
+  namespace: "my_namespace"
+  queries:
+    - query: "SELECT * FROM performance_schema.global_status"
+      response_format: "variables"
+      query_namespace: "my_first_query_namespace"
+    - query: "SELECT * FROM mysql.innodb_table_stats"
+      response_format: "table"
+      query_namespace: "my_second_query_namespace"
+
+  # Host DSN should be defined as "user:pass@tcp(127.0.0.1:3306)/"
+  # or "unix(/var/lib/mysql/mysql.sock)/",
+  # or another DSN format supported by <https://github.com/Go-SQL-Driver/MySQL/>.
+  # The username and password can either be set in the DSN or using the username
+  # and password config options. Those specified in the DSN take precedence.
+  hosts: ["root:root@tcp(172.17.0.2:3306)/"]
+----


### PR DESCRIPTION
## What does this PR do?

The MySQL query metricset doesn't have documentation. It's simple to use but the user needs to know which options are available and how to use them. `sql` module provides some examples but the syntax is slightly different