### PR TITLE
Fix `go vet` failure on TestDNSProcessorRunInParallel

### DIFF
--- a/libbeat/processors/dns/dns_test.go
+++ b/libbeat/processors/dns/dns_test.go
@@ -141,6 +141,7 @@ func TestDNSProcessorRunInParallel(t *testing.T) {
 
 	// Start several goroutines.
 	wg.Add(numGoroutines)
+	errs := make(chan error, numGoroutines*numEvents)
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
 			defer wg.Done()
@@ -153,11 +154,17 @@ func TestDNSProcessorRunInParallel(t *testing.T) {
 					},
 				})
 				if err != nil {
-					t.Fatal(err)
+					errs <- err
 				}
 			}
 		}()
 	}
 
 	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the failure on `make check`

```
# github.com/elastic/beats/v7/libbeat/processors/dns
processors/dns/dns_test.go:156:6: call to (*T).Fatal from a non-test goroutine
Error: failed running go vet, please fix the issues reported: running "go vet ./..." failed with exit code 2
make[1]: *** [check] Error 1
```

## Why is it important?

No error after the change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

