### PR TITLE
Cherry-pick #24775 to 7.x: Disable rust when preparing the python environment

### DIFF
--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -91,6 +91,10 @@ jenkins_setup() {
 
   # Workaround for Python virtualenv path being too long.
   export TEMP_PYTHON_ENV=$(mktemp -d)
+
+  # Workaround for cryptography package (pip dependency) relying on rust
+  export CRYPTOGRAPHY_DONT_BUILD_RUST=1
+
   export PYTHON_ENV="${TEMP_PYTHON_ENV}/python-env"
 
   # Write cached magefile binaries to workspace to ensure

--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -192,6 +192,12 @@ func PythonVirtualenv() (string, error) {
 	pythonVirtualenvLock.Lock()
 	defer pythonVirtualenvLock.Unlock()
 
+	// When upgrading pip we might run into an error with the cryptography package
+	// (pip dependency) will not compile if no recent rust development environment is available.
+	// We set `CRYPTOGRAPHY_DONT_BUILD_RUST=1`, to disable the need for python.
+	// See: https://github.com/pyca/cryptography/issues/5771
+	os.Setenv("CRYPTOGRAPHY_DONT_BUILD_RUST", "1")
+
 	// Determine the location of the virtualenv.
 	ve, err := pythonVirtualenvPath()
 	if err != nil {

--- a/libbeat/scripts/Makefile
+++ b/libbeat/scripts/Makefile
@@ -267,6 +267,7 @@ load-tests: ## @testing Runs load tests
 
 # Sets up the virtual python environment
 .PHONY: python-env
+python-env: export CRYPTOGRAPHY_DONT_BUILD_RUST=1 
 python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
 	@test -e ${PYTHON_ENV}/bin/activate || ${PYTHON_EXE} -m venv ${VENV_PARAMS} ${PYTHON_ENV}
 	@. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -q --upgrade pip ; \


### PR DESCRIPTION
Cherry-pick of PR #24775 to 7.x branch. Original message: 



<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When setting up the python environment or upgrading pip the build might
fail because rust is not available or recent enough.
We set the `CRYPTOGRAPHY_DONT_BUILD_RUST=1` environment variable as
mitigation whenever we prepare the python test environment.

## Why is it important?

Do not fail the release build when building artifacts.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related https://github.com/pyca/cryptography/issues/5771
