### PR TITLE
mergify: add backport label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,6 +10,8 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.x"
+        labels:
+          - "backport"
   - name: backport patches to 7.12 branch
     conditions:
       - merged
@@ -21,6 +23,8 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.12"
+        labels:
+          - "backport"
   - name: backport patches to 7.11 branch
     conditions:
       - merged
@@ -32,6 +36,8 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.11"
+        labels:
+          - "backport"
   - name: ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
## What does this PR do?

Set `backport` label for the backported PRs with `Mergify`

It uses the `labels` option -> https://docs.mergify.io/actions/backport/#options

## Why is it important?

Use the same backport process as done with the other backport tools