### PR TITLE
Cherry-pick #24334 to 7.x: Refactor use of system.hostfs to fix cgroup metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -144,6 +144,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix ILM alias not being created if `setup.ilm.check_exists: false` and `setup.ilm.overwrite: true` has been configured. {pull}24480[24480]
 - Allow cgroup self-monitoring to see alternate `hostfs` paths {pull}24334[24334]
 
+- Fix issue discovering docker containers and metadata after reconnections {pull}24318[24318]
+- Allow cgroup self-monitoring to see alternate `hostfs` paths {pull}24334[24334]
 
 *Auditbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #24334 to 7.x branch. Original message: 

## What does this PR do?

This is a fix for https://github.com/elastic/beats/issues/23267, wherein we weren't passing a `hostfs` to the metricbeat self-monitor code. In order to fix this in a somewhat clean way, I ended up migrating all of the hostfs handling to `libbeat/path`, and out of the system module entirely. This is a bit of a weird edge case for `libbeat/path`, so just tell me if this should be done somewhat differently.

## Why is it important?
As explained in the linked issue, this is causing problems for users setting `hostfs`.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally
- Pull down, build.
- Make sure the `socket`, `process`,`entropy` and `diskio` are working correctly.
- Run metricbeat with an alternate `system.hostfs` setting, such as in a container, like this:
```
docker run --mount type=bind,source=/proc,target=/hostfs/proc,readonly --mount type=bind,source=/sys/fs/cgroup,target=/hostfs/sys/fs/cgroup,readonly --mount type=bind,source=/,target=/hostfs,readonly --net=host docker.elastic.co/beats/metricbeat:8.0.0 -e -system.hostfs=/hostfs -E 'output.elasticsearch.hosts=["localhost:9200"]'
```

Insure that the above metricsets are still working, and that no errors like `instance/metrics.go:285 error getting group status: open /proc/33861/cgroup: no such file or directory` appear.

## Related issues

- https://github.com/elastic/beats/issues/23267


## Logs

Tested, it looks like we're properly reporting cgroup metrics inside a docker container:
```
2021-03-03T21:42:58.879Z        INFO    [monitoring]    log/log.go:152  Total non-zero metrics  {"monitoring": {"metrics": {"beat":{"cgroup":{"cpu":{"cfs":{"period":{"us":100000}},"id":"2716b9eb8166589954bcd5e6e8c73c3f08913e1604d60e27bb0f631014a5789e"},"cpuacct":{"id":"2716b9eb8166589954bcd5e6e8c73c3f08913e1604d60e27bb0f631014a5789e","total":{"ns":8121549013889171}},"memory":{"id":"2716b9eb8166589954bcd5e6e8c73c3f08913e1604d60e27bb0f631014a5789e","mem":{"limit":{"bytes":9223372036854771712},"usage":{"bytes":11272822784}}}},"cpu":{"system":{"ticks":7910,"time":{"ms":7911}},"total":{"ticks":14340,"time":{"ms":14347},"value":14340},"user":{"ticks":6430,"time":{"ms":6436}}},"handles":{"limit":{"hard":1048576,"soft":1048576},"open":10},"info":{"ephemeral_id":"c3361a23-ba63-4044-8926-e3e188e48715","uptime":{"ms":270554}},"memstats":{"gc_next":16976352,"memory_alloc":9944136,"memory_sys":75580416,"memory_total":484400016,"rss":86827008},"runtime":{"goroutines":16}},"libbeat":{"config":{"module":{"running":3,"starts":3},"reloads":1,"scans":1},"output":{"events":{"acked":628,"active":0,"batches":53,"total":628},"read":{"bytes":25316},"type":"elasticsearch","write":{"bytes":1123236}},"pipeline":{"clients":0,"events":{"active":4,"published":632,"retry":27,"total":632},"queue":{"acked":628}}},"metricbeat":{"system":{"cpu":{"events":28,"success":28},"filesystem":{"events":10,"success":10},"fsstat":{"events":5,"success":5},"load":{"events":28,"success":28},"memory":{"events":28,"success":28},"network":{"events":242,"success":242},"process":{"events":235,"success":235},"process_summary":{"events":27,"success":28},"socket_summary":{"events":28,"success":28},"uptime":{"events":1,"success":1}}},"system":{"cpu":{"cores":4},"load":{"1":3.76,"15":3.76,"5":3.54,"norm":{"1":0.94,"15":0.94,"5":0.885}}}}}}
```
