### PR TITLE
Cherry-pick to 7.x: CI: install-go resilience (#24809)

### DIFF
--- a/.ci/scripts/install-go.sh
+++ b/.ci/scripts/install-go.sh
@@ -11,13 +11,15 @@ GVM_CMD="${HOME}/bin/gvm"
 
 if command -v go
 then
+    set +e
     echo "Found Go. Checking version.."
     FOUND_GO_VERSION=$(go version|awk '{print $3}'|sed s/go//)
-    if [ $FOUND_GO_VERSION == $GO_VERSION ]
+    if [ "$FOUND_GO_VERSION" == "$GO_VERSION" ]
     then
         echo "Versions match. No need to install Go. Exiting."
         exit 0
     fi
+    set -e
 fi
 
 if [ "${ARCH}" == "aarch64" ] ; then


### PR DESCRIPTION
Backports the following commits to 7.x:
 - CI: install-go resilience (#24809)