### PR TITLE
[CI] Normalise the tarball with the test results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -731,10 +731,11 @@ def archiveTestOutput(Map args = [:]) {
 * disk space of the jenkins instance
 */
 def tarAndUploadArtifacts(Map args = [:]) {
-  tar(file: args.file, dir: args.location, archive: false, allowMissing: true)
+  def fileName = args.file.replaceAll('[^A-Za-z-0-9]','-')
+  tar(file: fileName, dir: args.location, archive: false, allowMissing: true)
   googleStorageUploadExt(bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
                          credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
-                         pattern: "${args.file}",
+                         pattern: "${fileName}",
                          sharedPublicly: true)
 }
 


### PR DESCRIPTION
## What does this PR do?

Normalise the file name to avoid any kind of special chars

## Why is it important?

Fixes an issue when using the CI labels `foo&&bar`

![image](https://user-images.githubusercontent.com/2871786/111469242-5cc33e00-871e-11eb-98dc-aca07d02661f.png)

```
10:36:18  + tar --exclude=test-build-artifacts-auditbeat-macos-macosx
10:36:18  tar: Must specify one of -c, -r, -t, -u, -x

10:37:25  + gsutil -m -q cp -a public-read test-build-artifacts-auditbeat-macos-macosx
10:37:27  CommandException: Wrong number of arguments for "cp" command.
```

## Issues

Caused by https://github.com/elastic/beats/pull/24362
