### PR TITLE
Skip TestActions for Auditbeat on darwin/amd64

### DIFF
--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -65,6 +65,8 @@ func TestData(t *testing.T) {
 }
 
 func TestActions(t *testing.T) {
+	skipOnCIForDarwinAMD64(t)
+
 	defer abtest.SetupDataDir(t)()
 
 	bucket, err := datastore.OpenBucket(bucketName)
@@ -173,6 +175,8 @@ func TestActions(t *testing.T) {
 }
 
 func TestExcludedFiles(t *testing.T) {
+	skipOnCIForDarwinAMD64(t)
+
 	defer abtest.SetupDataDir(t)()
 
 	bucket, err := datastore.OpenBucket(bucketName)
@@ -227,6 +231,8 @@ func TestExcludedFiles(t *testing.T) {
 }
 
 func TestIncludedExcludedFiles(t *testing.T) {
+	skipOnCIForDarwinAMD64(t)
+
 	defer abtest.SetupDataDir(t)()
 
 	bucket, err := datastore.OpenBucket(bucketName)
@@ -978,5 +984,11 @@ func getConfig(path ...string) map[string]interface{} {
 		"module":        "file_integrity",
 		"paths":         path,
 		"exclude_files": []string{`(?i)\.sw[nop]$`, `[/\\]\.git([/\\]|$)`},
+	}
+}
+
+func skipOnCIForDarwinAMD64(t testing.TB) {
+	if os.Getenv("BUILD_ID") != "" && runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
+		t.Skip("Skip test on CI for darwin/amd64")
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This skips TestActions, TestExcludedFiles, and TestIncludedExcludedFiles on darwin/amd64.
I could not reproduce this on my local macbook, but it's failing in the CI environment.

https://github.com/elastic/beats/issues/24637

## Why is it important?

CI should be green.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates https://github.com/elastic/beats/issues/24637
