### PR TITLE
Kubernetes_secrets provider improvements

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
@@ -629,6 +629,11 @@ rules:
       - events
       - pods
     verbs: ["get", "list", "watch"]
+  # Enable this rule only if planing to use kubernetes_secrets provider
+  #- apiGroups: [""]
+  #  resources:
+  #  - secrets
+  #  verbs: ["get"]
   - apiGroups: ["extensions"]
     resources:
       - replicasets

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-role.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-role.yaml
@@ -12,6 +12,11 @@ rules:
       - events
       - pods
     verbs: ["get", "list", "watch"]
+  # Enable this rule only if planing to use kubernetes_secrets provider
+  #- apiGroups: [""]
+  #  resources:
+  #  - secrets
+  #  verbs: ["get"]
   - apiGroups: ["extensions"]
     resources:
       - replicasets

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -47,6 +47,9 @@ func ContextProviderBuilder(logger *logger.Logger, c *config.Config) (corecomp.C
 
 func (p *contextProviderK8sSecrets) Fetch(key string) (string, bool) {
 	// key = "kubernetes_secrets.somenamespace.somesecret.value"
+	if p.client == nil {
+		return "", false
+	}
 	tokens := strings.Split(key, ".")
 	if len(tokens) > 0 && tokens[0] != "kubernetes_secrets" {
 		return "", false


### PR DESCRIPTION
Minor leftovers from https://github.com/elastic/beats/pull/24789.

1. Return from `Fetch()` if k8s client is not initialised. This can happen if the provider failed to get started with `Run()` cause api can be unreachable. In such cases `Fetch()` will then panic. We need to skip `Fetch()` in such cases.
2. Add the commented out section in Agent's k8s manifests about Secrets api.