### PR TITLE
[elastic-agent] ensure container is backwards compatible

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -143,6 +143,9 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 		return err
 	}
 
+	elasticCloud := envBool("ELASTIC_AGENT_CLOUD")
+	// if not in cloud mode, always run the agent
+	runAgent := !elasticCloud
 	// create access configuration from ENV and config files
 	cfg := defaultAccessConfig()
 	for _, f := range []string{"fleet-setup.yml", "credentials.yml"} {
@@ -155,13 +158,14 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			if err != nil {
 				return fmt.Errorf("unpacking config file(%s): %s", f, err)
 			}
+			// if in elastic cloud mode, only run the agent when configured
+			runAgent = true
 		}
 	}
 
 	// start apm-server legacy process when in cloud mode
 	var wg sync.WaitGroup
 	var apmProc *process.Info
-	_, elasticCloud := os.LookupEnv("ELASTIC_AGENT_CLOUD")
 	apmPath := os.Getenv("APM_SERVER_PATH")
 	if elasticCloud {
 		logInfo(streams, "Starting in elastic cloud mode")
@@ -202,13 +206,18 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 					apmProc.Stop()
 					logInfo(streams, "Initiate shutdown legacy apm-server.")
 				}
-				wg.Wait()
 			}()
 		}
 	}
 
-	// run the main elastic-agent container command
-	return runContainerCmd(streams, cmd, cfg)
+	var err error
+	if runAgent {
+		// run the main elastic-agent container command
+		err = runContainerCmd(streams, cmd, cfg)
+	}
+	// wait until APM Server shut down
+	wg.Wait()
+	return err
 }
 
 func runContainerCmd(streams *cli.IOStreams, cmd *cobra.Command, cfg setupConfig) error {


### PR DESCRIPTION

## What does this PR do?
Only run setup and the elastic agent if configuration is provided, when in cloud mode

## Why is it important?
backwards compatibility
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## How to test this PR locally
Build docker container and then run the following command
```
docker run  \
--env ELASTIC_AGENT_CLOUD=true \
--env APM_SERVER_PATH=/myapp/apm-server/ \
--env CONFIG_PATH=/myapp/config \
--env HOME_PATH="/myapp" \
-v <path>:/myapp \
--rm docker.elastic.co/beats/elastic-agent:8.0.0-SNAPSHOT
```
*  `ELASTIC_AGENT_CLOUD=false`: the agent should always be started
*  `ELASTIC_AGENT_CLOUD=true`: the agent should only be started if a `myapp/config/fleet-setup.yml` file is provided

Check that the container keeps running until the process(es) are terminated. 

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
closes #25005

