### PR TITLE
Remove duplicate decode_xml entry

### DIFF
--- a/libbeat/docs/processors-list.asciidoc
+++ b/libbeat/docs/processors-list.asciidoc
@@ -116,9 +116,6 @@ endif::[]
 ifndef::no_urldecode_processor[]
 * <<urldecode, `urldecode`>>
 endif::[]
-ifndef::no_decode_xml_processor[]
-* <<decode_xml, `decode_xml`>>
-endif::[]
 //# end::processors-list[]
 
 //# tag::processors-include[]


### PR DESCRIPTION
A duplicated log line was introduced in https://github.com/elastic/beats/pull/24726