### PR TITLE
Cherry-pick #24864 to 7.x: Use identifier in HarvesterGroup in filestream

### DIFF
--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -176,9 +176,11 @@ func (e *inputTestingEnvironment) requireOffsetInRegistry(filename string, expec
 		e.t.Fatalf("cannot stat file when cheking for offset: %+v", err)
 	}
 
-	identifier, _ := newINodeDeviceIdentifier(nil)
-	src := identifier.GetSource(loginp.FSEvent{Info: fi, Op: loginp.OpCreate, NewPath: filepath})
-	entry := e.getRegistryState(src.Name())
+	id := getIDFromPath(filepath, fi)
+	entry, err := e.getRegistryState(id)
+	if err != nil {
+		e.t.Fatalf(err.Error())
+	}
 
 	require.Equal(e.t, expectedOffset, entry.Cursor.Offset)
 }
@@ -204,21 +206,30 @@ func (e *inputTestingEnvironment) requireNoEntryInRegistry(filename string) {
 
 // requireOffsetInRegistry checks if the expected offset is set for a file.
 func (e *inputTestingEnvironment) requireOffsetInRegistryByID(key string, expectedOffset int) {
-	entry := e.getRegistryState(key)
+	entry, err := e.getRegistryState(key)
+	if err != nil {
+		e.t.Fatalf(err.Error())
+	}
 
 	require.Equal(e.t, expectedOffset, entry.Cursor.Offset)
 }
 
-func (e *inputTestingEnvironment) getRegistryState(key string) registryEntry {
+func (e *inputTestingEnvironment) getRegistryState(key string) (registryEntry, error) {
 	inputStore, _ := e.stateStore.Access()
 
 	var entry registryEntry
 	err := inputStore.Get(key, &entry)
 	if err != nil {
-		e.t.Fatalf("error when getting expected key '%s' from store: %+v", key, err)
+		return registryEntry{}, fmt.Errorf("error when getting expected key '%s' from store: %+v", key, err)
 	}
 
-	return entry
+	return entry, nil
+}
+
+func getIDFromPath(filepath string, fi os.FileInfo) string {
+	identifier, _ := newINodeDeviceIdentifier(nil)
+	src := identifier.GetSource(loginp.FSEvent{Info: fi, Op: loginp.OpCreate, NewPath: filepath})
+	return "filestream::.global::" + src.Name()
 }
 
 // waitUntilEventCount waits until total count events arrive to the client.

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -129,11 +129,12 @@ type defaultHarvesterGroup struct {
 	harvester    Harvester
 	cleanTimeout time.Duration
 	store        *store
+	identifier   *sourceIdentifier
 	tg           unison.TaskGroup
 }
 
 func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
-	sourceName := s.Name()
+	sourceName := hg.identifier.ID(s)
 
 	ctx.Logger = ctx.Logger.With("source", sourceName)
 	ctx.Logger.Debug("Starting harvester for file")
@@ -185,7 +186,7 @@ func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
 // Stop stops the running Harvester for a given Source.
 func (hg *defaultHarvesterGroup) Stop(s Source) {
 	hg.tg.Go(func(_ unison.Canceler) error {
-		hg.readers.remove(s.Name())
+		hg.readers.remove(hg.identifier.ID(s))
 		return nil
 	})
 }

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -67,6 +67,7 @@ func (inp *managedInput) Run(
 		cleanTimeout: inp.cleanTimeout,
 		harvester:    inp.harvester,
 		store:        groupStore,
+		identifier:   inp.sourceIdentifier,
 		tg:           unison.TaskGroup{},
 	}
 


### PR DESCRIPTION
Cherry-pick of PR #24864 to 7.x branch. Original message: 

## What does this PR do?

This PR adds `sourceIdentifier` to `defaultHarvesterGroup` so it uses the same method to access entries in the registry as the `Prospector`.

## Why is it important?

Previously, the `HarvesterGroup` and `Prospector` looked for the same resources but got different IDs. `HarvesterGroup` was not aware of the `filestream::{user_id}` prefix, thus the `Prospector` never found the entries created by the `HarvesterGroup` and vica versa.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~