### PR TITLE
[mergify] assign the original author

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,6 +6,8 @@ pull_request_rules:
       - label=backport-v7.13.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.x"
   - name: backport patches to 7.12 branch
@@ -15,6 +17,8 @@ pull_request_rules:
       - label=backport-v7.12.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.12"
   - name: backport patches to 7.11 branch
@@ -24,6 +28,8 @@ pull_request_rules:
       - label=backport-v7.11.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.11"
   - name: ask to resolve conflict


### PR DESCRIPTION
## What does this PR do?

Mergify now supports the original author assignation. https://docs.mergify.io/actions/backport/#options

## Why is it important?

To help with the tracking when mergify creates backports