### PR TITLE
Cherry-pick to 7.11: Fix error in Journalbeat commands (#24880)

### DIFF
--- a/libbeat/docs/tab-widgets/setup-deb-rpm-linux-widget.asciidoc
+++ b/libbeat/docs/tab-widgets/setup-deb-rpm-linux-widget.asciidoc
@@ -28,7 +28,7 @@
        aria-labelledby="deb-setup">
 ++++
 
-include::setup.asciidoc[tag=mac]
+include::setup.asciidoc[tag=deb]
 
 ++++
   </div>
@@ -39,7 +39,7 @@ include::setup.asciidoc[tag=mac]
        hidden="">
 ++++
 
-include::setup.asciidoc[tag=linux]
+include::setup.asciidoc[tag=rpm]
 
 ++++
   </div>
@@ -50,7 +50,7 @@ include::setup.asciidoc[tag=linux]
        hidden="">
 ++++
 
-include::setup.asciidoc[tag=win]
+include::setup.asciidoc[tag=linux]
 
 ++++
   </div>


### PR DESCRIPTION
Backports the following commits to 7.11:
 - Fix error in Journalbeat commands (#24880)