### PR TITLE
New option `suffix` in `logging.files` to control how Beat log files are rotated

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -613,6 +613,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `decode_xml_wineventlog` processor. {issue}23910[23910] {pull}25115[25115]
 - Add new setting `gc_percent` for tuning the garbage collector limits via configuration file. {pull}25394[25394]
 - Add `unit` and `metric_type` properties to fields.yml for populating field metadata in Elasticsearch templates {pull}25419[25419]
+- Add new option `suffix` to `logging.files` to control how log files are rotated. {pull}25464[25464]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1437,6 +1437,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. auditbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2340,6 +2340,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. filebeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1615,6 +1615,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. heartbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1380,6 +1380,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. journalbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -63,6 +63,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. {{.BeatName}}.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/libbeat/common/file/interval_rotator.go
+++ b/libbeat/common/file/interval_rotator.go
@@ -18,93 +18,51 @@
 package file
 
 import (
-	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 type intervalRotator struct {
-	interval    time.Duration
-	lastRotate  time.Time
-	fileFormat  string
-	clock       clock
-	weekly      bool
-	arbitrary   bool
-	newInterval func(lastTime time.Time, currentTime time.Time) bool
+	log        Logger
+	interval   time.Duration
+	lastRotate time.Time
+	filename   string
+	fileFormat string
+	clock      clock
+	weekly     bool
+	arbitrary  bool
 }
 
-type clock interface {
-	Now() time.Time
-}
-
-type realClock struct{}
-
-func (realClock) Now() time.Time {
-	return time.Now()
-}
-
-func newIntervalRotator(log Logger, interval time.Duration, rotateOnStartup bool, filename string) (*intervalRotator, error) {
-	if interval == 0 {
-		return nil, nil
+func newIntervalRotator(log Logger, interval time.Duration, filename string) rotater {
+	ir := &intervalRotator{
+		filename: filename,
+		log:      log,
+		interval: (interval / time.Second) * time.Second, // drop fractional seconds
+		clock:    realClock{},
 	}
-	if interval < time.Second && interval != 0 {
-		return nil, errors.New("the minimum time interval for log rotation is 1 second")
-	}
-
-	ir := &intervalRotator{interval: (interval / time.Second) * time.Second} // drop fractional seconds
-	ir.initialize(log, rotateOnStartup, filename)
-	return ir, nil
+	ir.initialize()
+	return ir
 }
 
-func (r *intervalRotator) initialize(log Logger, rotateOnStartup bool, filename string) {
-	r.clock = realClock{}
-
-	switch r.interval {
-	case time.Second:
-		r.fileFormat = "2006-01-02-15-04-05"
-		r.newInterval = newSecond
-	case time.Minute:
-		r.fileFormat = "2006-01-02-15-04"
-		r.newInterval = newMinute
-	case time.Hour:
-		r.fileFormat = "2006-01-02-15"
-		r.newInterval = newHour
-	case 24 * time.Hour: // calendar day
-		r.fileFormat = "2006-01-02"
-		r.newInterval = newDay
-	case 7 * 24 * time.Hour: // calendar week
-		r.fileFormat = ""
-		r.newInterval = newWeek
-		r.weekly = true
-	case 30 * 24 * time.Hour: // calendar month
-		r.fileFormat = "2006-01"
-		r.newInterval = newMonth
-	case 365 * 24 * time.Hour: // calendar year
-		r.fileFormat = "2006"
-		r.newInterval = newYear
-	default:
-		r.arbitrary = true
-		r.fileFormat = "2006-01-02-15-04-05"
-		r.newInterval = func(lastTime time.Time, currentTime time.Time) bool {
-			lastInterval := lastTime.Unix() / (int64(r.interval) / int64(time.Second))
-			currentInterval := currentTime.Unix() / (int64(r.interval) / int64(time.Second))
-			return lastInterval != currentInterval
+func (r *intervalRotator) initialize() {
+	fi, err := os.Stat(r.filename)
+	if err != nil {
+		if r.log != nil {
+			r.log.Debugw("Not attempting to find last rotated time, configured logs dir cannot be opened: %v", err)
 		}
+		return
 	}
+	r.lastRotate = fi.ModTime()
+}
 
-	if !rotateOnStartup {
-		fi, err := os.Stat(filename)
-		if err != nil {
-			if log != nil {
-				log.Debugw("Not attempting to find last rotated time, configured logs dir cannot be opened: %v", err)
-			}
-			return
-		}
-		r.lastRotate = fi.ModTime()
-	}
+func (r *intervalRotator) ActiveFile() string {
+	return r.filename
 }
 
 func (r *intervalRotator) LogPrefix(filename string, modTime time.Time) string {
@@ -127,14 +85,53 @@ func (r *intervalRotator) LogPrefix(filename string, modTime time.Time) string {
 	return fmt.Sprintf("%s-%s-", filename, t.Format(r.fileFormat))
 }
 
-func (r *intervalRotator) NewInterval() bool {
-	now := r.clock.Now()
-	newInterval := r.newInterval(r.lastRotate, now)
-	return newInterval
+func (r *intervalRotator) RotatedFiles() []string {
+	files, err := filepath.Glob(r.filename + "*")
+	if err != nil {
+		if r.log != nil {
+			r.log.Debugw("failed to list existing logs: %+v", err)
+		}
+	}
+	r.SortIntervalLogs(files)
+	return files
 }
 
-func (r *intervalRotator) Rotate() {
-	r.lastRotate = r.clock.Now()
+func (r *intervalRotator) Rotate(reason rotateReason, t time.Time) error {
+	fi, err := os.Stat(r.ActiveFile())
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "failed to rotate backups")
+	}
+
+	logPrefix := r.LogPrefix(r.filename, fi.ModTime())
+	files, err := filepath.Glob(logPrefix + "*")
+	if err != nil {
+		return errors.Wrap(err, "failed to list logs during rotation")
+	}
+
+	var targetFilename string
+	if len(files) == 0 {
+		targetFilename = logPrefix + "1"
+	} else {
+		r.SortIntervalLogs(files)
+		lastLogIndex, _, err := IntervalLogIndex(files[len(files)-1])
+		if err != nil {
+			return errors.Wrap(err, "failed to locate last log index during rotation")
+		}
+		targetFilename = logPrefix + strconv.Itoa(int(lastLogIndex)+1)
+	}
+
+	if err := os.Rename(r.filename, targetFilename); err != nil {
+		return errors.Wrap(err, "failed to rotate backups")
+	}
+
+	if r.log != nil {
+		r.log.Debugw("Rotating file", "filename", r.filename, "reason", reason)
+	}
+
+	r.lastRotate = t
+	return nil
 }
 
 func (r *intervalRotator) SortIntervalLogs(strings []string) {
@@ -171,35 +168,4 @@ func IntervalLogIndex(filename string) (uint64, int, error) {
 	s64 := filename[i:]
 	u64, err := strconv.ParseUint(s64, 10, 64)
 	return u64, i, err
-}
-
-func newSecond(lastTime time.Time, currentTime time.Time) bool {
-	return lastTime.Second() != currentTime.Second() || newMinute(lastTime, currentTime)
-}
-
-func newMinute(lastTime time.Time, currentTime time.Time) bool {
-	return lastTime.Minute() != currentTime.Minute() || newHour(lastTime, currentTime)
-}
-
-func newHour(lastTime time.Time, currentTime time.Time) bool {
-	return lastTime.Hour() != currentTime.Hour() || newDay(lastTime, currentTime)
-}
-
-func newDay(lastTime time.Time, currentTime time.Time) bool {
-	return lastTime.Day() != currentTime.Day() || newMonth(lastTime, currentTime)
-}
-
-func newWeek(lastTime time.Time, currentTime time.Time) bool {
-	lastYear, lastWeek := lastTime.ISOWeek()
-	currentYear, currentWeek := currentTime.ISOWeek()
-	return lastWeek != currentWeek ||
-		lastYear != currentYear
-}
-
-func newMonth(lastTime time.Time, currentTime time.Time) bool {
-	return lastTime.Month() != currentTime.Month() || newYear(lastTime, currentTime)
-}
-
-func newYear(lastTime time.Time, currentTime time.Time) bool {
-	return lastTime.Year() != currentTime.Year()
 }

--- a/libbeat/common/file/interval_rotator.go
+++ b/libbeat/common/file/interval_rotator.go
@@ -113,9 +113,6 @@ func (r *intervalRotator) RotatedFiles() []string {
 			r.log.Debugw("failed to list existing logs: %+v", err)
 		}
 	}
-	if len(files) == 1 && files[0] == r.ActiveFile() {
-		return []string{}
-	}
 	r.SortIntervalLogs(files)
 	return files
 }

--- a/libbeat/common/file/interval_rotator_test.go
+++ b/libbeat/common/file/interval_rotator_test.go
@@ -70,7 +70,7 @@ func TestWeeklyRotator(t *testing.T) {
 	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
 
 	// Monday, 2019-Jan-7
-	clock.time = clock.time.Add(24 * time.Hour)
+	clock.time = clock.time.Add(7 * 24 * time.Hour)
 	a.lastRotate = a.clock.Now()
 	assert.Equal(t, "foo-2019-02-", a.LogPrefix("foo", time.Now()))
 }

--- a/libbeat/common/file/interval_rotator_test.go
+++ b/libbeat/common/file/interval_rotator_test.go
@@ -18,255 +18,252 @@
 package file
 
 import (
-	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestSecondRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 100, time.Local)}
-	a.clock = clock
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
-
-	n := a.NewInterval()
-	assert.False(t, n)
-
-	clock.time = clock.time.Add(900 * time.Millisecond)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(100 * time.Millisecond)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-00-02-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestMinuteRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(time.Minute)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := &testClock{time.Date(2018, 12, 31, 0, 1, 1, 0, time.Local)}
-	a.clock = clock
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
-
-	n := a.NewInterval()
-	assert.False(t, n)
-
-	clock.time = clock.time.Add(58 * time.Second)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-02-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestHourlyRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(time.Hour)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := &testClock{time.Date(2018, 12, 31, 1, 0, 1, 0, time.Local)}
-	a.clock = clock
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
-
-	n := a.NewInterval()
-	assert.False(t, n)
-
-	clock.time = clock.time.Add(58 * time.Minute)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Minute + 59*time.Second)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-02-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestDailyRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(24 * time.Hour)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
-	a.clock = clock
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
-
-	n := a.NewInterval()
-	assert.False(t, n)
-
-	clock.time = clock.time.Add(23 * time.Hour)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Hour)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2019-01-01-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestWeeklyRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(7 * 24 * time.Hour)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Monday, 2018-Dec-31
-	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
-	a.clock = clock
-	a.Rotate()
-	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
-
-	n := a.NewInterval()
-	assert.False(t, n)
-
-	// Sunday, 2019-Jan-6
-	clock.time = clock.time.Add(6 * 24 * time.Hour)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
-
-	// Monday, 2019-Jan-7
-	clock.time = clock.time.Add(24 * time.Hour)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2019-02-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestMonthlyRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(30 * 24 * time.Hour)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := &testClock{time.Date(2018, 12, 1, 0, 0, 0, 0, time.Local)}
-	a.clock = clock
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
-
-	n := a.NewInterval()
-	assert.False(t, n)
-
-	clock.time = clock.time.Add(30 * 24 * time.Hour)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(24 * time.Hour)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestYearlyRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(365 * 24 * time.Hour)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
-	a.clock = clock
-	a.Rotate()
-	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
-
-	n := a.NewInterval()
-	assert.False(t, n)
-
-	clock.time = clock.time.Add(23 * time.Hour)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Hour)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2019-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestArbitraryIntervalRotator(t *testing.T) {
-	a, err := newMockIntervalRotator(3 * time.Second)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Monday, 2018-Dec-31
-	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 0, time.Local)}
-	a.clock = clock
-	assert.Equal(t, "foo-2018-12-30-00-00-00-", a.LogPrefix("foo", time.Date(2018, 12, 30, 0, 0, 0, 0, time.Local)))
-	a.Rotate()
-	n := a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.False(t, n)
-	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-
-	clock.time = clock.time.Add(time.Second)
-	n = a.NewInterval()
-	assert.True(t, n)
-	a.Rotate()
-	assert.Equal(t, "foo-2018-12-31-00-00-06-", a.LogPrefix("foo", time.Now()))
-}
-
-func TestIntervalIsTruncatedToSeconds(t *testing.T) {
-	a, err := newMockIntervalRotator(2345 * time.Millisecond)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Equal(t, 2*time.Second, a.interval)
-}
-
-func TestZeroIntervalIsNil(t *testing.T) {
-	a, err := newMockIntervalRotator(0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.True(t, a == nil)
-}
+//func TestSecondRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(time.Second)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 100, time.Local)}
+//	a.clock = clock
+//	a.lastRotate = a.clock.Now()
+//	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
+//
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//
+//	clock.time = clock.time.Add(900 * time.Millisecond)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(100 * time.Millisecond)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-00-00-02-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestMinuteRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(time.Minute)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	clock := &testClock{time.Date(2018, 12, 31, 0, 1, 1, 0, time.Local)}
+//	a.clock = clock
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
+//
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//
+//	clock.time = clock.time.Add(58 * time.Second)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Second)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-00-02-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestHourlyRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(time.Hour)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	clock := &testClock{time.Date(2018, 12, 31, 1, 0, 1, 0, time.Local)}
+//	a.clock = clock
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
+//
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//
+//	clock.time = clock.time.Add(58 * time.Minute)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Minute + 59*time.Second)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-02-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestDailyRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(24 * time.Hour)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+//	a.clock = clock
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
+//
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//
+//	clock.time = clock.time.Add(23 * time.Hour)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Hour)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2019-01-01-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestWeeklyRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(7 * 24 * time.Hour)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	// Monday, 2018-Dec-31
+//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+//	a.clock = clock
+//	a.Rotate()
+//	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+//
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//
+//	// Sunday, 2019-Jan-6
+//	clock.time = clock.time.Add(6 * 24 * time.Hour)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+//
+//	// Monday, 2019-Jan-7
+//	clock.time = clock.time.Add(24 * time.Hour)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2019-02-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestMonthlyRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(30 * 24 * time.Hour)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	clock := &testClock{time.Date(2018, 12, 1, 0, 0, 0, 0, time.Local)}
+//	a.clock = clock
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
+//
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//
+//	clock.time = clock.time.Add(30 * 24 * time.Hour)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(24 * time.Hour)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestYearlyRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(365 * 24 * time.Hour)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+//	a.clock = clock
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
+//
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//
+//	clock.time = clock.time.Add(23 * time.Hour)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Hour)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2019-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestArbitraryIntervalRotator(t *testing.T) {
+//	a, err := newMockIntervalRotator(3 * time.Second)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//
+//	// Monday, 2018-Dec-31
+//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 0, time.Local)}
+//	a.clock = clock
+//	assert.Equal(t, "foo-2018-12-30-00-00-00-", a.LogPrefix("foo", time.Date(2018, 12, 30, 0, 0, 0, 0, time.Local)))
+//	a.Rotate()
+//	n := a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Second)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Second)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Second)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Second)
+//	n = a.NewInterval()
+//	assert.False(t, n)
+//	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+//
+//	clock.time = clock.time.Add(time.Second)
+//	n = a.NewInterval()
+//	assert.True(t, n)
+//	a.Rotate()
+//	assert.Equal(t, "foo-2018-12-31-00-00-06-", a.LogPrefix("foo", time.Now()))
+//}
+//
+//func TestIntervalIsTruncatedToSeconds(t *testing.T) {
+//	a, err := newMockIntervalRotator(2345 * time.Millisecond)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	assert.Equal(t, 2*time.Second, a.interval)
+//}
+//
+//func TestZeroIntervalIsNil(t *testing.T) {
+//	a, err := newMockIntervalRotator(0)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	assert.True(t, a == nil)
+//}
 
 type testClock struct {
 	time time.Time
@@ -276,6 +273,6 @@ func (t testClock) Now() time.Time {
 	return t.time
 }
 
-func newMockIntervalRotator(interval time.Duration) (*intervalRotator, error) {
-	return newIntervalRotator(nil, interval, false, "foo")
+func newMockIntervalRotator(interval time.Duration) rotater {
+	return newIntervalRotator(nil, interval, "foo")
 }

--- a/libbeat/common/file/interval_rotator_test.go
+++ b/libbeat/common/file/interval_rotator_test.go
@@ -18,252 +18,127 @@
 package file
 
 import (
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-//func TestSecondRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(time.Second)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 100, time.Local)}
-//	a.clock = clock
-//	a.lastRotate = a.clock.Now()
-//	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
-//
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//
-//	clock.time = clock.time.Add(900 * time.Millisecond)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(100 * time.Millisecond)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-00-00-02-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestMinuteRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(time.Minute)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	clock := &testClock{time.Date(2018, 12, 31, 0, 1, 1, 0, time.Local)}
-//	a.clock = clock
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
-//
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//
-//	clock.time = clock.time.Add(58 * time.Second)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Second)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-00-02-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestHourlyRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(time.Hour)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	clock := &testClock{time.Date(2018, 12, 31, 1, 0, 1, 0, time.Local)}
-//	a.clock = clock
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
-//
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//
-//	clock.time = clock.time.Add(58 * time.Minute)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Minute + 59*time.Second)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-02-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestDailyRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(24 * time.Hour)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
-//	a.clock = clock
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
-//
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//
-//	clock.time = clock.time.Add(23 * time.Hour)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Hour)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2019-01-01-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestWeeklyRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(7 * 24 * time.Hour)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	// Monday, 2018-Dec-31
-//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
-//	a.clock = clock
-//	a.Rotate()
-//	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
-//
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//
-//	// Sunday, 2019-Jan-6
-//	clock.time = clock.time.Add(6 * 24 * time.Hour)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
-//
-//	// Monday, 2019-Jan-7
-//	clock.time = clock.time.Add(24 * time.Hour)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2019-02-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestMonthlyRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(30 * 24 * time.Hour)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	clock := &testClock{time.Date(2018, 12, 1, 0, 0, 0, 0, time.Local)}
-//	a.clock = clock
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
-//
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//
-//	clock.time = clock.time.Add(30 * 24 * time.Hour)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(24 * time.Hour)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestYearlyRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(365 * 24 * time.Hour)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
-//	a.clock = clock
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
-//
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//
-//	clock.time = clock.time.Add(23 * time.Hour)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Hour)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2019-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestArbitraryIntervalRotator(t *testing.T) {
-//	a, err := newMockIntervalRotator(3 * time.Second)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//
-//	// Monday, 2018-Dec-31
-//	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 0, time.Local)}
-//	a.clock = clock
-//	assert.Equal(t, "foo-2018-12-30-00-00-00-", a.LogPrefix("foo", time.Date(2018, 12, 30, 0, 0, 0, 0, time.Local)))
-//	a.Rotate()
-//	n := a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Second)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Second)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Second)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Second)
-//	n = a.NewInterval()
-//	assert.False(t, n)
-//	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
-//
-//	clock.time = clock.time.Add(time.Second)
-//	n = a.NewInterval()
-//	assert.True(t, n)
-//	a.Rotate()
-//	assert.Equal(t, "foo-2018-12-31-00-00-06-", a.LogPrefix("foo", time.Now()))
-//}
-//
-//func TestIntervalIsTruncatedToSeconds(t *testing.T) {
-//	a, err := newMockIntervalRotator(2345 * time.Millisecond)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	assert.Equal(t, 2*time.Second, a.interval)
-//}
-//
-//func TestZeroIntervalIsNil(t *testing.T) {
-//	a, err := newMockIntervalRotator(0)
-//	if err != nil {
-//		t.Fatal(err)
-//	}
-//	assert.True(t, a == nil)
-//}
+func TestSecondRotator(t *testing.T) {
+	a := newMockIntervalRotator(time.Second)
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 100, time.Local)}
+	a.clock = clock
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-31-00-00-01-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestMinuteRotator(t *testing.T) {
+	a := newMockIntervalRotator(time.Minute)
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 1, 1, 0, time.Local)}
+	a.clock = clock
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-31-00-01-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestHourlyRotator(t *testing.T) {
+	a := newMockIntervalRotator(time.Hour)
+
+	clock := &testClock{time.Date(2018, 12, 31, 1, 0, 1, 0, time.Local)}
+	a.clock = clock
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-31-01-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestDailyRotator(t *testing.T) {
+	a := newMockIntervalRotator(24 * time.Hour)
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-31-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestWeeklyRotator(t *testing.T) {
+	a := newMockIntervalRotator(7 * 24 * time.Hour)
+
+	// Monday, 2018-Dec-31
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+
+	// Monday, 2019-Jan-7
+	clock.time = clock.time.Add(24 * time.Hour)
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2019-02-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestMonthlyRotator(t *testing.T) {
+	a := newMockIntervalRotator(30 * 24 * time.Hour)
+
+	clock := &testClock{time.Date(2018, 12, 1, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(30 * 24 * time.Hour)
+	assert.Equal(t, "foo-2018-12-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(24 * time.Hour)
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2019-01-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestYearlyRotator(t *testing.T) {
+	a := newMockIntervalRotator(365 * 24 * time.Hour)
+
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 0, 0, time.Local)}
+	a.clock = clock
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(23 * time.Hour)
+	assert.Equal(t, "foo-2018-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Hour)
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2019-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestArbitraryIntervalRotator(t *testing.T) {
+	a := newMockIntervalRotator(3 * time.Second)
+
+	// Monday, 2018-Dec-31
+	clock := &testClock{time.Date(2018, 12, 31, 0, 0, 1, 0, time.Local)}
+	a.clock = clock
+	assert.Equal(t, "foo-2018-12-30-00-00-00-", a.LogPrefix("foo", time.Date(2018, 12, 30, 0, 0, 0, 0, time.Local)))
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	assert.Equal(t, "foo-2018-12-31-00-00-00-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	assert.Equal(t, "foo-2018-12-31-00-00-03-", a.LogPrefix("foo", time.Now()))
+
+	clock.time = clock.time.Add(time.Second)
+	a.lastRotate = a.clock.Now()
+	assert.Equal(t, "foo-2018-12-31-00-00-06-", a.LogPrefix("foo", time.Now()))
+}
+
+func TestIntervalIsTruncatedToSeconds(t *testing.T) {
+	a := newMockIntervalRotator(2345 * time.Millisecond)
+	assert.Equal(t, 2*time.Second, a.interval)
+}
 
 type testClock struct {
 	time time.Time
@@ -273,6 +148,7 @@ func (t testClock) Now() time.Time {
 	return t.time
 }
 
-func newMockIntervalRotator(interval time.Duration) rotater {
-	return newIntervalRotator(nil, interval, "foo")
+func newMockIntervalRotator(interval time.Duration) *intervalRotator {
+	r := newIntervalRotator(nil, interval, "foo").(*intervalRotator)
+	return r
 }

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -427,7 +427,11 @@ func newRotater(log Logger, s SuffixType, filename string, maxBackups uint, inte
 	case SuffixDate:
 		return newDateRotater(log, filename)
 	default:
-		return nil
+		return &countRotator{
+			log:        log,
+			filename:   filename,
+			maxBackups: maxBackups,
+		}
 	}
 }
 

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -479,9 +479,6 @@ func (d *dateRotator) RotatedFiles() []string {
 			d.log.Debugw("failed to list existing logs: %+v", err)
 		}
 	}
-	if len(files) == 1 && files[0] == d.ActiveFile() {
-		return []string{}
-	}
 
 	d.SortModTimeLogs(files)
 	return files

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -221,11 +221,10 @@ func (r *Rotator) Write(data []byte) (int, error) {
 	} else {
 		if reason, t := r.isRotationTriggered(dataLen); reason != rotateReasonNoRotate {
 			if err := r.rotateWithTime(reason, t); err != nil {
-				return 0, errors.Wrap(err, "error file rotating files reason: %s: %+v", reason, err)
+				return 0, errors.Wrapf(err, "error file rotating files reason: %s", reason)
 			}
 
-			err = r.openFile()
-			if err != nil {
+			if err := r.openFile(); err != nil {
 				return 0, errors.Wrap(err, "failed to open existing log file for writing")
 			}
 		}

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -28,33 +29,26 @@ import (
 	"github.com/pkg/errors"
 )
 
-// MaxBackupsLimit is the upper bound on the number of backup files. Any values
-// greater will result in an error.
-const MaxBackupsLimit = 1024
-
-// rotateReason is the reason why file rotation occurred.
-type rotateReason uint32
+type SuffixType uint32
 
 const (
-	rotateReasonInitializing rotateReason = iota + 1
-	rotateReasonFileSize
-	rotateReasonManualTrigger
-	rotateReasonTimeInterval
+	// MaxBackupsLimit is the upper bound on the number of backup files. Any values
+	// greater will result in an error.
+	MaxBackupsLimit = 1024
+
+	SuffixCount SuffixType = iota + 1
+	SuffixDate
 )
 
-func (rr rotateReason) String() string {
-	switch rr {
-	case rotateReasonInitializing:
-		return "initializing"
-	case rotateReasonFileSize:
-		return "file size"
-	case rotateReasonManualTrigger:
-		return "manual trigger"
-	case rotateReasonTimeInterval:
-		return "time interval"
-	default:
-		return "unknown"
-	}
+var suffixes = map[string]SuffixType{
+	"count": SuffixCount,
+	"date":  SuffixDate,
+}
+
+type rotater interface {
+	ActiveFile() string
+	RotatedFiles() []string
+	Rotate(reason rotateReason, rotateTime time.Time) error
 }
 
 // Rotator is a io.WriteCloser that automatically rotates the file it is
@@ -62,18 +56,20 @@ func (rr rotateReason) String() string {
 // basis. It also purges the oldest rotated files when the maximum number of
 // backups is reached.
 type Rotator struct {
+	rot      rotater
+	triggers []trigger
+
 	filename        string
 	maxSizeBytes    uint
 	maxBackups      uint
+	interval        time.Duration
 	permissions     os.FileMode
 	log             Logger // Optional Logger (may be nil).
-	interval        time.Duration
+	suffix          SuffixType
 	rotateOnStartup bool
-	intervalRotator *intervalRotator // Optional, may be nil
 	redirectStderr  bool
 
 	file  *os.File
-	size  uint
 	mutex sync.Mutex
 }
 
@@ -84,6 +80,14 @@ type Logger interface {
 
 // RotatorOption is a configuration option for Rotator.
 type RotatorOption func(r *Rotator)
+
+// Interval sets the time interval for log rotation in addition to log
+// rotation by size. The default is 0 for disabled.
+func Suffix(s SuffixType) RotatorOption {
+	return func(r *Rotator) {
+		r.suffix = s
+	}
+}
 
 // MaxSizeBytes configures the maximum number of bytes that a file should
 // contain before being rotated. The default is 10 MiB.
@@ -145,12 +149,12 @@ func RedirectStderr(redirect bool) RotatorOption {
 // NewFileRotator returns a new Rotator.
 func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error) {
 	r := &Rotator{
-		filename:        filename,
 		maxSizeBytes:    10 * 1024 * 1024, // 10 MiB
 		maxBackups:      7,
 		permissions:     0600,
 		interval:        0,
 		rotateOnStartup: true,
+		suffix:          SuffixCount,
 	}
 
 	for _, opt := range options {
@@ -166,11 +170,13 @@ func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error)
 	if r.permissions > os.ModePerm {
 		return nil, errors.Errorf("file rotator permissions mask of %o is invalid", r.permissions)
 	}
-	var err error
-	r.intervalRotator, err = newIntervalRotator(r.log, r.interval, r.rotateOnStartup, r.filename)
-	if err != nil {
-		return nil, err
+
+	if r.interval != 0 && r.interval < time.Second {
+		return nil, errors.New("the minimum time interval for log rotation is 1 second")
 	}
+
+	r.rot = newRotater(r.log, r.suffix, filename, r.maxBackups, r.interval)
+	r.triggers = newTriggers(r.rotateOnStartup, r.interval, r.maxSizeBytes)
 
 	if r.log != nil {
 		r.log.Debugw("Initialized file rotator",
@@ -178,7 +184,7 @@ func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error)
 			"max_size_bytes", r.maxSizeBytes,
 			"max_backups", r.maxBackups,
 			"permissions", r.permissions,
-			"interval", r.interval,
+			"suffix", r.suffix,
 		)
 	}
 
@@ -202,25 +208,122 @@ func (r *Rotator) Write(data []byte) (int, error) {
 		if err := r.openNew(); err != nil {
 			return 0, err
 		}
-	} else if r.intervalRotator != nil && r.intervalRotator.NewInterval() {
-		if err := r.rotate(rotateReasonTimeInterval); err != nil {
-			return 0, err
-		}
-		if err := r.openFile(); err != nil {
-			return 0, err
-		}
-	} else if r.size+dataLen > r.maxSizeBytes {
-		if err := r.rotate(rotateReasonFileSize); err != nil {
-			return 0, err
-		}
-		if err := r.openFile(); err != nil {
-			return 0, err
+	} else {
+		if reason, t := r.isRotationTriggered(dataLen); reason != rotateReasonNoRotate {
+			err := r.rot.Rotate(reason, t)
+			if err != nil {
+				return 0, err
+			}
+
+			err = r.openFile()
+			if err != nil {
+				return 0, err
+			}
 		}
 	}
 
 	n, err := r.file.Write(data)
-	r.size += uint(n)
 	return n, errors.Wrap(err, "failed to write to file")
+}
+
+// openNew opens r's log file for the first time, creating it if it doesn't
+// exist, and performing an initial rotation if r.rotateOnStartup is set.
+func (r *Rotator) openNew() error {
+	err := os.MkdirAll(r.dir(), r.dirMode())
+	if err != nil {
+		return errors.Wrap(err, "failed to make directories for new file")
+	}
+
+	_, err = os.Stat(r.rot.ActiveFile())
+	if err == nil {
+		// check if the file has to be rotated before writing to it
+		reason, t := r.isRotationTriggered(0)
+		if reason == rotateReasonNoRotate {
+			return r.appendToFile()
+		}
+		if err = r.rot.Rotate(reason, t); err != nil {
+			return err
+		}
+	}
+
+	return r.openFile()
+}
+
+// appendToFile opens an existing log file for appending. Unlike openFile it
+// does not call MkdirAll because it is an error for the file to not already
+// exist.
+func (r *Rotator) appendToFile() error {
+	var err error
+	r.file, err = os.OpenFile(r.rot.ActiveFile(), os.O_WRONLY|os.O_APPEND, r.permissions)
+	if err != nil {
+		return errors.Wrap(err, "failed to append to existing file")
+	}
+	if r.redirectStderr {
+		RedirectStandardError(r.file)
+	}
+	return nil
+}
+
+func (r *Rotator) openFile() error {
+	err := os.MkdirAll(r.dir(), r.dirMode())
+	if err != nil {
+		return errors.Wrap(err, "failed to make directories for new file")
+	}
+
+	r.file, err = os.OpenFile(r.rot.ActiveFile(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, r.permissions)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to open new file '%s'", r.rot.ActiveFile()))
+	}
+	if r.redirectStderr {
+		RedirectStandardError(r.file)
+	}
+	return nil
+}
+
+func (r *Rotator) rotate(reason rotateReason) error {
+	if err := r.closeFile(); err != nil {
+		return errors.Wrap(err, "error file closing current file")
+	}
+
+	if err := r.rot.Rotate(reason, time.Now()); err != nil {
+		return errors.Wrap(err, "failed to rotate backups")
+	}
+
+	return r.purge()
+}
+
+func (r *Rotator) purge() error {
+	rotatedFiles := r.rot.RotatedFiles()
+	if uint(len(rotatedFiles)) <= r.maxBackups {
+		return nil
+	}
+
+	filesToPurge := rotatedFiles[r.maxBackups:]
+	for _, name := range filesToPurge {
+		_, err := os.Stat(name)
+		switch {
+		case err == nil:
+			if err = os.Remove(name); err != nil {
+				return errors.Wrapf(err, "failed to delete %v during rotation", name)
+			}
+		case os.IsNotExist(err):
+			return nil
+		default:
+			return errors.Wrapf(err, "failed on %v during rotation", name)
+		}
+	}
+
+	return nil
+}
+
+func (r *Rotator) isRotationTriggered(dataLen uint) (rotateReason, time.Time) {
+	for _, t := range r.triggers {
+		reason := t.TriggerRotation(dataLen)
+		if reason != rotateReasonNoRotate {
+			return reason, time.Now()
+		}
+	}
+	return rotateReasonNoRotate, time.Time{}
 }
 
 // Sync commits the current contents of the file to stable storage. Typically,
@@ -249,15 +352,8 @@ func (r *Rotator) Close() error {
 	return r.closeFile()
 }
 
-func (r *Rotator) backupName(n uint) string {
-	if n == 0 {
-		return r.filename
-	}
-	return r.filename + "." + strconv.Itoa(int(n))
-}
-
 func (r *Rotator) dir() string {
-	return filepath.Dir(r.filename)
+	return filepath.Dir(r.rot.ActiveFile())
 }
 
 func (r *Rotator) dirMode() os.FileMode {
@@ -271,191 +367,125 @@ func (r *Rotator) dirMode() os.FileMode {
 	return os.FileMode(mode)
 }
 
-// openNew opens r's log file for the first time, creating it if it doesn't
-// exist, and performing an initial rotation if r.rotateOnStartup is set.
-func (r *Rotator) openNew() error {
-	err := os.MkdirAll(r.dir(), r.dirMode())
-	if err != nil {
-		return errors.Wrap(err, "failed to make directories for new file")
-	}
-
-	_, err = os.Stat(r.filename)
-	if err == nil {
-		if !r.rotateOnStartup {
-			// If the file exists and rotateOnStartup is false, then we just want to
-			// append to the existing file.
-			return r.appendToFile()
-		}
-		if err = r.rotate(rotateReasonInitializing); err != nil {
-			return err
-		}
-	}
-
-	return r.openFile()
-}
-
-func (r *Rotator) openFile() error {
-	err := os.MkdirAll(r.dir(), r.dirMode())
-	if err != nil {
-		return errors.Wrap(err, "failed to make directories for new file")
-	}
-
-	r.file, err = os.OpenFile(r.filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, r.permissions)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to open new file '%s'", r.filename))
-	}
-	if r.redirectStderr {
-		RedirectStandardError(r.file)
-	}
-	return nil
-}
-
-// appendToFile opens an existing log file for appending. Unlike openFile it
-// does not call MkdirAll because it is an error for the file to not already
-// exist.
-func (r *Rotator) appendToFile() error {
-	var err error
-	r.file, err = os.OpenFile(r.filename, os.O_WRONLY|os.O_APPEND, r.permissions)
-	if err != nil {
-		return errors.Wrap(err, "failed to append to existing file")
-	}
-	if r.redirectStderr {
-		RedirectStandardError(r.file)
-	}
-	return nil
-}
-
 func (r *Rotator) closeFile() error {
 	if r.file == nil {
 		return nil
 	}
 	err := r.file.Close()
 	r.file = nil
-	r.size = 0
 	return err
 }
 
-func (r *Rotator) purgeOldBackups() error {
-	if r.intervalRotator != nil {
-		return r.purgeOldIntervalBackups()
-	}
-	return r.purgeOldSizedBackups()
+type countRotator struct {
+	log             Logger
+	filename        string
+	intervalRotator *intervalRotator
+	maxBackups      uint
 }
 
-func (r *Rotator) purgeOldIntervalBackups() error {
-	files, err := filepath.Glob(r.filename + "*")
-	if err != nil {
-		return errors.Wrap(err, "failed to list existing logs during rotation")
-	}
+type dateRotator struct {
+	log             Logger
+	format          string
+	filenamePrefix  string
+	currentFilename string
+	intervalRotator *intervalRotator
+}
 
-	if len(files) > int(r.maxBackups) {
-
-		// sort log filenames numerically
-		r.intervalRotator.SortIntervalLogs(files)
-
-		for i := len(files) - int(r.maxBackups) - 1; i >= 0; i-- {
-			f := files[i]
-			_, err := os.Stat(f)
-			switch {
-			case err == nil:
-				if err = os.Remove(f); err != nil {
-					return errors.Wrapf(err, "failed to delete %v during rotation", f)
-				}
-			case os.IsNotExist(err):
-				return errors.Wrapf(err, "failed to delete non-existent %v during rotation", f)
-			default:
-				return errors.Wrapf(err, "failed on %v during rotation", f)
-			}
+func newRotater(log Logger, s SuffixType, filename string, maxBackups uint, interval time.Duration) rotater {
+	switch s {
+	case SuffixCount:
+		if interval > 0 {
+			return newIntervalRotator(log, interval, filename)
 		}
-	}
-
-	return nil
-}
-
-func (r *Rotator) purgeOldSizedBackups() error {
-	for i := r.maxBackups; i < MaxBackupsLimit; i++ {
-		name := r.backupName(i + 1)
-
-		_, err := os.Stat(name)
-		switch {
-		case err == nil:
-			if err = os.Remove(name); err != nil {
-				return errors.Wrapf(err, "failed to delete %v during rotation", name)
-			}
-		case os.IsNotExist(err):
-			return nil
-		default:
-			return errors.Wrapf(err, "failed on %v during rotation", name)
+		return &countRotator{
+			log:        log,
+			filename:   filename,
+			maxBackups: maxBackups,
 		}
-	}
-
-	return nil
-}
-
-func (r *Rotator) rotate(reason rotateReason) error {
-	if err := r.closeFile(); err != nil {
-		return errors.Wrap(err, "error file closing current file")
-	}
-
-	var err error
-	if r.intervalRotator != nil {
-		// Interval and size rotation use different filename patterns, so we use
-		// rotateByInterval if interval rotation is enabled, even if this specific
-		// rotation is triggered by size.
-		err = r.rotateByInterval(reason)
-	} else {
-		err = r.rotateBySize(reason)
-	}
-	if err != nil {
-		return errors.Wrap(err, "failed to rotate backups")
-	}
-
-	return r.purgeOldBackups()
-}
-
-func (r *Rotator) rotateByInterval(reason rotateReason) error {
-	fi, err := os.Stat(r.filename)
-	if os.IsNotExist(err) {
+	case SuffixDate:
+		return &dateRotator{
+			log:             log,
+			format:          "2006010215:04:05.9999",
+			filenamePrefix:  filename,
+			currentFilename: filename + "TODO",
+		}
+	default:
 		return nil
-	} else if err != nil {
-		return errors.Wrap(err, "failed to rotate backups")
+	}
+}
+
+func (d *dateRotator) ActiveFile() string {
+	return d.currentFilename
+}
+
+func (d *dateRotator) Rotate(reason rotateReason, rotateTime time.Time) error {
+	if d.log != nil {
+		d.log.Debugw("Rotating file", "filename", d.currentFilename, "reason", reason)
 	}
 
-	logPrefix := r.intervalRotator.LogPrefix(r.filename, fi.ModTime())
-	files, err := filepath.Glob(logPrefix + "*")
-	if err != nil {
-		return errors.Wrap(err, "failed to list logs during rotation")
-	}
-
-	var targetFilename string
-	if len(files) == 0 {
-		targetFilename = logPrefix + "1"
-	} else {
-		r.intervalRotator.SortIntervalLogs(files)
-		lastLogIndex, _, err := IntervalLogIndex(files[len(files)-1])
-		if err != nil {
-			return errors.Wrap(err, "failed to locate last log index during rotation")
-		}
-		targetFilename = logPrefix + strconv.Itoa(int(lastLogIndex)+1)
-	}
-
-	if err := os.Rename(r.filename, targetFilename); err != nil {
-		return errors.Wrap(err, "failed to rotate backups")
-	}
-
-	if r.log != nil {
-		r.log.Debugw("Rotating file", "filename", r.filename, "reason", reason)
-	}
-
-	r.intervalRotator.Rotate()
-
+	d.currentFilename = d.filenamePrefix + rotateTime.Format(d.format)
 	return nil
 }
 
-func (r *Rotator) rotateBySize(reason rotateReason) error {
-	for i := r.maxBackups + 1; i > 0; i-- {
-		old := r.backupName(i - 1)
-		older := r.backupName(i)
+func (d *dateRotator) RotatedFiles() []string {
+	files, err := filepath.Glob(d.filenamePrefix + "*")
+	if err != nil {
+		if d.log != nil {
+			d.log.Debugw("failed to list existing logs: %+v", err)
+		}
+	}
+	d.SortModTimeLogs(files)
+	return files
+}
+
+func (d *dateRotator) SortModTimeLogs(strings []string) {
+	sort.Slice(
+		strings,
+		func(i, j int) bool {
+			return d.OrderLog(strings[i]).After(d.OrderLog(strings[j]))
+		},
+	)
+}
+
+func (d *dateRotator) OrderLog(filename string) time.Time {
+	ts, err := time.Parse(d.format, filepath.Base(filename))
+	if err != nil {
+		return time.Time{}
+	}
+	return ts
+}
+
+func (c *countRotator) ActiveFile() string {
+	return c.filename
+}
+
+func (c *countRotator) RotatedFiles() []string {
+	files := make([]string, 0)
+	for i := c.maxBackups + 1; i > 0; i-- {
+		name := c.backupName(i)
+		if _, err := os.Stat(name); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			c.log.Debugw("failed to stat rotated file")
+			return files
+		}
+		files = append(files, name)
+	}
+
+	return files
+}
+
+func (c *countRotator) backupName(n uint) string {
+	if n == 0 {
+		return c.ActiveFile()
+	}
+	return c.ActiveFile() + "." + strconv.Itoa(int(n))
+}
+
+func (c *countRotator) Rotate(reason rotateReason, _ time.Time) error {
+	for i := c.maxBackups + 1; i > 0; i-- {
+		old := c.backupName(i - 1)
+		older := c.backupName(i)
 
 		if _, err := os.Stat(old); os.IsNotExist(err) {
 			continue
@@ -470,10 +500,20 @@ func (r *Rotator) rotateBySize(reason rotateReason) error {
 			return errors.Wrap(err, "failed to rotate backups")
 		} else if i == 1 {
 			// Log when rotation of the main file occurs.
-			if r.log != nil {
-				r.log.Debugw("Rotating file", "filename", old, "reason", reason)
+			if c.log != nil {
+				c.log.Debugw("Rotating file", "filename", old, "reason", reason)
 			}
 		}
 	}
+	return nil
+}
+
+func (s *SuffixType) Unpack(v string) error {
+	val, ok := suffixes[v]
+	if !ok {
+		return fmt.Errorf("invalid suffix type")
+	}
+
+	*s = val
 	return nil
 }

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -439,7 +439,7 @@ func newDateRotater(log Logger, filename string) rotater {
 	d := &dateRotator{
 		log:            log,
 		filenamePrefix: filename,
-		format:         "2006010215:04:05.99",
+		format:         "2006010215:04:05",
 	}
 
 	d.currentFilename = d.filenamePrefix + "-" + time.Now().Format(d.format)

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -461,7 +461,7 @@ func (c *countRotator) ActiveFile() string {
 
 func (c *countRotator) RotatedFiles() []string {
 	files := make([]string, 0)
-	for i := c.maxBackups + 1; i > 0; i-- {
+	for i := uint(1); i <= c.maxBackups+1; i++ {
 		name := c.backupName(i)
 		if _, err := os.Stat(name); os.IsNotExist(err) {
 			continue

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -560,11 +560,26 @@ func (c *countRotator) Rotate(reason rotateReason, _ time.Time) error {
 }
 
 func (s *SuffixType) Unpack(v string) error {
+	i, err := strconv.Atoi(v)
+	if err == nil {
+		t := SuffixType(i)
+		v = t.String()
+	}
+
 	val, ok := suffixes[v]
 	if !ok {
-		return fmt.Errorf("invalid suffix type")
+		return fmt.Errorf("invalid suffix type: %+v", v)
 	}
 
 	*s = val
 	return nil
+}
+
+func (s *SuffixType) String() string {
+	for k, v := range suffixes {
+		if v == *s {
+			return k
+		}
+	}
+	return ""
 }

--- a/libbeat/common/file/rotator_test.go
+++ b/libbeat/common/file/rotator_test.go
@@ -18,8 +18,10 @@
 package file_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"sync"
 	"testing"
@@ -197,6 +199,40 @@ func TestRotateOnStartup(t *testing.T) {
 	AssertDirContents(t, dir, logname, logname+".1")
 }
 
+func TestRotateDateSuffix(t *testing.T) {
+	dir := t.TempDir()
+
+	logname := "beatname"
+	filename := filepath.Join(dir, logname)
+
+	r, err := file.NewFileRotator(filename, file.Suffix(file.SuffixDate), file.MaxBackups(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	WriteMsg(t, r)
+
+	firstExpectedPattern := fmt.Sprintf("%s-%s.*", logname, time.Now().Format("2006010215:04:05"))
+	AssertDirContentsPattern(t, dir, firstExpectedPattern)
+
+	time.Sleep(1500 * time.Millisecond)
+	secondExpectedPattern := fmt.Sprintf("%s-%s.*", logname, time.Now().Format("2006010215:04:05"))
+
+	Rotate(t, r)
+	WriteMsg(t, r)
+
+	AssertDirContentsPattern(t, dir, firstExpectedPattern, secondExpectedPattern)
+
+	time.Sleep(1500 * time.Millisecond)
+	thirdExpectedPattern := fmt.Sprintf("%s-%s.*", logname, time.Now().Format("2006010215:04:05"))
+
+	Rotate(t, r)
+	WriteMsg(t, r)
+
+	AssertDirContentsPattern(t, dir, secondExpectedPattern, thirdExpectedPattern)
+}
+
 func CreateFile(t *testing.T, filename string) {
 	t.Helper()
 	f, err := os.Create(filename)
@@ -225,6 +261,33 @@ func AssertDirContents(t *testing.T, dir string, files ...string) {
 	sort.Strings(files)
 	sort.Strings(names)
 	assert.EqualValues(t, files, names)
+}
+
+func AssertDirContentsPattern(t *testing.T, dir string, patterns ...string) {
+	t.Helper()
+
+	f, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(patterns) != len(names) {
+		t.Fatal("unexpected number of files")
+	}
+
+	sort.Strings(patterns)
+	sort.Strings(names)
+	for i := 0; i < len(patterns); i++ {
+		matches, err := regexp.MatchString(patterns[i], names[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.True(t, matches, "pattern: %s name: %s", patterns[i], names[i])
+	}
 }
 
 func WriteMsg(t *testing.T, r *file.Rotator) {

--- a/libbeat/common/file/rotator_test.go
+++ b/libbeat/common/file/rotator_test.go
@@ -18,7 +18,6 @@
 package file_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -37,11 +36,7 @@ const logMessage = "Test file rotator.\n"
 func TestFileRotator(t *testing.T) {
 	logp.TestingSetup()
 
-	dir, err := ioutil.TempDir("", "file_rotator")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := filepath.Join(dir, "sample.log")
 	r, err := file.NewFileRotator(filename,
@@ -72,15 +67,11 @@ func TestFileRotator(t *testing.T) {
 	AssertDirContents(t, dir, "sample.log.1", "sample.log.2")
 
 	Rotate(t, r)
-	AssertDirContents(t, dir, "sample.log.2")
+	AssertDirContents(t, dir, "sample.log.2", "sample.log.3")
 }
 
 func TestFileRotatorConcurrently(t *testing.T) {
-	dir, err := ioutil.TempDir("", "file_rotator")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	filename := filepath.Join(dir, "sample.log")
 	r, err := file.NewFileRotator(filename, file.MaxBackups(2))
@@ -101,11 +92,7 @@ func TestFileRotatorConcurrently(t *testing.T) {
 }
 
 func TestDailyRotation(t *testing.T) {
-	dir, err := ioutil.TempDir("", "daily_file_rotator")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logname := "daily"
 	dateFormat := "2006-01-02"
@@ -173,11 +160,7 @@ func TestDailyRotation(t *testing.T) {
 
 // Tests the FileConfig.RotateOnStartup parameter
 func TestRotateOnStartup(t *testing.T) {
-	dir, err := ioutil.TempDir("", "rotate_on_open")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logname := "rotate_on_open"
 	filename := filepath.Join(dir, logname)

--- a/libbeat/common/file/trigger.go
+++ b/libbeat/common/file/trigger.go
@@ -47,6 +47,7 @@ func (rr rotateReason) String() string {
 	}
 }
 
+// trigger interface causes the log writer to rotate the active file.
 type trigger interface {
 	TriggerRotation(dataLen uint) rotateReason
 }
@@ -66,6 +67,7 @@ func newTriggers(rotateOnStartup bool, interval time.Duration, maxSizeBytes uint
 	return triggers
 }
 
+// initTrigger is triggered once on startup.
 type initTrigger struct {
 	triggered bool
 }
@@ -78,6 +80,7 @@ func (t *initTrigger) TriggerRotation(_ uint) rotateReason {
 	return rotateReasonNoRotate
 }
 
+// sizeTrigger starts a rotation when the file reaches the configured size.
 type sizeTrigger struct {
 	maxSizeBytes uint
 	size         uint
@@ -92,6 +95,7 @@ func (t *sizeTrigger) TriggerRotation(dataLen uint) rotateReason {
 	return rotateReasonNoRotate
 }
 
+// intervalTrigger rotates the files after the configured interval.
 type intervalTrigger struct {
 	interval    time.Duration
 	clock       clock

--- a/libbeat/common/file/trigger.go
+++ b/libbeat/common/file/trigger.go
@@ -58,12 +58,24 @@ func newTriggers(rotateOnStartup bool, interval time.Duration, maxSizeBytes uint
 		triggers = append(triggers, &initTrigger{})
 	}
 	if interval > 0 {
-		triggers = append(triggers, &intervalTrigger{})
+		triggers = append(triggers, newIntervalTrigger(interval))
 	}
 	if maxSizeBytes > 0 {
 		triggers = append(triggers, &sizeTrigger{maxSizeBytes: maxSizeBytes, size: 0})
 	}
 	return triggers
+}
+
+type initTrigger struct {
+	triggered bool
+}
+
+func (t *initTrigger) TriggerRotation(_ uint) rotateReason {
+	if !t.triggered {
+		t.triggered = true
+		return rotateReasonInitializing
+	}
+	return rotateReasonNoRotate
 }
 
 type sizeTrigger struct {
@@ -130,18 +142,6 @@ func (t *intervalTrigger) TriggerRotation(_ uint) rotateReason {
 	if t.newInterval(t.lastRotate, now) {
 		t.lastRotate = now
 		return rotateReasonTimeInterval
-	}
-	return rotateReasonNoRotate
-}
-
-type initTrigger struct {
-	triggered bool
-}
-
-func (t *initTrigger) TriggerRotation(_ uint) rotateReason {
-	if !t.triggered {
-		t.triggered = true
-		return rotateReasonInitializing
 	}
 	return rotateReasonNoRotate
 }

--- a/libbeat/common/file/trigger.go
+++ b/libbeat/common/file/trigger.go
@@ -1,0 +1,178 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package file
+
+import (
+	"time"
+)
+
+// rotateReason is the reason why file rotation occurred.
+type rotateReason uint32
+
+const (
+	rotateReasonNoRotate rotateReason = iota
+	rotateReasonInitializing
+	rotateReasonFileSize
+	rotateReasonManualTrigger
+	rotateReasonTimeInterval
+)
+
+func (rr rotateReason) String() string {
+	switch rr {
+	case rotateReasonInitializing:
+		return "initializing"
+	case rotateReasonFileSize:
+		return "file size"
+	case rotateReasonManualTrigger:
+		return "manual trigger"
+	case rotateReasonTimeInterval:
+		return "time interval"
+	default:
+		return "unknown"
+	}
+}
+
+type trigger interface {
+	TriggerRotation(dataLen uint) rotateReason
+}
+
+func newTriggers(rotateOnStartup bool, interval time.Duration, maxSizeBytes uint) []trigger {
+	triggers := make([]trigger, 0)
+
+	if rotateOnStartup {
+		triggers = append(triggers, &initTrigger{})
+	}
+	if interval > 0 {
+		triggers = append(triggers, &intervalTrigger{})
+	}
+	if maxSizeBytes > 0 {
+		triggers = append(triggers, &sizeTrigger{maxSizeBytes: maxSizeBytes, size: 0})
+	}
+	return triggers
+}
+
+type sizeTrigger struct {
+	maxSizeBytes uint
+	size         uint
+}
+
+func (t *sizeTrigger) TriggerRotation(dataLen uint) rotateReason {
+	if t.size+dataLen > t.maxSizeBytes {
+		t.size = 0
+		return rotateReasonFileSize
+	}
+	t.size += dataLen
+	return rotateReasonNoRotate
+}
+
+type intervalTrigger struct {
+	interval    time.Duration
+	clock       clock
+	lastRotate  time.Time
+	newInterval func(lastTime time.Time, currentTime time.Time) bool
+}
+
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+func newIntervalTrigger(interval time.Duration) trigger {
+	t := intervalTrigger{interval: interval, clock: realClock{}}
+
+	switch interval {
+	case time.Second:
+		t.newInterval = newSecond
+	case time.Minute:
+		t.newInterval = newMinute
+	case time.Hour:
+		t.newInterval = newHour
+	case 24 * time.Hour: // calendar day
+		t.newInterval = newDay
+	case 7 * 24 * time.Hour: // calendar week
+		t.newInterval = newWeek
+	case 30 * 24 * time.Hour: // calendar month
+		t.newInterval = newMonth
+	case 365 * 24 * time.Hour: // calendar year
+		t.newInterval = newYear
+	default:
+		t.newInterval = func(lastTime time.Time, currentTime time.Time) bool {
+			lastInterval := lastTime.Unix() / (int64(t.interval) / int64(time.Second))
+			currentInterval := currentTime.Unix() / (int64(t.interval) / int64(time.Second))
+			return lastInterval != currentInterval
+		}
+	}
+	return &t
+}
+
+func (t *intervalTrigger) TriggerRotation(_ uint) rotateReason {
+	now := t.clock.Now()
+	if t.newInterval(t.lastRotate, now) {
+		t.lastRotate = now
+		return rotateReasonTimeInterval
+	}
+	return rotateReasonNoRotate
+}
+
+type initTrigger struct {
+	triggered bool
+}
+
+func (t *initTrigger) TriggerRotation(_ uint) rotateReason {
+	if !t.triggered {
+		t.triggered = true
+		return rotateReasonInitializing
+	}
+	return rotateReasonNoRotate
+}
+
+func newSecond(lastTime time.Time, currentTime time.Time) bool {
+	return lastTime.Second() != currentTime.Second() || newMinute(lastTime, currentTime)
+}
+
+func newMinute(lastTime time.Time, currentTime time.Time) bool {
+	return lastTime.Minute() != currentTime.Minute() || newHour(lastTime, currentTime)
+}
+
+func newHour(lastTime time.Time, currentTime time.Time) bool {
+	return lastTime.Hour() != currentTime.Hour() || newDay(lastTime, currentTime)
+}
+
+func newDay(lastTime time.Time, currentTime time.Time) bool {
+	return lastTime.Day() != currentTime.Day() || newMonth(lastTime, currentTime)
+}
+
+func newWeek(lastTime time.Time, currentTime time.Time) bool {
+	lastYear, lastWeek := lastTime.ISOWeek()
+	currentYear, currentWeek := currentTime.ISOWeek()
+	return lastWeek != currentWeek ||
+		lastYear != currentYear
+}
+
+func newMonth(lastTime time.Time, currentTime time.Time) bool {
+	return lastTime.Month() != currentTime.Month() || newYear(lastTime, currentTime)
+}
+
+func newYear(lastTime time.Time, currentTime time.Time) bool {
+	return lastTime.Year() != currentTime.Year()
+}

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -239,6 +239,15 @@ Intervals must be at least 1s. Values of 1m, 1h, 24h, 7*24h, 30*24h, and 365*24h
 are boundary-aligned with minutes, hours, days, weeks, months, and years as
 reported by the local system clock. All other intervals are calculated from the
 unix epoch. Defaults to disabled.
+
+[float]
+==== `logging.files.suffix`
+
+When a log rotation happens it can either rename older files with
+an incresing index if `count` is configured. The other option is `date`
+that appends the current date and time to the end of the filename.
+When the log is rotated a new file is created and older files
+remain untouched.
 endif::serverless[]
 
 [float]

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -50,7 +50,7 @@ type Config struct {
 type FileConfig struct {
 	Path            string          `config:"path" yaml:"path"`
 	Name            string          `config:"name" yaml:"name"`
-	Suffix          file.SuffixType `config:"suffix_type" yaml:"suffix_type"`
+	Suffix          file.SuffixType `config:"suffix" yaml:"suffix"`
 	MaxSize         uint            `config:"rotateeverybytes" yaml:"rotateeverybytes" validate:"min=1"`
 	MaxBackups      uint            `config:"keepfiles" yaml:"keepfiles" validate:"max=1024"`
 	Permissions     uint32          `config:"permissions"`

--- a/libbeat/logp/config.go
+++ b/libbeat/logp/config.go
@@ -19,6 +19,8 @@ package logp
 
 import (
 	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common/file"
 )
 
 // Config contains the configuration options for the logger. To create a Config
@@ -46,17 +48,20 @@ type Config struct {
 
 // FileConfig contains the configuration options for the file output.
 type FileConfig struct {
-	Path            string        `config:"path" yaml:"path"`
-	Name            string        `config:"name" yaml:"name"`
-	MaxSize         uint          `config:"rotateeverybytes" yaml:"rotateeverybytes" validate:"min=1"`
-	MaxBackups      uint          `config:"keepfiles" yaml:"keepfiles" validate:"max=1024"`
-	Permissions     uint32        `config:"permissions"`
-	Interval        time.Duration `config:"interval"`
-	RotateOnStartup bool          `config:"rotateonstartup"`
-	RedirectStderr  bool          `config:"redirect_stderr" yaml:"redirect_stderr"`
+	Path            string          `config:"path" yaml:"path"`
+	Name            string          `config:"name" yaml:"name"`
+	Suffix          file.SuffixType `config:"suffix_type" yaml:"suffix_type"`
+	MaxSize         uint            `config:"rotateeverybytes" yaml:"rotateeverybytes" validate:"min=1"`
+	MaxBackups      uint            `config:"keepfiles" yaml:"keepfiles" validate:"max=1024"`
+	Permissions     uint32          `config:"permissions"`
+	Interval        time.Duration   `config:"interval"`
+	RotateOnStartup bool            `config:"rotateonstartup"`
+	RedirectStderr  bool            `config:"redirect_stderr" yaml:"redirect_stderr"`
 }
 
-const defaultLevel = InfoLevel
+const (
+	defaultLevel = InfoLevel
+)
 
 // DefaultConfig returns the default config options for a given environment the
 // Beat is supposed to be run within.
@@ -64,6 +69,7 @@ func DefaultConfig(environment Environment) Config {
 	return Config{
 		Level: defaultLevel,
 		Files: FileConfig{
+			Suffix:          file.SuffixCount,
 			MaxSize:         10 * 1024 * 1024,
 			MaxBackups:      7,
 			Permissions:     0600,

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -239,6 +239,7 @@ func makeFileOutput(cfg Config) (zapcore.Core, error) {
 		file.Interval(cfg.Files.Interval),
 		file.RotateOnStartup(cfg.Files.RotateOnStartup),
 		file.RedirectStderr(cfg.Files.RedirectStderr),
+		file.Suffix(cfg.Files.Suffix),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create file rotator")

--- a/libbeat/outputs/fileout/config.go
+++ b/libbeat/outputs/fileout/config.go
@@ -25,23 +25,25 @@ import (
 )
 
 type config struct {
-	Path            string       `config:"path"`
-	Filename        string       `config:"filename"`
-	RotateEveryKb   uint         `config:"rotate_every_kb" validate:"min=1"`
-	NumberOfFiles   uint         `config:"number_of_files"`
-	Codec           codec.Config `config:"codec"`
-	Permissions     uint32       `config:"permissions"`
-	RotateOnStartup bool         `config:"rotate_on_startup"`
+	Path            string          `config:"path"`
+	Filename        string          `config:"filename"`
+	Suffix          file.SuffixType `config:"suffix"`
+	RotateEveryKb   uint            `config:"rotate_every_kb" validate:"min=1"`
+	NumberOfFiles   uint            `config:"number_of_files"`
+	Codec           codec.Config    `config:"codec"`
+	Permissions     uint32          `config:"permissions"`
+	RotateOnStartup bool            `config:"rotate_on_startup"`
 }
 
-var (
-	defaultConfig = config{
+func defaultConfig() config {
+	return config{
+		Suffix:          file.SuffixCount,
 		NumberOfFiles:   7,
 		RotateEveryKb:   10 * 1024,
 		Permissions:     0600,
 		RotateOnStartup: true,
 	}
-)
+}
 
 func (c *config) Validate() error {
 	if c.NumberOfFiles < 2 || c.NumberOfFiles > file.MaxBackupsLimit {

--- a/libbeat/outputs/fileout/file.go
+++ b/libbeat/outputs/fileout/file.go
@@ -51,7 +51,7 @@ func makeFileout(
 	observer outputs.Observer,
 	cfg *common.Config,
 ) (outputs.Group, error) {
-	config := defaultConfig
+	config := defaultConfig()
 	if err := cfg.Unpack(&config); err != nil {
 		return outputs.Fail(err)
 	}
@@ -84,6 +84,7 @@ func (out *fileOutput) init(beat beat.Info, c config) error {
 	var err error
 	out.rotator, err = file.NewFileRotator(
 		path,
+		file.Suffix(c.Suffix),
 		file.MaxSizeBytes(c.RotateEveryKb*1024),
 		file.MaxBackups(c.NumberOfFiles),
 		file.Permissions(os.FileMode(c.Permissions)),

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2234,6 +2234,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. metricbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1932,6 +1932,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. packetbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1360,6 +1360,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. winlogbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1493,6 +1493,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. auditbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -118,7 +118,7 @@ func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 		file.Interval(defaultCfg.Files.Interval),
 		file.RotateOnStartup(defaultCfg.Files.RotateOnStartup),
 		file.RedirectStderr(defaultCfg.Files.RedirectStderr),
-		file.Suffix(file.SuffixDate),
+		file.Suffix(cfg.Files.Suffix),
 	)
 	if err != nil {
 		return nil, errors.New("failed to create internal file rotator")

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -96,7 +96,8 @@ func DefaultLoggingConfig() *Config {
 	cfg.Level = logp.InfoLevel
 	cfg.ToFiles = true
 	cfg.Files.Path = paths.Logs()
-	cfg.Files.Name = fmt.Sprintf("%s.log", agentName)
+	cfg.Files.Name = agentName
+	cfg.Files.Suffix = file.SuffixDate
 
 	return &cfg
 }
@@ -117,6 +118,7 @@ func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 		file.Interval(defaultCfg.Files.Interval),
 		file.RotateOnStartup(defaultCfg.Files.RotateOnStartup),
 		file.RedirectStderr(defaultCfg.Files.RedirectStderr),
+		file.Suffix(defaultCfg.Files.Suffix),
 	)
 	if err != nil {
 		return nil, errors.New("failed to create internal file rotator")

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -118,7 +118,7 @@ func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 		file.Interval(defaultCfg.Files.Interval),
 		file.RotateOnStartup(defaultCfg.Files.RotateOnStartup),
 		file.RedirectStderr(defaultCfg.Files.RedirectStderr),
-		file.Suffix(defaultCfg.Files.Suffix),
+		file.Suffix(file.SuffixDate),
 	)
 	if err != nil {
 		return nil, errors.New("failed to create internal file rotator")

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -4437,6 +4437,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. filebeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1339,6 +1339,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. functionbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1615,6 +1615,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. heartbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2735,6 +2735,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. metricbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -952,6 +952,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. osquerybeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -1932,6 +1932,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. packetbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1403,6 +1403,11 @@ logging.files:
   # file. Defaults to true.
   # rotateonstartup: true
 
+  # Rotated files are either suffixed with a number e.g. winlogbeat.1 when
+  # renamed during rotation. Or when set to date, the date is added to
+  # the end of the file. On rotation a new file is created, older files are untouched.
+  #suffix: count
+
 # Set to true to log messages in JSON format.
 #logging.json: false
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a new option named `logging.files.suffix` to control how files are rotated. Two values are available: `count` and `date`.

`count` is the current default behaviour. `date` is the new feature. It adds the date to the end of the file. Thus, if a file is rotated, there is no need for renaming, the Beat can just open a new file and start writing logs.

When `count` is selected a number is incremented: `{beatname}` becomes `{beatname}.1`
When `date` is selected the datetime is added: `{beatname}-2021050512:12:34`

### Architecture

There is a single `Rotator` that is responsible for managing and writing to the active log file. On `Write` the Beat checks if the file has to be rotated first. This check is now done by a list of `triggers`. This tells the Beat if the log has to be rotated or not.

```golang
type trigger interface {
    TriggerRotation(dataLen uint) rotateReason
}
```

Available triggers:
- `initTrigger`: triggers a rotation when the Beat starts
- `sizeTrigger`: triggers a rotation when the size of the active file has reached the limit
- `intervalTrigger`: triggers a rotation if the specified interval has passed

If a rotation is triggered, there a `rotater` rotates the files.

```golang
type rotater interface {
    ActiveFile() string
    RotatedFiles() []string
    Rotate(reason rotateReason, rotateTime time.Time) error
}
```
Available rotaters:
- `countRotator`: renames inactive files based on a count and starts a new active file
- `intervalRotator`: renames inactive files based on the current time and starts a new active file
- `dateRotator`: starts a new active file

## Why is it important?

Logging is blocking Beats and Agent on Windows: https://github.com/elastic/beats/issues/25424
If we set logging to `date` in Agent this issue can be resolved.

Previously rotation methods and triggers were too tightly coupled. Now they are separated into different layers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.