### PR TITLE
[elastic-agent] Add hint to version command for binary

### DIFF
--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
@@ -64,7 +64,7 @@ func NewCommandWithArgs(streams *cli.IOStreams) *cobra.Command {
 			binaryOnly, _ := cmd.Flags().GetBool("binary-only")
 			if !binaryOnly {
 				if d, err := queryDaemon(); err != nil {
-					returnErr = fmt.Errorf("could not get version. failed to communicate with running daemon: %w\nUse --binary-only flag to skip trying to retrieve version from running daemon.", err)
+					returnErr = fmt.Errorf("could not get version. failed to communicate with running daemon: %w\nUse --binary-only flag to skip trying to retrieve version from running daemon", err)
 				} else {
 					daemon = d
 					if isMismatch(&binary, daemon) {

--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
@@ -64,7 +64,7 @@ func NewCommandWithArgs(streams *cli.IOStreams) *cobra.Command {
 			binaryOnly, _ := cmd.Flags().GetBool("binary-only")
 			if !binaryOnly {
 				if d, err := queryDaemon(); err != nil {
-					returnErr = fmt.Errorf("failed to communicate with running daemon: %w", err)
+					returnErr = fmt.Errorf("could not get version. failed to communicate with running daemon: %w\n Use --binary-only flag to get version from binary.", err)
 				} else {
 					daemon = d
 					if isMismatch(&binary, daemon) {

--- a/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
+++ b/x-pack/elastic-agent/pkg/basecmd/version/cmd.go
@@ -64,7 +64,7 @@ func NewCommandWithArgs(streams *cli.IOStreams) *cobra.Command {
 			binaryOnly, _ := cmd.Flags().GetBool("binary-only")
 			if !binaryOnly {
 				if d, err := queryDaemon(); err != nil {
-					returnErr = fmt.Errorf("could not get version. failed to communicate with running daemon: %w\n Use --binary-only flag to get version from binary.", err)
+					returnErr = fmt.Errorf("could not get version. failed to communicate with running daemon: %w\nUse --binary-only flag to skip trying to retrieve version from running daemon.", err)
 				} else {
 					daemon = d
 					if isMismatch(&binary, daemon) {


### PR DESCRIPTION
By default when running `elastic-agent version` it is expected that the daemon is running. If it is not running, an error is shown. Then the flag --binary-only should be used. A hint for this is added here to the error message for users.
