### PR TITLE
Add --fleet-server-service-token. Rename --fleet-server to --fleet-server-es.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -86,3 +86,4 @@
 - Add STATE_PATH, CONFIG_PATH, LOGS_PATH to Elastic Agent docker image {pull}24817[24817]
 - Add status subcommand {pull}24856[24856]
 - Add leader_election provider for k8s {pull}24267[24267]
+- Add --fleet-server-service-token and FLEET_SERVER_SERVICE_TOKEN options {pull}25083[25083]

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -52,8 +52,9 @@ func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("url", "", "", "URL to enroll Agent into Fleet")
 	cmd.Flags().StringP("kibana-url", "k", "", "URL of Kibana to enroll Agent into Fleet")
 	cmd.Flags().StringP("enrollment-token", "t", "", "Enrollment token to use to enroll Agent into Fleet")
-	cmd.Flags().StringP("fleet-server", "", "", "Start and run a Fleet Server along side this Elastic Agent")
-	cmd.Flags().StringP("fleet-server-elasticsearch-ca", "", "", "Path to certificate authority to use with communicate with elasticsearch")
+	cmd.Flags().StringP("fleet-server-es", "", "", "Start and run a Fleet Server along side this Elastic Agent connecting to the provided elasticsearch")
+	cmd.Flags().StringP("fleet-server-es-ca", "", "", "Path to certificate authority to use with communicate with elasticsearch")
+	cmd.Flags().StringP("fleet-server-service-token", "", "", "Service token to use for communication with elasticsearch")
 	cmd.Flags().StringP("fleet-server-policy", "", "", "Start and run a Fleet Server on this specific policy")
 	cmd.Flags().StringP("fleet-server-host", "", "", "Fleet Server HTTP binding host (overrides the policy)")
 	cmd.Flags().Uint16P("fleet-server-port", "", 0, "Fleet Server HTTP binding port (overrides the policy)")
@@ -76,8 +77,9 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 	if token == "" {
 		token, _ = cmd.Flags().GetString("enrollment-token")
 	}
-	fServer, _ := cmd.Flags().GetString("fleet-server")
-	fElasticSearchCA, _ := cmd.Flags().GetString("fleet-server-elasticsearch-ca")
+	fServer, _ := cmd.Flags().GetString("fleet-server-es")
+	fElasticSearchCA, _ := cmd.Flags().GetString("fleet-server-es-ca")
+	fServiceToken, _ := cmd.Flags().GetString("fleet-server-service-token")
 	fPolicy, _ := cmd.Flags().GetString("fleet-server-policy")
 	fHost, _ := cmd.Flags().GetString("fleet-server-host")
 	fPort, _ := cmd.Flags().GetUint16("fleet-server-port")
@@ -99,12 +101,16 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 		args = append(args, token)
 	}
 	if fServer != "" {
-		args = append(args, "--fleet-server")
+		args = append(args, "--fleet-server-es")
 		args = append(args, fServer)
 	}
 	if fElasticSearchCA != "" {
-		args = append(args, "--fleet-server-elasticsearch-ca")
+		args = append(args, "--fleet-server-es-ca")
 		args = append(args, fElasticSearchCA)
+	}
+	if fServiceToken != "" {
+		args = append(args, "--fleet-server-service-token")
+		args = append(args, fServiceToken)
 	}
 	if fPolicy != "" {
 		args = append(args, "--fleet-server-policy")
@@ -210,8 +216,9 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 		url, _ = cmd.Flags().GetString("kibana-url")
 	}
 	enrollmentToken, _ := cmd.Flags().GetString("enrollment-token")
-	fServer, _ := cmd.Flags().GetString("fleet-server")
-	fElasticSearchCA, _ := cmd.Flags().GetString("fleet-server-elasticsearch-ca")
+	fServer, _ := cmd.Flags().GetString("fleet-server-es")
+	fElasticSearchCA, _ := cmd.Flags().GetString("fleet-server-es-ca")
+	fServiceToken, _ := cmd.Flags().GetString("fleet-server-service-token")
 	fPolicy, _ := cmd.Flags().GetString("fleet-server-policy")
 	fHost, _ := cmd.Flags().GetString("fleet-server-host")
 	fPort, _ := cmd.Flags().GetUint16("fleet-server-port")
@@ -238,6 +245,7 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 		FleetServer: enrollCmdFleetServerOption{
 			ConnStr:         fServer,
 			ElasticsearchCA: fElasticSearchCA,
+			ServiceToken:    fServiceToken,
 			PolicyID:        fPolicy,
 			Host:            fHost,
 			Port:            fPort,

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -68,6 +68,7 @@ type enrollCmd struct {
 type enrollCmdFleetServerOption struct {
 	ConnStr         string
 	ElasticsearchCA string
+	ServiceToken    string
 	PolicyID        string
 	Host            string
 	Port            uint16
@@ -219,7 +220,8 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context) (string, error) {
 	}
 
 	fleetConfig, err := createFleetServerBootstrapConfig(
-		c.options.FleetServer.ConnStr, c.options.FleetServer.PolicyID,
+		c.options.FleetServer.ConnStr, c.options.FleetServer.ServiceToken,
+		c.options.FleetServer.PolicyID,
 		c.options.FleetServer.Host, c.options.FleetServer.Port,
 		c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA)
 	if err != nil {
@@ -389,7 +391,8 @@ func (c *enrollCmd) enroll(ctx context.Context) error {
 	}
 	if c.options.FleetServer.ConnStr != "" {
 		serverConfig, err := createFleetServerBootstrapConfig(
-			c.options.FleetServer.ConnStr, c.options.FleetServer.PolicyID,
+			c.options.FleetServer.ConnStr, c.options.FleetServer.ServiceToken,
+			c.options.FleetServer.PolicyID,
 			c.options.FleetServer.Host, c.options.FleetServer.Port,
 			c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA)
 		if err != nil {
@@ -693,8 +696,8 @@ func storeAgentInfo(s saver, reader io.Reader) error {
 	return nil
 }
 
-func createFleetServerBootstrapConfig(connStr string, policyID string, host string, port uint16, cert string, key string, esCA string) (*configuration.FleetAgentConfig, error) {
-	es, err := configuration.ElasticsearchFromConnStr(connStr)
+func createFleetServerBootstrapConfig(connStr string, serviceToken string, policyID string, host string, port uint16, cert string, key string, esCA string) (*configuration.FleetAgentConfig, error) {
+	es, err := configuration.ElasticsearchFromConnStr(connStr, serviceToken)
 	if err != nil {
 		return nil, err
 	}

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -101,7 +101,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 	if url != "" && token != "" {
 		askEnroll = false
 	}
-	fleetServer, _ := cmd.Flags().GetString("fleet-server")
+	fleetServer, _ := cmd.Flags().GetString("fleet-server-es")
 	if fleetServer != "" {
 		askEnroll = false
 	}

--- a/x-pack/elastic-agent/pkg/agent/configuration/fleet_server.go
+++ b/x-pack/elastic-agent/pkg/agent/configuration/fleet_server.go
@@ -33,16 +33,17 @@ type FleetServerOutputConfig struct {
 
 // Elasticsearch is the configuration for elasticsearch.
 type Elasticsearch struct {
-	Protocol string            `config:"protocol" yaml:"protocol"`
-	Hosts    []string          `config:"hosts" yaml:"hosts"`
-	Path     string            `config:"path" yaml:"path,omitempty"`
-	Username string            `config:"username" yaml:"username"`
-	Password string            `config:"password" yaml:"password"`
-	TLS      *tlscommon.Config `config:"ssl" yaml:"ssl,omitempty"`
+	Protocol     string            `config:"protocol" yaml:"protocol"`
+	Hosts        []string          `config:"hosts" yaml:"hosts"`
+	Path         string            `config:"path" yaml:"path,omitempty"`
+	Username     string            `config:"username" yaml:"username,omitempty"`
+	Password     string            `config:"password" yaml:"password,omitempty"`
+	ServiceToken string            `config:"service_token" yaml:"service_token,omitempty"`
+	TLS          *tlscommon.Config `config:"ssl" yaml:"ssl,omitempty"`
 }
 
 // ElasticsearchFromConnStr returns an Elasticsearch configuration from the connection string.
-func ElasticsearchFromConnStr(conn string) (Elasticsearch, error) {
+func ElasticsearchFromConnStr(conn string, serviceToken string) (Elasticsearch, error) {
 	u, err := url.Parse(conn)
 	if err != nil {
 		return Elasticsearch{}, err
@@ -53,19 +54,24 @@ func ElasticsearchFromConnStr(conn string) (Elasticsearch, error) {
 	if u.Host == "" {
 		return Elasticsearch{}, errors.New("invalid connection string: must include a host")
 	}
-	if u.User == nil || u.User.Username() == "" {
-		return Elasticsearch{}, errors.New("invalid connection string: must include a username")
-	}
-	password, ok := u.User.Password()
-	if !ok {
-		return Elasticsearch{}, errors.New("invalid connection string: must include a password")
-	}
-	return Elasticsearch{
+	cfg := Elasticsearch{
 		Protocol: u.Scheme,
 		Hosts:    []string{u.Host},
 		Path:     u.Path,
-		Username: u.User.Username(),
-		Password: password,
 		TLS:      nil,
-	}, nil
+	}
+	if serviceToken != "" {
+		cfg.ServiceToken = serviceToken
+		return cfg, nil
+	}
+	if u.User == nil || u.User.Username() == "" {
+		return Elasticsearch{}, errors.New("invalid connection string: must include a username unless a service token is provided")
+	}
+	password, ok := u.User.Password()
+	if !ok {
+		return Elasticsearch{}, errors.New("invalid connection string: must include a password unless a service token is provided")
+	}
+	cfg.Username = u.User.Username()
+	cfg.Password = password
+	return cfg, nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds a new `--fleet-server-service-token` flag to the `install` and `enroll` command. Adds a new `FLEET_SERVER_SERVICE_TOKEN` to `container` command.

This also renames the `--fleet-server` to `--fleet-server-es` for the `install` and `enroll` command. The previous `--fleet-server` flag was confusing based on the name. This does not affect the `container` command.

When providing the `--fleet-server-service-token` the username and password from the `--fleet-server-es` are not required and are ignored if both are provided.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To support the addition of service tokens this is required to allow the `install`, `enroll` and the `container` to authenticate with service tokens.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
$ sudo ./elastic-agent install --fleet-server-es http://localhost:9200 --fleet-server-service-token ${token}
```

