### PR TITLE
CI: curl seems to be available but where cannot find it

### DIFF
--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -8,10 +8,12 @@ IF NOT EXIST "%PROGRAMFILES(X86)%" (
 )
 set PATH=%WORKSPACE%\bin;C:\ProgramData\chocolatey\bin;C:\tools\mingw%MINGW_ARCH%\bin;%PATH%
 
-where /q curl
-IF ERRORLEVEL 1 (
+curl --version >nul 2>&1 && (
+    echo found curl
+) || (
     choco install curl -y --no-progress --skipdownloadcache
 )
+
 mkdir %WORKSPACE%\bin
 
 IF EXIST "%PROGRAMFILES(X86)%" (


### PR DESCRIPTION
## What does this PR do?

Use the curl binary if it's there instead installing, somehow `where` cannot find it, but as far as I see the curl is already provisioned in the Windows workers. 

## Why is it important?

Reduce the interactions with chocolatey as much as possible.