### PR TITLE
Support summary and detailed file metrics in filestream input

### DIFF
--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -144,6 +144,25 @@ Furthermore, to avoid duplicate of rotated log messages, do not use the
 `path` method for `file_identity`. Or exclude the rotated files with `exclude_files`
 option.
 
+[id="{beatname_lc}-input-{type}-options"]
+==== Input options
+
+
+The `filestream` input supports the following configuration options plus the
+<<{beatname_lc}-input-{type}-common-options>> described later.
+
+[float]
+[[filestream-input-id]]
+===== `id`
+
+Every input has an id attribute. It is used for identifing states in the registry
+and during collecting file metrics. By default it is set to `.global` for every input.
+
+You must configure an id for your inputs if you would like to collect the
+same file from different input instances so Filebeat can tell apart the
+states in the registry. After you configured an ID, do not change it, unless
+you accpet that the input will not be able to find its file states in the registry.
+
 include::../inputs/input-filestream-file-options.asciidoc[]
 
 include::../inputs/input-filestream-reader-options.asciidoc[]

--- a/filebeat/input/filestream/config.go
+++ b/filebeat/input/filestream/config.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile"
@@ -30,6 +31,8 @@ import (
 
 // Config stores the options of a file stream.
 type config struct {
+	ID string `config:"id"`
+
 	Reader readerConfig `config:",inline"`
 
 	Paths          []string                `config:"paths"`
@@ -80,6 +83,7 @@ type backoffConfig struct {
 
 func defaultConfig() config {
 	return config{
+		ID:             loginp.GlobalInputID,
 		Reader:         defaultReaderConfig(),
 		Paths:          []string{},
 		Close:          defaultCloserConfig(),

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/acker"
 	"github.com/elastic/beats/v7/libbeat/common/transform/typeconv"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
 )
@@ -81,6 +82,9 @@ func (e *inputTestingEnvironment) mustCreateInput(config map[string]interface{})
 
 func (e *inputTestingEnvironment) getManager() v2.InputManager {
 	e.pluginInitOnce.Do(func() {
+		if monitoring.Default.GetRegistry("filebeat.filestream.readers") != nil {
+			monitoring.Default.Remove("filebeat.filestream.readers")
+		}
 		e.plugin = Plugin(logp.L(), e.stateStore)
 	})
 	return e.plugin.Manager

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -63,9 +63,10 @@ func (inp *managedInput) Run(
 
 	hg := &defaultHarvesterGroup{
 		pipeline:     pipeline,
-		readers:      newReaderGroupWithLimit(inp.harvesterLimit),
+		readers:      newReaderGroupWithLimit(inp.harvesterLimit, inp.manager.metrics),
 		cleanTimeout: inp.cleanTimeout,
 		harvester:    inp.harvester,
+		metrics:      inp.manager.metrics,
 		store:        groupStore,
 		identifier:   inp.sourceIdentifier,
 		tg:           unison.TaskGroup{},

--- a/filebeat/input/filestream/internal/input-logfile/metrics.go
+++ b/filebeat/input/filestream/internal/input-logfile/metrics.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package input_logfile
+
+import "github.com/elastic/beats/v7/libbeat/monitoring"
+
+// readerMetrics contains the basic summary of file readers in filestream input.
+type readerMetrics struct {
+	reg     *monitoring.Registry
+	started *monitoring.Int
+	stopped *monitoring.Int
+	running *monitoring.Int
+	failed  *monitoring.Int
+}
+
+func newReaderMetrics(pluginName string) *readerMetrics {
+	r := monitoring.Default.NewRegistry("filebeat." + pluginName + ".readers")
+	return &readerMetrics{
+		reg:     r,
+		started: monitoring.NewInt(r, "started"),
+		stopped: monitoring.NewInt(r, "stopped"),
+		running: monitoring.NewInt(r, "running"),
+		failed:  monitoring.NewInt(r, "failed"),
+	}
+}
+
+func (r *readerMetrics) onReaderStarted() {
+	r.started.Inc()
+	r.running.Inc()
+}
+
+func (r *readerMetrics) onReaderStopped() {
+	r.stopped.Inc()
+	r.running.Dec()
+}
+
+func (r *readerMetrics) onReaderGroupStopped(count int64) {
+	r.stopped.Add(count)
+	r.running.Sub(count)
+}
+
+func (r *readerMetrics) onReaderFailed() {
+	r.failed.Inc()
+}

--- a/filebeat/input/filestream/metrics.go
+++ b/filebeat/input/filestream/metrics.go
@@ -1,0 +1,147 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filestream
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+type filesProgress struct {
+	sync.Mutex
+
+	table map[string]*progressMetrics
+}
+
+func newFilesProgress() *filesProgress {
+	return &filesProgress{
+		table: make(map[string]*progressMetrics),
+	}
+}
+
+func (p *filesProgress) add(id string, m *progressMetrics) {
+	p.Lock()
+	defer p.Unlock()
+
+	p.table[id] = m
+}
+
+func (p *filesProgress) isMonitored(id string) bool {
+	p.Lock()
+	defer p.Unlock()
+
+	_, ok := p.table[id]
+	return ok
+}
+
+func (p *filesProgress) remove(id string) {
+	p.Lock()
+	defer p.Unlock()
+
+	if m, ok := p.table[id]; ok {
+		m.cancel()
+		delete(p.table, id)
+	}
+}
+
+func (p *filesProgress) updatePath(id, path string) {
+	p.Lock()
+	defer p.Unlock()
+
+	if m, ok := p.table[id]; ok {
+		m.path.Set(path)
+	}
+}
+
+func (p *filesProgress) updateOnPublish(id string, lastPublished, lastPublishedEventTs time.Time, offset int64) {
+	p.Lock()
+	defer p.Unlock()
+
+	if m, ok := p.table[id]; ok {
+		m.updateOnPublish(lastPublished, lastPublishedEventTs, offset)
+	}
+}
+
+// progressMetrics contians detailed metrics about every opened file.
+type progressMetrics struct {
+	all *filesProgress
+	id  string
+
+	reg                  *monitoring.Registry
+	path                 *monitoring.String
+	stateID              *monitoring.String
+	started              *monitoring.String
+	lastPublished        *monitoring.Timestamp
+	lastPublishedEventTs *monitoring.Timestamp
+	currentSize          *monitoring.Int
+	readOffset           *monitoring.Int
+	status               *monitoring.String
+	cancel               context.CancelFunc
+}
+
+func newProgressMetrics(inputID, path, stateID string, cancel context.CancelFunc, started bool) *progressMetrics {
+	if inputID == loginp.GlobalInputID {
+		inputID = loginp.GlobalInputID[1:]
+	}
+	registryID := pluginName + ".files." + inputID + "." + stateID
+	r := monitoring.GetNamespace("dataset").GetRegistry().NewRegistry(registryID)
+	reg := &progressMetrics{
+		id:          stateID,
+		reg:         r,
+		path:        monitoring.NewString(r, "path"),
+		stateID:     monitoring.NewString(r, "state_id"),
+		currentSize: monitoring.NewInt(r, "size"),
+		readOffset:  monitoring.NewInt(r, "read_offset"),
+		status:      monitoring.NewString(r, "status"),
+		cancel:      cancel,
+	}
+
+	reg.path.Set(path)
+	reg.stateID.Set(stateID)
+
+	state := "INACTIVE"
+	if started {
+		state = "ACTIVE"
+
+		reg.started = monitoring.NewString(r, "start_time")
+		reg.lastPublished = monitoring.NewTimestamp(r, "last_event_published_time")
+		reg.lastPublishedEventTs = monitoring.NewTimestamp(r, "last_event_timestamp")
+		reg.started.Set(time.Now().String())
+	}
+	reg.status.Set(state)
+
+	return reg
+}
+
+func (p *progressMetrics) updateOnPublish(lastPublished, lastPublishedEventTs time.Time, offset int64) {
+	p.lastPublished.Set(lastPublished)
+	p.lastPublishedEventTs.Set(lastPublishedEventTs)
+	p.readOffset.Set(offset)
+}
+
+func (p *progressMetrics) updateCurrentSize(size int64) {
+	p.currentSize.Set(size)
+}
+
+func (p *progressMetrics) stop() {
+	p.all.remove(p.id)
+}

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -56,6 +56,7 @@ var (
 type fileProspector struct {
 	filewatcher         loginp.FSWatcher
 	identifier          fileIdentifier
+	metrics             *filesProgress
 	ignoreOlder         time.Duration
 	ignoreInactiveSince ignoreInactiveType
 	cleanRemoved        bool
@@ -209,6 +210,8 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 					if err != nil {
 						log.Errorf("Failed to update cursor meta data of entry %s: %v", src.Name(), err)
 					}
+
+					p.metrics.updatePath(src.Name(), fe.NewPath)
 
 					if p.stateChangeCloser.Renamed {
 						log.Debugf("Stopping harvester as file %s has been renamed and close.on_state_change.renamed is enabled.", src.Name())

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -82,6 +82,7 @@ func TestProspector_InitCleanIfRemoved(t *testing.T) {
 			testStore := newMockProspectorCleaner(testCase.entries)
 			p := fileProspector{
 				identifier:   mustPathIdentifier(false),
+				metrics:      newFilesProgress(),
 				cleanRemoved: testCase.cleanRemoved,
 				filewatcher:  &mockFileWatcher{filesOnDisk: testCase.filesOnDisk},
 			}
@@ -151,6 +152,7 @@ func TestProspector_InitUpdateIdentifiers(t *testing.T) {
 			p := fileProspector{
 				identifier:  mustPathIdentifier(false),
 				filewatcher: &mockFileWatcher{filesOnDisk: testCase.filesOnDisk},
+				metrics:     newFilesProgress(),
 			}
 			p.Init(testStore)
 
@@ -246,6 +248,7 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 			p := fileProspector{
 				filewatcher: &mockFileWatcher{events: test.events},
 				identifier:  mustPathIdentifier(false),
+				metrics:     newFilesProgress(),
 				ignoreOlder: test.ignoreOlder,
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
@@ -284,6 +287,7 @@ func TestProspectorDeletedFile(t *testing.T) {
 			p := fileProspector{
 				filewatcher:  &mockFileWatcher{events: test.events},
 				identifier:   mustPathIdentifier(false),
+				metrics:      newFilesProgress(),
 				cleanRemoved: test.cleanRemoved,
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}
@@ -363,6 +367,7 @@ func TestProspectorRenamedFile(t *testing.T) {
 			p := fileProspector{
 				filewatcher:       &mockFileWatcher{events: test.events},
 				identifier:        mustPathIdentifier(test.trackRename),
+				metrics:           newFilesProgress(),
 				stateChangeCloser: stateChangeCloserConfig{Renamed: test.closeRenamed},
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}


### PR DESCRIPTION
## What does this PR do?

This PR adds support for metrics in `filestream` input. The summary of reader metrics is enabled by default so the same numbers are reported as in `log` input.

More detailed metrics are disabled by default. Users can enable it by setting `detailed_metrics` to true. These metrics are the same as what `log` input provides. But as we have received numerous complaints about it not being configurable, I have separated it from the other metrics. Now users can configure whether they would like to collect these metrics or not.

## Why is it important?

It makes the inner parts of `filestream` observable. Required for feature-parity with `log` input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~