### PR TITLE
[Filebeat] Fix IPtables pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -389,6 +389,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve PanOS parsing and ingest pipeline. {issue}22413[22413] {issue}22748[22748] {pull}24799[24799]
 - Fix S3 input validation for non amazonaws.com domains. {issue}24420[24420] {pull}24861[24861]
 - Fix google_workspace and okta modules pagination when next page template is empty. {pull}24967[24967]
+- Fix IPtable Pipeline and Ubiquity dashboard. {issue}24878[24878] {pull}24928[24928]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -389,7 +389,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve PanOS parsing and ingest pipeline. {issue}22413[22413] {issue}22748[22748] {pull}24799[24799]
 - Fix S3 input validation for non amazonaws.com domains. {issue}24420[24420] {pull}24861[24861]
 - Fix google_workspace and okta modules pagination when next page template is empty. {pull}24967[24967]
-- Fix IPtable Pipeline and Ubiquity dashboard. {issue}24878[24878] {pull}24928[24928]
 - Fix IPtables Pipeline and Ubiquiti dashboard. {issue}24878[24878] {pull}24928[24928]
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -390,6 +390,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix S3 input validation for non amazonaws.com domains. {issue}24420[24420] {pull}24861[24861]
 - Fix google_workspace and okta modules pagination when next page template is empty. {pull}24967[24967]
 - Fix IPtable Pipeline and Ubiquity dashboard. {issue}24878[24878] {pull}24928[24928]
+- Fix IPtables Pipeline and Ubiquiti dashboard. {issue}24878[24878] {pull}24928[24928]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/iptables/_meta/kibana/7/dashboard/Filebeat-Iptables-Ubiquiti-Firewall-Overview.json
+++ b/x-pack/filebeat/module/iptables/_meta/kibana/7/dashboard/Filebeat-Iptables-Ubiquiti-Firewall-Overview.json
@@ -628,7 +628,7 @@
             "index": "filebeat-*",
             "query": {
               "language": "kuery",
-              "query": "iptables.ubiquiti.rule_set :* and event.outcome : \"deny\""
+              "query": "iptables.ubiquiti.rule_set :* and event.action : \"drop\""
             },
             "version": true
           }
@@ -659,7 +659,7 @@
             "index": "filebeat-*",
             "query": {
               "language": "kuery",
-              "query": "iptables.ubiquiti.rule_set :* and event.outcome : \"allow\""
+              "query": "iptables.ubiquiti.rule_set :* and event.action : \"accept\""
             },
             "version": true
           }

--- a/x-pack/filebeat/module/iptables/log/config/input.yml
+++ b/x-pack/filebeat/module/iptables/log/config/input.yml
@@ -20,38 +20,6 @@ publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 processors:
   - add_locale: ~
-{{ if .community_id }}
-  - dissect:
-      tokenizer: "%{} SRC=%{source.ip} DST=%{destination.ip} "
-      field: "message"
-      target_prefix: ""
-  - dissect:
-      tokenizer: "%{} PROTO=%{network.transport} "
-      field: "message"
-      target_prefix: ""
-  - if:
-      or:
-        - equals.network.transport: TCP
-        - equals.network.transport: UDP
-        - equals.network.transport: SCTP
-    then:
-      dissect:
-        tokenizer: "%{} SPT=%{source.port} DPT=%{destination.port} "
-        field: "message"
-        target_prefix: ""
-    else:
-      dissect:
-        when:or:
-          - equals.network.transport: ICMP
-          - equals.network.transport: ICMPv6
-        tokenizer: "%{} TYPE=%{iptables.icmp.type} CODE=%{iptables.icmp.code} "
-        field: "message"
-        target_prefix: ""
-  - community_id:
-      fields:
-        icmp_type: iptables.icmp.type
-        icmp_code: iptables.icmp.code
-{{ end}}
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -213,11 +213,11 @@ processors:
 - set:
     field: event.outcome
     value: success
-    if: "ctx?.event?.action != null && ctx?.event?.action == accept"
+    if: "ctx?.event?.action != null && ctx?.event?.action == 'accept'"
 - set:
     field: event.outcome
     value: failure
-    if: "ctx?.event?.action != null && ctx?.event?.action == drop"
+    if: "ctx?.event?.action != null && ctx?.event?.action == 'drop'"
 - set:
     field: event.kind
     value: event

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -211,6 +211,14 @@ processors:
       }
 
 - set:
+    field: event.outcome
+    value: success
+    if: "ctx?.event?.action != null && ctx?.event?.action == accept"
+- set:
+    field: event.outcome
+    value: failure
+    if: "ctx?.event?.action != null && ctx?.event?.action == drop"
+- set:
     field: event.kind
     value: event
 - append:

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -231,14 +231,6 @@ processors:
       }
 
 - set:
-    field: event.outcome
-    value: success
-    if: "ctx?.event?.type != null && ctx.event.type.contains('allowed')"
-- set:
-    field: event.outcome
-    value: failure
-    if: "ctx?.event?.type != null && ctx.event.type.contains('denied')"
-- set:
     field: event.kind
     value: event
 - append:

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -6,11 +6,13 @@ processors:
 - grok:
     field: message
     patterns:
-    - '%{SYSLOGTIMESTAMP:iptables.raw_date}%{GREEDYDATA}\[%{UBIQUITI_LABEL}\]%{IPTABLES}%{SPACE}'
-    - '%{SYSLOGTIMESTAMP:iptables.raw_date}%{GREEDYDATA}%{IPTABLES}%{SPACE}'
+    - '%{SYSLOGTIMESTAMP:iptables.raw_date}%{SPACE}%{IPTABLES_HOSTNAME}%{GREEDYDATA}\[%{UBIQUITI_LABEL}\]%{IPTABLES}%{SPACE}'
+    - '%{SYSLOGTIMESTAMP:iptables.raw_date}%{SPACE}%{IPTABLES_ACTION}%{GREEDYDATA}%{IPTABLES}%{SPACE}'
     - '%{GREEDYDATA}\[%{UBIQUITI_LABEL}\]%{IPTABLES}%{SPACE}'
     - '%{GREEDYDATA}%{IPTABLES}%{SPACE}'
     pattern_definitions:
+      IPTABLES_HOSTNAME: '%{HOSTNAME:observer.name}%{SPACE}kernel:'
+      IPTABLES_ACTION: '(:?%{WORD:event.action}:|%{IPTABLES_HOSTNAME}%{SPACE}iptables%{SPACE}%{WORD:event.action}|%{IPTABLES_HOSTNAME})'
       UNSIGNED_INT: '[0-9]+'
       ETHTYPE: (?:[A-Fa-f0-9]{2}):(?:[A-Fa-f0-9]{2})
       ETHTYPE_DISCARD: (?::[A-Fa-f0-9]{2})*
@@ -85,6 +87,9 @@ processors:
 - lowercase:
     field: network.transport
     ignore_missing: true
+- lowercase:
+    field: event.action
+    ignore_missing: true
 - geoip:
     field: source.ip
     target_field: source.geo
@@ -145,8 +150,8 @@ processors:
           object: event
           key: action
         map:
-          D: drop
-          A: accept
+          d: drop
+          a: accept
       - source:
           object: event
           key: action
@@ -156,6 +161,8 @@ processors:
         map:
           drop: denied
           accept: allowed
+          deny: denied
+          drop_input: denied
       - source:
           object: network
           key: transport
@@ -181,7 +188,10 @@ processors:
           }
         }
       }
-
+- community_id:
+    ignore_missing: true
+    icmp_type: iptables.icmp.type
+    icmp_code: iptables.icmp.code
 - script:
     lang: painless
     params:
@@ -213,11 +223,11 @@ processors:
 - set:
     field: event.outcome
     value: success
-    if: "ctx?.event?.action != null && ctx?.event?.action == 'accept'"
+    if: "ctx?.event?.type != null && ctx.event.type.contains('allowed')"
 - set:
     field: event.outcome
     value: failure
-    if: "ctx?.event?.action != null && ctx?.event?.action == 'drop'"
+    if: "ctx?.event?.type != null && ctx.event.type.contains('denied')"
 - set:
     field: event.kind
     value: event

--- a/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/iptables/log/ingest/pipeline.yml
@@ -61,7 +61,7 @@ processors:
     pattern_definitions:
       UBIQUITI_FIELD: '[^-]*'
 - date:
-    if: ctx.event.timezone == null
+    if: ctx?.iptables?.raw_date != null && ctx.event.timezone == null
     field: iptables.raw_date
     formats:
     - MMM  d HH:mm:ss
@@ -71,7 +71,7 @@ processors:
         field: error.message
         value: '{{ _ingest.on_failure_message }}'
 - date:
-    if: ctx.event.timezone != null
+    if: ctx?.iptables?.raw_date != null && ctx.event.timezone != null
     field: iptables.raw_date
     formats:
     - MMM  d HH:mm:ss
@@ -84,6 +84,16 @@ processors:
 - remove:
     field: iptables.raw_date
     ignore_missing: true
+- set:
+    field: observer.name
+    value: "{{hostname}}"
+    ignore_empty_value: true
+    if: ctx?.observer?.name == null
+- set:
+    field: observer.hostname
+    value: "{{hostname}}"
+    ignore_empty_value: true
+    if: ctx?.observer?.name == null
 - lowercase:
     field: network.transport
     ignore_missing: true

--- a/x-pack/filebeat/module/iptables/log/manifest.yml
+++ b/x-pack/filebeat/module/iptables/log/manifest.yml
@@ -12,8 +12,6 @@ var:
     default: 9001
   - name: input
     default: syslog
-  - name: community_id
-    default: true
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/input.yml

--- a/x-pack/filebeat/module/iptables/log/test/geo.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/geo.log-expected.json
@@ -10,7 +10,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",

--- a/x-pack/filebeat/module/iptables/log/test/geo.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/geo.log-expected.json
@@ -10,6 +10,7 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",

--- a/x-pack/filebeat/module/iptables/log/test/geo.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/geo.log-expected.json
@@ -45,6 +45,7 @@
         "network.type": "ipv4",
         "observer.egress.zone": "lan",
         "observer.ingress.zone": "wan",
+        "observer.name": "Hostname",
         "related.ip": [
             "158.109.0.1",
             "10.4.0.5"

--- a/x-pack/filebeat/module/iptables/log/test/icmp.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/icmp.log-expected.json
@@ -2,14 +2,17 @@
     {
         "destination.ip": "192.0.2.83",
         "destination.mac": "90:10:28:5f:62:24",
+        "event.action": "deny",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",

--- a/x-pack/filebeat/module/iptables/log/test/icmp.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/icmp.log-expected.json
@@ -9,7 +9,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",

--- a/x-pack/filebeat/module/iptables/log/test/iptables.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/iptables.log-expected.json
@@ -10,7 +10,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -64,7 +63,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -115,7 +113,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -169,7 +166,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -223,7 +219,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -277,7 +272,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -328,7 +322,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -382,7 +375,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -436,7 +428,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -487,7 +478,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",

--- a/x-pack/filebeat/module/iptables/log/test/iptables.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/iptables.log-expected.json
@@ -3,14 +3,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 445,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -36,6 +39,7 @@
         "network.community_id": "1:VD3aeZ6cGYX6uwOAUQ9NuxbobMI=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "203.0.113.36",
             "172.16.54.114"
@@ -53,14 +57,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 1433,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -83,6 +90,7 @@
         "network.community_id": "1:r9MnuXFtcWUKzbVQ2vXn7XSQ2Fg=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "198.51.100.198",
             "172.16.54.114"
@@ -100,14 +108,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 445,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -133,6 +144,7 @@
         "network.community_id": "1:vgBSpDUKSSgxOm6Y52jw6tCgiN8=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "203.0.113.201",
             "172.16.54.114"
@@ -150,14 +162,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 80,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -183,6 +198,7 @@
         "network.community_id": "1:PCNGbo6CtVQoE5Hch+6oMfbeTP4=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "203.0.113.246",
             "172.16.54.114"
@@ -200,14 +216,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 445,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -233,6 +252,7 @@
         "network.community_id": "1:Wb/3DTwtWE8C20/hm2JpmBAhsro=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "203.0.113.208",
             "172.16.54.114"
@@ -250,14 +270,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 445,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -280,6 +303,7 @@
         "network.community_id": "1:+s7vkEgPnzTAoksA2Q0gAzgymfI=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "198.51.100.160",
             "172.16.54.114"
@@ -297,14 +321,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 445,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -330,6 +357,7 @@
         "network.community_id": "1:6Pvyzf2+vqgsRxWx+eU9MXEhAFE=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "198.51.100.115",
             "172.16.54.114"
@@ -347,14 +375,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 445,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -380,6 +411,7 @@
         "network.community_id": "1:g+bRFDuqViJEc5vzlOapz2LPhFo=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "198.51.100.167",
             "172.16.54.114"
@@ -397,14 +429,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 139,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -427,6 +462,7 @@
         "network.community_id": "1:a/4LVq88msR/LgVGzZeIkmlNXz4=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "198.51.100.19",
             "172.16.54.114"
@@ -444,14 +480,17 @@
         "destination.ip": "172.16.54.114",
         "destination.mac": "90:10:35:5a:1e:3a",
         "destination.port": 8088,
+        "event.action": "drop_input",
         "event.category": [
             "network"
         ],
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
+            "denied",
             "connection"
         ],
         "fileset.name": "log",
@@ -474,6 +513,7 @@
         "network.community_id": "1:1l65fWlqrJCJB7vBaqSgHnJoMbQ=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "example-host",
         "related.ip": [
             "198.51.100.68",
             "172.16.54.114"

--- a/x-pack/filebeat/module/iptables/log/test/ipv6.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/ipv6.log-expected.json
@@ -27,6 +27,7 @@
         "log.original": "Jan 22 09:05:05 ubuntu-bionic kernel: [16571.459614] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=868225 PROTO=ICMPv6 TYPE=128 CODE=0 ID=3427 SEQ=1 ",
         "network.community_id": "1:u2vMS3HiWth2lIMKHB1fjELshpQ=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -66,6 +67,7 @@
         "log.original": "Jan 22 09:05:05 ubuntu-bionic kernel: [16571.459695] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=770819 PROTO=ICMPv6 TYPE=129 CODE=0 ID=3427 SEQ=1 ",
         "network.community_id": "1:YDcnf7YthUKAbDNo6Cs3rX4jq4w=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -105,6 +107,7 @@
         "log.original": "Jan 22 09:05:06 ubuntu-bionic kernel: [16572.482458] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=868225 PROTO=ICMPv6 TYPE=128 CODE=0 ID=3427 SEQ=2 ",
         "network.community_id": "1:u2vMS3HiWth2lIMKHB1fjELshpQ=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -144,6 +147,7 @@
         "log.original": "Jan 22 09:05:06 ubuntu-bionic kernel: [16572.482476] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=770819 PROTO=ICMPv6 TYPE=129 CODE=0 ID=3427 SEQ=2 ",
         "network.community_id": "1:YDcnf7YthUKAbDNo6Cs3rX4jq4w=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -183,6 +187,7 @@
         "log.original": "Jan 22 09:05:07 ubuntu-bionic kernel: [16573.506336] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=868225 PROTO=ICMPv6 TYPE=128 CODE=0 ID=3427 SEQ=3 ",
         "network.community_id": "1:u2vMS3HiWth2lIMKHB1fjELshpQ=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -222,6 +227,7 @@
         "log.original": "Jan 22 09:05:07 ubuntu-bionic kernel: [16573.506356] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=770819 PROTO=ICMPv6 TYPE=129 CODE=0 ID=3427 SEQ=3 ",
         "network.community_id": "1:YDcnf7YthUKAbDNo6Cs3rX4jq4w=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -261,6 +267,7 @@
         "log.original": "Jan 22 09:05:08 ubuntu-bionic kernel: [16574.533989] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=868225 PROTO=ICMPv6 TYPE=128 CODE=0 ID=3427 SEQ=4 ",
         "network.community_id": "1:u2vMS3HiWth2lIMKHB1fjELshpQ=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -300,6 +307,7 @@
         "log.original": "Jan 22 09:05:08 ubuntu-bionic kernel: [16574.534007] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=770819 PROTO=ICMPv6 TYPE=129 CODE=0 ID=3427 SEQ=4 ",
         "network.community_id": "1:YDcnf7YthUKAbDNo6Cs3rX4jq4w=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -339,6 +347,7 @@
         "log.original": "Jan 22 09:05:09 ubuntu-bionic kernel: [16575.553704] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=868225 PROTO=ICMPv6 TYPE=128 CODE=0 ID=3427 SEQ=5 ",
         "network.community_id": "1:u2vMS3HiWth2lIMKHB1fjELshpQ=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -378,6 +387,7 @@
         "log.original": "Jan 22 09:05:09 ubuntu-bionic kernel: [16575.553722] IN= OUT=lo SRC=2001:0db8:0000:0000:0000:0000:0000:0001 DST=2001:0db8:0000:0000:0000:0000:0000:0002 LEN=104 TC=0 HOPLIMIT=64 FLOWLBL=770819 PROTO=ICMPv6 TYPE=129 CODE=0 ID=3427 SEQ=5 ",
         "network.community_id": "1:YDcnf7YthUKAbDNo6Cs3rX4jq4w=",
         "network.transport": "ipv6-icmp",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "2001:0db8:0000:0000:0000:0000:0000:0001",
             "2001:0db8:0000:0000:0000:0000:0000:0002"
@@ -418,6 +428,7 @@
         "network.community_id": "1:XZrSeKYMvsI3xGPWG5JqrtsD87U=",
         "network.transport": "ipv6-icmp",
         "network.type": "ipv6",
+        "observer.name": "ubuntu-bionic",
         "related.ip": [
             "fe80:0000:0000:0000:0084:88ff:feae:790a",
             "ff02:0000:0000:0000:0000:0000:0000:0016"

--- a/x-pack/filebeat/module/iptables/log/test/ubiquiti.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/ubiquiti.log-expected.json
@@ -10,6 +10,7 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",
@@ -59,6 +60,7 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",
@@ -116,6 +118,7 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -176,6 +179,7 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",
@@ -232,6 +236,7 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
+        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",

--- a/x-pack/filebeat/module/iptables/log/test/ubiquiti.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/ubiquiti.log-expected.json
@@ -10,7 +10,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",
@@ -61,7 +60,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",
@@ -120,7 +118,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
             "denied",
@@ -182,7 +179,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",
@@ -240,7 +236,6 @@
         "event.dataset": "iptables.log",
         "event.kind": "event",
         "event.module": "iptables",
-        "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
             "allowed",

--- a/x-pack/filebeat/module/iptables/log/test/ubiquiti.log-expected.json
+++ b/x-pack/filebeat/module/iptables/log/test/ubiquiti.log-expected.json
@@ -34,6 +34,7 @@
         "network.community_id": "1:3qoibVBmc9hsnHpP4Ms5HO6ls7Q=",
         "network.transport": "udp",
         "network.type": "ipv4",
+        "observer.name": "MainFirewall",
         "related.ip": [
             "192.168.48.137",
             "255.55.174.225"
@@ -92,6 +93,7 @@
         "network.community_id": "1:7bPQdYPL4yePwQJZt0I1dvVXLHc=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "MainFirewall",
         "related.ip": [
             "192.168.134.158",
             "192.0.2.25"
@@ -153,6 +155,7 @@
         "network.type": "ipv4",
         "observer.egress.zone": "dest",
         "observer.ingress.zone": "source",
+        "observer.name": "MainFirewall",
         "related.ip": [
             "192.168.110.116",
             "192.0.2.25"
@@ -210,6 +213,7 @@
         "network.community_id": "1:6BwNFzns3BNljtYZJCwhPO5Qoq0=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "MainFirewall",
         "related.ip": [
             "192.168.110.116",
             "192.0.2.25"
@@ -267,6 +271,7 @@
         "network.community_id": "1:6BwNFzns3BNljtYZJCwhPO5Qoq0=",
         "network.transport": "tcp",
         "network.type": "ipv4",
+        "observer.name": "MainFirewall",
         "related.ip": [
             "192.168.110.116",
             "192.0.2.25"


### PR DESCRIPTION
## What does this PR do?

Fixes the Ubiquiti dashboard as part of the IPtables module and updates the grok patterns to better parse the sample data.

## Why is it important?

Ubiquiti dashboard was never updated when pipeline was modified so fields don't match.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

```
GENERATE=true TESTING_FILEBEAT_MODULES=iptables TESTING_FILEBEAT_FILESETS=log mage -v pythonIntegTest
```
## Related issues

- Closes #24878

## Use cases


## Screenshots


## Logs

