### PR TITLE
Negative partition edge case patch bitmask

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -243,6 +243,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix 'make setup' instructions for a new beat {pull}24944[24944]
 - Fix inode removal tracking code when files are replaced by files with the same name {pull}25002[25002]
 - Fix `mage GenerateCustomBeat` instructions for a new beat {pull}17679[17679]
+- Fix negative Kafka partition bug {pull}25048[25048]
 
 *Auditbeat*
 

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -272,11 +272,8 @@ func makeFieldsHashPartitioner(log *logp.Logger, fields []string, dropFail bool)
 }
 
 func hash2Partition(hash uint32, numPartitions int32) (int32, error) {
-	p := int32(hash) % numPartitions
-	if p < 0 {
-		p = -p
-	}
-	return p, nil
+	p := int32(hash) & 0x7FFFFFFF
+	return p % numPartitions, nil
 }
 
 func hashFieldValue(h hash.Hash32, event common.MapStr, field string) error {

--- a/libbeat/outputs/kafka/partition.go
+++ b/libbeat/outputs/kafka/partition.go
@@ -272,11 +272,11 @@ func makeFieldsHashPartitioner(log *logp.Logger, fields []string, dropFail bool)
 }
 
 func hash2Partition(hash uint32, numPartitions int32) (int32, error) {
-	p := int32(hash)
+	p := int32(hash) % numPartitions
 	if p < 0 {
 		p = -p
 	}
-	return p % numPartitions, nil
+	return p, nil
 }
 
 func hashFieldValue(h hash.Hash32, event common.MapStr, field string) error {

--- a/libbeat/outputs/kafka/partition_test.go
+++ b/libbeat/outputs/kafka/partition_test.go
@@ -327,9 +327,9 @@ var hash2PartitionTests = []struct {
 	numPartitions int32
 	expectedResult int32
 }{
-	{"hash of max uint32, partitions 12", uint32(0xFFFFFFFF), 12, 1},
+	{"hash of max uint32, partitions 12", uint32(0xFFFFFFFF), 12, 7},
 	{"hash of max int32, partitions 12", uint32(0x7FFFFFFF), 12, 7},
-	{"hash of max int32 + 1, partitions 12", uint32(0x80000000), 12, 8},
+	{"hash of max int32 + 1, partitions 12", uint32(0x80000000), 12, 0},
 	{"hash of min int32, partitions 12", uint32(0x00000000), 12, 0},
 	{"hash of min int32 + 1, partitions 12", uint32(0x00000001), 12, 1},
 }

--- a/libbeat/outputs/kafka/partition_test.go
+++ b/libbeat/outputs/kafka/partition_test.go
@@ -320,3 +320,25 @@ func partTestHashInvariant(N int) partTestScenario {
 		return nil
 	}
 }
+
+var hash2PartitionTests = []struct {
+	testName string
+	hash uint32
+	numPartitions int32
+	expectedResult int32
+}{
+	{"hash of max uint32, partitions 12", uint32(0xFFFFFFFF), 12, 1},
+	{"hash of max int32, partitions 12", uint32(0x7FFFFFFF), 12, 7},
+	{"hash of max int32 + 1, partitions 12", uint32(0x80000000), 12, 8},
+	{"hash of min int32, partitions 12", uint32(0x00000000), 12, 0},
+	{"hash of min int32 + 1, partitions 12", uint32(0x00000001), 12, 1},
+}
+
+func TestHash2Partition(t *testing.T) {
+	for _, tt := range hash2PartitionTests {
+		t.Run(tt.testName, func(t *testing.T) {
+			var partition, _ = hash2Partition(tt.hash, tt.numPartitions)
+			assert.Equal(t, tt.expectedResult, partition)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fix a bug in Kafka output "partition to hash method" which results in a negative Kafka partition.
Demo of the bug available on my other branch. https://github.com/cbrown184/beats/tree/negative_partition_edge_case_demo_test

You can reproduce this with any key that gives the hash value of 2147483648. E.g the string "16000002EFEBA11E"

## Why is it important?

When the partition key hash is equal to 2147483648 Filebeat gets stuck in an endless loop.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

## Related issues
https://discuss.elastic.co/t/negative-kafka-partition-bug/270046/3

This bug was discussed previously in this thread.
https://discuss.elastic.co/t/filebeat-kafka-output-hash-hash-get-negative-partition-cause-stuck/265153

## Use cases

hash(16000002EFEBA11E) = 2147483648
Int32(2147483648) = -2147483648
-(-2147483648) = -2147483648
-2147483648 % 3 = -2
Kafka doesn't have -2 partition, STUCK.
Kafka doesn't have -2 partition, so the kafka producer becomes stuck forever.

## Screenshots

## Logs

Filebeat endless loop

2021-02-23T13:18:40.911+0800	DEBUG	[kafka]	kafka/client.go:169	got event.Meta["partition"] = -2
2021-02-23T13:18:40.911+0800	DEBUG	[kafka]	kafka/client.go:179	got event.Meta["topic"] = hashtest
2021-02-23T13:18:40.911+0800	DEBUG	[kafka]	kafka/client.go:273	finished kafka batch
2021-02-23T13:18:40.911+0800	DEBUG	[kafka]	kafka/client.go:287	Kafka publish failed with: kafka: partitioner returned an invalid partition index
2021-02-23T13:18:40.911+0800	DEBUG	[kafka]	kafka/client.go:169	got event.Me


Error Logs in production
2021-04-09T13:48:02Z DBG  Kafka publish failed with: kafka: partitioner returned an invalid partition index

Demo test failing
=== RUN   TestHashMaxIntPlusOneDoesNotReturnNegativePartition
    partition_test.go:328: 
        	Error Trace:	partition_test.go:328
        	Error:      	Should be true
        	Test:       	TestHashMaxIntPlusOneDoesNotReturnNegativePartition
--- FAIL: TestHashMaxIntPlusOneDoesNotReturnNegativePartition (0.00s)

FAIL

Expected :8
Actual   :-8
