### PR TITLE
Cherry-pick to 7.x: Module sophosxg > junos (#24750)

### DIFF
--- a/filebeat/docs/modules/juniper.asciidoc
+++ b/filebeat/docs/modules/juniper.asciidoc
@@ -73,7 +73,7 @@ Versions above this are expected to work but have not been tested.
 
 [source,yaml]
 ----
-- module: sophosxg
+- module: junos
   firewall:
     enabled: true
     var.input: udp

--- a/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
@@ -68,7 +68,7 @@ Versions above this are expected to work but have not been tested.
 
 [source,yaml]
 ----
-- module: sophosxg
+- module: junos
   firewall:
     enabled: true
     var.input: udp


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Module sophosxg > junos (#24750)