### PR TITLE
[Github Action] Add `backport` workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,39 @@
+on:
+  pull_request_target:
+    branches:
+      - master
+    types:
+      - labeled
+      - closed
+
+jobs:
+  backport:
+    name: Backport PR
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'auto-backport')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'auto-backport')
+        || (github.event.action == 'closed')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'elastic/kibana-github-actions'
+          ref: main
+          path: ./actions
+
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+
+      - name: Run Backport
+        uses: ./actions/backport
+        with:
+          github_token: ${{secrets.KIBANAMACHINE_TOKEN}}
+          commit_user: kibanamachine
+          commit_email: 42973632+kibanamachine@users.noreply.github.com
+          auto_merge: 'true'
+          auto_merge_method: 'squash'
+          manual_backport_command_template: 'node scripts/backport --pr %pullNumber%'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Run Backport
         uses: ./actions/backport
         with:
-          github_token: ${{secrets.KIBANAMACHINE_TOKEN}}
+          github_token: ${{secrets.BACKPORT_ACTION_TOKEN}}
           commit_user: kibanamachine
-          commit_email: 42973632+kibanamachine@users.noreply.github.com
+          commit_email: beats-backport-action@users.noreply.github.com
           auto_merge: 'true'
           auto_merge_method: 'squash'
           manual_backport_command_template: 'node scripts/backport --pr %pullNumber%'


### PR DESCRIPTION
This adds the [backport Github action](https://github.com/elastic/kibana-github-actions/blob/main/backport/action.yml). 

It will automatically create backports for PRs containing the `auto-backport` label. The PRs will be merged automatically when they pass CI (this can be turned off if deemed too scary).

@brianseeders looks good to you?