### PR TITLE
Cherry-pick #25002 to 7.12: Fix inode removal tracking code

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -119,6 +119,19 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - The `o365input` and `o365` module now recover from an authentication problem or other fatal errors, instead of terminating. {pull}21258[21258]
 - Periodic metrics in logs will now report `libbeat.output.events.active` and `beat.memstats.rss`
 
+  as gauges (rather than counters). {pull}22877[22877]
+- Use PROGRAMDATA environment variable instead of C:\ProgramData for windows install service {pull}22874[22874]
+- Fix reporting of cgroup metrics when running under Docker {pull}22879[22879]
+- Fix typo in config docs {pull}23185[23185]
+- Add FAQ entry for madvdontneed variable {pull}23429[23429]
+- Fix panic due to unhandled DeletedFinalStateUnknown in k8s OnDelete {pull}23419[23419]
+- Fix error loop with runaway CPU use when the Kafka output encounters some connection errors {pull}23484[23484]
+- Fix ILM setup log reporting that a policy or an alias was created, even though the creation of any resource was disabled. {issue}24046[24046] {pull}24480[24480]
+- Fix ILM alias not being created if `setup.ilm.check_exists: false` and `setup.ilm.overwrite: true` has been configured. {pull}24480[24480]
+- Fix issue discovering docker containers and metadata after reconnections {pull}24318[24318]
+- Allow cgroup self-monitoring to see alternate `hostfs` paths {pull}24334[24334]
+- Fix 'make setup' instructions for a new beat {pull}24944[24944]
+- Fix inode removal tracking code when files are replaced by files with the same name {pull}25002[25002]
 
 *Auditbeat*
 

--- a/libbeat/common/file/file_other.go
+++ b/libbeat/common/file/file_other.go
@@ -65,8 +65,13 @@ func ReadOpen(path string) (*os.File, error) {
 
 // IsRemoved checks wheter the file held by f is removed.
 func IsRemoved(f *os.File) bool {
-	_, err := os.Stat(f.Name())
-	return err != nil
+	stat, err := f.Stat()
+	if err != nil {
+		// if we got an error from a Stat call just assume we are removed
+		return true
+	}
+	sysStat := stat.Sys().(*syscall.Stat_t)
+	return sysStat.Nlink == 0
 }
 
 // InodeString returns the inode in string.

--- a/libbeat/common/file/file_other_test.go
+++ b/libbeat/common/file/file_other_test.go
@@ -67,6 +67,20 @@ func TestGetOSFileStateStat(t *testing.T) {
 	}
 }
 
+func TestRemoved(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	assert.NoError(t, err)
+
+	assert.NoError(t, os.Remove(file.Name()))
+
+	replaced, err := os.Create(file.Name())
+	assert.NoError(t, err)
+	defer os.Remove(replaced.Name())
+	defer replaced.Close()
+
+	assert.True(t, IsRemoved(file))
+}
+
 func BenchmarkStateString(b *testing.B) {
 	var samples [50]uint64
 	for i, v := 0, uint64(0); i < len(samples); i, v = i+1, v+math.MaxUint64/uint64(len(samples)) {


### PR DESCRIPTION
Cherry-pick of PR #25002 to 7.12 branch. Original message: 

## What does this PR do?

So, there's a bug that customers seem to be running into when using filebeat with logrotate and logs that are fairly large. General idea goes like this:

1. logrotate is rotating files based off of some large maximum file size
2. it's configured to rename files sequentially (i.e. `*.log.1`, `*.log.2`) as they're rotated
3. logs are filling fast and rotated quickly
4. a file comes to the end of the logrotate retention and is unlinked, a new file is renamed to be the same name as the old file
5. we currently check if a file is removed by doing a `Stat` based off of the name of the file
6. it no longer exists, but a new file has taken its place with the same name
7. we detect this as the file not having been deleted and so we keep the file descriptor open and continue to read directly from the file descriptor
8. customer's disk fills up because filebeat maintaining an open file descriptor doesn't allow the space taken by the unlinked file to be reclaimed by the OS

The unit test tests this scenario by creating a file, removing it but keeping the file open, creating another file in the same path, and then calling `IsRemoved` on the first file. The old code fails this test.

The new code uses `Stat_t` to look at the actual link reference count for the underlying inode and returns true if the count is 0.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.