### PR TITLE
Stabilize TestFilestreamTruncate test

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -860,8 +860,6 @@ func TestFilestreamSymlinkRemoved(t *testing.T) {
 
 // test_truncate from test_harvester.py
 func TestFilestreamTruncate(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/25217")
-
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"
@@ -870,8 +868,9 @@ func TestFilestreamTruncate(t *testing.T) {
 		"paths": []string{
 			env.abspath("*"),
 		},
-		"prospector.scanner.check_interval": "1ms",
-		"prospector.scanner.symlinks":       "true",
+		"prospector.scanner.check_interval":  "1ms",
+		"prospector.scanner.resend_on_touch": "true",
+		"prospector.scanner.symlinks":        "true",
 	})
 
 	lines := []byte("first line\nsecond line\nthird line\n")
@@ -897,8 +896,7 @@ func TestFilestreamTruncate(t *testing.T) {
 	moreLines := []byte("forth line\nfifth line\n")
 	env.mustWriteLinesToFile(testlogName, moreLines)
 
-	env.waitUntilEventCount(5)
-	env.requireOffsetInRegistry(testlogName, len(moreLines))
+	env.waitUntilOffsetInRegistry(testlogName, len(moreLines))
 
 	cancelInput()
 	env.waitUntilInputStops()


### PR DESCRIPTION
## What does this PR do?

This PR stabilizes the flaky `TestFilestreamTruncate` test by making it more lenient. The input does not guarantee that all events are received by the output as truncation might lead to dataloss. This is now reflected in the test.

## Why is it important?

The test must be stable.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes #25217
