### PR TITLE
[Elastic Agent] Fix status and inspect command to work inside running container

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -52,6 +52,8 @@
 - Respect host configuration for exposed processes endpoint {pull}25114[25114]
 - Set --inscure in container when FLEET_SERVER_ENABLE and FLEET_INSECURE set {pull}25137[25137]
 - Fixed: limit for retries to Kibana configurable {issue}25063[25063]
+- Fix issue with status and inspect inside of container {pull}25204[25204]
+
 ==== New features
 
 - Prepare packaging for endpoint and asc files {pull}20186[20186]

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/kibana"
@@ -164,7 +165,7 @@ func logContainerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 func containerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	// set paths early so all action below use the defined paths
-	if err := setPaths(); err != nil {
+	if err := setPaths("", "", "", true); err != nil {
 		return err
 	}
 
@@ -635,13 +636,13 @@ func logToStderr(cfg *configuration.Configuration) {
 	}
 }
 
-func setPaths() error {
-	statePath := envWithDefault(defaultStateDirectory, "STATE_PATH")
+func setPaths(statePath, configPath, logsPath string, writePaths bool) error {
+	statePath = envWithDefault(statePath, "STATE_PATH")
 	if statePath == "" {
-		return errors.New("STATE_PATH cannot be set to an empty string")
+		statePath = defaultStateDirectory
 	}
 	topPath := filepath.Join(statePath, "data")
-	configPath := envWithDefault("", "CONFIG_PATH")
+	configPath = envWithDefault(configPath, "CONFIG_PATH")
 	if configPath == "" {
 		configPath = statePath
 	}
@@ -662,19 +663,73 @@ func setPaths() error {
 	if err := syncDir(srcDownloads, destDownloads); err != nil {
 		return fmt.Errorf("syncing download directory to STATE_PATH(%s) failed: %s", statePath, err)
 	}
+	originalTop := paths.Top()
 	paths.SetTop(topPath)
 	paths.SetConfig(configPath)
 	// when custom top path is provided the home directory is not versioned
 	paths.SetVersionHome(false)
 	// set LOGS_PATH is given
-	if logsPath := envWithDefault("", "LOGS_PATH"); logsPath != "" {
+	logsPath = envWithDefault(logsPath, "LOGS_PATH")
+	if logsPath != "" {
 		paths.SetLogs(logsPath)
 		// ensure that the logs directory exists
 		if err := os.MkdirAll(filepath.Join(logsPath), 0755); err != nil {
 			return fmt.Errorf("preparing LOGS_PATH(%s) failed: %s", logsPath, err)
 		}
 	}
+	// persist the paths so other commands in the container will use the correct paths
+	if writePaths {
+		if err := writeContainerPaths(originalTop, statePath, configPath, logsPath); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+type containerPaths struct {
+	StatePath  string `config:"state_path" yaml:"state_path"`
+	ConfigPath string `config:"state_path" yaml:"config_path,omitempty"`
+	LogsPath   string `config:"state_path" yaml:"logs_path,omitempty"`
+}
+
+func writeContainerPaths(original, statePath, configPath, logsPath string) error {
+	pathFile := filepath.Join(original, "container-paths.yml")
+	fp, err := os.Create(pathFile)
+	if err != nil {
+		return fmt.Errorf("failed creating %s: %s", pathFile, err)
+	}
+	b, err := yaml.Marshal(containerPaths{
+		StatePath:  statePath,
+		ConfigPath: configPath,
+		LogsPath:   logsPath,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal for %s: %s", pathFile, err)
+	}
+	_, err = fp.Write(b)
+	if err != nil {
+		return fmt.Errorf("failed to write %s: %s", pathFile, err)
+	}
+	return nil
+}
+
+func tryContainerLoadPaths() error {
+	pathFile := filepath.Join(paths.Top(), "container-paths.yml")
+	_, err := os.Stat(pathFile)
+	if os.IsNotExist(err) {
+		// no container-paths.yml file exists, so nothing to do
+		return nil
+	}
+	cfg, err := config.LoadFile(pathFile)
+	if err != nil {
+		return fmt.Errorf("failed to load %s: %s", pathFile, err)
+	}
+	var paths containerPaths
+	err = cfg.Unpack(&paths)
+	if err != nil {
+		return fmt.Errorf("failed to unpack %s: %s", pathFile, err)
+	}
+	return setPaths(paths.StatePath, paths.ConfigPath, paths.LogsPath, false)
 }
 
 func syncDir(src string, dest string) error {

--- a/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
@@ -84,6 +84,11 @@ func newInspectOutputCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.
 }
 
 func inspectConfig(cfgPath string) error {
+	err := tryContainerLoadPaths()
+	if err != nil {
+		return err
+	}
+
 	fullCfg, err := operations.LoadFullAgentConfig(cfgPath, true)
 	if err != nil {
 		return err

--- a/x-pack/elastic-agent/pkg/agent/cmd/status.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/status.go
@@ -48,6 +48,11 @@ func newStatusCommand(_ []string, streams *cli.IOStreams) *cobra.Command {
 }
 
 func statusCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
+	err := tryContainerLoadPaths()
+	if err != nil {
+		return err
+	}
+
 	output, _ := cmd.Flags().GetString("output")
 	outputFunc, ok := outputs[output]
 	if !ok {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes issue where the `status` and `inspect` command did not work. This has to do with how the `container` command must setup the paths so it works correctly in a container.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So the `status` and the `inspect` command can work inside of a container, without setting a special environment for it to work.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24956 

