### PR TITLE
Add breaking changes for 7.12

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.12.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.12.asciidoc
@@ -1,0 +1,18 @@
+[[breaking-changes-7.12]]
+
+=== Breaking changes in 7.12
+++++
+<titleabbrev>7.12</titleabbrev>
+++++
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+
+No breaking changes.
+
+// end::notable-breaking-changes[]
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.12>>
+
 * <<breaking-changes-7.11>>
 
 * <<breaking-changes-7.10>>
@@ -34,6 +36,9 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+
+include::breaking-7.12.asciidoc[]
 
 include::breaking-7.11.asciidoc[]
 


### PR DESCRIPTION
Adds breaking changes file for 7.12. There were no PRs tagged as breaking changes, so I'm assuming we don't need to add anything to this file. Let me know if we do.