### PR TITLE
Add support for providing label selectors in kubernetes autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -22,6 +22,18 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Skip add_kubernetes_metadata processor when kubernetes metadata are already present {pull}27689[27689]
 - Remove deprecated/undocumented IncludeCreatorMetadata setting from kubernetes metadata config options {pull}28006[28006]
 - Remove deprecated fields from kubernetes module {pull}28046[28046]
+- Added `certificate` TLS verification mode to ignore server name mismatch. {issue}12283[12283] {pull}20293[20293]
+- Autodiscover doesn't generate any configuration when a variable is missing. Previously it generated an incomplete configuration. {pull}20898[20898]
+- Remove redundant `cloudfoundry.*.timestamp` fields. This value is set in `@timestamp`. {pull}21175[21175]
+- Allow embedding of CAs, Certificate of private keys for anything that support TLS in ouputs and inputs. {pull}21179[21179]
+- Update to Golang 1.12.1. {pull}11330[11330]
+- Disable Alibaba Cloud and Tencent Cloud metadata providers by default. {pull}13812[12812]
+- API address is a required setting in `add_cloudfoundry_metadata`. {pull}21759[21759]
+- Update to ECS 1.7.0. {pull}22571[22571]
+- Add support for SCRAM-SHA-512 and SCRAM-SHA-256 in Kafka output. {pull}12867[12867]
+- Use alias to report container image in k8s metadata. {pull}24380[24380]
+- Set `cleanup_timeout` to zero by default in docker and kubernetes autodiscover in all beats except Filebeat where it is kept to 60 seconds. {pull}24681[24681]
+- Add support for providing label selectors in kubernetes autodiscover {pull}24574[24574]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -34,13 +34,14 @@ import (
 // Config for kubernetes autodiscover provider
 type Config struct {
 	KubeConfig     string        `config:"kube_config"`
-	Namespace      string        `config:"namespace"`
 	SyncPeriod     time.Duration `config:"sync_period"`
 	CleanupTimeout time.Duration `config:"cleanup_timeout" validate:"positive"`
 
 	// Needed when resource is a pod
-	HostDeprecated string `config:"host"`
-	Node           string `config:"node"`
+	HostDeprecated string            `config:"host"`
+	Node           string            `config:"node"`
+	Namespace      string            `config:"namespace"`
+	Selector       common.MapStr     `config:"selector"`
 	// Scope can be either node or cluster.
 	Scope    string `config:"scope"`
 	Resource string `config:"resource"`

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -76,6 +76,7 @@ func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pu
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, kubernetes.WatchOptions{
 		SyncTimeout:  config.SyncPeriod,
 		Node:         config.Node,
+		Selector:     config.Selector,
 		IsUpdated:    isUpdated,
 		HonorReSyncs: true,
 	}, nil)

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -83,6 +83,7 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 		SyncTimeout:  config.SyncPeriod,
 		Node:         config.Node,
 		Namespace:    config.Namespace,
+		Selector:     config.Selector,
 		HonorReSyncs: true,
 	}, nil)
 	if err != nil {

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -56,6 +56,7 @@ func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface,
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
 		SyncTimeout:  config.SyncPeriod,
 		Namespace:    config.Namespace,
+		Selector:     config.Selector,
 		HonorReSyncs: true,
 	}, nil)
 

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -69,6 +70,8 @@ type WatchOptions struct {
 	Node string
 	// Namespace is used for filtering watched resource to given namespace, use "" for all namespaces
 	Namespace string
+	// Selector allows you to choose what are the labels based off of which resources need to be watched on
+	Selector common.MapStr
 	// IsUpdated allows registering a func that allows the invoker of the Watch to decide what amounts to an update
 	// vs what does not.
 	IsUpdated func(old, new interface{}) bool

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -223,6 +223,8 @@ The `kubernetes` autodiscover provider has the following configuration settings:
   metadata. If it is not set, the processor collects metadata from all
   namespaces. It is unset by default. The namespace configuration only applies to
   kubernetes resources that are namespace scoped.
+`selector`:: (Optional) Selector allows configuring a map of label key/value pairs based
+on which the Kubernetes objects are queried by the Kubernetes client
 `cleanup_timeout`:: (Optional) Specify the time of inactivity before stopping the
 running configuration for a container,
 ifeval::["{beatname_lc}"=="filebeat"]


### PR DESCRIPTION
Enhancement

## What does this PR do?

This PR allows usage of label selectors to narrow down the list of pods/services being monitored by beats when using kubernetes autodiscover

## Why is it important?
This is useful in variety of use cases:
* Nodes are segmented as various zones and we need to monitor each zone independantly
* provide higher qos for pods labeled as production as compared to dev

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      kube_config: ${HOME}/.kube/config
      namespace: "kube-system"
      selector:
        foo: bar
      resource: service
      annotations.dedot: false
      add_resource_metadata:
        namespace.enabled: true
      builders:
        - type: hints

output.console.pretty: true
```
