### PR TITLE
elastic-agent: add elastic cloud support to docker image

### DIFF
--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -326,6 +326,9 @@ func Package() {
 
 func requiredPackagesPresent(basePath, beat, version string, requiredPackages []string) bool {
 	for _, pkg := range requiredPackages {
+		if _, ok := os.LookupEnv(snapshotEnv); ok {
+			version += "-SNAPSHOT"
+		}
 		packageName := fmt.Sprintf("%s-%s-%s", beat, version, pkg)
 		path := filepath.Join(basePath, "build", "distributions", packageName)
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -679,9 +679,8 @@ func defaultAccessConfig() setupConfig {
 				// Remove FLEET_SETUP in 8.x
 				// The FLEET_SETUP environment variable boolean is a fallback to the old name. The name was updated to
 				// reflect that its setting up Fleet in Kibana versus setting up Fleet Server.
-				Setup: envBool("KIBANA_FLEET_SETUP", "FLEET_SETUP"),
-				Host:  envWithDefault("http://kibana:5601", "KIBANA_FLEET_HOST", "KIBANA_HOST"),
-				//TODO(simitt): check why ELASTICSEARCH values are used here?
+				Setup:    envBool("KIBANA_FLEET_SETUP", "FLEET_SETUP"),
+				Host:     envWithDefault("http://kibana:5601", "KIBANA_FLEET_HOST", "KIBANA_HOST"),
 				Username: envWithDefault("elastic", "KIBANA_FLEET_USERNAME", "KIBANA_USERNAME", "ELASTICSEARCH_USERNAME"),
 				Password: envWithDefault("changeme", "KIBANA_FLEET_PASSWORD", "KIBANA_PASSWORD", "ELASTICSEARCH_PASSWORD"),
 				CA:       envWithDefault("", "KIBANA_FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA"),

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -6,12 +6,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -20,19 +22,21 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/kibana"
+	"github.com/elastic/beats/v7/libbeat/logp"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/program"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/install/tar"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
 const (
-	defaultKibanaHost = "http://kibana:5601"
-	defaultESHost     = "http://elasticsearch:9200"
-	defaultUsername   = "elastic"
-	defaultPassword   = "changeme"
-	defaultTokenName  = "Default"
-
 	requestRetrySleep = 1 * time.Second // sleep 1 sec between retries for HTTP requests
 	maxRequestRetries = 30              // maximum number of retries for HTTP requests
 )
@@ -44,7 +48,7 @@ var (
 )
 
 func newContainerCommand(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
-	return &cobra.Command{
+	cmd := cobra.Command{
 		Hidden: true, // not exposed over help; used by container entrypoint only
 		Use:    "container",
 		Short:  "Bootstrap Elastic Agent to run inside of a container",
@@ -112,15 +116,50 @@ all the above actions will be skipped, because the Elastic Agent has already bee
 occurs on every start of the container set FLEET_FORCE to 1.
 `,
 		Run: func(c *cobra.Command, args []string) {
-			if err := containerCmd(streams, c, flags, args); err != nil {
+			iscloud, err := c.Flags().GetBool("cloud")
+			if err != nil {
+				fmt.Fprintf(streams.Err, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			if iscloud {
+				err = containerCloudCmd(streams, c, flags, args)
+			} else {
+				err = containerCmd(streams, c, flags, defaultAccessConfig())
+			}
+			if err != nil {
 				fmt.Fprintf(streams.Err, "Error: %v\n", err)
 				os.Exit(1)
 			}
 		},
 	}
+	cmd.Flags().Bool("cloud", false, "Start container in cloud mode")
+	return &cmd
 }
 
-func containerCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+func containerCloudCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+	log, err := logger.New("bootstrap")
+	if err != nil {
+		return err
+	}
+	log.Info("Starting Elastic Agent container in cloud mode")
+	// run legacy APM Server if APM_SERVER_PATH is given
+	if apmPath := os.Getenv("APM_SERVER_PATH"); apmPath != "" {
+		if err := runLegacyAPMServer(log, apmPath, args); err != nil {
+			return err
+		}
+	}
+	// setup and start Fleet Server respecting configuration files
+	cfg := defaultAccessConfig()
+	if err := readYaml(filepath.Join(paths.Config(), "fleet-setup.yml"), &cfg); err != nil {
+		return errors.New(err, "parsing fleet-setup.yml")
+	}
+	if err := readYaml(filepath.Join(paths.Config(), "credentials.yml"), &cfg); err != nil {
+		return errors.New(err, "parsing credentials.yml")
+	}
+	return containerCmd(streams, cmd, flags, cfg)
+}
+
+func containerCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, cfg setupConfig) error {
 	var err error
 	var client *kibana.Client
 	executable, err := os.Executable()
@@ -129,16 +168,13 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags
 	}
 
 	_, err = os.Stat(paths.AgentConfigFile())
-	if !os.IsNotExist(err) && !envBool("FLEET_FORCE") {
+	if !os.IsNotExist(err) && !cfg.Fleet.Force {
 		// already enrolled, just run the standard run
 		return run(flags, streams)
 	}
 
-	// Remove FLEET_SETUP in 8.x
-	// The FLEET_SETUP environment variable boolean is a fallback to the old name. The name was updated to
-	// reflect that its setting up Fleet in Kibana versus setting up Fleet Server.
-	if envBool("KIBANA_FLEET_SETUP", "FLEET_SETUP") {
-		client, err = kibanaClient()
+	if cfg.Kibana.Fleet.Setup {
+		client, err = kibanaClient(cfg.Kibana)
 		if err != nil {
 			return err
 		}
@@ -148,21 +184,21 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags
 			return err
 		}
 	}
-	if envBool("FLEET_ENROLL", "FLEET_SERVER_ENABLE") {
+	if cfg.Fleet.Enroll {
 		if client == nil {
-			client, err = kibanaClient()
+			client, err = kibanaClient(cfg.Kibana)
 			if err != nil {
 				return err
 			}
 		}
 		var policy *kibanaPolicy
-		token := envWithDefault("", "FLEET_ENROLLMENT_TOKEN")
+		token := cfg.Fleet.EnrollmentToken
 		if token == "" {
-			policy, err = kibanaFetchPolicy(client, streams)
+			policy, err = kibanaFetchPolicy(client, cfg, streams)
 			if err != nil {
 				return err
 			}
-			token, err = kibanaFetchToken(client, policy, streams)
+			token, err = kibanaFetchToken(client, policy, streams, cfg.Fleet.TokenName)
 			if err != nil {
 				return err
 			}
@@ -171,7 +207,7 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags
 		if policy != nil {
 			policyID = policy.ID
 		}
-		cmdArgs, err := buildEnrollArgs(token, policyID)
+		cmdArgs, err := buildEnrollArgs(cfg, token, policyID)
 		if err != nil {
 			return err
 		}
@@ -191,67 +227,57 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags
 	return run(flags, streams)
 }
 
-func buildEnrollArgs(token string, policyID string) ([]string, error) {
+func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, error) {
 	args := []string{"enroll", "-f"}
-	if envBool("FLEET_SERVER_ENABLE") {
-		connStr, err := buildFleetServerConnStr()
+	if cfg.FleetServer.Enable {
+		connStr, err := buildFleetServerConnStr(cfg.FleetServer)
 		if err != nil {
 			return nil, err
 		}
 		args = append(args, "--fleet-server", connStr)
 		if policyID == "" {
-			policyID = envWithDefault("", "FLEET_SERVER_POLICY_ID")
+			policyID = cfg.FleetServer.PolicyID
 		}
 		if policyID != "" {
 			args = append(args, "--fleet-server-policy", policyID)
 		}
-		ca := envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA", "ELASTICSEARCH_CA")
-		if ca != "" {
-			args = append(args, "--fleet-server-elasticsearch-ca", ca)
+		if cfg.FleetServer.Elasticsearch.CA != "" {
+			args = append(args, "--fleet-server-elasticsearch-ca", cfg.FleetServer.Elasticsearch.CA)
 		}
-		host := envWithDefault("", "FLEET_SERVER_HOST")
-		if host != "" {
-			args = append(args, "--fleet-server-host", host)
+		if cfg.FleetServer.Host != "" {
+			args = append(args, "--fleet-server-host", cfg.FleetServer.Host)
 		}
-		port := envWithDefault("", "FLEET_SERVER_PORT")
-		if port != "" {
-			args = append(args, "--fleet-server-port", port)
+		if cfg.FleetServer.Port != "" {
+			args = append(args, "--fleet-server-port", cfg.FleetServer.Port)
 		}
-		cert := envWithDefault("", "FLEET_SERVER_CERT")
-		if cert != "" {
-			args = append(args, "--fleet-server-cert", cert)
+		if cfg.FleetServer.Cert != "" {
+			args = append(args, "--fleet-server-cert", cfg.FleetServer.Cert)
 		}
-		certKey := envWithDefault("", "FLEET_SERVER_CERT_KEY")
-		if certKey != "" {
-			args = append(args, "--fleet-server-cert-key", certKey)
+		if cfg.FleetServer.CertKey != "" {
+			args = append(args, "--fleet-server-cert-key", cfg.FleetServer.CertKey)
 		}
-		if envBool("FLEET_SERVER_INSECURE_HTTP") {
+		if cfg.FleetServer.InsecureHTTP {
 			args = append(args, "--fleet-server-insecure-http")
 			args = append(args, "--insecure")
 		}
 	} else {
-		url := envWithDefault("", "FLEET_URL")
-		if url == "" {
+		if cfg.Fleet.URL == "" {
 			return nil, errors.New("FLEET_URL is required when FLEET_ENROLL is true without FLEET_SERVER_ENABLE")
 		}
-		args = append(args, "--url", url)
-		if envBool("FLEET_INSECURE") {
+		args = append(args, "--url", cfg.Fleet.URL)
+		if cfg.Fleet.Insecure {
 			args = append(args, "--insecure")
 		}
-		ca := envWithDefault("", "FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA")
-		if ca != "" {
-			args = append(args, "--certificate-authorities", ca)
+		if cfg.Fleet.CA != "" {
+			args = append(args, "--certificate-authorities", cfg.Fleet.CA)
 		}
 	}
 	args = append(args, "--enrollment-token", token)
 	return args, nil
 }
 
-func buildFleetServerConnStr() (string, error) {
-	host := envWithDefault(defaultESHost, "FLEET_SERVER_ELASTICSEARCH_HOST", "ELASTICSEARCH_HOST")
-	username := envWithDefault(defaultUsername, "FLEET_SERVER_ELASTICSEARCH_USERNAME", "ELASTICSEARCH_USERNAME")
-	password := envWithDefault(defaultPassword, "FLEET_SERVER_ELASTICSEARCH_PASSWORD", "ELASTICSEARCH_PASSWORD")
-	u, err := url.Parse(host)
+func buildFleetServerConnStr(cfg fleetServerConfig) (string, error) {
+	u, err := url.Parse(cfg.Elasticsearch.Host)
 	if err != nil {
 		return "", err
 	}
@@ -259,7 +285,7 @@ func buildFleetServerConnStr() (string, error) {
 	if u.Path != "" {
 		path += "/" + strings.TrimLeft(u.Path, "/")
 	}
-	return fmt.Sprintf("%s://%s:%s@%s%s", u.Scheme, username, password, u.Host, path), nil
+	return fmt.Sprintf("%s://%s:%s@%s%s", u.Scheme, cfg.Elasticsearch.Username, cfg.Elasticsearch.Password, u.Host, path), nil
 }
 
 func kibanaSetup(client *kibana.Client, streams *cli.IOStreams) error {
@@ -274,22 +300,22 @@ func kibanaSetup(client *kibana.Client, streams *cli.IOStreams) error {
 	return nil
 }
 
-func kibanaFetchPolicy(client *kibana.Client, streams *cli.IOStreams) (*kibanaPolicy, error) {
+func kibanaFetchPolicy(client *kibana.Client, cfg setupConfig, streams *cli.IOStreams) (*kibanaPolicy, error) {
 	var policies kibanaPolicies
 	err := performGET(client, "/api/fleet/agent_policies", &policies, streams.Err, "Kibana fetch policy")
 	if err != nil {
 		return nil, err
 	}
-	return findPolicy(policies.Items)
+	return findPolicy(cfg, policies.Items)
 }
 
-func kibanaFetchToken(client *kibana.Client, policy *kibanaPolicy, streams *cli.IOStreams) (string, error) {
+func kibanaFetchToken(client *kibana.Client, policy *kibanaPolicy, streams *cli.IOStreams, tokenName string) (string, error) {
 	var keys kibanaAPIKeys
 	err := performGET(client, "/api/fleet/enrollment-api-keys", &keys, streams.Err, "Kibana fetch token")
 	if err != nil {
 		return "", err
 	}
-	key, err := findKey(keys.List, policy)
+	key, err := findKey(keys.List, policy, tokenName)
 	if err != nil {
 		return "", err
 	}
@@ -301,32 +327,26 @@ func kibanaFetchToken(client *kibana.Client, policy *kibanaPolicy, streams *cli.
 	return keyDetail.Item.APIKey, nil
 }
 
-func kibanaClient() (*kibana.Client, error) {
-	host := envWithDefault(defaultKibanaHost, "KIBANA_FLEET_HOST", "KIBANA_HOST")
-	username := envWithDefault(defaultUsername, "KIBANA_FLEET_USERNAME", "KIBANA_USERNAME", "ELASTICSEARCH_USERNAME")
-	password := envWithDefault(defaultPassword, "KIBANA_FLEET_PASSWORD", "KIBANA_PASSWORD", "ELASTICSEARCH_PASSWORD")
-
+func kibanaClient(cfg kibanaConfig) (*kibana.Client, error) {
 	var tls *tlscommon.Config
-	ca := envWithDefault("", "KIBANA_FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA")
-	if ca != "" {
+	if cfg.Fleet.CA != "" {
 		tls = &tlscommon.Config{
-			CAs: []string{ca},
+			CAs: []string{cfg.Fleet.CA},
 		}
 	}
 	return kibana.NewClientWithConfig(&kibana.ClientConfig{
-		Host:          host,
-		Username:      username,
-		Password:      password,
+		Host:          cfg.Fleet.Host,
+		Username:      cfg.Fleet.Username,
+		Password:      cfg.Fleet.Password,
 		IgnoreVersion: true,
 		TLS:           tls,
 	})
 }
 
-func findPolicy(policies []kibanaPolicy) (*kibanaPolicy, error) {
-	fleetServerEnabled := envBool("FLEET_SERVER_ENABLE")
-	policyName := envWithDefault("", "FLEET_TOKEN_POLICY_NAME")
-	if fleetServerEnabled {
-		policyName = envWithDefault("", "FLEET_SERVER_POLICY_NAME", "FLEET_TOKEN_POLICY_NAME")
+func findPolicy(cfg setupConfig, policies []kibanaPolicy) (*kibanaPolicy, error) {
+	policyName := cfg.Fleet.TokenPolicyName
+	if cfg.FleetServer.Enable {
+		policyName = cfg.FleetServer.PolicyName
 	}
 	for _, policy := range policies {
 		if policy.Status != "active" {
@@ -336,7 +356,7 @@ func findPolicy(policies []kibanaPolicy) (*kibanaPolicy, error) {
 			if policyName == policy.Name {
 				return &policy, nil
 			}
-		} else if fleetServerEnabled {
+		} else if cfg.FleetServer.Enable {
 			if policy.IsDefaultFleetServer {
 				return &policy, nil
 			}
@@ -349,8 +369,7 @@ func findPolicy(policies []kibanaPolicy) (*kibanaPolicy, error) {
 	return nil, fmt.Errorf(`unable to find policy named "%s"`, policyName)
 }
 
-func findKey(keys []kibanaAPIKey, policy *kibanaPolicy) (*kibanaAPIKey, error) {
-	tokenName := envWithDefault(defaultTokenName, "FLEET_TOKEN_NAME")
+func findKey(keys []kibanaAPIKey, policy *kibanaPolicy, tokenName string) (*kibanaAPIKey, error) {
 	for _, key := range keys {
 		name := strings.TrimSpace(tokenNameStrip.ReplaceAllString(key.Name, ""))
 		if name == tokenName && key.PolicyID == policy.ID {
@@ -437,6 +456,78 @@ func truncateString(b []byte) string {
 	return strings.Replace(string(runes), "\n", " ", -1)
 }
 
+//runLegacyAPMServer by extracting bundled apm-server from elastic-agent
+//and passing on args
+func runLegacyAPMServer(log *logp.Logger, path string, args []string) error {
+	name := "apm-server"
+	log.Info("Preparing apm-server for legacy mode.")
+	log.Infof("Extracting apm-server into install directory %s.", path)
+	cfg := artifact.DefaultConfig()
+
+	installer, err := tar.NewInstaller(cfg)
+	if err != nil {
+		return errors.New(err, "creating installer")
+	}
+	spec := program.Spec{Name: name, Cmd: name, Artifact: name}
+	version := release.Version()
+	if release.Snapshot() {
+		version = fmt.Sprintf("%s-SNAPSHOT", version)
+	}
+	// Extract the bundled apm-server binary into the APM_SERVER_PATH
+	if err := installer.Install(context.Background(), spec, version, path); err != nil {
+		return errors.New(err,
+			fmt.Sprintf("installing %s (%s) from %s to %s", spec.Name, version, cfg.TargetDirectory, path))
+	}
+
+	// Start apm-server process respecting args
+	log.Info("Starting legacy apm-server daemon as a subprocess..")
+	pattern := filepath.Join(path, fmt.Sprintf("%s-%s-%s*", spec.Cmd, version, cfg.OS()), spec.Cmd)
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return errors.New(err, fmt.Sprintf("searching apm-server in %s", pattern))
+	}
+	if len(files) != 1 {
+		return errors.New("multiple apm-server versions installed")
+	}
+	f, err := filepath.Abs(files[0])
+	if err != nil {
+		return errors.New(err, fmt.Sprintf("absPath for %s", files[0]))
+	}
+	proc, err := process.Start(log, f, nil, os.Geteuid(), os.Getegid(), args...)
+	if err != nil {
+		return err
+	}
+	log.Info("Legacy apm-server daemon started...")
+
+	go func() {
+		st, err := proc.Process.Wait()
+		if err != nil {
+			log.Error(errors.New(err, "waiting for apm-server process"))
+		} else {
+			log.Warnf("Process apm-server exited with %d", st.ExitCode())
+		}
+		// sending kill signal to current process (elastic-agent)
+		p, err := os.FindProcess(os.Getpid())
+		if err != nil {
+			log.Error(errors.New(err, "finding elastic-agent process"))
+		}
+		p.Signal(os.Interrupt)
+		log.Info("Shutdown elastic-agent initiated..")
+	}()
+	return nil
+}
+
+func readYaml(f string, cfg *setupConfig) error {
+	c, err := config.LoadFile(f)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return c.Unpack(cfg)
+}
+
 type kibanaPolicy struct {
 	ID                   string `json:"id"`
 	Name                 string `json:"name"`
@@ -463,4 +554,98 @@ type kibanaAPIKeys struct {
 
 type kibanaAPIKeyDetail struct {
 	Item kibanaAPIKey `json:"item"`
+}
+
+// setup configuration
+
+type setupConfig struct {
+	Fleet       fleetConfig       `config:"fleet"`
+	FleetServer fleetServerConfig `config:"fleet_server"`
+	Kibana      kibanaConfig      `config:"kibana"`
+}
+
+type elasticsearchConfig struct {
+	CA       string `config:"ca"`
+	Host     string `config:"host"`
+	Username string `config:"username"`
+	Password string `config:"password"`
+}
+
+type fleetConfig struct {
+	CA              string `config:"ca"`
+	Enroll          bool   `config:"enroll"`
+	EnrollmentToken string `config:"enrollment_token"`
+	Force           bool   `config:"force"`
+	Insecure        bool   `config:"insecure"`
+	TokenName       string `config:"token_name"`
+	TokenPolicyName string `config:"token_policy_name"`
+	URL             string `config:"url"`
+}
+
+type fleetServerConfig struct {
+	Cert          string              `config:"cert"`
+	CertKey       string              `config:"certKey"`
+	Elasticsearch elasticsearchConfig `config:"elasticsearch"`
+	Enable        bool                `config:"enable"`
+	Host          string              `config:"host"`
+	InsecureHTTP  bool                `config:"insecure_http"`
+	PolicyID      string              `config:"policy_id"`
+	PolicyName    string              `config:"policy_name"`
+	Port          string              `config:"port"`
+}
+
+type kibanaConfig struct {
+	Fleet kibanaFleetConfig `config:"fleet"`
+}
+
+type kibanaFleetConfig struct {
+	CA       string `config:"ca"`
+	Host     string `config:"host"`
+	Password string `config:"password"`
+	Setup    bool   `config:"setup"`
+	Username string `config:"username"`
+}
+
+func defaultAccessConfig() setupConfig {
+	return setupConfig{
+		Fleet: fleetConfig{
+			CA:              envWithDefault("", "FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA"),
+			Enroll:          envBool("FLEET_ENROLL", "FLEET_SERVER_ENABLE"),
+			EnrollmentToken: envWithDefault("", "FLEET_ENROLLMENT_TOKEN"),
+			Force:           envBool("FLEET_FORCE"),
+			Insecure:        envBool("FLEET_INSECURE"),
+			TokenName:       envWithDefault("Default", "FLEET_TOKEN_NAME"),
+			TokenPolicyName: envWithDefault("", "FLEET_TOKEN_POLICY_NAME"),
+			URL:             envWithDefault("", "FLEET_URL"),
+		},
+		FleetServer: fleetServerConfig{
+			Cert:    envWithDefault("", "FLEET_SERVER_CERT"),
+			CertKey: envWithDefault("", "FLEET_SERVER_CERT_KEY"),
+			Elasticsearch: elasticsearchConfig{
+				Host:     envWithDefault("http://elasticsearch:9200", "FLEET_SERVER_ELASTICSEARCH_HOST", "ELASTICSEARCH_HOST"),
+				Username: envWithDefault("elastic", "FLEET_SERVER_ELASTICSEARCH_USERNAME", "ELASTICSEARCH_USERNAME"),
+				Password: envWithDefault("changeme", "FLEET_SERVER_ELASTICSEARCH_PASSWORD", "ELASTICSEARCH_PASSWORD"),
+				CA:       envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA", "ELASTICSEARCH_CA"),
+			},
+			Enable:       envBool("FLEET_SERVER_ENABLE"),
+			Host:         envWithDefault("", "FLEET_SERVER_HOST"),
+			InsecureHTTP: envBool("FLEET_SERVER_INSECURE_HTTP"),
+			PolicyID:     envWithDefault("", "FLEET_SERVER_POLICY_ID"),
+			PolicyName:   envWithDefault("", "FLEET_SERVER_POLICY_NAME", "FLEET_TOKEN_POLICY_NAME"),
+			Port:         envWithDefault("", "FLEET_SERVER_PORT"),
+		},
+		Kibana: kibanaConfig{
+			Fleet: kibanaFleetConfig{
+				// Remove FLEET_SETUP in 8.x
+				// The FLEET_SETUP environment variable boolean is a fallback to the old name. The name was updated to
+				// reflect that its setting up Fleet in Kibana versus setting up Fleet Server.
+				Setup: envBool("KIBANA_FLEET_SETUP", "FLEET_SETUP"),
+				Host:  envWithDefault("http://kibana:5601", "KIBANA_FLEET_HOST", "KIBANA_HOST"),
+				//TODO(simitt): check why ELASTICSEARCH values are used here?
+				Username: envWithDefault("elastic", "KIBANA_FLEET_USERNAME", "KIBANA_USERNAME", "ELASTICSEARCH_USERNAME"),
+				Password: envWithDefault("changeme", "KIBANA_FLEET_PASSWORD", "KIBANA_PASSWORD", "ELASTICSEARCH_PASSWORD"),
+				CA:       envWithDefault("", "KIBANA_FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA"),
+			},
+		},
+	}
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds support for running a legacy APM Server alongside the Elastic Agent:
* Start APM Server legacy if in legacy mode
* Reads additional config files for setup flags and merges them to default and ENV values before starting the Elastic Agent
* Terminate processes if one of them is terminated

Setting `container --cloud` as docker entry point initiates the cloud setup. 


The PR does not introduce any changes for the current `container` command, when the `cloud` flag is not passed in. 


## Why is it important?
The change is required for migrating current ECE/ESS APM sliders to new sliders, supporting the Elastic Agent with Fleet Server alongside the legacy APM Server.

## Checklist

- [ ] E2E tests will be living in the dedicated repo, see https://github.com/elastic/e2e-testing/issues/890

## Related issues

implements #23697
## Use cases

ECE/ESS deployments containing Elastic Agent and legacy APM Server binaries. 

## How to test this
(0) add `apm-server` to the [`packed_beats` in the x-pack/elastic-agent/magefile.go#L583-L589](https://github.com/simitt/beats/blob/fde90470c1778f410415e2cf9918139cd7231cbc/x-pack/elastic-agent/magefile.go#L583-L589) and adjust the location of where to find the apm-server repository. 
(1) change the docker entry point to call `container --cloud` 
(2) from `x-pack/elastic-agent` run: `DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 TYPES=docker mage package` 
(3) start the docker container with and without an `APM_SERVER_PATH` and observe that the APM Server should be installed to this path if given. Stop the `apm-server` or the `elastic-agent` process inside the container and observe that the other process is also terminated and the container is stopped. 