### PR TITLE
[Elastic Agent] Deprecate kibana-url param

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -50,7 +50,7 @@ func newEnrollCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command
 
 func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("url", "", "", "URL to enroll Agent into Fleet")
-	cmd.Flags().StringP("kibana-url", "k", "", "URL of Kibana to enroll Agent into Fleet")
+	cmd.Flags().StringP("kibana-url", "k", "", "URL of Fleet-Server to enroll Agent into Fleet-Server (deprecated)")
 	cmd.Flags().StringP("enrollment-token", "t", "", "Enrollment token to use to enroll Agent into Fleet")
 	cmd.Flags().StringP("fleet-server-es", "", "", "Start and run a Fleet Server along side this Elastic Agent connecting to the provided elasticsearch")
 	cmd.Flags().StringP("fleet-server-es-ca", "", "", "Path to certificate authority to use with communicate with elasticsearch")


### PR DESCRIPTION
The kibana-url param should not be used anymore and is replaced by --url. The flag should be full removed for 7.14. This PR marks it as deprecated and updates the description.

