### PR TITLE
Cherry-pick to 7.x: Update replace.asciidoc (#25055)

### DIFF
--- a/libbeat/processors/actions/docs/replace.asciidoc
+++ b/libbeat/processors/actions/docs/replace.asciidoc
@@ -11,15 +11,15 @@ contains a `field: field-name`, `pattern: regex-pattern` and
 `replacement: replacement-string`, where:
 
 * `field` is the original field name
-* `pattern` is regex pattern to match field's value
-* `replacement` is the replacement string to use for updating the field's value
+* `pattern` is the regex pattern to match the field's value
+* `replacement` is the replacement string to use to update the field's value
 
 The `replace` processor cannot be used to replace value with a completely new value. 
 
-TIP: You can replace field value to truncate part of field value or replace 
+TIP: The `replacement` field value can be used to truncate the `field` value or replace
 it with a new string. It can also be used for masking PII information.
 
-Following example will change path from /usr/bin to /usr/local/bin
+The following example will change path from /usr/bin to /usr/local/bin:
 
 [source,yaml]
 -------
@@ -35,15 +35,14 @@ processors:
 
 The `replace` processor has following configuration settings:
 
-`ignore_missing`:: (Optional) If set to true, no error is logged in case a specifiedfield 
-is missing. Default is `false`.
+`ignore_missing`:: (Optional) If set to `true`, no error is logged if the specified field 
+is missing. The default is `false`.
 
-`fail_on_error`:: (Optional) If set to true, in case of an error the replacement of
-field values is stopped and the original event is returned. If set to false, replacement
-continues even if an error occurs during replacement. Default is `true`.
+`fail_on_error`:: (Optional) If set to `true` and there's an error, the replacement of
+field values is stopped and the original event is returned. If set to `false`, replacement
+continues even if an error occurs during replacement. The default is `true`.
 
 See <<conditions>> for a list of supported conditions.
 
 You can specify multiple `ignore_missing` processors under the `processors`
 section.
-


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update replace.asciidoc (#25055)