### PR TITLE
Cherry-pick #24761 to 7.x: [libbeat] Print failed object when encoding

### DIFF
--- a/libbeat/esleg/eslegclient/bulkapi.go
+++ b/libbeat/esleg/eslegclient/bulkapi.go
@@ -227,7 +227,7 @@ func (conn *Connection) sendBulkRequest(requ *bulkRequest) (int, BulkResult, err
 func bulkEncode(log *logp.Logger, out BulkWriter, body []interface{}) error {
 	for _, obj := range body {
 		if err := out.AddRaw(obj); err != nil {
-			log.Debugf("Failed to encode message: %s", err)
+			log.Debugf("Failed to encode message: %v %s", obj, err)
 			return err
 		}
 	}


### PR DESCRIPTION
Cherry-pick of PR #24761 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Prints the failed object when an encoding error is found.

## Why is it important?

It helps troubleshooting.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
