### PR TITLE
Fix related.ip field 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -527,6 +527,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
 - Protect against accessing an undefined variable in Security module. {pull}22937[22937]
 - Change `event.code` and `winlog.event_id` from int to keyword. {pull}25176[25176]
+- Fix related.ip field in renameCommonAuthFields (pull)24892[24892]
 
 *Functionbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -527,7 +527,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
 - Protect against accessing an undefined variable in Security module. {pull}22937[22937]
 - Change `event.code` and `winlog.event_id` from int to keyword. {pull}25176[25176]
-- Fix related.ip field in renameCommonAuthFields (pull)24892[24892]
+- Fix related.ip field in renameCommonAuthFields {pull}24892[24892]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -1850,7 +1850,6 @@ var security = (function () {
                 {from: "winlog.event_data.AccountName", to: "user.name"},
                 {from: "winlog.event_data.AccountDomain", to: "user.domain"},
                 {from: "winlog.event_data.ClientAddress", to: "source.ip", type: "ip"},
-                {from: "winlog.event_data.ClientAddress", to: "related.ip", type: "ip"},
                 {from: "winlog.event_data.ClientName", to: "source.domain"},
                 {from: "winlog.event_data.LogonID", to: "winlog.logon.id"},
             ],
@@ -1860,6 +1859,12 @@ var security = (function () {
         .Add(function(evt) {
             var user = evt.Get("winlog.event_data.AccountName");
             evt.AppendTo('related.user', user);
+        })
+        .Add(function(evt) {
+            var ip = evt.Get("source.ip");
+            if (ip) {
+                evt.Put('related.ip', ip);
+            }
         })
         .Build();
 
@@ -2028,7 +2033,6 @@ var security = (function () {
                 {from: "winlog.event_data.ProcessId", to: "process.pid", type: "long"},
                 {from: "winlog.event_data.ProcessName", to: "process.executable"},
                 {from: "winlog.event_data.IpAddress", to: "source.ip", type: "ip"},
-                {from: "winlog.event_data.IpAddress", to: "related.ip", type: "ip"},
                 {from: "winlog.event_data.IpPort", to: "source.port", type: "long"},
                 {from: "winlog.event_data.WorkstationName", to: "source.domain"},
             ],
@@ -2046,6 +2050,12 @@ var security = (function () {
                 return;
             }
             evt.Put("process.name", path.basename(exe));
+        })
+        .Add(function(evt) {
+            var ip = evt.Get("source.ip");
+            if (ip) {
+                evt.Put('related.ip', ip);
+            }
         })
         .Build();
 

--- a/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
+++ b/x-pack/winlogbeat/module/security/config/winlogbeat-security.js
@@ -2028,7 +2028,7 @@ var security = (function () {
                 {from: "winlog.event_data.ProcessId", to: "process.pid", type: "long"},
                 {from: "winlog.event_data.ProcessName", to: "process.executable"},
                 {from: "winlog.event_data.IpAddress", to: "source.ip", type: "ip"},
-                {from: "winlog.event_data.ClientAddress", to: "related.ip", type: "ip"},
+                {from: "winlog.event_data.IpAddress", to: "related.ip", type: "ip"},
                 {from: "winlog.event_data.IpPort", to: "source.port", type: "long"},
                 {from: "winlog.event_data.WorkstationName", to: "source.domain"},
             ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4768.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4768.evtx.golden.json
@@ -22,6 +22,7 @@
       "level": "information"
     },
     "related": {
+      "ip": "::1",
       "user": "at_adm"
     },
     "source": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4769.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4769.evtx.golden.json
@@ -22,6 +22,7 @@
       "level": "information"
     },
     "related": {
+      "ip": "::1",
       "user": "at_adm"
     },
     "source": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4770.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4770.evtx.golden.json
@@ -22,6 +22,7 @@
       "level": "information"
     },
     "related": {
+      "ip": "::1",
       "user": "DC_TEST2K12$"
     },
     "source": {

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
@@ -195,6 +195,7 @@
       "pid": 448
     },
     "related": {
+      "ip": "127.0.0.1",
       "user": [
         "vagrant",
         "VAGRANT-2012-R2$"
@@ -858,6 +859,7 @@
       "pid": 2812
     },
     "related": {
+      "ip": "10.0.2.2",
       "user": [
         "vagrant",
         "VAGRANT-2012-R2$"
@@ -1449,6 +1451,7 @@
       "pid": 836
     },
     "related": {
+      "ip": "::1",
       "user": "bosch"
     },
     "source": {


### PR DESCRIPTION
## What does this PR do?

Fix a bug found when populating related.ip field information in the renameCommonAuthFields
The wrong field winlog.event_data.ClientAddress was copied into related.ip instead of **winlog.event_data.IpAddress**  which is the proper one.

## Why is it important?

The related.ip information was not populated correctly in some events. For example: 4624,4648,4625

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/24891


