### PR TITLE
Cherry-pick #25447 to 7.13: Agent: Fix panic on receiving osquery action due to bad merge to 7.x

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -231,7 +231,7 @@ func newManaged(
 
 	actionDispatcher.MustRegister(
 		&fleetapi.ActionApp{},
-		handlers.NewAppAction(log),
+		handlers.NewAppAction(log, managedApplication.srv),
 	)
 
 	actionDispatcher.MustRegister(

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
@@ -24,9 +24,10 @@ type AppAction struct {
 }
 
 // NewAppAction creates a new AppAction handler.
-func NewAppAction(log *logger.Logger) *AppAction {
+func NewAppAction(log *logger.Logger, srv *server.Server) *AppAction {
 	return &AppAction{
 		log: log,
+		srv: srv,
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of PR #25447 to 7.13 branch. Original message: 

## What does this PR do?

Fix panic on receiving osquery action due to bad merge to 7.x, due to bad merge 23 days ago.
Addresses https://github.com/elastic/beats/issues/25441

## Why is it important?

Without this fix the agent crashes upon receiving an action.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## Related issues

- Closes  https://github.com/elastic/beats/issues/25441

