### PR TITLE
libbeat: add support for defining unit and metric_type field metadata in ES templates

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -607,6 +607,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add kubernetes.pod.ip field in kubernetes metadata. {pull}25037[25037]
 - Discover changes in Kubernetes namespace metadata as soon as they happen. {pull}25117[25117]
 - Add `decode_xml_wineventlog` processor. {issue}23910[23910] {pull}25115[25115]
+- Add `unit` and `metric_type` properties to fields.yml for populating field metadata in Elasticsearch templates {pull}25419[25419]
 
 *Auditbeat*
 

--- a/libbeat/mapping/field_test.go
+++ b/libbeat/mapping/field_test.go
@@ -332,6 +332,24 @@ func TestFieldValidate(t *testing.T) {
 				"object_type_params": []common.MapStr{{"object_type": "scaled_float", "object_type_mapping_type": "float"}}},
 			err: true,
 		},
+		"valid unit": {
+			cfg:   common.MapStr{"type": "long", "unit": "nanos"},
+			err:   false,
+			field: Field{Type: "long", Unit: "nanos"},
+		},
+		"invalid unit": {
+			cfg: common.MapStr{"type": "long", "unit": "celsius"},
+			err: true,
+		},
+		"valid metric type": {
+			cfg:   common.MapStr{"type": "long", "metric_type": "gauge"},
+			err:   false,
+			field: Field{Type: "long", MetricType: "gauge"},
+		},
+		"invalid metric type": {
+			cfg: common.MapStr{"type": "long", "metric_type": "timer"},
+			err: true,
+		},
 	}
 
 	for name, test := range tests {

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -26,6 +26,13 @@ import (
 	"github.com/elastic/beats/v7/libbeat/mapping"
 )
 
+var (
+	minVersionAlias     = common.MustNewVersion("6.4.0")
+	minVersionFieldMeta = common.MustNewVersion("7.6.0")
+	minVersionHistogram = common.MustNewVersion("7.6.0")
+	minVersionWildcard  = common.MustNewVersion("7.9.0")
+)
+
 // Processor struct to process fields to template
 type Processor struct {
 	EsVersion       common.Version
@@ -80,7 +87,7 @@ func (p *Processor) Process(fields mapping.Fields, state *fieldState, output com
 		case "text":
 			indexMapping = p.text(&field)
 		case "wildcard":
-			noWildcards := p.EsVersion.LessThan(common.MustNewVersion("7.9.0"))
+			noWildcards := p.EsVersion.LessThan(minVersionWildcard)
 			if !p.ElasticLicensed || noWildcards {
 				indexMapping = p.keyword(&field)
 			} else {
@@ -138,7 +145,7 @@ func addToDefaultFields(f *mapping.Field) {
 }
 
 func (p *Processor) other(f *mapping.Field) common.MapStr {
-	property := getDefaultProperties(f)
+	property := p.getDefaultProperties(f)
 	if f.Type != "" {
 		property["type"] = f.Type
 	}
@@ -147,13 +154,13 @@ func (p *Processor) other(f *mapping.Field) common.MapStr {
 }
 
 func (p *Processor) integer(f *mapping.Field) common.MapStr {
-	property := getDefaultProperties(f)
+	property := p.getDefaultProperties(f)
 	property["type"] = "long"
 	return property
 }
 
 func (p *Processor) scaledFloat(f *mapping.Field, params ...common.MapStr) common.MapStr {
-	property := getDefaultProperties(f)
+	property := p.getDefaultProperties(f)
 	property["type"] = "scaled_float"
 
 	if p.EsVersion.IsMajor(2) {
@@ -219,7 +226,7 @@ func (p *Processor) group(f *mapping.Field, output common.MapStr) (common.MapStr
 }
 
 func (p *Processor) halfFloat(f *mapping.Field) common.MapStr {
-	property := getDefaultProperties(f)
+	property := p.getDefaultProperties(f)
 	property["type"] = "half_float"
 
 	if p.EsVersion.IsMajor(2) {
@@ -229,7 +236,7 @@ func (p *Processor) halfFloat(f *mapping.Field) common.MapStr {
 }
 
 func (p *Processor) ip(f *mapping.Field) common.MapStr {
-	property := getDefaultProperties(f)
+	property := p.getDefaultProperties(f)
 
 	property["type"] = "ip"
 
@@ -242,7 +249,7 @@ func (p *Processor) ip(f *mapping.Field) common.MapStr {
 }
 
 func (p *Processor) keyword(f *mapping.Field) common.MapStr {
-	property := getDefaultProperties(f)
+	property := p.getDefaultProperties(f)
 
 	property["type"] = "keyword"
 
@@ -269,7 +276,7 @@ func (p *Processor) keyword(f *mapping.Field) common.MapStr {
 }
 
 func (p *Processor) wildcard(f *mapping.Field) common.MapStr {
-	property := getDefaultProperties(f)
+	property := p.getDefaultProperties(f)
 
 	property["type"] = "wildcard"
 
@@ -291,7 +298,7 @@ func (p *Processor) wildcard(f *mapping.Field) common.MapStr {
 }
 
 func (p *Processor) text(f *mapping.Field) common.MapStr {
-	properties := getDefaultProperties(f)
+	properties := p.getDefaultProperties(f)
 
 	properties["type"] = "text"
 
@@ -327,7 +334,7 @@ func (p *Processor) text(f *mapping.Field) common.MapStr {
 }
 
 func (p *Processor) array(f *mapping.Field) common.MapStr {
-	properties := getDefaultProperties(f)
+	properties := p.getDefaultProperties(f)
 	if f.ObjectType != "" {
 		properties["type"] = f.ObjectType
 	}
@@ -336,7 +343,7 @@ func (p *Processor) array(f *mapping.Field) common.MapStr {
 
 func (p *Processor) alias(f *mapping.Field) common.MapStr {
 	// Aliases were introduced in Elasticsearch 6.4, ignore if unsupported
-	if p.EsVersion.LessThan(common.MustNewVersion("6.4.0")) {
+	if p.EsVersion.LessThan(minVersionAlias) {
 		return nil
 	}
 
@@ -344,7 +351,7 @@ func (p *Processor) alias(f *mapping.Field) common.MapStr {
 	if !p.Migration && f.MigrationAlias {
 		return nil
 	}
-	properties := getDefaultProperties(f)
+	properties := p.getDefaultProperties(f)
 	properties["type"] = "alias"
 	properties["path"] = f.AliasPath
 
@@ -353,11 +360,11 @@ func (p *Processor) alias(f *mapping.Field) common.MapStr {
 
 func (p *Processor) histogram(f *mapping.Field) common.MapStr {
 	// Histograms were introduced in Elasticsearch 7.6, ignore if unsupported
-	if p.EsVersion.LessThan(common.MustNewVersion("7.6.0")) {
+	if p.EsVersion.LessThan(minVersionHistogram) {
 		return nil
 	}
 
-	properties := getDefaultProperties(f)
+	properties := p.getDefaultProperties(f)
 	properties["type"] = "histogram"
 
 	return properties
@@ -380,7 +387,7 @@ func (p *Processor) object(f *mapping.Field) common.MapStr {
 	}
 
 	for _, otp := range otParams {
-		dynProperties := getDefaultProperties(f)
+		dynProperties := p.getDefaultProperties(f)
 		var matchingType string
 
 		switch otp.ObjectType {
@@ -428,7 +435,7 @@ func (p *Processor) object(f *mapping.Field) common.MapStr {
 		p.addDynamicTemplate(path, pathMatch, dynProperties, matchingType)
 	}
 
-	properties := getDefaultProperties(f)
+	properties := p.getDefaultProperties(f)
 	properties["type"] = "object"
 	if f.Enabled != nil {
 		properties["enabled"] = *f.Enabled
@@ -473,7 +480,7 @@ func (p *Processor) addDynamicTemplate(path string, pathMatch string, properties
 	p.dynamicTemplates = append(p.dynamicTemplates, dynamicTemplate)
 }
 
-func getDefaultProperties(f *mapping.Field) common.MapStr {
+func (p *Processor) getDefaultProperties(f *mapping.Field) common.MapStr {
 	// Currently no defaults exist
 	properties := common.MapStr{}
 
@@ -489,15 +496,18 @@ func getDefaultProperties(f *mapping.Field) common.MapStr {
 		properties["copy_to"] = f.CopyTo
 	}
 
-	if f.MetricType != "" || f.Unit != "" {
-		meta := common.MapStr{}
-		if f.MetricType != "" {
-			meta["metric_type"] = f.MetricType
+	if !p.EsVersion.LessThan(minVersionFieldMeta) {
+		fmt.Println(p.EsVersion)
+		if f.MetricType != "" || f.Unit != "" {
+			meta := common.MapStr{}
+			if f.MetricType != "" {
+				meta["metric_type"] = f.MetricType
+			}
+			if f.Unit != "" {
+				meta["unit"] = f.Unit
+			}
+			properties["meta"] = meta
 		}
-		if f.Unit != "" {
-			meta["unit"] = f.Unit
-		}
-		properties["meta"] = meta
 	}
 
 	return properties

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -497,7 +497,6 @@ func (p *Processor) getDefaultProperties(f *mapping.Field) common.MapStr {
 	}
 
 	if !p.EsVersion.LessThan(minVersionFieldMeta) {
-		fmt.Println(p.EsVersion)
 		if f.MetricType != "" || f.Unit != "" {
 			meta := common.MapStr{}
 			if f.MetricType != "" {

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -488,5 +488,17 @@ func getDefaultProperties(f *mapping.Field) common.MapStr {
 	if f.CopyTo != "" {
 		properties["copy_to"] = f.CopyTo
 	}
+
+	if f.MetricType != "" || f.Unit != "" {
+		meta := common.MapStr{}
+		if f.MetricType != "" {
+			meta["metric_type"] = f.MetricType
+		}
+		if f.Unit != "" {
+			meta["unit"] = f.Unit
+		}
+		properties["meta"] = meta
+	}
+
 	return properties
 }

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -309,6 +309,18 @@ func TestProcessor(t *testing.T) {
 			output:   pEsVersion76.histogram(&mapping.Field{Type: "histogram"}),
 			expected: common.MapStr{"type": "histogram"},
 		},
+		{
+			output:   p.other(&mapping.Field{Type: "long", MetricType: "gauge"}),
+			expected: common.MapStr{"type": "long", "meta": common.MapStr{"metric_type": "gauge"}},
+		},
+		{
+			output:   p.other(&mapping.Field{Type: "long", Unit: "nanos"}),
+			expected: common.MapStr{"type": "long", "meta": common.MapStr{"unit": "nanos"}},
+		},
+		{
+			output:   p.other(&mapping.Field{Type: "long", MetricType: "gauge", Unit: "nanos"}),
+			expected: common.MapStr{"type": "long", "meta": common.MapStr{"metric_type": "gauge", "unit": "nanos"}},
+		},
 	}
 
 	for _, test := range tests {

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -310,15 +310,20 @@ func TestProcessor(t *testing.T) {
 			expected: common.MapStr{"type": "histogram"},
 		},
 		{
-			output:   p.other(&mapping.Field{Type: "long", MetricType: "gauge"}),
+			// "p" has EsVersion 7.0.0; field metadata requires ES 7.6.0+
+			output:   p.other(&mapping.Field{Type: "long", MetricType: "gauge", Unit: "nanos"}),
+			expected: common.MapStr{"type": "long"},
+		},
+		{
+			output:   pEsVersion76.other(&mapping.Field{Type: "long", MetricType: "gauge"}),
 			expected: common.MapStr{"type": "long", "meta": common.MapStr{"metric_type": "gauge"}},
 		},
 		{
-			output:   p.other(&mapping.Field{Type: "long", Unit: "nanos"}),
+			output:   pEsVersion76.other(&mapping.Field{Type: "long", Unit: "nanos"}),
 			expected: common.MapStr{"type": "long", "meta": common.MapStr{"unit": "nanos"}},
 		},
 		{
-			output:   p.other(&mapping.Field{Type: "long", MetricType: "gauge", Unit: "nanos"}),
+			output:   pEsVersion76.other(&mapping.Field{Type: "long", MetricType: "gauge", Unit: "nanos"}),
 			expected: common.MapStr{"type": "long", "meta": common.MapStr{"metric_type": "gauge", "unit": "nanos"}},
 		},
 	}


### PR DESCRIPTION
## What does this PR do?

Add optional `unit` and `metric_type` properties to fields in fields.yml, which are used to set field metadata in Elasticsearch templates. These are allowed only for numeric field types, and we check the values against those defined in the Elasticsearch docs at https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-field-meta.html

## Why is it important?

We would like to add unit/metric_type field metadata in fields defined by APM Server.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.