### PR TITLE
Update k8s manifests to use proper roles' scope for leaderelection

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -231,6 +231,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metricbeat
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: metricbeat
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: metricbeat
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metricbeat
@@ -272,20 +286,6 @@ rules:
   - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  namespace: kube-system
-  name: metricbeat
-subjects:
-  - kind: ServiceAccount
-    name: metricbeat
-    namespace: kube-system
-roleRef:
-  kind: Role
-  name: metricbeat
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: metricbeat
@@ -293,11 +293,11 @@ metadata:
   labels:
     k8s-app: metricbeat
 rules:
-- apiGroups:
-    - coordination.k8s.io
-  resources:
-    - leases
-  verbs: ["get", "create", "update"]
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs: ["get", "create", "update"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -147,7 +147,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:7.12.0
+        image: docker.elastic.co/beats/metricbeat:8.0.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -270,12 +270,34 @@ rules:
   - "/metrics"
   verbs:
   - get
-- apiGroups:
-    - coordination.k8s.io
-  resources:
-    - leases
-  verbs:
-    - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metricbeat
+subjects:
+  - kind: ServiceAccount
+    name: metricbeat
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: metricbeat
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metricbeat
+  namespace: kube-system
+  labels:
+    k8s-app: metricbeat
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - ["get", "create", "update"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -147,7 +147,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:8.0.0
+        image: docker.elastic.co/beats/metricbeat:7.12.0
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
@@ -274,6 +274,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  namespace: kube-system
   name: metricbeat
 subjects:
   - kind: ServiceAccount
@@ -292,12 +293,11 @@ metadata:
   labels:
     k8s-app: metricbeat
 rules:
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - ["get", "create", "update"]
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs: ["get", "create", "update"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/kubernetes/metricbeat/metricbeat-role-binding.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role-binding.yaml
@@ -10,3 +10,16 @@ roleRef:
   kind: ClusterRole
   name: metricbeat
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metricbeat
+subjects:
+  - kind: ServiceAccount
+    name: metricbeat
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: metricbeat
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kubernetes/metricbeat/metricbeat-role-binding.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role-binding.yaml
@@ -15,6 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: metricbeat
+  namespace: kube-system
 subjects:
   - kind: ServiceAccount
     name: metricbeat

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -38,9 +38,18 @@ rules:
   - "/metrics"
   verbs:
   - get
-- apiGroups:
-    - coordination.k8s.io
-  resources:
-    - leases
-  verbs:
-    - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metricbeat
+  namespace: kube-system
+  labels:
+    k8s-app: metricbeat
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - ["get", "create", "update"]

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -51,5 +51,4 @@ rules:
       - coordination.k8s.io
     resources:
       - leases
-    verbs:
-      - ["get", "create", "update"]
+    verbs: ["get", "create", "update"]


### PR DESCRIPTION
## What does this PR do?
This PR updates the roles required for using the leaderelection feature with `lease` Objects as lockObjects.

## Why is it important?
To improve the access/privileges we use for leaderelection.