### PR TITLE
Clarify that the Tomcat module is for ingesting access logs

### DIFF
--- a/filebeat/docs/modules/tomcat.asciidoc
+++ b/filebeat/docs/modules/tomcat.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
-This is a module for receiving Apache Tomcat logs over Syslog or a file.
+This is a module for receiving Apache Tomcat access logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]
 

--- a/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
@@ -7,7 +7,7 @@
 
 experimental[]
 
-This is a module for receiving Apache Tomcat logs over Syslog or a file.
+This is a module for receiving Apache Tomcat access logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]
 


### PR DESCRIPTION
i.e. not for catalina logs or localhost logs.

Ref: https://elastic.slack.com/archives/C0D8SUKB2/p1615818929152600
```

Andy Hunt  26 minutes ago
Hello Beats people - Would someone please be able to confirm my thinking that the Tomcat module is intended to parse *access* logs, and not the catalina logs? My tests seem to confirm this - if someone agrees, I'll raise a docs PR to clarify this (edited) 

Kaiyan Sheng:china:  6 minutes ago
@asr might know the answer :slightly_smiling_face:

Adrian Serrano  2 minutes ago
yes @andyh, looks like access logs only

Andy Hunt  < 1 minute ago
Thanks Adrian!
```