### PR TITLE
[Elastic Agent] Adjust some naming to fleet-server

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -65,11 +65,11 @@ environment variables to run inside of the container.
 
 The following actions are possible and grouped based on the actions.
 
-* Elastic Agent Fleet Enrollment
+* Elastic Agent Fleet Server Enrollment
   This enrolls the Elastic Agent into a Fleet Server. It is also possible to have this create a new enrollment token
   for this specific Elastic Agent.
 
-  FLEET_ENROLL - set to 1 for enrollment into fleet-server. If not set, Elastic Agent is run in standalone mode.
+  FLEET_ENROLL - set to 1 for enrollment into Fleet Server. If not set, Elastic Agent is run in standalone mode.
   FLEET_URL - URL of the Fleet Server to enroll into
   FLEET_ENROLLMENT_TOKEN - token to use for enrollment. This is not needed in case FLEET_SERVER_ENABLED and FLEET_ENROLL is set. Then the token is fetched from Kibana.
   FLEET_CA - path to certificate authority to use with communicate with Fleet Server [$KIBANA_CA]

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -28,8 +28,8 @@ import (
 func newEnrollCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enroll",
-		Short: "Enroll the Agent into Fleet",
-		Long:  "This will enroll the Agent into Fleet.",
+		Short: "Enroll the Agent into Fleet Server",
+		Long:  "This will enroll the Agent into Fleet Server.",
 		Run: func(c *cobra.Command, args []string) {
 			if err := enroll(streams, c, args); err != nil {
 				fmt.Fprintf(streams.Err, "Error: %v\n", err)
@@ -49,9 +49,9 @@ func newEnrollCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command
 }
 
 func addEnrollFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("url", "", "", "URL to enroll Agent into Fleet")
+	cmd.Flags().StringP("url", "", "", "URL to enroll Agent into Fleet Server")
 	cmd.Flags().StringP("kibana-url", "k", "", "URL of Fleet-Server to enroll Agent into Fleet-Server (deprecated)")
-	cmd.Flags().StringP("enrollment-token", "t", "", "Enrollment token to use to enroll Agent into Fleet")
+	cmd.Flags().StringP("enrollment-token", "t", "", "Enrollment token to use to enroll Agent into Fleet Server")
 	cmd.Flags().StringP("fleet-server-es", "", "", "Start and run a Fleet Server along side this Elastic Agent connecting to the provided elasticsearch")
 	cmd.Flags().StringP("fleet-server-es-ca", "", "", "Path to certificate authority to use with communicate with elasticsearch")
 	cmd.Flags().StringP("fleet-server-service-token", "", "", "Service token to use for communication with elasticsearch")

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -109,7 +109,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 		askEnroll = false
 	}
 	if askEnroll {
-		confirm, err := c.Confirm("Do you want to enroll this Agent into Fleet?", true)
+		confirm, err := c.Confirm("Do you want to enroll this Agent into Fleet Server?", true)
 		if err != nil {
 			return fmt.Errorf("problem reading prompt response")
 		}
@@ -135,7 +135,7 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 			}
 		}
 		if token == "" {
-			token, err = c.ReadInput("Fleet enrollment token:")
+			token, err = c.ReadInput("Fleet Server enrollment token:")
 			if err != nil {
 				return fmt.Errorf("problem reading prompt response")
 			}

--- a/x-pack/elastic-agent/pkg/remote/client.go
+++ b/x-pack/elastic-agent/pkg/remote/client.go
@@ -25,7 +25,7 @@ import (
 const (
 	defaultPort = 8220
 
-	retryOnBadConnTimeout = 5 * time.Minute
+	retryOnBadConnTimeout = 6 * time.Minute
 )
 
 type requestFunc func(string, string, url.Values, io.Reader) (*http.Request, error)
@@ -188,11 +188,14 @@ func (c *Client) Send(
 	}
 
 	requester.lastUsed = time.Now().UTC()
+	c.log.Debugf("Start request, last used: %v", requester.lastUsed)
 	resp, err := requester.client.Do(req.WithContext(ctx))
 	if err != nil {
+		c.log.Debugf("Request failed")
 		requester.lastErr = err
 		requester.lastErrOcc = time.Now().UTC()
 	} else {
+		c.log.Debugf("Request successful")
 		requester.lastErr = nil
 		requester.lastErrOcc = time.Time{}
 	}

--- a/x-pack/elastic-agent/pkg/remote/client.go
+++ b/x-pack/elastic-agent/pkg/remote/client.go
@@ -25,7 +25,7 @@ import (
 const (
 	defaultPort = 8220
 
-	retryOnBadConnTimeout = 6 * time.Minute
+	retryOnBadConnTimeout = 5 * time.Minute
 )
 
 type requestFunc func(string, string, url.Values, io.Reader) (*http.Request, error)

--- a/x-pack/elastic-agent/pkg/remote/client.go
+++ b/x-pack/elastic-agent/pkg/remote/client.go
@@ -188,14 +188,11 @@ func (c *Client) Send(
 	}
 
 	requester.lastUsed = time.Now().UTC()
-	c.log.Debugf("Start request, last used: %v", requester.lastUsed)
 	resp, err := requester.client.Do(req.WithContext(ctx))
 	if err != nil {
-		c.log.Debugf("Request failed")
 		requester.lastErr = err
 		requester.lastErrOcc = time.Now().UTC()
 	} else {
-		c.log.Debugf("Request successful")
 		requester.lastErr = nil
 		requester.lastErrOcc = time.Time{}
 	}


### PR DESCRIPTION
During testing Elastic Agent / Fleet-server and going through the code I found a few more cases where we mix between Fleet and Fleet Server. But during making changes I was not sure in all cases if we should talk about fleet-server or Fleet itself. On the code side, I think we should always be accurate and have technical accurate comments and naming. If we check into fleet-server, it should mention fleet-server.

But on the user facing messaging I was a bit torn. For example when a new policy is retrieved. It is retrieved from fleet-server but at the same time for a user using Cloud, it should be an implementation detail if the config was retrieved from Fleet or fleet-server. I'm personally leaning towards also having it "technical correct" in the logs because users looking at the logs likely have a problem with the system, know partially about the setup and it helps debugging.

Would be nice to get @mostlyjason @ph @blakerouse @urso opinion on this.