### PR TITLE
[Heartbeat] Merge synthetic root fields into events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -812,6 +812,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add mime type detection for http responses. {pull}22976[22976]
 - Handle datastreams for fleet. {pull}24223[24223]
 - Add --sandbox option for browser monitor. {pull}24172[24172]
+- Support additional 'root' fields from synthetics. {pull}24770[24770]
 
 *Journalbeat*
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -16,18 +16,18 @@ import (
 )
 
 type SynthEvent struct {
-	Type                 string                 `json:"type"`
-	PackageVersion       string                 `json:"package_version"`
-	Step                 *Step                  `json:"step"`
-	Journey              *Journey               `json:"journey"`
-	TimestampEpochMicros float64                `json:"@timestamp"`
-	Payload              common.MapStr          `json:"payload"`
-	Blob                 string                 `json:"blob"`
-	BlobMime             string                 `json:"blob_mime"`
-	Error                *SynthError            `json:"error"`
-	URL                  string                 `json:"url"`
-	Status               string                 `json:"status"`
-	RootFields           common.MapStr			`json:"root_fields"`
+	Type                 string        `json:"type"`
+	PackageVersion       string        `json:"package_version"`
+	Step                 *Step         `json:"step"`
+	Journey              *Journey      `json:"journey"`
+	TimestampEpochMicros float64       `json:"@timestamp"`
+	Payload              common.MapStr `json:"payload"`
+	Blob                 string        `json:"blob"`
+	BlobMime             string        `json:"blob_mime"`
+	Error                *SynthError   `json:"error"`
+	URL                  string        `json:"url"`
+	Status               string        `json:"status"`
+	RootFields           common.MapStr `json:"root_fields"`
 	index                int
 }
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -16,30 +16,33 @@ import (
 )
 
 type SynthEvent struct {
-	Type                 string        `json:"type"`
-	PackageVersion       string        `json:"package_version"`
-	Step                 *Step         `json:"step"`
-	Journey              *Journey      `json:"journey"`
-	TimestampEpochMicros float64       `json:"@timestamp"`
-	Payload              common.MapStr `json:"payload"`
-	Blob                 string        `json:"blob"`
-	BlobMime             string        `json:"blob_mime"`
-	Error                *SynthError   `json:"error"`
-	URL                  string        `json:"url"`
-	Status               string        `json:"status"`
+	Type                 string                 `json:"type"`
+	PackageVersion       string                 `json:"package_version"`
+	Step                 *Step                  `json:"step"`
+	Journey              *Journey               `json:"journey"`
+	TimestampEpochMicros float64                `json:"@timestamp"`
+	Payload              common.MapStr          `json:"payload"`
+	Blob                 string                 `json:"blob"`
+	BlobMime             string                 `json:"blob_mime"`
+	Error                *SynthError            `json:"error"`
+	URL                  string                 `json:"url"`
+	Status               string                 `json:"status"`
+	RootFields           map[string]interface{} `json:"root_fields"`
 	index                int
 }
 
 func (se SynthEvent) ToMap() (m common.MapStr) {
 	// We don't add @timestamp to the map string since that's specially handled in beat.Event
-	m = common.MapStr{
+	// Use the root fields as a base, and layer additional, stricter, fields on top
+	m = se.RootFields
+	m.DeepUpdate(common.MapStr{
 		"synthetics": common.MapStr{
 			"type":            se.Type,
 			"package_version": se.PackageVersion,
 			"payload":         se.Payload,
 			"index":           se.index,
 		},
-	}
+	})
 	if se.Blob != "" {
 		m.Put("synthetics.blob", se.Blob)
 	}

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -34,7 +34,11 @@ type SynthEvent struct {
 func (se SynthEvent) ToMap() (m common.MapStr) {
 	// We don't add @timestamp to the map string since that's specially handled in beat.Event
 	// Use the root fields as a base, and layer additional, stricter, fields on top
-	m = se.RootFields
+	if se.RootFields != nil {
+		m = se.RootFields
+	} else {
+		m = common.MapStr{}
+	}
 	m.DeepUpdate(common.MapStr{
 		"synthetics": common.MapStr{
 			"type":            se.Type,

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes_test.go
@@ -6,10 +6,11 @@ package synthexec
 
 import (
 	"encoding/json"
-	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/go-lookslike"
@@ -36,7 +37,7 @@ func TestToMap(t *testing.T) {
 		{
 			"root fields with URL",
 			common.MapStr{
-				"type": "journey/start",
+				"type":            "journey/start",
 				"package_version": "1.2.3",
 				"root_fields": map[string]interface{}{
 					"synthetics": map[string]interface{}{
@@ -48,21 +49,21 @@ func TestToMap(t *testing.T) {
 			},
 			common.MapStr{
 				"synthetics": common.MapStr{
-					"type":   "journey/start",
+					"type":            "journey/start",
 					"package_version": "1.2.3",
-					"nested": "v1",
+					"nested":          "v1",
 				},
-				"url": wrappers.URLFields(testUrl),
+				"url":           wrappers.URLFields(testUrl),
 				"truly_at_root": "v2",
 			},
 		},
 		{
 			"root fields, step metadata",
 			common.MapStr{
-				"type": "step/start",
+				"type":            "step/start",
 				"package_version": "1.2.3",
-				"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
-				"step": common.MapStr{"name": "MyStep", "status": "success", "index": 42},
+				"journey":         common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+				"step":            common.MapStr{"name": "MyStep", "status": "success", "index": 42},
 				"root_fields": map[string]interface{}{
 					"synthetics": map[string]interface{}{
 						"nested": "v1",
@@ -72,11 +73,11 @@ func TestToMap(t *testing.T) {
 			},
 			common.MapStr{
 				"synthetics": common.MapStr{
-					"type":   "step/start",
+					"type":            "step/start",
 					"package_version": "1.2.3",
-					"nested": "v1",
-					"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
-					"step": common.MapStr{"name": "MyStep", "status": "success", "index": 42},
+					"nested":          "v1",
+					"journey":         common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+					"step":            common.MapStr{"name": "MyStep", "status": "success", "index": 42},
 				},
 				"truly_at_root": "v2",
 			},
@@ -84,30 +85,30 @@ func TestToMap(t *testing.T) {
 		{
 			"weird error, and blob, no URL",
 			common.MapStr{
-				"type": "someType",
+				"type":            "someType",
 				"package_version": "1.2.3",
-				"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
-				"step": common.MapStr{"name": "MyStep", "index": 42, "status": "down"},
+				"journey":         common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+				"step":            common.MapStr{"name": "MyStep", "index": 42, "status": "down"},
 				"error": common.MapStr{
-					"name": "MyErrorName",
+					"name":    "MyErrorName",
 					"message": "MyErrorMessage",
-					"stack": "MyErrorStack",
+					"stack":   "MyErrorStack",
 				},
-				"blob": "ablob",
+				"blob":      "ablob",
 				"blob_mime": "application/weird",
 			},
 			common.MapStr{
 				"synthetics": common.MapStr{
-					"type":   "someType",
+					"type":            "someType",
 					"package_version": "1.2.3",
-					"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
-					"step": common.MapStr{"name": "MyStep", "index": 42, "status": "down"},
+					"journey":         common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+					"step":            common.MapStr{"name": "MyStep", "index": 42, "status": "down"},
 					"error": common.MapStr{
-						"name": "MyErrorName",
+						"name":    "MyErrorName",
 						"message": "MyErrorMessage",
-						"stack": "MyErrorStack",
+						"stack":   "MyErrorStack",
 					},
-					"blob": "ablob",
+					"blob":      "ablob",
 					"blob_mime": "application/weird",
 				},
 			},

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes_test.go
@@ -6,6 +6,8 @@ package synthexec
 
 import (
 	"encoding/json"
+	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
+	"net/url"
 	"testing"
 	"time"
 
@@ -21,31 +23,116 @@ func TestSynthEventTimestamp(t *testing.T) {
 	require.Equal(t, time.Unix(0, int64(time.Millisecond)), se.Timestamp())
 }
 
-func TestRootFields(t *testing.T) {
-	// Actually marshal to JSON and back to test the struct tags for deserialization from JSON
-	source := common.MapStr{
-		"type": "journey/start",
-		"root_fields": map[string]interface{}{
-			"synthetics": map[string]interface{}{
-				"nested": "v1",
+func TestToMap(t *testing.T) {
+	testUrl, _ := url.Parse("http://testurl")
+
+	type testCase struct {
+		name     string
+		source   common.MapStr
+		expected common.MapStr
+	}
+
+	testCases := []testCase{
+		{
+			"root fields with URL",
+			common.MapStr{
+				"type": "journey/start",
+				"package_version": "1.2.3",
+				"root_fields": map[string]interface{}{
+					"synthetics": map[string]interface{}{
+						"nested": "v1",
+					},
+					"truly_at_root": "v2",
+				},
+				"url": testUrl.String(),
 			},
-			"truly_at_root": "v2",
+			common.MapStr{
+				"synthetics": common.MapStr{
+					"type":   "journey/start",
+					"package_version": "1.2.3",
+					"nested": "v1",
+				},
+				"url": wrappers.URLFields(testUrl),
+				"truly_at_root": "v2",
+			},
+		},
+		{
+			"root fields, step metadata",
+			common.MapStr{
+				"type": "step/start",
+				"package_version": "1.2.3",
+				"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+				"step": common.MapStr{"name": "MyStep", "status": "success", "index": 42},
+				"root_fields": map[string]interface{}{
+					"synthetics": map[string]interface{}{
+						"nested": "v1",
+					},
+					"truly_at_root": "v2",
+				},
+			},
+			common.MapStr{
+				"synthetics": common.MapStr{
+					"type":   "step/start",
+					"package_version": "1.2.3",
+					"nested": "v1",
+					"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+					"step": common.MapStr{"name": "MyStep", "status": "success", "index": 42},
+				},
+				"truly_at_root": "v2",
+			},
+		},
+		{
+			"weird error, and blob, no URL",
+			common.MapStr{
+				"type": "someType",
+				"package_version": "1.2.3",
+				"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+				"step": common.MapStr{"name": "MyStep", "index": 42, "status": "down"},
+				"error": common.MapStr{
+					"name": "MyErrorName",
+					"message": "MyErrorMessage",
+					"stack": "MyErrorStack",
+				},
+				"blob": "ablob",
+				"blob_mime": "application/weird",
+			},
+			common.MapStr{
+				"synthetics": common.MapStr{
+					"type":   "someType",
+					"package_version": "1.2.3",
+					"journey": common.MapStr{"name": "MyJourney", "id": "MyJourney"},
+					"step": common.MapStr{"name": "MyStep", "index": 42, "status": "down"},
+					"error": common.MapStr{
+						"name": "MyErrorName",
+						"message": "MyErrorMessage",
+						"stack": "MyErrorStack",
+					},
+					"blob": "ablob",
+					"blob_mime": "application/weird",
+				},
+			},
 		},
 	}
-	jsonBytes, err := json.Marshal(source)
-	require.NoError(t, err)
-	se := &SynthEvent{}
-	err = json.Unmarshal(jsonBytes, se)
-	require.NoError(t, err)
 
-	m := se.ToMap()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Actually marshal to JSON and back to test the struct tags for deserialization from JSON
+			jsonBytes, err := json.Marshal(tc.source)
+			require.NoError(t, err)
+			se := &SynthEvent{}
+			err = json.Unmarshal(jsonBytes, se)
+			require.NoError(t, err)
 
-	// Test that even deep maps merge correctly
-	testslike.Test(t, lookslike.MustCompile(common.MapStr{
-		"synthetics": common.MapStr{
-			"type":   "journey/start",
-			"nested": "v1",
-		},
-		"truly_at_root": "v2",
-	}), m)
+			m := se.ToMap()
+
+			// Index will always be zero in thee tests, so helpfully include it
+			llvalidator := lookslike.Strict(lookslike.Compose(
+				lookslike.MustCompile(tc.expected),
+				lookslike.MustCompile(common.MapStr{"synthetics": common.MapStr{"index": 0}}),
+			))
+
+			// Test that even deep maps merge correctly
+			testslike.Test(t, llvalidator, m)
+		})
+	}
 }

--- a/x-pack/heartbeat/sample-synthetics-config/heartbeat.yml
+++ b/x-pack/heartbeat/sample-synthetics-config/heartbeat.yml
@@ -9,8 +9,6 @@ heartbeat.monitors:
   enabled: true
   id: todos-suite
   name: Todos Suite
-  data_stream:
-    namespace: myns
   source:
     local:
       path: "/home/andrewvc/projects/synthetics/examples/todos/"
@@ -21,14 +19,10 @@ heartbeat.monitors:
   urls: http://www.google.com
   schedule: "@every 15s"
   name: Simple HTTP
-  data_stream:
-    namespace: myns
 - type: browser
   enabled: false
   id: my-monitor
   name: My Monitor
-  data_stream:
-    namespace: myns
   source:
     inline:
       script:


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/24768

This allows synthetics to drive more field names without requiring heartbeat updates. Any fields in `root_fields` get merged into the event root.

This also improves the testing in this area of the code, which was somewhat lean (and really was only tested in larger functional tests run elsewhere)

## Why is it important?

Without this any field change must be made in two places (synthetics and here), this simplifies our arch. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Check that things still work end-to-end without any obvious breakage
