### PR TITLE
[Filebeat] Add single quotes around configurable string values in O365

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -287,6 +287,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix integer overflow in S3 offsets when collecting very large files. {pull}22523[22523]
 - Fix CredentialsJSON unpacking for `gcp-pubsub` and `httpjson` inputs. {pull}23277[23277]
 - Strip Azure Eventhub connection string in debug logs. {pulll}25066[25066]
+- Fix o365 module config when client_secret contains special characters. {issue}25058[25058]
 
 *Filebeat*
 

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -300,8 +300,11 @@ func getTemplateFunctions(vars map[string]interface{}) (template.FuncMap, error)
 			return false
 		},
 		"tojson": func(v interface{}) (string, error) {
-			bytes, err := json.Marshal(v)
-			return string(bytes), err
+			var buf strings.Builder
+			enc := json.NewEncoder(&buf)
+			enc.SetEscapeHTML(false)
+			err := enc.Encode(v)
+			return buf.String(), err
 		},
 		"IngestPipeline": func(shortID string) string {
 			return formatPipelineID(

--- a/x-pack/filebeat/module/o365/audit/config/input.yml
+++ b/x-pack/filebeat/module/o365/audit/config/input.yml
@@ -1,15 +1,15 @@
 {{ if eq .input "o365audit" }}
 
 type: o365audit
-{{ if .application_id }}application_id: {{ .application_id }}{{ end }}
+{{ if .application_id }}application_id: '{{ .application_id }}'{{ end }}
 tenant_id:
 {{ range .tenants }}
- - {{ .id }}
+ - '{{ .id }}'
 {{ end }}
-{{ if .certificate }}certificate: {{ .certificate }}{{ end }}
-{{ if .key }}key: {{ .key }}{{ end }}
-{{ if .key_passphrase }}key_passphrase: {{ .key_passphrase }}{{ end }}
-{{ if .client_secret }}client_secret: {{ .client_secret }}{{ end }}
+{{ if .certificate }}certificate: '{{ .certificate }}'{{ end }}
+{{ if .key }}key: '{{ .key }}'{{ end }}
+{{ if .key_passphrase }}key_passphrase: '{{ .key_passphrase }}'{{ end }}
+{{ if .client_secret }}client_secret: '{{ .client_secret }}'{{ end }}
 {{ if eq "string" (printf "%T" .content_type) }}
 content_type: {{ .content_type }}
 {{ else }}


### PR DESCRIPTION
## What does this PR do?

Values passed in by users that are expected to be strings should be single-quoted.

Also, this fixes the `tojson` function to not escape &, <, and > to to \u0026, \u003c, and \u003e. This
caused problems if the value is an api keys or password that contained one of those characters.

Fixes #25058

## Why is it important?

We don't want to create arbitrary restrictions on the allowed characters in client secrets.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes #25058
