### PR TITLE
Cherry-pick #25044 to 7.12: Disable logstash TestFetch flaky test

### DIFF
--- a/metricbeat/module/logstash/logstash_integration_test.go
+++ b/metricbeat/module/logstash/logstash_integration_test.go
@@ -41,6 +41,7 @@ var metricSets = []string{
 }
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/25043")
 	service := compose.EnsureUpWithTimeout(t, 300, "logstash")
 
 	for _, metricSet := range metricSets {


### PR DESCRIPTION
Cherry-pick of PR #25044 to 7.12 branch. Original message: 

## What does this PR do?

This PR is to disable logstash `TestFetch` flaky test.

## Related issues

- Relates https://github.com/elastic/beats/issues/25043