### PR TITLE
Cherry-pick #25262 to 7.13: Add more context to cryptic error message to Functionbeat AWS manager

### DIFF
--- a/x-pack/functionbeat/manager/aws/op_ensure_bucket.go
+++ b/x-pack/functionbeat/manager/aws/op_ensure_bucket.go
@@ -56,5 +56,5 @@ func (o *opEnsureBucket) Execute(_ executor.Context) error {
 	}
 
 	// Catchall for unauthorized access.
-	return fmt.Errorf("bucket '%s' already exist and you don't have permission to access it", o.bucketName)
+	return fmt.Errorf("bucket '%s' already exist and you don't have permission to access it: %+v", o.bucketName, err)
 }


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#25262 to 7.13 branch. Original message: 

Previously we only got the error:
```
Function: {functionname}, could not deploy, error: bucket '{bucketname}' already exist and you don't have permission to access it
```

Now we get more details.