### PR TITLE
Cherry-pick #24639 to 7.x:  [Filebeat] Remove conflicting "message" field

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,6 +256,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - in httpjson input using encode_as "application/x-www-form-urlencoded" now sets Content-Type correctly {issue}24331[24331] {pull}24336[24336]
 - Fix default `scope` in `add_nomad_metadata`. {issue}24559[24559]
 - Fix Cisco ASA parser for message 722051. {pull}24410[24410]
+- Remove `message` field that is generated from `o365audit.ExchangeMetaData.Subject`. {issue}24478[24478] {pull}24639[24639]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/o365/audit/config/pipeline.js
+++ b/x-pack/filebeat/module/o365/audit/config/pipeline.js
@@ -397,7 +397,6 @@ function dataLossPreventionSchema(debug) {
 
             // Exchange metadata
             {from: 'o365audit.ExchangeMetaData.From', to: 'source.user.email'},
-            {from: 'o365audit.ExchangeMetaData.Subject', to: 'message'},
 
             // Policy details
             {from: 'o365audit.PolicyId', to: 'rule.id'},

--- a/x-pack/filebeat/module/o365/audit/test/13-dlp-exchange.log-expected.json
+++ b/x-pack/filebeat/module/o365/audit/test/13-dlp-exchange.log-expected.json
@@ -20,7 +20,6 @@
         "host.id": "0e1dddce-163e-4b0b-9e33-87ba56ac4655",
         "input.type": "log",
         "log.offset": 0,
-        "message": "Here's the phony data",
         "o365.audit.CreationTime": "2020-02-24T20:11:15",
         "o365.audit.ExchangeMetaData.BCC": [],
         "o365.audit.ExchangeMetaData.CC": [
@@ -169,7 +168,6 @@
         "host.id": "0e1dddce-163e-4b0b-9e33-87ba56ac4655",
         "input.type": "log",
         "log.offset": 2230,
-        "message": "Here's the phony data",
         "o365.audit.CreationTime": "2020-02-24T20:11:15",
         "o365.audit.ExchangeMetaData.BCC": [],
         "o365.audit.ExchangeMetaData.CC": [
@@ -318,7 +316,6 @@
         "host.id": "0e1dddce-163e-4b0b-9e33-87ba56ac4655",
         "input.type": "log",
         "log.offset": 4459,
-        "message": "Here's the phony data",
         "o365.audit.CreationTime": "2020-02-24T20:11:15",
         "o365.audit.ExceptionInfo.Reason": "{ \"Justification\": \"I really need to share those files\" }",
         "o365.audit.ExchangeMetaData.BCC": [],
@@ -468,7 +465,6 @@
         "host.id": "0e1dddce-163e-4b0b-9e33-87ba56ac4655",
         "input.type": "log",
         "log.offset": 6769,
-        "message": "Here's the phony data",
         "o365.audit.CreationTime": "2020-02-24T20:11:15",
         "o365.audit.ExceptionInfo.FalsePositive": true,
         "o365.audit.ExchangeMetaData.BCC": [],
@@ -618,7 +614,6 @@
         "host.id": "0e1dddce-163e-4b0b-9e33-87ba56ac4655",
         "input.type": "log",
         "log.offset": 9041,
-        "message": "Here's the phony data",
         "o365.audit.CreationTime": "2020-02-24T20:11:15",
         "o365.audit.ExchangeMetaData.BCC": [],
         "o365.audit.ExchangeMetaData.CC": [


### PR DESCRIPTION
Cherry-pick of PR #24639 to 7.x branch. Original message:

## What does this PR do?

Resolves #24478 . Removes field conversion from `o365audit.ExchangeMetaData.Subject` to `message` as the `message` field is special and conflicts when using logstash and kafka.

## Why is it important?

`message` field is special and conflicts when using logstash and kafka.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this PR locally

## Related issues

Resolves #24478 

## Use cases


## Screenshots


## Logs

