### PR TITLE
Cherry-pick #24828 to 7.12: Fix s3 input documentation

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -11,8 +11,6 @@
 <titleabbrev>AWS S3</titleabbrev>
 ++++
 
-beta[]
-
 Use the `aws-s3` input to retrieve logs from S3 objects that are pointed by messages
 from specific SQS queues. This input can, for example, be used to receive S3
 server access logs to monitor detailed records for the requests that are made to


### PR DESCRIPTION
Cherry-pick of PR #24828 to 7.12 branch. Original message: 

This PR is to fix Filebeat S3 input documentation to remove the beta label. This should have been a part of https://github.com/elastic/beats/pull/23631.