### PR TITLE
Cherry-pick #24606 to 7.x: Update Golang to 1.15.10

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -103,3 +103,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Update Go version to 1.15.7. {pull}22495[22495]
 - Update Go version to 1.15.8. {pull}23955[23955]
 - Update Go version to 1.15.9. {pull}24442[24442]
+- Update Go version to 1.15.10. {pull}24606[24606]

--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/filebeat/Dockerfile
+++ b/filebeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/journalbeat/Dockerfile
+++ b/journalbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/libbeat/Dockerfile
+++ b/libbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,6 +1,6 @@
 :stack-version: 7.11.0
 :doc-branch: 7.x
-:go-version: 1.15.9
+:go-version: 1.15.10
 :release-state: unreleased
 :python: 3.7
 :docker: 1.12

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/metricbeat/module/http/_meta/Dockerfile
+++ b/metricbeat/module/http/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 COPY test/main.go main.go
 

--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/x-pack/functionbeat/Dockerfile
+++ b/x-pack/functionbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \

--- a/x-pack/libbeat/Dockerfile
+++ b/x-pack/libbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.9
+FROM golang:1.15.10
 
 RUN \
     apt-get update \


### PR DESCRIPTION
Cherry-pick of PR #24606 to 7.x branch. Original message: 

Requires: https://github.com/elastic/golang-crossbuild/pull/81