### PR TITLE
[elastic-agent] Use fleet.url for container cmd

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -317,6 +317,9 @@ func buildEnrollArgs(cfg setupConfig, token string, policyID string) ([]string, 
 		if cfg.FleetServer.CertKey != "" {
 			args = append(args, "--fleet-server-cert-key", cfg.FleetServer.CertKey)
 		}
+		if cfg.Fleet.URL != "" {
+			args = append(args, "--url", cfg.Fleet.URL)
+		}
 		if cfg.FleetServer.InsecureHTTP {
 			args = append(args, "--fleet-server-insecure-http")
 			args = append(args, "--insecure")


### PR DESCRIPTION

## What does this PR do?
When running the elastic-agent container command with `fleet-server.enable:true` and providing `--url`, `--fleet-server-cert` and `--fleet-server-cert-key`, the container returns a setup error, claiming that `url` is not set. 
This PR ensures that the URL is also set for fleet server setup. 

Previous related: https://github.com/elastic/beats/pull/24904

## Why is it important?
This is important as otherwise no certificate and cert-key could ever be configured for the Fleet Server. When only Fleet Server and Elastic-Agent communicate with each other, certificates are created on-the-fly and communication is secured. But one also needs to be able to use a secure connection and certificates e.g. from a proxy to the Fleet Server. 
