### PR TITLE
Cherry-pick #25073 to 7.12: Fix panic when Hearbeat monitor initialization fails twice

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -214,6 +214,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed excessive memory usage introduced in 7.5 due to over-allocating memory for HTTP checks. {pull}15639[15639]
 - Fixed scheduler shutdown issues which would in rare situations cause a panic due to semaphore misuse. {pull}16397[16397]
 - Fixed TCP TLS checks to properly validate hostnames, this broke in 7.x and only worked for IP SANs. {pull}17549[17549]
+- Fix panic when initialization of ICMP monitors fail twice. {pull}25073[25073]
 
 *Journalbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #25073 to 7.12 branch. Original message: 

## What does this PR do?

Prevents a panic happening when ICMP initialization fails twice.

Initialization was only tried once. Second time a nil object and a nil error are returned, producing nil pointer dereferences later.

With static configurations the first failure inmediatelly stops heartbeat, so this is not a problem, but with autodiscover multiple initialization attempts may happen.

## Why is it important?

Prevent unexpected panics when introducing ICMP configurations through autodiscover.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Configure two ICMP monitors using autodiscover without NET_RAW capabilities.
- Failures should be printed, but Heartbeat should continue running.

## Related issues

- Discovered while testing https://github.com/elastic/beats/pull/24742.

## Logs

For the record, stack trace printed when this issue happens:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x251fcfd]

goroutine 74 [running]:
github.com/elastic/beats/v7/heartbeat/monitors/active/icmp.(*stdICMPLoop).checkNetworkMode(0x0, 0x29c9292, 0x2, 0x0, 0xc000100400)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/active/icmp/stdloop.go:170 +0x5d
github.com/elastic/beats/v7/heartbeat/monitors/active/icmp.(*jobFactory).makePlugin(0xc000954a20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2d0eda0, 0x3e69478)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/active/icmp/icmp.go:94 +0x7a
github.com/elastic/beats/v7/heartbeat/monitors/active/icmp.create(0x29ca5fc, 0x4, 0xc0008151a0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/active/icmp/icmp.go:62 +0x2b5
github.com/elastic/beats/v7/heartbeat/monitors/plugin.(*PluginFactory).Create(...)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/plugin/plugin.go:164
github.com/elastic/beats/v7/heartbeat/monitors.newMonitorUnsafe(0xc0008151a0, 0xc000010020, 0x0, 0x0, 0x0, 0x0, 0xab7702fa0e1a4b9e, 0x0, 0x0)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/monitor.go:160 +0x3af
github.com/elastic/beats/v7/heartbeat/monitors.newMonitor(0xc0008151a0, 0xc000010020, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc00061dc48, 0x14c2490)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/monitor.go:105 +0x6c
github.com/elastic/beats/v7/heartbeat/monitors.checkMonitorConfig(0xc0008151a0, 0xc000010020, 0x0, 0x0, 0xc000738140)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/monitor.go:76 +0x53
github.com/elastic/beats/v7/heartbeat/monitors.(*RunnerFactory).CheckConfig(0xc00011c000, 0xc0008151a0, 0x0, 0x0)
	/home/jaime/gocode/src/github.com/elastic/beats/heartbeat/monitors/factory.go:85 +0x47
github.com/elastic/beats/v7/libbeat/autodiscover.(*Autodiscover).handleStart(0xc00022a750, 0xc0008153b0, 0x29cbcf7)
	/home/jaime/gocode/src/github.com/elastic/beats/libbeat/autodiscover/autodiscover.go:210 +0x484
github.com/elastic/beats/v7/libbeat/autodiscover.(*Autodiscover).worker(0xc00022a750)
	/home/jaime/gocode/src/github.com/elastic/beats/libbeat/autodiscover/autodiscover.go:140 +0x4ea
created by github.com/elastic/beats/v7/libbeat/autodiscover.(*Autodiscover).Start
	/home/jaime/gocode/src/github.com/elastic/beats/libbeat/autodiscover/autodiscover.go:121 +0x111
jaime@voyager:~/gocode/src/github.com/elastic/beats/heartbeat$ 
```