### PR TITLE
[Heartbeat] Add context to HTTP body read errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -395,6 +395,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Fixed excessive memory usage introduced in 7.5 due to over-allocating memory for HTTP checks. {pull}15639[15639]
 - Fixed TCP TLS checks to properly validate hostnames, this broke in 7.x and only worked for IP SANs. {pull}17549[17549]
+- Add Context to otherwise ambiguous HTTP body read errors. {pull}25499[25499]
 
 *Journalbeat*
 

--- a/heartbeat/monitors/active/http/respbody.go
+++ b/heartbeat/monitors/active/http/respbody.go
@@ -115,7 +115,12 @@ func readPrefixAndHash(body io.ReadCloser, maxPrefixSize int) (respSize int, pre
 		n += m
 	}
 
-	// Note that io.EOF is distinct from io.UnexpectedEOF
+	// The ErrUnexpectedEOF message can be confusing to users, so we clarify it here
+	if err == io.ErrUnexpectedEOF {
+		return 0, "", "", fmt.Errorf("connection closed unexpectedly: %w", err)
+	}
+
+	// Note that io.EOF is distinct from io.ErrUnexpectedEOF
 	if err != nil && err != io.EOF {
 		return 0, "", "", err
 	}

--- a/heartbeat/monitors/active/http/respbody.go
+++ b/heartbeat/monitors/active/http/respbody.go
@@ -20,6 +20,7 @@ package http
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -58,7 +59,7 @@ func processBody(resp *http.Response, config responseConfig, validator multiVali
 	respBody, bodyLenBytes, bodyHash, respErr := readBody(resp, bufferBodyBytes)
 	// If we encounter an error while reading the body just fail early
 	if respErr != nil {
-		return nil, "", reason.IOFailed(respErr)
+		return nil, "", reason.IOFailed(fmt.Errorf("failed reading HTTP response body: %w", respErr))
 	}
 
 	// Run any validations
@@ -114,6 +115,7 @@ func readPrefixAndHash(body io.ReadCloser, maxPrefixSize int) (respSize int, pre
 		n += m
 	}
 
+	// Note that io.EOF is distinct from io.UnexpectedEOF
 	if err != nil && err != io.EOF {
 		return 0, "", "", err
 	}


### PR DESCRIPTION
This change adds clarity to HTTP body read errors, wrapping the error with a more identifiable message. Prior to this, you'd just get the low level error, which made it hard to know exactly where it came from.

Fixes: https://github.com/elastic/beats/issues/25500

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

