### PR TITLE
Cherry-pick #24838 to 7.x: Prevent uninstall failures on empty config 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@
 - Fix failing installation on windows 7 {pull}[24387]24387
 - Fix capabilities resolution in inspect command {pull}[24346]24346
 - Logging to file disabled on enroll {issue}[24173]24173
+- Prevent uninstall failures on empty config {pull}[24838]24838
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/install/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/install/uninstall.go
@@ -34,6 +34,11 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 
+const (
+	inputsKey  = "inputs"
+	outputsKey = "outputs"
+)
+
 // Uninstall uninstalls persistently Elastic Agent on the system.
 func Uninstall(cfgFile string) error {
 	// uninstall the current service
@@ -139,6 +144,11 @@ func uninstallPrograms(ctx context.Context, cfgFile string) error {
 		return err
 	}
 
+	// nothing to remove
+	if len(pp) == 0 {
+		return nil
+	}
+
 	uninstaller, err := uninstall.NewUninstaller()
 	if err != nil {
 		return err
@@ -165,6 +175,17 @@ func programsFromConfig(cfg *config.Config) ([]program.Program, error) {
 	if err != nil {
 		return nil, errors.New("failed to create a map from config", err)
 	}
+
+	// if no input is defined nothing to remove
+	if _, found := mm[inputsKey]; !found {
+		return nil, nil
+	}
+
+	// if no output is defined nothing to remove
+	if _, found := mm[outputsKey]; !found {
+		return nil, nil
+	}
+
 	ast, err := transpiler.NewAST(mm)
 	if err != nil {
 		return nil, errors.New("failed to create a ast from config", err)


### PR DESCRIPTION
Cherry-pick of PR #24838 to 7.x branch. Original message:

## What does this PR do?

This PR checks upfront for inputs and outputs definition in a config. 
Program func which is called from uninstall fails on missing output which causes uninstall to fail. 

Also if no programs are there to be uninstalled we dont even instatiate uninstaller as a micro perf optimization 

## Why is it important?

Unistall working

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

