### PR TITLE
Cherry-pick #24912 to 7.x: Kubernetes_secrets provider improvements

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yml
@@ -1,3 +1,655 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: elastic-agent
+  namespace: kube-system
+  labels:
+    app: elastic-agent
+spec:
+  selector:
+    matchLabels:
+      app: elastic-agent
+  template:
+    metadata:
+      labels:
+        app: elastic-agent
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: elastic-agent
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: elastic-agent
+          image: docker.elastic.co/beats/elastic-agent:8.0.0
+          args: ["-c", "/etc/agent.yml", "-e"]
+          env:
+            - name: ES_USERNAME
+              value: "elastic"
+            - name: ES_PASSWORD
+              value: ""
+            - name: ES_HOST
+              value: ""
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: datastreams
+              mountPath: /etc/agent.yml
+              readOnly: true
+              subPath: agent.yml
+            - name: proc
+              mountPath: /hostfs/proc
+              readOnly: true
+            - name: cgroup
+              mountPath: /hostfs/sys/fs/cgroup
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+      volumes:
+        - name: datastreams
+          configMap:
+            defaultMode: 0640
+            name: agent-node-datastreams
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlog
+          hostPath:
+            path: /var/log
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-node-datastreams
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-agent
+data:
+  agent.yml: |-
+    outputs:
+      default:
+        type: elasticsearch
+        hosts:
+          - >-
+            ${ES_HOST}
+        username: ${ES_USERNAME}
+        password: ${ES_PASSWORD}
+    agent:
+      monitoring:
+        enabled: true
+        use_output: default
+        logs: true
+        metrics: true
+    providers.kubernetes:
+      node: ${NODE_NAME}
+      scope: node
+    inputs:
+      - name: system-logs
+        type: logfile
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.10.7
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              dataset: system.auth
+              type: logs
+            paths:
+              - /var/log/auth.log*
+              - /var/log/secure*
+            exclude_files:
+              - .gz$
+            multiline:
+              pattern: ^\s
+              match: after
+            processors:
+              - add_fields:
+                  target: ''
+                  fields:
+                    ecs.version: 1.9.0
+          - data_stream:
+              dataset: system.syslog
+              type: logs
+            paths:
+              - /var/log/messages*
+              - /var/log/syslog*
+            exclude_files:
+              - .gz$
+            multiline:
+              pattern: ^\s
+              match: after
+            processors:
+              - add_fields:
+                  target: ''
+                  fields:
+                    ecs.version: 1.9.0
+      - name: container-log
+        type: logfile
+        use_output: default
+        meta:
+          package:
+            name: log
+            version: 0.4.6
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              dataset: generic
+            symlinks: true
+            paths:
+              - /var/log/containers/*${kubernetes.container.id}.log
+      - name: system-metrics
+        type: system/metrics
+        use_output: default
+        meta:
+          package:
+            name: system
+            version: 0.10.9
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              dataset: system.core
+              type: metrics
+            metricsets:
+              - core
+            core.metrics:
+              - percentages
+          - data_stream:
+              dataset: system.cpu
+              type: metrics
+            period: 10s
+            cpu.metrics:
+              - percentages
+              - normalized_percentages
+            metricsets:
+              - cpu
+          - data_stream:
+              dataset: system.diskio
+              type: metrics
+            period: 10s
+            diskio.include_devices: null
+            metricsets:
+              - diskio
+          - data_stream:
+              dataset: system.filesystem
+              type: metrics
+            period: 1m
+            metricsets:
+              - filesystem
+            processors:
+              - drop_event.when.regexp:
+                  system.filesystem.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+          - data_stream:
+              dataset: system.fsstat
+              type: metrics
+            period: 1m
+            metricsets:
+              - fsstat
+            processors:
+              - drop_event.when.regexp:
+                  system.fsstat.mount_point: ^/(sys|cgroup|proc|dev|etc|host|lib|snap)($|/)
+          - data_stream:
+              dataset: system.load
+              type: metrics
+            period: 10s
+            metricsets:
+              - load
+          - data_stream:
+              dataset: system.memory
+              type: metrics
+            period: 10s
+            metricsets:
+              - memory
+          - data_stream:
+              dataset: system.network
+              type: metrics
+            period: 10s
+            network.interfaces: null
+            metricsets:
+              - network
+          - data_stream:
+              dataset: system.process
+              type: metrics
+            process.include_top_n.by_memory: 5
+            period: 10s
+            processes:
+              - .*
+            process.include_top_n.by_cpu: 5
+            process.cgroups.enabled: false
+            process.cmdline.cache.enabled: true
+            metricsets:
+              - process
+            process.include_cpu_ticks: false
+            system.hostfs: /hostfs
+          - data_stream:
+              dataset: system.process_summary
+              type: metrics
+            period: 10s
+            metricsets:
+              - process_summary
+            system.hostfs: /hostfs
+          - data_stream:
+              dataset: system.socket_summary
+              type: metrics
+            period: 10s
+            metricsets:
+              - socket_summary
+            system.hostfs: /hostfs
+      - name: kubernetes-node-metrics
+        type: kubernetes/metrics
+        use_output: default
+        meta:
+          package:
+            name: kubernetes
+            version: 0.2.8
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              dataset: kubernetes.controllermanager
+              type: metrics
+            metricsets:
+              - controllermanager
+            hosts:
+              - '${kubernetes.pod.ip}:10252'
+            period: 10s
+            condition: ${kubernetes.pod.labels.component} == 'kube-controller-manager'
+          - data_stream:
+              dataset: kubernetes.scheduler
+              type: metrics
+            metricsets:
+              - scheduler
+            hosts:
+              - '${kubernetes.pod.ip}:10251'
+            period: 10s
+            condition: ${kubernetes.pod.labels.component} == 'kube-scheduler'
+          - data_stream:
+              dataset: kubernetes.proxy
+              type: metrics
+            metricsets:
+              - proxy
+            hosts:
+              - 'localhost:10249'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.container
+              type: metrics
+            metricsets:
+              - container
+            add_metadata: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            hosts:
+              - 'https://${env.NODE_NAME}:10250'
+            period: 10s
+            ssl.verification_mode: none
+          - data_stream:
+              dataset: kubernetes.node
+              type: metrics
+            metricsets:
+              - node
+            add_metadata: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            hosts:
+              - 'https://${env.NODE_NAME}:10250'
+            period: 10s
+            ssl.verification_mode: none
+          - data_stream:
+              dataset: kubernetes.pod
+              type: metrics
+            metricsets:
+              - pod
+            add_metadata: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            hosts:
+              - 'https://${env.NODE_NAME}:10250'
+            period: 10s
+            ssl.verification_mode: none
+          - data_stream:
+              dataset: kubernetes.system
+              type: metrics
+            metricsets:
+              - system
+            add_metadata: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            hosts:
+              - 'https://${env.NODE_NAME}:10250'
+            period: 10s
+            ssl.verification_mode: none
+          - data_stream:
+              dataset: kubernetes.volume
+              type: metrics
+            metricsets:
+              - volume
+            add_metadata: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            hosts:
+              - 'https://${env.NODE_NAME}:10250'
+            period: 10s
+            ssl.verification_mode: none
+      # Add extra input blocks here, based on conditions
+      # so as to automatically identify targeted Pods and start monitoring them
+      # using a predefined integration. For instance:
+      #- name: redis
+      #  type: redis/metrics
+      #  use_output: default
+      #  meta:
+      #    package:
+      #      name: redis
+      #      version: 0.3.6
+      #  data_stream:
+      #    namespace: default
+      #  streams:
+      #    - data_stream:
+      #        dataset: redis.info
+      #        type: metrics
+      #      metricsets:
+      #        - info
+      #      hosts:
+      #        - '${kubernetes.pod.ip}:6379'
+      #      idle_timeout: 20s
+      #      maxconn: 10
+      #      network: tcp
+      #      period: 10s
+      #      condition: ${kubernetes.pod.labels.app} == 'redis'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: elastic-agent
+  namespace: kube-system
+  labels:
+    app: elastic-agent
+spec:
+  selector:
+    matchLabels:
+      app: elastic-agent
+  template:
+    metadata:
+      labels:
+        app: elastic-agent
+    spec:
+      serviceAccountName: elastic-agent
+      containers:
+        - name: elastic-agent
+          image: docker.elastic.co/beats/elastic-agent:8.0.0
+          args: ["-c", "/etc/agent.yml", "-e"]
+          env:
+            - name: ES_USERNAME
+              value: "elastic"
+            - name: ES_PASSWORD
+              value: ""
+            - name: ES_HOST
+              value: ""
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # this is needed because we cannot use hostNetwork
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+            - name: datastreams
+              mountPath: /etc/agent.yml
+              readOnly: true
+              subPath: agent.yml
+      volumes:
+        - name: datastreams
+          configMap:
+            defaultMode: 0640
+            name: agent-deployment-datastreams
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-deployment-datastreams
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-agent
+data:
+  # This part requires `kube-state-metrics` up and running under `kube-system` namespace
+  agent.yml: |-
+    outputs:
+      default:
+        type: elasticsearch
+        hosts:
+          - >-
+            ${ES_HOST}
+        username: ${ES_USERNAME}
+        password: ${ES_PASSWORD}
+    agent:
+      monitoring:
+        enabled: true
+        use_output: default
+        logs: true
+        metrics: true
+    inputs:
+      - name: kubernetes-cluster-metrics
+        type: kubernetes/metrics
+        use_output: default
+        meta:
+          package:
+            name: kubernetes
+            version: 0.2.8
+        data_stream:
+          namespace: default
+        streams:
+          - data_stream:
+              dataset: kubernetes.apiserver
+              type: metrics
+            metricsets:
+              - apiserver
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            hosts:
+              - 'https://${env.KUBERNETES_SERVICE_HOST}:${env.KUBERNETES_SERVICE_PORT}'
+            period: 30s
+            ssl.certificate_authorities:
+              - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - data_stream:
+              dataset: kubernetes.event
+              type: metrics
+            metricsets:
+              - event
+            period: 10s
+            add_metadata: true
+          - data_stream:
+              dataset: kubernetes.state_container
+              type: metrics
+            metricsets:
+              - state_container
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_cronjob
+              type: metrics
+            metricsets:
+              - state_cronjob
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_deployment
+              type: metrics
+            metricsets:
+              - state_deployment
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_node
+              type: metrics
+            metricsets:
+              - state_node
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_persistentvolume
+              type: metrics
+            metricsets:
+              - state_persistentvolume
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_persistentvolumeclaim
+              type: metrics
+            metricsets:
+              - state_persistentvolumeclaim
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_pod
+              type: metrics
+            metricsets:
+              - state_pod
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_replicaset
+              type: metrics
+            metricsets:
+              - state_replicaset
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_resourcequota
+              type: metrics
+            metricsets:
+              - state_resourcequota
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_service
+              type: metrics
+            metricsets:
+              - state_service
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_statefulset
+              type: metrics
+            metricsets:
+              - state_statefulset
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+          - data_stream:
+              dataset: kubernetes.state_storageclass
+              type: metrics
+            metricsets:
+              - state_storageclass
+            add_metadata: true
+            hosts:
+              - 'kube-state-metrics:8080'
+            period: 10s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+  - kind: ServiceAccount
+    name: elastic-agent
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+  labels:
+    k8s-app: elastic-agent
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+    verbs: ["get", "list", "watch"]
+  # Enable this rule only if planing to use kubernetes_secrets provider
+  #- apiGroups: [""]
+  #  resources:
+  #  - secrets
+  #  verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+  # required for apiserver
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-role.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-role.yaml
@@ -12,6 +12,11 @@ rules:
       - events
       - pods
     verbs: ["get", "list", "watch"]
+  # Enable this rule only if planing to use kubernetes_secrets provider
+  #- apiGroups: [""]
+  #  resources:
+  #  - secrets
+  #  verbs: ["get"]
   - apiGroups: ["extensions"]
     resources:
       - replicasets

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetessecrets/kubernetes_secrets.go
@@ -47,6 +47,9 @@ func ContextProviderBuilder(logger *logger.Logger, c *config.Config) (corecomp.C
 
 func (p *contextProviderK8sSecrets) Fetch(key string) (string, bool) {
 	// key = "kubernetes_secrets.somenamespace.somesecret.value"
+	if p.client == nil {
+		return "", false
+	}
 	tokens := strings.Split(key, ".")
 	if len(tokens) > 0 && tokens[0] != "kubernetes_secrets" {
 		return "", false


### PR DESCRIPTION
Cherry-pick of PR #24912 to 7.x branch. Original message: 

Minor leftovers from https://github.com/elastic/beats/pull/24789.

1. Return from `Fetch()` if k8s client is not initialised. This can happen if the provider failed to get started with `Run()` cause api can be unreachable. In such cases `Fetch()` will then panic. We need to skip `Fetch()` in such cases.
2. Add the commented out section in Agent's k8s manifests about Secrets api.