### PR TITLE
Cherry-pick #24425 to 7.x: Add tests for truncated and symlinked files

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -735,4 +736,170 @@ func TestFilestreamTruncateBlockedOutput(t *testing.T) {
 
 	cancelInput()
 	env.waitUntilInputStops()
+}
+
+// test_symlinks_enabled from test_harvester.py
+func TestFilestreamSymlinksEnabled(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.symlinks": "true",
+	})
+
+	testlines := []byte("first line\n")
+	env.mustWriteLinesToFile(testlogName, testlines)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(1)
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireOffsetInRegistry(testlogName, len(testlines))
+}
+
+// test_symlink_rotated from test_harvester.py
+func TestFilestreamSymlinkRotated(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	firstTestlogName := "test1.log"
+	secondTestlogName := "test2.log"
+	symlinkName := "test.log"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.check_interval": "1ms",
+		"prospector.scanner.symlinks":       "true",
+		"close.on_state_change.removed":     "false",
+		"clean_removed":                     "false",
+	})
+
+	commonLine := "first line in file "
+	for i, path := range []string{firstTestlogName, secondTestlogName} {
+		env.mustWriteLinesToFile(path, []byte(commonLine+strconv.Itoa(i)+"\n"))
+	}
+
+	env.mustSymlink(firstTestlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(1)
+
+	expectedOffset := len(commonLine) + 2
+	env.requireOffsetInRegistry(firstTestlogName, expectedOffset)
+
+	// rotate symlink
+	env.mustRemoveFile(symlinkName)
+	env.mustSymlink(secondTestlogName, symlinkName)
+
+	moreLines := "second line in file 2\nthird line in file 2\n"
+	env.mustAppendLinesToFile(secondTestlogName, []byte(moreLines))
+
+	env.waitUntilEventCount(4)
+	env.requireOffsetInRegistry(firstTestlogName, expectedOffset)
+	env.requireOffsetInRegistry(secondTestlogName, expectedOffset+len(moreLines))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(2)
+}
+
+// test_symlink_removed from test_harvester.py
+func TestFilestreamSymlinkRemoved(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath(symlinkName),
+		},
+		"prospector.scanner.check_interval": "1ms",
+		"prospector.scanner.symlinks":       "true",
+		"close.on_state_change.removed":     "false",
+		"clean_removed":                     "false",
+	})
+
+	line := []byte("first line\n")
+	env.mustWriteLinesToFile(testlogName, line)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(1)
+
+	env.requireOffsetInRegistry(testlogName, len(line))
+
+	// remove symlink
+	env.mustRemoveFile(symlinkName)
+
+	env.mustAppendLinesToFile(testlogName, line)
+
+	env.waitUntilEventCount(2)
+	env.requireOffsetInRegistry(testlogName, 2*len(line))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(1)
+}
+
+// test_truncate from test_harvester.py
+func TestFilestreamTruncate(t *testing.T) {
+	env := newInputTestingEnvironment(t)
+
+	testlogName := "test.log"
+	symlinkName := "test.log.symlink"
+	inp := env.mustCreateInput(map[string]interface{}{
+		"paths": []string{
+			env.abspath("*"),
+		},
+		"prospector.scanner.check_interval": "1ms",
+		"prospector.scanner.symlinks":       "true",
+	})
+
+	lines := []byte("first line\nsecond line\nthird line\n")
+	env.mustWriteLinesToFile(testlogName, lines)
+
+	env.mustSymlink(testlogName, symlinkName)
+
+	ctx, cancelInput := context.WithCancel(context.Background())
+	env.startInput(ctx, inp)
+
+	env.waitUntilEventCount(3)
+
+	env.requireOffsetInRegistry(testlogName, len(lines))
+
+	// remove symlink
+	env.mustRemoveFile(symlinkName)
+	env.mustTruncateFile(testlogName, 0)
+	env.waitUntilOffsetInRegistry(testlogName, 0)
+
+	// recreate symlink
+	env.mustSymlink(testlogName, symlinkName)
+
+	moreLines := []byte("forth line\nfifth line\n")
+	env.mustWriteLinesToFile(testlogName, moreLines)
+
+	env.waitUntilEventCount(5)
+	env.requireOffsetInRegistry(testlogName, len(moreLines))
+
+	cancelInput()
+	env.waitUntilInputStops()
+
+	env.requireRegistryEntryCount(1)
 }


### PR DESCRIPTION
Cherry-pick of PR #24425 to 7.x branch. Original message: 

## What does this PR do?

Add support for better support truncated files with symlinks and adds migrates related tests from `test_harvester.py`.

## Why is it important?

Increase coverage.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~