### PR TITLE
Cherry-pick to 7.x: Fix includes to fix broken doc build (#25401)

### DIFF
--- a/filebeat/docs/modules/zookeeper.asciidoc
+++ b/filebeat/docs/modules/zookeeper.asciidoc
@@ -1,0 +1,86 @@
+////
+This file is generated! See scripts/docs_collector.py
+////
+
+[[filebeat-module-zookeeper]]
+:modulename: zookeeper
+:has-dashboards: false
+
+== ZooKeeper module
+
+The +{modulename}+ module collects and parses the logs created by https://zookeeper.apache.org/[Apache ZooKeeper]
+
+include::../include/what-happens.asciidoc[]
+
+include::../include/gs-link.asciidoc[]
+
+[float]
+=== Compatibility
+
+The +{modulename}+ module was tested with logs from versions 3.7.0.
+
+include::../include/configuring-intro.asciidoc[]
+
+//set the fileset name used in the included example
+:fileset_ex: audit
+
+include::../include/config-option-intro.asciidoc[]
+
+The following example shows how to set paths in the +modules.d/{modulename}.yml+
+file to override the default paths for logs:
+
+[source,yaml]
+-----
+- module: zookeeper
+  audit:
+    enabled: true
+    var.paths:
+      - "/path/to/logs/zookeeper_audit.log*"
+  log:
+    enabled: true
+    var.paths:
+      - "/path/to/logs/zookeeper.log*"
+-----
+
+
+To specify the same settings at the command line, you use:
+
+[source,yaml]
+-----
+-M "zookeeper.audit.var.paths=[/path/to/logs/zookeeper_audit.log*]" -M "zookeeper.log.var.paths=[/path/to/logs/zookeeper.log*]"
+-----
+
+[float]
+=== Audit logging
+
+Audit logging is available since Zookeeper 3.6.0, but it is disabled by default. To enable it, you can add the following setting to the configuration file:
+["source","sh"]
+----------------------
+audit.enable=true
+----------------------
+
+[float]
+==== `audit` fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+include::../include/timezone-support.asciidoc[]
+
+[float]
+==== `log` fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+include::../include/timezone-support.asciidoc[]
+
+:fileset_ex!:
+
+:modulename!:
+
+
+[float]
+=== Fields
+
+For a description of each field in the module, see the
+<<exported-fields-zookeeper,exported fields>> section.
+

--- a/x-pack/filebeat/module/zookeeper/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zookeeper/_meta/docs.asciidoc
@@ -1,0 +1,73 @@
+:modulename: zookeeper
+:has-dashboards: false
+
+== ZooKeeper module
+
+The +{modulename}+ module collects and parses the logs created by https://zookeeper.apache.org/[Apache ZooKeeper]
+
+include::../include/what-happens.asciidoc[]
+
+include::../include/gs-link.asciidoc[]
+
+[float]
+=== Compatibility
+
+The +{modulename}+ module was tested with logs from versions 3.7.0.
+
+include::../include/configuring-intro.asciidoc[]
+
+//set the fileset name used in the included example
+:fileset_ex: audit
+
+include::../include/config-option-intro.asciidoc[]
+
+The following example shows how to set paths in the +modules.d/{modulename}.yml+
+file to override the default paths for logs:
+
+[source,yaml]
+-----
+- module: zookeeper
+  audit:
+    enabled: true
+    var.paths:
+      - "/path/to/logs/zookeeper_audit.log*"
+  log:
+    enabled: true
+    var.paths:
+      - "/path/to/logs/zookeeper.log*"
+-----
+
+
+To specify the same settings at the command line, you use:
+
+[source,yaml]
+-----
+-M "zookeeper.audit.var.paths=[/path/to/logs/zookeeper_audit.log*]" -M "zookeeper.log.var.paths=[/path/to/logs/zookeeper.log*]"
+-----
+
+[float]
+=== Audit logging
+
+Audit logging is available since Zookeeper 3.6.0, but it is disabled by default. To enable it, you can add the following setting to the configuration file:
+["source","sh"]
+----------------------
+audit.enable=true
+----------------------
+
+[float]
+==== `audit` fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+include::../include/timezone-support.asciidoc[]
+
+[float]
+==== `log` fileset settings
+
+include::../include/var-paths.asciidoc[]
+
+include::../include/timezone-support.asciidoc[]
+
+:fileset_ex!:
+
+:modulename!:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix includes to fix broken doc build (#25401)