### PR TITLE
[Elastic Agent] Cloud container legacy apm files.

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
@@ -548,7 +549,9 @@ func runLegacyAPMServer(streams *cli.IOStreams, path string) (*process.Info, err
 	apmDir := filepath.Join(path, files[0].Name())
 	// Extract the ingest pipeline definition to the HOME_DIR
 	if home := os.Getenv("HOME_PATH"); home != "" {
-		syncDir(filepath.Join(apmDir, "ingest"), filepath.Join(home, "ingest"))
+		if err := syncDir(filepath.Join(apmDir, "ingest"), filepath.Join(home, "ingest")); err != nil {
+			return nil, fmt.Errorf("syncing APM ingest directory to HOME_PATH(%s) failed: %s", home, err)
+		}
 	}
 	// Start apm-server process respecting path ENVs
 	apmBinary := filepath.Join(apmDir, spec.Cmd)

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"os/exec"
@@ -17,7 +18,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
@@ -532,26 +532,26 @@ func runLegacyAPMServer(streams *cli.IOStreams, path string) (*process.Info, err
 	if release.Snapshot() {
 		version = fmt.Sprintf("%s-SNAPSHOT", version)
 	}
-	// Extract the bundled apm-server binary into the APM_SERVER_PATH
+	// Extract the bundled apm-server into the APM_SERVER_PATH
 	if err := installer.Install(context.Background(), spec, version, path); err != nil {
 		return nil, errors.New(err,
 			fmt.Sprintf("installing %s (%s) from %s to %s", spec.Name, version, cfg.TargetDirectory, path))
 	}
-
-	// Start apm-server process respecting args
-	logInfo(streams, "Starting legacy apm-server daemon as a subprocess.")
-	pattern := filepath.Join(path, fmt.Sprintf("%s-%s-%s*", spec.Cmd, version, cfg.OS()), spec.Cmd)
-	files, err := filepath.Glob(pattern)
+	// Get the apm-server directory
+	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		return nil, errors.New(err, fmt.Sprintf("searching apm-server in %s", pattern))
+		return nil, errors.New(err, fmt.Sprintf("reading directory %s", path))
 	}
-	if len(files) != 1 {
-		return nil, errors.New("multiple apm-server versions installed")
+	if len(files) != 1 || !files[0].IsDir() {
+		return nil, errors.New("expected one directory")
 	}
-	f, err := filepath.Abs(files[0])
-	if err != nil {
-		return nil, errors.New(err, fmt.Sprintf("absPath for %s", files[0]))
+	apmDir := filepath.Join(path, files[0].Name())
+	// Extract the ingest pipeline definition to the HOME_DIR
+	if home := os.Getenv("HOME_PATH"); home != "" {
+		syncDir(filepath.Join(apmDir, "ingest"), filepath.Join(home, "ingest"))
 	}
+	// Start apm-server process respecting path ENVs
+	apmBinary := filepath.Join(apmDir, spec.Cmd)
 	log, err := logger.New("apm-server", false)
 	if err != nil {
 		return nil, err
@@ -568,7 +568,8 @@ func runLegacyAPMServer(streams *cli.IOStreams, path string) (*process.Info, err
 	addEnv("--path.data", "DATA_PATH")
 	addEnv("--path.logs", "LOGS_PATH")
 	addEnv("--httpprof", "HTTPPROF")
-	return process.Start(log, f, nil, os.Geteuid(), os.Getegid(), args...)
+	logInfo(streams, "Starting legacy apm-server daemon as a subprocess.")
+	return process.Start(log, apmBinary, nil, os.Geteuid(), os.Getegid(), args...)
 }
 
 func logToStderr(cfg *configuration.Configuration) {
@@ -602,7 +603,9 @@ func setPaths() error {
 		}
 	}
 	// sync the downloads to the data directory
-	if err := syncDownloads(statePath); err != nil {
+	srcDownloads := filepath.Join(paths.Home(), "downloads")
+	destDownloads := filepath.Join(statePath, "data", "downloads")
+	if err := syncDir(srcDownloads, destDownloads); err != nil {
 		return fmt.Errorf("syncing download directory to STATE_PATH(%s) failed: %s", statePath, err)
 	}
 	paths.SetTop(topPath)
@@ -620,22 +623,20 @@ func setPaths() error {
 	return nil
 }
 
-func syncDownloads(dataPath string) error {
-	srcDownloads := filepath.Join(paths.Home(), "downloads")
-	destDownloads := filepath.Join(dataPath, "data", "downloads")
-	return filepath.Walk(srcDownloads, func(path string, info os.FileInfo, err error) error {
+func syncDir(src string, dest string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		relativePath := strings.TrimPrefix(path, srcDownloads)
+		relativePath := strings.TrimPrefix(path, src)
 		if info.IsDir() {
-			err = os.MkdirAll(filepath.Join(destDownloads, relativePath), info.Mode())
+			err = os.MkdirAll(filepath.Join(dest, relativePath), info.Mode())
 			if err != nil {
 				return err
 			}
 			return nil
 		}
-		return copyFile(filepath.Join(destDownloads, relativePath), path, info.Mode())
+		return copyFile(filepath.Join(dest, relativePath), path, info.Mode())
 	})
 }
 


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Sync legacy apm `ingest` folder to `HOME` directory.

## Why is it important?
The APM Server fails to connect to Elasticsearch if it can't read the ingest pipeline definitions. 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
