### PR TITLE
[Filebeat] Fix cisco asa parser for message 302022

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -403,6 +403,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix default `scope` in `add_nomad_metadata`. {issue}24559[24559]
 - Fix Cisco ASA parser for message 722051. {pull}24410[24410]
 - Fix `google_workspace` pagination. {pull}24668[24668]
+- Fix Cisco ASA parser for message 302022. {pull}24697[24697]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -403,7 +403,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix default `scope` in `add_nomad_metadata`. {issue}24559[24559]
 - Fix Cisco ASA parser for message 722051. {pull}24410[24410]
 - Fix `google_workspace` pagination. {pull}24668[24668]
-- Fix Cisco ASA parser for message 302022. {pull}24697[24697]
+- Fix Cisco ASA parser for message 302022. {issue}24405[24405] {pull}24697[24697]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
@@ -45,7 +45,9 @@
         ],
         "related.ip": [
             "10.10.10.10",
-            "192.168.2.2"
+            "8.8.8.8",
+            "192.168.2.2",
+            "8.8.5.4"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
@@ -103,7 +105,9 @@
         ],
         "related.ip": [
             "10.10.10.10",
-            "192.168.2.2"
+            "8.8.8.8",
+            "192.168.2.2",
+            "8.8.5.4"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
@@ -151,6 +155,7 @@
         ],
         "related.ip": [
             "192.168.2.2",
+            "8.8.8.8",
             "10.10.10.10"
         ],
         "service.type": "cisco",
@@ -285,6 +290,7 @@
         ],
         "related.ip": [
             "192.168.2.2",
+            "8.8.8.8",
             "10.10.10.10"
         ],
         "service.type": "cisco",
@@ -340,7 +346,9 @@
         ],
         "related.ip": [
             "10.10.10.10",
-            "192.168.2.2"
+            "8.8.8.8",
+            "192.168.2.2",
+            "8.8.5.4"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
@@ -615,6 +623,7 @@
         ],
         "related.ip": [
             "10.10.10.10",
+            "8.8.8.8",
             "192.168.2.2"
         ],
         "service.type": "cisco",
@@ -749,6 +758,7 @@
         ],
         "related.ip": [
             "10.192.46.90",
+            "8.8.8.8",
             "10.10.10.10"
         ],
         "service.type": "cisco",
@@ -796,6 +806,7 @@
         ],
         "related.ip": [
             "192.168.2.2",
+            "8.8.8.8",
             "10.10.10.10"
         ],
         "service.type": "cisco",
@@ -909,6 +920,7 @@
         ],
         "related.ip": [
             "192.168.2.2",
+            "8.8.8.8",
             "10.10.10.10"
         ],
         "service.type": "cisco",
@@ -1237,7 +1249,9 @@
         ],
         "related.ip": [
             "10.10.10.10",
-            "192.168.2.2"
+            "8.8.8.4",
+            "192.168.2.2",
+            "8.8.8.8"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
@@ -1295,7 +1309,9 @@
         ],
         "related.ip": [
             "10.10.10.10",
-            "192.168.2.2"
+            "8.8.8.4",
+            "192.168.2.2",
+            "8.8.8.8"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
@@ -1598,6 +1614,174 @@
         "source.address": "192.168.2.2",
         "source.ip": "192.168.2.2",
         "source.port": 24223,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
+    },
+    {
+        "cisco.asa.destination_interface": "net",
+        "cisco.asa.message_id": "302022",
+        "cisco.asa.source_interface": "fw1111",
+        "destination.address": "192.168.2.2",
+        "destination.ip": "192.168.2.2",
+        "destination.nat.ip": "8.8.8.8",
+        "destination.nat.port": "10051",
+        "destination.port": 10051,
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 302022,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-302022: Built director stub TCP connection for fw1111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
+        "event.severity": 6,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info"
+        ],
+        "fileset.name": "asa",
+        "host.hostname": "dev01",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 4472,
+        "network.iana_number": 6,
+        "network.transport": "tcp",
+        "observer.egress.interface.name": "fw1111",
+        "observer.hostname": "dev01",
+        "observer.ingress.interface.name": "net",
+        "observer.product": "asa",
+        "observer.type": "firewall",
+        "observer.vendor": "Cisco",
+        "related.hosts": [
+            "dev01"
+        ],
+        "related.ip": [
+            "10.10.10.10",
+            "8.8.8.5",
+            "192.168.2.2",
+            "8.8.8.8"
+        ],
+        "service.type": "cisco",
+        "source.address": "10.10.10.10",
+        "source.ip": "10.10.10.10",
+        "source.nat.ip": "8.8.8.5",
+        "source.nat.port": "38540",
+        "source.port": 38540,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
+    },
+    {
+        "cisco.asa.destination_interface": "net",
+        "cisco.asa.message_id": "302022",
+        "cisco.asa.source_interface": "fw111",
+        "destination.address": "192.168.2.2",
+        "destination.ip": "192.168.2.2",
+        "destination.nat.ip": "8.8.8.8",
+        "destination.nat.port": "10051",
+        "destination.port": 10051,
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 302022,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-302022: Built forwarder  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.168.2.2/10051 (8.8.8.8/10051)",
+        "event.severity": 6,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info"
+        ],
+        "fileset.name": "asa",
+        "host.hostname": "dev01",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 4631,
+        "network.iana_number": 6,
+        "network.transport": "tcp",
+        "observer.egress.interface.name": "fw111",
+        "observer.hostname": "dev01",
+        "observer.ingress.interface.name": "net",
+        "observer.product": "asa",
+        "observer.type": "firewall",
+        "observer.vendor": "Cisco",
+        "related.hosts": [
+            "dev01"
+        ],
+        "related.ip": [
+            "10.10.10.10",
+            "8.8.8.5",
+            "192.168.2.2",
+            "8.8.8.8"
+        ],
+        "service.type": "cisco",
+        "source.address": "10.10.10.10",
+        "source.ip": "10.10.10.10",
+        "source.nat.ip": "8.8.8.5",
+        "source.nat.port": "38540",
+        "source.port": 38540,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
+    },
+    {
+        "cisco.asa.destination_interface": "net",
+        "cisco.asa.message_id": "302022",
+        "cisco.asa.source_interface": "fw111",
+        "destination.address": "192.1682.2.2",
+        "destination.domain": "192.1682.2.2",
+        "destination.nat.ip": "8.8.8.8",
+        "destination.nat.port": "10051",
+        "destination.port": 10051,
+        "event.action": "firewall-rule",
+        "event.category": [
+            "network"
+        ],
+        "event.code": 302022,
+        "event.dataset": "cisco.asa",
+        "event.kind": "event",
+        "event.module": "cisco",
+        "event.original": "%ASA-6-302022: Built backup  stub TCP connection for fw111:10.10.10.10/38540 (8.8.8.5/38540) to net:192.1682.2.2/10051 (8.8.8.8/10051)",
+        "event.severity": 6,
+        "event.timezone": "-02:00",
+        "event.type": [
+            "info"
+        ],
+        "fileset.name": "asa",
+        "host.hostname": "dev01",
+        "input.type": "log",
+        "log.level": "informational",
+        "log.offset": 4791,
+        "network.iana_number": 6,
+        "network.transport": "tcp",
+        "observer.egress.interface.name": "fw111",
+        "observer.hostname": "dev01",
+        "observer.ingress.interface.name": "net",
+        "observer.product": "asa",
+        "observer.type": "firewall",
+        "observer.vendor": "Cisco",
+        "related.hosts": [
+            "dev01",
+            "192.1682.2.2"
+        ],
+        "related.ip": [
+            "10.10.10.10",
+            "8.8.8.5",
+            "8.8.8.8"
+        ],
+        "service.type": "cisco",
+        "source.address": "10.10.10.10",
+        "source.ip": "10.10.10.10",
+        "source.nat.ip": "8.8.8.5",
+        "source.nat.port": "38540",
+        "source.port": 38540,
         "tags": [
             "cisco-asa",
             "forwarded"

--- a/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/additional_messages.log-expected.json
@@ -1625,8 +1625,6 @@
         "cisco.asa.source_interface": "fw1111",
         "destination.address": "192.168.2.2",
         "destination.ip": "192.168.2.2",
-        "destination.nat.ip": "8.8.8.8",
-        "destination.nat.port": "10051",
         "destination.port": 10051,
         "event.action": "firewall-rule",
         "event.category": [
@@ -1660,15 +1658,11 @@
         ],
         "related.ip": [
             "10.10.10.10",
-            "8.8.8.5",
-            "192.168.2.2",
-            "8.8.8.8"
+            "192.168.2.2"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
         "source.ip": "10.10.10.10",
-        "source.nat.ip": "8.8.8.5",
-        "source.nat.port": "38540",
         "source.port": 38540,
         "tags": [
             "cisco-asa",
@@ -1681,8 +1675,6 @@
         "cisco.asa.source_interface": "fw111",
         "destination.address": "192.168.2.2",
         "destination.ip": "192.168.2.2",
-        "destination.nat.ip": "8.8.8.8",
-        "destination.nat.port": "10051",
         "destination.port": 10051,
         "event.action": "firewall-rule",
         "event.category": [
@@ -1716,15 +1708,11 @@
         ],
         "related.ip": [
             "10.10.10.10",
-            "8.8.8.5",
-            "192.168.2.2",
-            "8.8.8.8"
+            "192.168.2.2"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
         "source.ip": "10.10.10.10",
-        "source.nat.ip": "8.8.8.5",
-        "source.nat.port": "38540",
         "source.port": 38540,
         "tags": [
             "cisco-asa",
@@ -1737,8 +1725,6 @@
         "cisco.asa.source_interface": "fw111",
         "destination.address": "192.1682.2.2",
         "destination.domain": "192.1682.2.2",
-        "destination.nat.ip": "8.8.8.8",
-        "destination.nat.port": "10051",
         "destination.port": 10051,
         "event.action": "firewall-rule",
         "event.category": [
@@ -1772,15 +1758,11 @@
             "192.1682.2.2"
         ],
         "related.ip": [
-            "10.10.10.10",
-            "8.8.8.5",
-            "8.8.8.8"
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "source.address": "10.10.10.10",
         "source.ip": "10.10.10.10",
-        "source.nat.ip": "8.8.8.5",
-        "source.nat.port": "38540",
         "source.port": 38540,
         "tags": [
             "cisco-asa",

--- a/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/hostnames.log-expected.json
@@ -36,6 +36,9 @@
             "target.destination.hostname.local",
             "Prod-host.name.addr"
         ],
+        "related.ip": [
+            "10.0.55.66"
+        ],
         "service.type": "cisco",
         "source.domain": "Prod-host.name.addr",
         "source.nat.ip": "10.0.55.66",

--- a/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
@@ -451,6 +451,7 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "192.0.2.222",
+            "192.0.2.43",
             "10.123.1.35"
         ],
         "service.type": "cisco",
@@ -554,7 +555,8 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "192.0.2.1",
-            "10.123.3.42"
+            "10.123.3.42",
+            "10.123.3.130"
         ],
         "service.type": "cisco",
         "source.address": "192.0.2.1",
@@ -812,7 +814,8 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "192.0.0.17",
-            "192.168.3.42"
+            "192.168.3.42",
+            "10.0.0.130"
         ],
         "service.type": "cisco",
         "source.address": "192.0.0.17",
@@ -3335,6 +3338,7 @@
         ],
         "related.ip": [
             "10.1.1.45",
+            "192.88.99.1",
             "192.88.99.129"
         ],
         "server.domain": "bad.example.com",
@@ -3393,6 +3397,7 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "10.1.1.1",
+            "10.2.1.1",
             "192.0.2.223"
         ],
         "service.type": "cisco",
@@ -3450,6 +3455,7 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "10.1.1.1",
+            "10.2.1.1",
             "192.0.2.223"
         ],
         "service.type": "cisco",

--- a/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/ftd/test/sample.log-expected.json
@@ -442,6 +442,7 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "192.0.2.222",
+            "192.0.2.43",
             "10.123.1.35"
         ],
         "service.type": "cisco",
@@ -543,7 +544,8 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "192.0.2.1",
-            "10.123.3.42"
+            "10.123.3.42",
+            "10.123.3.130"
         ],
         "service.type": "cisco",
         "source.address": "192.0.2.1",
@@ -796,7 +798,8 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "192.0.0.17",
-            "192.168.3.42"
+            "192.168.3.42",
+            "10.0.0.130"
         ],
         "service.type": "cisco",
         "source.address": "192.0.0.17",
@@ -3321,6 +3324,7 @@
         ],
         "related.ip": [
             "10.1.1.45",
+            "192.88.99.1",
             "192.88.99.129"
         ],
         "server.domain": "bad.example.com",
@@ -3379,7 +3383,9 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "10.1.1.1",
-            "192.0.2.223"
+            "10.2.1.1",
+            "192.0.2.223",
+            "192.0.2.225"
         ],
         "service.type": "cisco",
         "source.address": "10.1.1.1",
@@ -3436,6 +3442,7 @@
         "observer.vendor": "Cisco",
         "related.ip": [
             "10.1.1.1",
+            "10.2.1.1",
             "192.0.2.223"
         ],
         "service.type": "cisco",

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -318,7 +318,7 @@ processors:
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302022'"
       field: "message"
-      pattern: "Built %{} stub %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{source.nat.ip}/%{source.nat.port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{destination.nat.ip}/%{destination.nat.port})"
+      pattern: "Built %{} stub %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} %{} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} %{}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302023'"
       field: "message"

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -318,7 +318,7 @@ processors:
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302022'"
       field: "message"
-      pattern: "Built %{} stub %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+      pattern: "Built %{} stub %{network.transport} connection for %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} (%{source.nat.ip}/%{source.nat.port}) to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port} (%{destination.nat.ip}/%{destination.nat.port})"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '302023'"
       field: "message"
@@ -1616,8 +1616,18 @@ processors:
       allow_duplicates: false
   - append:
       field: related.ip
+      value: "{{source.nat.ip}}"
+      if: "ctx?.source?.nat?.ip != null"
+      allow_duplicates: false
+  - append:
+      field: related.ip
       value: "{{destination.ip}}"
       if: "ctx?.destination?.ip != null"
+      allow_duplicates: false
+  - append:
+      field: related.ip
+      value: "{{destination.nat.ip}}"
+      if: "ctx?.destination?.nat?.ip != null"
       allow_duplicates: false
   - append:
       field: related.user


### PR DESCRIPTION
## What does this PR do?

- fix parser to include mapped address and ports for message 302022
- add NAT addresses to related.ip

## Why is it important?

Previous dissect pattern caused illegal_argument_exception

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

``` bash
TESTING_FILEBEAT_MODULES=cisco TESTING_FILEBEAT_FILESETS=asa mage -v pythonIntegTest
```

## Related issues

- Closes #24405 