### PR TITLE
Cherry-pick #24588 to 6.8: Add docs about PostgreSQL monitoring

### DIFF
--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -22,19 +22,63 @@ on Debian.
 include::../include/running-modules.asciidoc[]
 
 [float]
-=== Example dashboards
+=== Supported log formats
 
-This module comes with two sample dashboards.
+This module can collect any logs from PostgreSQL servers, but to be able to
+better analyze their contents and extract more information, they should be
+formatted in a determined way.
 
-The first dashboard is for regular logs.
+There are some settings to take into account for the log format.
 
-[role="screenshot"]
-image::./images/filebeat-postgresql-overview.png[]
+Log lines should be preffixed with the timestamp in milliseconds, the process
+id, the user id and the database name. This uses to be the default in most
+distributions, and is translated to this setting in the configuration file:
 
-The second one shows the slowlogs of PostgreSQL.
+["source","sh"]
+----------------------------
+log_line_prefix = '%m [%p] %q%u@%d '
+----------------------------
 
-[role="screenshot"]
-image::./images/filebeat-postgresql-slowlog-overview.png[]
+PostgreSQL server can be configured to log statements and their durations and
+this module is able to collect this information. To be able to correlate each
+duration with their statements, they must be logged in the same line. This
+happens when the following options are used:
+
+["source","sh"]
+----------------------------
+log_duration = 'on'
+log_statement = 'none'
+log_min_duration_statement = 0
+----------------------------
+
+Setting a zero value in `log_min_duration_statement` will log all statements
+executed by a client. You probably want to configure it to a higher value, so it
+logs only slower statements. This value is configured in milliseconds.
+
+When using `log_statement` and `log_duration` together, statements and durations
+are logged in different lines, and {beatname_uc} is not able to correlate both
+values, for this reason it is recommended to disable `log_statement`.
+
+NOTE: The PostgreSQL module of Metricbeat is also able to collect information
+about all statements executed in the server. You may chose which one is better
+for your needings. An important difference is that the Metricbeat module
+collects aggregated information when the statement is executed several times,
+but cannot know when each statement was executed. This information can be
+obtained from logs.
+
+Other logging options that you may consider to enable are the following ones:
+
+["source","sh"]
+----------------------------
+log_checkpoints = 'on';
+log_connections = 'on';
+log_disconnections = 'on';
+log_lock_waits = 'on';
+----------------------------
+
+Both `log_connections` and `log_disconnections` can cause a lot of events if you
+don't have persistent connections, so enable with care.
+
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -69,6 +113,21 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+=== Example dashboards
+
+This module comes with two sample dashboards.
+
+The first dashboard is for regular logs.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-overview.png[]
+
+The second one shows the slowlogs of PostgreSQL. If `log_min_duration_statement`
+is not used, this dashboard will show incomplete or no data.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-slowlog-overview.png[]
 
 :has-dashboards!:
 

--- a/filebeat/module/postgresql/_meta/docs.asciidoc
+++ b/filebeat/module/postgresql/_meta/docs.asciidoc
@@ -17,19 +17,63 @@ on Debian.
 include::../include/running-modules.asciidoc[]
 
 [float]
-=== Example dashboards
+=== Supported log formats
 
-This module comes with two sample dashboards.
+This module can collect any logs from PostgreSQL servers, but to be able to
+better analyze their contents and extract more information, they should be
+formatted in a determined way.
 
-The first dashboard is for regular logs.
+There are some settings to take into account for the log format.
 
-[role="screenshot"]
-image::./images/filebeat-postgresql-overview.png[]
+Log lines should be preffixed with the timestamp in milliseconds, the process
+id, the user id and the database name. This uses to be the default in most
+distributions, and is translated to this setting in the configuration file:
 
-The second one shows the slowlogs of PostgreSQL.
+["source","sh"]
+----------------------------
+log_line_prefix = '%m [%p] %q%u@%d '
+----------------------------
 
-[role="screenshot"]
-image::./images/filebeat-postgresql-slowlog-overview.png[]
+PostgreSQL server can be configured to log statements and their durations and
+this module is able to collect this information. To be able to correlate each
+duration with their statements, they must be logged in the same line. This
+happens when the following options are used:
+
+["source","sh"]
+----------------------------
+log_duration = 'on'
+log_statement = 'none'
+log_min_duration_statement = 0
+----------------------------
+
+Setting a zero value in `log_min_duration_statement` will log all statements
+executed by a client. You probably want to configure it to a higher value, so it
+logs only slower statements. This value is configured in milliseconds.
+
+When using `log_statement` and `log_duration` together, statements and durations
+are logged in different lines, and {beatname_uc} is not able to correlate both
+values, for this reason it is recommended to disable `log_statement`.
+
+NOTE: The PostgreSQL module of Metricbeat is also able to collect information
+about all statements executed in the server. You may chose which one is better
+for your needings. An important difference is that the Metricbeat module
+collects aggregated information when the statement is executed several times,
+but cannot know when each statement was executed. This information can be
+obtained from logs.
+
+Other logging options that you may consider to enable are the following ones:
+
+["source","sh"]
+----------------------------
+log_checkpoints = 'on';
+log_connections = 'on';
+log_disconnections = 'on';
+log_lock_waits = 'on';
+----------------------------
+
+Both `log_connections` and `log_disconnections` can cause a lot of events if you
+don't have persistent connections, so enable with care.
+
 
 include::../include/configuring-intro.asciidoc[]
 
@@ -64,6 +108,21 @@ include::../include/config-option-intro.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+[float]
+=== Example dashboards
+
+This module comes with two sample dashboards.
+
+The first dashboard is for regular logs.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-overview.png[]
+
+The second one shows the slowlogs of PostgreSQL. If `log_min_duration_statement`
+is not used, this dashboard will show incomplete or no data.
+
+[role="screenshot"]
+image::./images/filebeat-postgresql-slowlog-overview.png[]
 
 :has-dashboards!:
 

--- a/metricbeat/docs/modules/postgresql.asciidoc
+++ b/metricbeat/docs/modules/postgresql.asciidoc
@@ -77,6 +77,10 @@ metricbeat.modules:
     # Stats about every PostgreSQL process
     - activity
 
+    # Stats about every statement executed in the server. It requires the
+    # `pg_stats_statement` library to be configured in the server.
+    #- statement
+
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -559,6 +559,10 @@ metricbeat.modules:
     # Stats about every PostgreSQL process
     - activity
 
+    # Stats about every statement executed in the server. It requires the
+    # `pg_stats_statement` library to be configured in the server.
+    #- statement
+
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:

--- a/metricbeat/module/postgresql/_meta/config.reference.yml
+++ b/metricbeat/module/postgresql/_meta/config.reference.yml
@@ -10,6 +10,10 @@
     # Stats about every PostgreSQL process
     - activity
 
+    # Stats about every statement executed in the server. It requires the
+    # `pg_stats_statement` library to be configured in the server.
+    #- statement
+
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:

--- a/metricbeat/module/postgresql/statement/_meta/docs.asciidoc
+++ b/metricbeat/module/postgresql/statement/_meta/docs.asciidoc
@@ -1,1 +1,41 @@
 This is the `statement` metricset of the PostgreSQL module. 
+
+This module collects information from the `pg_stat_statements` view, that keeps
+track of planning and execution statistics of all SQL statements executed by
+the server.
+
+`pg_stat_statements` is included by an additional module in PostgreSQL. This
+module requires additional shared memory, and is disabled by default.
+
+You can enable it by adding this module to the configuration as a shared
+preloaded library.
+
+["source"]
+-------------------------------------------
+shared_preload_libraries = 'pg_stat_statements'
+pg_stat_statements.max = 10000
+pg_stat_statements.track = all
+-------------------------------------------
+
+NOTE: Preloading this library in your server will increase the memory usage of
+your PostgreSQL server. Use it with care.
+
+Once the server is started with this module, it starts collecting statistics
+about all statements executed. To make these statistics available in the
+`pg_stat_statements` view, the following statement needs to be executed in the
+server:
+
+["source","sql"]
+-------------------------------------------
+CREATE EXTENSION pg_stat_statements;
+-------------------------------------------
+
+You can read more about the available options for this module in the
+https://www.postgresql.org/docs/13/pgstatstatements.html[official documentation].
+
+NOTE: The PostgreSQL module of Filebeat is also able to collect information
+about statements executed in the server from its logs. You may chose which one
+is better for your needings. An important difference is that the Metricbeat
+module collects aggregated information when the statement is executed several
+times, but cannot know when each statement was executed. This information can be
+obtained from logs.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -559,6 +559,10 @@ metricbeat.modules:
     # Stats about every PostgreSQL process
     - activity
 
+    # Stats about every statement executed in the server. It requires the
+    # `pg_stats_statement` library to be configured in the server.
+    #- statement
+
   period: 10s
 
   # The host must be passed as PostgreSQL URL. Example:


### PR DESCRIPTION
Cherry-pick of PR #24588 to 6.8 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Add documentation in PostgreSQL modules about recommended configuration.

## Why is it important?

To better leverage PostgreSQL modules.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #14337.
- Related to #20321.
- Part of elastic/integrations#366.