### PR TITLE
CI: disable packaging since docker pull rate limit

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -87,9 +87,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -85,9 +85,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -84,9 +84,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -37,9 +37,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -79,9 +79,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false     ## e2e is enabled only for x-pack beats
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -85,9 +85,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -85,9 +85,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/x-pack/dockerlogbeat/Jenkinsfile.yml
+++ b/x-pack/dockerlogbeat/Jenkinsfile.yml
@@ -25,9 +25,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -89,9 +89,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -92,9 +92,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -85,9 +85,13 @@ stages:
         e2e:
             enabled: false
             entrypoint: 'metricbeat-test.sh'
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -86,9 +86,13 @@ stages:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        when:
+            disabled: true
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        when:
+            disabled: true


### PR DESCRIPTION
## What does this PR do?

Disable the packaging in the pipeline (still run on another pipeline anyway)

## Why is it important?

The docker pull rate-limit is causing issues so let's reduce the packaging that consumes some pulling for the time being, though there is a build to generate new AMI with more cached docker images.


## Important

If the new AMI images with the cached docker images work as expected we won't need to merge this PR, this is only to reduce the environmental failures.