### PR TITLE
Build Packetbeat packages serially

### DIFF
--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -63,28 +63,7 @@ func BuildGoDaemon() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
-	// These Windows builds write temporary .s and .o files into the packetbeat
-	// dir so they cannot be run in parallel. Changing to a different CWD does
-	// not change where the temp files get written so that cannot be used as a
-	// fix.
-	if err := devtools.CrossBuild(devtools.ForPlatforms("windows"), devtools.Serially()); err != nil {
-		return err
-	}
-
-	return devtools.CrossBuild(devtools.ForPlatforms("!windows"))
-}
-
-// CrossBuildXPack cross-builds the beat with XPack for all target platforms.
-func CrossBuildXPack() error {
-	// These Windows builds write temporary .s and .o files into the packetbeat
-	// dir so they cannot be run in parallel. Changing to a different CWD does
-	// not change where the temp files get written so that cannot be used as a
-	// fix.
-	if err := devtools.CrossBuildXPack(devtools.ForPlatforms("windows"), devtools.Serially()); err != nil {
-		return err
-	}
-
-	return devtools.CrossBuildXPack(devtools.ForPlatforms("!windows"))
+	return packetbeat.CrossBuild()
 }
 
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.

--- a/packetbeat/scripts/mage/build.go
+++ b/packetbeat/scripts/mage/build.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mage
+
+import devtools "github.com/elastic/beats/v7/dev-tools/mage"
+
+// CrossBuild cross-builds the beat for all target platforms.
+func CrossBuild() error {
+	// Run all builds serially to try to address failures that might be caused
+	// by concurrent builds. See https://github.com/elastic/beats/issues/24304.
+	return devtools.CrossBuild(devtools.Serially())
+}

--- a/x-pack/packetbeat/magefile.go
+++ b/x-pack/packetbeat/magefile.go
@@ -61,7 +61,7 @@ func GolangCrossBuild() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
-	return devtools.CrossBuild()
+	return packetbeat.CrossBuild()
 }
 
 // BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).


### PR DESCRIPTION
## What does this PR do?

Relates: https://github.com/elastic/beats/issues/24304

Try building Packetbeat packages serially as opposed to concurrent cross-compiles for various goos/goarch combos.
Test this to see if it impacts some of the spurious failures we see. I've never been able to reproduce the failure locally so
it's hard to know if this will fix it.

## Why is it important?

Packaging builds should be stable on CI.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates: https://github.com/elastic/beats/issues/24304
