### PR TITLE
mergify: use the head instead the base branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -68,7 +68,7 @@ pull_request_rules:
     conditions:
       - merged
       - label=automation
-      - base~=^update-stack-version
+      - head~=^update-stack-version
       - files~=^testing/environments/snapshot.*\.yml$
     actions:
       delete_head_branch:


### PR DESCRIPTION
## What does this PR do?

Use the head -> `The name of the branch where the pull request changes are implemented.`

## Why is it important?

Otherwise those branches are not deleted