### PR TITLE
[Heartbeat] Fix null pointer in zip url on retry

### DIFF
--- a/x-pack/heartbeat/monitors/browser/source/zipurl.go
+++ b/x-pack/heartbeat/monitors/browser/source/zipurl.go
@@ -174,7 +174,7 @@ func retryingZipRequest(method string, z *ZipURLSource) (resp *http.Response, er
 		}
 		time.Sleep(time.Second)
 	}
-	if resp.StatusCode > 300 {
+	if resp != nil && resp.StatusCode > 300 {
 		return nil, fmt.Errorf("failed to retrieve zip, received status of %d requesting zip URL", resp.StatusCode)
 	}
 	return resp, err

--- a/x-pack/heartbeat/monitors/browser/source/zipurl_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/zipurl_test.go
@@ -78,6 +78,20 @@ func TestZipUrlWithSameEtag(t *testing.T) {
 	require.Equal(t, zus.TargetDirectory, target, "Target directory should be same")
 }
 
+func TestZipUrlWithBadUrl(t *testing.T) {
+	_, teardown := setupTests()
+	defer teardown()
+
+	zus := ZipURLSource{
+		URL:     "http://notahost.notadomaintoehutoeuhn",
+		Folder:  "/",
+		Retries: 2,
+	}
+	err := zus.Fetch()
+	defer zus.Close()
+	require.Error(t, err)
+}
+
 func setupTests() (addr string, teardown func()) {
 	// go offline, so we dont invoke npm install for unit tests
 	GoOffline()


### PR DESCRIPTION
Fixes a rare null pointer in synthetics zip url codepath
## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~