### PR TITLE
Cherry-pick #24679 to 7.x: Skip Auditbeat test_non_recursive on Darwin on CI

### DIFF
--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -1,5 +1,6 @@
 import time
 import unittest
+import platform
 from auditbeat import *
 
 
@@ -61,6 +62,8 @@ class Test(BaseTest):
             else:
                 break
 
+    @unittest.skipIf(os.getenv("BUILD_ID") is not None and platform.system() == 'Darwin',
+                     'Flaky test: https://github.com/elastic/beats/issues/24678')
     def test_non_recursive(self):
         """
         file_integrity monitors watched directories (non recursive).
@@ -130,7 +133,7 @@ class Test(BaseTest):
             # assert file inside subdir is not reported
             assert self.log_contains(file3) is False
 
-    @unittest.skip("Skipped as flaky: https://github.com/elastic/beats/issues/7731")
+    @unittest.skipIf(os.getenv("BUILD_ID") is not None, "Skipped as flaky: https://github.com/elastic/beats/issues/7731")
     def test_recursive(self):
         """
         file_integrity monitors watched directories (recursive).


### PR DESCRIPTION
Cherry-pick of PR #24679 to 7.x branch. Original message: 

## What does this PR do?

Skips a test that has been failing on CI. See https://github.com/elastic/beats/issues/24678.

## Why is it important?

It makes CI more reliable.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes: https://github.com/elastic/beats/issues/24678
- Relates https://github.com/elastic/beats/pull/24648

