### PR TITLE
[CI] Add resilience when installing required tooling

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -20,6 +20,7 @@ IF EXIST "%PROGRAMFILES(X86)%" (
     curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.4/gvm-windows-amd64.exe
     IF ERRORLEVEL 1 (
         REM gvm installation has failed.
+        del bin\gvm.exe /s /f /q
         exit /b 1
     )
 ) ELSE (
@@ -27,6 +28,7 @@ IF EXIST "%PROGRAMFILES(X86)%" (
     curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.2.4/gvm-windows-386.exe
     IF ERRORLEVEL 1 (
         REM gvm installation has failed.
+        del bin\gvm.exe /s /f /q
         exit /b 1
     )
 )
@@ -34,6 +36,11 @@ IF EXIST "%PROGRAMFILES(X86)%" (
 SET GVM_BIN=gvm.exe
 WHERE /q %GVM_BIN%
 %GVM_BIN% version
+IF ERRORLEVEL 1 (
+    REM gvm is not configured correctly.
+    rmdir %WORKSPACE%\.gvm /s /q
+    exit /b 1
+)
 
 REM Install the given go version
 %GVM_BIN% --debug install %GO_VERSION%
@@ -44,6 +51,7 @@ FOR /f "tokens=*" %%i IN ('"%GVM_BIN%" use %GO_VERSION% --format=batch') DO %%i
 go env
 IF ERRORLEVEL 1 (
     REM go is not configured correctly.
+    rmdir %WORKSPACE%\.gvm /s /q
     exit /b 1
 )
 

--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -36,11 +36,6 @@ IF EXIST "%PROGRAMFILES(X86)%" (
 SET GVM_BIN=gvm.exe
 WHERE /q %GVM_BIN%
 %GVM_BIN% version
-IF ERRORLEVEL 1 (
-    REM gvm is not configured correctly.
-    rmdir %WORKSPACE%\.gvm /s /q
-    exit /b 1
-)
 
 REM Install the given go version
 %GVM_BIN% --debug install %GO_VERSION%

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -665,7 +665,7 @@ def installTools(args) {
         git config --global user.name "beatsmachine"
       fi''')
   } else {
-    retryWithSleep(retries: 2, seconds: 5, backoff: true){ bat(label: "${stepHeader} - Install Go/Mage/Python ${GO_VERSION}", script: ".ci/scripts/install-tools.bat") }
+    retryWithSleep(retries: 3, seconds: 5, backoff: true){ bat(label: "${stepHeader} - Install Go/Mage/Python ${GO_VERSION}", script: ".ci/scripts/install-tools.bat") }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Add more resilience when installing the required tooling with the retry and the context for Windows

## Why is it important?

Reduce environmental build failures

For instance

first retry failed with 

![image](https://user-images.githubusercontent.com/2871786/111173217-5f972500-859e-11eb-8385-310550756ae1.png)


And then 

![image](https://user-images.githubusercontent.com/2871786/111173274-6d4caa80-859e-11eb-94ab-5daf2bffee76.png)
