### PR TITLE
[filebeat][tomcat][bug] fixed error from beats about non iterable list for tomcat module

### DIFF
--- a/filebeat/docs/modules/tomcat.asciidoc
+++ b/filebeat/docs/modules/tomcat.asciidoc
@@ -33,6 +33,10 @@ NOTE: This was converted from RSA NetWitness log parser XML "apachetomcat" devic
 
 The input from which messages are read. One of `file`, `tcp` or `udp`.
 
+*`var.paths`*::
+
+The paths from which files are read. Needs to be a list. Only works when `var.input` is set to `file`.
+
 *`var.syslog_host`*::
 
 The address to listen to UDP or TCP based syslog traffic.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2100,6 +2100,7 @@ filebeat.modules:
 
     # Set paths for the log files when file input is used.
     # var.paths:
+    #   - /var/log/tomcat/*.log
 
     # Toggle output of non-ECS fields (default true).
     # var.rsa_fields: true

--- a/x-pack/filebeat/module/tomcat/_meta/config.yml
+++ b/x-pack/filebeat/module/tomcat/_meta/config.yml
@@ -9,6 +9,7 @@
 
     # Set paths for the log files when file input is used.
     # var.paths:
+    #   - /var/log/tomcat/*.log
 
     # Toggle output of non-ECS fields (default true).
     # var.rsa_fields: true

--- a/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
@@ -28,6 +28,10 @@ NOTE: This was converted from RSA NetWitness log parser XML "apachetomcat" devic
 
 The input from which messages are read. One of `file`, `tcp` or `udp`.
 
+*`var.paths`*::
+
+The paths from which files are read. Needs to be a list. Only works when `var.input` is set to `file`.
+
 *`var.syslog_host`*::
 
 The address to listen to UDP or TCP based syslog traffic.

--- a/x-pack/filebeat/modules.d/tomcat.yml.disabled
+++ b/x-pack/filebeat/modules.d/tomcat.yml.disabled
@@ -12,6 +12,7 @@
 
     # Set paths for the log files when file input is used.
     # var.paths:
+    #   - /var/log/tomcat/*.log
 
     # Toggle output of non-ECS fields (default true).
     # var.rsa_fields: true


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Cleanup
- Docs
-->

## What does this PR do?

Append the yml list format to the `modules.d` definition of tomcat and explained it in the docs.

## Why is it important?

If you just activate the tomcat module or copy and paste the configuration from the `modules.d` or `filebeat.reference.yml` you will receive an error when starting filebeat with version 7.11.1. 

`Exiting: Error getting config for fileset tomcat/log: Error interpreting the template of the input: template: text:5:24: executing "text" at <.paths>: range can't iterate over C:\Users\philipp\Downloads\demotomcat\*.log`

I think the documentation should state that there is a need for a list, even if only a single path is used.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~ I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
