### PR TITLE
[Elastic Agent] Update log message for capabilities

### DIFF
--- a/x-pack/elastic-agent/pkg/capabilities/input.go
+++ b/x-pack/elastic-agent/pkg/capabilities/input.go
@@ -123,13 +123,13 @@ func (c *inputCapability) name() string {
 		return c.Name
 	}
 
-	t := "A"
+	t := "allow"
 	if c.Type == denyKey {
-		t = "D"
+		t = "deny"
 	}
 
 	// e.g IA(*) or ID(system/*)
-	c.Name = fmt.Sprintf("I%s(%s)", t, c.Input)
+	c.Name = fmt.Sprintf("I %s(%s)", t, c.Input)
 	return c.Name
 }
 
@@ -164,8 +164,8 @@ func (c *inputCapability) renderInputs(inputs []map[string]interface{}) ([]map[s
 
 		input[conditionKey] = isSupported
 		if !isSupported {
-			msg := fmt.Sprintf("input '%s' is left out due to capability restriction '%s'", inputType, c.name())
-			c.log.Errorf(msg)
+			msg := fmt.Sprintf("input '%s' is not run due to capability restriction '%s'", inputType, c.name())
+			c.log.Infof(msg)
 			c.reporter.Update(state.Degraded, msg, nil)
 		}
 

--- a/x-pack/elastic-agent/pkg/capabilities/output.go
+++ b/x-pack/elastic-agent/pkg/capabilities/output.go
@@ -66,7 +66,7 @@ func (c *outputCapability) Apply(cfgMap map[string]interface{}) (map[string]inte
 		if ok {
 			renderedOutputs, err := c.renderOutputs(outputs)
 			if err != nil {
-				c.log.Errorf("marking outputs failed for capability '%s': %v", c.name(), err)
+				c.log.Errorf("marking outputs as failed for the capability '%s': %v", c.name(), err)
 				return cfgMap, err
 			}
 
@@ -89,13 +89,13 @@ func (c *outputCapability) name() string {
 		return c.Name
 	}
 
-	t := "A"
+	t := "allow"
 	if c.Type == denyKey {
-		t = "D"
+		t = "deny"
 	}
 
 	// e.g OA(*) or OD(logstash)
-	c.Name = fmt.Sprintf("O%s(%s)", t, c.Output)
+	c.Name = fmt.Sprintf("Output %s(%s)", t, c.Output)
 	return c.Name
 }
 


### PR DESCRIPTION
Before this change the log message was a bit cryptic when an input was blocked and I first had to look at the code to fully understand it: `input 'system/metrics' is left out due to capability restriction 'ID(*)'` ID in this context means input blocked. Not sure if this is obvious to users.

I made the log message a bit more verbose to contain allow / deny in the log message. In addition, I moved the log message to the info level. If a user remove the capabilities for a certain input, I'm not sure if we should log it on the error level. On the other hand, Fleet should probably already make sure it is not sending down incompatible policies.