### PR TITLE
Cherry-pick to 7.12: Update command-reference.asciidoc (#25404)

### DIFF
--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -758,7 +758,8 @@ necessary to analyze data for anomalies.
 endif::[]
 
 This command sets up the environment without actually running
-{beatname_uc} and ingesting data.
+{beatname_uc} and ingesting data. Specify optional flags to set up a subset of
+assets.
 
 *SYNOPSIS*
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Update command-reference.asciidoc (#25404)