### PR TITLE
Cherry-pick #24410 to 7.x: Handle brackets <> in Cisco ASA 722051 message

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -254,6 +254,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Netlow module issue with missing `internal_networks` config parameter. {issue}24094[24094] {pull}24110[24110]
 - in httpjson input using encode_as "application/x-www-form-urlencoded" now sets Content-Type correctly {issue}24331[24331] {pull}24336[24336]
 - Fix default `scope` in `add_nomad_metadata`. {issue}24559[24559]
+- Fix Cisco ASA parser for message 722051. {pull}24410[24410]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/additional_messages.log
+++ b/x-pack/filebeat/module/cisco/asa/test/additional_messages.log
@@ -64,7 +64,7 @@ Apr 27 02:03:03 dev01: %ASA-6-605005: Login permitted from 10.10.0.87/6651 to FC
 Apr 27 02:03:03 dev01: %ASA-6-611101: User authentication succeeded: IP address: 10.10.0.87, Uname: admin
 Apr 27 02:03:03 dev01: %ASA-5-713049: Group = 91.240.17.178, IP = 91.240.17.178, Security negotiation complete for LAN-to-LAN Group (91.240.17.178) Responder, Inbound SPI = 0x276b1da2, Outbound SPI = 0x0e1a581d
 Apr 27 02:03:03 dev01: %ASA-4-113019: Group = 91.240.17.178, Username = 91.240.17.178, IP = 91.240.17.178, Session disconnected. Session Type: LAN-to-LAN, Duration: 0h:32m:16s, Bytes xmt: 297103, Bytes rcv: 1216163, Reason: User Requested
-Apr 27 02:03:03 dev01: %ASA-4-722051: Group some-policy User testuser IP 8.8.8.8 IPv4 Address 8.8.4.4 IPv6 address 2001:4860:4860::8888 assigned to session
+Apr 27 02:03:03 dev01: %ASA-4-722051: Group <VPN5Policy> User <john> IP <192.168.50.3> IPv4 Address <192.168.50.5> IPv6 address <::> assigned to session
 Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User testuser IP 8.8.8.8 WebVPN session terminated: User Requested.
 Apr 27 02:03:03 dev01: %ASA-6-716002: Group another-policy User alice IP 192.168.50.1 WebVPN session terminated: Idle timeout.
 Apr 27 02:03:03 dev01: %ASA-3-710003: TCP access denied by ACL from 104.46.88.19/6370 to outside:195.74.114.34/23

--- a/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
@@ -3061,7 +3061,7 @@
         ]
     },
     {
-        "cisco.asa.assigned_ip": "8.8.4.4",
+        "cisco.asa.assigned_ip": "192.168.50.5",
         "cisco.asa.message_id": "722051",
         "event.action": "firewall-rule",
         "event.category": [
@@ -3071,7 +3071,7 @@
         "event.dataset": "cisco.asa",
         "event.kind": "event",
         "event.module": "cisco",
-        "event.original": "%ASA-4-722051: Group some-policy User testuser IP 8.8.8.8 IPv4 Address 8.8.4.4 IPv6 address 2001:4860:4860::8888 assigned to session",
+        "event.original": "%ASA-4-722051: Group <VPN5Policy> User <john> IP <192.168.50.3> IPv4 Address <192.168.50.5> IPv6 address <::> assigned to session",
         "event.severity": 4,
         "event.timezone": "-02:00",
         "event.type": [
@@ -3090,22 +3090,15 @@
             "dev01"
         ],
         "related.ip": [
-            "8.8.8.8"
+            "192.168.50.3"
         ],
         "related.user": [
-            "testuser"
+            "john"
         ],
         "service.type": "cisco",
-        "source.address": "8.8.8.8",
-        "source.as.number": 15169,
-        "source.as.organization.name": "Google LLC",
-        "source.geo.continent_name": "North America",
-        "source.geo.country_iso_code": "US",
-        "source.geo.country_name": "United States",
-        "source.geo.location.lat": 37.751,
-        "source.geo.location.lon": -97.822,
-        "source.ip": "8.8.8.8",
-        "source.user.name": "testuser",
+        "source.address": "192.168.50.3",
+        "source.ip": "192.168.50.3",
+        "source.user.name": "john",
         "tags": [
             "cisco-asa",
             "forwarded"
@@ -3132,7 +3125,7 @@
         "host.hostname": "dev01",
         "input.type": "log",
         "log.level": "informational",
-        "log.offset": 9683,
+        "log.offset": 9680,
         "observer.hostname": "dev01",
         "observer.product": "asa",
         "observer.type": "firewall",
@@ -3183,7 +3176,7 @@
         "host.hostname": "dev01",
         "input.type": "log",
         "log.level": "informational",
-        "log.offset": 9810,
+        "log.offset": 9807,
         "observer.hostname": "dev01",
         "observer.product": "asa",
         "observer.type": "firewall",
@@ -3240,7 +3233,7 @@
         "host.hostname": "dev01",
         "input.type": "log",
         "log.level": "error",
-        "log.offset": 9937,
+        "log.offset": 9934,
         "network.iana_number": 6,
         "network.transport": "tcp",
         "observer.hostname": "dev01",

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -555,7 +555,7 @@ processors:
   - dissect:
       if: "ctx._temp_.cisco.message_id == '722051'"
       field: "message"
-      pattern: "Group %{} User %{source.user.name} IP %{source.address} IPv4 Address %{_temp_.cisco.assigned_ip} %{}"
+      pattern: "Group %{} User <%{source.user.name}> IP <%{source.address}> IPv4 Address <%{_temp_.cisco.assigned_ip}> %{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '733100'"
       field: "message"


### PR DESCRIPTION
Cherry-pick of PR #24410 to 7.x branch. Original message: 

## What does this PR do?

The current dissect filter  for handling 722051 messages throwing mapper_parsing exceptions and dropping that log.
To fix this, dissect filter needs to be updated according to message.

## Why is it important?

Without this fix, the log will be dropped by ingest nodes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally
```
PUT filebeat-7.10.2-2021.03.05-000001/_doc/33?pipeline=filebeat-7.10.2-cisco-asa-asa-ftd-pipeline
{
  "message":"<164>Mar 05 2021 23:37:14: %ASA-4-722051: Group <GroupPolicy_CompanyPush> User <john> IP <1.2.3.4> IPv4 Address <172.23.82.82> IPv6 address <::> assigned to session\0x0a"
}
```

## Logs

Example Message: 

`<164>Mar 05 2021 23:37:14: %ASA-4-722051: Group <GroupPolicy_CompanyPush> User <john> IP <1.2.3.4> IPv4 Address <172.23.82.82> IPv6 address <::> assigned to session\0x0a`
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "mapper_parsing_exception",
        "reason" : "failed to parse field [cisco.asa.assigned_ip] of type [ip] in document with id '11'. Preview of field's value: '<172.23.82.82>'"
      }
    ],
    "type" : "mapper_parsing_exception",
    "reason" : "failed to parse field [cisco.asa.assigned_ip] of type [ip] in document with id '11'. Preview of field's value: '<172.23.82.82>'",
    "caused_by" : {
      "type" : "illegal_argument_exception",
      "reason" : "'<172.23.87.37>' is not an IP string literal."
    }
  },
  "status" : 400
}
```