### PR TITLE
[Elastic Agent] Fix Docker container to allow state to properly be handled

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/filters/stream_checker_test.go
@@ -249,7 +249,7 @@ func TestStreamCheck(t *testing.T) {
 		},
 	}
 
-	log, err := logger.New("")
+	log, err := logger.New("", false)
 	assert.NoError(t, err)
 
 	for _, tc := range testCases {

--- a/x-pack/elastic-agent/pkg/agent/application/fleet_server_bootstrap.go
+++ b/x-pack/elastic-agent/pkg/agent/application/fleet_server_bootstrap.go
@@ -56,7 +56,7 @@ func newFleetServerBootstrap(
 	}
 
 	if log == nil {
-		log, err = logger.NewFromConfig("", cfg.Settings.LoggingConfig)
+		log, err = logger.NewFromConfig("", cfg.Settings.LoggingConfig, false)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/gateway/fleet/fleet_gateway_test.go
@@ -118,7 +118,7 @@ func withGateway(agentInfo agentInfo, settings *fleetGatewaySettings, fn withGat
 		client := newTestingClient()
 		dispatcher := newTestingDispatcher()
 
-		log, _ := logger.New("fleet_gateway")
+		log, _ := logger.New("fleet_gateway", false)
 		rep := getReporter(agentInfo, log, t)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -252,7 +252,7 @@ func TestFleetGateway(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		log, _ := logger.New("tst")
+		log, _ := logger.New("tst", false)
 		stateStore, err := store.NewStateStore(log, storage.NewDiskStore(paths.AgentStateStoreFile()))
 		require.NoError(t, err)
 
@@ -342,7 +342,7 @@ func TestFleetGateway(t *testing.T) {
 		dispatcher := newTestingDispatcher()
 
 		ctx, cancel := context.WithCancel(context.Background())
-		log, _ := logger.New("tst")
+		log, _ := logger.New("tst", false)
 
 		stateStore, err := store.NewStateStore(log, storage.NewDiskStore(paths.AgentStateStoreFile()))
 		require.NoError(t, err)

--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -76,7 +76,7 @@ func newLocal(
 	}
 
 	if log == nil {
-		log, err = logger.NewFromConfig("", cfg.Settings.LoggingConfig)
+		log, err = logger.NewFromConfig("", cfg.Settings.LoggingConfig, true)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode_test.go
@@ -41,7 +41,7 @@ func TestManagedModeRouting(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	log, _ := logger.New("")
+	log, _ := logger.New("", false)
 	router, _ := router.New(log, streamFn)
 	agentInfo, _ := info.NewAgentInfo()
 	nullStore := &storage.NullStore{}

--- a/x-pack/elastic-agent/pkg/agent/application/paths/common.go
+++ b/x-pack/elastic-agent/pkg/agent/application/paths/common.go
@@ -94,6 +94,14 @@ func Config() string {
 	return configPath
 }
 
+// SetConfig overrides the Config path.
+//
+// Used by the container subcommand to adjust the overall config path allowing state can be maintained between container
+// restarts.
+func SetConfig(path string) {
+	configPath = path
+}
+
 // ConfigFile returns the path to the configuration file.
 func ConfigFile() string {
 	if configFilePath == "" || configFilePath == DefaultConfigName {

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change_test.go
@@ -34,7 +34,7 @@ func (m *mockEmitter) Emitter(policy *config.Config) error {
 }
 
 func TestPolicyChange(t *testing.T) {
-	log, _ := logger.New("")
+	log, _ := logger.New("", false)
 	ack := noopacker.NewAcker()
 	agentInfo, _ := info.NewAgentInfo()
 	nullStore := &storage.NullStore{}
@@ -89,7 +89,7 @@ func TestPolicyChange(t *testing.T) {
 }
 
 func TestPolicyAcked(t *testing.T) {
-	log, _ := logger.New("")
+	log, _ := logger.New("", false)
 	agentInfo, _ := info.NewAgentInfo()
 	nullStore := &storage.NullStore{}
 

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/dispatcher/dispatcher.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/dispatcher/dispatcher.go
@@ -31,7 +31,7 @@ type ActionDispatcher struct {
 func New(ctx context.Context, log *logger.Logger, def actions.Handler) (*ActionDispatcher, error) {
 	var err error
 	if log == nil {
-		log, err = logger.New("action_dispatcher")
+		log, err = logger.New("action_dispatcher", false)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/router/router.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/router/router.go
@@ -26,7 +26,7 @@ type router struct {
 func New(log *logger.Logger, factory pipeline.StreamFunc) (pipeline.Router, error) {
 	var err error
 	if log == nil {
-		log, err = logger.New("router")
+		log, err = logger.New("router", false)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker_test.go
@@ -129,7 +129,7 @@ func TestChecker(t *testing.T) {
 
 func testableChecker(t *testing.T, pider *testPider) (*CrashChecker, chan error) {
 	errChan := make(chan error, 1)
-	l, _ := logger.New("")
+	l, _ := logger.New("", false)
 	ch, err := NewCrashChecker(context.Background(), errChan, l)
 	require.NoError(t, err)
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/common.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/common.go
@@ -7,36 +7,15 @@ package cmd
 import (
 	"flag"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	// import logp flags
 	_ "github.com/elastic/beats/v7/libbeat/logp/configure"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/basecmd"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
-
-const (
-	defaultConfig     = "elastic-agent.yml"
-	hashLen           = 6
-	commitFile        = ".elastic-agent.active.commit"
-	agentLockFileName = "agent.lock"
-)
-
-type globalFlags struct {
-	PathConfigFile string
-}
-
-// Config returns path which identifies configuration file.
-func (f *globalFlags) Config() string {
-	if len(f.PathConfigFile) == 0 || f.PathConfigFile == defaultConfig {
-		return filepath.Join(paths.Config(), defaultConfig)
-	}
-	return f.PathConfigFile
-}
 
 // NewCommand returns the default command for the agent.
 func NewCommand() *cobra.Command {
@@ -49,13 +28,13 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 		Use: "elastic-agent [subcommand]",
 	}
 
-	flags := &globalFlags{}
-
 	// path flags
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.home"))
+	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.home.unversioned"))
+	cmd.PersistentFlags().MarkHidden("path.home.unversioned") // hidden used internally by container subcommand
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.config"))
+	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("c"))
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("path.logs"))
-	cmd.PersistentFlags().StringVarP(&flags.PathConfigFile, "c", "c", defaultConfig, `Configuration file, relative to path.config`)
 
 	// logging flags
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("v"))
@@ -64,19 +43,19 @@ func NewCommandWithArgs(args []string, streams *cli.IOStreams) *cobra.Command {
 	cmd.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup("environment"))
 
 	// sub-commands
-	run := newRunCommandWithArgs(flags, args, streams)
+	run := newRunCommandWithArgs(args, streams)
 	cmd.AddCommand(basecmd.NewDefaultCommandsWithArgs(args, streams)...)
 	cmd.AddCommand(run)
-	cmd.AddCommand(newInstallCommandWithArgs(flags, args, streams))
-	cmd.AddCommand(newUninstallCommandWithArgs(flags, args, streams))
-	cmd.AddCommand(newUpgradeCommandWithArgs(flags, args, streams))
-	cmd.AddCommand(newEnrollCommandWithArgs(flags, args, streams))
-	cmd.AddCommand(newInspectCommandWithArgs(flags, args, streams))
-	cmd.AddCommand(newWatchCommandWithArgs(flags, args, streams))
-	cmd.AddCommand(newContainerCommand(flags, args, streams))
+	cmd.AddCommand(newInstallCommandWithArgs(args, streams))
+	cmd.AddCommand(newUninstallCommandWithArgs(args, streams))
+	cmd.AddCommand(newUpgradeCommandWithArgs(args, streams))
+	cmd.AddCommand(newEnrollCommandWithArgs(args, streams))
+	cmd.AddCommand(newInspectCommandWithArgs(args, streams))
+	cmd.AddCommand(newWatchCommandWithArgs(args, streams))
+	cmd.AddCommand(newContainerCommand(args, streams))
 
 	// windows special hidden sub-command (only added on windows)
-	reexec := newReExecWindowsCommand(flags, args, streams)
+	reexec := newReExecWindowsCommand(args, streams)
 	if reexec != nil {
 		cmd.AddCommand(reexec)
 	}

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -7,6 +7,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"os"
 	"os/signal"
 	"strconv"
@@ -23,13 +24,13 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
-func newEnrollCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newEnrollCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enroll",
 		Short: "Enroll the Agent into Fleet",
 		Long:  "This will enroll the Agent into Fleet.",
 		Run: func(c *cobra.Command, args []string) {
-			if err := enroll(streams, c, flags, args); err != nil {
+			if err := enroll(streams, c, args); err != nil {
 				fmt.Fprintf(streams.Err, "Error: %v\n", err)
 				os.Exit(1)
 			}
@@ -145,13 +146,13 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 	return args
 }
 
-func enroll(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+func enroll(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 	fromInstall, _ := cmd.Flags().GetBool("from-install")
 	if !fromInstall {
 		warn.PrintNotGA(streams.Out)
 	}
 
-	pathConfigFile := flags.Config()
+	pathConfigFile := paths.ConfigFile()
 	rawConfig, err := config.LoadFile(pathConfigFile)
 	if err != nil {
 		return errors.New(err,

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -7,11 +7,12 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 
 	"github.com/spf13/cobra"
 
@@ -198,7 +199,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 	cfg.Settings.LoggingConfig.ToFiles = false
 	cfg.Settings.LoggingConfig.ToStderr = true
 
-	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig)
+	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig, false)
 	if err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd_test.go
@@ -45,7 +45,7 @@ func (m *mockStore) Save(in io.Reader) error {
 }
 
 func TestEnroll(t *testing.T) {
-	log, _ := logger.New("tst")
+	log, _ := logger.New("tst", false)
 
 	t.Run("fail to save is propagated", withTLSServer(
 		func(t *testing.T) *http.ServeMux {

--- a/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
@@ -129,7 +129,7 @@ func printConfig(cfg *config.Config) error {
 }
 
 func newErrorLogger() (*logger.Logger, error) {
-	return logger.NewWithLogpLevel("", logp.ErrorLevel)
+	return logger.NewWithLogpLevel("", logp.ErrorLevel, false)
 }
 
 func inspectOutputs(cfgPath string, agentInfo *info.AgentInfo) error {

--- a/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
@@ -34,26 +34,26 @@ import (
 	"github.com/elastic/go-sysinfo"
 )
 
-func newInspectCommandWithArgs(flags *globalFlags, s []string, streams *cli.IOStreams) *cobra.Command {
+func newInspectCommandWithArgs(s []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect",
 		Short: "Shows configuration of the agent",
 		Long:  "Shows current configuration of the agent",
 		Args:  cobra.ExactArgs(0),
 		Run: func(c *cobra.Command, args []string) {
-			if err := inspectConfig(flags.Config()); err != nil {
+			if err := inspectConfig(paths.ConfigFile()); err != nil {
 				fmt.Fprintf(streams.Err, "%v\n", err)
 				os.Exit(1)
 			}
 		},
 	}
 
-	cmd.AddCommand(newInspectOutputCommandWithArgs(flags, s, streams))
+	cmd.AddCommand(newInspectOutputCommandWithArgs(s, streams))
 
 	return cmd
 }
 
-func newInspectOutputCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newInspectOutputCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "output",
 		Short: "Displays configuration generated for output",
@@ -62,7 +62,7 @@ func newInspectOutputCommandWithArgs(flags *globalFlags, _ []string, streams *cl
 		RunE: func(c *cobra.Command, args []string) error {
 			outName, _ := c.Flags().GetString("output")
 			program, _ := c.Flags().GetString("program")
-			cfgPath := flags.Config()
+			cfgPath := paths.ConfigFile()
 			agentInfo, err := info.NewAgentInfo()
 			if err != nil {
 				return err

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -19,7 +19,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
 
-func newInstallCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newInstallCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install Elastic Agent permanently on this system",
@@ -29,7 +29,7 @@ Unless all the require command-line parameters are provided or -f is used this c
 would like the Agent to operate.
 `,
 		Run: func(c *cobra.Command, args []string) {
-			if err := installCmd(streams, c, flags, args); err != nil {
+			if err := installCmd(streams, c, args); err != nil {
 				fmt.Fprintf(streams.Err, "Error: %v\n", err)
 				os.Exit(1)
 			}
@@ -42,7 +42,7 @@ would like the Agent to operate.
 	return cmd
 }
 
-func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+func installCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 	isAdmin, err := install.HasRoot()
 	if err != nil {
 		return fmt.Errorf("unable to perform install command while checking for administrator rights, %v", err)
@@ -57,7 +57,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, 
 	}
 
 	// check the lock to ensure that elastic-agent is not already running in this directory
-	locker := filelock.NewAppLocker(paths.Data(), agentLockFileName)
+	locker := filelock.NewAppLocker(paths.Data(), paths.AgentLockFileName)
 	if err := locker.TryLock(); err != nil {
 		if err == filelock.ErrAppAlreadyRunning {
 			return fmt.Errorf("cannot perform installation as Elastic Agent is already running from this directory")
@@ -141,7 +141,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, 
 			}
 		}
 	}
-	cfgFile := flags.Config()
+	cfgFile := paths.ConfigFile()
 	err = install.Install(cfgFile)
 	if err != nil {
 		return err

--- a/x-pack/elastic-agent/pkg/agent/cmd/reexec.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/reexec.go
@@ -12,6 +12,6 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
 
-func newReExecWindowsCommand(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newReExecWindowsCommand(_ []string, streams *cli.IOStreams) *cobra.Command {
 	return nil
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/reexec_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/reexec_windows.go
@@ -20,7 +20,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
 
-func newReExecWindowsCommand(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newReExecWindowsCommand(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Hidden: true,
 		Use:    "reexec_windows <service_name> <pid>",

--- a/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/uninstall.go
@@ -17,7 +17,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
 
-func newUninstallCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newUninstallCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: "Uninstall permanent Elastic Agent from this system",
@@ -26,7 +26,7 @@ func newUninstallCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IO
 Unless -f is used this command will ask confirmation before performing removal.
 `,
 		Run: func(c *cobra.Command, args []string) {
-			if err := uninstallCmd(streams, c, flags, args); err != nil {
+			if err := uninstallCmd(streams, c, args); err != nil {
 				fmt.Fprintf(streams.Err, "Error: %v\n", err)
 				os.Exit(1)
 			}
@@ -38,7 +38,7 @@ Unless -f is used this command will ask confirmation before performing removal.
 	return cmd
 }
 
-func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 	isAdmin, err := install.HasRoot()
 	if err != nil {
 		return fmt.Errorf("unable to perform command while checking for administrator rights, %v", err)
@@ -78,7 +78,7 @@ func uninstallCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags
 		}
 	}
 
-	err = install.Uninstall(flags.Config())
+	err = install.Uninstall(paths.ConfigFile())
 	if err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/agent/cmd/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/upgrade.go
@@ -17,13 +17,13 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 )
 
-func newUpgradeCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newUpgradeCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade <version>",
 		Short: "Upgrade the currently running Elastic Agent to the specified version",
 		Args:  cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {
-			if err := upgradeCmd(streams, c, flags, args); err != nil {
+			if err := upgradeCmd(streams, c, args); err != nil {
 				fmt.Fprintf(streams.Err, "%v\n", err)
 				os.Exit(1)
 			}
@@ -35,7 +35,7 @@ func newUpgradeCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOSt
 	return cmd
 }
 
-func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
+func upgradeCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(streams.Out, "The upgrade process of Elastic Agent is currently EXPERIMENTAL and should not be used in production")
 
 	version := args[0]

--- a/x-pack/elastic-agent/pkg/agent/cmd/watch.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/watch.go
@@ -34,13 +34,13 @@ const (
 	watcherLockFile = "watcher.lock"
 )
 
-func newWatchCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStreams) *cobra.Command {
+func newWatchCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "watch",
 		Short: "Watch watches Elastic Agent for failures and initiates rollback.",
 		Long:  `Watch watches Elastic Agent for failures and initiates rollback.`,
 		Run: func(c *cobra.Command, args []string) {
-			if err := watchCmd(streams, c, flags, args); err != nil {
+			if err := watchCmd(streams, c, args); err != nil {
 				fmt.Fprintf(streams.Err, "Error: %v\n", err)
 				os.Exit(1)
 			}
@@ -50,8 +50,8 @@ func newWatchCommandWithArgs(flags *globalFlags, _ []string, streams *cli.IOStre
 	return cmd
 }
 
-func watchCmd(streams *cli.IOStreams, cmd *cobra.Command, flags *globalFlags, args []string) error {
-	log, err := configuredLogger(flags)
+func watchCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
+	log, err := configuredLogger()
 	if err != nil {
 		return err
 	}
@@ -181,8 +181,8 @@ func gracePeriod(marker *upgrade.UpdateMarker) (bool, time.Duration) {
 	return false, gracePeriodDuration
 }
 
-func configuredLogger(flags *globalFlags) (*logger.Logger, error) {
-	pathConfigFile := flags.Config()
+func configuredLogger() (*logger.Logger, error) {
+	pathConfigFile := paths.ConfigFile()
 	rawConfig, err := config.LoadFile(pathConfigFile)
 	if err != nil {
 		return nil, errors.New(err,

--- a/x-pack/elastic-agent/pkg/agent/cmd/watch.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/watch.go
@@ -201,7 +201,7 @@ func configuredLogger() (*logger.Logger, error) {
 
 	cfg.Settings.LoggingConfig.Beat = watcherName
 
-	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig)
+	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig, false)
 	if err != nil {
 		return nil, err
 	}

--- a/x-pack/elastic-agent/pkg/agent/control/control_test.go
+++ b/x-pack/elastic-agent/pkg/agent/control/control_test.go
@@ -72,7 +72,7 @@ func newErrorLogger(t *testing.T) *logger.Logger {
 	loggerCfg := logger.DefaultLoggingConfig()
 	loggerCfg.Level = logp.ErrorLevel
 
-	log, err := logger.NewFromConfig("", loggerCfg)
+	log, err := logger.NewFromConfig("", loggerCfg, false)
 	require.NoError(t, err)
 	return log
 }

--- a/x-pack/elastic-agent/pkg/agent/install/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/install/uninstall.go
@@ -119,7 +119,7 @@ func delayedRemoval(path string) {
 }
 
 func uninstallPrograms(ctx context.Context, cfgFile string) error {
-	log, err := logger.NewWithLogpLevel("", logp.ErrorLevel)
+	log, err := logger.NewWithLogpLevel("", logp.ErrorLevel, false)
 	if err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/common_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/common_test.go
@@ -92,7 +92,7 @@ func getTestOperator(t *testing.T, downloadPath string, installPath string, p *a
 func getLogger() *logger.Logger {
 	loggerCfg := logger.DefaultLoggingConfig()
 	loggerCfg.Level = logp.ErrorLevel
-	l, _ := logger.NewFromConfig("", loggerCfg)
+	l, _ := logger.NewFromConfig("", loggerCfg, false)
 	return l
 }
 

--- a/x-pack/elastic-agent/pkg/agent/stateresolver/stateresolver_test.go
+++ b/x-pack/elastic-agent/pkg/agent/stateresolver/stateresolver_test.go
@@ -25,7 +25,7 @@ func TestStateResolverAcking(t *testing.T) {
 	}
 
 	t.Run("when we ACK the should state", func(t *testing.T) {
-		log, _ := logger.New("")
+		log, _ := logger.New("", false)
 		r, err := NewStateResolver(log)
 		require.NoError(t, err)
 
@@ -44,7 +44,7 @@ func TestStateResolverAcking(t *testing.T) {
 	})
 
 	t.Run("when we don't ACK the should state", func(t *testing.T) {
-		log, _ := logger.New("")
+		log, _ := logger.New("", false)
 		r, err := NewStateResolver(log)
 		require.NoError(t, err)
 

--- a/x-pack/elastic-agent/pkg/agent/storage/store/action_store_test.go
+++ b/x-pack/elastic-agent/pkg/agent/storage/store/action_store_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestActionStore(t *testing.T) {
-	log, _ := logger.New("action_store")
+	log, _ := logger.New("action_store", false)
 	withFile := func(fn func(t *testing.T, file string)) func(*testing.T) {
 		return func(t *testing.T) {
 			dir, err := ioutil.TempDir("", "action-store")

--- a/x-pack/elastic-agent/pkg/agent/storage/store/state_store_test.go
+++ b/x-pack/elastic-agent/pkg/agent/storage/store/state_store_test.go
@@ -31,7 +31,7 @@ func TestStateStore(t *testing.T) {
 }
 
 func runTestStateStore(t *testing.T, ackToken string) {
-	log, _ := logger.New("state_store")
+	log, _ := logger.New("state_store", false)
 	withFile := func(fn func(t *testing.T, file string)) func(*testing.T) {
 		return func(t *testing.T) {
 			dir, err := ioutil.TempDir("", "state-store")

--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd_test.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd_test.go
@@ -128,7 +128,7 @@ func newErrorLogger(t *testing.T) *logger.Logger {
 	loggerCfg := logger.DefaultLoggingConfig()
 	loggerCfg.Level = logp.ErrorLevel
 
-	log, err := logger.NewFromConfig("", loggerCfg)
+	log, err := logger.NewFromConfig("", loggerCfg, false)
 	require.NoError(t, err)
 	return log
 }

--- a/x-pack/elastic-agent/pkg/capabilities/capabilities_test.go
+++ b/x-pack/elastic-agent/pkg/capabilities/capabilities_test.go
@@ -29,7 +29,7 @@ func TestLoadCapabilities(t *testing.T) {
 		"no_caps",
 	}
 
-	l, _ := logger.New("test")
+	l, _ := logger.New("test", false)
 
 	for _, tc := range testCases {
 		t.Run(tc, func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestInvalidLoadCapabilities(t *testing.T) {
 		"invalid_output",
 	}
 
-	l, _ := logger.New("test")
+	l, _ := logger.New("test", false)
 
 	for _, tc := range testCases {
 		t.Run(tc, func(t *testing.T) {
@@ -342,7 +342,7 @@ func newErrorLogger(t *testing.T) *logger.Logger {
 	loggerCfg := logger.DefaultLoggingConfig()
 	loggerCfg.Level = logp.ErrorLevel
 
-	log, err := logger.NewFromConfig("", loggerCfg)
+	log, err := logger.NewFromConfig("", loggerCfg, false)
 	require.NoError(t, err)
 	return log
 }

--- a/x-pack/elastic-agent/pkg/capabilities/input_test.go
+++ b/x-pack/elastic-agent/pkg/capabilities/input_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestMultiInput(t *testing.T) {
 	tr := &testReporter{}
-	l, _ := logger.New("test")
+	l, _ := logger.New("test", false)
 	t.Run("no match", func(t *testing.T) {
 
 		rd := &ruleDefinitions{
@@ -184,7 +184,7 @@ func TestMultiInput(t *testing.T) {
 }
 
 func TestInput(t *testing.T) {
-	l, _ := logger.New("test")
+	l, _ := logger.New("test", false)
 	tr := &testReporter{}
 	t.Run("invalid rule", func(t *testing.T) {
 		r := &upgradeCapability{}

--- a/x-pack/elastic-agent/pkg/capabilities/output_test.go
+++ b/x-pack/elastic-agent/pkg/capabilities/output_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestMultiOutput(t *testing.T) {
 	tr := &testReporter{}
-	l, _ := logger.New("test")
+	l, _ := logger.New("test", false)
 	t.Run("no match", func(t *testing.T) {
 		rd := &ruleDefinitions{
 			Capabilities: []ruler{&outputCapability{
@@ -167,7 +167,7 @@ func TestMultiOutput(t *testing.T) {
 
 func TestOutput(t *testing.T) {
 	tr := &testReporter{}
-	l, _ := logger.New("test")
+	l, _ := logger.New("test", false)
 	t.Run("invalid rule", func(t *testing.T) {
 		r := &upgradeCapability{}
 		cap, err := newOutputCapability(l, r, tr)

--- a/x-pack/elastic-agent/pkg/capabilities/upgrade_test.go
+++ b/x-pack/elastic-agent/pkg/capabilities/upgrade_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestUpgrade(t *testing.T) {
 	tr := &testReporter{}
-	l, _ := logger.New("test")
+	l, _ := logger.New("test", false)
 	t.Run("invalid rule", func(t *testing.T) {
 		r := &inputCapability{}
 		cap, err := newUpgradeCapability(l, r, tr)

--- a/x-pack/elastic-agent/pkg/composable/controller_test.go
+++ b/x-pack/elastic-agent/pkg/composable/controller_test.go
@@ -75,7 +75,7 @@ func TestController(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	log, err := logger.New("")
+	log, err := logger.New("", false)
 	require.NoError(t, err)
 	c, err := composable.New(log, cfg)
 	require.NoError(t, err)

--- a/x-pack/elastic-agent/pkg/composable/providers/host/host_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/host/host_test.go
@@ -31,7 +31,7 @@ func TestContextProvider(t *testing.T) {
 	})
 	require.NoError(t, err)
 	builder, _ := composable.Providers.GetContextProvider("host")
-	log, err := logger.New("host_test")
+	log, err := logger.New("host_test", false)
 	require.NoError(t, err)
 	provider, err := builder(log, c)
 	require.NoError(t, err)

--- a/x-pack/elastic-agent/pkg/config/operations/inspector.go
+++ b/x-pack/elastic-agent/pkg/config/operations/inspector.go
@@ -113,5 +113,5 @@ func loadFleetConfig(cfg *config.Config) (map[string]interface{}, error) {
 }
 
 func newErrorLogger() (*logger.Logger, error) {
-	return logger.NewWithLogpLevel("", logp.ErrorLevel)
+	return logger.NewWithLogpLevel("", logp.ErrorLevel, false)
 }

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -30,33 +30,33 @@ type Logger = logp.Logger
 type Config = logp.Config
 
 // New returns a configured ECS Logger
-func New(name string) (*Logger, error) {
+func New(name string, logInternal bool) (*Logger, error) {
 	defaultCfg := DefaultLoggingConfig()
-	return new(name, defaultCfg)
+	return new(name, defaultCfg, logInternal)
 }
 
 // NewWithLogpLevel returns a configured logp Logger with specified level.
-func NewWithLogpLevel(name string, level logp.Level) (*Logger, error) {
+func NewWithLogpLevel(name string, level logp.Level, logInternal bool) (*Logger, error) {
 	defaultCfg := DefaultLoggingConfig()
 	defaultCfg.Level = level
 
-	return new(name, defaultCfg)
+	return new(name, defaultCfg, logInternal)
 }
 
 // NewFromConfig takes the user configuration and generate the right logger.
 // TODO: Finish implementation, need support on the library that we use.
-func NewFromConfig(name string, cfg *Config) (*Logger, error) {
-	return new(name, cfg)
+func NewFromConfig(name string, cfg *Config, logInternal bool) (*Logger, error) {
+	return new(name, cfg, logInternal)
 }
 
-func new(name string, cfg *Config) (*Logger, error) {
+func new(name string, cfg *Config, logInternal bool) (*Logger, error) {
 	commonCfg, err := toCommonConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	var outputs []zapcore.Core
-	if cfg.ToFiles {
+	if logInternal {
 		internal, err := makeInternalFileOutput(cfg)
 		if err != nil {
 			return nil, err

--- a/x-pack/elastic-agent/pkg/core/server/server_test.go
+++ b/x-pack/elastic-agent/pkg/core/server/server_test.go
@@ -627,7 +627,7 @@ func newErrorLogger(t *testing.T) *logger.Logger {
 	loggerCfg := logger.DefaultLoggingConfig()
 	loggerCfg.Level = logp.ErrorLevel
 
-	log, err := logger.NewFromConfig("", loggerCfg)
+	log, err := logger.NewFromConfig("", loggerCfg, false)
 	require.NoError(t, err)
 	return log
 }

--- a/x-pack/elastic-agent/pkg/core/status/reporter_test.go
+++ b/x-pack/elastic-agent/pkg/core/status/reporter_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestReporter(t *testing.T) {
-	l, _ := logger.New("")
+	l, _ := logger.New("", false)
 	t.Run("healthy by default", func(t *testing.T) {
 		r := NewController(l)
 		assert.Equal(t, Healthy, r.StatusCode())

--- a/x-pack/elastic-agent/pkg/filewatcher/watcher.go
+++ b/x-pack/elastic-agent/pkg/filewatcher/watcher.go
@@ -50,7 +50,7 @@ type Watch struct {
 func New(log *logger.Logger, f Comparer) (*Watch, error) {
 	var err error
 	if log == nil {
-		log, err = logger.New("watcher")
+		log, err = logger.New("watcher", false)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker_test.go
@@ -27,7 +27,7 @@ func TestAcker(t *testing.T) {
 		Events []fleetapi.AckEvent `json:"events"`
 	}
 
-	log, _ := logger.New("fleet_acker")
+	log, _ := logger.New("fleet_acker", false)
 	client := newTestingClient()
 	agentInfo := &testAgentInfo{}
 	acker, err := NewAcker(log, agentInfo, client)

--- a/x-pack/elastic-agent/pkg/fleetapi/acker/lazy/lazy_acker_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/acker/lazy/lazy_acker_test.go
@@ -29,7 +29,7 @@ func TestLazyAcker(t *testing.T) {
 		Events []fleetapi.AckEvent `json:"events"`
 	}
 
-	log, _ := logger.New("")
+	log, _ := logger.New("", false)
 	client := newTestingClient()
 	agentInfo := &testAgentInfo{}
 	acker, err := fleet.NewAcker(log, agentInfo, client)

--- a/x-pack/elastic-agent/pkg/fleetapi/client/client.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/client/client.go
@@ -50,7 +50,7 @@ func init() {
 				return nil, err
 			}
 
-			l, err := logger.New("fleet_client")
+			l, err := logger.New("fleet_client", false)
 			if err != nil {
 				return nil, errors.New(err, "could not create the logger for debugging HTTP request")
 			}

--- a/x-pack/elastic-agent/pkg/fleetapi/helper_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/helper_test.go
@@ -46,7 +46,7 @@ func withServerWithAuthClient(
 ) func(t *testing.T) {
 
 	return withServer(m, func(t *testing.T, host string) {
-		log, _ := logger.New("")
+		log, _ := logger.New("", false)
 		cfg := &kibana.Config{
 			Host: host,
 		}

--- a/x-pack/elastic-agent/pkg/kibana/client.go
+++ b/x-pack/elastic-agent/pkg/kibana/client.go
@@ -79,7 +79,7 @@ func NewConfigFromURL(kURL string) (*Config, error) {
 func NewWithRawConfig(log *logger.Logger, config *config.Config, wrapper wrapperFunc) (*Client, error) {
 	l := log
 	if l == nil {
-		log, err := logger.New("kibana_client")
+		log, err := logger.New("kibana_client", false)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/kibana/client_test.go
+++ b/x-pack/elastic-agent/pkg/kibana/client_test.go
@@ -35,7 +35,7 @@ func addCatchAll(mux *http.ServeMux, t *testing.T) *http.ServeMux {
 }
 
 func TestPortDefaults(t *testing.T) {
-	l, err := logger.New("")
+	l, err := logger.New("", false)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -70,7 +70,7 @@ func TestPortDefaults(t *testing.T) {
 // - Prefix.
 func TestHTTPClient(t *testing.T) {
 	ctx := context.Background()
-	l, err := logger.New("")
+	l, err := logger.New("", false)
 	require.NoError(t, err)
 
 	t.Run("Guard against double slashes on path", withServer(

--- a/x-pack/elastic-agent/pkg/reporter/fleet/reporter_test.go
+++ b/x-pack/elastic-agent/pkg/reporter/fleet/reporter_test.go
@@ -209,7 +209,7 @@ func getEvents(count int) []reporter.Event {
 }
 
 func newTestReporter(frequency time.Duration, threshold int) *Reporter {
-	log, _ := logger.New("")
+	log, _ := logger.New("", false)
 	r := &Reporter{
 		info:      &testInfo{},
 		queue:     make([]fleetapi.SerializableEvent, 0),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This fixes the Elastic Agent Docker image to allow a proper state to be stored for the image. Previously this was not possible for the state to be placed into a volume which prevent restarts of the container to maintain its previous state.

This changes the Elastic Agent to not version its directory when running under Docker. This is key to allowing the state to be storable and being that an Elastic Agent container cannot be self-upgraded it is acceptable that it is not versioned.

Because of how the Elastic Agent ships with the builds in the download directory the state could not mount over that directory of Elastic Agent would need to re-download those files. This changes the container sub-command to rsync the builds download directory into the state directory before actually running. This allows new downloads to stay in the state directory and allows the running Elastic Agent to use the binaries that shipped with the image.

By default the state of the Docker container goes to `/usr/share/elastic-agent/state`. This can changed with `STATE_PATH` environment. Log path defaults to `$STATE_PATH/logs` but that can also log to a completely different path by setting `LOG_PATH` environment.

Another fix in the PR is that the Elastic Agent logging now goes to the container output instead of to the `elastic-agent.log`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Critical to allow the state of the Elastic Agent to persist restarts of the Elastic Agent Docker image.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] State is stored in `/usr/share/elastic-agent/state`.
- [x] State path can be changed with `STATE_PATH`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
$ # Build the docker container in dev-mode
$ cd x-pack/elastic-agent
$ PLATFORMS="+all linux/amd64" mage dev:package
$ # Run the docker container
$ docker run -it -e KIBANA_FLEET_SETUP=1 -e ELASTICSEARCH_HOST=http://host.docker.internal:9200 -e KIBANA_HOST=http://host.docker.internal:5601 -e FLEET_ENROLL=1 -e FLEET_URL=http://host.docker.internal:8220 -e FLEET_INSECURE=1 docker.elastic.co/beats/elastic-agent:8.0.0
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24160
- Closes #24271 