### PR TITLE
Cherry-pick #24564 to 7.x: Set event.type for Packetbeat flow events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -683,6 +683,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 
 - Upgrade to ECS 1.8.0. {pull}23783[23783]
+- Add `event.type: [connection]` to flow events and include `end` for final flows. {pull}24564[24564]
 
 *Functionbeat*
 

--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -220,6 +220,12 @@ func createEvent(
 		"category": []string{"network_traffic", "network"},
 		"action":   "network_flow",
 	}
+	eventType := []string{"connection"}
+	if isOver {
+		eventType = append(eventType, "end")
+	}
+	event["type"] = eventType
+
 	flow := common.MapStr{
 		"id":    common.NetString(f.id.Serialize()),
 		"final": isOver,

--- a/packetbeat/tests/system/test_0060_flows.py
+++ b/packetbeat/tests/system/test_0060_flows.py
@@ -47,6 +47,7 @@ class Test(BaseTest):
             'source.bytes': 1480,
             'destination.packets': 10,
             'destination.bytes': 181133,
+            'event.type': ['connection', 'end'],
         })
 
         start_ts = parse_timestamp(objs[0]['event.start'])


### PR DESCRIPTION
Cherry-pick of PR #24564 to 7.x branch. Original message: 

## What does this PR do?

Add `event.type: [connection]` to flow events and include `end` for final flows.

## Why is it important?

This helps the data comply to ECS.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

```
  "event": {
    "type": [
      "connection",
      "end"
    ],
    "start": "2021-03-16T15:14:29.826Z",
    "end": "2021-03-16T15:14:29.826Z",
    "duration": 273694,
    "dataset": "flow",
    "kind": "event",
    "category": [
      "network"
    ],
    "action": "network_flow"
  }
```
