### PR TITLE
[Filebeat][httpjson] Change append transform to initiate new fields as a slice

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -105,6 +105,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Rename `network.direction` values in crowdstrike/falcon to `ingress`/`egress`. {pull}23041[23041]
 - Possible values for Netflow's locality fields (source.locality, destination.locality and flow.locality) are now `internal` and `external`, instead of `private` and `public`. {issue}24272[24272] {pull}24295[24295]
 - Add User Agent Parser for Azure Sign In Logs Ingest Pipeline {pull}23201[23201]
+- Changes filebeat httpjson input's append transform to create a list even with only a single value{pull}25074[25074]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -121,7 +121,7 @@ The access limitations are described in the corresponding configuration sections
 [float]
 ==== `append`
 
-Appends a value to a list. If the field does not exist, the first entry will be a scalar value, and subsequent additions will convert the value to a list.
+Appends a value to an array. If the field does not exist, the first entry will create a new array. If the field exists, the value is appended to the existing field and converted to a list.
 
 ["source","yaml",subs="attributes"]
 ----

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_append.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_append.go
@@ -125,7 +125,7 @@ func appendToCommonMap(m common.MapStr, key, val string) error {
 	if val == "" {
 		return nil
 	}
-	var value interface{} = val
+	var value interface{}
 	if found, _ := m.HasKey(key); found {
 		prev, _ := m.GetValue(key)
 		switch t := prev.(type) {
@@ -137,6 +137,8 @@ func appendToCommonMap(m common.MapStr, key, val string) error {
 			value = []interface{}{prev, val}
 		}
 
+	} else {
+		value = []interface{}{val}
 	}
 	if _, err := m.Put(key, value); err != nil {
 		return err

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_append_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_append_test.go
@@ -22,7 +22,7 @@ func TestNewAppend(t *testing.T) {
 		expectedErr    string
 	}{
 		{
-			name:        "newAppendResponse target body",
+			name:        "newAppendResponse targets body",
 			constructor: newAppendResponse,
 			config: map[string]interface{}{
 				"target": "body.foo",

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_append_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_append_test.go
@@ -22,7 +22,7 @@ func TestNewAppend(t *testing.T) {
 		expectedErr    string
 	}{
 		{
-			name:        "newAppendResponse targets body",
+			name:        "newAppendResponse target body",
 			constructor: newAppendResponse,
 			config: map[string]interface{}{
 				"target": "body.foo",
@@ -145,6 +145,16 @@ func TestAppendFunctions(t *testing.T) {
 			paramKey:    "a_key",
 			paramVal:    "another_value",
 			expectedTr:  transformable{"body": common.MapStr{"a_key": []interface{}{"a_value", "another_value"}}},
+			expectedErr: nil,
+		},
+		{
+			name:        "appendBodyWithSingleValue",
+			tfunc:       appendBody,
+			paramCtx:    &transformContext{},
+			paramTr:     transformable{"body": common.MapStr{}},
+			paramKey:    "a_key",
+			paramVal:    "a_value",
+			expectedTr:  transformable{"body": common.MapStr{"a_key": []interface{}{"a_value"}}},
 			expectedErr: nil,
 		},
 		{


### PR DESCRIPTION
## What does this PR do?

Currently the append transform for httpjson only creates an array/list/slice once at least 2 values has been appended to a specific field. This creates a situation in which there is no possibilities with any transform, to create a list object that only has a single value.

## Why is it important?

Allows users that communicates with API's that requires single value lists as a key/value pair.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #25060 
- Closes #24952 

