### PR TITLE
CI: split stages in categories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@feature/filterStage') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@feature/filterStage') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,7 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
+            setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
           }
         }
       }
@@ -77,7 +78,6 @@ pipeline {
           withGithubNotify(context: "Lint") {
             withBeatsEnv(archive: false, id: "lint") {
               dumpVariables()
-              setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
               whenTrue(env.ONLY_DOCS == 'true') {
                 cmd(label: "make check", script: "make check")
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,6 +63,10 @@ pipeline {
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
           withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
+          }
+        }
+        withMageEnv(version: "${env.GO_VERSION}"){
+          dir("${BASE_DIR}"){
             setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
           setEnvVar('GO_MOD_CHANGES', isGitRegionMatch(patterns: [ '^go.mod' ], shouldMatchAll: false).toString())
           setEnvVar('PACKAGING_CHANGES', isGitRegionMatch(patterns: [ '^dev-tools/packaging/.*' ], shouldMatchAll: false).toString())
           setEnvVar('GO_VERSION', readFile(".go-version").trim())
-          withBeatsEnv() {
+          withEnv(["HOME=${env.WORKSPACE}"]) {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
             setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
           }
@@ -76,7 +76,7 @@ pipeline {
       steps {
         stageStatusCache(id: 'Lint'){
           withGithubNotify(context: "Lint") {
-            withBeatsContext(archive: false, id: "lint") {
+            withBeatsEnv(archive: false, id: "lint") {
               dumpVariables()
               whenTrue(env.ONLY_DOCS == 'true') {
                 cmd(label: "make check", script: "make check")
@@ -290,7 +290,7 @@ def k8sTest(Map args = [:]) {
       stage("${args.context} ${v}"){
         withEnv(["K8S_VERSION=${v}", "KIND_VERSION=v0.7.0", "KUBECONFIG=${env.WORKSPACE}/kubecfg"]){
           withGithubNotify(context: "${args.context} ${v}") {
-            withBeatsContext(archive: false, withModule: false) {
+            withBeatsEnv(archive: false, withModule: false) {
               retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kind", script: ".ci/scripts/install-kind.sh") }
               retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kubectl", script: ".ci/scripts/install-kubectl.sh") }
               try {
@@ -540,7 +540,7 @@ def target(Map args = [:]) {
   def dockerArch = args.get('dockerArch', 'amd64')
   withNode(labels: args.label, sleepMin: 30, sleepMax: 200, forceWorkspace: true){
     withGithubNotify(context: "${context}") {
-      withBeatsContext(archive: true, withModule: withModule, directory: directory, id: args.id) {
+      withBeatsEnv(archive: true, withModule: withModule, directory: directory, id: args.id) {
         dumpVariables()
         // make commands use -C <folder> while mage commands require the dir(folder)
         // let's support this scenario with the location variable.
@@ -565,13 +565,15 @@ def target(Map args = [:]) {
   }
 }
 
-
-
 /**
-* This method wraps all the environment to run any commands.
+* This method wraps all the environment setup and pre-requirements to run any commands.
 */
 def withBeatsEnv(Map args = [:], Closure body) {
-  def goRoot, path, magefile, pythonEnv, gox_flags, userProfile
+  def archive = args.get('archive', true)
+  def withModule = args.get('withModule', false)
+  def directory = args.get('directory', '')
+
+  def goRoot, path, magefile, pythonEnv, testResults, artifacts, gox_flags, userProfile
 
   if(isUnix()) {
     if (isArm() && is64arm()) {
@@ -585,6 +587,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
     path = "${env.WORKSPACE}/bin:${goRoot}/bin:${env.PATH}"
     magefile = "${WORKSPACE}/.magefile"
     pythonEnv = "${WORKSPACE}/python-env"
+    testResults = '**/build/TEST*.xml'
+    artifacts = '**/build/TEST*.out'
   } else {
     // NOTE: to support Windows 7 32 bits the arch in the mingw and go context paths is required.
     def mingwArch = is32() ? '32' : '64'
@@ -595,9 +599,20 @@ def withBeatsEnv(Map args = [:], Closure body) {
     goRoot = "${userProfile}\\.gvm\\versions\\go${GO_VERSION}.windows.${goArch}"
     path = "${env.WORKSPACE}\\bin;${goRoot}\\bin;${chocoPath};${chocoPython3Path};C:\\tools\\mingw${mingwArch}\\bin;${env.PATH}"
     magefile = "${env.WORKSPACE}\\.magefile"
+    testResults = "**\\build\\TEST*.xml"
+    artifacts = "**\\build\\TEST*.out"
     gox_flags = '-arch 386'
   }
 
+  // IMPORTANT: Somehow windows workers got a different opinion regarding removing the workspace.
+  //            Windows workers are ephemerals, so this should not really affect us.
+  if(isUnix()) {
+    deleteDir()
+  }
+
+  unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+  // NOTE: This is required to run after the unstash
+  def module = withModule ? getCommonModuleInTheChangeSet(directory) : ''
   withEnv([
     "DOCKER_PULL=0",
     "GOPATH=${env.WORKSPACE}",
@@ -605,6 +620,7 @@ def withBeatsEnv(Map args = [:], Closure body) {
     "GOX_FLAGS=${gox_flags}",
     "HOME=${env.WORKSPACE}",
     "MAGEFILE_CACHE=${magefile}",
+    "MODULE=${module}",
     "PATH=${path}",
     "PYTHON_ENV=${pythonEnv}",
     "RACE_DETECTOR=true",
@@ -613,65 +629,32 @@ def withBeatsEnv(Map args = [:], Closure body) {
     "OLD_USERPROFILE=${env.USERPROFILE}",
     "USERPROFILE=${userProfile}"
   ]) {
-    body()
-  }
-}
-
-/**
-* This method wraps all the environment setup and pre-requirements to run any commands.
-*/
-def withBeatsContext(Map args = [:], Closure body) {
-  def archive = args.get('archive', true)
-  def withModule = args.get('withModule', false)
-  def directory = args.get('directory', '')
-
-  def testResults, artifacts
-
-  if(isUnix()) {
-    testResults = '**/build/TEST*.xml'
-    artifacts = '**/build/TEST*.out'
-    // IMPORTANT: Somehow windows workers got a different opinion regarding removing the workspace.
-    //            Windows workers are ephemerals, so this should not really affect us.
-    deleteDir()
-  } else {
-    testResults = "**\\build\\TEST*.xml"
-    artifacts = "**\\build\\TEST*.out"
-  }
-
-  unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-  // NOTE: This is required to run after the unstash
-  def module = withModule ? getCommonModuleInTheChangeSet(directory) : ''
-  withEnv([
-    "MODULE=${module}"
-  ]) {
-    withBeatsEnv(args) {
-      if(isDockerInstalled()) {
-        dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-        dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
-      }
-      dir("${env.BASE_DIR}") {
-        installTools(args)
-        // Skip to upload the generated files by default.
-        def upload = false
-        try {
-          // Add more stability when dependencies are not accessible temporarily
-          // See https://github.com/elastic/beats/issues/21609
-          // retry/try/catch approach reports errors, let's avoid it to keep the
-          // notifications cleaner.
-          if (cmd(label: 'Download modules to local cache', script: 'go mod download', returnStatus: true) > 0) {
-            cmd(label: 'Download modules to local cache - retry', script: 'go mod download', returnStatus: true)
-          }
-          body()
-        } catch(err) {
-          // Upload the generated files ONLY if the step failed. This will avoid any overhead with Google Storage
-          upload = true
-          error("Error '${err.toString()}'")
-        } finally {
-          if (archive) {
-            archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)
-          }
-          tearDown()
+    if(isDockerInstalled()) {
+      dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
+      dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
+    }
+    dir("${env.BASE_DIR}") {
+      installTools(args)
+      // Skip to upload the generated files by default.
+      def upload = false
+      try {
+        // Add more stability when dependencies are not accessible temporarily
+        // See https://github.com/elastic/beats/issues/21609
+        // retry/try/catch approach reports errors, let's avoid it to keep the
+        // notifications cleaner.
+        if (cmd(label: 'Download modules to local cache', script: 'go mod download', returnStatus: true) > 0) {
+          cmd(label: 'Download modules to local cache - retry', script: 'go mod download', returnStatus: true)
         }
+        body()
+      } catch(err) {
+        // Upload the generated files ONLY if the step failed. This will avoid any overhead with Google Storage
+        upload = true
+        error("Error '${err.toString()}'")
+      } finally {
+        if (archive) {
+          archiveTestOutput(testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)
+        }
+        tearDown()
       }
     }
   }
@@ -855,7 +838,7 @@ def startCloudTestEnv(Map args = [:]) {
   def dirs = args.get('dirs',[])
   stage("${name}-prepare-cloud-env"){
     withCloudTestEnv() {
-      withBeatsContext(archive: false, withModule: false) {
+      withBeatsEnv(archive: false, withModule: false) {
         try {
           dirs?.each { folder ->
             retryWithSleep(retries: 2, seconds: 5, backoff: true){
@@ -897,7 +880,7 @@ def terraformCleanup(Map args = [:]) {
   String directory = args.dir
   stage("${name}-tear-down-cloud-env"){
     withCloudTestEnv() {
-      withBeatsContext(archive: false, withModule: false) {
+      withBeatsEnv(archive: false, withModule: false) {
         unstash("terraform-${name}")
         retryWithSleep(retries: 2, seconds: 5, backoff: true) {
           sh(label: "Terraform Cleanup", script: ".ci/scripts/terraform-cleanup.sh ${directory}")

--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -13,13 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C auditbeat check;
           make -C auditbeat update;
           make -C x-pack/auditbeat check;
           make -C x-pack/auditbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -33,10 +34,13 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
+        stage: mandatory
     crosscompile:
         make: "make -C auditbeat crosscompile"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -50,46 +54,56 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-            #- "windows-7-32-bit" https://github.com/elastic/beats/issues/19831
-            #- "windows-2008-r2" https://github.com/elastic/beats/issues/19799
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
+    #windows-2008:  See https://github.com/elastic/beats/issues/19799
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-2008-r2"
+    #    stage: extended
     #windows-7:  See https://github.com/elastic/beats/issues/19831
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.
     #        - "windows-7"
-    #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test filebeat for windows-7"
-    #        labels:
-    #            - "windows-7"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
+    #    stage: extended
+    #windows-7-32:  See https://github.com/elastic/beats/issues/19831
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-7-32-bit"
+    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -13,8 +13,10 @@ when:
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
-       make: |
-        make -C deploy/kubernetes all;
-        make check-no-changes;
+        make: |
+            make -C deploy/kubernetes all;
+            make check-no-changes;
+        stage: lint
     k8sTest:
         k8sTest: "v1.18.2,v1.17.2,v1.16.4,v1.15.7,v1.14.10"
+        stage: mandatory

--- a/dev-tools/Jenkinsfile.yml
+++ b/dev-tools/Jenkinsfile.yml
@@ -13,4 +13,5 @@ when:
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
-       make: "make -C dev-tools check"
+        make: "make -C dev-tools check"
+        stage: lint

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -13,13 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C filebeat check;
           make -C filebeat update;
           make -C x-pack/filebeat check;
           make -C x-pack/filebeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -33,9 +34,11 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -49,45 +52,48 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
             #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19795
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     #windows-7:  See https://github.com/elastic/beats/issues/22317
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.
     #        - "windows-7"
     #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test filebeat for windows-7"
-    #        labels:
-    #            - "windows-7"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
+    #    stage: packaging
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/generator/Jenkinsfile.yml
+++ b/generator/Jenkinsfile.yml
@@ -17,8 +17,10 @@ platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     metricbeat-test:
         make: "make -C generator/_templates/metricbeat test test-package"
+        stage: mandatory
     beat-test:
         make: "make -C generator/_templates/beat test test-package"
+        stage: mandatory
     macos-metricbeat:
         make: "make -C generator/_templates/metricbeat test"
         platforms:             ## override default label in this specific stage.
@@ -32,6 +34,7 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     macos-beat:
         make: "make -C generator/_templates/beat test"
         platforms:             ## override default label in this specific stage.
@@ -45,3 +48,4 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -13,13 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C heartbeat check;
           make -C heartbeat update;
           make -C x-pack/heartbeat check;
           make -C x-pack/heartbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -33,8 +34,10 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -48,45 +51,56 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -13,11 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C journalbeat check;
           make -C journalbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -31,15 +32,19 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
+        stage: mandatory
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -12,13 +12,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C libbeat check;
           make -C libbeat update;
           make -C x-pack/libbeat check;
           make -C x-pack/libbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -32,7 +33,10 @@ stages:
                 - "armTest"
     build:
         mage: "mage build test"
+        stage: mandatory
     crosscompile:
         make: "make -C libbeat crosscompile"
+        stage: mandatory
     stress-tests:
         make: "make STRESS_TEST_OPTIONS='-timeout=20m -race -v -parallel 1' -C libbeat stress-tests"
+        stage: mandatory

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -13,23 +13,28 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C metricbeat check;
           make -C metricbeat update;
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
           make check-no-changes;
+        stage: lint
     unitTest:
         mage: "mage build unitTest"
+        stage: mandatory
     goIntegTest:
         mage: "mage goIntegTest"
         withModule: true
+        stage: mandatory
     pythonIntegTest:
         mage: "mage pythonIntegTest"
         withModule: true
+        stage: mandatory
     crosscompile:
         make: "make -C metricbeat crosscompile"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -47,41 +52,51 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false     ## e2e is enabled only for x-pack beats
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -13,7 +13,7 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C packetbeat check;
           make -C packetbeat update;
@@ -21,6 +21,7 @@ stages:
           cd x-pack/packetbeat;
           mage check;
           mage update;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -34,8 +35,10 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -49,45 +52,56 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -13,45 +13,59 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C winlogbeat check;
           make -C winlogbeat update;
           make -C x-pack/winlogbeat check;
           make -C x-pack/winlogbeat update;
           make check-no-changes;
+        stage: lint
     crosscompile:
         make: "make -C winlogbeat crosscompile"
+        stage: mandatory
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-            - "windows-2008-r2"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
+    windows-2008:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2008-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -13,13 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/auditbeat check;
           make -C x-pack/auditbeat update;
           make -C auditbeat check;
           make -C auditbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -33,9 +34,11 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage update build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -49,45 +52,56 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/x-pack/dockerlogbeat/Jenkinsfile.yml
+++ b/x-pack/dockerlogbeat/Jenkinsfile.yml
@@ -13,21 +13,25 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/dockerlogbeat check;
           make -C x-pack/dockerlogbeat update;
           make check-no-changes;
+        stage: lint
     build:
         mage: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
+        stage: mandatory
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -13,11 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/elastic-agent check;
           make -C x-pack/elastic-agent update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -31,8 +32,10 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -46,52 +49,56 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     #windows-7-32:  See https://github.com/elastic/beats/issues/22316
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.
     #        - "windows-7-32-bit"
-    #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test x-pack/elastic-agent for windows-7-32"
-    #        labels:
-    #            - "windows-7-32"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
+    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -13,13 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/filebeat check;
           make -C x-pack/filebeat update;
           make -C filebeat check;
           make -C filebeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -33,9 +34,11 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -49,52 +52,56 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     #windows-7-32:  See https://github.com/elastic/beats/issues/22315
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.
     #        - "windows-7-32-bit"
-    #    when:                  ## Override the top-level when.
-    #        comments:
-    #            - "/test x-pack/filebeat for windows-7-32"
-    #        labels:
-    #            - "windows-7-32"
-    #        branches: true     ## for all the branches
-    #        tags: true         ## for all the tags
+    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -13,11 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/functionbeat check;
           make -C x-pack/functionbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -31,6 +32,7 @@ stages:
                 - "armTest"
     build:
         mage: "mage build test && GO_VERSION=1.13.1 mage testGCPFunctions"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -44,39 +46,49 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -13,15 +13,17 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/heartbeat check;
           make -C x-pack/heartbeat update;
           make -C heartbeat check;
           make -C heartbeat update;
           make check-no-changes;
+        stage: lint
     build:
         mage: "mage build test"
+        stage: mandatory
     macos:
         mage: "mage build test"
         platforms:             ## override default label in this specific stage.
@@ -35,6 +37,7 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
 # TODO: there are windows test failures already reported
 # https://github.com/elastic/beats/issues/23957 and https://github.com/elastic/beats/issues/23958
 # waiting for being fixed.
@@ -42,41 +45,51 @@ stages:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-2019"
+#        stage: mandatory
 #    windows-2016:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-2016"
+#        stage: extended
 #    windows-2012:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-2012-r2"
+#        stage: extended
 #    windows-10:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-10"
+#        stage: extended
 #    windows-2008:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-2008-r2"
+#        stage: extended
 #    windows-8:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-8"
+#        stage: extended
 #    windows-7:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-7"
+#        stage: extended
 #    windows-7-32:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-7-32-bit"
+#        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/x-pack/libbeat/Jenkinsfile.yml
+++ b/x-pack/libbeat/Jenkinsfile.yml
@@ -13,11 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/libbeat check;
           make -C x-pack/libbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -31,5 +32,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
+        stage: mandatory

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -13,15 +13,17 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
           make -C metricbeat check;
           make -C metricbeat update;
           make check-no-changes;
+        stage: lint
     unitTest:
         mage: "mage build unitTest"
+        stage: mandatory
     cloud:
         cloud: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
@@ -34,6 +36,7 @@ stages:
                 - "/test x-pack/metricbeat for aws cloud"
             labels:
                 - "aws"
+        stage: extended
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -47,47 +50,58 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     # windows-7-32 builder has been disabled due to https://github.com/elastic/beats/issues/24337
     #windows-7-32:
     #    mage: "mage build unitTest"
     #    platforms:             ## override default labels in this specific stage.
     #        - "windows-7-32-bit"
+    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
             entrypoint: 'metricbeat-test.sh'
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -13,13 +13,15 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/osquerybeat check;
           make -C x-pack/osquerybeat update;
           make check-no-changes;
+        stage: lint
     build:
         mage: "mage build test"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -33,35 +35,44 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -13,7 +13,7 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    Lint:
+    lint:
         mage: |
           mage check;
           mage update;
@@ -21,6 +21,7 @@ stages:
           make -C packetbeat check;
           make -C packetbeat update;
           make check-no-changes;
+        stage: lint
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -34,8 +35,10 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     build:
         mage: "mage build test"
+        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
@@ -49,46 +52,57 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         withModule: true
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
+        stage: packaging
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
           - "arm"
+        stage: packaging

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -13,7 +13,7 @@ when:
     tags: true                 ## for all the tags
 platform: "windows-2019"       ## default label for all the stages
 stages:
-    Lint:
+    lint:
         make: |
           make -C x-pack/winlogbeat check;
           make -C x-pack/winlogbeat update;
@@ -22,42 +22,52 @@ stages:
           make check-no-changes;
         platforms:             ## override default labels in this specific stage.
             - "immutable && ubuntu-18"
+        stage: lint
     build:
         mage: "mage build unitTest"
         withModule: true
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
+        stage: extended
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
+        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
+        stage: extended
     windows-2008:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2008-r2"
+        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
+        stage: extended
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7"
+        stage: extended
     windows-7-32:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-7-32-bit"
+        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
             enabled: false
         platforms:             ## override default labels in this specific stage.
             - "immutable && ubuntu-18"
+        stage: packaging


### PR DESCRIPTION
## What does this PR do?

Split the pipeline in four meta-stages:

1. the `linting` -> requires ![21](https://img.shields.io/badge/21%20-green) workers for each merge commit (branches)
1. the `build/test` for the core platforms (linux, windows-2019 and arm) -> requires ![41](https://img.shields.io/badge/41%20-green)  workers for each merge commit (branches)
1. the `build/test` for the extended platforms (windows <=2016, macOS)  -> requires ![113](https://img.shields.io/badge/113%20-green)  workers for each merge commit (branches)
1. the `packaging` -> requires ![30](https://img.shields.io/badge/31%20-green)  workers for each merge commit (branches)

## Why is it important?


Potentially, this will reduce the CI load by provisioning less number of workers in parallel, which at the moment is causing issues with timeouts. This should help to smooth the required CI workers in batches and affecting a bit less the other pipelines.

## Issues

Superseedes https://github.com/elastic/beats/pull/24790

## UI

If failures in one of the stages in the `build/test` meta-stage

![image](https://user-images.githubusercontent.com/2871786/115684725-8429ae00-a34f-11eb-9a5a-b4336987bbd4.png)

If no failures but caching the linting:

![image](https://user-images.githubusercontent.com/2871786/115419185-0ac87900-a1f2-11eb-975a-4e776afa14ae.png)

