### PR TITLE
Cherry-pick #24719 to 7.x: [Filebeat] Fix gcp/vpcflow module defaulting to file input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -223,7 +223,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix netflow module ignoring detect_sequence_reset flag. {issue}24268[24268] {pull}24270[24270]
 - Fix Cisco ASA parser for message 302022. {issue}24405[24405] {pull}24697[24697]
 - Fix gcp/vpcflow module error where input type was defaulting to file. {pull}24719[24719]
-- Fix date parsing in GSuite/login and Google Workspace/login filesets. {issue}24694[24694]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -222,6 +222,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `google_workspace` pagination. {pull}24668[24668]
 - Fix netflow module ignoring detect_sequence_reset flag. {issue}24268[24268] {pull}24270[24270]
 - Fix Cisco ASA parser for message 302022. {issue}24405[24405] {pull}24697[24697]
+- Fix gcp/vpcflow module error where input type was defaulting to file. {pull}24719[24719]
+- Fix date parsing in GSuite/login and Google Workspace/login filesets. {issue}24694[24694]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/gcp/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/gcp/vpcflow/manifest.yml
@@ -2,7 +2,7 @@ module_version: "1.0"
 
 var:
   - name: input
-    default: google-pubsub
+    default: gcp-pubsub
   - name: project_id
     default: SET_PROJECT_NAME
   - name: topic


### PR DESCRIPTION
Cherry-pick of PR #24719 to 7.x branch. Original message: 

## What does this PR do?

The pubsub input was renamed from google-pubsub to gcp-pubsub and the vpcflow filesets manifest
was not updated. As a result it's defaulting to the file input. This fixes the manifest.

The workaround is to explicitly set the input type:

    vpcflow:
      enabled: true
      var.input: gcp-pubsub

## Why is it important?

The input won't start using existing configurations causing a breaking change.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

`
Exiting: Failed to start crawler: starting input failed: Error while initializing input: No paths were defined for input accessing config
`
