### PR TITLE
feat: support building integrations in arm

### DIFF
--- a/.ci/build-docker-images.groovy
+++ b/.ci/build-docker-images.groovy
@@ -124,7 +124,7 @@ def generateBuildStep(Map args = [:]) {
         dir("${BASE_DIR}/${beatPath}"){
           retryWithSleep(retries: 3, seconds: 5, backoff: true){
             sh(label: 'Build', script: "mage compose:buildSupportedVersions");
-            sh(label: 'Push', script: "mage compose:pushSupportedVersions");
+            sh(label: 'Push', script: "mage manifesttool:pushSupportedVersions");
           }
         }
       }

--- a/dev-tools/mage/target/manifesttool/manifesttool.go
+++ b/dev-tools/mage/target/manifesttool/manifesttool.go
@@ -64,7 +64,7 @@ func (m ManifestTool) pushForEachVariant() error {
 	for _, f := range files {
 		err := forEachSupportedVersion(f)
 		if err != nil {
-			return errors.Wrapf(err, "pushing '%s' for supported versions defined in %s", f)
+			return errors.Wrapf(err, "pushing supported versions defined in %s", f)
 		}
 	}
 

--- a/dev-tools/mage/target/manifesttool/manifesttool.go
+++ b/dev-tools/mage/target/manifesttool/manifesttool.go
@@ -47,6 +47,10 @@ type ManifestTool mg.Namespace
 
 // PushSupportedVersions pushes images for versions defined in supported-versions.yml files
 func (m ManifestTool) PushSupportedVersions() error {
+	if runtime.GOOS != "linux" {
+		return errors.Errorf("pushing supported versions in '%s' is not supported. Only linux is supported at this moment", runtime.GOOS)
+	}
+
 	fmt.Println(">> manifest-tool: Pushing docker images for supported versions")
 	return m.pushForEachVariant()
 }

--- a/dev-tools/mage/target/manifesttool/manifesttool.go
+++ b/dev-tools/mage/target/manifesttool/manifesttool.go
@@ -145,13 +145,13 @@ func forEachSupportedVersion(file string) error {
 		}
 
 		// this file path uses *NIX separator, because the images are supposed to be built under linux
-		dockerConfigFile := homeDir + "/.docker/config.json"
+		dockerConfigDir := homeDir + "/.docker"
 
 		image := fmt.Sprintf("docker.elastic.co/integrations-ci/beats-%s:%s", module, tag)
 		var stderr bytes.Buffer
 		_, err = sh.Exec(
 			map[string]string{}, nil, &stderr,
-			"docker", "run", "--rm", "--mount", "src="+dockerConfigFile+",target=/docker-config,type=bind",
+			"docker", "run", "--rm", "--mount", "src="+dockerConfigDir+",target=/docker-config,type=bind",
 			manifestToolImage,
 			"--platforms", platform,
 			"--template", image,

--- a/dev-tools/mage/target/manifesttool/manifesttool.go
+++ b/dev-tools/mage/target/manifesttool/manifesttool.go
@@ -1,0 +1,164 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package manifesttool
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/magefile/mage/mg"
+	"github.com/magefile/mage/sh"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+)
+
+const manifestToolImage = "docker.elastic.co/infra/manifest-tool:latest"
+
+// SupportedVersions is the definition of supported version files
+type SupportedVersions struct {
+	Variants []map[string]string `yaml:"variants"`
+}
+
+// ManifestTool are targets to build multi-platform images with manifest-tool
+type ManifestTool mg.Namespace
+
+// PushSupportedVersions pushes images for versions defined in supported-versions.yml files
+func (m ManifestTool) PushSupportedVersions() error {
+	fmt.Println(">> manifest-tool: Pushing docker images for supported versions")
+	return m.pushForEachVariant()
+}
+
+func (m ManifestTool) pushForEachVariant() error {
+	files, err := findSupportedVersionsFiles()
+	if err != nil {
+		return errors.Wrap(err, "finding supported versions files")
+	}
+
+	for _, f := range files {
+		err := forEachSupportedVersion(f)
+		if err != nil {
+			return errors.Wrapf(err, "pushing '%s' for supported versions defined in %s", f)
+		}
+	}
+
+	return nil
+}
+
+func findSupportedVersionsFiles() ([]string, error) {
+	if f := os.Getenv("SUPPORTED_VERSIONS_FILE"); len(f) > 0 {
+		return []string{f}, nil
+	}
+
+	if module := os.Getenv("MODULE"); len(module) > 0 {
+		path := filepath.Join("module", module, "_meta/supported-versions.yml")
+		return []string{path}, nil
+	}
+
+	if input := os.Getenv("INPUT"); len(input) > 0 {
+		path := filepath.Join("input", input, "_meta/supported-versions.yml")
+		return []string{path}, nil
+	}
+
+	return devtools.FindFilesRecursive(func(path string, _ os.FileInfo) bool {
+		return filepath.Base(path) == "supported-versions.yml"
+	})
+}
+
+func forEachSupportedVersion(file string) error {
+	d, err := ioutil.ReadFile(file)
+	if err != nil {
+		return errors.Wrapf(err, "reading supported versions file %s", file)
+	}
+
+	module := filepath.Base(filepath.Dir(filepath.Dir(file)))
+
+	moduleUppercase := strings.ToUpper(module)
+
+	var supportedVersions SupportedVersions
+
+	err = yaml.Unmarshal(d, &supportedVersions)
+	if err != nil {
+		return errors.Wrapf(err, "parsing supported versions file %s", file)
+	}
+
+	for _, variant := range supportedVersions.Variants {
+		index := "1"
+		var codename string
+		var version string
+		for k, v := range variant {
+			switch k {
+			case moduleUppercase + "_VERSION":
+				version = v
+			case moduleUppercase + "_CODENAME":
+			case moduleUppercase + "_VARIANT":
+				codename = v
+			case moduleUppercase + "_INDEX":
+				index = v
+			default:
+				codename = ""
+				version = ""
+				index = "1"
+			}
+		}
+
+		var tag string
+		if codename == "" {
+			tag = fmt.Sprintf("%s-%s", version, index)
+		} else {
+			tag = fmt.Sprintf("%s-%s-%s", codename, version, index)
+		}
+
+		// supported platforms on CI: linux/amd64, linux/arm64
+		platform := runtime.GOOS + "/" + runtime.GOARCH
+		fmt.Printf(">> manifest-tool: Pushing images for module '%s', tag '%s' on platform '%s'\n", module, tag, platform)
+
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return err
+		}
+
+		// this file path uses *NIX separator, because the images are supposed to be built under linux
+		dockerConfigFile := homeDir + "/.docker/config.json"
+
+		image := fmt.Sprintf("docker.elastic.co/integrations-ci/beats-%s:%s", module, tag)
+		var stderr bytes.Buffer
+		_, err = sh.Exec(
+			map[string]string{}, nil, &stderr,
+			"docker", "run", "--rm", "--mount", "src="+dockerConfigFile+",target=/docker-config,type=bind",
+			manifestToolImage,
+			"--platforms", platform,
+			"--template", image,
+			"--target", image,
+		)
+		if err != nil {
+			io.Copy(os.Stderr, &stderr)
+			return err
+		}
+	}
+	fmt.Println(">> manifest-tool: OK")
+
+	return nil
+}

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -51,6 +51,8 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/manifesttool"
+	// mage:import
 	_ "github.com/elastic/beats/v7/metricbeat/scripts/mage/target/metricset"
 )
 

--- a/metricbeat/module/ceph/_meta/supported-versions.yml
+++ b/metricbeat/module/ceph/_meta/supported-versions.yml
@@ -1,5 +1,10 @@
 variants:
   - CEPH_CODENAME: jewel
     CEPH_VERSION: master-6373c6a-jewel-centos-7-x86_64
+    CEPH_INDEX: 1
+  - CEPH_CODENAME: jewel
+    CEPH_VERSION: master-6373c6a-jewel-centos-7-x86_64
+    CEPH_INDEX: 2
   - CEPH_CODENAME: nautilus
     CEPH_VERSION: master-97985eb-nautilus-centos-7-x86_64
+    CEPH_INDEX: 2

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -24,6 +24,8 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/manifesttool"
+	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/test"

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -26,6 +26,8 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/manifesttool"
+	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 	// mage:import
 	_ "github.com/elastic/beats/v7/metricbeat/scripts/mage/target/metricset"

--- a/x-pack/packetbeat/magefile.go
+++ b/x-pack/packetbeat/magefile.go
@@ -21,6 +21,8 @@ import (
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
 	// mage:import
+	_ "github.com/elastic/beats/v7/dev-tools/mage/target/manifesttool"
+	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
It extracts the logic to build&push integrations' docker images using mage to a method in the pipeline, that will be used to be run in parallel: one branch for amd and one for arm. The result is having the integrations built in ARM format.

Besides that, we are adding a new mage command `manifesttool:pushSupportedVersions` for pushing the integration images with multi-platform support. We are using a tool provided by Infra to perform that task, which we wrapped into the new mage command. This mage command:

- will be run only on linux machines, because is coupled with the CI workers. That could be changed for new images.
- it will calculate the Docker tag used on the `compose:buildSupportedVersions` reading the values from the `supported-versions.yml` file for each integration module. It will add logic to build the proper tag based in the `${MODULE}_VARIANT` and `${MODULE}_VERSION`, and for the specific use case of `ceph` we are adding an `${MODULE}_INDEX` to control the custom image number we use internally for tracking changes.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
The integrations are built for AMD only, and the e2e testing framework needs to consume them in ARM to provide a full experience testing in ARM.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Do we need to use an agent in the first stage? Instead, I think we can move that agent to the checkout stage


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #25194


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

## Other considerations
Maybe this approach could be discarded if we realise that maintaining ARM/AMD images for the integrations is overkill. It could be the case where we have to build and maintain the binaries for each integration in both platforms, very likely because there is no ARM flavour of the image. Because the existence of ARM images for the integrations is blocking elastic/e2e-testing#707, maybe we can get to the point of not running e2e tests for the integrations.