### PR TITLE
[Metricbeat] [SM] Reduce number of calls to cluster/stats and cache shard data

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -152,7 +152,7 @@ func NewModule(base *mb.BaseModule, xpackEnabledMetricsets []string, logger *log
 	}
 
 	// These metricsets are exactly the ones required if xpack.enabled == true
-	raw["metricsets"] = xpackEnabledMetricsets
+	//raw["metricsets"] = xpackEnabledMetricsets
 
 	newConfig, err := common.NewConfigFrom(raw)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/cluster_state.go
+++ b/metricbeat/module/elasticsearch/cluster_state.go
@@ -64,7 +64,7 @@ func (c *clusterStatsResponseCache) GetClusterState(http *helper.HTTP, resetURI 
 	if elapsedFromLastFetch == 0 || elapsedFromLastFetch >= (time.Duration(float64(c.configuredModulePeriod)*FetchPeriodThreshold)) {
 		//Fetch data again
 		var err error
-		if c.responseData, err = fetchPath(http, resetURI, "_cluster/state", ""); err != nil {
+		if c.responseData, err = fetchPath(http, resetURI, "_cluster/state/version,nodes,master_node,routing_table", ""); err != nil {
 			return nil, err
 		}
 

--- a/metricbeat/module/elasticsearch/cluster_state.go
+++ b/metricbeat/module/elasticsearch/cluster_state.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package elasticsearch
+
+import (
+	"github.com/elastic/beats/v7/metricbeat/helper"
+	"sync"
+	"time"
+)
+
+// FetchPeriodThreshold is the threshold to use when checking if the cluster state call in this cache should be
+// fetched again. It's used as a percentage so 0.9 means that cache is invalidated if at least 90% of period time has
+// passed. This small threshold is to avoid race conditions where one of the X calls is that happen after each period do
+// not fetch new data while other does, becoming unsync. It does not fully solve the problem because the period waits
+// aren't guaranteed but it should be mostly enough.
+const FetchPeriodThreshold = 0.9
+
+var clusterStateCache = &clusterStatsResponseCache{}
+
+type clusterStatsResponseCache struct {
+	sync.Mutex
+	lastFetch              time.Time
+	configuredModulePeriod time.Duration
+	responseData           []byte
+}
+
+func GetClusterStateResponseCache(period time.Duration) *clusterStatsResponseCache {
+	clusterStateCache.Lock()
+	defer clusterStateCache.Unlock()
+
+	if clusterStateCache.configuredModulePeriod == 0 {
+		clusterStateCache = &clusterStatsResponseCache{
+			Mutex:                  sync.Mutex{},
+			lastFetch:              time.Now().Add(-period * 2),
+			configuredModulePeriod: period,
+			responseData:           nil,
+		}
+	}
+
+	return clusterStateCache
+}
+
+func (c *clusterStatsResponseCache) GetClusterState(http *helper.HTTP, resetURI string, _ []string) ([]byte, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	elapsedFromLastFetch := time.Since(c.lastFetch)
+
+	//Check the lifetime of current response data
+	if elapsedFromLastFetch == 0 || elapsedFromLastFetch >= (time.Duration(float64(c.configuredModulePeriod)*FetchPeriodThreshold)) {
+		//Fetch data again
+		var err error
+		if c.responseData, err = fetchPath(http, resetURI, "_cluster/state", ""); err != nil {
+			return nil, err
+		}
+
+		c.lastFetch = time.Now()
+	}
+
+	return c.responseData, nil
+}

--- a/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/cluster_stats.go
@@ -68,7 +68,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}
 
 	if m.MetricSet.XPack {
-		err = eventMappingXPack(r, m, *info, content)
+		err = eventMappingXPack(m.Module().Config().Period, r, m, *info, content)
 		if err != nil {
 			// Since this is an x-pack code path, we log the error but don't
 			// return it. Otherwise it would get reported into `metricbeat-*`

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -193,11 +193,6 @@ func addClusterStateFields(idx *Index, clusterStateBytes []byte) error {
 		return err
 	}
 
-	indexMetadata, err := getClusterStateMetricForIndex(clusterState, idx.Index, "metadata")
-	if err != nil {
-		return errors.Wrap(err, "failed to get index metadata from cluster state")
-	}
-
 	indexRoutingTable, err := getClusterStateMetricForIndex(clusterState, idx.Index, "routing_table")
 	if err != nil {
 		return errors.Wrap(err, "failed to get index routing table from cluster state")
@@ -207,15 +202,6 @@ func addClusterStateFields(idx *Index, clusterStateBytes []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get shards from routing table")
 	}
-
-	created, err := getIndexCreated(indexMetadata)
-	if err != nil {
-		return errors.Wrap(err, "failed to get index creation time")
-	}
-	idx.Created = created
-
-	// "index_stats.version.created", <--- don't think this is being used in the UI, so can we skip it?
-	// "index_stats.version.upgraded", <--- don't think this is being used in the UI, so can we skip it?
 
 	status, err := getIndexStatus(shards)
 	if err != nil {

--- a/metricbeat/module/elasticsearch/index/index.go
+++ b/metricbeat/module/elasticsearch/index/index.go
@@ -90,7 +90,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	}
 
 	if m.XPack {
-		err = eventsMappingXPack(r, m, *info, content)
+		err = eventsMappingXPack(m.Module().Config().Period, r, m, *info, content)
 		if err != nil {
 			// Since this is an x-pack code path, we log the error but don't
 			// return it. Otherwise it would get reported into `metricbeat-*`

--- a/metricbeat/module/elasticsearch/shard/data_xpack.go
+++ b/metricbeat/module/elasticsearch/shard/data_xpack.go
@@ -153,5 +153,5 @@ func getEventID(stateID string, shard common.MapStr) (string, error) {
 		shardType = "r"
 	}
 
-	return stateID + ":" + nodeID + ":" + indexName + ":" + shardNumberStr + ":" + shardType, nil
+	return nodeID + ":" + indexName + ":" + shardNumberStr + ":" + shardType, nil
 }

--- a/metricbeat/module/elasticsearch/shard/data_xpack.go
+++ b/metricbeat/module/elasticsearch/shard/data_xpack.go
@@ -31,80 +31,104 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/module/elasticsearch"
 )
 
-func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, content []byte) error {
+func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, cache map[string]string, content []byte) (map[string]string, error) {
 	stateData := &stateStruct{}
 	err := json.Unmarshal(content, stateData)
 	if err != nil {
-		return errors.Wrap(err, "failure parsing Elasticsearch Cluster State API response")
+		return cache, errors.Wrap(err, "failure parsing Elasticsearch Cluster State API response")
 	}
 
 	// TODO: This is currently needed because the cluser_uuid is `na` in stateData in case not the full state is requested.
 	// Will be fixed in: https://github.com/elastic/elasticsearch/pull/30656
 	clusterID, err := elasticsearch.GetClusterID(m.HTTP, m.HostData().SanitizedURI+statePath, stateData.MasterNode)
 	if err != nil {
-		return errors.Wrap(err, "failed to get cluster ID from Elasticsearch")
+		return cache, errors.Wrap(err, "failed to get cluster ID from Elasticsearch")
 	}
+
+	newCache := make(map[string]string)
 
 	var errs multierror.Errors
 	for _, index := range stateData.RoutingTable.Indices {
 		for _, shards := range index.Shards {
 			for _, shard := range shards {
-				event := mb.Event{}
-				fields, err := schema.Apply(shard)
+				event, omit, err := handleShard(shard, stateData, clusterID, m.Module().Config().Period, cache, newCache)
 				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failure to apply shard schema"))
+					return cache, err
+				}
+
+				if omit {
 					continue
 				}
 
-				// Handle node field: could be string or null
-				err = elasticsearch.PassThruField("node", shard, fields)
-				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failure passing through node field"))
-					continue
-				}
-
-				// Handle relocating_node field: could be string or null
-				err = elasticsearch.PassThruField("relocating_node", shard, fields)
-				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failure passing through relocating_node field"))
-					continue
-				}
-
-				event.RootFields = common.MapStr{
-					"timestamp":    time.Now(),
-					"cluster_uuid": clusterID,
-					"interval_ms":  m.Module().Config().Period.Nanoseconds() / 1000 / 1000,
-					"type":         "shards",
-					"shard":        fields,
-					"state_uuid":   stateData.StateID,
-				}
-
-				// Build source_node object
-				nodeID, ok := shard["node"]
-				if !ok {
-					continue
-				}
-				if nodeID != nil { // shard has not been allocated yet
-					sourceNode, err := getSourceNode(nodeID.(string), stateData)
-					if err != nil {
-						errs = append(errs, errors.Wrap(err, "failure getting source node information"))
-						continue
-					}
-					event.RootFields.Put("source_node", sourceNode)
-				}
-
-				event.ID, err = getEventID(stateData.StateID, fields)
-				if err != nil {
-					errs = append(errs, errors.Wrap(err, "failure getting event ID"))
-					continue
-				}
-
-				event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
 				r.Event(event)
 			}
 		}
 	}
-	return errs.Err()
+
+	return newCache, errs.Err()
+}
+
+func handleShard(shard common.MapStr, stateData *stateStruct, clusterID string, period time.Duration, cache map[string]string, newCache map[string]string) (event mb.Event, omit bool, err error) {
+	fields, err := schema.Apply(shard)
+	if err != nil {
+		return mb.Event{}, true, errors.Wrap(err, "failure to apply shard schema")
+	}
+
+	// Handle node field: could be string or null
+	err = elasticsearch.PassThruField("node", shard, fields)
+	if err != nil {
+		return mb.Event{}, true, errors.Wrap(err, "failure passing through node field")
+	}
+
+	// Handle relocating_node field: could be string or null
+	err = elasticsearch.PassThruField("relocating_node", shard, fields)
+	if err != nil {
+		return mb.Event{}, true, errors.Wrap(err, "failure passing through relocating_node field")
+	}
+
+	event.RootFields = common.MapStr{
+		"timestamp":    time.Now(),
+		"cluster_uuid": clusterID,
+		"interval_ms":  period.Nanoseconds() / 1000 / 1000,
+		"type":         "shards",
+		"shard":        fields,
+		"state_uuid":   stateData.StateID,
+	}
+
+	// Build source_node object
+	nodeID, ok := shard["node"]
+	if !ok {
+		return mb.Event{}, true, errors.New("a 'node' key with the node id was not found on elasticsearch response")
+	}
+	if nodeID != nil { // shard has not been allocated yet
+		sourceNode, err := getSourceNode(nodeID.(string), stateData)
+		if err != nil {
+			return mb.Event{}, true, errors.Wrap(err, "failure getting source node information")
+		}
+		event.RootFields.Put("source_node", sourceNode)
+	}
+
+	event.ID, err = getEventID(stateData.StateID, fields)
+	if err != nil {
+		return mb.Event{}, true, errors.Wrap(err, "failure getting event ID")
+	}
+
+	event.Index = elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
+
+	// Create a new cache and replace old one on every fetch call
+	content := fields.String()
+	newCache[event.ID] = content
+
+	old, ok := cache[event.ID]
+	if !ok {
+		return event, false, nil
+	}
+
+	if old != fields.String() {
+		return event, false, nil
+	}
+
+	return mb.Event{}, true, nil
 }
 
 func getSourceNode(nodeID string, stateData *stateStruct) (common.MapStr, error) {
@@ -120,6 +144,15 @@ func getSourceNode(nodeID string, stateData *stateStruct) (common.MapStr, error)
 }
 
 func getEventID(stateID string, shard common.MapStr) (string, error) {
+	shardID, err := getShardID(shard)
+	if err != nil {
+		return "", err
+	}
+
+	return stateID + ":" + shardID, nil
+}
+
+func getShardID(shard common.MapStr) (string, error) {
 	var nodeID string
 	if shard["node"] == nil {
 		nodeID = "_na"
@@ -153,5 +186,5 @@ func getEventID(stateID string, shard common.MapStr) (string, error) {
 		shardType = "r"
 	}
 
-	return stateID + ":" + nodeID + ":" + indexName + ":" + shardNumberStr + ":" + shardType, nil
+	return nodeID + ":" + indexName + ":" + shardNumberStr + ":" + shardType, nil
 }

--- a/metricbeat/module/elasticsearch/shard/data_xpack.go
+++ b/metricbeat/module/elasticsearch/shard/data_xpack.go
@@ -153,5 +153,5 @@ func getEventID(stateID string, shard common.MapStr) (string, error) {
 		shardType = "r"
 	}
 
-	return nodeID + ":" + indexName + ":" + shardNumberStr + ":" + shardType, nil
+	return stateID + ":" + nodeID + ":" + indexName + ":" + shardNumberStr + ":" + shardType, nil
 }

--- a/metricbeat/module/elasticsearch/shard/shard.go
+++ b/metricbeat/module/elasticsearch/shard/shard.go
@@ -59,10 +59,15 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return nil
 	}
 
-	content, err := m.HTTP.FetchContent()
+	content, err := elasticsearch.GetClusterStateResponseCache(m.Module().Config().Period).GetClusterState(m.HTTP, m.HTTP.GetURI(), nil)
 	if err != nil {
 		return err
 	}
+
+	//content, err := m.HTTP.FetchContent()
+	//if err != nil {
+	//	return err
+	//}
 
 	if m.XPack {
 		err = eventsMappingXPack(r, m, content)


### PR DESCRIPTION
* Number of calls to cluster_state will be 1 per period instead of 3 or 4.
* Shard related docs will be inserted once every time the cluster state ID changes. There are some caveats here though:
  * First batch of Shards just after executing Metricbeat will be sent over the network, even if the data already exists.
  * A single change in a shard will resend all shards as new docs AFAIK. I think this cannot be avoided for a bunch of reasons, mainly because shards don't have a cross cluster ID but I'd need to investigate more how Elasticsearch works with shards. Now we compose and shard ID with something like: `cluster state ID + node id + index name + shard number + shard type`. The problem is that if I remove the cluster state ID, changes on the shards aren't updated on Elasticsearch because Metricbeat cannot update documents by design (I think Filebeat can). This is because the `create` command of the Bulk API that we use, indexes the specified document ID if it does not already exist. Anyways, maybe it's enough with this change, we can always iterate.
* Metricsets and Periods can be chosen individually, but remember to maintain the flag of `xpack.enabled: true` while testing.
* Metadata information has been removed from `cluster/stats` API call to reduce the amount of data returned