### PR TITLE
Cherry-pick to 7.11: chore: do not pass beat version (#24586)

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -342,7 +342,6 @@ def triggerE2ETests(String suite) {
     booleanParam(name: 'notifyOnGreenBuilds', value: !isPR()),
     booleanParam(name: 'BEATS_USE_CI_SNAPSHOTS', value: true),
     string(name: 'runTestsSuites', value: suite),
-    string(name: 'BEAT_VERSION', value: env.BEAT_VERSION),
     string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_E2E_TESTS_NAME),
     string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
     string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT),


### PR DESCRIPTION
Backports the following commits to 7.11:
 - chore: do not pass beat version (#24586)