### PR TITLE
Agent skip flaky test on windows

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -139,6 +139,10 @@ func TestConfigurableRun(t *testing.T) {
 }
 
 func TestConfigurableFailed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Flaky test (windows): https://github.com/elastic/beats/issues/25424")
+	}
+
 	p := getProgram("configurable", "1.0")
 
 	operator := getTestOperator(t, downloadPath, installPath, p)


### PR DESCRIPTION
Skip flaky test.

Relates: https://github.com/elastic/beats/issues/25424
