### PR TITLE
Cherry-pick to 7.13: fix processors/script documentation (#24527)

### DIFF
--- a/libbeat/processors/script/docs/script.asciidoc
+++ b/libbeat/processors/script/docs/script.asciidoc
@@ -70,6 +70,7 @@ function process(event) {
     if (event.Get("event.code") === 1102) {
         event.Put("event.action", "cleared");
     }
+    return event;
 }
 
 function test() {


### PR DESCRIPTION
Backports the following commits to 7.13:
 - fix processors/script documentation (#24527)