### PR TITLE
[Winlogbeat] Add SplitCommandLine implementation in Go

### DIFF
--- a/libbeat/processors/script/javascript/module/windows/windows_test.go
+++ b/libbeat/processors/script/javascript/module/windows/windows_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build windows
-
 package windows
 
 import (
@@ -25,33 +23,118 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const quotedCommandLine = `"C:\Program Files (x86)\Steam\bin\cef\cef.win7x64\steamwebhelper.exe" "-lang=en_US" "-cachedir=C:\Users\jimmy\AppData\Local\Steam\htmlcache" "-steampid=796" "-buildid=1546909276" "-steamid=0" "-steamuniverse=Dev" "-clientui=C:\Program Files (x86)\Steam\clientui" --disable-spell-checking --disable-out-of-process-pac --enable-blink-features=ResizeObserver,Worklet,AudioWorklet --disable-features=TouchpadAndWheelScrollLatching,AsyncWheelEvents --enable-media-stream --disable-smooth-scrolling --num-raster-threads=4 --enable-direct-write "--log-file=C:\Program Files (x86)\Steam\logs\cef_log.txt"`
-
-func TestSplitCommandLine(t *testing.T) {
-	args := SplitCommandLine(quotedCommandLine)
-
-	for _, a := range args {
-		t.Log(a)
+func TestCommandLineToArgv(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		args []string
+	}{
+		{
+			cmd:  ``,
+			args: nil,
+		},
+		{
+			cmd:  ` `,
+			args: nil,
+		},
+		{
+			cmd:  "\t",
+			args: nil,
+		},
+		{
+			cmd:  `test`,
+			args: []string{`test`},
+		},
+		{
+			cmd:  `test a b c`,
+			args: []string{`test`, `a`, `b`, `c`},
+		},
+		{
+			cmd:  `test "`,
+			args: []string{`test`, ``},
+		},
+		{
+			cmd:  `test ""`,
+			args: []string{`test`, ``},
+		},
+		{
+			cmd:  `test """`,
+			args: []string{`test`, `"`},
+		},
+		{
+			cmd:  `test "" a`,
+			args: []string{`test`, ``, `a`},
+		},
+		{
+			cmd:  `test "123"`,
+			args: []string{`test`, `123`},
+		},
+		{
+			cmd:  `test \"123\"`,
+			args: []string{`test`, `"123"`},
+		},
+		{
+			cmd:  `test \"123 456\"`,
+			args: []string{`test`, `"123`, `456"`},
+		},
+		{
+			cmd:  `test \\"`,
+			args: []string{`test`, `\`},
+		},
+		{
+			cmd:  `test \\\"`,
+			args: []string{`test`, `\"`},
+		},
+		{
+			cmd:  `test \\\\\"`,
+			args: []string{`test`, `\\"`},
+		},
+		{
+			cmd:  `test \\\"x`,
+			args: []string{`test`, `\"x`},
+		},
+		{
+			cmd:  `test """"\""\\\"`,
+			args: []string{`test`, `""\"`},
+		},
+		{
+			cmd:  `"cmd line" abc`,
+			args: []string{`cmd line`, `abc`},
+		},
+		{
+			cmd:  `test \\\\\""x"""y z`,
+			args: []string{`test`, `\\"x"y z`},
+		},
+		{
+			cmd:  "test\tb\t\"x\ty\"",
+			args: []string{`test`, `b`, "x\ty"},
+		},
+		{
+			cmd: `"C:\Program Files (x86)\Steam\bin\cef\cef.win7x64\steamwebhelper.exe" "-lang=en_US" "-cachedir=C:\Users\jimmy\AppData\Local\Steam\htmlcache" "-steampid=796" "-buildid=1546909276" "-steamid=0" "-steamuniverse=Dev" "-clientui=C:\Program Files (x86)\Steam\clientui" --disable-spell-checking --disable-out-of-process-pac --enable-blink-features=ResizeObserver,Worklet,AudioWorklet --disable-features=TouchpadAndWheelScrollLatching,AsyncWheelEvents --enable-media-stream --disable-smooth-scrolling --num-raster-threads=4 --enable-direct-write "--log-file=C:\Program Files (x86)\Steam\logs\cef_log.txt"`,
+			args: []string{
+				`C:\Program Files (x86)\Steam\bin\cef\cef.win7x64\steamwebhelper.exe`,
+				`-lang=en_US`,
+				`-cachedir=C:\Users\jimmy\AppData\Local\Steam\htmlcache`,
+				`-steampid=796`,
+				`-buildid=1546909276`,
+				`-steamid=0`,
+				`-steamuniverse=Dev`,
+				`-clientui=C:\Program Files (x86)\Steam\clientui`,
+				`--disable-spell-checking`,
+				`--disable-out-of-process-pac`,
+				`--enable-blink-features=ResizeObserver,Worklet,AudioWorklet`,
+				`--disable-features=TouchpadAndWheelScrollLatching,AsyncWheelEvents`,
+				`--enable-media-stream`,
+				`--disable-smooth-scrolling`,
+				`--num-raster-threads=4`,
+				`--enable-direct-write`,
+				`--log-file=C:\Program Files (x86)\Steam\logs\cef_log.txt`,
+			},
+		},
 	}
 
-	expected := []string{
-		`C:\Program Files (x86)\Steam\bin\cef\cef.win7x64\steamwebhelper.exe`,
-		`-lang=en_US`,
-		`-cachedir=C:\Users\jimmy\AppData\Local\Steam\htmlcache`,
-		`-steampid=796`,
-		`-buildid=1546909276`,
-		`-steamid=0`,
-		`-steamuniverse=Dev`,
-		`-clientui=C:\Program Files (x86)\Steam\clientui`,
-		`--disable-spell-checking`,
-		`--disable-out-of-process-pac`,
-		`--enable-blink-features=ResizeObserver,Worklet,AudioWorklet`,
-		`--disable-features=TouchpadAndWheelScrollLatching,AsyncWheelEvents`,
-		`--enable-media-stream`,
-		`--disable-smooth-scrolling`,
-		`--num-raster-threads=4`,
-		`--enable-direct-write`,
-		`--log-file=C:\Program Files (x86)\Steam\logs\cef_log.txt`,
+	for _, tc := range cases {
+		t.Run(tc.cmd, func(t *testing.T) {
+			assert.Equal(t, tc.args, SplitCommandLine(tc.cmd))
+		})
 	}
-	assert.Equal(t, expected, args)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Implements SplitCommandLine function in pure Go removing the syscall requirement.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

With this change, winlogbeat JS processors can be used in any platform.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
