### PR TITLE
Cherry-pick #24741 to 7.x: Fix nil panic when overwriting metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,6 +155,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix inode removal tracking code when files are replaced by files with the same name {pull}25002[25002]
 - Fix negative Kafka partition bug {pull}25048[25048]
 - Fix bug with annotations dedot config on k8s not used {pull}25111[25111]
+- Fix panic when overwriting metadata {pull}24741[24741]
 
 *Auditbeat*
 

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -79,11 +79,17 @@ func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, expandKeys, o
 		case "@metadata":
 			switch m := v.(type) {
 			case map[string]string:
+				if event.Meta == nil && len(m) > 0 {
+					event.Meta = common.MapStr{}
+				}
 				for meta, value := range m {
 					event.Meta[meta] = value
 				}
 
 			case map[string]interface{}:
+				if event.Meta == nil {
+					event.Meta = common.MapStr{}
+				}
 				event.Meta.DeepUpdate(common.MapStr(m))
 
 			default:

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -472,6 +472,25 @@ func TestExpandKeysError(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestOverwriteMetadata(t *testing.T) {
+	testConfig := common.MustNewConfigFrom(map[string]interface{}{
+		"fields":         fields,
+		"target":         "",
+		"overwrite_keys": true,
+	})
+
+	input := common.MapStr{
+		"msg": "{\"@metadata\":{\"beat\":\"libbeat\"},\"msg\":\"overwrite metadata test\"}",
+	}
+
+	expected := common.MapStr{
+		"msg": "overwrite metadata test",
+	}
+	actual := getActualValue(t, testConfig, input)
+
+	assert.Equal(t, expected, actual)
+}
+
 func getActualValue(t *testing.T, config *common.Config, input common.MapStr) common.MapStr {
 	log := logp.NewLogger("decode_json_fields_test")
 


### PR DESCRIPTION
Cherry-pick of PR #24741 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

I'm using Filebeat writing data into Kafka and having another Filebeat reading from Kafka. I got this error when I was trying to decode the `message` field into root-level via `decode_json_fields` processor.

```
panic: assignment to entry in nil map

goroutine 105 [running]:
github.com/elastic/beats/libbeat/common.MapStr.Update(0x0, 0xc0001620c0)
	/go/src/github.com/elastic/beats/libbeat/common/mapstr.go:61 +0xd3
github.com/elastic/beats/libbeat/common/jsontransform.WriteJSONKeys(0xc0000b8080, 0xc000162090, 0x101)
	/go/src/github.com/elastic/beats/libbeat/common/jsontransform/jsonhelper.go:67 +0x9ad
github.com/elastic/beats/libbeat/processors/actions.(*decodeJSONFields).Run(0xc0001710c0, 0xc0000b8080, 0xc00017bb00, 0x0, 0x0)
	/go/src/github.com/elastic/beats/libbeat/processors/actions/decode_json_fields.go:145 +0x751
github.com/elastic/beats/libbeat/publisher/processing.(*group).Run(0xc000768d50, 0xc0000b8080, 0xc0000b8080, 0x0, 0x0)
	/go/src/github.com/elastic/beats/libbeat/publisher/processing/processors.go:104 +0x94
github.com/elastic/beats/libbeat/publisher/processing.(*group).Run(0xc000768d20, 0xc0000b8080, 0x203000, 0x7f10562985b0, 0x7f1056295ff8)
	/go/src/github.com/elastic/beats/libbeat/publisher/processing/processors.go:104 +0x94
github.com/elastic/beats/libbeat/publisher/pipeline.(*client).publish(0xc000184f80, 0xe3ed9c0, 0xed7ed39c7, 0x3da5020, 0x0, 0xc00017abd0, 0x2551760, 0xc0001b8410, 0x0)
	/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/client.go:89 +0x571
github.com/elastic/beats/libbeat/publisher/pipeline.(*client).Publish(0xc000184f80, 0xe3ed9c0, 0xed7ed39c7, 0x3da5020, 0x0, 0xc00017abd0, 0x2551760, 0xc0001b8410, 0x0)
	/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/client.go:68 +0xc2
github.com/elastic/beats/filebeat/channel.(*outlet).OnEvent(0xc000768f60, 0xe3ed9c0, 0xed7ed39c7, 0x3da5020, 0x0, 0xc00017abd0, 0x2551760, 0xc0001b8410, 0x0, 0x0)
	/go/src/github.com/elastic/beats/filebeat/channel/outlet.go:64 +0x7e
github.com/elastic/beats/filebeat/input/kafka.(*groupHandler).ConsumeClaim(0xc000164000, 0x2a49a00, 0xc0007b6080, 0x2a3cd60, 0xc000495c80, 0xa, 0x0)
	/go/src/github.com/elastic/beats/filebeat/input/kafka/input.go:332 +0x1c5
github.com/elastic/beats/vendor/github.com/Shopify/sarama.(*consumerGroupSession).consume(0xc0007b6080, 0xc00027f380, 0xa, 0x0)
	/go/src/github.com/elastic/beats/vendor/github.com/Shopify/sarama/consumer_group.go:615 +0x27f
github.com/elastic/beats/vendor/github.com/Shopify/sarama.newConsumerGroupSession.func2(0xc0007b6080, 0xc00027f380, 0xa, 0xc000000000)
	/go/src/github.com/elastic/beats/vendor/github.com/Shopify/sarama/consumer_group.go:544 +0xd0
created by github.com/elastic/beats/vendor/github.com/Shopify/sarama.newConsumerGroupSession
	/go/src/github.com/elastic/beats/vendor/github.com/Shopify/sarama/consumer_group.go:536 +0x526
```

## Why is it important?

The Filebeat process will crash without the fix.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

using unittest.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #6381

## Note

Filebeat will actually output JSONs with duplicated keys when I'm trying to overwrite the `@metadata` field. And I'm not pretty sure if that's good for beats. Check the example below:

#### Filebeat configuration
```
filebeat.inputs:
  - type: stdin
    enabled: true
output.console:
    enabled: true

processors:
  - decode_json_fields:
      fields: [ "message" ]
      target: ""
      overwrite_keys: true
```

#### Input
```
{"@timestamp":"2021-03-24T12:17:54.978Z","@metadata":{"beat":"filebeat","type":"_doc","version":"7.0.0"},"message":"overwrite metadata test"}
```
#### Output
```
{"@timestamp":"2021-03-24T12:17:54.978Z","@metadata":{"beat":"filebeat","type":"_doc","version":"8.0.0","type":"_doc","version":"7.0.0","beat":"filebeat"},"log":{"offset":0,"file":{"path":""}},"message":"overwrite metadata test","input":{"type":"stdin"},"agent":{"name":"MacBook","type":"filebeat","version":"8.0.0","ephemeral_id":"ephemeral_id","id":"id"},"ecs":{"version":"1.8.0"},"host":{"name":"MacBook"}}
```
