### PR TITLE
Cherry-pick #24904 to 7.x: [Elastic Agent] Add check for URL set when cert and cert key.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -46,6 +46,7 @@
 - Verify communication to Kibana before updating Fleet client. {pull}24489[24489]
 - Fix nil pointer when null is generated as list item. {issue}23734[23734]
 - Add support for filestream input. {pull}24820[24820]
+- Add check for URL set when cert and cert key. {pull}24904[24904]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -294,6 +294,10 @@ func (c *enrollCmd) prepareFleetTLS() error {
 		c.options.URL = fmt.Sprintf("https://%s:%d", hostname, port)
 		c.options.CAs = []string{string(ca.Crt())}
 	}
+	// running with custom Cert and CertKey; URL is required to be set
+	if c.options.URL == "" {
+		return errors.New("url is required when a certificate is provided")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Cherry-pick of PR #24904 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a check to ensure that `--url` is provided when `--fleet-server-cert` and `--fleet-server-cert-key` is provided.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So its clear that when those 2 parameters are provided that a communicate URL `--url` must also be provided.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24893 
