### PR TITLE
Check native environment before starting

### DIFF
--- a/libbeat/cmd/platformcheck/platformcheck.go
+++ b/libbeat/cmd/platformcheck/platformcheck.go
@@ -1,0 +1,31 @@
+// +build linux windows
+
+package platformcheck
+
+import (
+	"fmt"
+	"math/bits"
+	"strings"
+
+	"github.com/shirou/gopsutil/host"
+)
+
+func CheckNativePlatformCompat() error {
+	const compiledArchBits = bits.UintSize // 32 if the binary was compiled for 32 bit architecture.
+
+	if compiledArchBits > 32 {
+		// We assume that 64bit binaries can only be run on 64bit systems
+		return nil
+	}
+
+	arch, err := host.KernelArch()
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(arch, "64") {
+		return fmt.Errorf("trying to run %vBit binary on 64Bit system", compiledArchBits)
+	}
+
+	return nil
+}

--- a/libbeat/cmd/platformcheck/platformcheck.go
+++ b/libbeat/cmd/platformcheck/platformcheck.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // +build linux windows
 
 package platformcheck

--- a/libbeat/cmd/platformcheck/platformcheck_other.go
+++ b/libbeat/cmd/platformcheck/platformcheck_other.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // +build !linux,!windows
 
 package platformcheck

--- a/libbeat/cmd/platformcheck/platformcheck_other.go
+++ b/libbeat/cmd/platformcheck/platformcheck_other.go
@@ -1,0 +1,7 @@
+// +build !linux,!windows
+
+package platformcheck
+
+func CheckNativePlatformCompat() error {
+	return nil
+}

--- a/libbeat/cmd/platformcheck/platformcheck_test.go
+++ b/libbeat/cmd/platformcheck/platformcheck_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package platformcheck
 
 import (

--- a/libbeat/cmd/platformcheck/platformcheck_test.go
+++ b/libbeat/cmd/platformcheck/platformcheck_test.go
@@ -1,0 +1,48 @@
+package platformcheck
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckPlatformCompat(t *testing.T) {
+	if !(runtime.GOARCH == "amd64" && (runtime.GOOS == "linux" ||
+		runtime.GOOS == "windows")) {
+		t.Skip("Test not support on current platform")
+	}
+
+	// compile test helper
+	tmp := t.TempDir()
+	helper := filepath.Join(tmp, "helper")
+
+	cmd := exec.Command("go", "test", "-c", "-o", helper)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "GOARCH=386")
+	require.NoError(t, cmd.Run(), "failed to compile test helper")
+
+	// run test helper
+	cmd = exec.Command(helper, "-test.v", "-test.run", "TestHelper")
+	cmd.Env = []string{"GO_USE_HELPER=1"}
+	output, err := cmd.Output()
+	if err != nil {
+		t.Logf("32bit binary tester failed.\n Output: %s", output)
+	}
+}
+
+func TestHelper(t *testing.T) {
+	if os.Getenv("GO_USE_HELPER") != "1" {
+		t.Log("ignore helper")
+		return
+	}
+
+	err := CheckNativePlatformCompat()
+	if err.Error() != "trying to run 32Bit binary on 64Bit system" {
+		t.Error("expected the native platform check to fail")
+	}
+}

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/cmd/platformcheck"
 )
 
 func init() {
@@ -56,6 +57,11 @@ type BeatsRootCmd struct {
 // run command, which will be called if no args are given (for backwards compatibility),
 // and beat settings
 func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings) *BeatsRootCmd {
+	if err := platformcheck.CheckNativePlatformCompat(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize: %v\n", err)
+		os.Exit(1)
+	}
+
 	if settings.IndexPrefix == "" {
 		settings.IndexPrefix = settings.Name
 	}

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -9,6 +9,7 @@
 
 - Docker container is not run as root by default. {pull}21213[21213]
 - Read Fleet connection information from `fleet.*` instead of `fleet.kibana.*`. {pull}24713[24713]
+- Beats build for 32Bit Windows or Linux system will refuse to run on a 64bit system. {pull}25186[25186]
 
 ==== Bugfixes
 - Fix rename *ConfigChange to *PolicyChange to align on changes in the UI. {pull}20779[20779]

--- a/x-pack/elastic-agent/main.go
+++ b/x-pack/elastic-agent/main.go
@@ -10,11 +10,17 @@ import (
 	"os"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/cmd/platformcheck"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/cmd"
 )
 
 // Setups and Runs agent.
 func main() {
+	if err := platformcheck.CheckNativePlatformCompat(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to initialize: %v\n", err)
+		os.Exit(1)
+	}
+
 	rand.Seed(time.Now().UnixNano())
 	command := cmd.NewCommand()
 	if err := command.Execute(); err != nil {


### PR DESCRIPTION
Running Beats/Agent build for 32bits sometimes leads to problems on
64bit platforms. Some system metrics do have different sizing on 32 and
64bit architectures, which can trip up Agent/Beats wrongly interpreting
the given data.

On Windows/Linux it is possible to run 32bit binaries. Now a check will
be run to fail on startup if the architecture does not match the
binaries architecture.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Enhancement

## What does this PR do?

On Windows/Linux it is possible to run 32bit binaries. Now a check will be run to fail on startup if the architecture does not match the binaries architecture.

## Why is it important?

Running Beats/Agent build for 32bits sometimes leads to problems on 64bit platforms. Some system metrics do have different sizing on 32 and 64bit architectures, which can trip up Agent/Beats wrongly interpreting the given data.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

The change contains an unit test.

Compile Beats or Agent with GOARCH=386 on a 64bit linux/windows and try to run it. The binary fails with exit code 1 + complains that you tried to run a 32bit binary on a 64bit system.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24092 