### PR TITLE
[Heartbeat] Retry zip URL target directory test

### DIFF
--- a/x-pack/heartbeat/monitors/browser/source/zipurl_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/zipurl_test.go
@@ -52,6 +52,7 @@ func TestZipUrlTargetDirectory(t *testing.T) {
 	zus := &ZipURLSource{
 		URL:             fmt.Sprintf("http://%s/fixtures/todos.zip", address),
 		Folder:          "/",
+		Retries:         3,
 		TargetDirectory: "/tmp/synthetics/blah",
 	}
 	fetchAndCheckDir(t, zus)


### PR DESCRIPTION
We occasionally have flaky test failures due to this test not using retries against the target HTTP server. It runs fine on fast computers like my laptop, but can be flaky on CI with errors like: 

```
=== RUN   TestZipUrlTargetDirectory
    zipurl_test.go:134: 
        	Error Trace:	zipurl_test.go:134
        	            				zipurl_test.go:57
        	Error:      	Received unexpected error:
        	            	could not check if zip source changed for http://localhost:1234/fixtures/todos.zip: Head "http://localhost:1234/fixtures/todos.zip": dial tcp 127.0.0.1:1234: connect: connection refused
        	Test:       	TestZipUrlTargetDirectory
--- FAIL: TestZipUrlTargetDirectory (1.50s)
```

All the other tests, which are not flaky, set retries, this brings this test inline with those.