### PR TITLE
Cherry-pick #21631 to 7.x: Add harvester_limit to filestream

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -35,6 +35,7 @@ import (
 
 var (
 	ErrHarvesterAlreadyRunning = errors.New("harvester is already running for file")
+	ErrHarvesterLimitReached   = errors.New("harvester limit reached")
 )
 
 // Harvester is the reader which collects the lines from
@@ -51,11 +52,17 @@ type Harvester interface {
 
 type readerGroup struct {
 	mu    sync.Mutex
+	limit uint64
 	table map[string]context.CancelFunc
 }
 
 func newReaderGroup() *readerGroup {
+	return newReaderGroupWithLimit(0)
+}
+
+func newReaderGroupWithLimit(limit uint64) *readerGroup {
 	return &readerGroup{
+		limit: limit,
 		table: make(map[string]context.CancelFunc),
 	}
 }
@@ -69,6 +76,10 @@ func newReaderGroup() *readerGroup {
 func (r *readerGroup) newContext(id string, cancelation v2.Canceler) (context.Context, context.CancelFunc, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
+	if 0 < r.limit && r.limit <= uint64(len(r.table)) {
+		return nil, nil, ErrHarvesterLimitReached
+	}
 
 	if _, ok := r.table[id]; ok {
 		return nil, nil, ErrHarvesterAlreadyRunning
@@ -121,7 +132,6 @@ type defaultHarvesterGroup struct {
 	tg           unison.TaskGroup
 }
 
-// Start starts the Harvester for a Source. It does not block.
 func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
 	sourceName := s.Name()
 

--- a/filebeat/input/filestream/internal/input-logfile/harvester_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester_test.go
@@ -85,6 +85,16 @@ func TestReaderGroup(t *testing.T) {
 		require.Equal(t, 1, len(rg.table))
 		require.Nil(t, newCtx.Err())
 	})
+
+	t.Run("assert new harvester cannot be added if limit is reached", func(t *testing.T) {
+		rg := newReaderGroupWithLimit(1)
+		require.Equal(t, 0, len(rg.table))
+		ctx, cf, err := rg.newContext("test-id", context.Background())
+		requireGroupSuccess(t, ctx, cf, err)
+		ctx, cf, err = rg.newContext("test-id", context.Background())
+		requireGroupError(t, ctx, cf, err)
+	})
+
 }
 
 func TestDefaultHarvesterGroup(t *testing.T) {

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -36,6 +36,7 @@ type managedInput struct {
 	prospector       Prospector
 	harvester        Harvester
 	cleanTimeout     time.Duration
+	harvesterLimit   uint64
 }
 
 // Name is required to implement the v2.Input interface
@@ -62,7 +63,7 @@ func (inp *managedInput) Run(
 
 	hg := &defaultHarvesterGroup{
 		pipeline:     pipeline,
-		readers:      newReaderGroup(),
+		readers:      newReaderGroupWithLimit(inp.harvesterLimit),
 		cleanTimeout: inp.cleanTimeout,
 		harvester:    inp.harvester,
 		store:        groupStore,

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -155,9 +155,10 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 	}
 
 	settings := struct {
-		ID           string        `config:"id"`
-		CleanTimeout time.Duration `config:"clean_timeout"`
-	}{ID: "", CleanTimeout: cim.DefaultCleanTimeout}
+		ID             string        `config:"id"`
+		CleanTimeout   time.Duration `config:"clean_timeout"`
+		HarvesterLimit uint64        `config:"harvester_limit"`
+	}{ID: "", CleanTimeout: cim.DefaultCleanTimeout, HarvesterLimit: 0}
 	if err := config.Unpack(&settings); err != nil {
 		return nil, err
 	}
@@ -190,6 +191,7 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 		harvester:        harvester,
 		sourceIdentifier: sourceIdentifier,
 		cleanTimeout:     settings.CleanTimeout,
+		harvesterLimit:   settings.HarvesterLimit,
 	}, nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #21631 to 7.x branch. Original message: 

## What does this PR do?

This PR adds `harvester_limit` to the input `filestream` to limit the number of readers started for the input. If the limit has been reached no harvester is started, an error is returned and the input does not wait for other Harvesters to stop.

## Why is it important?

This lets users limit the number of readers which encourage the adoption of the new input.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~