### PR TITLE
Add services to the list of allowed resources for heartbeat in kubernetes

### DIFF
--- a/deploy/kubernetes/heartbeat-kubernetes.yaml
+++ b/deploy/kubernetes/heartbeat-kubernetes.yaml
@@ -147,6 +147,7 @@ rules:
   - nodes
   - namespaces
   - pods
+  - services
   verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources:

--- a/deploy/kubernetes/heartbeat/heartbeat-role.yaml
+++ b/deploy/kubernetes/heartbeat/heartbeat-role.yaml
@@ -10,6 +10,7 @@ rules:
   - nodes
   - namespaces
   - pods
+  - services
   verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources:


### PR DESCRIPTION
## What does this PR do?

Add `services` to the list of resources heartbeat can get, list or watch in kubernetes.

## Why is it important?

This is needed for services autodiscover.