### PR TITLE
Only show deprecation warnings for CN-based verification once

### DIFF
--- a/libbeat/common/transport/tlscommon/config.go
+++ b/libbeat/common/transport/tlscommon/config.go
@@ -19,11 +19,14 @@ package tlscommon
 
 import (
 	"crypto/tls"
+	"sync"
 
 	"github.com/joeshaw/multierror"
 
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 )
+
+var warnOnce sync.Once
 
 // Config defines the user configurable options in the yaml file.
 type Config struct {
@@ -98,7 +101,9 @@ func LoadTLSConfig(config *Config) (*TLSConfig, error) {
 // Validate values the TLSConfig struct making sure certificate sure we have both a certificate and
 // a key.
 func (c *Config) Validate() error {
-	cfgwarn.Deprecate("8.0.0", "Treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is going to be removed. Please update your certificates if needed.")
+	warnOnce.Do(func() {
+		cfgwarn.Deprecate("8.0.0", "Treating the CommonName field on X.509 certificates as a host name when no Subject Alternative Names are present is going to be removed. Please update your certificates if needed.")
+	})
 
 	return c.Certificate.Validate()
 }


### PR DESCRIPTION
## What does this PR do?

I haven't tracked down all of the code paths that call `Validate`, but customers are complaining about how much noise this deprecation warning is adding to their logs. I think it makes sense just to warn once, so it should be enough just to wrap this in a global `sync.Once`.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~