### PR TITLE
[Winlogbeat] Update experimental flag on winlogbeat documentation

### DIFF
--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -81,8 +81,6 @@ winlogbeat.event_logs:
 [float]
 ==== `event_logs.batch_read_size`
 
-experimental[]
-
 The maximum number of event log records to read from the Windows API in a single
 batch. The default batch size is 100. Most Windows versions return an error if
 the value is larger than 1024. *{vista_and_newer}*
@@ -414,12 +412,10 @@ example of how to read from an `.evtx` file in the <<reading-from-evtx,FAQ>>.
 [float]
 ==== `event_logs.api`
 
-experimental[]
-
 This selects the event log reader implementation that is used to read events
 from the Windows APIs. You should only set this option when testing experimental
 features. When the value is set to `wineventlog-experimental` Winlogbeat will
-replace the default event log reader with the experimental implementation.
+replace the default event log reader with the **experimental** implementation.
 We are evaluating this implementation to see if it can provide increased
 performance and reduce CPU usage. *{vista_and_newer}*
 


### PR DESCRIPTION
- remove experimental from batch_read_size
- remove experimental from api (using wineventlog-experimental) is
  still experimental but setting the API isn't
- syncs with documentation for agent winlog input


## What does this PR do?

Update winlog documentation

- remove experimental from batch_read_size
- remove experimental from api (using wineventlog-experimental) is
  still experimental but setting the API isn't
- syncs with documentation for agent winlog input

## Why is it important?

Setting these options is GA.  Note that using the
`wineventlog-experimental` setting for api is still considered
experimental.


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.