### PR TITLE
Use max_primary_shard_size instead of max_size

### DIFF
--- a/libbeat/idxmgmt/ilm/config.go
+++ b/libbeat/idxmgmt/ilm/config.go
@@ -48,8 +48,8 @@ var DefaultPolicy = mapstr.M{
 			"hot": mapstr.M{
 				"actions": mapstr.M{
 					"rollover": mapstr.M{
-						"max_size": "50gb",
-						"max_age":  "30d",
+						"max_primary_shard_size": "50gb",
+						"max_age":                "30d",
 					},
 				},
 			},

--- a/libbeat/tests/system/idxmgmt.py
+++ b/libbeat/tests/system/idxmgmt.py
@@ -95,7 +95,7 @@ class IdxMgmt(unittest.TestCase):
     def assert_policy_created(self, policy):
         resp = self._client.transport.perform_request('GET', '/_ilm/policy/' + policy)
         assert policy in resp
-        assert resp[policy]["policy"]["phases"]["hot"]["actions"]["rollover"]["max_size"] == "50gb"
+        assert resp[policy]["policy"]["phases"]["hot"]["actions"]["rollover"]["max_primary_shard_size"] == "50gb"
         assert resp[policy]["policy"]["phases"]["hot"]["actions"]["rollover"]["max_age"] == "30d"
 
     def assert_docs_written_to_data_stream(self, data_stream):

--- a/libbeat/tests/system/test_ilm.py
+++ b/libbeat/tests/system/test_ilm.py
@@ -196,7 +196,7 @@ class TestCommandExportILMPolicy(BaseTest):
     def assert_log_contains_policy(self):
         assert self.log_contains(MSG_ILM_POLICY_LOADED)
         assert self.log_contains('"max_age": "30d"')
-        assert self.log_contains('"max_size": "50gb"')
+        assert self.log_contains('"max_primary_shard_size": "50gb"')
 
     def test_default(self):
         """
@@ -246,7 +246,7 @@ class TestCommandExportILMPolicy(BaseTest):
         file = os.path.join(base_path, "policy", self.policy_name + '.json')
         with open(file) as f:
             policy = json.load(f)
-        assert policy["policy"]["phases"]["hot"]["actions"]["rollover"]["max_size"] == "50gb", policy
+        assert policy["policy"]["phases"]["hot"]["actions"]["rollover"]["max_primary_shard_size"] == "50gb", policy
         assert policy["policy"]["phases"]["hot"]["actions"]["rollover"]["max_age"] == "30d", policy
 
         os.remove(file)
@@ -266,7 +266,7 @@ class TestCommandExportILMPolicy(BaseTest):
         file = os.path.join(base_path, "policy", self.policy_name + '.json')
         with open(file) as f:
             policy = json.load(f)
-        assert policy["policy"]["phases"]["hot"]["actions"]["rollover"]["max_size"] == "50gb", policy
+        assert policy["policy"]["phases"]["hot"]["actions"]["rollover"]["max_primary_shard_size"] == "50gb", policy
         assert policy["policy"]["phases"]["hot"]["actions"]["rollover"]["max_age"] == "30d", policy
 
         os.remove(file)


### PR DESCRIPTION
Based on change from https://github.com/elastic/elasticsearch/pull/69995

Users are having a hard time to have the "right sized shards" (~50gb),
but they also need to adjust the number of primaries to keep up with the
ingest load. This doesn't well with the `max_size` option but it should
work nicely with the newly introduced `max_primary_shard_size`.

This change the default ILM policy shipped with beats.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
