### PR TITLE
Juniper doc: module sophosxg > junos

### DIFF
--- a/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
@@ -68,7 +68,7 @@ Versions above this are expected to work but have not been tested.
 
 [source,yaml]
 ----
-- module: sophosxg
+- module: junos
   firewall:
     enabled: true
     var.input: udp


### PR DESCRIPTION
## What does this PR do?

Hopefully correct redo of https://github.com/elastic/beats/pull/24750.

New to Juniper docs topic, but confused why the sophosxg module is referenced under the junos module.

## Why is it important?

Legibility

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] NA: I have added an entry in CHANGELOG.next.asciidoc or CHANGELOG-developer.next.asciidoc.

## Screenshots

guide/en/beats/filebeat/current/filebeat-module-juniper.html#_compatibility_19

![image](https://user-images.githubusercontent.com/26751266/112535583-14d19600-8d72-11eb-9be5-fabe169ce70a.png)
