### PR TITLE
[Elastic Agent] Reduce log level for listener cleanup to debug

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -55,6 +55,7 @@
 - Fixed: limit for retries to Kibana configurable {issue}25063[25063]
 - Fix issue with status and inspect inside of container {pull}25204[25204]
 - Remove FLEET_SERVER_POLICY_NAME env variable as it was not used {pull}25149[25149]
+- Reduce log level for listener cleanup to debug {pull}25274
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/control/server/listener.go
+++ b/x-pack/elastic-agent/pkg/agent/control/server/listener.go
@@ -21,10 +21,7 @@ import (
 func createListener(log *logger.Logger) (net.Listener, error) {
 	path := strings.TrimPrefix(control.Address(), "unix://")
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		err = os.Remove(path)
-		if err != nil && !os.IsNotExist(err) {
-			log.Errorf("%s", errors.New(err, fmt.Sprintf("Failed to cleanup %s", path), errors.TypeFilesystem, errors.M("path", path)))
-		}
+		cleanupListener(log)
 	}
 	dir := filepath.Dir(path)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
@@ -48,7 +45,7 @@ func createListener(log *logger.Logger) (net.Listener, error) {
 
 func cleanupListener(log *logger.Logger) {
 	path := strings.TrimPrefix(control.Address(), "unix://")
-	if err := os.Remove(path); err != nil {
-		log.Errorf("%s", errors.New(err, fmt.Sprintf("Failed to cleanup %s", path), errors.TypeFilesystem, errors.M("path", path)))
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Debug("%s", errors.New(err, fmt.Sprintf("Failed to cleanup %s", path), errors.TypeFilesystem, errors.M("path", path)))
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Cleans up the log message when removing the listener socket fails.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So its not reported or confusing to users, its okay if it fails.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #25131 
