### PR TITLE
Fix config checks for decode_xml processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -129,6 +129,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `mage GenerateCustomBeat` instructions for a new beat {pull}17679[17679]
 - Fix bug with annotations dedot config on k8s not used {pull}25111[25111]
 - Fix negative Kafka partition bug {pull}25048[25048]
+- Fix decode_xml processor config checks. {pull}25310[25310]
 
 *Auditbeat*
 

--- a/libbeat/processors/decode_xml/decode_xml.go
+++ b/libbeat/processors/decode_xml/decode_xml.go
@@ -51,8 +51,13 @@ const (
 func init() {
 	processors.RegisterPlugin(procName,
 		checks.ConfigChecked(New,
-			checks.RequireFields("fields"),
-			checks.AllowedFields("fields", "overwrite_keys", "add_error_key", "target", "document_id")))
+			checks.RequireFields("field"),
+			checks.AllowedFields(
+				"field", "target_field",
+				"overwrite_keys", "document_id",
+				"to_lower", "ignore_missing",
+				"ignore_failure",
+			)))
 	jsprocessor.RegisterPlugin(procName, New)
 }
 

--- a/libbeat/processors/decode_xml/docs/decode_xml.asciidoc
+++ b/libbeat/processors/decode_xml/docs/decode_xml.asciidoc
@@ -97,10 +97,10 @@ value (`target_field:`) is treated as if the field was not set at all.
 
 `overwrite_keys`:: (Optional) A boolean that specifies whether keys that already
 exist in the event are overwritten by keys from the decoded XML object. The
-default value is false.
+default value is `true`.
 
 `to_lower`:: (Optional) Converts all keys to lowercase. Accepts either true or
-false. The default value is true.
+false. The default value is `true`.
 
 `document_id`:: (Optional) XML key to use as the document ID. If configured, the
 field will be removed from the original XML document and stored in


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes config checks for decode_xml.

This is fixed in master and 7.x as part of [a bigger refactor](https://github.com/elastic/beats/pull/24726/files#diff-25e0ff7431d27ce73c9f900a4041a89e567b6ca9f270c0a1d6df027ccb8b6049R54) that we do not will backport to 7.12.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
