### PR TITLE
Cherry-pick #24480 to 7.x: Improve ILM policy and alias setup log output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -139,6 +139,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix panic due to unhandled DeletedFinalStateUnknown in k8s OnDelete {pull}23419[23419]
 - Fix error loop with runaway CPU use when the Kafka output encounters some connection errors {pull}23484[23484]
 - Allow configuring credential_profile_name and shared_credential_file when using role_arn. {pull}24174[24174]
+- Fix ILM setup log reporting that a policy or an alias was created, even though the creation of any resource was disabled. {issue}24046[24046] {pull}24480[24480]
+- Fix ILM alias not being created if `setup.ilm.check_exists: false` and `setup.ilm.overwrite: true` has been configured. {pull}24480[24480]
+- Fix issue discovering docker containers and metadata after reconnections {pull}24318[24318]
 - Allow cgroup self-monitoring to see alternate `hostfs` paths {pull}24334[24334]
 
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -141,7 +141,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow configuring credential_profile_name and shared_credential_file when using role_arn. {pull}24174[24174]
 - Fix ILM setup log reporting that a policy or an alias was created, even though the creation of any resource was disabled. {issue}24046[24046] {pull}24480[24480]
 - Fix ILM alias not being created if `setup.ilm.check_exists: false` and `setup.ilm.overwrite: true` has been configured. {pull}24480[24480]
-- Fix issue discovering docker containers and metadata after reconnections {pull}24318[24318]
 - Allow cgroup self-monitoring to see alternate `hostfs` paths {pull}24334[24334]
 
 

--- a/libbeat/idxmgmt/ilm/ilm_test.go
+++ b/libbeat/idxmgmt/ilm/ilm_test.go
@@ -238,6 +238,27 @@ func TestDefaultSupport_Manager_EnsureAlias(t *testing.T) {
 			},
 			fail: ErrRequestFailed,
 		},
+		"overwrite non-existent": {
+			calls: []onCall{
+				onCreateAlias(alias).Return(nil),
+			},
+			fail: nil,
+			cfg:  map[string]interface{}{"check_exists": false, "overwrite": true},
+		},
+		"try overwrite existing": {
+			calls: []onCall{
+				onCreateAlias(alias).Return(errOf(ErrAliasAlreadyExists)),
+			},
+			fail: nil, // we detect that that the alias exists, and call it a day.
+			cfg:  map[string]interface{}{"check_exists": false, "overwrite": true},
+		},
+		"fail to overwrite": {
+			calls: []onCall{
+				onCreateAlias(alias).Return(errOf(ErrAliasCreateFailed)),
+			},
+			fail: ErrAliasCreateFailed,
+			cfg:  map[string]interface{}{"check_exists": false, "overwrite": true},
+		},
 	}
 
 	for name, test := range cases {
@@ -283,12 +304,14 @@ func TestDefaultSupport_Manager_EnsurePolicy(t *testing.T) {
 			},
 		},
 		"policy already exists": {
+			create: false,
 			calls: []onCall{
 				onHasILMPolicy(testPolicy.Name).Return(true, nil),
 			},
 		},
-		"overwrite existing": {
+		"overwrite": {
 			overwrite: true,
+			create:    true,
 			calls: []onCall{
 				onCreateILMPolicy(testPolicy).Return(nil),
 			},

--- a/libbeat/idxmgmt/ilm/std.go
+++ b/libbeat/idxmgmt/ilm/std.go
@@ -103,42 +103,77 @@ func (m *stdManager) CheckEnabled() (bool, error) {
 }
 
 func (m *stdManager) EnsureAlias() error {
-	if !m.checkExists {
-		return nil
+	log := m.log
+	overwrite := m.Overwrite()
+	name := m.alias.Name
+
+	var exists bool
+	if m.checkExists && !overwrite {
+		var err error
+		exists, err = m.client.HasAlias(name)
+		if err != nil {
+			return err
+		}
 	}
 
-	b, err := m.client.HasAlias(m.alias.Name)
-	if err != nil {
-		return err
-	}
-	if b {
+	switch {
+	case exists && !overwrite:
+		log.Infof("Index Alias %v exists already.", name)
+		return nil
+
+	case !exists || overwrite:
+		err := m.client.CreateAlias(m.alias)
+		if err != nil {
+			if ErrReason(err) != ErrAliasAlreadyExists {
+				log.Errorf("Index Alias %v setup failed: %v.", name, err)
+				return err
+			}
+			log.Infof("Index Alias %v exists already.", name)
+			return nil
+		}
+
+		log.Infof("Index Alias %v successfully created.", name)
+		return nil
+
+	default:
+		m.log.Infof("ILM index alias not created: exists=%v, overwrite=%v", exists, overwrite)
 		return nil
 	}
-
-	// This always assume it's a date pattern by sourrounding it by <...>
-	return m.client.CreateAlias(m.alias)
 }
 
 func (m *stdManager) EnsurePolicy(overwrite bool) (bool, error) {
 	log := m.log
 	overwrite = overwrite || m.Overwrite()
+	name := m.policy.Name
 
-	exists := true
+	var exists bool
 	if m.checkExists && !overwrite {
-		b, err := m.client.HasILMPolicy(m.policy.Name)
+		var err error
+		exists, err = m.client.HasILMPolicy(name)
 		if err != nil {
 			return false, err
 		}
-		exists = b
 	}
 
-	if !exists || overwrite {
-		return !exists, m.client.CreateILMPolicy(m.policy)
-	}
+	switch {
+	case exists && !overwrite:
+		log.Infof("ILM policy %v exists already.", name)
+		return false, nil
 
-	log.Infof("do not generate ilm policy: exists=%v, overwrite=%v",
-		exists, overwrite)
-	return false, nil
+	case !exists || overwrite:
+		err := m.client.CreateILMPolicy(m.policy)
+		if err != nil {
+			log.Errorf("ILM policy %v creation failed: %v", name, err)
+			return false, err
+		}
+
+		log.Infof("ILM policy %v successfully created.", name)
+		return true, err
+
+	default:
+		log.Infof("ILM policy not created: exists=%v, overwrite=%v.", exists, overwrite)
+		return false, nil
+	}
 }
 
 func (c *infoCache) Valid() bool {

--- a/libbeat/idxmgmt/std.go
+++ b/libbeat/idxmgmt/std.go
@@ -271,7 +271,6 @@ func (m *indexManager) Setup(loadTemplate, loadILM LoadMode) error {
 		if err != nil {
 			return err
 		}
-		log.Info("ILM policy successfully loaded.")
 
 		// The template should be updated if a new policy is created.
 		if policyCreated && templateComponent.enabled {
@@ -299,14 +298,9 @@ func (m *indexManager) Setup(loadTemplate, loadILM LoadMode) error {
 	}
 
 	if ilmComponent.load {
-		// ensure alias is created after the template is created
-		if err := m.ilm.EnsureAlias(); err != nil {
-			if ilm.ErrReason(err) != ilm.ErrAliasAlreadyExists {
-				return err
-			}
-			log.Info("Write alias exists already")
-		} else {
-			log.Info("Write alias successfully generated.")
+		err := m.ilm.EnsureAlias()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pytest
+import re
 import shutil
 import unittest
 
@@ -10,6 +11,9 @@ from base import BaseTest
 from idxmgmt import IdxMgmt
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+
+
+MSG_ILM_POLICY_LOADED = re.compile('ILM policy .* successfully created.')
 
 
 class TestRunILM(BaseTest):
@@ -46,7 +50,7 @@ class TestRunILM(BaseTest):
         self.render_config()
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
-        self.wait_until(lambda: self.log_contains("ILM policy successfully loaded"))
+        self.wait_until(lambda: self.log_contains(MSG_ILM_POLICY_LOADED))
         self.wait_until(lambda: self.log_contains("PublishEvents: 1 events have been published"))
         proc.check_kill_and_wait()
 
@@ -84,7 +88,7 @@ class TestRunILM(BaseTest):
 
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
-        self.wait_until(lambda: self.log_contains("ILM policy successfully loaded"))
+        self.wait_until(lambda: self.log_contains(MSG_ILM_POLICY_LOADED))
         self.wait_until(lambda: self.log_contains("PublishEvents: 1 events have been published"))
         proc.check_kill_and_wait()
 
@@ -103,7 +107,7 @@ class TestRunILM(BaseTest):
 
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
-        self.wait_until(lambda: self.log_contains("ILM policy successfully loaded"))
+        self.wait_until(lambda: self.log_contains(MSG_ILM_POLICY_LOADED))
         self.wait_until(lambda: self.log_contains("PublishEvents: 1 events have been published"))
         proc.check_kill_and_wait()
 
@@ -123,7 +127,7 @@ class TestRunILM(BaseTest):
 
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
-        self.wait_until(lambda: self.log_contains("ILM policy successfully loaded"))
+        self.wait_until(lambda: self.log_contains(MSG_ILM_POLICY_LOADED))
         self.wait_until(lambda: self.log_contains("PublishEvents: 1 events have been published"))
         proc.check_kill_and_wait()
 
@@ -143,7 +147,7 @@ class TestRunILM(BaseTest):
 
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
-        self.wait_until(lambda: self.log_contains("ILM policy successfully loaded"))
+        self.wait_until(lambda: self.log_contains(MSG_ILM_POLICY_LOADED))
         self.wait_until(lambda: self.log_contains("PublishEvents: 1 events have been published"))
         proc.check_kill_and_wait()
 
@@ -286,12 +290,12 @@ class TestCommandExportILMPolicy(BaseTest):
         self.cmd = "ilm-policy"
 
     def assert_log_contains_policy(self):
-        assert self.log_contains('ILM policy successfully loaded.')
+        assert self.log_contains(MSG_ILM_POLICY_LOADED)
         assert self.log_contains('"max_age": "30d"')
         assert self.log_contains('"max_size": "50gb"')
 
     def assert_log_contains_write_alias(self):
-        assert self.log_contains('Write alias successfully generated.')
+        assert self.log_contains(re.compile('Index Alias .* successfully created.'))
 
     def test_default(self):
         """


### PR DESCRIPTION
Cherry-pick of PR #24480 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Bug

## What does this PR do?

The idxmgmt has not all 'information' to properly log the outcome of the
policy and status setup. The PR moves the reporting to the ILM package
directly, and 'unifies' the logic of EnsurePolicy and EnsureAlias.

## Why is it important?

The change fixes the status reporting for the ILM and index alias setup, that is written to the logs.
With the fix one can tell if some resources have been installed, or not, depending on the actual settings in the configuration file. Before it was potentially reported that a policy/alias has been created, although the creation of the resources was disabled.

The change also updates EnsurePolicy/EnsureAlias to follow a similar pattern, which makes it a little easier to follow the code. We now allow EnsureAlias to create the first index and alias if `check_exists: false` and `overwrite: true`. If the alias already exists, no new alias will be created, as Elasticsearch will return an error.
This change in semantics fixes a setup that has ILM enabled with aforementioned settings, potentially indexing without the appropriate alias/index being setup ahead of time.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24046 