### PR TITLE
[Metricbeat] Remove elasticsearc.index.created from the SM code

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -132,6 +132,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for Consul 1.9. {pull}24123[24123]
 - Add support for the MemoryPressure, DiskPressure, OutOfDisk and PIDPressure status conditions in state_node. {pull}23905[23905]
 - Store `cloudfoundry.container.cpu.pct` in decimal form and as `scaled_float`. {pull}24219[24219]
+- Remove `index_stats.created` field from Elasticsearch/index Metricset {pull}25113[25113]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -46,7 +46,6 @@ type Index struct {
 	Total     indexStats `json:"total"`
 
 	Index   string     `json:"index"`
-	Created int64      `json:"created"`
 	Status  string     `json:"status"`
 	Hidden  bool       `json:"hidden"`
 	Shards  shardStats `json:"shards"`
@@ -130,7 +129,7 @@ type bulkStats struct {
 }
 
 func eventsMappingXPack(r mb.ReporterV2, m *MetricSet, info elasticsearch.Info, content []byte) error {
-	clusterStateMetrics := []string{"metadata", "routing_table"}
+	clusterStateMetrics := []string{"routing_table"}
 	clusterState, err := elasticsearch.GetClusterState(m.HTTP, m.HTTP.GetURI(), clusterStateMetrics)
 	if err != nil {
 		return errors.Wrap(err, "failure retrieving cluster state from Elasticsearch")

--- a/metricbeat/module/elasticsearch/index/data_xpack.go
+++ b/metricbeat/module/elasticsearch/index/data_xpack.go
@@ -45,10 +45,10 @@ type Index struct {
 	Primaries indexStats `json:"primaries"`
 	Total     indexStats `json:"total"`
 
-	Index   string     `json:"index"`
-	Status  string     `json:"status"`
-	Hidden  bool       `json:"hidden"`
-	Shards  shardStats `json:"shards"`
+	Index  string     `json:"index"`
+	Status string     `json:"status"`
+	Hidden bool       `json:"hidden"`
+	Shards shardStats `json:"shards"`
 }
 
 type indexStats struct {


### PR DESCRIPTION
## What does this PR do?

SM `index` metricset does an API HTTP call to elasticsearch to retrieve index metadata information. This information is required to populate field `elasticsearch.index.created` or (`index_stats.created` if `xpack.enabled: true` when configuring the module).

The code removes the API call to `/_cluster/state/metadata`.

## Why is it important?

The HTTP call to `/_cluster/state/metadata` can be VERY expensive. The reason for this is that it returns the entire mapping of all indices on a cluster. If a user has many indices and / or each index has many fields, this could lead to very heavy responses from elasticsearchr (20 Mb in big clusters measured with curl).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

* This is a breaking change, because users could be using field `elasticsearch.index.created` or `index_stats.created` and they will be removed.
* Stack Monitoring UI seems to keep working without any issues. I don't see this field populated anywhere.