### PR TITLE
Cherry-pick #25193 to 7.13: Proxy processes/elastic-agent to stats 

### DIFF
--- a/x-pack/elastic-agent/pkg/core/monitoring/server/server.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/server.go
@@ -44,11 +44,12 @@ func New(
 
 func exposeMetricsEndpoint(log *logger.Logger, config *common.Config, ns func(string) *monitoring.Namespace, routesFetchFn func() *sorted.Set, enableProcessStats bool) (*api.Server, error) {
 	r := mux.NewRouter()
-	r.Handle("/stats", createHandler(statsHandler(ns("stats"))))
+	statsHandler := statsHandler(ns("stats"))
+	r.Handle("/stats", createHandler(statsHandler))
 
 	if enableProcessStats {
 		r.HandleFunc("/processes", processesHandler(routesFetchFn))
-		r.Handle("/processes/{processID}", createHandler(processHandler()))
+		r.Handle("/processes/{processID}", createHandler(processHandler(statsHandler)))
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
Cherry-pick of PR #25193 to 7.13 branch. Original message:

## What does this PR do?

This PRs just make proxies `processes/elastic-agent` to `/stats` so metricbeat configuration on cloud can be a bit more simple

## Why is it important?

readability/usability on cloud side

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.