### PR TITLE
Add test to check if Prospector sets metadata of files on updates in filestream

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -97,6 +97,7 @@ func TestFilestreamMetadataUpdatedOnRename(t *testing.T) {
 	env.startInput(ctx, inp)
 
 	env.waitUntilEventCount(1)
+	env.waitUntilMetaInRegistry(testlogName, fileMeta{Source: env.abspath(testlogName), IdentifierName: "native"})
 	env.requireOffsetInRegistry(testlogName, len(testline))
 
 	testlogNameRenamed := "test.log.renamed"

--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -102,6 +102,10 @@ func TestFilestreamMetadataUpdatedOnRename(t *testing.T) {
 	testlogNameRenamed := "test.log.renamed"
 	env.mustRenameFile(testlogName, testlogNameRenamed)
 
+	// check if the metadata is updated and cursor data stays the same
+	env.waitUntilMetaInRegistry(testlogNameRenamed, fileMeta{Source: env.abspath(testlogNameRenamed), IdentifierName: "native"})
+	env.requireOffsetInRegistry(testlogNameRenamed, len(testline))
+
 	env.mustAppendLinesToFile(testlogNameRenamed, testline)
 
 	env.waitUntilEventCount(2)
@@ -109,8 +113,6 @@ func TestFilestreamMetadataUpdatedOnRename(t *testing.T) {
 
 	cancelInput()
 	env.waitUntilInputStops()
-
-	env.requireMetaInRegistry(testlogNameRenamed, env.abspath(testlogNameRenamed), "native")
 }
 
 // test_close_removed from test_harvester.py

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -270,7 +270,7 @@ func (s *store) findCursorMeta(key string, to interface{}) error {
 
 // updateMetadata updates the cursor metadata in the persistent store.
 func (s *store) updateMetadata(key string, meta interface{}) error {
-	resource := s.ephemeralStore.Find(key, false)
+	resource := s.ephemeralStore.Find(key, true)
 	if resource == nil {
 		return fmt.Errorf("resource '%s' not found", key)
 	}

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -113,6 +113,12 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 			case loginp.OpCreate, loginp.OpWrite:
 				if fe.Op == loginp.OpCreate {
 					log.Debugf("A new file %s has been found", fe.NewPath)
+
+					err := s.UpdateMetadata(src, fileMeta{Source: fe.NewPath, IdentifierName: p.identifier.Name()})
+					if err != nil {
+						log.Errorf("Failed to set cursor meta data of entry %s: %v", src.Name(), err)
+					}
+
 				} else if fe.Op == loginp.OpWrite {
 					log.Debugf("File %s has been updated", fe.NewPath)
 				}

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -169,7 +169,10 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 
 						meta.IdentifierName = p.identifier.Name()
 					}
-					s.UpdateMetadata(src, fileMeta{Source: src.newPath, IdentifierName: meta.IdentifierName})
+					err = s.UpdateMetadata(src, fileMeta{Source: src.newPath, IdentifierName: meta.IdentifierName})
+					if err != nil {
+						log.Errorf("Failed to update cursor meta data of entry %s: %v", src.Name(), err)
+					}
 
 					if p.stateChangeCloser.Renamed {
 						log.Debugf("Stopping harvester as file %s has been renamed and close.on_state_change.renamed is enabled.", src.Name())


### PR DESCRIPTION
## What does this PR do?

This PR adds a test to see if the `Prospector` is able to update file metadata in the registry.

Requires https://github.com/elastic/beats/pull/24864

## Why is it important?

It has not been tested automatically before.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~