### PR TITLE
packer-cache: cache the existing docker images on ARM and some more

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -21,13 +21,8 @@ source ./dev-tools/common.bash
 # couchbase:4.5.1
 # debian:latest
 # debian:stretch
-# docker.elastic.co/beats-dev/fpm:1.11.0
 # docker.elastic.co/beats/metricbeat:6.5.4
 # docker.elastic.co/beats/metricbeat:7.2.0
-# docker.elastic.co/elasticsearch/elasticsearch:7.2.0
-# docker.elastic.co/kibana/kibana:7.2.0
-# docker.elastic.co/logstash/logstash:7.2.0
-# docker.elastic.co/observability-ci/database-instantclient:12.2.0.1
 # envoyproxy/envoy:v1.7.0
 # exekias/localkube-image
 # haproxy:1.8
@@ -59,6 +54,7 @@ get_go_version
 
 DOCKER_IMAGES="docker.elastic.co/observability-ci/database-instantclient:12.2.0.1
 docker.elastic.co/observability-ci/database-enterprise:12.2.0.1
+docker.elastic.co/beats-dev/fpm:1.11.0
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-arm
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-base-arm-debian9
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-darwin
@@ -69,12 +65,17 @@ docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-main-debian9
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-mips
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-ppc
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-s390x
+docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
+docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+docker.elastic.co/logstash/logstash:8.0.0-SNAPSHOT
 golang:${GO_VERSION}
+golang:1.14.12-stretch
+centos:7
 "
 if [ -x "$(command -v docker)" ]; then
   for image in ${DOCKER_IMAGES}
   do
-  (retry 2 docker pull ${image}) || echo "Error pulling ${image} Docker image, we continue"
+    (retry 2 docker pull ${image}) || echo "Error pulling ${image} Docker image, we continue"
   done
 
   docker tag \
@@ -84,5 +85,5 @@ if [ -x "$(command -v docker)" ]; then
   docker tag \
     docker.elastic.co/observability-ci/database-enterprise:12.2.0.1 \
     store/oracle/database-enterprise:12.2.0.1 \
-    || echo "Error setting the Oracle Dtabase tag"
+    || echo "Error setting the Oracle Database tag"
 fi

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -75,7 +75,7 @@ centos:7
 if [ -x "$(command -v docker)" ]; then
   for image in ${DOCKER_IMAGES}
   do
-    (retry 2 docker pull ${image}) || echo "Error pulling ${image} Docker image, we continue"
+    (retry 2 docker pull ${image}) || echo "Error pulling ${image} Docker image. Continuing."
   done
 
   docker tag \

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -60,10 +60,12 @@ get_go_version
 DOCKER_IMAGES="docker.elastic.co/observability-ci/database-instantclient:12.2.0.1
 docker.elastic.co/observability-ci/database-enterprise:12.2.0.1
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-arm
+docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-base-arm-debian9
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-darwin
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-main
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-main-debian7
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-main-debian8
+docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-main-debian9
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-mips
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-ppc
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-s390x


### PR DESCRIPTION
## What does this PR do?

Cache more docker images to workaround the issue we see in the ARM ephemeral workers with the existing rate limit in the docker pull.

## Why is it important?

Rate limit causes build failures


## Test

docker pull is platform agnostic:

```
jenkins@beats-ci-immutable-ubuntu-1804-aarch64-1618391886589946761:~$ docker pull docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
8.0.0-SNAPSHOT: Pulling from elasticsearch/elasticsearch
5cfb807c1c07: Pull complete 
232a829a49a0: Pull complete 
305e6cd2445d: Pull complete 
5f24f0e9a71f: Pull complete 
03ddbb0b2c42: Pull complete 
Digest: sha256:6279ee9ac8013ecbff4608d310a6e58ff544500a7a80cb68b5967d2d19607f42
Status: Downloaded newer image for docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT
```

```
jenkins@beats-ci-immutable-ubuntu-1804-aarch64-1618391886589946761:~$ docker inspect docker.elastic.co/elasticsearch/elasticsearch:8.0.0-SNAPSHOT

...
        "Architecture": "arm64",
        "Variant": "v8",
        "Os": "linux",
        "Size": 561893423,
        "VirtualSize": 561893423,
...
```