### PR TITLE
Cherry-pick #24663 to 7.x: Improve healthcheck in consul docker image

### DIFF
--- a/metricbeat/module/consul/_meta/Dockerfile
+++ b/metricbeat/module/consul/_meta/Dockerfile
@@ -5,6 +5,5 @@ ENV CONSUL_BIND_INTERFACE='eth0'
 
 EXPOSE 8500
 
-# Use the same healthcheck as the Windows version of the image.
-# https://github.com/Microsoft/mssql-docker/blob/a3020afeec9be1eb2d67645ac739438eb8f2c545/windows/mssql-server-windows/dockerfile#L31
-HEALTHCHECK --interval=1s --retries=90 CMD curl http://0.0.0.0:8500/v1/agent/metrics
+# Wait till the service reports runtime metrics
+HEALTHCHECK --interval=1s --retries=90 CMD curl -s http://0.0.0.0:8500/v1/agent/metrics | grep -q consul.runtime

--- a/metricbeat/module/consul/docker-compose.yml
+++ b/metricbeat/module/consul/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.3'
 
 services:
   consul:
-    image: docker.elastic.co/integrations-ci/beats-consul:${CONSUL_VERSION:-1.9.3}-1
+    image: docker.elastic.co/integrations-ci/beats-consul:${CONSUL_VERSION:-1.9.3}-2
     build:
       context: ./_meta
       args:


### PR DESCRIPTION
Cherry-pick of PR #24663 to 7.x branch. Original message: 

Fix flaky test in Metricbeat Consul module.

Runtime fields are not reported till some seconds after startup in
Consul 1.9. If tests are fast enough, they will get events without
these expected fields, and will fail. Change the healthcheck to
ensure that these fields are being reported.

Tests with Consul 1.9 were introduced in #24123.

Closes #24589.