### PR TITLE
Cherry-pick #25111 to 7.x: Fix bug with annotations dedot config on k8s not used

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -151,6 +151,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `expand_keys` to the list of permitted config fields for `decode_json_fields` {24862}[24862]
 - Fix 'make setup' instructions for a new beat {pull}24944[24944]
 - Fix inode removal tracking code when files are replaced by files with the same name {pull}25002[25002]
+- Fix `mage GenerateCustomBeat` instructions for a new beat {pull}17679[17679]
+- Fix bug with annotations dedot config on k8s not used {pull}25111[25111]
+- Fix negative Kafka partition bug {pull}25048[25048]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -151,9 +151,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `expand_keys` to the list of permitted config fields for `decode_json_fields` {24862}[24862]
 - Fix 'make setup' instructions for a new beat {pull}24944[24944]
 - Fix inode removal tracking code when files are replaced by files with the same name {pull}25002[25002]
-- Fix `mage GenerateCustomBeat` instructions for a new beat {pull}17679[17679]
 - Fix bug with annotations dedot config on k8s not used {pull}25111[25111]
-- Fix negative Kafka partition bug {pull}25048[25048]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/metadata/pod_test.go
+++ b/libbeat/common/kubernetes/metadata/pod_test.go
@@ -247,10 +247,67 @@ func TestPod_Generate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test object with owner reference to replicaset honors annotations.dedot: false",
+			input: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					UID:       types.UID(uid),
+					Namespace: namespace,
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"k8s.app": "production",
+					},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps",
+							Kind:       "ReplicaSet",
+							Name:       "nginx-rs",
+							UID:        "005f3b90-4b9d-12f8-acf0-31020a8409087",
+							Controller: &boolean,
+						},
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				Spec: v1.PodSpec{
+					NodeName: "testnode",
+				},
+				Status: v1.PodStatus{PodIP: "127.0.0.5"},
+			},
+			output: common.MapStr{
+				"pod": common.MapStr{
+					"name": "obj",
+					"uid":  uid,
+					"ip":   "127.0.0.5",
+				},
+				"namespace": "default",
+				"deployment": common.MapStr{
+					"name": "nginx-deployment",
+				},
+				"replicaset": common.MapStr{
+					"name": "nginx-rs",
+				},
+				"node": common.MapStr{
+					"name": "testnode",
+				},
+				"labels": common.MapStr{
+					"foo": "bar",
+				},
+				"annotations": common.MapStr{
+					"k8s": common.MapStr{"app": "production"},
+				},
+			},
+		},
 	}
 
 	config, err := common.NewConfigFrom(map[string]interface{}{
-		"include_annotations": []string{"app"},
+		"include_annotations": []string{"app", "k8s.app"},
+		"annotations.dedot":   false,
 	})
 	assert.Nil(t, err)
 
@@ -283,7 +340,7 @@ func TestPod_GenerateFromName(t *testing.T) {
 						"foo": "bar",
 					},
 					Annotations: map[string]string{
-						"app": "production",
+						"k8s.app": "production",
 					},
 				},
 				TypeMeta: metav1.TypeMeta{
@@ -309,7 +366,7 @@ func TestPod_GenerateFromName(t *testing.T) {
 					"foo": "bar",
 				},
 				"annotations": common.MapStr{
-					"app": "production",
+					"k8s_app": "production",
 				},
 			},
 		},
@@ -370,7 +427,7 @@ func TestPod_GenerateFromName(t *testing.T) {
 
 	for _, test := range tests {
 		config, err := common.NewConfigFrom(map[string]interface{}{
-			"include_annotations": []string{"app"},
+			"include_annotations": []string{"app", "k8s.app"},
 		})
 		assert.Nil(t, err)
 		pods := cache.NewStore(cache.MetaNamespaceKeyFunc)

--- a/libbeat/common/kubernetes/metadata/resource.go
+++ b/libbeat/common/kubernetes/metadata/resource.go
@@ -61,7 +61,7 @@ func (r *Resource) Generate(kind string, obj kubernetes.Resource, options ...Fie
 		labelMap.Delete(label)
 	}
 
-	annotationsMap := generateMapSubset(accessor.GetAnnotations(), r.config.IncludeAnnotations, r.config.LabelsDedot)
+	annotationsMap := generateMapSubset(accessor.GetAnnotations(), r.config.IncludeAnnotations, r.config.AnnotationsDedot)
 
 	meta := common.MapStr{
 		strings.ToLower(kind): common.MapStr{


### PR DESCRIPTION
Cherry-pick of PR #25111 to 7.x branch. Original message: 

## What does this PR do?
This PR fixes a bug with k8s annotation's dedot option cannot be disabled cause we ignore its value and we use label's dedot option.

## Why is it important?
Annotation's dedot cannot be disabled.



## Related issues

- Closes https://github.com/elastic/beats/issues/25078
