### PR TITLE
Improve dissect performance

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -382,6 +382,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `fortinet.firewall.addr` when its a string, not an IP address. {issue}25585[25585] {pull}25608[25608]
 - Fix incorrect field name appending to `related.hash` in `threatintel.abusechmalware` ingest pipeline. {issue}25151[25151] {pull}25674[25674]
 - Fix `kibana.log` pipeline when `event.duration` calculation becomes a Long. {issue}24556[24556] {pull}25675[25675]
+- Improve dissect performance. {pull}25252[25252]
 
 *Heartbeat*
 

--- a/libbeat/processors/dissect/field.go
+++ b/libbeat/processors/dissect/field.go
@@ -31,7 +31,7 @@ type field interface {
 	Key() string
 	DataType() string
 	ID() int
-	Apply(b string, m Map)
+	Apply(b string, m Map) string // returns the key of this stored data
 	String() string
 	IsSaveable() bool
 	IsFixedLength() bool
@@ -119,8 +119,10 @@ type normalField struct {
 	baseField
 }
 
-func (f normalField) Apply(b string, m Map) {
-	m[f.Key()] = b
+func (f normalField) Apply(b string, m Map) string {
+	key := f.Key()
+	m[key] = b
+	return key
 }
 
 // skipField is an skip field without a name like this: `%{}`, this is often used to
@@ -134,7 +136,8 @@ type skipField struct {
 	baseField
 }
 
-func (f skipField) Apply(b string, m Map) {
+func (f skipField) Apply(b string, m Map) string {
+	return ""
 }
 
 func (f skipField) IsSaveable() bool {
@@ -154,8 +157,10 @@ type namedSkipField struct {
 	baseField
 }
 
-func (f namedSkipField) Apply(b string, m Map) {
-	m[f.Key()] = b
+func (f namedSkipField) Apply(b string, m Map) string {
+	key := f.Key()
+	m[key] = b
+	return key
 }
 
 func (f namedSkipField) IsSaveable() bool {
@@ -168,8 +173,10 @@ type pointerField struct {
 	baseField
 }
 
-func (f pointerField) Apply(b string, m Map) {
-	m[f.Key()] = b
+func (f pointerField) Apply(b string, m Map) string {
+	key := f.Key()
+	m[key] = b
+	return key
 }
 
 func (f pointerField) IsSaveable() bool {
@@ -187,12 +194,14 @@ type indirectField struct {
 	baseField
 }
 
-func (f indirectField) Apply(b string, m Map) {
-	v, ok := m[f.Key()]
+func (f indirectField) Apply(b string, m Map) string {
+	key := f.Key()
+	v, ok := m[key]
 	if ok {
 		m[v] = b
-		return
+		return v
 	}
+	return key
 }
 
 // appendField allow an extracted field to be append to a previously extracted values.
@@ -212,13 +221,15 @@ type appendField struct {
 	previous delimiter
 }
 
-func (f appendField) Apply(b string, m Map) {
-	v, ok := m[f.Key()]
+func (f appendField) Apply(b string, m Map) string {
+	key := f.Key()
+	v, ok := m[key]
 	if ok {
-		m[f.Key()] = v + f.JoinString() + b
-		return
+		m[key] = v + f.JoinString() + b
+		return key
 	}
-	m[f.Key()] = b
+	m[key] = b
+	return key
 }
 
 func (f appendField) JoinString() string {

--- a/libbeat/processors/dissect/processor.go
+++ b/libbeat/processors/dissect/processor.go
@@ -78,14 +78,7 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 		return event, fmt.Errorf("field is not a string, value: `%v`, field: `%s`", v, p.config.Field)
 	}
 
-	convertDataType := false
-	for _, f := range p.config.Tokenizer.parser.fields {
-		if f.DataType() != "" {
-			convertDataType = true
-		}
-	}
-
-	if convertDataType {
+	if p.config.Tokenizer.hasTypeConversion {
 		mc, err = p.config.Tokenizer.DissectConvert(s)
 	} else {
 		m, err = p.config.Tokenizer.Dissect(s)
@@ -104,7 +97,7 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 		return event, err
 	}
 
-	if convertDataType {
+	if p.config.Tokenizer.hasTypeConversion {
 		event, err = p.mapper(event, mapInterfaceToMapStr(mc))
 	} else {
 		event, err = p.mapper(event, mapToMapStr(m))


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Improve dissect performance, especially when there is data type conversion defined in dissect pattern. 

## Why is it important?

performance improvement.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] test dissect package

## How to test this PR locally

this can be simply tested by go test the dissect package.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
```
name                                   old time/op    new time/op    delta
DissectNoConversionOneValue-8            7.68µs ±39%    6.27µs ± 5%  -18.44%  (p=0.000 n=20+19)
DissectWithConversionOneValue-8          7.44µs ±10%    6.78µs ± 9%   -8.91%  (p=0.000 n=19+19)
DissectNoConversionMultipleValues-8      19.7µs ± 9%    18.5µs ± 5%   -6.27%  (p=0.000 n=19+18)
DissectWithConversionMultipleValues-8    22.9µs ± 7%    21.0µs ± 6%   -8.42%  (p=0.000 n=18+19)

name                                   old alloc/op   new alloc/op   delta
DissectNoConversionOneValue-8            2.64kB ± 0%    2.64kB ± 0%     ~     (p=0.264 n=19+20)
DissectWithConversionOneValue-8          2.64kB ± 0%    2.64kB ± 0%     ~     (p=0.413 n=20+20)
DissectNoConversionMultipleValues-8      5.81kB ± 0%    5.81kB ± 0%     ~     (p=0.310 n=19+20)
DissectWithConversionMultipleValues-8    5.81kB ± 0%    5.81kB ± 0%     ~     (p=0.783 n=20+20)

name                                   old allocs/op  new allocs/op  delta
DissectNoConversionOneValue-8              29.0 ± 0%      29.0 ± 0%     ~     (all equal)
DissectWithConversionOneValue-8            29.0 ± 0%      29.0 ± 0%     ~     (all equal)
DissectNoConversionMultipleValues-8        56.0 ± 0%      56.0 ± 0%     ~     (all equal)
DissectWithConversionMultipleValues-8      56.0 ± 0%      56.0 ± 0%     ~     (all equal)```