### PR TITLE
Cherry-pick #25034 to 7.12: Disable TestXPackEnabled flaky test in logstash metricbeat module

### DIFF
--- a/metricbeat/module/logstash/logstash_integration_test.go
+++ b/metricbeat/module/logstash/logstash_integration_test.go
@@ -72,6 +72,7 @@ func TestData(t *testing.T) {
 }
 
 func TestXPackEnabled(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/24822")
 	lsService := compose.EnsureUpWithTimeout(t, 300, "logstash")
 	esService := compose.EnsureUpWithTimeout(t, 300, "elasticsearch")
 


### PR DESCRIPTION
Cherry-pick of PR #25034 to 7.12 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to disable flaky test `TestXPackEnabled` in logstash metricbeat module.

## Related issues

- Relates https://github.com/elastic/beats/issues/24822
