### PR TITLE
Cherry-pick #24760 to 7.12: Fix nil pointer for nil list item

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -44,6 +44,7 @@
 - Fix docker enrollment issue related to Fleet Server change. {pull}24155[24155]
 - Improve log on failure of Endpoint Security installation. {pull}24429[24429]
 - Verify communication to Kibana before updating Fleet client. {pull}24489[24489]
+- Fix nil pointer when null is generated as list item. {issue}23734[23734]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config.yml
@@ -40,6 +40,8 @@ inputs:
   use_output: default
   streams:
     - metricset: status
+      processors:
+      - null
       data_stream:
         dataset: docker.status
     - metricset: info

--- a/x-pack/elastic-agent/pkg/agent/transpiler/ast.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/ast.go
@@ -126,7 +126,11 @@ func (d *Dict) Value() interface{} {
 func (d *Dict) Clone() Node {
 	nodes := make([]Node, 0, len(d.value))
 	for _, i := range d.value {
+		if i == nil {
+			continue
+		}
 		nodes = append(nodes, i.Clone())
+
 	}
 	return &Dict{value: nodes}
 }
@@ -350,6 +354,9 @@ func (l *List) Value() interface{} {
 func (l *List) Clone() Node {
 	nodes := make([]Node, 0, len(l.value))
 	for _, i := range l.value {
+		if i == nil {
+			continue
+		}
 		nodes = append(nodes, i.Clone())
 	}
 	return &List{value: nodes}


### PR DESCRIPTION
Cherry-pick of PR #24760 to 7.12 branch. Original message:

## What does this PR do?

This PR guards against a nil items which are part of the list. Fn call then casues agent to panic.

## Why is it important?

Fixes: #23734

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
