### PR TITLE
New option in `filestream`: `include_files` && check after symlink is resolved

### DIFF
--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -281,6 +281,10 @@ filebeat.inputs:
   # are matching any regular expression from the list. By default, no files are dropped.
   #prospector.scanner.exclude_files: ['.gz$']
 
+  # Include files. A list of regular expressions to match. Filebeat keeps only the files that
+  # are matching any regular expression from the list. By default, no files are dropped.
+  #prospector.scanner.include_files: ['.gz$']
+
   # Expand "**" patterns into regular glob patterns.
   #prospector.scanner.recursive_glob: true
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -283,7 +283,7 @@ filebeat.inputs:
 
   # Include files. A list of regular expressions to match. Filebeat keeps only the files that
   # are matching any regular expression from the list. By default, no files are dropped.
-  #prospector.scanner.include_files: ['.gz$']
+  #prospector.scanner.include_files: ['/var/log/.*']
 
   # Expand "**" patterns into regular glob patterns.
   #prospector.scanner.recursive_glob: true

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -688,6 +688,10 @@ filebeat.inputs:
   # are matching any regular expression from the list. By default, no files are dropped.
   #prospector.scanner.exclude_files: ['.gz$']
 
+  # Include files. A list of regular expressions to match. Filebeat keeps only the files that
+  # are matching any regular expression from the list. By default, no files are dropped.
+  #prospector.scanner.include_files: ['.gz$']
+
   # Expand "**" patterns into regular glob patterns.
   #prospector.scanner.recursive_glob: true
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -690,7 +690,7 @@ filebeat.inputs:
 
   # Include files. A list of regular expressions to match. Filebeat keeps only the files that
   # are matching any regular expression from the list. By default, no files are dropped.
-  #prospector.scanner.include_files: ['.gz$']
+  #prospector.scanner.include_files: ['/var/log/.*']
 
   # Expand "**" patterns into regular glob patterns.
   #prospector.scanner.recursive_glob: true

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -52,6 +52,7 @@ func TestFileScanner(t *testing.T) {
 	testCases := map[string]struct {
 		paths         []string
 		excludedFiles []match.Matcher
+		includedFiles []match.Matcher
 		symlinks      bool
 		expectedFiles []string
 	}{
@@ -63,6 +64,13 @@ func TestFileScanner(t *testing.T) {
 			paths: []string{excludedFilePath, includedFilePath},
 			excludedFiles: []match.Matcher{
 				match.MustCompile(excludedFileName),
+			},
+			expectedFiles: []string{includedFilePath},
+		},
+		"only include included_files": {
+			paths: []string{excludedFilePath, includedFilePath},
+			includedFiles: []match.Matcher{
+				match.MustCompile(includedFileName),
 			},
 			expectedFiles: []string{includedFilePath},
 		},
@@ -78,6 +86,7 @@ func TestFileScanner(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cfg := fileScannerConfig{
 				ExcludedFiles: test.excludedFiles,
+				IncludedFiles: test.includedFiles,
 				Symlinks:      test.symlinks,
 				RecursiveGlob: false,
 			}

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2692,6 +2692,10 @@ filebeat.inputs:
   # are matching any regular expression from the list. By default, no files are dropped.
   #prospector.scanner.exclude_files: ['.gz$']
 
+  # Include files. A list of regular expressions to match. Filebeat keeps only the files that
+  # are matching any regular expression from the list. By default, no files are dropped.
+  #prospector.scanner.include_files: ['.gz$']
+
   # Expand "**" patterns into regular glob patterns.
   #prospector.scanner.recursive_glob: true
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2694,7 +2694,7 @@ filebeat.inputs:
 
   # Include files. A list of regular expressions to match. Filebeat keeps only the files that
   # are matching any regular expression from the list. By default, no files are dropped.
-  #prospector.scanner.include_files: ['.gz$']
+  #prospector.scanner.include_files: ['/var/log/.*']
 
   # Expand "**" patterns into regular glob patterns.
   #prospector.scanner.recursive_glob: true


### PR DESCRIPTION
## What does this PR do?

This PR adds support for a new feature in `filestream` input named `include_files`. This option is the counterpart of `exclude_files`. It expects a list of regexes and it only includes files that match the regexes.

The PR also adds one more check after symlinks are resolved, the original file is tested again with the regexes in `include_files` and `exclude_files`.

## Why is it important?

`exclude_files` was not enough for disallowing files.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
