### PR TITLE
Allow role_arn work with access keys for AWS

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -246,6 +246,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix 'make setup' instructions for a new beat {pull}24944[24944]
 - Fix discovery of short-living and failing pods in Kubernetes autodiscover {issue}22718[22718] {pull}24742[24742]
 - Fix panic when overwriting metadata {pull}24741[24741]
+- Fix role_arn to work with access keys for AWS. {pull}25446[25446]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -63,8 +63,6 @@ func AutodiscoverBuilder(
 
 	// Construct MetricSet with a full regions list if there is no region specified.
 	if config.Regions == nil {
-		// set default region to make initial aws api call
-		awsCfg.Region = "us-west-1"
 		svcEC2 := ec2.New(awscommon.EnrichAWSConfigWithEndpoint(
 			config.AWSConfig.Endpoint, "ec2", awsCfg.Region, awsCfg))
 

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -64,10 +64,10 @@ func getAccessKeys(config ConfigAWS) awssdk.Config {
 	if config.RoleArn != "" {
 		logger.Debug("Using role arn and access keys for AWS credential")
 		return getRoleArn(config, awsConfig)
-	} else {
-		logger.Debug("Using access keys for AWS credential")
-		return awsConfig
 	}
+
+	logger.Debug("Using access keys for AWS credential")
+	return awsConfig
 }
 
 func getSharedCredentialProfile(config ConfigAWS) (awssdk.Config, error) {
@@ -101,10 +101,10 @@ func getSharedCredentialProfile(config ConfigAWS) (awssdk.Config, error) {
 	if config.RoleArn != "" {
 		logger.Debug("Using role arn and shared credential profile for AWS credential")
 		return getRoleArn(config, awsConfig), nil
-	} else {
-		logger.Debug("Using shared credential profile for AWS credential")
-		return awsConfig, nil
 	}
+
+	logger.Debug("Using shared credential profile for AWS credential")
+	return awsConfig, nil
 }
 
 func getRoleArn(config ConfigAWS, awsConfig awssdk.Config) awssdk.Config {

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -56,12 +56,6 @@ AWS_SECRET_ACCESS_KEY=abcd
 $ docker run --env-file env.list -d --name=metricbeat --user=root --volume="$(pwd)/metricbeat.aws.yml:/usr/share/metricbeat/metricbeat.yml:ro" docker.elastic.co/beats/metricbeat:7.11.1 metricbeat -e -E cloud.auth=elastic:1234 -E cloud.id=test-aws:1234
 ----
 
-* Use `role_arn`
-
-If `access_key_id` and `secret_access_key` are not given, then {beatname_lc} will
-check for `role_arn`. `role_arn` is used to specify which AWS IAM role to assume
-for generating temporary credentials.
-
 * Use `credential_profile_name` and/or `shared_credential_file`
 
 If `access_key_id`, `secret_access_key` and `role_arn` are all not given, then
@@ -80,10 +74,11 @@ for more details.
 
 * Use `role_arn`
 
-If `access_key_id` and `secret_access_key`, `credential_profile_name` and/or
-`shared_credential_file` are not given, then {beatname_lc} will check for
-`role_arn`. `role_arn` is used to specify which AWS IAM role to assume
-for generating temporary credentials.
+`role_arn` is used to specify which AWS IAM role to assume for generating
+temporary credentials. If `role_arn` is given, {beatname_lc} will check if
+access keys are given. If not, {beatname_lc} will check for credential profile
+name. If neither is given, default credential profile will be used. Please make
+sure credentials are given under either a credential profile or access keys.
 
 If running on Docker, the credential file needs to be provided via a volume
 mount. For example, with Metricbeat:


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to change `role_arn` config option to work not only with given credential profile but also access keys. With this change, `aws` integration will be able to use `role_arn` without volume mounting the credential profile file.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

With IAM role `test-role` setup, config below should work:
```
metricbeat.modules:
- module: aws
  period: 5m
  access_key_id: xxx
  secret_access_key: yyy
  role_arn: arn:aws:iam::1234:role/test-role
  metricsets:
    - ec2
```

## Related issues

This PR also fixed the `role_arn` related documentation.
- Closes https://github.com/elastic/beats/issues/24911
