### PR TITLE
Update Cyberarkpas/audit pipeline to use the new set processor with type ip

### DIFF
--- a/x-pack/filebeat/module/cyberarkpas/audit/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cyberarkpas/audit/ingest/pipeline.yml
@@ -986,16 +986,24 @@ processors:
   #
   # Populate ip/domain fields from address.
   #
-  - grok:
+  - convert:
       field: source.address
-      patterns:
-        - '(?:%{IP:source.ip}|%{GREEDYDATA:source.domain})'
-      ignore_failure: true
-  - grok:
+      target_field: source.ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - set:
+            field: source.domain
+            copy_from: source.address
+  - convert:
       field: destination.address
-      patterns:
-        - '(?:%{IP:destination.ip}|%{GREEDYDATA:destination.domain})'
-      ignore_failure: true
+      target_field: destination.ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - set:
+            field: destination.domain
+            copy_from: destination.address
 
   #
   # Populate related.ip


### PR DESCRIPTION
## What does this PR do?

Changes the `cyberarkpas/audit` ingest pipeline to use a `set` processor with  `type: ip` (added in ES 7.13), instead of a `grok` processor.

## Why is it important?

Aligns the pipeline with the code in `master` branch. When the feature was backported the required changes weren't available in the 7.x Elasticsearch used for tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
