### PR TITLE
Cherry-pick #24559 to 7.x: Fix default scope in add_nomad_metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -253,6 +253,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Zoom module pipeline failed to ingest some chat_channel events. {pull}23904[23904]
 - Fix Netlow module issue with missing `internal_networks` config parameter. {issue}24094[24094] {pull}24110[24110]
 - in httpjson input using encode_as "application/x-www-form-urlencoded" now sets Content-Type correctly {issue}24331[24331] {pull}24336[24336]
+- Fix netflow module ignoring detect_sequence_reset flag. {issue}24268[24268] {pull}24270[24270]
+- Fix default `scope` in `add_nomad_metadata`. {issue}24559[24559]
 
 *Heartbeat*
 

--- a/x-pack/libbeat/autodiscover/providers/nomad/config.go
+++ b/x-pack/libbeat/autodiscover/providers/nomad/config.go
@@ -64,7 +64,7 @@ func (c *Config) Validate() error {
 	case ScopeNode:
 	case ScopeCluster:
 	default:
-		return fmt.Errorf("invalid value for `scope`, select `%s` or `%s`", ScopeNode, ScopeCluster)
+		return fmt.Errorf("invalid value for `scope`: %s, select `%s` or `%s`", c.Scope, ScopeNode, ScopeCluster)
 	}
 	return nil
 }

--- a/x-pack/libbeat/processors/add_nomad_metadata/config.go
+++ b/x-pack/libbeat/processors/add_nomad_metadata/config.go
@@ -40,7 +40,7 @@ func (c *nomadAnnotatorConfig) Validate() error {
 	case ScopeNode:
 	case ScopeCluster:
 	default:
-		return fmt.Errorf("invalid value for `scope`, select `local` or `global`")
+		return fmt.Errorf("invalid value for `scope`: %s, select `%s` or `%s`", c.Scope, ScopeNode, ScopeCluster)
 	}
 	return nil
 }
@@ -57,7 +57,7 @@ func defaultNomadAnnotatorConfig() nomadAnnotatorConfig {
 		Region:          "",
 		Namespace:       "",
 		SecretID:        "",
-		Scope:           "local",
+		Scope:           ScopeNode,
 		syncPeriod:      5 * time.Second,
 		CleanupTimeout:  60 * time.Second,
 		DefaultMatchers: Enabled{true},


### PR DESCRIPTION
Cherry-pick of PR #24559 to 7.x branch. Original message: 

## What does this PR do?

Fix default scope in `add_nomad_metadata`. It is set to `local`, but it should be `node`. Error message also shows that `local` is a valid value.

With default configuration this is logged:
```
2021-03-16T12:37:36.611+0100	ERROR	instance/beat.go:953	Exiting: error initializing processors: fail to unpack the nomad configuration: invalid value for `scope`, select `local` or `global` accessing 'processors.0.add_nomad_metadata'
```

## Why is it important?

Current default is invalid and error message is misleading.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Discovered in #24557.
- Related to #16853.