### PR TITLE
Cherry-pick #25146 to 7.x: Add svc to agent k8s clusterRole

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -561,6 +561,7 @@ rules:
       - namespaces
       - events
       - pods
+      - services
     verbs: ["get", "list", "watch"]
   # Enable this rule only if planing to use kubernetes_secrets provider
   #- apiGroups: [""]

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-role.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-role.yaml
@@ -11,6 +11,7 @@ rules:
       - namespaces
       - events
       - pods
+      - services
     verbs: ["get", "list", "watch"]
   # Enable this rule only if planing to use kubernetes_secrets provider
   #- apiGroups: [""]


### PR DESCRIPTION
Cherry-pick of PR #25146 to 7.x branch. Original message: 

## What does this PR do?
This PR adds `services` object in ClusterRole of Agent so as to be able to fetch metadata for services when running Agent on k8s. This is not used directly but under the hood from `state_service` metricset.

## Why is it important?
`state_metricset` will not work without it.


We need this in `7.13` where manifests will be shipped for first time.