### PR TITLE
Cherry-pick #25357 to 7.13: Fix s3 input when there is a blank line in the log file

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,9 +256,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Strip Azure Eventhub connection string in debug logs. {pulll}25066[25066]
 - Updating Oauth2 flow for m365_defender fileset. {pull}24829[24829]
 - Fix o365 module config when client_secret contains special characters. {issue}25058[25058]
-- Change `checkpoint.source_object` from Long to Keyword. {issue}25124[25124] {pull}25145[25145]
 - Fix s3 input when there is a blank line in the log file. {pull}25357[25357]
-- Fix Nginx module pipelines. {issue}19088[19088] {pull}24699[24699]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -256,6 +256,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Strip Azure Eventhub connection string in debug logs. {pulll}25066[25066]
 - Updating Oauth2 flow for m365_defender fileset. {pull}24829[24829]
 - Fix o365 module config when client_secret contains special characters. {issue}25058[25058]
+- Change `checkpoint.source_object` from Long to Keyword. {issue}25124[25124] {pull}25145[25145]
+- Fix s3 input when there is a blank line in the log file. {pull}25357[25357]
+- Fix Nginx module pipelines. {issue}19088[19088] {pull}24699[24699]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/awss3/collector.go
+++ b/x-pack/filebeat/input/awss3/collector.go
@@ -397,7 +397,7 @@ func (c *s3Collector) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info,
 		}
 
 		if log == "" {
-			break
+			continue
 		}
 
 		// create event per log line
@@ -409,7 +409,6 @@ func (c *s3Collector) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info,
 			return err
 		}
 	}
-	return nil
 }
 
 func (c *s3Collector) decodeJSON(decoder *json.Decoder, objectHash string, s3Info s3Info, s3Ctx *s3Context) error {


### PR DESCRIPTION
Cherry-pick of PR #25357 to 7.13 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When there is an empty line in a log file, s3 input shouldn't abort the rest of the file. This PR is to skip the empty line and continue to ingest the rest of the log file.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/24872
