### PR TITLE
Update docs around Elastic Agent and fleet-server environment variables

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -65,23 +65,32 @@ environment variables to run inside of the container.
 
 The following actions are possible and grouped based on the actions.
 
-* Preparing Kibana for Fleet
-  This prepares the Fleet plugin that exists inside of Kibana. This must either be enabled here or done externally
-  before Fleet Server will actually successfully start.
+* Elastic Agent Fleet Enrollment
+  This enrolls the Elastic Agent into a Fleet Server. It is also possible to have this create a new enrollment token
+  for this specific Elastic Agent.
 
-  KIBANA_FLEET_SETUP - set to 1 enables this setup
-  KIBANA_FLEET_HOST - kibana host to enable Fleet on [$KIBANA_HOST]
-  KIBANA_FLEET_USERNAME - kibana username to enable Fleet [$KIBANA_USERNAME]
-  KIBANA_FLEET_PASSWORD - kibana password to enable Fleet [$KIBANA_PASSWORD]
-  KIBANA_FLEET_CA - path to certificate authority to use with communicate with Kibana [$KIBANA_CA]
-  KIBANA_REQUEST_RETRY_SLEEP - specifies sleep duration taken when agent performs a request to kibana [default 1s]
-  KIBANA_REQUEST_RETRY_COUNT - specifies number of retries agent performs when executing a request to kibana [default 30]
+  FLEET_ENROLL - set to 1 for enrollment into fleet-server. If not set, Elastic Agent is run in standalone mode.
+  FLEET_URL - URL of the Fleet Server to enroll into
+  FLEET_ENROLLMENT_TOKEN - token to use for enrollment.
+  FLEET_CA - path to certificate authority to use with communicate with Fleet Server [$KIBANA_CA]
+  FLEET_INSECURE - communicate with Fleet with either insecure HTTP or un-verified HTTPS
+
+  The following vars are need in the scenario that Elastic Agent should automatically fetch its own token.
+
+  KIBANA_FLEET_HOST - kibana host to enable create enrollment token on [$KIBANA_HOST]
+  KIBANA_FLEET_USERNAME - kibana username to create enrollment token [$KIBANA_USERNAME]
+  KIBANA_FLEET_PASSWORD - kibana password to create enrollment token [$KIBANA_PASSWORD]
+  FLEET_TOKEN_NAME - token name to use for fetching token from Kibana. This requires Kibana configs to be set.
+  FLEET_TOKEN_POLICY_NAME - token policy name to use for fetching token from Kibana. This requires Kibana configs to be set.
 
 * Bootstrapping Fleet Server
   This bootstraps the Fleet Server to be run by this Elastic Agent. At least one Fleet Server is required in a Fleet
-  deployment for other Elastic Agent to bootstrap.
+  deployment for other Elastic Agent to bootstrap. In case the Elastic Agent is run without fleet-server. These variables
+  are not needed.
 
-  FLEET_SERVER_ENABLE - set to 1 enables bootstrapping of Fleet Server (forces FLEET_ENROLL enabled)
+  If FLEET_SERVER_ENABLE and FLEET_ENROLL is set but no FLEET_ENROLLMENT_TOKEN, the token is automatically fetched from Kibana.
+
+  FLEET_SERVER_ENABLE - set to 1 enables bootstrapping of Fleet Server inside Elastic Agent (forces FLEET_ENROLL enabled)
   FLEET_SERVER_ELASTICSEARCH_HOST - elasticsearch host for Fleet Server to communicate with [$ELASTICSEARCH_HOST]
   FLEET_SERVER_ELASTICSEARCH_USERNAME - elasticsearch username for Fleet Server [$ELASTICSEARCH_USERNAME]
   FLEET_SERVER_ELASTICSEARCH_PASSWORD - elasticsearch password for Fleet Server [$ELASTICSEARCH_PASSWORD]
@@ -94,20 +103,18 @@ The following actions are possible and grouped based on the actions.
   FLEET_SERVER_CERT_KEY - path to private key for certificate to use for HTTPS endpoint
   FLEET_SERVER_INSECURE_HTTP - expose Fleet Server over HTTP (not recommended; insecure)
 
-* Elastic Agent Fleet Enrollment
-  This enrolls the Elastic Agent into a Fleet Server. It is also possible to have this create a new enrollment token
-  for this specific Elastic Agent.
+* Preparing Kibana for Fleet
+  This prepares the Fleet plugin that exists inside of Kibana. This must either be enabled here or done externally
+  before Fleet Server will actually successfully start. All the Kibana variables are not needed in case Elastic Agent
+  should not setup Fleet. To manually trigger KIBANA_FLEET_SETUP navigate to Kibana -> Fleet -> Agents and enabled it.
 
-  FLEET_ENROLL - set to 1 for enrollment to occur
-  FLEET_URL - URL of the Fleet Server to enroll into
-  FLEET_ENROLLMENT_TOKEN - token to use for enrollment
-  FLEET_TOKEN_NAME - token name to use for fetching token from Kibana
-  FLEET_TOKEN_POLICY_NAME - token policy name to use for fetching token from Kibana
-  FLEET_CA - path to certificate authority to use with communicate with Fleet Server [$KIBANA_CA]
-  FLEET_INSECURE - communicate with Fleet with either insecure HTTP or un-verified HTTPS
-  KIBANA_FLEET_HOST - kibana host to enable create enrollment token on [$KIBANA_HOST]
-  KIBANA_FLEET_USERNAME - kibana username to create enrollment token [$KIBANA_USERNAME]
-  KIBANA_FLEET_PASSWORD - kibana password to create enrollment token [$KIBANA_PASSWORD]
+  KIBANA_FLEET_SETUP - set to 1 enables the setup of Fleet in Kibana by Elastic Agent. This was previously FLEET_SETUP.
+  KIBANA_FLEET_HOST - Kibana host accessible from fleet-server. [$KIBANA_HOST]
+  KIBANA_FLEET_USERNAME - kibana username to enable Fleet [$KIBANA_USERNAME]
+  KIBANA_FLEET_PASSWORD - kibana password to enable Fleet [$KIBANA_PASSWORD]
+  KIBANA_FLEET_CA - path to certificate authority to use with communicate with Kibana [$KIBANA_CA]
+  KIBANA_REQUEST_RETRY_SLEEP - specifies sleep duration taken when agent performs a request to kibana [default 1s]
+  KIBANA_REQUEST_RETRY_COUNT - specifies number of retries agent performs when executing a request to kibana [default 30]
 
 The following environment variables are provided as a convenience to prevent a large number of environment variable to
 be used when the same credentials will be used across all the possible actions above.
@@ -120,6 +127,7 @@ be used when the same credentials will be used across all the possible actions a
   KIBANA_USERNAME - kibana username [$ELASTICSEARCH_USERNAME]
   KIBANA_PASSWORD - kibana password [$ELASTICSEARCH_PASSWORD]
   KIBANA_CA - path to certificate authority to use with communicate with Kibana [$ELASTICSEARCH_CA]
+
 
 By default when this command starts it will check for an existing fleet.yml. If that file already exists then
 all the above actions will be skipped, because the Elastic Agent has already been enrolled. To ensure that enrollment

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -97,7 +97,7 @@ The following actions are possible and grouped based on the actions.
   FLEET_SERVER_ELASTICSEARCH_CA - path to certificate authority to use with communicate with elasticsearch [$ELASTICSEARCH_CA]
   FLEET_SERVER_SERVICE_TOKEN - service token to use for communication with elasticsearch
   FLEET_SERVER_POLICY_ID - policy ID for Fleet Server to use for itself ("Default Fleet Server policy" used when undefined)
-  FLEET_SERVER_HOST - binding host for Fleet Server HTTP (overrides the policy)
+  FLEET_SERVER_HOST - binding host for Fleet Server HTTP (overrides the policy). By default this is 127.0.0.1. If run inside a container and needs to be accessible, 0.0.0.0 has to be used or a specific ip.
   FLEET_SERVER_PORT - binding port for Fleet Server HTTP (overrides the policy)
   FLEET_SERVER_CERT - path to certificate to use for HTTPS endpoint
   FLEET_SERVER_CERT_KEY - path to private key for certificate to use for HTTPS endpoint

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -97,7 +97,7 @@ The following actions are possible and grouped based on the actions.
   FLEET_SERVER_ELASTICSEARCH_CA - path to certificate authority to use with communicate with elasticsearch [$ELASTICSEARCH_CA]
   FLEET_SERVER_SERVICE_TOKEN - service token to use for communication with elasticsearch
   FLEET_SERVER_POLICY_ID - policy ID for Fleet Server to use for itself ("Default Fleet Server policy" used when undefined)
-  FLEET_SERVER_HOST - binding host for Fleet Server HTTP (overrides the policy). By default this is 127.0.0.1. If run inside a container and needs to be accessible, 0.0.0.0 has to be used or a specific ip.
+  FLEET_SERVER_HOST - binding host for Fleet Server HTTP (overrides the policy). By default this is 0.0.0.0.
   FLEET_SERVER_PORT - binding port for Fleet Server HTTP (overrides the policy)
   FLEET_SERVER_CERT - path to certificate to use for HTTPS endpoint
   FLEET_SERVER_CERT_KEY - path to private key for certificate to use for HTTPS endpoint

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -71,9 +71,9 @@ The following actions are possible and grouped based on the actions.
 
   FLEET_ENROLL - set to 1 for enrollment into fleet-server. If not set, Elastic Agent is run in standalone mode.
   FLEET_URL - URL of the Fleet Server to enroll into
-  FLEET_ENROLLMENT_TOKEN - token to use for enrollment.
+  FLEET_ENROLLMENT_TOKEN - token to use for enrollment. This is not needed in case FLEET_SERVER_ENABLED and FLEET_ENROLL is set. Then the token is fetched from Kibana.
   FLEET_CA - path to certificate authority to use with communicate with Fleet Server [$KIBANA_CA]
-  FLEET_INSECURE - communicate with Fleet with either insecure HTTP or un-verified HTTPS
+  FLEET_INSECURE - communicate with Fleet with either insecure HTTP or unverified HTTPS
 
   The following vars are need in the scenario that Elastic Agent should automatically fetch its own token.
 


### PR DESCRIPTION
The goal of this update is to make it more descriptive which environment variables are used in which scenario. I also changed the order of the docs as I assume in most cases, the simple Elastic Agent enrollment case is needed, fleet-server is the more advanced and only in special cases the setup of fleet is needed (testing etc.). So I put these at the end.

Later on, this should go into public docs.