### PR TITLE
Disable banner logging from Azure EventHubs library

### DIFF
--- a/x-pack/filebeat/input/azureeventhub/eph.go
+++ b/x-pack/filebeat/input/azureeventhub/eph.go
@@ -46,13 +46,15 @@ func (a *azureInput) runWithEPH() error {
 			fmt.Sprintf("%s%s%s", a.config.ConnectionString, eventHubConnector, a.config.EventHubName),
 			leaserCheckpointer,
 			leaserCheckpointer,
-			eph.WithConsumerGroup(a.config.ConsumerGroup))
+			eph.WithConsumerGroup(a.config.ConsumerGroup),
+			eph.WithNoBanner())
 	} else {
 		a.processor, err = eph.NewFromConnectionString(
 			a.workerCtx,
 			fmt.Sprintf("%s%s%s", a.config.ConnectionString, eventHubConnector, a.config.EventHubName),
 			leaserCheckpointer,
-			leaserCheckpointer)
+			leaserCheckpointer,
+			eph.WithNoBanner())
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
## What does this PR do?

The filebeat log contains this when you use the `azure-eventhub` input. This disables that output.

    Apr 05 15:14:43 something filebeat[410843]:    / ____/   _____  ____  / /_/ / / /_  __/ /_  _____
    Apr 05 15:14:43 something filebeat[410843]:   / __/ | | / / _ \/ __ \/ __/ /_/ / / / / __ \/ ___/
    Apr 05 15:14:43 something filebeat[410843]:  / /___ | |/ /  __/ / / / /_/ __  / /_/ / /_/ (__  )
    Apr 05 15:14:43 something filebeat[410843]: /_____/ |___/\___/_/ /_/\__/_/ /_/\__,_/_.___/____/
    Apr 05 15:14:43 something filebeat[410843]: => processing events, ctrl+c to exit

## Why is it important?

It's unnecessary log output that's from an embedded library.

## Checklist

- [x] My code follows the style guidelines of this project

## Logs

https://discuss.elastic.co/t/filebeat-azure-module-error-code-409-blobalreadyexists/269251?u=andrewkroh 
