### PR TITLE
Fix broken generator tests, updates to go.sum needed

### DIFF
--- a/generator/_templates/beat/{beat}/tools/tools.go
+++ b/generator/_templates/beat/{beat}/tools/tools.go
@@ -5,9 +5,11 @@
 package tools
 
 import (
+	_ "github.com/magefile/mage"
 	_ "github.com/pierrre/gotestcover"
 	_ "github.com/tsg/go-daemon"
 	_ "golang.org/x/tools/cmd/goimports"
+	_ "gotest.tools/gotestsum/cmd"
 
 	_ "github.com/mitchellh/gox"
 	_ "golang.org/x/lint/golint"

--- a/generator/_templates/metricbeat/{beat}/tools/tools.go
+++ b/generator/_templates/metricbeat/{beat}/tools/tools.go
@@ -5,9 +5,11 @@
 package tools
 
 import (
+	_ "github.com/magefile/mage"
 	_ "github.com/pierrre/gotestcover"
 	_ "github.com/tsg/go-daemon"
 	_ "golang.org/x/tools/cmd/goimports"
+	_ "gotest.tools/gotestsum/cmd"
 
 	_ "github.com/mitchellh/gox"
 	_ "golang.org/x/lint/golint"

--- a/generator/common/Makefile
+++ b/generator/common/Makefile
@@ -22,6 +22,7 @@ test: prepare-test
 test-package: test
 	cd ${BEAT_PATH} ; \
 	export PATH=$${GOPATH}/bin:$${PATH}; \
+	go mod tidy && \
 	mage package
 
 .PHONY: prepare-test


### PR DESCRIPTION
## What does this PR do?

Both generator tests were failing because the go.sum needed an update after running `mage test`.
The tools.go file was not updated to include gotest.tools/gotestsum/cmd which is installed while
running `mage test`.

The original errors were:

    go: updates to go.sum needed, disabled by -mod=readonly
    Error: running "go build -o build/golang-crossbuild/testbeat-windows-amd64.exe -buildmode pie -ldflags -s -extldflags=-Wl,--nxcompat -X github.com/elastic/beats/v7/libbeat/version.buildTime=2021-04-22T20:49:55Z -X github.com/elastic/beats/v7/libbeat/version.commit=c3a7a6abdf2a15cfd685e82ce1fe502296509825" failed with exit code 1
    Error: failed building for windows/amd64: exit status 1
    failed building for windows/amd64: exit status 1

    go: updates to go.sum needed, disabled by -mod=readonly
    Error: running "go build -o build/golang-crossbuild/testbeat-windows-386.exe -buildmode pie -ldflags -s -extldflags=-Wl,--nxcompat -X github.com/elastic/beats/v7/libbeat/version.buildTime=2021-04-22T20:49:55Z -X github.com/elastic/beats/v7/libbeat/version.commit=c3a7a6abdf2a15cfd685e82ce1fe502296509825" failed with exit code 1
    Error: failed building for windows/386: exit status 1
    failed building for windows/386: exit status 1

## Why is it important?

master build is red.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
