### PR TITLE
Skip flaky test TestFilestreamTruncate

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -860,6 +860,8 @@ func TestFilestreamSymlinkRemoved(t *testing.T) {
 
 // test_truncate from test_harvester.py
 func TestFilestreamTruncate(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/25217")
+
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"


### PR DESCRIPTION
## What does this PR do?

Skips TestFilestreamTruncate because it's flaky.

Related: #25217

## Why is it important?

To keep the builds green.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Relates #25217
