### PR TITLE
Cherry-pick #25229 to 7.x: Fix error message when count is missing in count based multiline

### DIFF
--- a/libbeat/reader/multiline/multiline_config.go
+++ b/libbeat/reader/multiline/multiline_config.go
@@ -42,7 +42,7 @@ var (
 	}
 
 	ErrMissingPattern = errors.New("multiline.pattern cannot be empty when pattern based matching is selected")
-	ErrMissingCount   = errors.New("multiline.pattern cannot be empty when pattern based matching is selected")
+	ErrMissingCount   = errors.New("multiline.count cannot be empty when count based aggregation is selected")
 )
 
 // Config holds the options of multiline readers.


### PR DESCRIPTION
Cherry-pick of PR #25229 to 7.x branch. Original message: 

## What does this PR do?

This PR fixes an error message when count based multiline is selected.

## Why is it important?

The error message was misleading.