### PR TITLE
Cherry-pick #24723 to 7.x: Log error when compose up cannot get host information

### DIFF
--- a/libbeat/tests/compose/compose.go
+++ b/libbeat/tests/compose/compose.go
@@ -112,7 +112,7 @@ func EnsureUp(t testing.TB, service string, options ...UpOption) HostInfo {
 	// Get host information
 	host, err := compose.HostInformation(service)
 	if err != nil {
-		t.Fatalf("getting host for %s", service)
+		t.Fatalf("getting host for %s: %v", service, err)
 	}
 
 	return host


### PR DESCRIPTION
Cherry-pick of PR #24723 to 7.x branch. Original message: 

Compose helper used in tests was not logging the original error when
it cannot get host information.