### PR TITLE
[elastic-agent] respect host configuration for http endpoint

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -49,6 +49,7 @@
 - Add support for filestream input. {pull}24820[24820]
 - Add check for URL set when cert and cert key. {pull}24904[24904]
 - Fix install command for Fleet Server bootstrap, remove need for --enrollment-token when using --fleet-server {pull}24981[24981]
+- Respect host configuration for exposed processes endpoint {pull}25114[25114]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/monitoring.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/monitoring.go
@@ -26,7 +26,7 @@ const (
 	// args: pipeline name, application name
 	agentMbEndpointFileFormatWin = `npipe:///elastic-agent`
 	// agentMbEndpointHTTP is used with cloud and exposes metrics on http endpoint
-	agentMbEndpointHTTP = "http://localhost:%d"
+	agentMbEndpointHTTP = "http://%s:%d"
 )
 
 // MonitoringEndpoint is an endpoint where process is exposing its metrics.
@@ -60,7 +60,7 @@ func getLoggingFile(spec program.Spec, operatingSystem, installPath, pipelineID 
 // AgentMonitoringEndpoint returns endpoint with exposed metrics for agent.
 func AgentMonitoringEndpoint(operatingSystem string, cfg *monitoringConfig.MonitoringHTTPConfig) string {
 	if cfg != nil && cfg.Enabled {
-		return fmt.Sprintf(agentMbEndpointHTTP, cfg.Port)
+		return fmt.Sprintf(agentMbEndpointHTTP, cfg.Host, cfg.Port)
 	}
 
 	if operatingSystem == "windows" {


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When http processes endpoint is enabled, do not hardcode http endpoint
to localhost, but respect configuration. 

## Why is it important?

Current implementation does not work for docker environments.
