### PR TITLE
Cherry-pick #25423 to 7.13: Do not use unversioned home with watcher binary path

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -61,6 +61,7 @@
 - Reduce log level for listener cleanup to debug {pull}25274[25274]
 - Delay the restart of application when a status report of failure is given {pull}25339[25339]
 - Don't log when upgrade capability doesn't apply {pull}25386[25386]
+- Fixed issue when unversioned home is set and invoked watcher failing with ENOENT {issue}25371[25371]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/paths/common.go
+++ b/x-pack/elastic-agent/pkg/agent/application/paths/common.go
@@ -75,7 +75,7 @@ func Home() string {
 	if unversionedHome {
 		return topPath
 	}
-	return versionedHome(topPath)
+	return VersionedHome(topPath)
 }
 
 // IsVersionHome returns true if the Home path is versioned based on build.
@@ -134,6 +134,11 @@ func SetLogs(path string) {
 	logsPath = path
 }
 
+// VersionedHome returns a versioned path based on a TopPath and used commit.
+func VersionedHome(base string) string {
+	return filepath.Join(base, "data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit()))
+}
+
 // initialTop returns the initial top-level path for the binary
 //
 // When nested in top-level/data/elastic-agent-${hash}/ the result is top-level/.
@@ -162,8 +167,4 @@ func retrieveExecutablePath() string {
 func insideData(exePath string) bool {
 	expectedPath := filepath.Join("data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit()))
 	return strings.HasSuffix(exePath, expectedPath)
-}
-
-func versionedHome(base string) string {
-	return filepath.Join(base, "data", fmt.Sprintf("elastic-agent-%s", release.ShortCommit()))
 }

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
@@ -101,7 +101,8 @@ func InvokeWatcher(log *logger.Logger) error {
 		return nil
 	}
 
-	cmd := invokeCmd()
+	versionedHome := paths.VersionedHome(paths.Top())
+	cmd := invokeCmd(versionedHome)
 	defer func() {
 		if cmd.Process != nil {
 			log.Debugf("releasing watcher %v", cmd.Process.Pid)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service.go
@@ -200,8 +200,8 @@ func (p *noopPidProvider) Name() string { return "noop" }
 
 func (p *noopPidProvider) PID(ctx context.Context) (int, error) { return 0, nil }
 
-func invokeCmd() *exec.Cmd {
-	homeExePath := filepath.Join(paths.Home(), agentName)
+func invokeCmd(topPath string) *exec.Cmd {
+	homeExePath := filepath.Join(topPath, agentName)
 
 	cmd := exec.Command(homeExePath, watcherSubcommand,
 		"--path.config", paths.Config(),

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service_darwin.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service_darwin.go
@@ -113,8 +113,8 @@ func (p *darwinPidProvider) piderFromCmd(ctx context.Context, name string, args 
 	}
 }
 
-func invokeCmd() *exec.Cmd {
-	homeExePath := filepath.Join(paths.Home(), agentName)
+func invokeCmd(topPath string) *exec.Cmd {
+	homeExePath := filepath.Join(topPath, agentName)
 
 	cmd := exec.Command(homeExePath, watcherSubcommand,
 		"--path.config", paths.Config(),

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/service_windows.go
@@ -61,8 +61,8 @@ func (p *pidProvider) PID(ctx context.Context) (int, error) {
 	return int(status.ProcessId), nil
 }
 
-func invokeCmd() *exec.Cmd {
-	homeExePath := filepath.Join(paths.Home(), agentName)
+func invokeCmd(topPath string) *exec.Cmd {
+	homeExePath := filepath.Join(topPath, agentName)
 
 	cmd := exec.Command(homeExePath, watcherSubcommand,
 		"--path.config", paths.Config(),


### PR DESCRIPTION
Cherry-pick of PR #25423 to 7.13 branch. Original message:

## What does this PR do?

The problem is when agent tries to invoke watcher which checks upgraded agent for failures and at the same time unversioned home path is set.

Usually agent took its home path which is `{top_path}/data/elastic-agent-{hash}/elastic-agent` and invoked `watch` sub-command on binary at that path.

When unversioned path is set it tries to run watcher from `{top_path}/data/elastic-agent` and as so it results in binary not found. 

Fixes: #25371

## Why is it important?

Reduce noise created by failng attempt to run this. This is just a case when running `container` sub-command which tempers paths. 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


cc @michel-laterman 
