### PR TITLE
Cherry-pick to 7.12: Clarify that the Tomcat module is for ingesting access logs (#24543)

### DIFF
--- a/filebeat/docs/modules/tomcat.asciidoc
+++ b/filebeat/docs/modules/tomcat.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
-This is a module for receiving Apache Tomcat logs over Syslog or a file.
+This is a module for receiving Apache Tomcat access logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]
 

--- a/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
@@ -7,7 +7,7 @@
 
 experimental[]
 
-This is a module for receiving Apache Tomcat logs over Syslog or a file.
+This is a module for receiving Apache Tomcat access logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Clarify that the Tomcat module is for ingesting access logs (#24543)