### PR TITLE
Remove post processing step from parser pipeline of `filestream`

### DIFF
--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -367,7 +367,7 @@ func (e *inputTestingEnvironment) requireEventContents(nr int, key, value string
 }
 
 func (e *inputTestingEnvironment) requireEventTimestamp(nr int, ts string) {
-	tm, err := time.Parse("2006-01-02 15:04:05.999 +0000", ts)
+	tm, err := time.Parse("2006-01-02T15:04:05.999", ts)
 	if err != nil {
 		e.t.Fatal(err)
 	}
@@ -379,7 +379,7 @@ func (e *inputTestingEnvironment) requireEventTimestamp(nr int, ts string) {
 	}
 
 	selectedEvent := events[nr]
-	require.True(e.t, selectedEvent.Timestamp.Equal(tm))
+	require.True(e.t, selectedEvent.Timestamp.Equal(tm), "got: %s, expected: %s", selectedEvent.Timestamp.String(), tm.String())
 }
 
 type testInputStore struct {

--- a/filebeat/input/filestream/environment_test.go
+++ b/filebeat/input/filestream/environment_test.go
@@ -367,6 +367,10 @@ func (e *inputTestingEnvironment) requireEventContents(nr int, key, value string
 }
 
 func (e *inputTestingEnvironment) requireEventTimestamp(nr int, ts string) {
+	tm, err := time.Parse("2006-01-02 15:04:05.999 +0000", ts)
+	if err != nil {
+		e.t.Fatal(err)
+	}
 	events := make([]beat.Event, 0)
 	for _, c := range e.pipeline.clients {
 		for _, evt := range c.GetEvents() {
@@ -375,7 +379,7 @@ func (e *inputTestingEnvironment) requireEventTimestamp(nr int, ts string) {
 	}
 
 	selectedEvent := events[nr]
-	require.Equal(e.t, ts, selectedEvent.Timestamp.String())
+	require.True(e.t, selectedEvent.Timestamp.Equal(tm))
 }
 
 type testInputStore struct {

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -58,7 +58,6 @@ type filestream struct {
 	encoding        encoding.Encoding
 	closerConfig    closerConfig
 	parserConfig    []common.ConfigNamespace
-	msgPostProc     []postProcesser
 }
 
 // Plugin creates a new filestream input plugin for creating a stateful input.
@@ -219,14 +218,14 @@ func (inp *filestream) open(log *logp.Logger, canceler input.Canceler, path stri
 
 	r = readfile.NewStripNewline(r, inp.readerConfig.LineTerminator)
 
+	r = readfile.NewFilemeta(r, path)
+
 	r, err = newParsers(r, parserConfig{maxBytes: inp.readerConfig.MaxBytes, lineTerminator: inp.readerConfig.LineTerminator}, inp.readerConfig.Parsers)
 	if err != nil {
 		return nil, err
 	}
 
 	r = readfile.NewLimitReader(r, inp.readerConfig.MaxBytes)
-
-	inp.msgPostProc = newPostProcessors(inp.readerConfig.Parsers)
 
 	return r, nil
 }
@@ -370,25 +369,11 @@ func matchAny(matchers []match.Matcher, text string) bool {
 }
 
 func (inp *filestream) eventFromMessage(m reader.Message, path string) beat.Event {
-	fields := common.MapStr{
-		"log": common.MapStr{
-			"offset": m.Bytes, // Offset here is the offset before the starting char.
-			"file": common.MapStr{
-				"path": path,
-			},
-		},
-	}
-	fields.DeepUpdate(m.Fields)
-	m.Fields = fields
-
-	for _, proc := range inp.msgPostProc {
-		proc.PostProcess(&m)
+	if m.Fields == nil {
+		m.Fields = common.MapStr{}
 	}
 
 	if len(m.Content) > 0 {
-		if m.Fields == nil {
-			m.Fields = common.MapStr{}
-		}
 		if _, ok := m.Fields["message"]; !ok {
 			m.Fields["message"] = string(m.Content)
 		}

--- a/filebeat/input/filestream/parser_test.go
+++ b/filebeat/input/filestream/parser_test.go
@@ -147,17 +147,17 @@ func TestParsersConfigAndReading(t *testing.T) {
 	}
 }
 
-func TestPostProcessingMessages(t *testing.T) {
+func TestJSONParsersWithFields(t *testing.T) {
 	tests := map[string]struct {
 		message         reader.Message
-		postProcessors  map[string]interface{}
+		config          map[string]interface{}
 		expectedMessage reader.Message
 	}{
 		"no postprocesser, no processing": {
 			message: reader.Message{
 				Content: []byte("line 1"),
 			},
-			postProcessors: map[string]interface{}{
+			config: map[string]interface{}{
 				"paths": []string{"dummy_path"},
 			},
 			expectedMessage: reader.Message{
@@ -169,7 +169,7 @@ func TestPostProcessingMessages(t *testing.T) {
 				Content: []byte("{\"key\":\"value\"}"),
 				Fields:  common.MapStr{},
 			},
-			postProcessors: map[string]interface{}{
+			config: map[string]interface{}{
 				"paths": []string{"dummy_path"},
 				"parsers": []map[string]interface{}{
 					map[string]interface{}{
@@ -191,7 +191,7 @@ func TestPostProcessingMessages(t *testing.T) {
 				Content: []byte("{\"key\":\"value\", \"my-id-field\":\"my-id\"}"),
 				Fields:  common.MapStr{},
 			},
-			postProcessors: map[string]interface{}{
+			config: map[string]interface{}{
 				"paths": []string{"dummy_path"},
 				"parsers": []map[string]interface{}{
 					map[string]interface{}{
@@ -220,7 +220,7 @@ func TestPostProcessingMessages(t *testing.T) {
 					"other-key": "other-value",
 				},
 			},
-			postProcessors: map[string]interface{}{
+			config: map[string]interface{}{
 				"paths": []string{"dummy_path"},
 				"parsers": []map[string]interface{}{
 					map[string]interface{}{
@@ -245,7 +245,7 @@ func TestPostProcessingMessages(t *testing.T) {
 		test := test
 		t.Run(name, func(t *testing.T) {
 			cfg := defaultConfig()
-			common.MustNewConfigFrom(test.postProcessors).Unpack(&cfg)
+			common.MustNewConfigFrom(test.config).Unpack(&cfg)
 			p, err := newParsers(msgReader(test.message), parserConfig{lineTerminator: readfile.AutoLineTerminator, maxBytes: 64}, cfg.Reader.Parsers)
 			if err != nil {
 				t.Fatalf("failed to init parser: %+v", err)

--- a/filebeat/input/filestream/parsers_integration_test.go
+++ b/filebeat/input/filestream/parsers_integration_test.go
@@ -52,7 +52,7 @@ func TestParsersAgentLogs(t *testing.T) {
 
 	env.requireEventContents(0, "message", "Harvester started for file: /var/log/auth.log")
 	env.requireEventContents(0, "log.level", "info")
-	env.requireEventTimestamp(0, "2021-05-12 16:15:09.411 +0000 +0000")
+	env.requireEventTimestamp(0, "2021-05-12 16:15:09.411 +0000")
 
 	cancelInput()
 	env.waitUntilInputStops()
@@ -163,7 +163,7 @@ func TestParsersTimestampInJSONMessage(t *testing.T) {
 	env.waitUntilEventCount(3)
 	env.requireOffsetInRegistry(testlogName, len(testline))
 
-	env.requireEventTimestamp(0, "2016-04-05 18:47:18.444 +0000 UTC")
+	env.requireEventTimestamp(0, "2016-04-05 18:47:18.444 +0000")
 	env.requireEventContents(1, "error.message", "@timestamp not overwritten (parse error on invalid)")
 	env.requireEventContents(2, "error.message", "@timestamp not overwritten (not string)")
 

--- a/filebeat/input/filestream/parsers_integration_test.go
+++ b/filebeat/input/filestream/parsers_integration_test.go
@@ -41,7 +41,7 @@ func TestParsersAgentLogs(t *testing.T) {
 		},
 	})
 
-	testline := []byte("{\"log.level\":\"info\",\"@timestamp\":\"2021-05-12T16:15:09.411+0200\",\"log.origin\":{\"file.name\":\"log/harvester.go\",\"file.line\":302},\"message\":\"Harvester started for file: /var/log/auth.log\",\"ecs.version\":\"1.6.0\"}\n")
+	testline := []byte("{\"log.level\":\"info\",\"@timestamp\":\"2021-05-12T16:15:09.411+0000\",\"log.origin\":{\"file.name\":\"log/harvester.go\",\"file.line\":302},\"message\":\"Harvester started for file: /var/log/auth.log\",\"ecs.version\":\"1.6.0\"}\n")
 	env.mustWriteLinesToFile(testlogName, testline)
 
 	ctx, cancelInput := context.WithCancel(context.Background())
@@ -52,7 +52,7 @@ func TestParsersAgentLogs(t *testing.T) {
 
 	env.requireEventContents(0, "message", "Harvester started for file: /var/log/auth.log")
 	env.requireEventContents(0, "log.level", "info")
-	env.requireEventTimestamp(0, "2021-05-12 16:15:09.411 +0200 CEST")
+	env.requireEventTimestamp(0, "2021-05-12 16:15:09.411 +0000 +0000")
 
 	cancelInput()
 	env.waitUntilInputStops()

--- a/filebeat/input/filestream/parsers_integration_test.go
+++ b/filebeat/input/filestream/parsers_integration_test.go
@@ -24,8 +24,7 @@ import (
 	"testing"
 )
 
-// test_docker_logs from test_json.py
-func TestParsersDockerLogs(t *testing.T) {
+func TestParsersAgentLogs(t *testing.T) {
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"
@@ -35,13 +34,14 @@ func TestParsersDockerLogs(t *testing.T) {
 		"parsers": []map[string]interface{}{
 			map[string]interface{}{
 				"ndjson": map[string]interface{}{
-					"message_key": "log",
+					"message_key":    "log",
+					"overwrite_keys": true,
 				},
 			},
 		},
 	})
 
-	testline := []byte("{\"log\":\"Fetching main repository github.com/elastic/beats...\\n\",\"stream\":\"stdout\",\"time\":\"2016-03-02T22:58:51.338462311Z\"}\n")
+	testline := []byte("{\"log.level\":\"info\",\"@timestamp\":\"2021-05-12T16:15:09.411+0200\",\"log.origin\":{\"file.name\":\"log/harvester.go\",\"file.line\":302},\"message\":\"Harvester started for file: /var/log/auth.log\",\"ecs.version\":\"1.6.0\"}\n")
 	env.mustWriteLinesToFile(testlogName, testline)
 
 	ctx, cancelInput := context.WithCancel(context.Background())
@@ -50,9 +50,9 @@ func TestParsersDockerLogs(t *testing.T) {
 	env.waitUntilEventCount(1)
 	env.requireOffsetInRegistry(testlogName, len(testline))
 
-	env.requireEventContents(0, "json.log", "Fetching main repository github.com/elastic/beats...\n")
-	env.requireEventContents(0, "json.time", "2016-03-02T22:58:51.338462311Z")
-	env.requireEventContents(0, "json.stream", "stdout")
+	env.requireEventContents(0, "message", "Harvester started for file: /var/log/auth.log")
+	env.requireEventContents(0, "log.level", "info")
+	env.requireEventTimestamp(0, "2021-05-12 16:15:09.411 +0200 CEST")
 
 	cancelInput()
 	env.waitUntilInputStops()
@@ -69,8 +69,8 @@ func TestParsersDockerLogsFiltering(t *testing.T) {
 		"parsers": []map[string]interface{}{
 			map[string]interface{}{
 				"ndjson": map[string]interface{}{
-					"message_key":     "log",
-					"keys_under_root": true,
+					"message_key": "log",
+					"target":      "",
 				},
 			},
 		},
@@ -107,9 +107,9 @@ func TestParsersSimpleJSONOverwrite(t *testing.T) {
 		"parsers": []map[string]interface{}{
 			map[string]interface{}{
 				"ndjson": map[string]interface{}{
-					"message_key":     "message",
-					"keys_under_root": true,
-					"overwrite_keys":  true,
+					"message_key":    "message",
+					"target":         "",
+					"overwrite_keys": true,
 				},
 			},
 		},
@@ -142,15 +142,15 @@ func TestParsersTimestampInJSONMessage(t *testing.T) {
 		"parsers": []map[string]interface{}{
 			map[string]interface{}{
 				"ndjson": map[string]interface{}{
-					"keys_under_root": true,
-					"overwrite_keys":  true,
-					"add_error_key":   true,
+					"target":         "",
+					"overwrite_keys": true,
+					"add_error_key":  true,
 				},
 			},
 		},
 	})
 
-	testline := []byte(`{"@timestamp":"2016-04-05T18:47:18.444Z"}
+	testline := []byte(`{"@timestamp":"2016-04-05T18:47:18.444Z", "msg":"hallo"}
 {"@timestamp":"invalid"}
 {"@timestamp":{"hello": "test"}}
 `)

--- a/filebeat/input/filestream/parsers_integration_test.go
+++ b/filebeat/input/filestream/parsers_integration_test.go
@@ -52,7 +52,7 @@ func TestParsersAgentLogs(t *testing.T) {
 
 	env.requireEventContents(0, "message", "Harvester started for file: /var/log/auth.log")
 	env.requireEventContents(0, "log.level", "info")
-	env.requireEventTimestamp(0, "2021-05-12 16:15:09.411 +0000")
+	env.requireEventTimestamp(0, "2021-05-12T16:15:09.411")
 
 	cancelInput()
 	env.waitUntilInputStops()
@@ -163,7 +163,7 @@ func TestParsersTimestampInJSONMessage(t *testing.T) {
 	env.waitUntilEventCount(3)
 	env.requireOffsetInRegistry(testlogName, len(testline))
 
-	env.requireEventTimestamp(0, "2016-04-05 18:47:18.444 +0000")
+	env.requireEventTimestamp(0, "2016-04-05T18:47:18.444")
 	env.requireEventContents(1, "error.message", "@timestamp not overwritten (parse error on invalid)")
 	env.requireEventContents(2, "error.message", "@timestamp not overwritten (not string)")
 

--- a/libbeat/reader/readjson/json_config.go
+++ b/libbeat/reader/readjson/json_config.go
@@ -17,6 +17,10 @@
 
 package readjson
 
+var (
+	parserCount = 1
+)
+
 // Config holds the options a JSON reader.
 type Config struct {
 	MessageKey          string `config:"message_key"`
@@ -26,6 +30,12 @@ type Config struct {
 	AddErrorKey         bool   `config:"add_error_key"`
 	IgnoreDecodingError bool   `config:"ignore_decoding_error"`
 	ExpandKeys          bool   `config:"expand_keys"`
+}
+
+type ParserConfig struct {
+	Config `config:",inline"`
+	Field  string `config:"field"`
+	Target string `config:"target"`
 }
 
 // Validate validates the Config option for JSON reader.

--- a/libbeat/reader/readjson/json_config.go
+++ b/libbeat/reader/readjson/json_config.go
@@ -17,10 +17,6 @@
 
 package readjson
 
-var (
-	parserCount = 1
-)
-
 // Config holds the options a JSON reader.
 type Config struct {
 	MessageKey          string `config:"message_key"`


### PR DESCRIPTION
## What does this PR do?

This PR removes the post-processing done by JSON parser. It has become possible because I moved adding `log` metadata to a `reader.Reader`. Thus, JSON parser can overwrite these values if necessary.

The PR also adds support for multiple parsers of the same type. It is not the best solution, so I am open to alternatives. At the moment JSON parser generates an ID for itself. The parsed keys are added to `Fields` under the key `"json{key}"`. The problem with this solution that the event looks somewhat ugly:

```json
{
    "@timestamp": "{my-timestamp}",
    "json1234-1234-1244": {
        "key": "value"
    }
}
```

## Why is it important?

Fixes the abstraction leak in `filestream` input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~