### PR TITLE
[Filebeat] Update Oauth2 flow for m365 defender fileset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -381,6 +381,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix date parsing in GSuite/login and Google Workspace/login filesets. {issue}24694[24694]
 - Fix date parsing in GSuite/login fileset. {issue}24694[24694]
 - Improve Cisco ASA/FTD parsing of messages - better support for identity FW messages. Change network.bytes, source.bytes, and destination.bytes to long from integer since value can exceed integer capacity.  Add descriptions for various processors for easier pipeline editing in Kibana UI. {pull}23766[23766]
+- Updating Oauth2 flow for m365_defender fileset. {pull}24829[24829]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/microsoft.asciidoc
+++ b/filebeat/docs/modules/microsoft.asciidoc
@@ -54,7 +54,9 @@ Example config:
     enabled: true
     var.oauth2.client.id: "123abc-879546asd-349587-ad64508"
     var.oauth2.client.secret: "980453~-Sg99gedf"
-    var.oauth2.token_url: "https://login.microsoftonline.com/INSERT-TENANT-ID/oauth2/token"
+    var.oauth2.token_url: "https://login.microsoftonline.com/INSERT-TENANT-ID/oauth2/v2.0/token"
+    var.oauth2.scopes:
+      - "https://api.security.microsoft.com/.default"
 ----
 
 *`var.oauth2.client.id`*::
@@ -68,6 +70,10 @@ The secret related to the client ID.
 *`var.oauth2.token_url`*::
 
 A predefined URL towards the Oauth2 service for Microsoft. The URL should always be the same with the exception of the Tenant ID that needs to be added to the full URL.
+
+*`var.oauth2.scopes`*::
+
+A list of included scopes, should use .default unless different is specified.
 
 [float]
 ==== 365 Defender ECS fields

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1369,7 +1369,11 @@ filebeat.modules:
     #var.oauth2.client.secret: ""
 
     # Oauth Token URL, should include the tenant ID
-    #var.oauth2.token_url: "https://login.microsoftonline.com/TENANT-ID/oauth2/token"
+    #var.oauth2.token_url: "https://login.microsoftonline.com/TENANT-ID/oauth2/v2.0/token"
+    
+    # Related scopes, default should be included
+    #var.oauth2.scopes:
+    #  - "https://api.security.microsoft.com/.default"
   dhcp:
     enabled: true
 

--- a/x-pack/filebeat/module/microsoft/_meta/config.yml
+++ b/x-pack/filebeat/module/microsoft/_meta/config.yml
@@ -25,7 +25,11 @@
     #var.oauth2.client.secret: ""
 
     # Oauth Token URL, should include the tenant ID
-    #var.oauth2.token_url: "https://login.microsoftonline.com/TENANT-ID/oauth2/token"
+    #var.oauth2.token_url: "https://login.microsoftonline.com/TENANT-ID/oauth2/v2.0/token"
+    
+    # Related scopes, default should be included
+    #var.oauth2.scopes:
+    #  - "https://api.security.microsoft.com/.default"
   dhcp:
     enabled: true
 

--- a/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
@@ -49,7 +49,9 @@ Example config:
     enabled: true
     var.oauth2.client.id: "123abc-879546asd-349587-ad64508"
     var.oauth2.client.secret: "980453~-Sg99gedf"
-    var.oauth2.token_url: "https://login.microsoftonline.com/INSERT-TENANT-ID/oauth2/token"
+    var.oauth2.token_url: "https://login.microsoftonline.com/INSERT-TENANT-ID/oauth2/v2.0/token"
+    var.oauth2.scopes:
+      - "https://api.security.microsoft.com/.default"
 ----
 
 *`var.oauth2.client.id`*::
@@ -63,6 +65,10 @@ The secret related to the client ID.
 *`var.oauth2.token_url`*::
 
 A predefined URL towards the Oauth2 service for Microsoft. The URL should always be the same with the exception of the Tenant ID that needs to be added to the full URL.
+
+*`var.oauth2.scopes`*::
+
+A list of included scopes, should use .default unless different is specified.
 
 [float]
 ==== 365 Defender ECS fields

--- a/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
+++ b/x-pack/filebeat/module/microsoft/m365_defender/config/defender.yml
@@ -6,8 +6,6 @@ config_version: "2"
 interval: {{ .interval }}
 
 auth.oauth2: {{ .oauth2 | tojson }}
-auth.oauth2.provider: azure
-auth.oauth2.azure.resource: https://api.securitycenter.windows.com/
 
 {{ if .proxy_url }}
 request.proxy_url: {{ .proxy_url }}

--- a/x-pack/filebeat/modules.d/microsoft.yml.disabled
+++ b/x-pack/filebeat/modules.d/microsoft.yml.disabled
@@ -28,7 +28,11 @@
     #var.oauth2.client.secret: ""
 
     # Oauth Token URL, should include the tenant ID
-    #var.oauth2.token_url: "https://login.microsoftonline.com/TENANT-ID/oauth2/token"
+    #var.oauth2.token_url: "https://login.microsoftonline.com/TENANT-ID/oauth2/v2.0/token"
+    
+    # Related scopes, default should be included
+    #var.oauth2.scopes:
+    #  - "https://api.security.microsoft.com/.default"
   dhcp:
     enabled: true
 


### PR DESCRIPTION
## What does this PR do?

Microsoft changed the Oauth2 flow from resource to scope based, so the default configuration and documentation needs to reflect that.

## Why is it important?

Module won't work without it.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

