### PR TITLE
[Winlogbeat] Retry ReportEvent in tests

### DIFF
--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -77,14 +77,14 @@ class WriteReadTest(BaseTest):
             level = win32evtlog.EVENTLOG_INFORMATION_TYPE
 
         # Retry on exception for up to 10 sec.
-        t = time.process_time()
+        t = time.monotonic()
         while True:
             try:
                 win32evtlogutil.ReportEvent(source, eventID,
                                             eventType=level, strings=[message], sid=sid)
                 break
             except:
-                if time.process_time() - t < 10:
+                if time.monotonic() - t < 10:
                     continue
                 raise
 

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import platform
 import sys
+import time
 import yaml
 
 if sys.platform.startswith("win"):
@@ -75,8 +76,17 @@ class WriteReadTest(BaseTest):
         if level is None:
             level = win32evtlog.EVENTLOG_INFORMATION_TYPE
 
-        win32evtlogutil.ReportEvent(source, eventID,
-                                    eventType=level, strings=[message], sid=sid)
+        # Retry on exception for up to 10 sec.
+        t = time.process_time()
+        while True:
+            try:
+                win32evtlogutil.ReportEvent(source, eventID,
+                                            eventType=level, strings=[message], sid=sid)
+                break
+            except:
+                if time.process_time() - t < 10:
+                    continue
+                raise
 
     def get_sid(self):
         if self.sid is None:


### PR DESCRIPTION
## What does this PR do?

Under Windows 7 and Windows 10, writes to a newly created event log fail occasionally. It seems that there is a delay between when an event log is created and publishing events to it is allowed.

## Why is it important?

Makes tests more reliable.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`. ~

