### PR TITLE
Cherry-pick #25163 to 7.x: Make agent retry values for bootstraping configurable 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -52,8 +52,8 @@
 - Respect host configuration for exposed processes endpoint {pull}25114[25114]
 - Set --inscure in container when FLEET_SERVER_ENABLE and FLEET_INSECURE set {pull}25137[25137]
 - Restart process on output change {pull}24907[24907]
-
 - Fixed: limit for retries to Kibana configurable {issue}25063[25063]
+
 ==== New features
 
 - Prepare packaging for endpoint and asc files {pull}20186[20186]

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -53,6 +53,7 @@
 - Set --inscure in container when FLEET_SERVER_ENABLE and FLEET_INSECURE set {pull}25137[25137]
 - Restart process on output change {pull}24907[24907]
 
+- Fixed: limit for retries to Kibana configurable {issue}25063[25063]
 ==== New features
 
 - Prepare packaging for endpoint and asc files {pull}20186[20186]


### PR DESCRIPTION
Cherry-pick of PR #25163 to 7.x branch. Original message:

## What does this PR do?

This PR adds an option to configure values used in container command for GET/POST request to kibana. 

## Why is it important?

https://github.com/elastic/beats/issues/25063

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

cc @simitt 