### PR TITLE
Page is used in multiple docs(metricbeat, filebeat) but is written fo…

### DIFF
--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -17,7 +17,7 @@ To configure AWS credentials, either put the credentials into the {beatname_uc} 
 ==== Supported Formats
 * Use `access_key_id`, `secret_access_key` and/or `session_token`
 
-Users can either put the credentials into metricbeat module configuration or use
+Users can either put the credentials into {beatname_uc} module configuration or use
 environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN` instead.
 
@@ -85,12 +85,12 @@ aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@exam
 ----
 
 Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
-the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/metricbeat/current/_live_reloading.html[live reloading]
-feature is enabled for Metricbeat, the user needs to manually restart Metricbeat after updating the config file in order
-to continue collecting Cloudwatch metrics. This will cause data loss if the config file is not updated with new
-credentials before the old ones expire. For Metricbeat, we recommend users to use access keys in config file to enable
+the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/{beatname_uc}/current/_live_reloading.html[live reloading]
+feature is enabled for {beatname_uc}, the user needs to manually restart {beatname_uc} after updating the config file in order
+to continue collecting data from Cloudwatch. This will cause data loss if the config file is not updated with new
+credentials before the old ones expire. For {beatname_uc}, we recommend users to use access keys in config file to enable
 aws module making AWS api calls without have to generate new temporary credentials and update the config frequently.
 
-IAM policy is an entity that defines permissions to an object within your AWS environment. Specific permissions needs
-to be added into the IAM user's policy to authorize Metricbeat to collect AWS monitoring metrics. Please see documentation
+IAM policy is an entity that defines permissions to an object within your AWS environment. Specific permissions need
+to be added into the IAM user's policy to authorize {beatname_uc} to collect data from AWS. Please see documentation
 under each metricset for required permissions.

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -1,3 +1,5 @@
+:beatname_url: {beats-ref-root}/{beatname_lc}/{branch}
+
 [float]
 === AWS Credentials Configuration
 To configure AWS credentials, either put the credentials into the {beatname_uc} configuration, or use a shared credentials file, as shown in the following examples.
@@ -85,7 +87,7 @@ aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@exam
 ----
 
 Because temporary security credentials are short term, after they expire, the user needs to generate new ones and modify
-the aws.yml config file with the new credentials. Unless https://www.elastic.co/guide/en/beats/{beatname_uc}/current/_live_reloading.html[live reloading]
+the aws.yml config file with the new credentials. Unless the {beatname_url}/_live_reloading.html[live reloading]
 feature is enabled for {beatname_uc}, the user needs to manually restart {beatname_uc} after updating the config file in order
 to continue collecting data from Cloudwatch. This will cause data loss if the config file is not updated with new
 credentials before the old ones expire. For {beatname_uc}, we recommend users to use access keys in config file to enable


### PR DESCRIPTION
…r metricbeat

Page is used in multiple docs(metricbeat, filebeat) but is written for metricbeat. Eg the file is used in the filebeat documentation as well ( https://www.elastic.co/guide/en/beats/filebeat/7.12/filebeat-module-aws.html ) replacing explicit metricbeat references with variable

## What does this PR do?

Fix references so they fit the context.

## Why is it important?

talking about metrricbeat while configuring filebeat is incorrect and confusing (the actual steps and implications don't change)

## Checklist

- [x] I have made corresponding changes to the documentation

## Screenshots


