### PR TITLE
Cherry-pick to 7.13: [Heartbeat]: ensure synthetics version co* [Heartbeat]: ensure synthetics version compatability for suites  * address review and fix notice  * fix lowercase struct  * fix version conflict and rebase  * update go.* stuff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.8.2
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/Azure/go-autorest/autorest/date v0.2.0
+	github.com/Masterminds/semver v1.4.2
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 	github.com/Shopify/sarama v0.0.0-00010101000000-000000000000
 	github.com/StackExchange/wmi v0.0.0-20170221213301-9f32b5905fd6

--- a/x-pack/heartbeat/monitors/browser/source/fixtures/todos/package.json
+++ b/x-pack/heartbeat/monitors/browser/source/fixtures/todos/package.json
@@ -4,7 +4,6 @@
   "description": "This suite tests the examples that ship with the open source Vue.js project.",
   "scripts": {},
   "dependencies": {
-    "@elastic/synthetics": "*",
-    "playwright-core": "=1.6.2"
+    "@elastic/synthetics": "^1.0.0-beta.1"
   }
 }

--- a/x-pack/heartbeat/monitors/browser/source/local.go
+++ b/x-pack/heartbeat/monitors/browser/source/local.go
@@ -42,7 +42,12 @@ func (l *LocalSource) Validate() error {
 	if !s.IsDir() {
 		return fmt.Errorf("%s: path points to a non-directory", base)
 	}
-
+	// ensure the used synthetics version dep used in suite does not
+	// exceed our supported range
+	err = validatePackageJSON(path.Join(l.OrigPath, "package.json"))
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/x-pack/heartbeat/monitors/browser/source/local_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/local_test.go
@@ -16,12 +16,14 @@ import (
 )
 
 func TestLocalSourceValidate(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	fixtureDir := path.Join(filepath.Dir(filename), "fixtures/todos")
 	tests := []struct {
 		name     string
 		OrigPath string
 		err      error
 	}{
-		{"valid", "./", nil},
+		{"valid", fixtureDir, nil},
 		{"invalid", "/not/a/path", ErrInvalidPath("/not/a/path")},
 		{"nopath", "", ErrNoPath},
 	}

--- a/x-pack/heartbeat/monitors/browser/source/validatepackage.go
+++ b/x-pack/heartbeat/monitors/browser/source/validatepackage.go
@@ -1,0 +1,83 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package source
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver"
+)
+
+// ensure compatability of synthetics by enforcing the installed
+// version never goes beyond this range
+const ExpectedSynthVersion = "<2.0.0"
+
+type packageJson struct {
+	Dependencies struct {
+		SynthVersion string `json:"@elastic/synthetics"`
+	} `json:"dependencies"`
+	DevDependencies struct {
+		SynthVersion string `json:"@elastic/synthetics"`
+	} `json:"devDependencies"`
+}
+
+var nonNumberRegex = regexp.MustCompile("\\D")
+
+// parsed a given dep version by ignoring all range tags (^, = , >, <)
+func parseVersion(version string) string {
+	dotParts := strings.SplitN(version, ".", 4)
+
+	parsed := []string{}
+	for _, v := range dotParts[:3] {
+		value := nonNumberRegex.ReplaceAllString(v, "")
+		parsed = append(parsed, value)
+	}
+	return strings.Join(parsed, ".")
+}
+
+func validateVersion(expected string, current string) error {
+	expectedRange, err := semver.NewConstraint(expected)
+	if err != nil {
+		return err
+	}
+
+	parsed := parseVersion(current)
+	currentVersion, err := semver.NewVersion(parsed)
+	if err != nil {
+		return fmt.Errorf("error parsing @elastic/synthetics version: '%s' %w", currentVersion, err)
+	}
+
+	isValid := expectedRange.Check(currentVersion)
+	if !isValid {
+		return fmt.Errorf("parsed @elastic/synthetics version '%s' is not compatible", current)
+	}
+	return nil
+}
+
+func validatePackageJSON(path string) error {
+	pkgData, err := ioutil.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("could not read file '%s': %w", path, err)
+	}
+	pkgJson := packageJson{}
+	err = json.Unmarshal(pkgData, &pkgJson)
+	if err != nil {
+		return fmt.Errorf("could not unmarshall @elastic/synthetics version: %w", err)
+	}
+
+	synthVersion := pkgJson.Dependencies.SynthVersion
+	if synthVersion == "" {
+		synthVersion = pkgJson.DevDependencies.SynthVersion
+	}
+	err = validateVersion(ExpectedSynthVersion, synthVersion)
+	if err != nil {
+		return fmt.Errorf("could not validate @elastic/synthetics version: '%s' %w", synthVersion, err)
+	}
+	return nil
+}

--- a/x-pack/heartbeat/monitors/browser/source/validatepackage_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/validatepackage_test.go
@@ -1,0 +1,85 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package source
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseVersionVersion(t *testing.T) {
+	tests := []struct {
+		given    string
+		expected string
+	}{{
+		given:    ">2.1.1",
+		expected: "2.1.1",
+	},
+		{
+			given:    "^0.0.1-alpha.preview+123.github",
+			expected: "0.0.1",
+		},
+		{
+			given:    "<=0.0.1-alpha.12",
+			expected: "0.0.1",
+		},
+		{
+			given:    "^1.0.3-beta",
+			expected: "1.0.3",
+		},
+		{
+			given:    "~^1.0.3",
+			expected: "1.0.3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("expected version %s does not match given %s", tt.expected, tt.given), func(t *testing.T) {
+			parsed := parseVersion(tt.given)
+			require.Equal(t, tt.expected, parsed)
+		})
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		expected  string
+		current   string
+		shouldErr bool
+	}{
+		{
+			expected:  "<2.0.0",
+			current:   "^1.1.1",
+			shouldErr: false,
+		},
+		{
+			expected:  "<2.0.0",
+			current:   "=2.1.1",
+			shouldErr: true,
+		},
+		{
+			expected:  "<2.0.0",
+			current:   "2.0.0",
+			shouldErr: true,
+		},
+		{
+			expected:  "<1.0.0",
+			current:   "0.0.1-alpha.11",
+			shouldErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("match expected %s with current %s version", tt.expected, tt.current), func(t *testing.T) {
+			err := validateVersion(tt.expected, tt.current)
+			if tt.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.Equal(t, nil, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backports the following commits to 7.13:
 - [Heartbeat]: ensure synthetics version co* [Heartbeat]: ensure synthetics version compatability for suites  * address review and fix notice  * fix lowercase struct  * fix version conflict and rebase  * update go.* stuff to master  * fix notice.txt  * move validate inside sourcempatability for suites (#24777)