### PR TITLE
Fix  `make check` failure in matchers.go, Go 1.16

### DIFF
--- a/libbeat/common/match/matchers.go
+++ b/libbeat/common/match/matchers.go
@@ -251,12 +251,8 @@ func (m *matchAny) Match(_ []byte) bool       { return true }
 func (m *matchAny) MatchString(_ string) bool { return true }
 func (m *matchAny) String() string            { return "<any>" }
 
-func bytesToString(b []byte) (s string) {
-	pb := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	ps := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	ps.Data = pb.Data
-	ps.Len = pb.Len
-	return
+func bytesToString(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
 }
 
 func stringToBytes(s string) (b []byte) {

--- a/libbeat/common/match/matchers.go
+++ b/libbeat/common/match/matchers.go
@@ -251,14 +251,19 @@ func (m *matchAny) Match(_ []byte) bool       { return true }
 func (m *matchAny) MatchString(_ string) bool { return true }
 func (m *matchAny) String() string            { return "<any>" }
 
-func bytesToString(b []byte) string {
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh := reflect.StringHeader{Data: bh.Data, Len: bh.Len}
-	return *(*string)(unsafe.Pointer(&sh))
+func bytesToString(b []byte) (s string) {
+	pb := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	ps := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	ps.Data = pb.Data
+	ps.Len = pb.Len
+	return
 }
 
-func stringToBytes(s string) []byte {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{Data: sh.Data, Len: sh.Len, Cap: sh.Len}
-	return *(*[]byte)(unsafe.Pointer(&bh))
+func stringToBytes(s string) (b []byte) {
+	pb := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	ps := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	pb.Data = ps.Data
+	pb.Len = ps.Len
+	pb.Cap = ps.Len
+	return
 }


### PR DESCRIPTION
## What does this PR do?

Fix `make check` failure in matchers.go with Go 1.16:

```
# github.com/elastic/beats/v7/libbeat/common/match
common/match/matchers.go:257:35: possible misuse of reflect.StringHeader
common/match/matchers.go:263:35: possible misuse of reflect.SliceHeader
Error: failed running go vet, please fix the issues reported: running "go vet ./..." failed with exit code 2
```
 
## Why is it important?

Fixes one remaining issue with running `make check`. The source tree passes go 1.16 `go vet` now.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

