### PR TITLE
Cherry-pick to 7.12: docs: fix out of date es ref (#25413)

### DIFF
--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -40,9 +40,9 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 ==== Other installation options
 
 * <<setup-repositories,APT or YUM>>
-* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page] 
+* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 * <<running-on-docker,Docker>>
-* <<running-on-kubernetes,Kubernetes>> 
+* <<running-on-kubernetes,Kubernetes>>
 
 [float]
 [[set-connection]]
@@ -56,11 +56,11 @@ include::{libbeat-dir}/shared/connecting-to-es.asciidoc[]
 
 {beatname_uc} uses <<auditbeat-modules,modules>> to collect audit information.
 
-By default, {beatname_uc} uses a configuration that's tailored to the operating 
+By default, {beatname_uc} uses a configuration that's tailored to the operating
 system where {beatname_uc} is running.
 
 To use a different configuration, change the module settings in
-+{beatname_lc}.yml+. 
++{beatname_lc}.yml+.
 
 The following example shows the `file_integrity` module configured to generate
 events whenever a file in one of the specified paths changes on disk:
@@ -99,7 +99,7 @@ include::{libbeat-dir}/tab-widgets/setup-widget.asciidoc[]
 +
 `-e` is optional and sends output to standard error instead of the configured log output.
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}
 and deploys the sample dashboards for visualizing the data in {kib}.
 
 [TIP]

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -145,7 +145,7 @@ include::{libbeat-dir}/tab-widgets/setup-widget.asciidoc[]
 +
 `-e` is optional and sends output to standard error instead of the configured log output.
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}
 and deploys the sample dashboards for visualizing the data in {kib}.
 
 This step does not load the ingest pipelines used to parse log lines. By

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -100,14 +100,14 @@ include::{libbeat-dir}/shared/config-check.asciidoc[]
 [[configurelocation]]
 === Step 4: Configure the Heartbeat location
 
-Heartbeat can be deployed in multiple locations so that you can detect 
+Heartbeat can be deployed in multiple locations so that you can detect
 differences in availability and response times across those locations.
 Configure the Heartbeat location to allow {kib} to display location-specific
 information on Uptime maps and perform Uptime anomaly detection based
 on location.
 
-To configure the location of a Heartbeat instance, modify the 
-`add_observer_metadata` processor in +{beatname_lc}.yml+.  The following 
+To configure the location of a Heartbeat instance, modify the
+`add_observer_metadata` processor in +{beatname_lc}.yml+.  The following
 example specifies the `geo.name` of the `add_observer_metadata` processor as
 `us-east-1a`:
 
@@ -148,7 +148,7 @@ include::{libbeat-dir}/tab-widgets/setup-widget.asciidoc[]
 +
 `-e` is optional and sends output to standard error instead of the configured log output.
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}.
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}.
 It does not install {beatname_uc} dashboards.  Heartbeat dashboards and
 installation steps are available in the
 https://github.com/elastic/uptime-contrib[uptime-contrib] GitHub repository.

--- a/journalbeat/docs/getting-started.asciidoc
+++ b/journalbeat/docs/getting-started.asciidoc
@@ -37,7 +37,7 @@ include::{libbeat-dir}/tab-widgets/install-deb-rpm-linux-widget.asciidoc[]
 ==== Other installation options
 
 * <<setup-repositories,APT or YUM>>
-* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page] 
+* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 * <<running-on-docker,Docker>>
 
 [float]
@@ -112,7 +112,7 @@ include::{libbeat-dir}/tab-widgets/setup-deb-rpm-linux-widget.asciidoc[]
 +
 `-e` is optional and sends output to standard error instead of the configured log output.
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}.
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}.
 
 [TIP]
 =====

--- a/libbeat/docs/howto/load-index-templates.asciidoc
+++ b/libbeat/docs/howto/load-index-templates.asciidoc
@@ -1,7 +1,7 @@
 [id="{beatname_lc}-template"]
 == Load the {es} index template
 
-{es} uses {ref}/indices-templates.html[index templates] to define:
+{es} uses {ref}/index-templates.html[index templates] to define:
 
 * Settings that control the behavior of your indices. The settings include the
 lifecycle policy used to manage indices as they grow and age.

--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -7,7 +7,7 @@
 ++++
 
 The `setup.template` section of the +{beatname_lc}.yml+ config file specifies
-the {ref}/indices-templates.html[index template] to use for setting
+the {ref}/index-templates.html[index template] to use for setting
 mappings in Elasticsearch. If template loading is enabled (the default),
 {beatname_uc} loads the index template automatically after successfully
 connecting to Elasticsearch.

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -8,7 +8,7 @@ This section gives general recommendations for upgrading {beats} shippers:
 * <<troubleshooting-upgrade>>
 
 If you're upgrading other products in the stack, also read the
-{stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide]. 
+{stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide].
 
 [[upgrading-minor-versions]]
 === Upgrade between minor versions
@@ -29,7 +29,7 @@ Before upgrading your {beats}, review the <<breaking-changes,breaking changes>>
 and the <<release-notes>>.
 
 If you're upgrading other products in the stack, also read the
-{stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide]. 
+{stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide].
 
 We recommend that you fully upgrade {es} and {kib} to version 7.0
 before upgrading {beats}. If you're on {beats} 6.0 through 6.7,
@@ -53,7 +53,7 @@ other products in the {stack}, upgrade {beats} as part of the
 Upgrading to 6.8 is required because the {es} index template was modified to
 be compatible with {es} 7.0 (the `_type` setting changed from `doc` to `_doc`).
 
-After upgrading to 6.8, use the {ref}/indices-templates.html#getting[Index
+After upgrading to 6.8, use the {ref}/index-templates.html#getting[Index
 Template API] to verify that the 6.8 index template has been created in {ES}.
 
 :asset: the index template
@@ -102,7 +102,7 @@ not using an external `config` directory, copy your old configuration over to
 the new installation.
 * Set `path.data` to point to your external data directory. If you are not using
 an external `data` directory, copy your old data directory over to the new
-installation. 
+installation.
 * Set `path.logs` to point to the location where you want to store your logs. If
 you do not specify this setting, logs are stored in the directory you extracted
 the archive to.
@@ -143,12 +143,12 @@ migration.6_to_7.enabled: true
 
 The field aliases let you use 6.x dashboards and visualizations with indices
 created by {beats} 7.0 or later. The aliases do *not* work with saved searches
-or with API calls that manipulate documents directly. 
+or with API calls that manipulate documents directly.
 
 Some fields also have type changes in 7.0 that affect the behavior of older
 dashboards and visualizations. To clarify:
 
-* *Some fields have type changes.* Your {kib} visualizations and aggregations 
+* *Some fields have type changes.* Your {kib} visualizations and aggregations
 will not work on these fields until the conflicts are resolved.
 
 * *Some fields have name changes, but no type changes.* The field aliases
@@ -193,11 +193,11 @@ This means that each version of the Beat creates a new index, and it's
 guaranteed that the correct index template for that version is applied. With
 these changes in place, you generally don't have to do anything to upgrade the
 index template when you move to a new version. Just load the new version of the
-index template *before* ingesting any data into {es}. 
+index template *before* ingesting any data into {es}.
 
 If you plan to run {beats} 6.7 or higher and 7.0 in parallel, make sure you
 <<enable-ecs-compatibility,enable the compatibility layer>> *before* you load
-the index template. 
+the index template.
 
 :asset: the index template
 :option: template
@@ -206,7 +206,7 @@ include::upgrade-setup-commands.asciidoc[]
 
 TIP: When loading the index template, you can also specify
 `-E setup.template.settings.index.number_of_shards=n` where `n` is the number of
-shards to use for the index. 
+shards to use for the index.
 
 [[non-es-outputs]]
 ==== How to use versioned index templates when the output is not {es}
@@ -222,11 +222,11 @@ Beats to manage the index template:
 [source,json]
 ----
     manage_template => false
-    index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}" 
+    index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}"
 ----
 
 When you use this configuration, the index name is set to match the index
-pattern in the {beats} index template. See the 
+pattern in the {beats} index template. See the
 {logstash-ref}/plugins-inputs-beats.html[{beats} input plugin] documentation
 for more information.
 
@@ -284,7 +284,7 @@ Before proceeding with the upgrade, make sure you back up the registry file.
 Starting with {beats} 7.0, index lifecycle management is on by default when
 sending data to {beats} clusters that support it. Make sure {beats} users have
 the privileges needed to use index lifecycle management, or disable index
-lifecycle management. 
+lifecycle management.
 
 For help troubleshooting authorization issues, see <<user-unauthorized>>.
 
@@ -329,7 +329,7 @@ DELETE /_template/metricbeat-{version}
 ----
 +
 Because the index template was loaded without the compatibility layer enabled,
-the required aliases were not created. 
+the required aliases were not created.
 
 . Load the correct index template. See <<upgrade-index-template>>.
 
@@ -348,27 +348,27 @@ new errors related to user authorization when you run version 7.0 against an
 
 *Solution:* Grant the `monitor` cluster privilege.
 
-===== `[cluster:admin/ilm/put] is unauthorized for user` 
+===== `[cluster:admin/ilm/put] is unauthorized for user`
 
-*Problem:* The {beats} user is not authorized to load ILM policies. 
+*Problem:* The {beats} user is not authorized to load ILM policies.
 
 *Solution:* Grant the `manage_ilm` cluster privilege.
 
-===== `[indices:admin/template/put] is unauthorized for user` 
+===== `[indices:admin/template/put] is unauthorized for user`
 
 *Problem:* Automatic index template loading is required when ILM is enabled, but the user
 is not authorized to manage index templates.
 
 *Solution:* Grant the `manage_index_templates` cluster privilege.
 
-===== `[indices:admin/aliases] is unauthorized for user` 
+===== `[indices:admin/aliases] is unauthorized for user`
 
 *Problem:* The {beats} user is unable to set up aliases needed by the compatibility
 layer.
 
 *Solution:* Grant the `manage` privilege on the {beats} indices.
 
-===== `[indices:data/write/bulk] is unauthorized for user` 
+===== `[indices:data/write/bulk] is unauthorized for user`
 
 *Problem:*  The {beats} user is unable to write events to {es}.
 
@@ -412,7 +412,7 @@ set as the default search fields, then specify the list of fields in the
 For example, here's a snippet that shows how to add default search fields to a
 Metricbeat 6.6 index. This example is truncated. Full examples for Metricbeat
 and Filebeat are available in
-https://github.com/elastic/beats/blob/master/libbeat/docs/troubleshooting/default_field.md[this file]. 
+https://github.com/elastic/beats/blob/master/libbeat/docs/troubleshooting/default_field.md[this file].
 
 [source,js]
 --------------------------------------------------
@@ -436,4 +436,3 @@ PUT /metricbeat-6.6.2-2019.04.09/_settings
 }
 --------------------------------------------------
 // CONSOLE
-

--- a/metricbeat/docs/getting-started.asciidoc
+++ b/metricbeat/docs/getting-started.asciidoc
@@ -51,9 +51,9 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 ==== Other installation options
 
 * <<setup-repositories,APT or YUM>>
-* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page] 
+* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 * <<running-on-docker,Docker>>
-* <<running-on-kubernetes,Kubernetes>> 
+* <<running-on-kubernetes,Kubernetes>>
 * <<running-on-cloudfoundry,Cloud Foundry>>
 
 [float]
@@ -116,7 +116,7 @@ include::{libbeat-dir}/tab-widgets/setup-widget.asciidoc[]
 +
 `-e` is optional and sends output to standard error instead of the configured log output.
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}
 and deploys the sample dashboards for visualizing the data in {kib}.
 
 [TIP]

--- a/packetbeat/docs/getting-started.asciidoc
+++ b/packetbeat/docs/getting-started.asciidoc
@@ -30,7 +30,7 @@ include::{libbeat-dir}/tab-widgets/spinup-stack-widget.asciidoc[]
 --
 
 * On most platforms, {beatname_uc} requires the libpcap packet capture
-library. Depending on your OS, you might need to install it: 
+library. Depending on your OS, you might need to install it:
 +
 --
 include::tab-widgets/install-libpcap-widget.asciidoc[]
@@ -54,7 +54,7 @@ include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 ==== Other installation options
 
 * <<setup-repositories,APT or YUM>>
-* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page] 
+* https://www.elastic.co/downloads/beats/{beatname_lc}[Download page]
 * <<running-on-docker,Docker>>
 
 [float]
@@ -94,7 +94,7 @@ packetbeat.interfaces.device: eth0
 ====
 On Linux, specify `packetbeat.interfaces.device: any` to capture all
 messages sent or received by the server where {beatname_uc} is installed.
-The `any` setting does not work on macOS.  
+The `any` setting does not work on macOS.
 ====
 +
 To see a list of available devices, run:
@@ -168,7 +168,7 @@ include::{libbeat-dir}/tab-widgets/setup-widget.asciidoc[]
 +
 `-e` is optional and sends output to standard error instead of the configured log output.
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}
 and deploys the sample dashboards for visualizing the data in {kib}.
 
 [TIP]

--- a/winlogbeat/docs/getting-started.asciidoc
+++ b/winlogbeat/docs/getting-started.asciidoc
@@ -127,7 +127,7 @@ visualizing your data. To load these assets:
 include::{libbeat-dir}/tab-widgets/setup.asciidoc[tag=win]
 --
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}
 and deploys the sample dashboards for visualizing the data in {kib}.
 
 [TIP]

--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -23,7 +23,7 @@ services to monitor and triggers
 
 The {beatname_uc} distribution contains the command line tools, configuration
 file, and binary code required to run {beatname_uc} in your serverless
-environment. 
+environment.
 
 To download and extract the package, use the commands that work with your
 system.
@@ -43,7 +43,7 @@ include::{libbeat-dir}/shared/connecting-to-es.asciidoc[]
 Before deploying {beatname_uc} to your cloud provider, you need to specify
 details about the cloud functions that you want to deploy, including the
 function name and type, and the triggers that will cause the function to
-execute. 
+execute.
 
 . In +{beatname_lc}.yml+, configure the functions that you want to deploy. The
 configuration settings vary depending on the type of function and cloud provider
@@ -124,7 +124,7 @@ include::{libbeat-dir}/tab-widgets/setup-linux-mac-win-widget.asciidoc[]
 +
 `-e` is optional and sends output to standard error instead of the configured log output.
 
-This step loads the recommended {ref}/indices-templates.html[index template] for writing to {es}.
+This step loads the recommended {ref}/index-templates.html[index template] for writing to {es}.
 
 [TIP]
 =====
@@ -163,7 +163,7 @@ function. For more information, see <<iam-permissions>>.
 
 . Deploy the cloud functions.
 +
-For example, the following command deploys a function called `cloudwatch`: 
+For example, the following command deploys a function called `cloudwatch`:
 +
 --
 include::tab-widgets/deploy-aws-widget.asciidoc[]
@@ -200,7 +200,7 @@ include::tab-widgets/credentials-google-widget.asciidoc[]
 
 . Deploy the cloud functions.
 +
-For example, the following command deploys a function called `storage`: 
+For example, the following command deploys a function called `storage`:
 +
 --
 include::tab-widgets/deploy-google-widget.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.12:
 - docs: fix out of date es ref (#25413)