### PR TITLE
[Filebeat] Enable HMAC Signature Validation for http_endpoint input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -852,8 +852,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add parsing for `haproxy.http.request.raw_request_line` field  {issue}25480[25480] {pull}25482[25482]
 - Mark `filestream` input beta. {pull}25560[25560]
 - Update PanOS module to parse Global Protect & User ID logs. {issue}24722[24722] {issue}24724[24724] {pull}24927[24927]
-- Add support for upper case field names in Sophos XG module {pull}24693[24693]
-- Add `fail_on_template_error` option for httpjson input. {pull}24784[24784]
 - Add HMAC signature validation support for http_endpoint input. {pull}24918[24918]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -852,6 +852,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add parsing for `haproxy.http.request.raw_request_line` field  {issue}25480[25480] {pull}25482[25482]
 - Mark `filestream` input beta. {pull}25560[25560]
 - Update PanOS module to parse Global Protect & User ID logs. {issue}24722[24722] {issue}24724[24724] {pull}24927[24927]
+- Add support for upper case field names in Sophos XG module {pull}24693[24693]
+- Add `fail_on_template_error` option for httpjson input. {pull}24784[24784]
+- Add HMAC signature validation support for http_endpoint input. {pull}24918[24918]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -139,12 +139,12 @@ The secret key used to calculate the HMAC signature. Typically, the webhook send
 [float]
 ==== `hmac.type`
 
-The hash algorithm to use for the HMAC comparison. At this time the only valid values are `sha256` or `sha1`
+The hash algorithm to use for the HMAC comparison. At this time the only valid values are `sha256` or `sha1`.
 
 [float]
 ==== `hmac.prefix`
 
-The prefix for the signature. Certain webhooks prefix the HMAC signature with a value, for example `sha256=`
+The prefix for the signature. Certain webhooks prefix the HMAC signature with a value, for example `sha256=`.
 
 [float]
 ==== `content_type`
@@ -170,7 +170,7 @@ If multiple interfaces is present the `listen_address` can be set to control whi
 [float]
 ==== `listen_port`
 
-Which port the listener binds to. Defaults to 8000
+Which port the listener binds to. Defaults to 8000.
 
 [float]
 ==== `url`

--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -82,6 +82,19 @@ Authentication or checking that a specific header includes a specific value
   secret.value: secretheadertoken
 ----
 
+Validate a HMAC signature from a specific header
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: http_endpoint
+  enabled: true
+  listen_address: 192.168.1.1
+  listen_port: 8080
+  hmac.header: "X-Hub-Signature-256"
+  hmac.key: "password123"
+  hmac.type: "sha256"
+  hmac.prefix: "sha256="
+----
 
 ==== Configuration options
 
@@ -112,6 +125,26 @@ The header to check for a specific value specified by `secret.value`. Certain we
 ==== `secret.value`
 
 The secret stored in the header name specified by `secret.header`. Certain webhooks provide the possibility to include a special header and secret to identify the source.
+
+[float]
+==== `hmac.header`
+
+The name of the header that contains the HMAC signature: `X-Dropbox-Signature`, `X-Hub-Signature-256`, etc.
+
+[float]
+==== `hmac.key`
+
+The secret key used to calculate the HMAC signature. Typically, the webhook sender provides this value.
+
+[float]
+==== `hmac.type`
+
+The hash algorithm to use for the HMAC comparison. At this time the only valid values are `sha256` or `sha1`
+
+[float]
+==== `hmac.prefix`
+
+The prefix for the signature. Certain webhooks prefix the HMAC signature with a value, for example `sha256=`
 
 [float]
 ==== `content_type`

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -73,7 +73,7 @@ func (c *config) Validate() error {
 	}
 
 	if c.HmacType != "" && !(c.HmacType == "sha1" || c.HmacType == "sha256") {
-		return errors.New("Both hmac.header and hmac.key must be set")
+		return errors.New("hmac.type must be sha1 or sha256")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -60,16 +60,16 @@ func (c *config) Validate() error {
 
 	if c.BasicAuth {
 		if c.Username == "" || c.Password == "" {
-			return errors.New("Username and password required when basicauth is enabled")
+			return errors.New("username and password required when basicauth is enabled")
 		}
 	}
 
 	if (c.SecretHeader != "" && c.SecretValue == "") || (c.SecretHeader == "" && c.SecretValue != "") {
-		return errors.New("Both secret.header and secret.value must be set")
+		return errors.New("both secret.header and secret.value must be set")
 	}
 
 	if (c.HMACHeader != "" && c.HMACKey == "") || (c.HMACHeader == "" && c.HMACKey != "") {
-		return errors.New("Both hmac.header and hmac.key must be set")
+		return errors.New("both hmac.header and hmac.key must be set")
 	}
 
 	if c.HMACType != "" && !(c.HMACType == "sha1" || c.HMACType == "sha256") {

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -26,6 +26,10 @@ type config struct {
 	ContentType   string                  `config:"content_type"`
 	SecretHeader  string                  `config:"secret.header"`
 	SecretValue   string                  `config:"secret.value"`
+	HmacHeader    string                  `config:"hmac.header"`
+	HmacKey       string                  `config:"hmac.key"`
+	HmacType      string                  `config:"hmac.type"`
+	HmacPrefix    string                  `config:"hmac.prefix"`
 }
 
 func defaultConfig() config {
@@ -42,6 +46,10 @@ func defaultConfig() config {
 		ContentType:   "application/json",
 		SecretHeader:  "",
 		SecretValue:   "",
+		HmacHeader:    "",
+		HmacKey:       "",
+		HmacType:      "",
+		HmacPrefix:    "",
 	}
 }
 
@@ -58,6 +66,14 @@ func (c *config) Validate() error {
 
 	if (c.SecretHeader != "" && c.SecretValue == "") || (c.SecretHeader == "" && c.SecretValue != "") {
 		return errors.New("Both secret.header and secret.value must be set")
+	}
+
+	if (c.HmacHeader != "" && c.HmacKey == "") || (c.HmacHeader == "" && c.HmacKey != "") {
+		return errors.New("Both hmac.header and hmac.key must be set")
+	}
+
+	if c.HmacType != "" && !(c.HmacType == "sha1" || c.HmacType == "sha256") {
+		return errors.New("Both hmac.header and hmac.key must be set")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -26,10 +26,10 @@ type config struct {
 	ContentType   string                  `config:"content_type"`
 	SecretHeader  string                  `config:"secret.header"`
 	SecretValue   string                  `config:"secret.value"`
-	HmacHeader    string                  `config:"hmac.header"`
-	HmacKey       string                  `config:"hmac.key"`
-	HmacType      string                  `config:"hmac.type"`
-	HmacPrefix    string                  `config:"hmac.prefix"`
+	HMACHeader    string                  `config:"hmac.header"`
+	HMACKey       string                  `config:"hmac.key"`
+	HMACType      string                  `config:"hmac.type"`
+	HMACPrefix    string                  `config:"hmac.prefix"`
 }
 
 func defaultConfig() config {
@@ -46,10 +46,10 @@ func defaultConfig() config {
 		ContentType:   "application/json",
 		SecretHeader:  "",
 		SecretValue:   "",
-		HmacHeader:    "",
-		HmacKey:       "",
-		HmacType:      "",
-		HmacPrefix:    "",
+		HMACHeader:    "",
+		HMACKey:       "",
+		HMACType:      "",
+		HMACPrefix:    "",
 	}
 }
 
@@ -68,11 +68,11 @@ func (c *config) Validate() error {
 		return errors.New("Both secret.header and secret.value must be set")
 	}
 
-	if (c.HmacHeader != "" && c.HmacKey == "") || (c.HmacHeader == "" && c.HmacKey != "") {
+	if (c.HMACHeader != "" && c.HMACKey == "") || (c.HMACHeader == "" && c.HMACKey != "") {
 		return errors.New("Both hmac.header and hmac.key must be set")
 	}
 
-	if c.HmacType != "" && !(c.HmacType == "sha1" || c.HmacType == "sha256") {
+	if c.HMACType != "" && !(c.HMACType == "sha1" || c.HMACType == "sha256") {
 		return errors.New("hmac.type must be sha1 or sha256")
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -29,8 +29,10 @@ type httpHandler struct {
 	responseBody string
 }
 
-var errBodyEmpty = errors.New("Body cannot be empty")
-var errUnsupportedType = errors.New("Only JSON objects are accepted")
+var (
+	errBodyEmpty       = errors.New("body cannot be empty")
+	errUnsupportedType = errors.New("only JSON objects are accepted")
+)
 
 // Triggers if middleware validation returns successful
 func (h *httpHandler) apiResponse(w http.ResponseWriter, r *http.Request) {
@@ -94,7 +96,7 @@ func httpReadJsonObject(body io.Reader) (obj common.MapStr, status int, err erro
 
 	obj = common.MapStr{}
 	if err := json.Unmarshal(contents, &obj); err != nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("Malformed JSON body: %w", err)
+		return nil, http.StatusBadRequest, fmt.Errorf("malformed JSON body: %w", err)
 	}
 
 	return obj, 0, nil

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -77,7 +77,9 @@ func withValidator(v validator, handler http.HandlerFunc) http.HandlerFunc {
 func sendErrorResponse(w http.ResponseWriter, status int, err error) {
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(status)
-	fmt.Fprintf(w, `{"message": %q}`, err.Error())
+	e := json.NewEncoder(w)
+	e.SetEscapeHTML(false)
+	e.Encode(common.MapStr{"message": err.Error()})
 }
 
 func httpReadJsonObject(body io.Reader) (obj common.MapStr, status int, err error) {

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -121,7 +121,7 @@ func (e *httpEndpoint) Run(ctx v2.Context, publisher stateless.Publisher) error 
 	}
 
 	if err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("Unable to start server due to error: %w", err)
+		return fmt.Errorf("unable to start server due to error: %w", err)
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -90,6 +90,10 @@ func (e *httpEndpoint) Run(ctx v2.Context, publisher stateless.Publisher) error 
 		contentType:  e.config.ContentType,
 		secretHeader: e.config.SecretHeader,
 		secretValue:  e.config.SecretValue,
+		hmacHeader:   e.config.HmacHeader,
+		hmacKey:      e.config.HmacKey,
+		hmacType:     e.config.HmacType,
+		hmacPrefix:   e.config.HmacPrefix,
 	}
 
 	handler := &httpHandler{

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -90,10 +90,10 @@ func (e *httpEndpoint) Run(ctx v2.Context, publisher stateless.Publisher) error 
 		contentType:  e.config.ContentType,
 		secretHeader: e.config.SecretHeader,
 		secretValue:  e.config.SecretValue,
-		hmacHeader:   e.config.HmacHeader,
-		hmacKey:      e.config.HmacKey,
-		hmacType:     e.config.HmacType,
-		hmacPrefix:   e.config.HmacPrefix,
+		hmacHeader:   e.config.HMACHeader,
+		hmacKey:      e.config.HMACKey,
+		hmacType:     e.config.HMACType,
+		hmacPrefix:   e.config.HMACPrefix,
 	}
 
 	handler := &httpHandler{

--- a/x-pack/filebeat/input/http_endpoint/validate.go
+++ b/x-pack/filebeat/input/http_endpoint/validate.go
@@ -37,9 +37,12 @@ type apiValidator struct {
 	hmacPrefix         string
 }
 
-var errIncorrectUserOrPass = errors.New("Incorrect username or password")
-var errIncorrectHeaderSecret = errors.New("Incorrect header or header secret")
-var errIncorrectHmacSignature = errors.New("Invalid HMAC signature")
+var (
+	errIncorrectUserOrPass    = errors.New("incorrect username or password")
+	errIncorrectHeaderSecret  = errors.New("incorrect header or header secret")
+	errMissingHMACHeader      = errors.New("missing HMAC header")
+	errIncorrectHMACSignature = errors.New("invalid HMAC signature")
+)
 
 func (v *apiValidator) ValidateHeader(r *http.Request) (int, error) {
 	if v.basicAuth {
@@ -56,11 +59,11 @@ func (v *apiValidator) ValidateHeader(r *http.Request) (int, error) {
 	}
 
 	if v.method != "" && v.method != r.Method {
-		return http.StatusMethodNotAllowed, fmt.Errorf("Only %v requests supported", v.method)
+		return http.StatusMethodNotAllowed, fmt.Errorf("only %v requests are allowed", v.method)
 	}
 
 	if v.contentType != "" && r.Header.Get("Content-Type") != v.contentType {
-		return http.StatusUnsupportedMediaType, fmt.Errorf("Wrong Content-Type header, expecting %v", v.contentType)
+		return http.StatusUnsupportedMediaType, fmt.Errorf("wrong Content-Type header, expecting %v", v.contentType)
 	}
 
 	if v.hmacHeader != "" && v.hmacKey != "" && v.hmacType != "" {

--- a/x-pack/filebeat/tests/system/test_http_endpoint.py
+++ b/x-pack/filebeat/tests/system/test_http_endpoint.py
@@ -1,6 +1,8 @@
 import jinja2
 import requests
 import sys
+import hmac
+import hashlib
 import os
 import json
 from filebeat import BaseTest
@@ -188,6 +190,63 @@ class Test(BaseTest):
         assert r.text == '{"message": "success"}'
         assert output[0]["input.type"] == "http_endpoint"
         assert output[0]["json.{}".format(self.prefix)] == message
+
+    def test_http_endpoint_valid_hmac(self):
+        """
+        Test http_endpoint input with valid hmac signature.
+        """
+        options = """
+  hmac.header: "X-Hub-Signature-256"
+  hmac.key: "password123"
+  hmac.type: "sha256"
+  hmac.prefix: "sha256="
+"""
+        self.get_config(options)
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.log_contains("Starting HTTP server on {}:{}".format(self.host, self.port)))
+
+        message = "somerandommessage"
+        payload = {self.prefix: message}
+
+        h = hmac.new("password123".encode(), json.dumps(payload).encode(), hashlib.sha256)
+        print(h.hexdigest())
+        headers = {"Content-Type": "application/json", "X-Hub-Signature-256": "sha256=" + h.hexdigest()}
+        r = requests.post(self.url, headers=headers, data=json.dumps(payload))
+
+        filebeat.check_kill_and_wait()
+        output = self.read_output()
+
+        assert r.text == '{"message": "success"}'
+        assert output[0]["input.type"] == "http_endpoint"
+        assert output[0]["json.{}".format(self.prefix)] == message
+
+    def test_http_endpoint_invalid_hmac(self):
+        """
+        Test http_endpoint input with invalid hmac signature.
+        """
+        options = """
+  hmac.header: "X-Hub-Signature-256"
+  hmac.key: "password123"
+  hmac.type: "sha256"
+  hmac.prefix: "sha256="
+"""
+        self.get_config(options)
+        filebeat = self.start_beat()
+        self.wait_until(lambda: self.log_contains("Starting HTTP server on {}:{}".format(self.host, self.port)))
+
+        message = "somerandommessage"
+        payload = {self.prefix: message}
+
+        h = hmac.new("password321".encode(), json.dumps(payload).encode(), hashlib.sha256)
+        headers = {"Content-Type": "application/json", "X-Hub-Signature-256": "shad256=" + h.hexdigest()}
+        r = requests.post(self.url, headers=headers, data=json.dumps(payload))
+
+        filebeat.check_kill_and_wait()
+
+        print("response:", r.status_code, r.text)
+
+        assert r.status_code == 401
+        assert r.text == '{"message": "Invalid HMAC signature"}'
 
     def test_http_endpoint_empty_body(self):
         """

--- a/x-pack/filebeat/tests/system/test_http_endpoint.py
+++ b/x-pack/filebeat/tests/system/test_http_endpoint.py
@@ -102,7 +102,7 @@ class Test(BaseTest):
         print("response:", r.status_code, r.text)
 
         assert r.status_code == 415
-        assert r.text == '{"message": "Wrong Content-Type header, expecting application/json"}'
+        assert r.json()['message'] == 'wrong Content-Type header, expecting application/json'
 
     def test_http_endpoint_missing_auth_value(self):
         """
@@ -115,7 +115,7 @@ class Test(BaseTest):
 """
         self.get_config(options)
         filebeat = self.start_beat()
-        self.wait_until(lambda: self.log_contains("Username and password required when basicauth is enabled"))
+        self.wait_until(lambda: self.log_contains("username and password required when basicauth is enabled"))
         filebeat.kill_and_wait()
 
     def test_http_endpoint_wrong_auth_value(self):
@@ -141,7 +141,7 @@ class Test(BaseTest):
         print("response:", r.status_code, r.text)
 
         assert r.status_code == 401
-        assert r.text == '{"message": "Incorrect username or password"}'
+        assert r.json()['message'] == 'incorrect username or password'
 
     def test_http_endpoint_wrong_auth_header(self):
         """
@@ -165,7 +165,7 @@ class Test(BaseTest):
         print("response:", r.status_code, r.text)
 
         assert r.status_code == 401
-        assert r.text == '{"message": "Incorrect header or header secret"}'
+        assert r.json()['message'] == 'incorrect header or header secret'
 
     def test_http_endpoint_correct_auth_header(self):
         """
@@ -246,7 +246,7 @@ class Test(BaseTest):
         print("response:", r.status_code, r.text)
 
         assert r.status_code == 401
-        assert r.text == '{"message": "Invalid HMAC signature"}'
+        self.assertRegex(r.json()['message'], 'invalid HMAC signature')
 
     def test_http_endpoint_empty_body(self):
         """
@@ -264,7 +264,7 @@ class Test(BaseTest):
         print("response:", r.status_code, r.text)
 
         assert r.status_code == 406
-        assert r.text == '{"message": "Body cannot be empty"}'
+        assert r.json()['message'] == 'body cannot be empty'
 
     def test_http_endpoint_malformed_json(self):
         """
@@ -283,7 +283,7 @@ class Test(BaseTest):
         print("response:", r.status_code, r.text)
 
         assert r.status_code == 400
-        assert r.text.startswith('{"message": "Malformed JSON body:')
+        self.assertRegex(r.json()['message'], 'malformed JSON body')
 
     def test_http_endpoint_get_request(self):
         """
@@ -302,4 +302,4 @@ class Test(BaseTest):
         print("response:", r.status_code, r.text)
 
         assert r.status_code == 405
-        assert r.text == '{"message": "Only POST requests supported"}'
+        assert r.json()['message'] == 'only POST requests are allowed'


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Adds the option of HMAC signature validation for the `http_endpoint` input. This PR adds support for `sha1` and `sha256` based HMAC validation and allows flexible configuration of the header containing the signature, the key, and an optional prefix.
## Why is it important?
Many webhook senders offer this as the only method of authenticating that the method was actually sent from them, for example, GitHub and Dropbox. This enables future modules to receive events from these types of senders and allows users the flexibility to configure their own inputs in the meantime. 

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This PR can be tested locally by configuring a webhook sender to send events to your machine. I personally used ngrok to expose the appropriate port from Filebeat, but there are other options. One simple sender to use for testing is configuring a webhook on any GitHub repo. 

https://docs.github.com/en/developers/webhooks-and-events/creating-webhooks#exposing-localhost-to-the-internet

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.
-->
- Closes #24917 
