### PR TITLE
Cherry-pick #24804 to 7.x: Stabilize filestream integration tests

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -129,11 +129,11 @@ func TestFilestreamCloseRemoved(t *testing.T) {
 		"close.on_state_change.removed":        "true",
 	})
 
-	ctx, cancelInput := context.WithCancel(context.Background())
-	env.startInput(ctx, inp)
-
 	testlines := []byte("first log line\n")
 	env.mustWriteLinesToFile(testlogName, testlines)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
 
 	// first event has made it successfully
 	env.waitUntilEventCount(1)
@@ -258,9 +258,6 @@ func TestFilestreamBOMUTF8(t *testing.T) {
 		"paths": []string{env.abspath(testlogName)},
 	})
 
-	ctx, cancelInput := context.WithCancel(context.Background())
-	env.startInput(ctx, inp)
-
 	// BOM: 0xEF,0xBB,0xBF
 	lines := append([]byte{0xEF, 0xBB, 0xBF}, []byte(`#Software: Microsoft Exchange Server
 #Version: 14.0.0.0
@@ -271,6 +268,9 @@ func TestFilestreamBOMUTF8(t *testing.T) {
 2016-04-05T00:00:02.145Z,,,,,"MDB:61914740-3f1b-4ddb-94e0-557196870cfa, Mailbox:49cb09c6-5b76-415d-a085-da0ad9079682, Event:269492711, MessageClass:IPM.Note.StorageQuotaWarning.Warning, CreationTime:2016-04-05T00:00:01.038Z, ClientType:System",,STOREDRIVER,NOTIFYMAPI,,,,,,,,,,,,,,,,,S:ItemEntryId=00-00-00-00-97-8F-07-43-51-44-61-4A-AD-BD-29-D4-97-4E-20-A0-07-00-0E-D6-03-16-80-DC-8C-44-9D-30-07-23-ED-71-B7-F7-00-8E-8F-BD-EB-57-00-00-3D-FB-CE-26-A4-8D-46-4C-A4-35-0F-A7-9B-FA-D7-B9-00-00-37-44-2F-CA-00-00
 `)...)
 	env.mustWriteLinesToFile(testlogName, lines)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
 
 	env.waitUntilEventCount(7)
 
@@ -300,9 +300,6 @@ func TestFilestreamUTF16BOMs(t *testing.T) {
 				"encoding": name,
 			})
 
-			ctx, cancelInput := context.WithCancel(context.Background())
-			env.startInput(ctx, inp)
-
 			line := []byte("first line\n")
 			buf := bytes.NewBuffer(nil)
 			writer := transform.NewWriter(buf, encoder)
@@ -310,6 +307,9 @@ func TestFilestreamUTF16BOMs(t *testing.T) {
 			writer.Close()
 
 			env.mustWriteLinesToFile(testlogName, buf.Bytes())
+
+			ctx, cancelInput := context.WithCancel(context.Background())
+			env.startInput(ctx, inp)
 
 			env.waitUntilEventCount(1)
 


### PR DESCRIPTION
Cherry-pick of PR #24804 to 7.x branch. Original message: 

## What does this PR do?

This PR stabilizes Golang integration tests of `filestream` input. Previously the prospector might not found the changes before the test has timed out.

## Why is it important?

More stable tests.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes https://github.com/elastic/beats/issues/24798