### PR TITLE
Fix error in Journalbeat commands

### DIFF
--- a/libbeat/docs/tab-widgets/setup-deb-rpm-linux-widget.asciidoc
+++ b/libbeat/docs/tab-widgets/setup-deb-rpm-linux-widget.asciidoc
@@ -28,7 +28,7 @@
        aria-labelledby="deb-setup">
 ++++
 
-include::setup.asciidoc[tag=mac]
+include::setup.asciidoc[tag=deb]
 
 ++++
   </div>
@@ -39,7 +39,7 @@ include::setup.asciidoc[tag=mac]
        hidden="">
 ++++
 
-include::setup.asciidoc[tag=linux]
+include::setup.asciidoc[tag=rpm]
 
 ++++
   </div>
@@ -50,7 +50,7 @@ include::setup.asciidoc[tag=linux]
        hidden="">
 ++++
 
-include::setup.asciidoc[tag=win]
+include::setup.asciidoc[tag=linux]
 
 ++++
   </div>


### PR DESCRIPTION
## What does this PR do?

Fixes bug in widget code that caused incorrect commands to render in the docs.

## Why is it important?

The documented command would not work on the platform given.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes elastic/beats#24846 
