### PR TITLE
Add cloud.service.name to add_cloud_metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -599,7 +599,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Add `wineventlog` schema to `decode_xml` processor. {issue}23910[23910] {pull}24726[24726]
-- Add new ECS 1.9 field `cloud.service.name` to `add_cloud_metadata` processor. {pull}1[1]
+- Add new ECS 1.9 field `cloud.service.name` to `add_cloud_metadata` processor. {pull}24993[24993]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -599,6 +599,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Add `wineventlog` schema to `decode_xml` processor. {issue}23910[23910] {pull}24726[24726]
+- Add new ECS 1.9 field `cloud.service.name` to `add_cloud_metadata` processor. {pull}1[1]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud.go
@@ -33,6 +33,9 @@ var alibabaCloudMetadataFetcher = provider{
 		ecsMetadataZoneURI := "/latest/meta-data/zone-id"
 
 		ecsSchema := func(m map[string]interface{}) common.MapStr {
+			m["service"] = common.MapStr{
+				"name": "ECS",
+			}
 			return common.MapStr(m)
 		}
 

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
@@ -81,6 +81,9 @@ func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
 			},
 			"region":            "cn-shenzhen",
 			"availability_zone": "cn-shenzhen-a",
+			"service": common.MapStr{
+				"name": "ECS",
+			},
 		},
 	}
 	assert.Equal(t, expected, actual.Fields)

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -33,13 +33,17 @@ var ec2MetadataFetcher = provider{
 
 	Create: func(_ string, config *common.Config) (metadataFetcher, error) {
 		ec2Schema := func(m map[string]interface{}) common.MapStr {
+			m["serviceName"] = "EC2"
 			out, _ := s.Schema{
 				"instance":          s.Object{"id": c.Str("instanceId")},
 				"machine":           s.Object{"type": c.Str("instanceType")},
 				"region":            c.Str("region"),
 				"availability_zone": c.Str("availabilityZone"),
-				"account":           s.Object{"id": c.Str("accountId")},
-				"image":             s.Object{"id": c.Str("imageId")},
+				"service": s.Object{
+					"name": c.Str("serviceName"),
+				},
+				"account": s.Object{"id": c.Str("accountId")},
+				"image":   s.Object{"id": c.Str("imageId")},
 			}.Apply(m)
 			return out
 		}

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -72,7 +72,7 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 	  "imageId" : "%s",
 	  "instanceType" : "%s",
 	  "devpayProductCodes" : null,
-	  "privateIp" : "10.0.0.1",	  
+	  "privateIp" : "10.0.0.1",
 	  "version" : "2010-08-31",
 	  "billingProducts" : null,
 	  "pendingTime" : "2016-09-20T15:43:02Z",
@@ -114,6 +114,9 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 					"image":             common.MapStr{"id": imageIDDoc1},
 					"region":            regionDoc1,
 					"availability_zone": availabilityZoneDoc1,
+					"service": common.MapStr{
+						"name": "EC2",
+					},
 				},
 			},
 		},
@@ -154,6 +157,9 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 					"image":             common.MapStr{"id": imageIDDoc1},
 					"region":            regionDoc1,
 					"availability_zone": availabilityZoneDoc1,
+					"service": common.MapStr{
+						"name": "EC2",
+					},
 				},
 			},
 		},
@@ -172,6 +178,9 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 					"image":             common.MapStr{"id": imageIDDoc1},
 					"region":            regionDoc1,
 					"availability_zone": availabilityZoneDoc1,
+					"service": common.MapStr{
+						"name": "EC2",
+					},
 				},
 			},
 		},
@@ -194,6 +203,9 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 					"image":             common.MapStr{"id": imageIDDoc1},
 					"region":            regionDoc1,
 					"availability_zone": availabilityZoneDoc1,
+					"service": common.MapStr{
+						"name": "EC2",
+					},
 				},
 			},
 		},
@@ -215,6 +227,9 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 					"image":             common.MapStr{"id": imageIDDoc1},
 					"region":            regionDoc1,
 					"availability_zone": availabilityZoneDoc1,
+					"service": common.MapStr{
+						"name": "EC2",
+					},
 				},
 			},
 		},

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm.go
@@ -33,6 +33,7 @@ var azureVMMetadataFetcher = provider{
 		azMetadataURI := "/metadata/instance/compute?api-version=2017-04-02"
 		azHeaders := map[string]string{"Metadata": "true"}
 		azSchema := func(m map[string]interface{}) common.MapStr {
+			m["serviceName"] = "Virtual Machines"
 			out, _ := s.Schema{
 				"account": s.Object{
 					"id": c.Str("subscriptionId"),
@@ -43,6 +44,9 @@ var azureVMMetadataFetcher = provider{
 				},
 				"machine": s.Object{
 					"type": c.Str("vmSize"),
+				},
+				"service": s.Object{
+					"name": c.Str("serviceName"),
 				},
 				"region": c.Str("location"),
 			}.Apply(m)

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
@@ -91,6 +91,9 @@ func TestRetrieveAzureMetadata(t *testing.T) {
 			"account": common.MapStr{
 				"id": "5tfb04c3-63de-4709-a9f9-9ab8c0411d5e",
 			},
+			"service": common.MapStr{
+				"name": "Virtual Machines",
+			},
 			"region": "eastus2",
 		},
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean.go
@@ -31,11 +31,15 @@ var doMetadataFetcher = provider{
 
 	Create: func(provider string, config *common.Config) (metadataFetcher, error) {
 		doSchema := func(m map[string]interface{}) common.MapStr {
+			m["serviceName"] = "Droplets"
 			out, _ := s.Schema{
 				"instance": s.Object{
 					"id": c.StrFromNum("droplet_id"),
 				},
 				"region": c.Str("region"),
+				"service": s.Object{
+					"name": c.Str("serviceName"),
+				},
 			}.Apply(m)
 			return out
 		}

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
@@ -117,6 +117,9 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 			"instance": common.MapStr{
 				"id": "1111111",
 			},
+			"service": common.MapStr{
+				"name": "Droplets",
+			},
 			"region": "nyc3",
 		},
 	}

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce.go
@@ -35,7 +35,11 @@ var gceMetadataFetcher = provider{
 		gceMetadataURI := "/computeMetadata/v1/?recursive=true&alt=json"
 		gceHeaders := map[string]string{"Metadata-Flavor": "Google"}
 		gceSchema := func(m map[string]interface{}) common.MapStr {
-			out := common.MapStr{}
+			out := common.MapStr{
+				"service": common.MapStr{
+					"name": "GCE",
+				},
+			}
 
 			trimLeadingPath := func(key string) {
 				v, err := out.GetValue(key)

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -167,6 +167,9 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 			"project": common.MapStr{
 				"id": "test-dev",
 			},
+			"service": common.MapStr{
+				"name": "GCE",
+			},
 		},
 	}
 	assert.Equal(t, expected, actual.Fields)

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova.go
@@ -46,6 +46,9 @@ var openstackNovaSSLMetadataFetcher = provider{
 func buildOpenstackNovaCreate(scheme string) func(provider string, c *common.Config) (metadataFetcher, error) {
 	return func(provider string, c *common.Config) (metadataFetcher, error) {
 		osSchema := func(m map[string]interface{}) common.MapStr {
+			m["service"] = common.MapStr{
+				"name": "Nova",
+			}
 			return common.MapStr(m)
 		}
 

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
@@ -109,6 +109,9 @@ func assertOpenstackNova(t *testing.T, config *common.Config) {
 				"type": "m1.xlarge",
 			},
 			"availability_zone": "az-test-2",
+			"service": common.MapStr{
+				"name": "Nova",
+			},
 		},
 	}
 	assert.Equal(t, expected, actual.Fields)

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud.go
@@ -33,6 +33,9 @@ var qcloudMetadataFetcher = provider{
 		qcloudMetadataZoneURI := "/meta-data/placement/zone"
 
 		qcloudSchema := func(m map[string]interface{}) common.MapStr {
+			m["service"] = common.MapStr{
+				"name": "CVM",
+			}
 			return common.MapStr(m)
 		}
 

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
@@ -81,6 +81,9 @@ func TestRetrieveQCloudMetadata(t *testing.T) {
 			},
 			"region":            "china-south-gz",
 			"availability_zone": "gz-azone2",
+			"service": common.MapStr{
+				"name": "CVM",
+			},
 		},
 	}
 	assert.Equal(t, expected, actual.Fields)


### PR DESCRIPTION
## What does this PR do?

This adds the new ECS 1.9 field `cloud.service.name` to `add_cloud_metadata`.

I tried to use the names of each service we're retrieving metadata for as it exists in the majority of the literature. In some cases this means this uses shorthand names (i.e. `EC2`) and, when shorthand isn't commonly in the cloud provider's docs (i.e. AWS), the full name is used (i.e. `Virtual Machines`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.