### PR TITLE
Cherry-pick #25176 to 7.13: [winlogbeat/libbeat] Change event.code and winlog.event_id type

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -336,6 +336,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Winlogbeat*
 
+- Change `event.code` and `winlog.event_id` from int to keyword. {pull}25176[25176]
 
 *Functionbeat*
 

--- a/libbeat/processors/decode_xml_wineventlog/processor.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor.go
@@ -139,8 +139,9 @@ func fields(evt winevent.Event) (common.MapStr, common.MapStr) {
 
 	ecs := common.MapStr{}
 
+	eventCode, _ := win.GetValue("event_id")
+	ecs.Put("event.code", eventCode)
 	ecs.Put("event.kind", "event")
-	ecs.Put("event.code", evt.EventIdentifier.ID)
 	ecs.Put("event.provider", evt.Provider.Name)
 	winevent.AddOptional(ecs, "event.action", evt.Task)
 	winevent.AddOptional(ecs, "host.name", evt.Computer)

--- a/libbeat/processors/decode_xml_wineventlog/processor_test.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor_test.go
@@ -55,7 +55,7 @@ func TestProcessor(t *testing.T) {
 			Output: common.MapStr{
 				"event": common.MapStr{
 					"action":   "Special Logon",
-					"code":     uint32(4672),
+					"code":     "4672",
 					"kind":     "event",
 					"outcome":  "success",
 					"provider": "Microsoft-Windows-Security-Auditing",
@@ -71,7 +71,7 @@ func TestProcessor(t *testing.T) {
 					"outcome":       "success",
 					"activity_id":   "{ffb23523-1f32-0000-c335-b2ff321fd701}",
 					"level":         "information",
-					"event_id":      uint32(4672),
+					"event_id":      "4672",
 					"provider_name": "Microsoft-Windows-Security-Auditing",
 					"record_id":     uint64(11303),
 					"computer_name": "vagrant",
@@ -129,7 +129,7 @@ func TestProcessor(t *testing.T) {
 					"outcome":       "success",
 					"activity_id":   "{ffb23523-1f32-0000-c335-b2ff321fd701}",
 					"level":         "information",
-					"event_id":      uint32(4672),
+					"event_id":      "4672",
 					"provider_name": "Microsoft-Windows-Security-Auditing",
 					"record_id":     uint64(11303),
 					"computer_name": "vagrant",

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -92,8 +92,9 @@ func (e Record) ToEvent() beat.Event {
 	// ECS data
 	m.Put("event.created", time.Now())
 
+	eventCode, _ := win.GetValue("event_id")
+	m.Put("event.code", eventCode)
 	m.Put("event.kind", "event")
-	m.Put("event.code", e.EventIdentifier.ID)
 	m.Put("event.provider", e.Provider.Name)
 
 	rename(m, "winlog.outcome", "event.outcome")

--- a/winlogbeat/sys/winevent/event.go
+++ b/winlogbeat/sys/winevent/event.go
@@ -98,7 +98,7 @@ func (e Event) Fields() common.MapStr {
 	win := common.MapStr{}
 
 	AddOptional(win, "channel", e.Channel)
-	AddOptional(win, "event_id", e.EventIdentifier.ID)
+	AddOptional(win, "event_id", fmt.Sprint(e.EventIdentifier.ID))
 	AddOptional(win, "provider_name", e.Provider.Name)
 	AddOptional(win, "record_id", e.RecordID)
 	AddOptional(win, "task", e.Task)

--- a/winlogbeat/tests/system/test_wineventlog.py
+++ b/winlogbeat/tests/system/test_wineventlog.py
@@ -68,11 +68,10 @@ class Test(WriteReadTest):
         wineventlog - Read unknown event ID
         """
         msg = "Unknown event ID"
-        event_id = 1111
-        self.write_event_log(msg, eventID=event_id)
+        self.write_event_log(msg, eventID=1111)
         evts = self.read_events()
         self.assertTrue(len(evts), 1)
-        self.assert_common_fields(evts[0], eventID=event_id, extra={
+        self.assert_common_fields(evts[0], eventID="1111", extra={
             "winlog.keywords": ["Classic"],
             "winlog.opcode": "Info",
         })
@@ -199,10 +198,10 @@ class Test(WriteReadTest):
             ]
         }, expected_events=4)
         self.assertTrue(len(evts), 4)
-        self.assertEqual(evts[0]["winlog.event_id"], 50)
-        self.assertEqual(evts[1]["winlog.event_id"], 100)
-        self.assertEqual(evts[2]["winlog.event_id"], 175)
-        self.assertEqual(evts[3]["winlog.event_id"], 200)
+        self.assertEqual(evts[0]["winlog.event_id"], "50")
+        self.assertEqual(evts[1]["winlog.event_id"], "100")
+        self.assertEqual(evts[2]["winlog.event_id"], "175")
+        self.assertEqual(evts[3]["winlog.event_id"], "200")
 
     def test_query_level_single(self):
         """
@@ -270,8 +269,8 @@ class Test(WriteReadTest):
             ]
         })
         self.assertTrue(len(evts), 1)
-        self.assertEqual(evts[0]["winlog.event_id"], 10)
-        self.assertEqual(evts[0]["event.code"], 10)
+        self.assertEqual(evts[0]["winlog.event_id"], "10")
+        self.assertEqual(evts[0]["event.code"], "10")
 
     def test_query_provider(self):
         """

--- a/winlogbeat/tests/system/winlogbeat.py
+++ b/winlogbeat/tests/system/winlogbeat.py
@@ -135,7 +135,7 @@ class WriteReadTest(BaseTest):
 
         return event_logs
 
-    def assert_common_fields(self, evt, msg=None, eventID=10, sid=None,
+    def assert_common_fields(self, evt, msg=None, eventID="10", sid=None,
                              level="information", extra=None):
 
         assert host_name(evt["winlog.computer_name"]).lower() == host_name(platform.node()).lower()

--- a/x-pack/winlogbeat/module/powershell/test/testdata/400.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/400.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 400,
+      "code": "400",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -46,7 +46,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 400,
+      "event_id": "400",
       "keywords": [
         "Classic"
       ],
@@ -63,7 +63,7 @@
       "category": [
         "process"
       ],
-      "code": 400,
+      "code": "400",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -105,7 +105,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 400,
+      "event_id": "400",
       "keywords": [
         "Classic"
       ],
@@ -122,7 +122,7 @@
       "category": [
         "process"
       ],
-      "code": 400,
+      "code": "400",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -162,7 +162,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 400,
+      "event_id": "400",
       "keywords": [
         "Classic"
       ],
@@ -179,7 +179,7 @@
       "category": [
         "process"
       ],
-      "code": 400,
+      "code": "400",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -213,7 +213,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 400,
+      "event_id": "400",
       "keywords": [
         "Classic"
       ],

--- a/x-pack/winlogbeat/module/powershell/test/testdata/403.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/403.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 403,
+      "code": "403",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -45,7 +45,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 403,
+      "event_id": "403",
       "keywords": [
         "Classic"
       ],
@@ -62,7 +62,7 @@
       "category": [
         "process"
       ],
-      "code": 403,
+      "code": "403",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -102,7 +102,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 403,
+      "event_id": "403",
       "keywords": [
         "Classic"
       ],
@@ -119,7 +119,7 @@
       "category": [
         "process"
       ],
-      "code": 403,
+      "code": "403",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -166,7 +166,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 403,
+      "event_id": "403",
       "keywords": [
         "Classic"
       ],
@@ -183,7 +183,7 @@
       "category": [
         "process"
       ],
-      "code": 403,
+      "code": "403",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -217,7 +217,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 403,
+      "event_id": "403",
       "keywords": [
         "Classic"
       ],

--- a/x-pack/winlogbeat/module/powershell/test/testdata/4103.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/4103.evtx.golden.json
@@ -12,7 +12,7 @@
       "category": [
         "process"
       ],
-      "code": 4103,
+      "code": "4103",
       "kind": "event",
       "module": "powershell",
       "provider": "Microsoft-Windows-PowerShell",
@@ -94,7 +94,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-PowerShell/Operational",
       "computer_name": "vagrant",
-      "event_id": 4103,
+      "event_id": "4103",
       "opcode": "To be used when operation is just executing a method",
       "process": {
         "pid": 3984,
@@ -119,7 +119,7 @@
       "category": [
         "process"
       ],
-      "code": 4103,
+      "code": "4103",
       "kind": "event",
       "module": "powershell",
       "provider": "Microsoft-Windows-PowerShell",
@@ -217,7 +217,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-PowerShell/Operational",
       "computer_name": "vagrant",
-      "event_id": 4103,
+      "event_id": "4103",
       "opcode": "To be used when operation is just executing a method",
       "process": {
         "pid": 5032,

--- a/x-pack/winlogbeat/module/powershell/test/testdata/4104.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/4104.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 4104,
+      "code": "4104",
       "kind": "event",
       "module": "powershell",
       "provider": "Microsoft-Windows-PowerShell",
@@ -36,7 +36,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-PowerShell/Operational",
       "computer_name": "vagrant",
-      "event_id": 4104,
+      "event_id": "4104",
       "opcode": "On create calls",
       "process": {
         "pid": 4844,
@@ -61,7 +61,7 @@
       "category": [
         "process"
       ],
-      "code": 4104,
+      "code": "4104",
       "kind": "event",
       "module": "powershell",
       "provider": "Microsoft-Windows-PowerShell",
@@ -96,7 +96,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-PowerShell/Operational",
       "computer_name": "vagrant",
-      "event_id": 4104,
+      "event_id": "4104",
       "opcode": "On create calls",
       "process": {
         "pid": 4844,

--- a/x-pack/winlogbeat/module/powershell/test/testdata/4105.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/4105.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 4105,
+      "code": "4105",
       "kind": "event",
       "module": "powershell",
       "provider": "Microsoft-Windows-PowerShell",
@@ -34,7 +34,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-PowerShell/Operational",
       "computer_name": "vagrant",
-      "event_id": 4105,
+      "event_id": "4105",
       "opcode": "On create calls",
       "process": {
         "pid": 4204,

--- a/x-pack/winlogbeat/module/powershell/test/testdata/4106.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/4106.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 4106,
+      "code": "4106",
       "kind": "event",
       "module": "powershell",
       "provider": "Microsoft-Windows-PowerShell",
@@ -34,7 +34,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-PowerShell/Operational",
       "computer_name": "vagrant",
-      "event_id": 4106,
+      "event_id": "4106",
       "opcode": "On create calls",
       "process": {
         "pid": 4776,

--- a/x-pack/winlogbeat/module/powershell/test/testdata/600.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/600.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 600,
+      "code": "600",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -49,7 +49,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 600,
+      "event_id": "600",
       "keywords": [
         "Classic"
       ],
@@ -66,7 +66,7 @@
       "category": [
         "process"
       ],
-      "code": 600,
+      "code": "600",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -106,7 +106,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 600,
+      "event_id": "600",
       "keywords": [
         "Classic"
       ],
@@ -123,7 +123,7 @@
       "category": [
         "process"
       ],
-      "code": 600,
+      "code": "600",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -155,7 +155,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 600,
+      "event_id": "600",
       "keywords": [
         "Classic"
       ],

--- a/x-pack/winlogbeat/module/powershell/test/testdata/800.evtx.golden.json
+++ b/x-pack/winlogbeat/module/powershell/test/testdata/800.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 800,
+      "code": "800",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -91,7 +91,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant-2019",
-      "event_id": 800,
+      "event_id": "800",
       "keywords": [
         "Classic"
       ],
@@ -108,7 +108,7 @@
       "category": [
         "process"
       ],
-      "code": 800,
+      "code": "800",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -174,7 +174,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 800,
+      "event_id": "800",
       "keywords": [
         "Classic"
       ],
@@ -191,7 +191,7 @@
       "category": [
         "process"
       ],
-      "code": 800,
+      "code": "800",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -268,7 +268,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 800,
+      "event_id": "800",
       "keywords": [
         "Classic"
       ],
@@ -285,7 +285,7 @@
       "category": [
         "process"
       ],
-      "code": 800,
+      "code": "800",
       "kind": "event",
       "module": "powershell",
       "provider": "PowerShell",
@@ -350,7 +350,7 @@
       "api": "wineventlog",
       "channel": "Windows PowerShell",
       "computer_name": "vagrant",
-      "event_id": 800,
+      "event_id": "800",
       "keywords": [
         "Classic"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/1100.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1100.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 1100,
+      "code": "1100",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -25,7 +25,7 @@
       "api": "wineventlog",
       "channel": "Security",
       "computer_name": "WIN-41OB2LO92CR.wlbeat.local",
-      "event_id": 1100,
+      "event_id": "1100",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/1102.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1102.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 1102,
+      "code": "1102",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -34,7 +34,7 @@
       "api": "wineventlog",
       "channel": "Security",
       "computer_name": "WIN-41OB2LO92CR.wlbeat.local",
-      "event_id": 1102,
+      "event_id": "1102",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/1104.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1104.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 1104,
+      "code": "1104",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -25,7 +25,7 @@
       "api": "wineventlog",
       "channel": "Security",
       "computer_name": "WIN-41OB2LO92CR.wlbeat.local",
-      "event_id": 1104,
+      "event_id": "1104",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/1105.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/1105.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 1105,
+      "code": "1105",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -25,7 +25,7 @@
       "api": "wineventlog",
       "channel": "Security",
       "computer_name": "WIN-41OB2LO92CR.wlbeat.local",
-      "event_id": 1105,
+      "event_id": "1105",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4670_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4670_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4670,
+      "code": "4670",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -57,7 +57,7 @@
         "SubjectUserName": "WIN-BVM4LI1L1Q6$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4670,
+      "event_id": "4670",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4706_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4706_WindowsSrv2016.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "configuration"
       ],
-      "code": 4706,
+      "code": "4706",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -46,7 +46,7 @@
         "TdoDirection": "3",
         "TdoType": "3"
       },
-      "event_id": 4706,
+      "event_id": "4706",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4707_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4707_WindowsSrv2016.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "configuration"
       ],
-      "code": 4707,
+      "code": "4707",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -41,7 +41,7 @@
         "SubjectUserName": "Administrator",
         "SubjectUserSid": "S-1-5-21-2024912787-2692429404-2351956786-500"
       },
-      "event_id": 4707,
+      "event_id": "4707",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4713_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4713_WindowsSrv2016.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "configuration"
       ],
-      "code": 4713,
+      "code": "4713",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -41,7 +41,7 @@
         "SubjectUserName": "WIN-BVM4LI1L1Q6$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4713,
+      "event_id": "4713",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4716_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4716_WindowsSrv2016.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "configuration"
       ],
-      "code": 4716,
+      "code": "4716",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -46,7 +46,7 @@
         "TdoDirection": "3",
         "TdoType": "3"
       },
-      "event_id": 4716,
+      "event_id": "4716",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4717_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4717_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4717,
+      "code": "4717",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -44,7 +44,7 @@
         "SubjectUserSid": "S-1-5-18",
         "TargetSid": "S-1-5-9"
       },
-      "event_id": 4717,
+      "event_id": "4717",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4718_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4718_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4718,
+      "code": "4718",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -44,7 +44,7 @@
         "SubjectUserSid": "S-1-5-18",
         "TargetSid": "S-1-5-32-545"
       },
-      "event_id": 4718,
+      "event_id": "4718",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4719.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4719.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4719,
+      "code": "4719",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -52,7 +52,7 @@
         "SubjectUserName": "WIN-41OB2LO92CR$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4719,
+      "event_id": "4719",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4719_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4719_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4719,
+      "code": "4719",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "SubjectUserName": "Administrator",
         "SubjectUserSid": "S-1-5-21-2024912787-2692429404-2351956786-500"
       },
-      "event_id": 4719,
+      "event_id": "4719",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4739_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4739_WindowsSrv2016.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "configuration"
       ],
-      "code": 4739,
+      "code": "4739",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -48,7 +48,7 @@
         "SubjectUserName": "WIN-BVM4LI1L1Q6$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4739,
+      "event_id": "4739",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4741.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4741.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4741,
+      "code": "4741",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -79,7 +79,7 @@
         "UserPrincipalName": "-",
         "UserWorkstations": "-"
       },
-      "event_id": 4741,
+      "event_id": "4741",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4742.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4742.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4742,
+      "code": "4742",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -77,7 +77,7 @@
         "UserPrincipalName": "-",
         "UserWorkstations": "-"
       },
-      "event_id": 4742,
+      "event_id": "4742",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4743.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4743.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4743,
+      "code": "4743",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2902",
         "TargetUserName": "TESTCOMPUTEROBJ$"
       },
-      "event_id": 4743,
+      "event_id": "4743",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4744.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4744.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4744,
+      "code": "4744",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2903",
         "TargetUserName": "testdistlocal"
       },
-      "event_id": 4744,
+      "event_id": "4744",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4745.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4745.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4745,
+      "code": "4745",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2903",
         "TargetUserName": "testdistlocal1"
       },
-      "event_id": 4745,
+      "event_id": "4745",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4746.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4746.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4746,
+      "code": "4746",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -62,7 +62,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2903",
         "TargetUserName": "testdistlocal1"
       },
-      "event_id": 4746,
+      "event_id": "4746",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4747.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4747.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4747,
+      "code": "4747",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -62,7 +62,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2903",
         "TargetUserName": "testdistlocal1"
       },
-      "event_id": 4747,
+      "event_id": "4747",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4748.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4748.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4748,
+      "code": "4748",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2903",
         "TargetUserName": "testdistlocal1"
       },
-      "event_id": 4748,
+      "event_id": "4748",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4749.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4749.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4749,
+      "code": "4749",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2904",
         "TargetUserName": "testglobal"
       },
-      "event_id": 4749,
+      "event_id": "4749",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4750.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4750.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4750,
+      "code": "4750",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2904",
         "TargetUserName": "testglobal1"
       },
-      "event_id": 4750,
+      "event_id": "4750",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4751.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4751.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4751,
+      "code": "4751",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -62,7 +62,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2904",
         "TargetUserName": "testglobal1"
       },
-      "event_id": 4751,
+      "event_id": "4751",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4752.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4752.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4752,
+      "code": "4752",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -62,7 +62,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2904",
         "TargetUserName": "testglobal1"
       },
-      "event_id": 4752,
+      "event_id": "4752",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4753.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4753.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4753,
+      "code": "4753",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2904",
         "TargetUserName": "testglobal1"
       },
-      "event_id": 4753,
+      "event_id": "4753",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4759.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4759.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4759,
+      "code": "4759",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2905",
         "TargetUserName": "testuni"
       },
-      "event_id": 4759,
+      "event_id": "4759",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4760.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4760.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4760,
+      "code": "4760",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2905",
         "TargetUserName": "testuni2"
       },
-      "event_id": 4760,
+      "event_id": "4760",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4761.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4761.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4761,
+      "code": "4761",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -62,7 +62,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2905",
         "TargetUserName": "testuni2"
       },
-      "event_id": 4761,
+      "event_id": "4761",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4762.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4762.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4762,
+      "code": "4762",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -62,7 +62,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2905",
         "TargetUserName": "testuni2"
       },
-      "event_id": 4762,
+      "event_id": "4762",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4763.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4763.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4763,
+      "code": "4763",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "TargetSid": "S-1-5-21-1717121054-434620538-60925301-2905",
         "TargetUserName": "testuni2"
       },
-      "event_id": 4763,
+      "event_id": "4763",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4817_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4817_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4817,
+      "code": "4817",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "SubjectUserName": "WIN-BVM4LI1L1Q6$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4817,
+      "event_id": "4817",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4902_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4902_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4902,
+      "code": "4902",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -31,7 +31,7 @@
         "PuaCount": "0",
         "PuaPolicyId": "0x9fd2"
       },
-      "event_id": 4902,
+      "event_id": "4902",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4904_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4904_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4904,
+      "code": "4904",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "SubjectUserName": "WIN-BVM4LI1L1Q6$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4904,
+      "event_id": "4904",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4905_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4905_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4905,
+      "code": "4905",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "SubjectUserName": "WIN-BVM4LI1L1Q6$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4905,
+      "event_id": "4905",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4906_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4906_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4906,
+      "code": "4906",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -30,7 +30,7 @@
       "event_data": {
         "CrashOnAuditFailValue": "1"
       },
-      "event_id": 4906,
+      "event_id": "4906",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4907_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4907_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4907,
+      "code": "4907",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -52,7 +52,7 @@
         "SubjectUserName": "WIN-BVM4LI1L1Q6$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4907,
+      "event_id": "4907",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/4908_WindowsSrv2016.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/4908_WindowsSrv2016.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4908,
+      "code": "4908",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -38,7 +38,7 @@
           "S-1-5-32-123-54-65"
         ]
       },
-      "event_id": 4908,
+      "event_id": "4908",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4673.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4673.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4673,
+      "code": "4673",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "SubjectUserName": "DC_TEST2K12$",
         "SubjectUserSid": "S-1-5-18"
       },
-      "event_id": 4673,
+      "event_id": "4673",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4674.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4674.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4674,
+      "code": "4674",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -59,7 +59,7 @@
         "SubjectUserName": "at_adm",
         "SubjectUserSid": "S-1-5-21-1717121054-434620538-60925301-2794"
       },
-      "event_id": 4674,
+      "event_id": "4674",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4697.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4697.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4697,
+      "code": "4697",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "SubjectUserName": "Administrator",
         "SubjectUserSid": "S-1-5-21-101361758-2486510592-3018839910-500"
       },
-      "event_id": 4697,
+      "event_id": "4697",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4698.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4698.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4698,
+      "code": "4698",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -43,7 +43,7 @@
         "TaskContent": "\u003c?xml version=\"1.0\" encoding=\"UTF-16\"?\u003e\n\u003cTask version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\"\u003e\n  \u003cRegistrationInfo\u003e\n    \u003cDate\u003e2020-04-01T16:34:34.574883\u003c/Date\u003e\n    \u003cAuthor\u003eTEST\\at_adm\u003c/Author\u003e\n  \u003c/RegistrationInfo\u003e\n  \u003cTriggers\u003e\n    \u003cTimeTrigger\u003e\n      \u003cStartBoundary\u003e2020-04-01T16:33:41.3123848\u003c/StartBoundary\u003e\n      \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003c/TimeTrigger\u003e\n  \u003c/Triggers\u003e\n  \u003cPrincipals\u003e\n    \u003cPrincipal id=\"Author\"\u003e\n      \u003cRunLevel\u003eLeastPrivilege\u003c/RunLevel\u003e\n      \u003cUserId\u003eTEST\\at_adm\u003c/UserId\u003e\n      \u003cLogonType\u003eInteractiveToken\u003c/LogonType\u003e\n    \u003c/Principal\u003e\n  \u003c/Principals\u003e\n  \u003cSettings\u003e\n    \u003cMultipleInstancesPolicy\u003eIgnoreNew\u003c/MultipleInstancesPolicy\u003e\n    \u003cDisallowStartIfOnBatteries\u003etrue\u003c/DisallowStartIfOnBatteries\u003e\n    \u003cStopIfGoingOnBatteries\u003etrue\u003c/StopIfGoingOnBatteries\u003e\n    \u003cAllowHardTerminate\u003etrue\u003c/AllowHardTerminate\u003e\n    \u003cStartWhenAvailable\u003efalse\u003c/StartWhenAvailable\u003e\n    \u003cRunOnlyIfNetworkAvailable\u003efalse\u003c/RunOnlyIfNetworkAvailable\u003e\n    \u003cIdleSettings\u003e\n      \u003cStopOnIdleEnd\u003etrue\u003c/StopOnIdleEnd\u003e\n      \u003cRestartOnIdle\u003efalse\u003c/RestartOnIdle\u003e\n    \u003c/IdleSettings\u003e\n    \u003cAllowStartOnDemand\u003etrue\u003c/AllowStartOnDemand\u003e\n    \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003cHidden\u003efalse\u003c/Hidden\u003e\n    \u003cRunOnlyIfIdle\u003efalse\u003c/RunOnlyIfIdle\u003e\n    \u003cWakeToRun\u003efalse\u003c/WakeToRun\u003e\n    \u003cExecutionTimeLimit\u003eP3D\u003c/ExecutionTimeLimit\u003e\n    \u003cPriority\u003e7\u003c/Priority\u003e\n  \u003c/Settings\u003e\n  \u003cActions Context=\"Author\"\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\calc.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\mspaint.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n  \u003c/Actions\u003e\n\u003c/Task\u003e",
         "TaskName": "\\test1"
       },
-      "event_id": 4698,
+      "event_id": "4698",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4699.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4699.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4699,
+      "code": "4699",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -43,7 +43,7 @@
         "TaskContent": "\u003c?xml version=\"1.0\" encoding=\"UTF-16\"?\u003e\n\u003cTask version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\"\u003e\n  \u003cRegistrationInfo\u003e\n    \u003cDate\u003e2020-04-01T16:34:34.574883\u003c/Date\u003e\n    \u003cAuthor\u003eTEST\\at_adm\u003c/Author\u003e\n  \u003c/RegistrationInfo\u003e\n  \u003cTriggers\u003e\n    \u003cTimeTrigger\u003e\n      \u003cStartBoundary\u003e2020-04-01T16:33:41.3123848\u003c/StartBoundary\u003e\n      \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003c/TimeTrigger\u003e\n  \u003c/Triggers\u003e\n  \u003cPrincipals\u003e\n    \u003cPrincipal id=\"Author\"\u003e\n      \u003cRunLevel\u003eLeastPrivilege\u003c/RunLevel\u003e\n      \u003cUserId\u003eTEST\\at_adm\u003c/UserId\u003e\n      \u003cLogonType\u003eInteractiveToken\u003c/LogonType\u003e\n    \u003c/Principal\u003e\n  \u003c/Principals\u003e\n  \u003cSettings\u003e\n    \u003cMultipleInstancesPolicy\u003eIgnoreNew\u003c/MultipleInstancesPolicy\u003e\n    \u003cDisallowStartIfOnBatteries\u003etrue\u003c/DisallowStartIfOnBatteries\u003e\n    \u003cStopIfGoingOnBatteries\u003etrue\u003c/StopIfGoingOnBatteries\u003e\n    \u003cAllowHardTerminate\u003etrue\u003c/AllowHardTerminate\u003e\n    \u003cStartWhenAvailable\u003efalse\u003c/StartWhenAvailable\u003e\n    \u003cRunOnlyIfNetworkAvailable\u003efalse\u003c/RunOnlyIfNetworkAvailable\u003e\n    \u003cIdleSettings\u003e\n      \u003cStopOnIdleEnd\u003etrue\u003c/StopOnIdleEnd\u003e\n      \u003cRestartOnIdle\u003efalse\u003c/RestartOnIdle\u003e\n    \u003c/IdleSettings\u003e\n    \u003cAllowStartOnDemand\u003etrue\u003c/AllowStartOnDemand\u003e\n    \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003cHidden\u003efalse\u003c/Hidden\u003e\n    \u003cRunOnlyIfIdle\u003efalse\u003c/RunOnlyIfIdle\u003e\n    \u003cWakeToRun\u003efalse\u003c/WakeToRun\u003e\n    \u003cExecutionTimeLimit\u003eP3D\u003c/ExecutionTimeLimit\u003e\n    \u003cPriority\u003e7\u003c/Priority\u003e\n  \u003c/Settings\u003e\n  \u003cActions Context=\"Author\"\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\calc.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n  \u003c/Actions\u003e\n\u003c/Task\u003e",
         "TaskName": "\\test1"
       },
-      "event_id": 4699,
+      "event_id": "4699",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4700.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4700.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4700,
+      "code": "4700",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -43,7 +43,7 @@
         "TaskContent": "\u003c?xml version=\"1.0\" encoding=\"UTF-16\"?\u003e\n\u003cTask version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\"\u003e\n  \u003cRegistrationInfo\u003e\n    \u003cDate\u003e2020-04-01T16:34:34.574883\u003c/Date\u003e\n    \u003cAuthor\u003eTEST\\at_adm\u003c/Author\u003e\n  \u003c/RegistrationInfo\u003e\n  \u003cTriggers\u003e\n    \u003cTimeTrigger\u003e\n      \u003cStartBoundary\u003e2020-04-01T16:33:41.3123848\u003c/StartBoundary\u003e\n      \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003c/TimeTrigger\u003e\n  \u003c/Triggers\u003e\n  \u003cPrincipals\u003e\n    \u003cPrincipal id=\"Author\"\u003e\n      \u003cRunLevel\u003eLeastPrivilege\u003c/RunLevel\u003e\n      \u003cUserId\u003eTEST\\at_adm\u003c/UserId\u003e\n      \u003cLogonType\u003eInteractiveToken\u003c/LogonType\u003e\n    \u003c/Principal\u003e\n  \u003c/Principals\u003e\n  \u003cSettings\u003e\n    \u003cMultipleInstancesPolicy\u003eIgnoreNew\u003c/MultipleInstancesPolicy\u003e\n    \u003cDisallowStartIfOnBatteries\u003etrue\u003c/DisallowStartIfOnBatteries\u003e\n    \u003cStopIfGoingOnBatteries\u003etrue\u003c/StopIfGoingOnBatteries\u003e\n    \u003cAllowHardTerminate\u003etrue\u003c/AllowHardTerminate\u003e\n    \u003cStartWhenAvailable\u003efalse\u003c/StartWhenAvailable\u003e\n    \u003cRunOnlyIfNetworkAvailable\u003efalse\u003c/RunOnlyIfNetworkAvailable\u003e\n    \u003cIdleSettings\u003e\n      \u003cStopOnIdleEnd\u003etrue\u003c/StopOnIdleEnd\u003e\n      \u003cRestartOnIdle\u003efalse\u003c/RestartOnIdle\u003e\n    \u003c/IdleSettings\u003e\n    \u003cAllowStartOnDemand\u003etrue\u003c/AllowStartOnDemand\u003e\n    \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003cHidden\u003efalse\u003c/Hidden\u003e\n    \u003cRunOnlyIfIdle\u003efalse\u003c/RunOnlyIfIdle\u003e\n    \u003cWakeToRun\u003efalse\u003c/WakeToRun\u003e\n    \u003cExecutionTimeLimit\u003eP3D\u003c/ExecutionTimeLimit\u003e\n    \u003cPriority\u003e7\u003c/Priority\u003e\n  \u003c/Settings\u003e\n  \u003cActions Context=\"Author\"\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\calc.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\mspaint.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n  \u003c/Actions\u003e\n\u003c/Task\u003e",
         "TaskName": "\\test1"
       },
-      "event_id": 4700,
+      "event_id": "4700",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4701.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4701.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4701,
+      "code": "4701",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -43,7 +43,7 @@
         "TaskContent": "\u003c?xml version=\"1.0\" encoding=\"UTF-16\"?\u003e\n\u003cTask version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\"\u003e\n  \u003cRegistrationInfo\u003e\n    \u003cDate\u003e2020-04-01T16:34:34.574883\u003c/Date\u003e\n    \u003cAuthor\u003eTEST\\at_adm\u003c/Author\u003e\n  \u003c/RegistrationInfo\u003e\n  \u003cTriggers\u003e\n    \u003cTimeTrigger\u003e\n      \u003cStartBoundary\u003e2020-04-01T16:33:41.3123848\u003c/StartBoundary\u003e\n      \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003c/TimeTrigger\u003e\n  \u003c/Triggers\u003e\n  \u003cPrincipals\u003e\n    \u003cPrincipal id=\"Author\"\u003e\n      \u003cRunLevel\u003eLeastPrivilege\u003c/RunLevel\u003e\n      \u003cUserId\u003eTEST\\at_adm\u003c/UserId\u003e\n      \u003cLogonType\u003eInteractiveToken\u003c/LogonType\u003e\n    \u003c/Principal\u003e\n  \u003c/Principals\u003e\n  \u003cSettings\u003e\n    \u003cMultipleInstancesPolicy\u003eIgnoreNew\u003c/MultipleInstancesPolicy\u003e\n    \u003cDisallowStartIfOnBatteries\u003etrue\u003c/DisallowStartIfOnBatteries\u003e\n    \u003cStopIfGoingOnBatteries\u003etrue\u003c/StopIfGoingOnBatteries\u003e\n    \u003cAllowHardTerminate\u003etrue\u003c/AllowHardTerminate\u003e\n    \u003cStartWhenAvailable\u003efalse\u003c/StartWhenAvailable\u003e\n    \u003cRunOnlyIfNetworkAvailable\u003efalse\u003c/RunOnlyIfNetworkAvailable\u003e\n    \u003cIdleSettings\u003e\n      \u003cStopOnIdleEnd\u003etrue\u003c/StopOnIdleEnd\u003e\n      \u003cRestartOnIdle\u003efalse\u003c/RestartOnIdle\u003e\n    \u003c/IdleSettings\u003e\n    \u003cAllowStartOnDemand\u003etrue\u003c/AllowStartOnDemand\u003e\n    \u003cEnabled\u003efalse\u003c/Enabled\u003e\n    \u003cHidden\u003efalse\u003c/Hidden\u003e\n    \u003cRunOnlyIfIdle\u003efalse\u003c/RunOnlyIfIdle\u003e\n    \u003cWakeToRun\u003efalse\u003c/WakeToRun\u003e\n    \u003cExecutionTimeLimit\u003eP3D\u003c/ExecutionTimeLimit\u003e\n    \u003cPriority\u003e7\u003c/Priority\u003e\n  \u003c/Settings\u003e\n  \u003cActions Context=\"Author\"\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\calc.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\mspaint.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n  \u003c/Actions\u003e\n\u003c/Task\u003e",
         "TaskName": "\\test1"
       },
-      "event_id": 4701,
+      "event_id": "4701",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4702.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4702.evtx.golden.json
@@ -7,7 +7,7 @@
         "iam",
         "configuration"
       ],
-      "code": 4702,
+      "code": "4702",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -43,7 +43,7 @@
         "TaskContentNew": "\u003c?xml version=\"1.0\" encoding=\"UTF-16\"?\u003e\n\u003cTask version=\"1.2\" xmlns=\"http://schemas.microsoft.com/windows/2004/02/mit/task\"\u003e\n  \u003cRegistrationInfo\u003e\n    \u003cDate\u003e2020-04-01T16:34:34.574883\u003c/Date\u003e\n    \u003cAuthor\u003eTEST\\at_adm\u003c/Author\u003e\n  \u003c/RegistrationInfo\u003e\n  \u003cTriggers\u003e\n    \u003cTimeTrigger\u003e\n      \u003cStartBoundary\u003e2020-04-01T16:33:41.3123848\u003c/StartBoundary\u003e\n      \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003c/TimeTrigger\u003e\n  \u003c/Triggers\u003e\n  \u003cPrincipals\u003e\n    \u003cPrincipal id=\"Author\"\u003e\n      \u003cRunLevel\u003eLeastPrivilege\u003c/RunLevel\u003e\n      \u003cUserId\u003eTEST\\at_adm\u003c/UserId\u003e\n      \u003cLogonType\u003eInteractiveToken\u003c/LogonType\u003e\n    \u003c/Principal\u003e\n  \u003c/Principals\u003e\n  \u003cSettings\u003e\n    \u003cMultipleInstancesPolicy\u003eIgnoreNew\u003c/MultipleInstancesPolicy\u003e\n    \u003cDisallowStartIfOnBatteries\u003etrue\u003c/DisallowStartIfOnBatteries\u003e\n    \u003cStopIfGoingOnBatteries\u003etrue\u003c/StopIfGoingOnBatteries\u003e\n    \u003cAllowHardTerminate\u003etrue\u003c/AllowHardTerminate\u003e\n    \u003cStartWhenAvailable\u003efalse\u003c/StartWhenAvailable\u003e\n    \u003cRunOnlyIfNetworkAvailable\u003efalse\u003c/RunOnlyIfNetworkAvailable\u003e\n    \u003cIdleSettings\u003e\n      \u003cStopOnIdleEnd\u003etrue\u003c/StopOnIdleEnd\u003e\n      \u003cRestartOnIdle\u003efalse\u003c/RestartOnIdle\u003e\n    \u003c/IdleSettings\u003e\n    \u003cAllowStartOnDemand\u003etrue\u003c/AllowStartOnDemand\u003e\n    \u003cEnabled\u003etrue\u003c/Enabled\u003e\n    \u003cHidden\u003efalse\u003c/Hidden\u003e\n    \u003cRunOnlyIfIdle\u003efalse\u003c/RunOnlyIfIdle\u003e\n    \u003cWakeToRun\u003efalse\u003c/WakeToRun\u003e\n    \u003cExecutionTimeLimit\u003eP3D\u003c/ExecutionTimeLimit\u003e\n    \u003cPriority\u003e7\u003c/Priority\u003e\n  \u003c/Settings\u003e\n  \u003cActions Context=\"Author\"\u003e\n    \u003cExec\u003e\n      \u003cCommand\u003e%windir%\\system32\\calc.exe\u003c/Command\u003e\n    \u003c/Exec\u003e\n  \u003c/Actions\u003e\n\u003c/Task\u003e",
         "TaskName": "\\test1"
       },
-      "event_id": 4702,
+      "event_id": "4702",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4768.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4768.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4768,
+      "code": "4768",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -55,7 +55,7 @@
           "Forwardable"
         ]
       },
-      "event_id": 4768,
+      "event_id": "4768",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4769.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4769.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4769,
+      "code": "4769",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -54,7 +54,7 @@
         ],
         "TransmittedServices": "-"
       },
-      "event_id": 4769,
+      "event_id": "4769",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4770.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4770.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4770,
+      "code": "4770",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
           "Name-canonicalize"
         ]
       },
-      "event_id": 4770,
+      "event_id": "4770",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4771.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4771.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4771,
+      "code": "4771",
       "kind": "event",
       "module": "security",
       "outcome": "failure",
@@ -51,7 +51,7 @@
           "Forwardable"
         ]
       },
-      "event_id": 4771,
+      "event_id": "4771",
       "keywords": [
         "Audit Failure"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4776.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4776.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4776,
+      "code": "4776",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -37,7 +37,7 @@
         "TargetUserName": "at_adm",
         "Workstation": "EQP01777"
       },
-      "event_id": 4776,
+      "event_id": "4776",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4778.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4778.evtx.golden.json
@@ -7,7 +7,7 @@
         "authentication",
         "session"
       ],
-      "code": 4778,
+      "code": "4778",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -46,7 +46,7 @@
         "LogonID": "0x76fea87",
         "SessionName": "RDP-Tcp#127"
       },
-      "event_id": 4778,
+      "event_id": "4778",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4779.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012_4779.evtx.golden.json
@@ -7,7 +7,7 @@
         "authentication",
         "session"
       ],
-      "code": 4779,
+      "code": "4779",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -46,7 +46,7 @@
         "LogonID": "0x60d1ccb",
         "SessionName": "RDP-Tcp#116"
       },
-      "event_id": 4779,
+      "event_id": "4779",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2012r2-logon.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -61,7 +61,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -90,7 +90,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -145,7 +145,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -174,7 +174,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -232,7 +232,7 @@
         "TargetUserSid": "S-1-5-21-3541430928-2051711210-1391384369-1001",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -261,7 +261,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -316,7 +316,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -345,7 +345,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -397,7 +397,7 @@
         "TargetUserSid": "S-1-5-7",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -426,7 +426,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -478,7 +478,7 @@
         "TargetUserSid": "S-1-5-21-3541430928-2051711210-1391384369-1001",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -507,7 +507,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -559,7 +559,7 @@
         "TargetUserSid": "S-1-5-21-3541430928-2051711210-1391384369-1001",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -588,7 +588,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -640,7 +640,7 @@
         "TargetUserSid": "S-1-5-21-3541430928-2051711210-1391384369-1001",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -669,7 +669,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -724,7 +724,7 @@
         "TargetUserSid": "S-1-5-21-3541430928-2051711210-1391384369-1001",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -753,7 +753,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -808,7 +808,7 @@
         "TargetUserSid": "S-1-5-90-2",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -837,7 +837,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -895,7 +895,7 @@
         "TargetUserSid": "S-1-5-21-3541430928-2051711210-1391384369-1001",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -924,7 +924,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -979,7 +979,7 @@
         "TargetUserSid": "S-1-5-90-3",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -1008,7 +1008,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -1063,7 +1063,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -1092,7 +1092,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -1147,7 +1147,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -1176,7 +1176,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -1231,7 +1231,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -1260,7 +1260,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -1315,7 +1315,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -1344,7 +1344,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4624,
+      "code": "4624",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -1399,7 +1399,7 @@
         "TargetUserSid": "S-1-5-18",
         "TransmittedServices": "-"
       },
-      "event_id": 4624,
+      "event_id": "4624",
       "keywords": [
         "Audit Success"
       ],
@@ -1428,7 +1428,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4625,
+      "code": "4625",
       "kind": "event",
       "module": "security",
       "outcome": "failure",
@@ -1483,7 +1483,7 @@
         "TargetUserSid": "S-1-0-0",
         "TransmittedServices": "-"
       },
-      "event_id": 4625,
+      "event_id": "4625",
       "keywords": [
         "Audit Failure"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-4672.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-4672.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4672,
+      "code": "4672",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "SubjectUserName": "vagrant",
         "SubjectUserSid": "S-1-5-21-1766348727-1038078804-3833492317-1000"
       },
-      "event_id": 4672,
+      "event_id": "4672",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-logoff.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016-logoff.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4634,
+      "code": "4634",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -40,7 +40,7 @@
         "TargetUserName": "audittest",
         "TargetUserSid": "S-1-5-21-101361758-2486510592-3018839910-1000"
       },
-      "event_id": 4634,
+      "event_id": "4634",
       "keywords": [
         "Audit Success"
       ],
@@ -68,7 +68,7 @@
       "category": [
         "authentication"
       ],
-      "code": 4634,
+      "code": "4634",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -102,7 +102,7 @@
         "TargetUserName": "Administrator",
         "TargetUserSid": "S-1-5-21-101361758-2486510592-3018839910-500"
       },
-      "event_id": 4634,
+      "event_id": "4634",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4720_Account_Created.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4720_Account_Created.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4720,
+      "code": "4720",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -74,7 +74,7 @@
         "UserPrincipalName": "-",
         "UserWorkstations": "%%1793"
       },
-      "event_id": 4720,
+      "event_id": "4720",
       "keywords": [
         "Audit Success"
       ],
@@ -101,7 +101,7 @@
       "category": [
         "iam"
       ],
-      "code": 4720,
+      "code": "4720",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -169,7 +169,7 @@
         "UserPrincipalName": "-",
         "UserWorkstations": "%%1793"
       },
-      "event_id": 4720,
+      "event_id": "4720",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4722_Account_Enabled.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4722_Account_Enabled.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4722,
+      "code": "4722",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -47,7 +47,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1000",
         "TargetUserName": "audittest"
       },
-      "event_id": 4722,
+      "event_id": "4722",
       "keywords": [
         "Audit Success"
       ],
@@ -74,7 +74,7 @@
       "category": [
         "iam"
       ],
-      "code": 4722,
+      "code": "4722",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -115,7 +115,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1006",
         "TargetUserName": "audittest0609"
       },
-      "event_id": 4722,
+      "event_id": "4722",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4723_Password_Change.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4723_Password_Change.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4723,
+      "code": "4723",
       "kind": "event",
       "module": "security",
       "outcome": "failure",
@@ -45,7 +45,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-500",
         "TargetUserName": "Administrator"
       },
-      "event_id": 4723,
+      "event_id": "4723",
       "keywords": [
         "Audit Failure"
       ],
@@ -72,7 +72,7 @@
       "category": [
         "iam"
       ],
-      "code": 4723,
+      "code": "4723",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -111,7 +111,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-500",
         "TargetUserName": "Administrator"
       },
-      "event_id": 4723,
+      "event_id": "4723",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4724_Password_Reset.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4724_Password_Reset.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4724,
+      "code": "4724",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -47,7 +47,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1005",
         "TargetUserName": "elastictest1"
       },
-      "event_id": 4724,
+      "event_id": "4724",
       "keywords": [
         "Audit Success"
       ],
@@ -74,7 +74,7 @@
       "category": [
         "iam"
       ],
-      "code": 4724,
+      "code": "4724",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -115,7 +115,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1006",
         "TargetUserName": "audittest0609"
       },
-      "event_id": 4724,
+      "event_id": "4724",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4725_Account_Disabled.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4725_Account_Disabled.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4725,
+      "code": "4725",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -47,7 +47,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1000",
         "TargetUserName": "audittest"
       },
-      "event_id": 4725,
+      "event_id": "4725",
       "keywords": [
         "Audit Success"
       ],
@@ -74,7 +74,7 @@
       "category": [
         "iam"
       ],
-      "code": 4725,
+      "code": "4725",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -115,7 +115,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1006",
         "TargetUserName": "audittest0609"
       },
-      "event_id": 4725,
+      "event_id": "4725",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4726_Account_Deleted.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4726_Account_Deleted.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4726,
+      "code": "4726",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -48,7 +48,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1001",
         "TargetUserName": "audittest23"
       },
-      "event_id": 4726,
+      "event_id": "4726",
       "keywords": [
         "Audit Success"
       ],
@@ -75,7 +75,7 @@
       "category": [
         "iam"
       ],
-      "code": 4726,
+      "code": "4726",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -117,7 +117,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1000",
         "TargetUserName": "audittest"
       },
-      "event_id": 4726,
+      "event_id": "4726",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4727.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4727.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4727,
+      "code": "4727",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1110",
         "TargetUserName": "DnsUpdateProxy"
       },
-      "event_id": 4727,
+      "event_id": "4727",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4728.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4728.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4728,
+      "code": "4728",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -59,7 +59,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1112",
         "TargetUserName": "test_group2"
       },
-      "event_id": 4728,
+      "event_id": "4728",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4729.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4729.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4729,
+      "code": "4729",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -59,7 +59,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1112",
         "TargetUserName": "test_group2v2"
       },
-      "event_id": 4729,
+      "event_id": "4729",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4730.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4730.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4730,
+      "code": "4730",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1112",
         "TargetUserName": "test_group2v2"
       },
-      "event_id": 4730,
+      "event_id": "4730",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4731.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4731.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4731,
+      "code": "4731",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1111",
         "TargetUserName": "test_group1"
       },
-      "event_id": 4731,
+      "event_id": "4731",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4732.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4732.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4732,
+      "code": "4732",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -59,7 +59,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1111",
         "TargetUserName": "test_group1"
       },
-      "event_id": 4732,
+      "event_id": "4732",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4733.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4733.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4733,
+      "code": "4733",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -59,7 +59,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1111",
         "TargetUserName": "test_group1"
       },
-      "event_id": 4733,
+      "event_id": "4733",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4734.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4734.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4734,
+      "code": "4734",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1111",
         "TargetUserName": "test_group1v1"
       },
-      "event_id": 4734,
+      "event_id": "4734",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4735.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4735.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4735,
+      "code": "4735",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1111",
         "TargetUserName": "test_group1v1"
       },
-      "event_id": 4735,
+      "event_id": "4735",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4737.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4737.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4737,
+      "code": "4737",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1112",
         "TargetUserName": "test_group2v2"
       },
-      "event_id": 4737,
+      "event_id": "4737",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4738_Account_Changed.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4738_Account_Changed.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4738,
+      "code": "4738",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -73,7 +73,7 @@
         "UserPrincipalName": "-",
         "UserWorkstations": "%%1793"
       },
-      "event_id": 4738,
+      "event_id": "4738",
       "keywords": [
         "Audit Success"
       ],
@@ -100,7 +100,7 @@
       "category": [
         "iam"
       ],
-      "code": 4738,
+      "code": "4738",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -167,7 +167,7 @@
         "UserPrincipalName": "-",
         "UserWorkstations": "%%1793"
       },
-      "event_id": 4738,
+      "event_id": "4738",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4740_Account_Locked_Out.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4740_Account_Locked_Out.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4740,
+      "code": "4740",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -47,7 +47,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1005",
         "TargetUserName": "elastictest1"
       },
-      "event_id": 4740,
+      "event_id": "4740",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4754.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4754.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4754,
+      "code": "4754",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1113",
         "TargetUserName": "Test_group3"
       },
-      "event_id": 4754,
+      "event_id": "4754",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4755.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4755.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4755,
+      "code": "4755",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1113",
         "TargetUserName": "Test_group3v2"
       },
-      "event_id": 4755,
+      "event_id": "4755",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4756.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4756.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4756,
+      "code": "4756",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -59,7 +59,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1113",
         "TargetUserName": "Test_group3v2"
       },
-      "event_id": 4756,
+      "event_id": "4756",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4757.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4757.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4757,
+      "code": "4757",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -59,7 +59,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1113",
         "TargetUserName": "Test_group3v2"
       },
-      "event_id": 4757,
+      "event_id": "4757",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4758.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4758.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4758,
+      "code": "4758",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1113",
         "TargetUserName": "Test_group3v2"
       },
-      "event_id": 4758,
+      "event_id": "4758",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4764.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4764.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4764,
+      "code": "4764",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -50,7 +50,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1112",
         "TargetUserName": "test_group2v2"
       },
-      "event_id": 4764,
+      "event_id": "4764",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4767_Account_Unlocked.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4767_Account_Unlocked.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4767,
+      "code": "4767",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -47,7 +47,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1005",
         "TargetUserName": "elastictest1"
       },
-      "event_id": 4767,
+      "event_id": "4767",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4781_Account_Renamed.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4781_Account_Renamed.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4781,
+      "code": "4781",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -50,7 +50,7 @@
         "TargetDomainName": "WIN-41OB2LO92CR",
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1006"
       },
-      "event_id": 4781,
+      "event_id": "4781",
       "keywords": [
         "Audit Success"
       ],
@@ -77,7 +77,7 @@
       "category": [
         "iam"
       ],
-      "code": 4781,
+      "code": "4781",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -121,7 +121,7 @@
         "TargetDomainName": "WIN-41OB2LO92CR",
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1006"
       },
-      "event_id": 4781,
+      "event_id": "4781",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4798.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4798.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4798,
+      "code": "4798",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -49,7 +49,7 @@
         "TargetSid": "S-1-5-21-101361758-2486510592-3018839910-1005",
         "TargetUserName": "elastictest1"
       },
-      "event_id": 4798,
+      "event_id": "4798",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4799.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4799.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4799,
+      "code": "4799",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -51,7 +51,7 @@
         "TargetSid": "S-1-5-32-544",
         "TargetUserName": "Administrators"
       },
-      "event_id": 4799,
+      "event_id": "4799",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4964.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2016_4964.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "iam"
       ],
-      "code": 4964,
+      "code": "4964",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -48,7 +48,7 @@
         "TargetUserName": "Administrator",
         "TargetUserSid": "S-1-5-21-101361758-2486510592-3018839910-500"
       },
-      "event_id": 4964,
+      "event_id": "4964",
       "keywords": [
         "Audit Success"
       ],
@@ -75,7 +75,7 @@
       "category": [
         "iam"
       ],
-      "code": 4964,
+      "code": "4964",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -117,7 +117,7 @@
         "TargetUserName": "Administrator",
         "TargetUserSid": "S-1-5-21-101361758-2486510592-3018839910-500"
       },
-      "event_id": 4964,
+      "event_id": "4964",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4688_Process_Created.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4688_Process_Created.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 4688,
+      "code": "4688",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -62,7 +62,7 @@
         "TargetUserSid": "S-1-0-0",
         "TokenElevationType": "%%1937"
       },
-      "event_id": 4688,
+      "event_id": "4688",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4689_Process_Exited.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/security-windows2019_4689_Process_Exited.evtx.golden.json
@@ -6,7 +6,7 @@
       "category": [
         "process"
       ],
-      "code": 4689,
+      "code": "4689",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -45,7 +45,7 @@
         "SubjectUserName": "vagrant",
         "SubjectUserSid": "S-1-5-21-1610636575-2290000098-1654242922-1000"
       },
-      "event_id": 4689,
+      "event_id": "4689",
       "keywords": [
         "Audit Success"
       ],
@@ -72,7 +72,7 @@
       "category": [
         "process"
       ],
-      "code": 4689,
+      "code": "4689",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -111,7 +111,7 @@
         "SubjectUserName": "vagrant",
         "SubjectUserSid": "S-1-5-21-1610636575-2290000098-1654242922-1000"
       },
-      "event_id": 4689,
+      "event_id": "4689",
       "keywords": [
         "Audit Success"
       ],
@@ -138,7 +138,7 @@
       "category": [
         "process"
       ],
-      "code": 4689,
+      "code": "4689",
       "kind": "event",
       "module": "security",
       "outcome": "success",
@@ -177,7 +177,7 @@
         "SubjectUserName": "vagrant",
         "SubjectUserSid": "S-1-5-21-1610636575-2290000098-1654242922-1000"
       },
-      "event_id": 4689,
+      "event_id": "4689",
       "keywords": [
         "Audit Success"
       ],

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-10.2-dns.evtx.golden.json
@@ -30,7 +30,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -64,7 +64,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -111,7 +111,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -145,7 +145,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -193,7 +193,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -227,7 +227,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -279,7 +279,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -313,7 +313,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -360,7 +360,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -394,7 +394,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -447,7 +447,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -481,7 +481,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -524,7 +524,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -558,7 +558,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -610,7 +610,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -644,7 +644,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -683,7 +683,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -717,7 +717,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -772,7 +772,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -806,7 +806,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -893,7 +893,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -927,7 +927,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -970,7 +970,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1004,7 +1004,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1051,7 +1051,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1085,7 +1085,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1137,7 +1137,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1171,7 +1171,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1210,7 +1210,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1244,7 +1244,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1297,7 +1297,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1331,7 +1331,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1378,7 +1378,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1412,7 +1412,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1459,7 +1459,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1493,7 +1493,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1567,7 +1567,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1601,7 +1601,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1654,7 +1654,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1688,7 +1688,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1787,7 +1787,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1821,7 +1821,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -1908,7 +1908,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1942,7 +1942,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2034,7 +2034,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2068,7 +2068,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2125,7 +2125,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2159,7 +2159,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2253,7 +2253,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2287,7 +2287,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2384,7 +2384,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2418,7 +2418,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2461,7 +2461,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2495,7 +2495,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2583,7 +2583,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2617,7 +2617,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2664,7 +2664,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2698,7 +2698,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2786,7 +2786,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2820,7 +2820,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2863,7 +2863,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2897,7 +2897,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -2940,7 +2940,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2974,7 +2974,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3056,7 +3056,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3090,7 +3090,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3161,7 +3161,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3195,7 +3195,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3238,7 +3238,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3272,7 +3272,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3350,7 +3350,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3384,7 +3384,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3477,7 +3477,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3511,7 +3511,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3605,7 +3605,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3639,7 +3639,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3682,7 +3682,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3716,7 +3716,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3809,7 +3809,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3843,7 +3843,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -3930,7 +3930,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -3964,7 +3964,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4007,7 +4007,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4041,7 +4041,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4080,7 +4080,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4114,7 +4114,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4170,7 +4170,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4204,7 +4204,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4287,7 +4287,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4321,7 +4321,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4408,7 +4408,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4442,7 +4442,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4493,7 +4493,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4527,7 +4527,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4621,7 +4621,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4655,7 +4655,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4707,7 +4707,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4741,7 +4741,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4813,7 +4813,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4847,7 +4847,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4894,7 +4894,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -4928,7 +4928,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -4971,7 +4971,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5005,7 +5005,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5035,7 +5035,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5069,7 +5069,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5099,7 +5099,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5133,7 +5133,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5221,7 +5221,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5255,7 +5255,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5307,7 +5307,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5341,7 +5341,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5384,7 +5384,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5418,7 +5418,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5506,7 +5506,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5540,7 +5540,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5592,7 +5592,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5626,7 +5626,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5714,7 +5714,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5748,7 +5748,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5791,7 +5791,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5825,7 +5825,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5883,7 +5883,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -5917,7 +5917,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -5975,7 +5975,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6009,7 +6009,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6053,7 +6053,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6087,7 +6087,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6175,7 +6175,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6209,7 +6209,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6302,7 +6302,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6336,7 +6336,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6430,7 +6430,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6464,7 +6464,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6552,7 +6552,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6586,7 +6586,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6638,7 +6638,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6672,7 +6672,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6730,7 +6730,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6764,7 +6764,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6807,7 +6807,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6841,7 +6841,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -6929,7 +6929,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -6963,7 +6963,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7061,7 +7061,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7095,7 +7095,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7182,7 +7182,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7216,7 +7216,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7263,7 +7263,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7297,7 +7297,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7390,7 +7390,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7424,7 +7424,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7471,7 +7471,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7505,7 +7505,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7598,7 +7598,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7632,7 +7632,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7720,7 +7720,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7754,7 +7754,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7820,7 +7820,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7854,7 +7854,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -7948,7 +7948,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -7982,7 +7982,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8050,7 +8050,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8084,7 +8084,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8123,7 +8123,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8157,7 +8157,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8245,7 +8245,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8279,7 +8279,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8337,7 +8337,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8371,7 +8371,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8409,7 +8409,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8443,7 +8443,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8531,7 +8531,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8565,7 +8565,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8654,7 +8654,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8688,7 +8688,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8756,7 +8756,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8790,7 +8790,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8878,7 +8878,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -8912,7 +8912,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -8989,7 +8989,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9023,7 +9023,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9100,7 +9100,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9134,7 +9134,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9232,7 +9232,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9266,7 +9266,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9355,7 +9355,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9389,7 +9389,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9471,7 +9471,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9505,7 +9505,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9593,7 +9593,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9627,7 +9627,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9715,7 +9715,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9749,7 +9749,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9796,7 +9796,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9830,7 +9830,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9916,7 +9916,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -9950,7 +9950,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -9997,7 +9997,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10031,7 +10031,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10089,7 +10089,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10123,7 +10123,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10171,7 +10171,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10205,7 +10205,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10253,7 +10253,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10287,7 +10287,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10334,7 +10334,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10368,7 +10368,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10416,7 +10416,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10450,7 +10450,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10493,7 +10493,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10527,7 +10527,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10579,7 +10579,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10613,7 +10613,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10660,7 +10660,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10694,7 +10694,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10745,7 +10745,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10779,7 +10779,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10826,7 +10826,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10860,7 +10860,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10907,7 +10907,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -10941,7 +10941,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -10988,7 +10988,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11022,7 +11022,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11116,7 +11116,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11150,7 +11150,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11208,7 +11208,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11242,7 +11242,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11291,7 +11291,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11325,7 +11325,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11414,7 +11414,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11448,7 +11448,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11487,7 +11487,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11521,7 +11521,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11568,7 +11568,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11602,7 +11602,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11695,7 +11695,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11729,7 +11729,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11772,7 +11772,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11806,7 +11806,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11853,7 +11853,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -11887,7 +11887,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -11978,7 +11978,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12012,7 +12012,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -12109,7 +12109,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12143,7 +12143,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -12190,7 +12190,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12224,7 +12224,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -12317,7 +12317,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12351,7 +12351,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -12445,7 +12445,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12479,7 +12479,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -12568,7 +12568,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12602,7 +12602,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -12686,7 +12686,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12720,7 +12720,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -12814,7 +12814,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -12848,7 +12848,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13146,7 +13146,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13180,7 +13180,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13288,7 +13288,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13322,7 +13322,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13365,7 +13365,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13399,7 +13399,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13450,7 +13450,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13484,7 +13484,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13514,7 +13514,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13548,7 +13548,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13595,7 +13595,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13629,7 +13629,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13723,7 +13723,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13757,7 +13757,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13851,7 +13851,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13885,7 +13885,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -13932,7 +13932,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -13966,7 +13966,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14054,7 +14054,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14088,7 +14088,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14176,7 +14176,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14210,7 +14210,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14297,7 +14297,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14331,7 +14331,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14407,7 +14407,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14441,7 +14441,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14488,7 +14488,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14522,7 +14522,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14569,7 +14569,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14603,7 +14603,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14691,7 +14691,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14725,7 +14725,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14784,7 +14784,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14818,7 +14818,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14912,7 +14912,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -14946,7 +14946,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -14989,7 +14989,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15023,7 +15023,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15070,7 +15070,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15104,7 +15104,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15147,7 +15147,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15181,7 +15181,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15211,7 +15211,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15245,7 +15245,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15272,7 +15272,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15306,7 +15306,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15333,7 +15333,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15367,7 +15367,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15418,7 +15418,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15452,7 +15452,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15495,7 +15495,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15529,7 +15529,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {
@@ -15606,7 +15606,7 @@
       "category": [
         "network"
       ],
-      "code": 22,
+      "code": "22",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -15640,7 +15640,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2016",
-      "event_id": 22,
+      "event_id": "22",
       "process": {
         "pid": 2828,
         "thread": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-filedelete.evtx.golden.json
@@ -5,7 +5,7 @@
       "category": [
         "file"
       ],
-      "code": 23,
+      "code": "23",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -66,7 +66,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 23,
+      "event_id": "23",
       "process": {
         "pid": 664,
         "thread": {
@@ -88,7 +88,7 @@
       "category": [
         "file"
       ],
-      "code": 23,
+      "code": "23",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -142,7 +142,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 23,
+      "event_id": "23",
       "process": {
         "pid": 664,
         "thread": {
@@ -164,7 +164,7 @@
       "category": [
         "file"
       ],
-      "code": 23,
+      "code": "23",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -217,7 +217,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 23,
+      "event_id": "23",
       "process": {
         "pid": 1188,
         "thread": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-registry.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-11-registry.evtx.golden.json
@@ -6,7 +6,7 @@
         "configuration",
         "registry"
       ],
-      "code": 13,
+      "code": "13",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -47,7 +47,7 @@
         "EventType": "SetValue",
         "TargetObject": "HKU\\S-1-5-21-1067164964-2079179834-2367582738-1000\\Software\\Key 1"
       },
-      "event_id": 13,
+      "event_id": "13",
       "process": {
         "pid": 5496,
         "thread": {
@@ -70,7 +70,7 @@
         "configuration",
         "registry"
       ],
-      "code": 13,
+      "code": "13",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -105,7 +105,7 @@
         "EventType": "SetValue",
         "TargetObject": "HKU\\S-1-5-21-1067164964-2079179834-2367582738-1000\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{CEBFF5CD-ACE2-4F4F-9178-9926F41749EA}\\Count\\HRZR_PGYFRFFVBA"
       },
-      "event_id": 13,
+      "event_id": "13",
       "process": {
         "pid": 5496,
         "thread": {
@@ -128,7 +128,7 @@
         "configuration",
         "registry"
       ],
-      "code": 13,
+      "code": "13",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -169,7 +169,7 @@
         "EventType": "SetValue",
         "TargetObject": "HKU\\S-1-5-21-1067164964-2079179834-2367582738-1000\\Software\\Key 2"
       },
-      "event_id": 13,
+      "event_id": "13",
       "process": {
         "pid": 5496,
         "thread": {
@@ -192,7 +192,7 @@
         "configuration",
         "registry"
       ],
-      "code": 13,
+      "code": "13",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -227,7 +227,7 @@
         "EventType": "SetValue",
         "TargetObject": "HKU\\S-1-5-21-1067164964-2079179834-2367582738-1000\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{CEBFF5CD-ACE2-4F4F-9178-9926F41749EA}\\Count\\{S38OS404-1Q43-42S2-9305-67QR0O28SP23}\\ertrqvg.rkr"
       },
-      "event_id": 13,
+      "event_id": "13",
       "process": {
         "pid": 5496,
         "thread": {
@@ -250,7 +250,7 @@
         "configuration",
         "registry"
       ],
-      "code": 13,
+      "code": "13",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -285,7 +285,7 @@
         "EventType": "SetValue",
         "TargetObject": "HKU\\S-1-5-21-1067164964-2079179834-2367582738-1000\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\UserAssist\\{CEBFF5CD-ACE2-4F4F-9178-9926F41749EA}\\Count\\HRZR_PGYFRFFVBA"
       },
-      "event_id": 13,
+      "event_id": "13",
       "process": {
         "pid": 5496,
         "thread": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-loadimage.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-loadimage.evtx.golden.json
@@ -5,7 +5,7 @@
       "category": [
         "process"
       ],
-      "code": 7,
+      "code": "7",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -77,7 +77,7 @@
         "SignatureStatus": "Valid",
         "Signed": "true"
       },
-      "event_id": 7,
+      "event_id": "7",
       "process": {
         "pid": 1676,
         "thread": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-processcreate.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-12-processcreate.evtx.golden.json
@@ -5,7 +5,7 @@
       "category": [
         "process"
       ],
-      "code": 1,
+      "code": "1",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -77,7 +77,7 @@
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "1"
       },
-      "event_id": 1,
+      "event_id": "1",
       "process": {
         "pid": 7144,
         "thread": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-13-clipboardchange.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-13-clipboardchange.evtx.golden.json
@@ -2,7 +2,7 @@
   {
     "@timestamp": "2021-02-25T15:04:48.592Z",
     "event": {
-      "code": 24,
+      "code": "24",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -47,7 +47,7 @@
         "ClientInfo": "user: DESKTOP-I9CQVAQ\\luks",
         "Session": "1"
       },
-      "event_id": 24,
+      "event_id": "24",
       "process": {
         "pid": 3800,
         "thread": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-13-processtampering.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-13-processtampering.evtx.golden.json
@@ -5,7 +5,7 @@
       "category": [
         "process"
       ],
-      "code": 25,
+      "code": "25",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -35,7 +35,7 @@
       "event_data": {
         "Type": "Image is replaced"
       },
-      "event_id": 25,
+      "event_id": "25",
       "process": {
         "pid": 3800,
         "thread": {

--- a/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
+++ b/x-pack/winlogbeat/module/sysmon/test/testdata/sysmon-9.01.evtx.golden.json
@@ -5,7 +5,7 @@
       "category": [
         "configuration"
       ],
-      "code": 16,
+      "code": "16",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -26,7 +26,7 @@
       "event_data": {
         "Configuration": "C:\\Users\\vagrant\\Downloads\\\"C:\\Users\\vagrant\\Downloads\\Sysmon.exe\"  -i -n"
       },
-      "event_id": 16,
+      "event_id": "16",
       "process": {
         "pid": 4616,
         "thread": {
@@ -48,7 +48,7 @@
       "category": [
         "process"
       ],
-      "code": 4,
+      "code": "4",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -71,7 +71,7 @@
         "State": "Started",
         "Version": "9.01"
       },
-      "event_id": 4,
+      "event_id": "4",
       "process": {
         "pid": 4860,
         "thread": {
@@ -93,7 +93,7 @@
       "category": [
         "process"
       ],
-      "code": 1,
+      "code": "1",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -164,7 +164,7 @@
         "Product": "Sysinternals Sysmon",
         "TerminalSessionId": "0"
       },
-      "event_id": 1,
+      "event_id": "1",
       "process": {
         "pid": 4860,
         "thread": {
@@ -186,7 +186,7 @@
       "category": [
         "process"
       ],
-      "code": 1,
+      "code": "1",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -260,7 +260,7 @@
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
       },
-      "event_id": 1,
+      "event_id": "1",
       "process": {
         "pid": 4860,
         "thread": {
@@ -282,7 +282,7 @@
       "category": [
         "process"
       ],
-      "code": 5,
+      "code": "5",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -307,7 +307,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 5,
+      "event_id": "5",
       "process": {
         "pid": 4860,
         "thread": {
@@ -329,7 +329,7 @@
       "category": [
         "process"
       ],
-      "code": 5,
+      "code": "5",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -354,7 +354,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 5,
+      "event_id": "5",
       "process": {
         "pid": 4860,
         "thread": {
@@ -376,7 +376,7 @@
       "category": [
         "process"
       ],
-      "code": 1,
+      "code": "1",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -450,7 +450,7 @@
         "Product": "Microsoft® Windows® Operating System",
         "TerminalSessionId": "0"
       },
-      "event_id": 1,
+      "event_id": "1",
       "process": {
         "pid": 4860,
         "thread": {
@@ -476,7 +476,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -525,7 +525,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -551,7 +551,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -601,7 +601,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -627,7 +627,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -677,7 +677,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -703,7 +703,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -753,7 +753,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -779,7 +779,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -832,7 +832,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -859,7 +859,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -911,7 +911,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -937,7 +937,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -987,7 +987,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1013,7 +1013,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1062,7 +1062,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1088,7 +1088,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1140,7 +1140,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1166,7 +1166,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1218,7 +1218,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1244,7 +1244,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1293,7 +1293,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1319,7 +1319,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1368,7 +1368,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1394,7 +1394,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1447,7 +1447,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1473,7 +1473,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1526,7 +1526,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1552,7 +1552,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1605,7 +1605,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1631,7 +1631,7 @@
       "category": [
         "network"
       ],
-      "code": 3,
+      "code": "3",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1684,7 +1684,7 @@
       "event_data": {
         "SourcePortName": "netbios-ns"
       },
-      "event_id": 3,
+      "event_id": "3",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1706,7 +1706,7 @@
       "category": [
         "process"
       ],
-      "code": 5,
+      "code": "5",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1731,7 +1731,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 5,
+      "event_id": "5",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1753,7 +1753,7 @@
       "category": [
         "process"
       ],
-      "code": 5,
+      "code": "5",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1778,7 +1778,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 5,
+      "event_id": "5",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1800,7 +1800,7 @@
       "category": [
         "file"
       ],
-      "code": 2,
+      "code": "2",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1834,7 +1834,7 @@
         "CreationUtcTime": "2019-03-18 16:52:04.980",
         "PreviousCreationUtcTime": "2019-03-18 16:57:52.387"
       },
-      "event_id": 2,
+      "event_id": "2",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1856,7 +1856,7 @@
       "category": [
         "file"
       ],
-      "code": 2,
+      "code": "2",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1890,7 +1890,7 @@
         "CreationUtcTime": "2019-03-18 16:52:04.980",
         "PreviousCreationUtcTime": "2019-03-18 16:57:52.402"
       },
-      "event_id": 2,
+      "event_id": "2",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1912,7 +1912,7 @@
       "category": [
         "file"
       ],
-      "code": 2,
+      "code": "2",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -1946,7 +1946,7 @@
         "CreationUtcTime": "2019-03-18 16:52:05.028",
         "PreviousCreationUtcTime": "2019-03-18 16:57:52.402"
       },
-      "event_id": 2,
+      "event_id": "2",
       "process": {
         "pid": 4860,
         "thread": {
@@ -1968,7 +1968,7 @@
       "category": [
         "file"
       ],
-      "code": 2,
+      "code": "2",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2002,7 +2002,7 @@
         "CreationUtcTime": "2019-03-18 16:51:54.980",
         "PreviousCreationUtcTime": "2019-03-18 16:57:52.417"
       },
-      "event_id": 2,
+      "event_id": "2",
       "process": {
         "pid": 4860,
         "thread": {
@@ -2024,7 +2024,7 @@
       "category": [
         "process"
       ],
-      "code": 5,
+      "code": "5",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2049,7 +2049,7 @@
       "api": "wineventlog",
       "channel": "Microsoft-Windows-Sysmon/Operational",
       "computer_name": "vagrant-2012-r2",
-      "event_id": 5,
+      "event_id": "5",
       "process": {
         "pid": 4860,
         "thread": {
@@ -2071,7 +2071,7 @@
       "category": [
         "file"
       ],
-      "code": 2,
+      "code": "2",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2105,7 +2105,7 @@
         "CreationUtcTime": "2019-03-18 16:52:08.496",
         "PreviousCreationUtcTime": "2019-03-18 16:57:52.417"
       },
-      "event_id": 2,
+      "event_id": "2",
       "process": {
         "pid": 4860,
         "thread": {
@@ -2127,7 +2127,7 @@
       "category": [
         "file"
       ],
-      "code": 2,
+      "code": "2",
       "kind": "event",
       "module": "sysmon",
       "provider": "Microsoft-Windows-Sysmon",
@@ -2161,7 +2161,7 @@
         "CreationUtcTime": "2019-03-18 16:52:05.339",
         "PreviousCreationUtcTime": "2019-03-18 16:57:52.417"
       },
-      "event_id": 2,
+      "event_id": "2",
       "process": {
         "pid": 4860,
         "thread": {


### PR DESCRIPTION
Cherry-pick of PR #25176 to 7.13 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Changes `event.code` and `winlog.event_id` from int to keyword.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To be consistent with the expected ECS type.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
