### PR TITLE
[filebeat] Use fail_on_template_error on google_workspace and okta pagination

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -388,7 +388,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Updating Oauth2 flow for m365_defender fileset. {pull}24829[24829]
 - Improve PanOS parsing and ingest pipeline. {issue}22413[22413] {issue}22748[22748] {pull}24799[24799]
 - Fix S3 input validation for non amazonaws.com domains. {issue}24420[24420] {pull}24861[24861]
-- Use fail_on_template_error on google_workspace and okta pagination. {pull}24967[24967]
+- Fix google_workspace and okta modules pagination when next page template is empty. {pull}24967[24967]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -388,6 +388,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Updating Oauth2 flow for m365_defender fileset. {pull}24829[24829]
 - Improve PanOS parsing and ingest pipeline. {issue}22413[22413] {issue}22748[22748] {pull}24799[24799]
 - Fix S3 input validation for non amazonaws.com domains. {issue}24420[24420] {pull}24861[24861]
+- Use fail_on_template_error on google_workspace and okta pagination. {pull}24967[24967]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/google_workspace/admin/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/admin/config/config.yml
@@ -28,6 +28,7 @@ response.pagination:
   - set:
       target: url.params.pageToken
       value: "[[.last_response.body.nextPageToken]]"
+      fail_on_template_error: true
 cursor:
   last_execution_datetime:
     value: "[[formatDate now]]"

--- a/x-pack/filebeat/module/google_workspace/drive/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/drive/config/config.yml
@@ -28,6 +28,7 @@ response.pagination:
   - set:
       target: url.params.pageToken
       value: "[[.last_response.body.nextPageToken]]"
+      fail_on_template_error: true
 cursor:
   last_execution_datetime:
     value: "[[formatDate now]]"

--- a/x-pack/filebeat/module/google_workspace/groups/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/groups/config/config.yml
@@ -28,6 +28,7 @@ response.pagination:
   - set:
       target: url.params.pageToken
       value: "[[.last_response.body.nextPageToken]]"
+      fail_on_template_error: true
 cursor:
   last_execution_datetime:
     value: "[[formatDate now]]"

--- a/x-pack/filebeat/module/google_workspace/login/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/login/config/config.yml
@@ -28,6 +28,7 @@ response.pagination:
   - set:
       target: url.params.pageToken
       value: "[[.last_response.body.nextPageToken]]"
+      fail_on_template_error: true
 cursor:
   last_execution_datetime:
     value: "[[formatDate now]]"

--- a/x-pack/filebeat/module/google_workspace/saml/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/saml/config/config.yml
@@ -28,6 +28,7 @@ response.pagination:
   - set:
       target: url.params.pageToken
       value: "[[.last_response.body.nextPageToken]]"
+      fail_on_template_error: true
 cursor:
   last_execution_datetime:
     value: "[[formatDate now]]"

--- a/x-pack/filebeat/module/google_workspace/user_accounts/config/config.yml
+++ b/x-pack/filebeat/module/google_workspace/user_accounts/config/config.yml
@@ -28,6 +28,7 @@ response.pagination:
   - set:
       target: url.params.pageToken
       value: "[[.last_response.body.nextPageToken]]"
+      fail_on_template_error: true
 cursor:
   last_execution_datetime:
     value: "[[formatDate now]]"

--- a/x-pack/filebeat/module/okta/system/config/input.yml
+++ b/x-pack/filebeat/module/okta/system/config/input.yml
@@ -36,6 +36,7 @@ response.pagination:
   - set:
       target: url.value
       value: '[[ getRFC5988Link "next" .last_response.header.Link ]]'
+      fail_on_template_error: true
 
 cursor:
   published:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Uses `fail_on_template_error` option for `google_workspace` and `okta` modules pagination.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

In some cases, the expected value used to paginate might not be there, and we want this to interrupt the execution instead of doing a request with an unexpected empty value.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
