### PR TITLE
[Fleet] Handle POLICY_REASSIGN action

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_reassign.go
+++ b/x-pack/elastic-agent/pkg/agent/application/handler_action_policy_reassign.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package application
+
+import (
+	"context"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+// handlerPolicyReassign handles policy reassign change coming from fleet.
+type handlerPolicyReassign struct {
+	log *logger.Logger
+}
+
+// Handle handles POLICY_REASSIGN action.
+func (h *handlerPolicyReassign) Handle(ctx context.Context, a action, acker fleetAcker) error {
+	h.log.Debugf("handlerPolicyReassign: action '%+v' received", a)
+
+	if err := acker.Ack(ctx, a); err != nil {
+		h.log.Errorf("failed to acknowledge POLICY_REASSIGN action with id '%s'", a.ID)
+	} else if err := acker.Commit(ctx); err != nil {
+		h.log.Errorf("failed to commit acker after acknowledging action with id '%s'", a.ID)
+	}
+
+	return nil
+}

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -194,6 +194,11 @@ func newManaged(
 	)
 
 	actionDispatcher.MustRegister(
+		&fleetapi.ActionPolicyReassign{},
+		&handlerPolicyReassign{log: log},
+	)
+
+	actionDispatcher.MustRegister(
 		&fleetapi.ActionUnenroll{},
 		&handlerUnenroll{
 			log:        log,

--- a/x-pack/elastic-agent/pkg/fleetapi/action.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/action.go
@@ -19,6 +19,8 @@ const (
 	ActionTypeUnenroll = "UNENROLL"
 	// ActionTypePolicyChange specifies policy change action.
 	ActionTypePolicyChange = "POLICY_CHANGE"
+	// ActionTypePolicyReassign specifies policy reassign action.
+	ActionTypePolicyReassign = "POLICY_REASSIGN"
 	// ActionTypeSettings specifies change of agent settings.
 	ActionTypeSettings = "SETTINGS"
 	// ActionTypeApplication specifies agent action.
@@ -68,6 +70,31 @@ func (a *ActionUnknown) String() string {
 // OriginalType returns the original type of the action as returned by the API.
 func (a *ActionUnknown) OriginalType() string {
 	return a.originalType
+}
+
+// ActionPolicyReassign is a request to apply a new
+type ActionPolicyReassign struct {
+	ActionID   string
+	ActionType string
+}
+
+func (a *ActionPolicyReassign) String() string {
+	var s strings.Builder
+	s.WriteString("action_id: ")
+	s.WriteString(a.ActionID)
+	s.WriteString(", type: ")
+	s.WriteString(a.ActionType)
+	return s.String()
+}
+
+// Type returns the type of the Action.
+func (a *ActionPolicyReassign) Type() string {
+	return a.ActionType
+}
+
+// ID returns the ID of the Action.
+func (a *ActionPolicyReassign) ID() string {
+	return a.ActionID
 }
 
 // ActionPolicyChange is a request to apply a new
@@ -240,6 +267,11 @@ func (a *Actions) UnmarshalJSON(data []byte) error {
 				return errors.New(err,
 					"fail to decode POLICY_CHANGE action",
 					errors.TypeConfig)
+			}
+		case ActionTypePolicyReassign:
+			action = &ActionPolicyReassign{
+				ActionID:   response.ActionID,
+				ActionType: response.ActionType,
 			}
 		case ActionTypeApplication:
 			action = &ActionApp{


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/beats/issues/24447 
Handle `POLICY_REASSIGN` action

When an agent get a `POLICY_REASSIGN` action it should ack the action and checkin again to get the new policy.
