### PR TITLE
Cherry-pick to 7.x: [Elastic Agent]: Reduce allowed socket path length (#24914)

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/control/addr.go
+++ b/x-pack/elastic-agent/pkg/agent/control/addr.go
@@ -22,9 +22,9 @@ func Address() string {
 		return paths.SocketPath
 	}
 
-	// unix socket path cannot be longer than 107 characters
+	// unix socket path must be less than 104 characters
 	path := fmt.Sprintf("unix://%s.sock", filepath.Join(paths.TempDir(), "elastic-agent-control"))
-	if len(path) <= 107 {
+	if len(path) < 104 {
 		return path
 	}
 	// place in global /tmp to ensure that its small enough to fit; current path is way to long

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/monitoring.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/monitoring.go
@@ -33,9 +33,9 @@ func getMonitoringEndpoint(spec program.Spec, operatingSystem, pipelineID string
 	if operatingSystem == "windows" {
 		return fmt.Sprintf(mbEndpointFileFormatWin, pipelineID, spec.Cmd)
 	}
-	// unix socket path cannot be longer than 107 characters
+	// unix socket path must be less than 104 characters
 	path := fmt.Sprintf("unix://%s.sock", filepath.Join(paths.TempDir(), pipelineID, spec.Cmd, spec.Cmd))
-	if len(path) <= 107 {
+	if len(path) < 104 {
 		return path
 	}
 	// place in global /tmp to ensure that its small enough to fit; current path is way to long
@@ -58,9 +58,9 @@ func AgentMonitoringEndpoint(operatingSystem string) string {
 	if operatingSystem == "windows" {
 		return agentMbEndpointFileFormatWin
 	}
-	// unix socket path cannot be longer than 107 characters
+	// unix socket path must be less than 104 characters
 	path := fmt.Sprintf("unix://%s.sock", filepath.Join(paths.TempDir(), "elastic-agent"))
-	if len(path) <= 107 {
+	if len(path) < 104 {
 		return path
 	}
 	// place in global /tmp to ensure that its small enough to fit; current path is way to long


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Elastic Agent]: Reduce allowed socket path length (#24914)