### PR TITLE
[mergify] change title for the backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ pull_request_rules:
           - "7.x"
         labels:
           - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 7.13 branch
     conditions:
       - merged
@@ -25,6 +26,7 @@ pull_request_rules:
           - "7.13"
         labels:
           - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 7.12 branch
     conditions:
       - merged
@@ -38,19 +40,7 @@ pull_request_rules:
           - "7.12"
         labels:
           - "backport"
-  - name: backport patches to 7.11 branch
-    conditions:
-      - merged
-      - base=master
-      - label=backport-v7.11.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.11"
-        labels:
-          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: ask to resolve conflict
     conditions:
       - conflict


### PR DESCRIPTION
## What does this PR do?

Since https://github.com/Mergifyio/mergify-engine/issues/2419 has been solved we can now change the title.

This is a proposal to change the title in the PRs that are backported with `mergify`.

`[target-branch](backport #1234) title`

## Why is it important?

Highlight what's important in the title to easily filter target branches

## Task

- If we agree then we need to change the script in charge to generate the changelog.


