### PR TITLE
Cherry-pick to 7.x: Update command-reference.asciidoc (#25404)

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -756,7 +756,8 @@ necessary to analyze data for anomalies.
 endif::[]
 
 This command sets up the environment without actually running
-{beatname_uc} and ingesting data.
+{beatname_uc} and ingesting data. Specify optional flags to set up a subset of
+assets.
 
 *SYNOPSIS*
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update command-reference.asciidoc (#25404)