### PR TITLE
Remove make docs-preview instructions

### DIFF
--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -168,10 +168,8 @@ For more details check the <<testing>> guide.
 
 The documentation for each Beat is located under `{beatname}/docs` and is based
 on asciidoc. After changing the docs, you should verify that the docs are still
-building to avoid breaking the automated docs build. To build the docs run
-`make docs`. If you want to preview the docs for a specific Beat, run
-`make docs-preview` inside the folder for the Beat. This will automatically open
-your browser with the docs for preview.
+building to avoid breaking the automated docs build. To learn more about
+contributing docs, seethe https://github.com/elastic/docs/blob/master/README.asciidoc[Docs HOWTO].
 
 [float]
 [[dependencies]]

--- a/docs/devguide/contributing.asciidoc
+++ b/docs/devguide/contributing.asciidoc
@@ -169,7 +169,7 @@ For more details check the <<testing>> guide.
 The documentation for each Beat is located under `{beatname}/docs` and is based
 on asciidoc. After changing the docs, you should verify that the docs are still
 building to avoid breaking the automated docs build. To learn more about
-contributing docs, seethe https://github.com/elastic/docs/blob/master/README.asciidoc[Docs HOWTO].
+contributing docs, see the https://github.com/elastic/docs/blob/master/README.asciidoc[Docs HOWTO].
 
 [float]
 [[dependencies]]


### PR DESCRIPTION
This command hasn't worked for a long time. Now that we have PR builds, users don't really need to run a local build to avoid breaking the doc build. 