### PR TITLE
Cherry-pick #25132 to 7.x: Keep http and logging config during enroll 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -90,4 +90,5 @@
 - Add status subcommand {pull}24856[24856]
 - Add leader_election provider for k8s {pull}24267[24267]
 - Add --fleet-server-service-token and FLEET_SERVER_SERVICE_TOKEN options {pull}25083[25083]
+- Keep http and logging config during enroll {pull}25132[25132]
 - Log output of container to $LOGS_PATH/elastic-agent-start.log when LOGS_PATH set {pull}25150[25150]

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_id.go
@@ -19,6 +19,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/storage"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	monitoringConfig "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/config"
 )
 
 // defaultAgentConfigFile is a name of file used to store agent information
@@ -27,8 +28,9 @@ const defaultLogLevel = "info"
 const maxRetriesloadAgentInfo = 5
 
 type persistentAgentInfo struct {
-	ID       string `json:"id" yaml:"id" config:"id"`
-	LogLevel string `json:"logging.level,omitempty" yaml:"logging.level,omitempty" config:"logging.level,omitempty"`
+	ID             string                                 `json:"id" yaml:"id" config:"id"`
+	LogLevel       string                                 `json:"logging.level,omitempty" yaml:"logging.level,omitempty" config:"logging.level,omitempty"`
+	MonitoringHTTP *monitoringConfig.MonitoringHTTPConfig `json:"monitoring.http,omitempty" yaml:"monitoring.http,omitempty" config:"monitoring.http,omitempty"`
 }
 
 type ioStore interface {
@@ -90,7 +92,8 @@ func getInfoFromStore(s ioStore, logLevel string) (*persistentAgentInfo, error) 
 	agentInfoSubMap, found := configMap[agentInfoKey]
 	if !found {
 		return &persistentAgentInfo{
-			LogLevel: logLevel,
+			LogLevel:       logLevel,
+			MonitoringHTTP: monitoringConfig.DefaultConfig().HTTP,
 		}, nil
 	}
 
@@ -100,7 +103,8 @@ func getInfoFromStore(s ioStore, logLevel string) (*persistentAgentInfo, error) 
 	}
 
 	pid := &persistentAgentInfo{
-		LogLevel: logLevel,
+		LogLevel:       logLevel,
+		MonitoringHTTP: monitoringConfig.DefaultConfig().HTTP,
 	}
 	if err := cc.Unpack(&pid); err != nil {
 		return nil, errors.New(err, "failed to unpack stored config to map")

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
@@ -184,9 +184,12 @@ func fleetToReader(agentInfo *info.AgentInfo, cfg *configuration.Configuration) 
 	configToStore := map[string]interface{}{
 		"fleet": cfg.Fleet,
 		"agent": map[string]interface{}{
-			"id": agentInfo.AgentID(),
+			"id":              agentInfo.AgentID(),
+			"logging.level":   cfg.Settings.LoggingConfig.Level,
+			"monitoring.http": cfg.Settings.MonitoringConfig.HTTP,
 		},
 	}
+
 	data, err := yaml.Marshal(configToStore)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry-pick of PR #25132 to 7.x branch. Original message:

## What does this PR do?

At the moment all configuration is discarded when agent enrolls to fleet. 
This PR enables persistence of settings for logging and http (exposing metrics). 
Without this cloud is not able to set http endpoint and collect metrics from agent and processes

## Why is it important?

Cloud

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
