### PR TITLE
Cherry-pick #24824 to 7.12: [Filebeat] Update example config documentation for threatintel

### DIFF
--- a/filebeat/docs/modules/threatintel.asciidoc
+++ b/filebeat/docs/modules/threatintel.asciidoc
@@ -125,7 +125,7 @@ should look initially, and optionally any filters used to filter the results.
     var.input: httpjson
     var.url: https://SERVER/events/restSearch
     var.api_token: xVfaM3DSt8QEwO2J1ix00V4ZHJs14nq5GMsHcK6Z
-    var.initial_interval: 24h
+    var.first_interval: 24h
     var.interval: 60m
 ----
 
@@ -147,7 +147,7 @@ reference the MISP fields located on the MISP server itself.
     var.filters:
       - type: ["md5", "sha256", "url", "ip-src"]
       - threat_level: 4
-    var.initial_interval: 24h
+    var.first_interval: 24h
     var.interval: 60m
 ----
 

--- a/x-pack/filebeat/module/threatintel/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/threatintel/_meta/docs.asciidoc
@@ -120,7 +120,7 @@ should look initially, and optionally any filters used to filter the results.
     var.input: httpjson
     var.url: https://SERVER/events/restSearch
     var.api_token: xVfaM3DSt8QEwO2J1ix00V4ZHJs14nq5GMsHcK6Z
-    var.initial_interval: 24h
+    var.first_interval: 24h
     var.interval: 60m
 ----
 
@@ -142,7 +142,7 @@ reference the MISP fields located on the MISP server itself.
     var.filters:
       - type: ["md5", "sha256", "url", "ip-src"]
       - threat_level: 4
-    var.initial_interval: 24h
+    var.first_interval: 24h
     var.interval: 60m
 ----
 


### PR DESCRIPTION
Cherry-pick of PR #24824 to 7.12 branch. Original message: 

## What does this PR do?

Fixes a typo in the documentation example configuration for threatintel module.

## Why is it important?

Fixes a typo in the documentation example configuration for threatintel module.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
