### PR TITLE
Cherry-pick #24424 to 7.x: Add tests and support for truncated files in filestream input

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -59,6 +59,9 @@ type fileScanner struct {
 type fileWatcherConfig struct {
 	// Interval is the time between two scans.
 	Interval time.Duration `config:"check_interval"`
+	// ResendOnModTime  if a file has been changed according to modtime but the size is the same
+	// it is still considered truncation.
+	ResendOnModTime bool `config:"resend_on_touch"`
 	// Scanner is the configuration of the scanner.
 	Scanner fileScannerConfig `config:",inline"`
 }
@@ -66,11 +69,12 @@ type fileWatcherConfig struct {
 // fileWatcher gets the list of files from a FSWatcher and creates events by
 // comparing the files between its last two runs.
 type fileWatcher struct {
-	interval time.Duration
-	prev     map[string]os.FileInfo
-	scanner  loginp.FSScanner
-	log      *logp.Logger
-	events   chan loginp.FSEvent
+	interval        time.Duration
+	resendOnModTime bool
+	prev            map[string]os.FileInfo
+	scanner         loginp.FSScanner
+	log             *logp.Logger
+	events          chan loginp.FSEvent
 }
 
 func newFileWatcher(paths []string, ns *common.ConfigNamespace) (loginp.FSWatcher, error) {
@@ -98,18 +102,20 @@ func newScannerWatcher(paths []string, c *common.Config) (loginp.FSWatcher, erro
 		return nil, err
 	}
 	return &fileWatcher{
-		log:      logp.NewLogger(watcherDebugKey),
-		interval: config.Interval,
-		prev:     make(map[string]os.FileInfo, 0),
-		scanner:  scanner,
-		events:   make(chan loginp.FSEvent),
+		log:             logp.NewLogger(watcherDebugKey),
+		interval:        config.Interval,
+		resendOnModTime: config.ResendOnModTime,
+		prev:            make(map[string]os.FileInfo, 0),
+		scanner:         scanner,
+		events:          make(chan loginp.FSEvent),
 	}, nil
 }
 
 func defaultFileWatcherConfig() fileWatcherConfig {
 	return fileWatcherConfig{
-		Interval: 10 * time.Second,
-		Scanner:  defaultFileScannerConfig(),
+		Interval:        10 * time.Second,
+		ResendOnModTime: false,
+		Scanner:         defaultFileScannerConfig(),
 	}
 }
 
@@ -142,10 +148,18 @@ func (w *fileWatcher) watch(ctx unison.Canceler) {
 		}
 
 		if prevInfo.ModTime() != info.ModTime() {
-			select {
-			case <-ctx.Done():
-				return
-			case w.events <- writeEvent(path, info):
+			if prevInfo.Size() > info.Size() || w.resendOnModTime && prevInfo.Size() == info.Size() {
+				select {
+				case <-ctx.Done():
+					return
+				case w.events <- truncateEvent(path, info):
+				}
+			} else {
+				select {
+				case <-ctx.Done():
+					return
+				case w.events <- writeEvent(path, info):
+				}
 			}
 		}
 
@@ -196,6 +210,10 @@ func createEvent(path string, fi os.FileInfo) loginp.FSEvent {
 
 func writeEvent(path string, fi os.FileInfo) loginp.FSEvent {
 	return loginp.FSEvent{Op: loginp.OpWrite, OldPath: path, NewPath: path, Info: fi}
+}
+
+func truncateEvent(path string, fi os.FileInfo) loginp.FSEvent {
+	return loginp.FSEvent{Op: loginp.OpTruncate, OldPath: path, NewPath: path, Info: fi}
 }
 
 func renamedEvent(oldPath, path string, fi os.FileInfo) loginp.FSEvent {

--- a/filebeat/input/filestream/identifier.go
+++ b/filebeat/input/filestream/identifier.go
@@ -60,9 +60,10 @@ type fileIdentifier interface {
 // fileSource implements the Source interface
 // It is required to identify and manage file sources.
 type fileSource struct {
-	info    os.FileInfo
-	newPath string
-	oldPath string
+	info      os.FileInfo
+	newPath   string
+	oldPath   string
+	truncated bool
 
 	name                string
 	identifierGenerator string
@@ -103,6 +104,7 @@ func (i *inodeDeviceIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                i.name + identitySep + file.GetOSState(e.Info).String(),
 		identifierGenerator: i.name,
 	}
@@ -140,6 +142,7 @@ func (p *pathIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                p.name + identitySep + path,
 		identifierGenerator: p.name,
 	}

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -98,6 +98,7 @@ func (i *inodeMarkerIdentifier) GetSource(e loginp.FSEvent) fileSource {
 		info:                e.Info,
 		newPath:             e.NewPath,
 		oldPath:             e.OldPath,
+		truncated:           e.Op == loginp.OpTruncate,
 		name:                i.name + identitySep + osstate.InodeString() + "-" + i.markerContents(),
 		identifierGenerator: i.name,
 	}

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -29,6 +29,7 @@ import (
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/cleanup"
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -162,7 +163,7 @@ func (inp *filestream) Run(
 
 func initState(log *logp.Logger, c loginp.Cursor, s fileSource) state {
 	var state state
-	if c.IsNew() {
+	if c.IsNew() || s.truncated {
 		return state
 	}
 
@@ -175,7 +176,7 @@ func initState(log *logp.Logger, c loginp.Cursor, s fileSource) state {
 }
 
 func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, path string, offset int64) (reader.Reader, error) {
-	f, err := inp.openFile(path, offset)
+	f, err := inp.openFile(log, path, offset)
 	if err != nil {
 		return nil, err
 	}
@@ -224,20 +225,41 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, path stri
 // or the file cannot be opened because for example of failing read permissions, an error
 // is returned and the harvester is closed. The file will be picked up again the next time
 // the file system is scanned
-func (inp *filestream) openFile(path string, offset int64) (*os.File, error) {
-	err := inp.checkFileBeforeOpening(path)
+func (inp *filestream) openFile(log *logp.Logger, path string, offset int64) (*os.File, error) {
+	fi, err := os.Stat(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to stat source file %s: %s", path, err)
 	}
 
+	// it must be checked if the file is not a named pipe before we try to open it
+	// if it is a named pipe os.OpenFile fails, so there is no need to try opening it.
+	if fi.Mode()&os.ModeNamedPipe != 0 {
+		return nil, fmt.Errorf("failed to open file %s, named pipes are not supported", fi.Name())
+	}
+
+	ok := false
 	f, err := os.OpenFile(path, os.O_RDONLY, os.FileMode(0))
 	if err != nil {
 		return nil, fmt.Errorf("failed opening %s: %s", path, err)
 	}
+	defer cleanup.IfNot(&ok, cleanup.IgnoreError(f.Close))
 
+	fi, err = f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat source file %s: %s", path, err)
+	}
+
+	err = checkFileBeforeOpening(fi)
+	if err != nil {
+		return nil, err
+	}
+
+	if fi.Size() < offset {
+		log.Infof("File was truncated. Reading file from offset 0. Path=%s", path)
+		offset = 0
+	}
 	err = inp.initFileOffset(f, offset)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 
@@ -249,22 +271,14 @@ func (inp *filestream) openFile(path string, offset int64) (*os.File, error) {
 		}
 		return nil, fmt.Errorf("initialising encoding for '%v' failed: %v", f, err)
 	}
+	ok = true
 
 	return f, nil
 }
 
-func (inp *filestream) checkFileBeforeOpening(path string) error {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("failed to stat source file %s: %v", path, err)
-	}
-
+func checkFileBeforeOpening(fi os.FileInfo) error {
 	if !fi.Mode().IsRegular() {
 		return fmt.Errorf("tried to open non regular file: %q %s", fi.Mode(), fi.Name())
-	}
-
-	if fi.Mode()&os.ModeNamedPipe != 0 {
-		return fmt.Errorf("failed to open file %s, named pipes are not supported", path)
 	}
 
 	return nil
@@ -294,8 +308,7 @@ func (inp *filestream) readFromSource(
 		if err != nil {
 			switch err {
 			case ErrFileTruncate:
-				log.Info("File was truncated. Begin reading file from offset 0.")
-				s.Offset = 0
+				log.Infof("File was truncated. Begin reading file from offset 0. Path=%s", path)
 			case ErrClosed:
 				log.Info("Reader was closed. Closing.")
 			default:

--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/encoding"
@@ -513,6 +514,224 @@ func TestFilestreamCloseAfterIntervalRotatedAndNewRemoved(t *testing.T) {
 	env.mustRemoveFile(newFileName)
 
 	env.waitUntilHarvesterIsDone()
+
+	cancelInput()
+	env.waitUntilInputStops()
+}
+
+// test_truncated_file_open from test_harvester.py
+func TestFilestreamTruncatedFileOpen(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.mustTruncateFile(testlogName, 0)
+	time.Sleep(5 * time.Millisecond)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+	env.waitUntilEventCount(4)
+
+	cancelInput()
+	env.waitUntilInputStops()
+	env.requireOffsetInRegistry(testlogName, len(truncatedTestLines))
+}
+
+// test_truncated_file_closed from test_harvester.py
+func TestFilestreamTruncatedFileClosed(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+		"close.reader.on_eof":                "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.waitUntilHarvesterIsDone()
+
+	env.mustTruncateFile(testlogName, 0)
+	time.Sleep(5 * time.Millisecond)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+	env.waitUntilEventCount(4)
+
+	cancelInput()
+	env.waitUntilInputStops()
+	env.requireOffsetInRegistry(testlogName, len(truncatedTestLines))
+}
+
+// test_truncate from test_harvester.py
+func TestFilestreamTruncateWithSymlink(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(testlogName),
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+		"prospector.scanner.symlinks":        "true",
+	})
+
+	lines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, lines)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(3)
+
+	env.requireOffsetInRegistry(testlogName, len(lines))
+
+	// remove symlink
+	env.mustRemoveFile(symlinkName)
+	env.mustTruncateFile(testlogName, 0)
+	env.waitUntilOffsetInRegistry(testlogName, 0)
+
+	moreLines := []byte("forth line\nfifth line\n")
+	env.mustWriteLinesToFile(testlogName, moreLines)
+
+	env.waitUntilEventCount(5)
+	env.requireOffsetInRegistry(testlogName, len(moreLines))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(1)
+}
+
+func TestFilestreamTruncateBigScannerInterval(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "5s",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.mustTruncateFile(testlogName, 0)
+
+	truncatedTestLines := []byte("truncated first line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+
+	env.waitUntilEventCount(3)
+
+	cancelInput()
+	env.waitUntilInputStops()
+}
+
+func TestFilestreamTruncateCheckOffset(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	testlines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.waitUntilEventCount(3)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	env.mustTruncateFile(testlogName, 0)
+
+	env.waitUntilOffsetInRegistry(testlogName, 0)
+
+	cancelInput()
+	env.waitUntilInputStops()
+}
+
+func TestFilestreamTruncateBlockedOutput(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+	env.pipeline = &mockPipelineConnector{blocking: true}
+
+	testlogName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths":                              []string{env.abspath(testlogName)},
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+	})
+
+	testlines := []byte("first line\nsecond line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	for env.pipeline.clientsCount() != 1 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	env.pipeline.clients[0].waitUntilPublishingHasStarted()
+	env.pipeline.clients[0].canceler()
+
+	env.waitUntilEventCount(2)
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+
+	// extra lines are appended after first line is processed
+	// so it can interfere with the truncation of the file
+	env.mustAppendLinesToFile(testlogName, []byte("third line\n"))
+
+	env.mustTruncateFile(testlogName, 0)
+
+	env.waitUntilOffsetInRegistry(testlogName, 0)
+
+	// all newly started client has to be cancelled so events can be processed
+	env.pipeline.cancelAllClients()
+	// if a new client shows up, it should not block
+	env.pipeline.invertBlocking()
+
+	truncatedTestLines := []byte("truncated line\n")
+	env.mustWriteLinesToFile(testlogName, truncatedTestLines)
+
+	env.waitUntilEventCount(3)
+	env.waitUntilOffsetInRegistry(testlogName, len(truncatedTestLines))
 
 	cancelInput()
 	env.waitUntilInputStops()

--- a/filebeat/input/filestream/internal/input-logfile/fswatch.go
+++ b/filebeat/input/filestream/internal/input-logfile/fswatch.go
@@ -29,6 +29,7 @@ const (
 	OpWrite
 	OpDelete
 	OpRename
+	OpTruncate
 )
 
 // Operation describes what happened to a file.

--- a/filebeat/input/filestream/internal/input-logfile/prospector.go
+++ b/filebeat/input/filestream/internal/input-logfile/prospector.go
@@ -43,6 +43,9 @@ type StateMetadataUpdater interface {
 	UpdateMetadata(s Source, v interface{}) error
 	// Remove marks a state for deletion of a given Source.
 	Remove(s Source) error
+	// ResetCursor resets the cursor in the registry and drops previous state
+	// updates that are not yet ACKed.
+	ResetCursor(s Source, cur interface{}) error
 }
 
 // ProspectorCleaner cleans the state store before it starts running.

--- a/filebeat/input/filestream/internal/input-logfile/publish.go
+++ b/filebeat/input/filestream/internal/input-logfile/publish.go
@@ -124,11 +124,15 @@ func (op *updateOp) done(n uint) {
 // Execute updates the persistent store with the scheduled changes and releases the resource.
 func (op *updateOp) Execute(n uint) {
 	resource := op.resource
-	defer op.done(n)
 
 	resource.stateMutex.Lock()
 	defer resource.stateMutex.Unlock()
 
+	if resource.lockedVersion != op.resource.version {
+		return
+	}
+
+	defer op.done(n)
 	resource.activeCursorOperations -= n
 	if resource.activeCursorOperations == 0 {
 		resource.cursor = resource.pendingCursor

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -75,6 +75,10 @@ type resource struct {
 	// as long as pending is > 0 the resource is in used and must not be garbage collected.
 	pending atomic.Uint64
 
+	// current identity version when updated stateMutex must be locked.
+	// Pending updates will be discarded if it is increased.
+	version, lockedVersion uint
+
 	// lock guarantees only one input create updates for this entry
 	lock unison.Mutex
 
@@ -84,7 +88,7 @@ type resource struct {
 	// stateMutex is used to lock the resource when it is update/read from
 	// multiple go-routines like the ACK handler or the input publishing an
 	// event.
-	// stateMutex is used to access the fields 'stored', 'state' and 'internalInSync'
+	// stateMutex is used to access the fields 'stored', 'state', 'internalInSync' and 'version'.
 	stateMutex sync.Mutex
 
 	// stored indicates that the state is available in the registry file. It is false for new entries.
@@ -179,6 +183,11 @@ func (s *sourceStore) UpdateMetadata(src Source, v interface{}) error {
 func (s *sourceStore) Remove(src Source) error {
 	key := s.identifier.ID(src)
 	return s.store.remove(key)
+}
+
+func (s *sourceStore) ResetCursor(src Source, cur interface{}) error {
+	key := s.identifier.ID(src)
+	return s.store.resetCursor(key, cur)
 }
 
 // CleanIf sets the TTL of a resource if the predicate return true.
@@ -292,6 +301,29 @@ func (s *store) writeState(r *resource) {
 		r.stored = true
 		r.internalInSync = true
 	}
+}
+
+// resetCursor sets the cursor to the value in cur in the persistent store and
+// drops all pending cursor operations.
+func (s *store) resetCursor(key string, cur interface{}) error {
+	r := s.ephemeralStore.Find(key, false)
+	if r == nil {
+		return fmt.Errorf("resource '%s' not found", key)
+	}
+	defer r.Release()
+
+	r.stateMutex.Lock()
+	defer r.stateMutex.Unlock()
+
+	r.version++
+	r.UpdatesReleaseN(r.activeCursorOperations)
+	r.activeCursorOperations = 0
+	r.pendingCursor = nil
+	typeconv.Convert(&r.cursor, cur)
+
+	s.writeState(r)
+
+	return nil
 }
 
 // Removes marks an entry for removal by setting its TTL to zero.

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
@@ -224,6 +225,98 @@ func TestStore_UpdateTTL(t *testing.T) {
 		checkEqualStoreState(t, map[string]state{"test::key": wantMemoryState}, storeMemorySnapshot(store))
 		checkEqualStoreState(t, map[string]state{"test::key": wantInSyncState}, storeInSyncSnapshot(store))
 		checkEqualStoreState(t, map[string]state{"test::key": wantInSyncState}, backend.snapshot())
+	})
+}
+
+func TestStore_ResetCursor(t *testing.T) {
+	type cur struct {
+		Offset int
+	}
+	t.Run("reset cursor empty and lock it", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL: 60 * time.Second,
+			},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		require.Equal(t, uint(0), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, nil, res.cursor)
+		require.Equal(t, nil, res.pendingCursor)
+
+		store.resetCursor("test::key", cur{Offset: 10})
+
+		res = store.Get("test::key")
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, map[string]interface{}{"offset": int64(10)}, res.cursor)
+
+		res, err := lock(input.Context{}, store, "test::key")
+		require.NoError(t, err)
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(1), res.lockedVersion)
+	})
+
+	t.Run("reset cursor with no pending updates", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL:    60 * time.Second,
+				Cursor: cur{Offset: 6},
+			},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+		require.Equal(t, uint(0), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, map[string]interface{}{"offset": int64(6)}, res.cursor)
+		require.Equal(t, nil, res.pendingCursor)
+
+		store.resetCursor("test::key", cur{Offset: 0})
+
+		res = store.Get("test::key")
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, map[string]interface{}{"offset": int64(0)}, res.cursor)
+
+		res, err := lock(input.Context{}, store, "test::key")
+		require.NoError(t, err)
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(1), res.lockedVersion)
+	})
+
+	t.Run("reset cursor with pending updates", func(t *testing.T) {
+		store := testOpenStore(t, "test", createSampleStore(t, map[string]state{
+			"test::key": {
+				TTL:    60 * time.Second,
+				Cursor: cur{Offset: 6},
+			},
+		}))
+		defer store.Release()
+
+		res := store.Get("test::key")
+
+		// lock before creating a new update operation
+		res, err := lock(input.Context{}, store, "test::key")
+		require.NoError(t, err)
+		op, err := createUpdateOp(store, res, cur{Offset: 42})
+		require.NoError(t, err)
+
+		store.resetCursor("test::key", cur{Offset: 0})
+
+		// try to update cursor after it has been reset
+		op.Execute(1)
+		releaseResource(res)
+
+		res = store.Get("test::key")
+		require.Equal(t, uint(1), res.version)
+		require.Equal(t, uint(0), res.lockedVersion)
+		require.Equal(t, uint(0), res.activeCursorOperations)
+		require.Equal(t, map[string]interface{}{"offset": int64(0)}, res.cursor)
+		require.Equal(t, nil, res.pendingCursor)
+
 	})
 }
 

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -130,8 +130,13 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 						break
 					}
 				}
-
 				hg.Start(ctx, src)
+
+			case loginp.OpTruncate:
+				log.Debugf("File %s has been truncated", fe.NewPath)
+
+				s.ResetCursor(src, state{Offset: 0})
+				hg.Restart(ctx, src)
 
 			case loginp.OpDelete:
 				log.Debugf("File %s has been removed", fe.OldPath)


### PR DESCRIPTION
Cherry-pick of PR #24424 to 7.x branch. Original message: 

## What does this PR do?

Add support for truncated files and adds migrates related tests from `test_harvester.py`. It also adds more tests to cover the following cases:

* truncation is detected only by the `Prospector`
* truncation is detected first by the `Harvester` then by the `Prospector`
* truncation is detected first by the `Prospector` then by the `Harvester`
* file gets truncated when the output is not able to accept events

## Why is it important?

The support for stopping reading from truncated files was already implemented. However, `filestream` input could not start reading it from the beginning.

A new file system event is added called `OpTruncate`. When the size of a file has shrinked compared to the last time the scanner has encountered it, an `OpTruncate` event is emitted. When the prospector gets this event, the `HarvesterGroup` is restarting the `Harvester` of the file. Restarting basically means that the new `Harvester` cancels the previous reader and starts a new one.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~