### PR TITLE
Cherry-pick #25272 to 7.13: [Testing] 7.x Disable geoip downloader

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -14,6 +14,9 @@ services:
     - "transport.host=127.0.0.1"
     - "http.host=0.0.0.0"
     - "xpack.security.enabled=false"
+    # Disable geoip updates to prevent golden file test failures when the database
+    # changes and prevent race conditions between tests and database updates.
+    - "ingest.geoip.downloader.enabled=false"
 
   logstash:
     image: docker.elastic.co/logstash/logstash:7.13.0-SNAPSHOT


### PR DESCRIPTION
Cherry-pick of PR #25272 to 7.13 branch. Original message: 

This is the same change as https://github.com/elastic/beats/pull/25248 but not automated b/c the branches differ in that golden files don't need updated in 7.x. Once 7.14.0-SNAPSHOT is ready https://github.com/elastic/beats/pull/25192 will update them, but for now use 7.13.0-SNAPSHOT of the stack.

## What does this PR do?

Disable database updates via an Elasticsearch property ingest.geoip.downloader.enabled: false. This will cause Elasticsearch to use the circa 2019 maxmind database version that is embedded. This would work for now, but the embedded database will be removed in 8.x IIUC.


Closes: #25159

## Why is it important?

This prevents our golden file tests from failing everytime the database changes geo or asn values. It also prevents race conditions in tests that might run before the database has been updated or in cases where the downloader service is unavailable.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

- Closes: #25159
