### PR TITLE
[winlogbeat] Move windows event marhsaling to its own package

### DIFF
--- a/libbeat/processors/translate_sid/translatesid.go
+++ b/libbeat/processors/translate_sid/translatesid.go
@@ -32,7 +32,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
-	"github.com/elastic/beats/v7/winlogbeat/sys"
+	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
 )
 
 const logName = "processor.translate_sid"
@@ -117,7 +117,7 @@ func (p *processor) translateSID(event *beat.Event) error {
 		}
 	}
 	if p.AccountTypeTarget != "" {
-		if _, err = event.PutValue(p.AccountTypeTarget, sys.SIDType(accountType).String()); err != nil {
+		if _, err = event.PutValue(p.AccountTypeTarget, winevent.SIDType(accountType).String()); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/libbeat/processors/translate_sid/translatesid_test.go
+++ b/libbeat/processors/translate_sid/translatesid_test.go
@@ -29,21 +29,21 @@ import (
 	"golang.org/x/sys/windows"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/winlogbeat/sys"
+	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
 )
 
 func TestTranslateSID(t *testing.T) {
 	var tests = []struct {
 		SID         string
 		Account     string
-		AccountType sys.SIDType
+		AccountType winevent.SIDType
 		Domain      string
 		Assert      func(*testing.T, *beat.Event, error)
 	}{
 		{SID: "S-1-5-7", Domain: "NT AUTHORITY", Account: "ANONYMOUS LOGON"},
 		{SID: "S-1-0-0", Account: "NULL SID"},
 		{SID: "S-1-1-0", Account: "Everyone"},
-		{SID: "S-1-5-32-544", Domain: "BUILTIN", Account: "Administrators", AccountType: sys.SidTypeAlias},
+		{SID: "S-1-5-32-544", Domain: "BUILTIN", Account: "Administrators", AccountType: winevent.SidTypeAlias},
 		{SID: "S-1-5-113", Domain: "NT AUTHORITY", Account: "Local Account"},
 		{SID: "", Assert: assertInvalidSID},
 		{SID: "Not a SID", Assert: assertInvalidSID},

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -82,19 +82,19 @@ type Record struct {
 func (e Record) ToEvent() beat.Event {
 	win := e.Fields()
 
-	_ = win.Delete("keywords_raw")
-	_, _ = win.Put("api", e.API)
+	win.Delete("keywords_raw")
+	win.Put("api", e.API)
 
 	m := common.MapStr{
 		"winlog": win,
 	}
 
-	// // ECS data
-	_, _ = m.Put("event.created", time.Now())
+	// ECS data
+	m.Put("event.created", time.Now())
 
-	_, _ = m.Put("event.kind", "event")
-	_, _ = m.Put("event.code", e.EventIdentifier.ID)
-	_, _ = m.Put("event.provider", e.Provider.Name)
+	m.Put("event.kind", "event")
+	m.Put("event.code", e.EventIdentifier.ID)
+	m.Put("event.provider", e.Provider.Name)
 
 	rename(m, "winlog.outcome", "event.outcome")
 	rename(m, "winlog.level", "log.level")
@@ -120,8 +120,8 @@ func rename(m common.MapStr, oldKey, newKey string) {
 	if err != nil {
 		return
 	}
-	_, _ = m.Put(newKey, v)
-	_ = m.Delete(oldKey)
+	m.Put(newKey, v)
+	m.Delete(oldKey)
 }
 
 // incrementMetric increments a value in the specified expvar.Map. The key

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/winlogbeat/checkpoint"
 	"github.com/elastic/beats/v7/winlogbeat/sys"
+	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
 	win "github.com/elastic/beats/v7/winlogbeat/sys/wineventlog"
 )
 
@@ -317,14 +318,14 @@ func (l *winEventLog) eventHandles(maxRead int) ([]win.EvtHandle, int, error) {
 
 func (l *winEventLog) buildRecordFromXML(x []byte, recoveredErr error) (Record, error) {
 	includeXML := l.config.IncludeXML
-	e, err := sys.UnmarshalEventXML(x)
+	e, err := winevent.UnmarshalXML(x)
 	if err != nil {
 		e.RenderErr = append(e.RenderErr, err.Error())
 		// Add raw XML to event.original when decoding fails
 		includeXML = true
 	}
 
-	err = sys.PopulateAccount(&e.User)
+	err = winevent.PopulateAccount(&e.User)
 	if err != nil {
 		debugf("%s SID %s account lookup failed. %v", l.logPrefix,
 			e.User.Identifier, err)

--- a/winlogbeat/sys/winevent/event_test.go
+++ b/winlogbeat/sys/winevent/event_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package sys
+package winevent
 
 import (
 	"encoding/json"
@@ -154,7 +154,7 @@ func TestXML(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		event, err := UnmarshalEventXML([]byte(test.xml))
+		event, err := UnmarshalXML([]byte(test.xml))
 		if err != nil {
 			t.Error(err)
 			continue
@@ -175,7 +175,7 @@ func TestXML(t *testing.T) {
 // when the event is decoded.
 func TestInvalidXML(t *testing.T) {
 	evXML := strings.Replace(allXML, "%1", "\t&#xD;\n\x1b", -1)
-	ev, err := UnmarshalEventXML([]byte(evXML))
+	ev, err := UnmarshalXML([]byte(evXML))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "Creating WSMan shell on server with ResourceUri: \t\r\n\\u001b", ev.Message)
 }
@@ -236,14 +236,14 @@ const nonUnsignedIntVersion = `
 //
 // Reference: https://docs.microsoft.com/en-us/windows/win32/wes/schema-version-systempropertiestype-element
 func TestInvalidVersion(t *testing.T) {
-	ev, err := UnmarshalEventXML([]byte(nonUnsignedIntVersion))
+	ev, err := UnmarshalXML([]byte(nonUnsignedIntVersion))
 	assert.NoError(t, err)
 	assert.EqualValues(t, 0, ev.Version)
 }
 
 func BenchmarkXMLUnmarshal(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := UnmarshalEventXML([]byte(allXML))
+		_, err := UnmarshalXML([]byte(allXML))
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/winlogbeat/sys/winevent/maputil.go
+++ b/winlogbeat/sys/winevent/maputil.go
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package winevent
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/winlogbeat/sys"
+)
+
+// AddOptional adds a key and value to the given MapStr if the value is not the
+// zero value for the type of v. It is safe to call the function with a nil
+// MapStr.
+func AddOptional(m common.MapStr, key string, v interface{}) {
+	if m != nil && !isZero(v) {
+		_, _ = m.Put(key, v)
+	}
+}
+
+// AddPairs adds a new dictionary to the given MapStr. The key/value pairs are
+// added to the new dictionary. If any keys are duplicates, the first key/value
+// pair is added and the remaining duplicates are dropped.
+//
+// The new dictionary is added to the given MapStr and it is also returned for
+// convenience purposes.
+func AddPairs(m common.MapStr, key string, pairs []KeyValue) common.MapStr {
+	if len(pairs) == 0 {
+		return nil
+	}
+
+	h := make(common.MapStr, len(pairs))
+	for i, kv := range pairs {
+		// Ignore empty values.
+		if kv.Value == "" {
+			continue
+		}
+
+		// If the key name is empty or if it the default of "Data" then
+		// assign a generic name of paramN.
+		k := kv.Key
+		if k == "" || k == "Data" {
+			k = fmt.Sprintf("param%d", i+1)
+		}
+
+		// Do not overwrite.
+		_, err := h.GetValue(k)
+		if err == common.ErrKeyNotFound {
+			_, _ = h.Put(k, sys.RemoveWindowsLineEndings(kv.Value))
+		} else {
+			debugf("Dropping key/value (k=%s, v=%s) pair because key already "+
+				"exists. event=%+v", k, kv.Value, m)
+		}
+	}
+
+	if len(h) == 0 {
+		return nil
+	}
+
+	_, _ = m.Put(key, h)
+
+	return h
+}
+
+// isZero return true if the given value is the zero value for its type.
+func isZero(i interface{}) bool {
+	v := reflect.ValueOf(i)
+	switch v.Kind() {
+	case reflect.Array, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
+}

--- a/winlogbeat/sys/winevent/sid.go
+++ b/winlogbeat/sys/winevent/sid.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package sys
+package winevent
 
 import (
 	"fmt"

--- a/winlogbeat/sys/winevent/sid_test.go
+++ b/winlogbeat/sys/winevent/sid_test.go
@@ -17,7 +17,7 @@
 
 // +build !integration
 
-package sys
+package winevent
 
 import (
 	"testing"

--- a/winlogbeat/sys/winevent/sid_windows.go
+++ b/winlogbeat/sys/winevent/sid_windows.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package sys
+package winevent
 
 import "golang.org/x/sys/windows"
 

--- a/winlogbeat/sys/wineventlog/metadata_store.go
+++ b/winlogbeat/sys/wineventlog/metadata_store.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/winlogbeat/sys"
+	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
 )
 
 var (
@@ -295,7 +296,7 @@ func newEventMetadataFromEventHandle(publisher *PublisherMetadata, eventHandle E
 
 	// By parsing the XML we can get the names of the parameters even if the
 	// publisher metadata is unavailable or is out of sync with the events.
-	event, err := sys.UnmarshalEventXML([]byte(xml))
+	event, err := winevent.UnmarshalXML([]byte(xml))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal XML")
 	}

--- a/winlogbeat/sys/wineventlog/renderer_test.go
+++ b/winlogbeat/sys/wineventlog/renderer_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/winlogbeat/sys"
+	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
 )
 
 func TestRenderer(t *testing.T) {
@@ -166,10 +166,10 @@ func TestTemplateFunc(t *testing.T) {
 }
 
 // renderAllEvents reads all events and renders them.
-func renderAllEvents(t *testing.T, log EvtHandle, renderer *Renderer, ignoreMissingMetadataError bool) []*sys.Event {
+func renderAllEvents(t *testing.T, log EvtHandle, renderer *Renderer, ignoreMissingMetadataError bool) []*winevent.Event {
 	t.Helper()
 
-	var events []*sys.Event
+	var events []*winevent.Event
 	for {
 		h, done := nextHandle(t, log)
 		if done {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Moves decoding of windows events to its own package.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To make it easier to reuse by other packages, i.e.: we are working on a processor that will use this code.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

