### PR TITLE
Fix agent action input types wiring for 'service' type of apps

### DIFF
--- a/x-pack/elastic-agent/pkg/core/plugin/service/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/service/app.go
@@ -173,6 +173,9 @@ func (a *Application) Start(ctx context.Context, _ app.Taggable, cfg map[string]
 		if err != nil {
 			return err
 		}
+
+		// Set input types from the spec
+		a.srvState.SetInputTypes(a.desc.Spec().ActionInputTypes)
 	}
 
 	defer func() {


### PR DESCRIPTION
## What does this PR do?

Registers the action input types from the app spec correctly for the "service" type of apps.
This addresses the issue https://github.com/elastic/beats/pull/25291 with the endpoint that is running as a service.

## Why is it important?

Fixes the issue with actions routing to the endpoint.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues
- Closes https://github.com/elastic/beats/issues/25312

## Logs

Debug log after the change:
```
2021-04-26T11:56:59.448-0400	DEBUG	dispatcher/dispatcher.go:83	Dispatch 1 actions of types: *fleetapi.ActionApp
2021-04-26T11:56:59.448-0400	DEBUG	handlers/handler_action_application.go:36	handlerAppAction: action 'action_id: 1c4cc421-32c5-494c-9868-1b2249cc8eac, type: INPUT_ACTION, input_type: endpoint' received
```
