### PR TITLE
Fix ability to delete indices with wildcards in testing

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -19,6 +19,7 @@ services:
     - "script.context.ingest.cache_max_size=2000"
     - "script.context.processor_conditional.cache_max_size=2000"
     - "script.context.template.cache_max_size=2000"
+    - "action.destructive_requires_name=false"
 
   logstash:
     image: docker.elastic.co/logstash/logstash@sha256:e01cf165142edf8d67485115b938c94deeda66153e9516aa2ce69ee417c5fc33


### PR DESCRIPTION
## What does this PR do?

Looks like a recent commit to Elasticsearch broke CI in some builds that run `libbeat` tests. Here's the commit:

https://github.com/elastic/elasticsearch/commit/60f4d22722051ef918b8fe3892aaec2b538b287d

Here's an example build break:

```
[2021-04-01T21:57:08.934Z] tests/system/idxmgmt.py:31: in delete_index_and_alias
[2021-04-01T21:57:08.934Z]     self._client.transport.perform_request('DELETE', "/" + index + "*")
[2021-04-01T21:57:08.934Z] ../build/ve/docker/lib/python3.7/site-packages/elasticsearch/transport.py:352: in perform_request
[2021-04-01T21:57:08.934Z]     timeout=timeout,
[2021-04-01T21:57:08.934Z] ../build/ve/docker/lib/python3.7/site-packages/elasticsearch/connection/http_urllib3.py:256: in perform_request
[2021-04-01T21:57:08.934Z]     self._raise_error(response.status, raw_data)
[2021-04-01T21:57:08.934Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2021-04-01T21:57:08.934Z] 
[2021-04-01T21:57:08.934Z] self = <Urllib3HttpConnection: http://elasticsearch:9200>, status_code = 400
[2021-04-01T21:57:08.934Z] raw_data = '{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Wildcard expressions or all indices are not al...d"}],"type":"illegal_argument_exception","reason":"Wildcard expressions or all indices are not allowed"},"status":400}'
```

From:

https://github.com/elastic/beats/pull/24909