### PR TITLE
Cherry-pick #24718 to 7.x: [Filebeat] fix cisco amp @metadata._id calculation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -223,6 +223,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `google_workspace` pagination. {pull}24668[24668]
 - Fix netflow module ignoring detect_sequence_reset flag. {issue}24268[24268] {pull}24270[24270]
 - Fix Cisco ASA parser for message 302022. {issue}24405[24405] {pull}24697[24697]
+- Fix Cisco AMP `@metadata._id` calculation {issue}24717[24717] {pull}24718[24718]
 - Fix date parsing in GSuite/login and Google Workspace/login filesets. {issue}24694[24694]
 - Fix gcp/vpcflow module error where input type was defaulting to file. {pull}24719[24719]
 

--- a/x-pack/filebeat/module/cisco/amp/config/config.yml
+++ b/x-pack/filebeat/module/cisco/amp/config/config.yml
@@ -64,16 +64,16 @@ processors:
   - decode_json_fields:
       fields: [message]
       target: json
-  - if:
-      has_fields: ["json.data.detection_id"]
-    then:
-      - fingerprint:
-          fields: ["json.data.detection_id"]
-          target_field: "@metadata._id"
-    else:
-      - fingerprint:
-          fields: ["json.data.timestamp", "json.data.timestamp_nanoseconds", "json.data.event_type_id", "json.data.connector_guid"]
-          target_field: "@metadata._id"
+  - fingerprint:
+      fields:
+        - "json.data.timestamp"
+        - "json.data.timestamp_nanoseconds"
+        - "json.data.event_type_id"
+        - "json.data.connector_guid"
+        - "json.data.id"
+        - "json.data.detection_id"
+      target_field: "@metadata._id"
+      ignore_missing: true
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/cisco/amp/test/cisco_amp1.ndjson.log-expected.json
+++ b/x-pack/filebeat/module/cisco/amp/test/cisco_amp1.ndjson.log-expected.json
@@ -180,6 +180,59 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T10:06:39.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "24:78:d8:fd:c4:75"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6533241347137077251",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "24:78:d8:fd:c4:75"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 657000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6533241347137077000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "a78c29d1fa05c2b23d1dc9b75da8c053399143682fe3779bc466f10e1a997850",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_AMP_Threat_Quarantined",
+        "host.name": "Demo_AMP_Threat_Quarantined",
+        "input.type": "log",
+        "log.offset": 3885,
+        "related.hash": [
+            "a78c29d1fa05c2b23d1dc9b75da8c053399143682fe3779bc466f10e1a997850"
+        ],
+        "related.hosts": [
+            "Demo_AMP_Threat_Quarantined"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T10:05:52.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -300,6 +353,128 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T10:05:52.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "24:78:d8:fd:c4:75"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Overdrive.RET",
+        "cisco.amp.detection_id": "6533241145273614337",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "24:78:d8:fd:c4:75"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 525000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6533241145273614000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "a78c29d1fa05c2b23d1dc9b75da8c053399143682fe3779bc466f10e1a997850",
+        "file.name": "BIT4BBF.tmp",
+        "file.path": "\\\\?\\C:\\BIT4BBF.tmp",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_AMP_Threat_Quarantined",
+        "host.name": "Demo_AMP_Threat_Quarantined",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 7800,
+        "process.hash.md5": "54a47f6b5e09a77e61649109c6a08866",
+        "process.hash.sha1": "4af001b3c3816b860660cf2de2c0fd3c1dfb4878",
+        "process.hash.sha256": "121118a0f5e0e8c933efd28c9901e54e42792619a8a3a6d11e1f0025a7324bc2",
+        "process.name": "svchost.exe",
+        "process.pid": 896,
+        "related.hash": [
+            "a78c29d1fa05c2b23d1dc9b75da8c053399143682fe3779bc466f10e1a997850"
+        ],
+        "related.hosts": [
+            "Demo_AMP_Threat_Quarantined"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T10:05:52.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "24:78:d8:fd:c4:75"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6533241145273614338",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "24:78:d8:fd:c4:75"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 619000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6533241145273614000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "a78c29d1fa05c2b23d1dc9b75da8c053399143682fe3779bc466f10e1a997850",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_AMP_Threat_Quarantined",
+        "host.name": "Demo_AMP_Threat_Quarantined",
+        "input.type": "log",
+        "log.offset": 9301,
+        "related.hash": [
+            "a78c29d1fa05c2b23d1dc9b75da8c053399143682fe3779bc466f10e1a997850"
+        ],
+        "related.hosts": [
+            "Demo_AMP_Threat_Quarantined"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1229,6 +1404,128 @@
         ]
     },
     {
+        "@timestamp": "2021-01-13T15:36:52.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.0B965CA8AF-95.SBX.TG",
+        "cisco.amp.detection_id": "6411132837046517762",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 684000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411132837046518000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "0b965ca8afea0638749b71ec6ad53f94e8bd9f9b359f1cb2e707dbe52f5d3960",
+        "file.name": "11179468.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\11179468.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 38602,
+        "related.hash": [
+            "0b965ca8afea0638749b71ec6ad53f94e8bd9f9b359f1cb2e707dbe52f5d3960"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-13T15:36:52.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.0B965CA8AF-95.SBX.TG",
+        "cisco.amp.detection_id": "6411132837046517761",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 682000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411132837046518000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "84b6f7be5370c1998886214790c6892b",
+        "file.hash.sha1": "5faebef3bb880489195e80e6656ccf442ff7123b",
+        "file.hash.sha256": "0b965ca8afea0638749b71ec6ad53f94e8bd9f9b359f1cb2e707dbe52f5d3960",
+        "file.name": "MspthrdHash.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\MspthrdHash\\MspthrdHash.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 39856,
+        "related.hash": [
+            "0b965ca8afea0638749b71ec6ad53f94e8bd9f9b359f1cb2e707dbe52f5d3960",
+            "84b6f7be5370c1998886214790c6892b",
+            "5faebef3bb880489195e80e6656ccf442ff7123b"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-13T10:37:33.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -1772,6 +2069,59 @@
         ]
     },
     {
+        "@timestamp": "2020-12-25T05:49:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "e6:44:a0:56:f3:9a"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6525520937264087041",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "e6:44:a0:56:f3:9a"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 661000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6525520937264087000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "edb1ff2521fb4bf748111f92786d260d40407a2e8463dcd24bb09f908ee13eb9",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_AMP_Intel",
+        "host.name": "Demo_AMP_Intel",
+        "input.type": "log",
+        "log.offset": 53947,
+        "related.hash": [
+            "edb1ff2521fb4bf748111f92786d260d40407a2e8463dcd24bb09f908ee13eb9"
+        ],
+        "related.hosts": [
+            "Demo_AMP_Intel"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2020-12-25T05:30:44.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -1837,6 +2187,59 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2020-12-25T05:30:44.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "e6:44:a0:56:f3:9a"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6525516191325224961",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "e6:44:a0:56:f3:9a"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 500000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6525516191325225000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "f2863a775c7faa85aefa3814530d9356ff700ae8bf534584652c2b4b720ee117",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_AMP_Intel",
+        "host.name": "Demo_AMP_Intel",
+        "input.type": "log",
+        "log.offset": 56674,
+        "related.hash": [
+            "f2863a775c7faa85aefa3814530d9356ff700ae8bf534584652c2b4b720ee117"
+        ],
+        "related.hosts": [
+            "Demo_AMP_Intel"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [

--- a/x-pack/filebeat/module/cisco/amp/test/cisco_amp4.ndjson.log-expected.json
+++ b/x-pack/filebeat/module/cisco/amp/test/cisco_amp4.ndjson.log-expected.json
@@ -241,6 +241,75 @@
         ],
         "cisco.amp.connector_guid": "test_connector_guid",
         "cisco.amp.detection": "W32.E4FCCBFA69-95.SBX.TG",
+        "cisco.amp.detection_id": "6412680266518626319",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 587000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412680266518626000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014",
+        "file.name": "28242311.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\28242311.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 4969,
+        "process.hash.md5": "b5ede95ec8bc4ad6984758be42b152bd",
+        "process.hash.sha1": "f504774b72acfb23a46217aec9c6559fd7e4df64",
+        "process.hash.sha256": "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014",
+        "process.name": "QuotaGroup.exe",
+        "process.pid": 7120,
+        "related.hash": [
+            "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T20:18:05.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.E4FCCBFA69-95.SBX.TG",
         "cisco.amp.detection_id": "6412680266518626318",
         "cisco.amp.event_type_id": 1090519054,
         "cisco.amp.file.disposition": "Malicious",
@@ -278,6 +347,73 @@
             "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014",
             "b5ede95ec8bc4ad6984758be42b152bd",
             "f504774b72acfb23a46217aec9c6559fd7e4df64"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T20:18:05.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.E4FCCBFA69-95.SBX.TG",
+        "cisco.amp.detection_id": "6412680266518626317",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 494000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412680266518626000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014",
+        "file.name": "28242311.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\28242311.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 7890,
+        "process.hash.sha256": "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014",
+        "process.name": "28242311.exe",
+        "process.pid": 4788,
+        "related.hash": [
+            "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014"
         ],
         "related.hosts": [
             "Demo_Qakbot_3"
@@ -355,6 +491,112 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T20:18:05.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6412680266518626318",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 587000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412680266518626000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "input.type": "log",
+        "log.offset": 10708,
+        "related.hash": [
+            "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T20:18:05.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6412680266518626316",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 494000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412680266518626000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "input.type": "log",
+        "log.offset": 11817,
+        "related.hash": [
+            "e4fccbfa69222c71130a307956df1dd3013ecb1b523e145fab7abf1602330014"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1254,6 +1496,140 @@
             }
         ],
         "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.2CA2D550E6-100.SBX.VIOC",
+        "cisco.amp.detection_id": "6419303574240493599",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 461000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303574240494000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "2ca2d550e603d74dedda03156023135b38da3630cb014e3d00b1263358c5f00d",
+        "file.name": "taskse.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\taskse.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 31923,
+        "process.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "process.name": "tasksche.exe",
+        "process.pid": 2920,
+        "related.hash": [
+            "2ca2d550e603d74dedda03156023135b38da3630cb014e3d00b1263358c5f00d"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:11.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.4A468603FD.04426d77.auto.Talos",
+        "cisco.amp.detection_id": "6419303574240493597",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 430000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303574240494000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "4a468603fdcb7a2eb5770705898cf9ef37aade532a7964642ecd705a74794b79",
+        "file.name": "taskdl.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\taskdl.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 33372,
+        "process.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "process.name": "tasksche.exe",
+        "process.pid": 2920,
+        "related.hash": [
+            "4a468603fdcb7a2eb5770705898cf9ef37aade532a7964642ecd705a74794b79"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:11.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
         "cisco.amp.detection": "W32.Ransom:Gen.20gl.1201",
         "cisco.amp.detection_id": "6419303574240493595",
         "cisco.amp.event_type_id": 1090519054,
@@ -1377,6 +1753,112 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:11.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6419303574240493595",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 664000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303574240494000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "input.type": "log",
+        "log.offset": 37912,
+        "related.hash": [
+            "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:11.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6419303574240493594",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 664000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303574240494000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "input.type": "log",
+        "log.offset": 39032,
+        "related.hash": [
+            "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1775,6 +2257,152 @@
             }
         ],
         "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.2CA2D550E6-100.SBX.VIOC",
+        "cisco.amp.detection_id": "6419303569945526290",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 580000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303569945526000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "8495400f199ac77853c53b5a3f278f3e",
+        "file.hash.sha1": "be5d6279874da315e3080b06083757aad9b32c23",
+        "file.hash.sha256": "2ca2d550e603d74dedda03156023135b38da3630cb014e3d00b1263358c5f00d",
+        "file.name": "taskse.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\taskse.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 48256,
+        "process.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "process.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "process.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "process.name": "tasksche.exe",
+        "process.pid": 2920,
+        "related.hash": [
+            "2ca2d550e603d74dedda03156023135b38da3630cb014e3d00b1263358c5f00d",
+            "8495400f199ac77853c53b5a3f278f3e",
+            "be5d6279874da315e3080b06083757aad9b32c23"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:10.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.4A468603FD.04426d77.auto.Talos",
+        "cisco.amp.detection_id": "6419303569945526289",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 564000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303569945526000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "4fef5e34143e646dbf9907c4374276f5",
+        "file.hash.sha1": "47a9ad4125b6bd7c55e4e7da251e23f089407b8f",
+        "file.hash.sha256": "4a468603fdcb7a2eb5770705898cf9ef37aade532a7964642ecd705a74794b79",
+        "file.name": "taskdl.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\taskdl.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 49887,
+        "process.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "process.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "process.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "process.name": "tasksche.exe",
+        "process.pid": 2920,
+        "related.hash": [
+            "4a468603fdcb7a2eb5770705898cf9ef37aade532a7964642ecd705a74794b79",
+            "4fef5e34143e646dbf9907c4374276f5",
+            "47a9ad4125b6bd7c55e4e7da251e23f089407b8f"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:10.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
         "cisco.amp.detection_id": "6419303565650558981",
         "cisco.amp.event_type_id": 553648143,
         "cisco.amp.file.disposition": "Malicious",
@@ -1862,6 +2490,554 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558984",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 791000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 53765,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558983",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 783000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 55136,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558982",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 727000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\Windows\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 56507,
+        "process.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "process.name": "mssecsvc.exe",
+        "process.pid": 7144,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558981",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 721000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\WINDOWS\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 58030,
+        "process.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "process.name": "mssecsvc.exe",
+        "process.pid": 7144,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558980",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 646000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 59553,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558979",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 504000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 60814,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.24D004A104-95.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558978",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 426000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "file.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\WINDOWS\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 62075,
+        "process.hash.md5": "4e568dbe3fff1a0025eb432dc929b78f",
+        "process.hash.sha1": "7abcc82dc5a05b4f53fd0fbd386738e5555025cf",
+        "process.hash.sha256": "26f36ca31a1b977685f8df5f8436848b7d4143b47ec0dae68f8382c1b52a6c71",
+        "process.name": "lsass.exe",
+        "process.pid": 768,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+            "db349b97c37d22f5ea1d1841e3c89eb4",
+            "e889544aff85ffaf8b0d0da705105dee7c97fe26"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:29:09.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.24D004A104-95.SBX.TG",
+        "cisco.amp.detection_id": "6419303565650558977",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 399000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419303565650559000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "file.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 63680,
+        "process.hash.md5": "4e568dbe3fff1a0025eb432dc929b78f",
+        "process.hash.sha1": "7abcc82dc5a05b4f53fd0fbd386738e5555025cf",
+        "process.hash.sha256": "26f36ca31a1b977685f8df5f8436848b7d4143b47ec0dae68f8382c1b52a6c71",
+        "process.name": "lsass.exe",
+        "process.pid": 768,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+            "db349b97c37d22f5ea1d1841e3c89eb4",
+            "e889544aff85ffaf8b0d0da705105dee7c97fe26"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -2123,6 +3299,183 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T19:10:30.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.D177E09A9A-95.SBX.TG",
+        "cisco.amp.detection_id": "6412662850426241035",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 218000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412662850426241000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+        "file.name": "el2j9fcqj.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\el2j9fcqj.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 70734,
+        "related.hash": [
+            "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:10:30.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.D177E09A9A-95.SBX.TG",
+        "cisco.amp.detection_id": "6412662850426241034",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 218000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412662850426241000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+        "file.name": "kepv86368.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\kepv86368.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 71990,
+        "related.hash": [
+            "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T19:10:30.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.D177E09A9A-95.SBX.TG",
+        "cisco.amp.detection_id": "6412662850426241033",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 218000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412662850426241000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+        "file.name": "uqlq0o884.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\uqlq0o884.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 73246,
+        "related.hash": [
+            "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T18:03:55.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -2170,6 +3523,75 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T18:03:55.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.24D004A104-95.SBX.TG",
+        "cisco.amp.detection_id": "6419281601187807332",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 891000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419281601187807000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\WINDOWS\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 75695,
+        "process.hash.md5": "4e568dbe3fff1a0025eb432dc929b78f",
+        "process.hash.sha1": "7abcc82dc5a05b4f53fd0fbd386738e5555025cf",
+        "process.hash.sha256": "26f36ca31a1b977685f8df5f8436848b7d4143b47ec0dae68f8382c1b52a6c71",
+        "process.name": "lsass.exe",
+        "process.pid": 708,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -2243,6 +3665,59 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T18:03:52.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6419281588302905443",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 927000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419281588302905000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "input.type": "log",
+        "log.offset": 78808,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [
@@ -2399,6 +3874,187 @@
         "log.offset": 82330,
         "related.hash": [
             "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:51:19.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "Auto.BAC7BC5281.in10.tht.Talos",
+        "cisco.amp.detection_id": "6411538569722068995",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 495000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411538569722069000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff",
+        "file.name": "igvj$vN.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\Documents\\igvj$vN.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 83443,
+        "related.hash": [
+            "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:51:19.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "Auto.BAC7BC5281.in10.tht.Talos",
+        "cisco.amp.detection_id": "6411538569722068994",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 495000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411538569722069000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff",
+        "file.name": "6951045.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\6951045.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 84690,
+        "related.hash": [
+            "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:51:19.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "Auto.BAC7BC5281.in10.tht.Talos",
+        "cisco.amp.detection_id": "6411538569722068993",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 495000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411538569722069000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "dc41e47ebba549ec5e616ed9e88a0376",
+        "file.hash.sha1": "99fffe78e0cbd7b508eed13a8633903dd89ed5f1",
+        "file.hash.sha256": "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff",
+        "file.name": "MspthrdHash.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\MspthrdHash\\MspthrdHash.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 85948,
+        "related.hash": [
+            "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff",
+            "dc41e47ebba549ec5e616ed9e88a0376",
+            "99fffe78e0cbd7b508eed13a8633903dd89ed5f1"
         ],
         "related.hosts": [
             "Demo_Qakbot_1"
@@ -3085,6 +4741,209 @@
             }
         ],
         "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275399255031906",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 812000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275399255032000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 101558,
+        "process.hash.md5": "ad7b9c14083b52bc532fba5948342b98",
+        "process.hash.sha1": "ee8cbf12d87c4d388f09b4f69bed2e91682920b5",
+        "process.hash.sha256": "17f746d82695fa9b35493b41859d39d786d32b23a9d2e00f4011dec7a02402ae",
+        "process.name": "cmd.exe",
+        "process.pid": 3200,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:51.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275399255031905",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 235000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275399255032000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 103091,
+        "process.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "process.name": "tasksche.exe",
+        "process.pid": 2708,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:51.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275399255031904",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 172000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275399255032000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\Windows\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 104633,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:51.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
         "cisco.amp.detection_id": "6419275394960064599",
         "cisco.amp.event_type_id": 553648143,
         "cisco.amp.file.disposition": "Malicious",
@@ -3284,6 +5143,743 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064606",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 907000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 110571,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064605",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 907000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 111942,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064607",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 907000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 113313,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064604",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 891000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 114684,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064603",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 876000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 116055,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064602",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 845000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 117426,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064601",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 798000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 118797,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064598",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 767000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 120168,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064600",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 751000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 121539,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064599",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 735000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 122910,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:50.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275394960064597",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 423000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275394960065000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\WINDOWS\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 124281,
+        "process.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "process.name": "mssecsvc.exe",
+        "process.pid": 6404,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [

--- a/x-pack/filebeat/module/cisco/amp/test/cisco_amp5.ndjson.log-expected.json
+++ b/x-pack/filebeat/module/cisco/amp/test/cisco_amp5.ndjson.log-expected.json
@@ -192,6 +192,69 @@
             }
         ],
         "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6419275390665097297",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 831000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275390665097000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 3893,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:49.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
         "cisco.amp.detection": "W32.Gen.20gl.1201",
         "cisco.amp.detection_id": "6419275390665097296",
         "cisco.amp.event_type_id": 1090519054,
@@ -246,6 +309,132 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:49.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419275390665097295",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 643000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275390665097000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "file.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 6745,
+        "process.hash.md5": "4e568dbe3fff1a0025eb432dc929b78f",
+        "process.hash.sha1": "7abcc82dc5a05b4f53fd0fbd386738e5555025cf",
+        "process.hash.sha256": "26f36ca31a1b977685f8df5f8436848b7d4143b47ec0dae68f8382c1b52a6c71",
+        "process.name": "lsass.exe",
+        "process.pid": 708,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+            "db349b97c37d22f5ea1d1841e3c89eb4",
+            "e889544aff85ffaf8b0d0da705105dee7c97fe26"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T17:39:49.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6419275390665097296",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 721000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419275390665097000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "input.type": "log",
+        "log.offset": 8343,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [
@@ -321,6 +510,73 @@
         ],
         "cisco.amp.connector_guid": "test_connector_guid",
         "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6411525251028484105",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 214000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411525251028484000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "6894b3834bd541fa85df79e44568acac",
+        "file.hash.sha1": "8cf0ca99a8f5019d8583133b9a9379299c45470c",
+        "file.hash.sha256": "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff",
+        "file.name": "MspthrdHash.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\MspthrdHash\\MspthrdHash.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 10645,
+        "related.hash": [
+            "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff",
+            "6894b3834bd541fa85df79e44568acac",
+            "8cf0ca99a8f5019d8583133b9a9379299c45470c"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:59:38.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
         "cisco.amp.detection_id": "6411525251028484104",
         "cisco.amp.event_type_id": 1090519054,
         "cisco.amp.file.disposition": "Malicious",
@@ -368,6 +624,59 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:59:38.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6411525251028484104",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 698000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411525251028484000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "input.type": "log",
+        "log.offset": 13397,
+        "related.hash": [
+            "bac7bc52812bc63745d4c5904d18e1581e4f0c821b4cf8336c8dd8eab86385ff"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [
@@ -594,6 +903,246 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T16:55:47.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Ransom:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419264043361501262",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 872000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419264043361501000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+        "file.name": "u.wnry",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\u.wnry",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 19266,
+        "related.hash": [
+            "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:55:47.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Ransom:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419264043361501261",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 872000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419264043361501000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "7bf2b57f2a205768755c07f238fb32cc",
+        "file.hash.sha1": "45356a9dd616ed7161a3b9192e2f318d0ab5ad10",
+        "file.hash.sha256": "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+        "file.name": "@WanaDecryptor@.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\@WanaDecryptor@.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 20509,
+        "related.hash": [
+            "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+            "7bf2b57f2a205768755c07f238fb32cc",
+            "45356a9dd616ed7161a3b9192e2f318d0ab5ad10"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:55:47.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Ransom:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419229331435814969",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 763000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419264043361501000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+        "file.name": "u.wnry",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\u.wnry",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 21869,
+        "related.hash": [
+            "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:55:47.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Ransom:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419204905956802579",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 716000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419264043361501000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+        "file.name": "u.wnry",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\u.wnry",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 23112,
+        "related.hash": [
+            "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T16:55:46.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -687,6 +1236,132 @@
         "log.offset": 25559,
         "related.hash": [
             "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:55:46.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419264039066533964",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 749000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419264039066534000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "54a116ff80df6e6031059fc3036464df",
+        "file.hash.sha1": "61b9ae415fbe95bf4e6c616ce433cd20dce7dfe3",
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 26683,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+            "54a116ff80df6e6031059fc3036464df",
+            "61b9ae415fbe95bf4e6c616ce433cd20dce7dfe3"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:55:46.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419229322845880359",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 702000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419264039066534000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "54a116ff80df6e6031059fc3036464df",
+        "file.hash.sha1": "61b9ae415fbe95bf4e6c616ce433cd20dce7dfe3",
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 28003,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+            "54a116ff80df6e6031059fc3036464df",
+            "61b9ae415fbe95bf4e6c616ce433cd20dce7dfe3"
         ],
         "related.hosts": [
             "Demo_WannaCry_Ransomware"
@@ -850,6 +1525,124 @@
         "host.name": "Demo_Qakbot_3",
         "input.type": "log",
         "log.offset": 31725,
+        "related.hash": [
+            "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:35:01.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.D177E09A9A-95.SBX.TG",
+        "cisco.amp.detection_id": "6412622782676336647",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 198000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412622782676337000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+        "file.name": "kepv86368.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\kepv86368.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 32926,
+        "related.hash": [
+            "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T16:35:01.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.D177E09A9A-95.SBX.TG",
+        "cisco.amp.detection_id": "6412622782676336646",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 198000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412622782676337000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+        "file.name": "uqlq0o884.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\uqlq0o884.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 34182,
         "related.hash": [
             "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446"
         ],
@@ -1605,6 +2398,183 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T15:50:23.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419204897366867969",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 717000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419247189909832000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\Windows\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 78202,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T15:50:23.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419179204872503298",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 686000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419247189909832000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\Windows\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 79439,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T15:50:23.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419204897366867977",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 639000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419247189909832000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 80676,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T15:24:25.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -1652,6 +2622,73 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T15:24:25.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6412604589194870787",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 573000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412604589194871000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "32c9e6737dbdcbfb7563a3f27e2b1571",
+        "file.hash.sha1": "f5a171c879b90e77861daf19741b373646d791ff",
+        "file.hash.sha256": "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+        "file.name": "QuotaGroup.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\QuotaGroup\\QuotaGroup.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 83114,
+        "related.hash": [
+            "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+            "32c9e6737dbdcbfb7563a3f27e2b1571",
+            "f5a171c879b90e77861daf19741b373646d791ff"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1788,6 +2825,59 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T15:24:25.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "02:2f:e0:10:03:5d"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6412604589194870785",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "02:2f:e0:10:03:5d"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 994000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6412604589194871000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_3",
+        "host.name": "Demo_Qakbot_3",
+        "input.type": "log",
+        "log.offset": 87059,
+        "related.hash": [
+            "d177e09a9ae147741a3ef8b5d3aa9c359d70d602d32f2c4bb0e2d3208cdca446"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_3"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T15:18:49.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -1835,6 +2925,75 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T15:18:49.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419239055241773128",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 242000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419239055241773000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\WINDOWS\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 89361,
+        "process.hash.md5": "4e568dbe3fff1a0025eb432dc929b78f",
+        "process.hash.sha1": "7abcc82dc5a05b4f53fd0fbd386738e5555025cf",
+        "process.hash.sha256": "26f36ca31a1b977685f8df5f8436848b7d4143b47ec0dae68f8382c1b52a6c71",
+        "process.name": "lsass.exe",
+        "process.pid": 708,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [

--- a/x-pack/filebeat/module/cisco/amp/test/cisco_amp6.ndjson.log-expected.json
+++ b/x-pack/filebeat/module/cisco/amp/test/cisco_amp6.ndjson.log-expected.json
@@ -1025,6 +1025,79 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T14:41:03.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419229322845880359",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Clean",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 950000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419229322845880000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "file.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 21793,
+        "process.hash.md5": "4e568dbe3fff1a0025eb432dc929b78f",
+        "process.hash.sha1": "7abcc82dc5a05b4f53fd0fbd386738e5555025cf",
+        "process.hash.sha256": "26f36ca31a1b977685f8df5f8436848b7d4143b47ec0dae68f8382c1b52a6c71",
+        "process.name": "lsass.exe",
+        "process.pid": 708,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+            "db349b97c37d22f5ea1d1841e3c89eb4",
+            "e889544aff85ffaf8b0d0da705105dee7c97fe26"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T14:37:40.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -1188,6 +1261,187 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T14:37:40.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.DD6D4FEDD3-100.SBX.TG",
+        "cisco.amp.detection_id": "6411488666497056775",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 398000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411488666497057000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91",
+        "file.name": "qYf.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\Documents\\qYf.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 26906,
+        "related.hash": [
+            "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T14:37:40.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.DD6D4FEDD3-100.SBX.TG",
+        "cisco.amp.detection_id": "6411488666497056774",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 398000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411488666497057000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.sha256": "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91",
+        "file.name": "4191700.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\Temp\\4191700.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 28140,
+        "related.hash": [
+            "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T14:37:40.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.DD6D4FEDD3-100.SBX.TG",
+        "cisco.amp.detection_id": "6411488666497056773",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 398000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411488666497057000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "6894b3834bd541fa85df79e44568acac",
+        "file.hash.sha1": "8cf0ca99a8f5019d8583133b9a9379299c45470c",
+        "file.hash.sha256": "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91",
+        "file.name": "MspthrdHash.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\MspthrdHash\\MspthrdHash.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 29393,
+        "related.hash": [
+            "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91",
+            "6894b3834bd541fa85df79e44568acac",
+            "8cf0ca99a8f5019d8583133b9a9379299c45470c"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T14:09:00.000Z",
         "cisco.amp.cloud_ioc.description": "Qakbot is a worm that spreads through network shares and removable drives. It downloads additional files, steals information, and opens a back door on the compromised computer. The worm also contains rootkit functionality to allow it to hide its presence. A command or file path similar to one used by Qakbot for spreading across the network or persistence was seen.",
         "cisco.amp.cloud_ioc.short_description": "W32.Qakbot.ioc",
@@ -1285,6 +1539,69 @@
         "log.offset": 32509,
         "related.hash": [
             "d5221f6847978682234cb8ebfa951cb56b1323658679a820b168bbc1f5261a3b"
+        ],
+        "related.hosts": [
+            "Demo_Low_Prev_Retro"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T13:46:00.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "df:d1:ed:2d:c8:fc"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.D5221F6847-100.SBX.TG",
+        "cisco.amp.detection_id": "6264772016730013699",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "df:d1:ed:2d:c8:fc"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 65000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6264772016730014000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "48a0bf05b9706a00d2a0ff6260412f11",
+        "file.hash.sha1": "5058b16a86beee96927371210b9a9f682976a50a",
+        "file.hash.sha256": "d5221f6847978682234cb8ebfa951cb56b1323658679a820b168bbc1f5261a3b",
+        "file.name": "report.pdf.exe",
+        "file.path": "\\\\?\\C:\\Users\\rsteadman\\Downloads\\report.pdf.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Low_Prev_Retro",
+        "host.name": "Demo_Low_Prev_Retro",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 33628,
+        "related.hash": [
+            "d5221f6847978682234cb8ebfa951cb56b1323658679a820b168bbc1f5261a3b",
+            "48a0bf05b9706a00d2a0ff6260412f11",
+            "5058b16a86beee96927371210b9a9f682976a50a"
         ],
         "related.hosts": [
             "Demo_Low_Prev_Retro"
@@ -1406,6 +1723,73 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T13:43:32.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419214500913741862",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 366000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419214500913742000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "file.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "file.name": "mssecsvc.exe",
+        "file.path": "\\\\?\\C:\\Windows\\mssecsvc.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 37453,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+            "db349b97c37d22f5ea1d1841e3c89eb4",
+            "e889544aff85ffaf8b0d0da705105dee7c97fe26"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1753,6 +2137,59 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T13:43:32.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6419214500913741856",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 709000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419214500913742000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "input.type": "log",
+        "log.offset": 45976,
+        "related.hash": [
+            "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T13:43:30.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -1798,6 +2235,79 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T13:43:29.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6419214488028839966",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 916000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419214488028840000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\Windows\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 48216,
+        "process.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "process.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "process.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "process.name": "mssecsvc.exe",
+        "process.pid": 5580,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -2002,6 +2512,69 @@
         "host.user.name": "user@testdomain.com",
         "input.type": "log",
         "log.offset": 53134,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T13:06:19.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6419204910251769881",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 34000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419204910251770000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 54407,
         "related.hash": [
             "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
         ],
@@ -2360,6 +2933,122 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T13:06:18.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6419204905956802580",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 286000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419204905956803000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 63166,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T13:06:18.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6419204905956802579",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 800000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419204905956803000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "input.type": "log",
+        "log.offset": 64439,
+        "related.hash": [
+            "b9c5d4339809e0ad9a00d4d3dd26fdf44a32819a54abf846bb9b560d81391c25"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [

--- a/x-pack/filebeat/module/cisco/amp/test/cisco_amp7.ndjson.log-expected.json
+++ b/x-pack/filebeat/module/cisco/amp/test/cisco_amp7.ndjson.log-expected.json
@@ -476,6 +476,73 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T12:57:45.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "f9:65:da:22:2a:41"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6411462918168117252",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "f9:65:da:22:2a:41"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 573000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411462918168117000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "a97fb86da4e010974860e5024137b56b",
+        "file.hash.sha1": "75a94b8aa3b9a7c4de4f866b508111ac5a6f2b12",
+        "file.hash.sha256": "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91",
+        "file.name": "MspthrdHash.exe",
+        "file.path": "\\\\?\\C:\\Users\\johndoe\\AppData\\Local\\MspthrdHash\\MspthrdHash.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_1",
+        "host.name": "Demo_Qakbot_1",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 9881,
+        "related.hash": [
+            "dd6d4fedd34a4d0e5c62b0e6d8c734d157ee921e07cddc82251755bed0de3f91",
+            "a97fb86da4e010974860e5024137b56b",
+            "75a94b8aa3b9a7c4de4f866b508111ac5a6f2b12"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_1"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T12:32:14.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -885,6 +952,59 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T12:02:58.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "d1:e2:b6:61:ef:7a"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6411444887895408641",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "d1:e2:b6:61:ef:7a"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 772000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6411444887895409000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "a280012eeedb19a9b4a7ddfb3c4dca316ce96ad376d98092351529c4db052e62",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_Qakbot_2",
+        "host.name": "Demo_Qakbot_2",
+        "input.type": "log",
+        "log.offset": 20427,
+        "related.hash": [
+            "a280012eeedb19a9b4a7ddfb3c4dca316ce96ad376d98092351529c4db052e62"
+        ],
+        "related.hosts": [
+            "Demo_Qakbot_2"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T11:58:57.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -932,6 +1052,75 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T11:58:57.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.Variant:Gen.20gl.1201",
+        "cisco.amp.detection_id": "6419187549993959449",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 193000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419187549993959000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\WINDOWS\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 22729,
+        "process.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "process.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "process.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "process.name": "mssecsvc.exe",
+        "process.pid": 2980,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1005,6 +1194,59 @@
         ],
         "related.user": [
             "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T11:58:54.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection_id": "6419187537109057560",
+        "cisco.amp.event_type_id": 553648143,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 884000000,
+        "event.action": "Threat Quarantined",
+        "event.category": [
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419187537109058000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "input.type": "log",
+        "log.offset": 25859,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1222,6 +1464,69 @@
         ]
     },
     {
+        "@timestamp": "2021-01-14T11:28:45.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "d2:78:15:4a:f4:a2"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.FCE5B6784D-100.SBX.TG",
+        "cisco.amp.detection_id": "6533671595485954049",
+        "cisco.amp.event_type_id": 553648147,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "d2:78:15:4a:f4:a2"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 899000000,
+        "event.action": "Retrospective Detection",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6533671595485954000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 3,
+        "file.hash.md5": "5df0c4ebca109779dc8afc745d612637",
+        "file.hash.sha1": "bdb11107a33eaeded6a838eb2a0e6167637dbe9c",
+        "file.hash.sha256": "fce5b6784dc9f44cdc1d6214bb7b68d3029db049dcaf734edc9660bb3373bc79",
+        "file.name": "pp32.exe",
+        "file.path": "\\\\?\\C:\\pp32.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_AMP_Exploit_Prevention_Audit",
+        "host.name": "Demo_AMP_Exploit_Prevention_Audit",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "input.type": "log",
+        "log.offset": 31671,
+        "related.hash": [
+            "fce5b6784dc9f44cdc1d6214bb7b68d3029db049dcaf734edc9660bb3373bc79",
+            "5df0c4ebca109779dc8afc745d612637",
+            "bdb11107a33eaeded6a838eb2a0e6167637dbe9c"
+        ],
+        "related.hosts": [
+            "Demo_AMP_Exploit_Prevention_Audit"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
         "@timestamp": "2021-01-14T11:26:38.000Z",
         "cisco.amp.computer.active": true,
         "cisco.amp.computer.connector_guid": "test_connector_guid",
@@ -1269,6 +1574,69 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T11:26:38.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6419179222052372503",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 437000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419179222052372000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 34184,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1434,6 +1802,69 @@
         "related.ip": [
             "8.8.8.8",
             "10.10.10.10"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T11:26:37.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.File.MalParent",
+        "cisco.amp.detection_id": "6419179217757405206",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 797000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419179217757405000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\ProgramData\\qzkbplcgew884\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 39029,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
         ],
         "service.type": "cisco",
         "tags": [
@@ -1910,6 +2341,79 @@
         "host.user.name": "user@testdomain.com",
         "input.type": "log",
         "log.offset": 49034,
+        "related.hash": [
+            "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+            "84c82835a5d21bbcf75a61706d8ab549",
+            "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467"
+        ],
+        "related.hosts": [
+            "Demo_WannaCry_Ransomware"
+        ],
+        "related.ip": [
+            "8.8.8.8",
+            "10.10.10.10"
+        ],
+        "related.user": [
+            "user@testdomain.com"
+        ],
+        "service.type": "cisco",
+        "tags": [
+            "cisco-amp",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2021-01-14T11:26:35.000Z",
+        "cisco.amp.computer.active": true,
+        "cisco.amp.computer.connector_guid": "test_connector_guid",
+        "cisco.amp.computer.external_ip": "8.8.8.8",
+        "cisco.amp.computer.network_addresses": [
+            {
+                "ip": "10.10.10.10",
+                "mac": "53:74:31:cb:37:50"
+            }
+        ],
+        "cisco.amp.connector_guid": "test_connector_guid",
+        "cisco.amp.detection": "W32.ED01EBFBC9-100.SBX.TG",
+        "cisco.amp.detection_id": "6419179204872503300",
+        "cisco.amp.event_type_id": 1090519054,
+        "cisco.amp.file.disposition": "Malicious",
+        "cisco.amp.file.parent.disposition": "Malicious",
+        "cisco.amp.group_guids": [
+            "test_group_guid"
+        ],
+        "cisco.amp.related.mac": [
+            "53:74:31:cb:37:50"
+        ],
+        "cisco.amp.timestamp_nanoseconds": 894000000,
+        "event.action": "Threat Detected",
+        "event.category": [
+            "file",
+            "malware"
+        ],
+        "event.dataset": "cisco.amp",
+        "event.id": 6419179209167471000,
+        "event.kind": "alert",
+        "event.module": "cisco",
+        "event.severity": 2,
+        "file.hash.md5": "84c82835a5d21bbcf75a61706d8ab549",
+        "file.hash.sha1": "5ff465afaabcbf0150d1a3ab2c2e74f3a4426467",
+        "file.hash.sha256": "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
+        "file.name": "tasksche.exe",
+        "file.path": "\\\\?\\C:\\WINDOWS\\tasksche.exe",
+        "fileset.name": "amp",
+        "host.hostname": "Demo_WannaCry_Ransomware",
+        "host.name": "Demo_WannaCry_Ransomware",
+        "host.os.family": "windows",
+        "host.os.platform": "windows",
+        "host.user.name": "user@testdomain.com",
+        "input.type": "log",
+        "log.offset": 50398,
+        "process.hash.md5": "db349b97c37d22f5ea1d1841e3c89eb4",
+        "process.hash.sha1": "e889544aff85ffaf8b0d0da705105dee7c97fe26",
+        "process.hash.sha256": "24d004a104d4d54034dbcffc2a4b19a11f39008a575aa614ea04703480b1022c",
+        "process.name": "mssecsvc.exe",
+        "process.pid": 3020,
         "related.hash": [
             "ed01ebfbc9eb5bbea545af4d01bf5f1071661840480439c6e5babe8e080e41aa",
             "84c82835a5d21bbcf75a61706d8ab549",


### PR DESCRIPTION
Cherry-pick of PR #24718 to 7.x branch. Original message: 

## What does this PR do?

switches from just `detection_id` to a list of 

  - data.timestamp
  - data.timestamp_nanoseconds
  - data.event_type_id
  - data.connector_guid
  - data.id
  - data.detection_id

## Why is it important?

documents were being overwritten because `detection_id` wasn't
sufficient to uniquely identify a document

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

``` bash
TESTING_FILEBEAT_MODULES=cisco mage -v pythonIntegTest
```

## Related issues

- Closes #24717