### PR TITLE
Rename Osquery Manager default datastream

### DIFF
--- a/x-pack/osquerybeat/internal/config/config.go
+++ b/x-pack/osquerybeat/internal/config/config.go
@@ -15,11 +15,11 @@ import (
 // streams:
 // - id: '123456'
 //   data_stream:
-// 	dataset: osquery_managed.result
+// 	dataset: osquery_manager.result
 // 	type: logs
 //   query: select * from usb_devices
 
-const DefaultStreamIndex = "logs-osquery_managed.result-default"
+const DefaultStreamIndex = "logs-osquery_manager.result-default"
 
 type StreamConfig struct {
 	ID       string        `config:"id"`


### PR DESCRIPTION
## What does this PR do?

Renames the Osquery Manager default datastream, to make it consistent with the package.
Related to this change: https://github.com/elastic/integrations/pull/814
Part of: https://github.com/elastic/security-team/issues/949

## Why is it important?

This is the agreed upon naming convention for the new package and the data stream  for upcoming release of osquerybeat as a part of 7.13 release.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes #123
- Relates https://github.com/elastic/security-team/issues/949
- Requires https://github.com/elastic/integrations/pull/814

