### PR TITLE
Mark cyberark module as deprecated

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -109,6 +109,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change logging in logs input to structure logging. Some log message formats have changed. {pull}25299[25299]
 - All url.* fields apart from url.original in the Apache, Nginx, IIS, Traefik, S3Access, Cisco, F5, Fortinet, Google Workspace, Imperva, Microsoft, Netscout, O365, Sophos, Squid, Suricata, Zeek, Zia, Zoom, and ZScaler modules are now url unescaped due to using the Elasticsearch uri_parts processor. {pull}24699[24699]
 - Deprecated the cyberark module (replaced by cyberarkpas). {issue}25261[25261] {pull}25505[25505]
+
 *Heartbeat*
 
 *Journalbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -108,7 +108,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Changes filebeat httpjson input's append transform to create a list even with only a single value{pull}25074[25074]
 - Change logging in logs input to structure logging. Some log message formats have changed. {pull}25299[25299]
 - All url.* fields apart from url.original in the Apache, Nginx, IIS, Traefik, S3Access, Cisco, F5, Fortinet, Google Workspace, Imperva, Microsoft, Netscout, O365, Sophos, Squid, Suricata, Zeek, Zia, Zoom, and ZScaler modules are now url unescaped due to using the Elasticsearch uri_parts processor. {pull}24699[24699]
-
+- Deprecated the cyberark module (replaced by cyberarkpas). {issue}25261[25261] {pull}25505[25505]
 *Heartbeat*
 
 *Journalbeat*

--- a/filebeat/docs/modules/cyberark.asciidoc
+++ b/filebeat/docs/modules/cyberark.asciidoc
@@ -10,7 +10,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Cyberark module
 
-experimental[]
+deprecated::[7.13.0,"This module is deprecated. Use the <<filebeat-module-cyberarkpas,CyberArk Privileged Account Security module.>>"]
 
 This is a module for receiving Cyber-Ark logs over Syslog or a file.
 
@@ -25,7 +25,7 @@ include::../include/config-option-intro.asciidoc[]
 [float]
 ==== `corepas` fileset settings
 
-experimental[]
+deprecated::[7.13.0]
 
 NOTE: This was converted from RSA NetWitness log parser XML "cyberark" device revision 124.
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -769,6 +769,8 @@ filebeat.modules:
     #var.paths:
 
 #------------------------------ Cyber-Ark Module ------------------------------
+# The cyberark module is deprecated and will be removed in future releases.
+# Please use the Cyberark Privileged Account Security (cyberarkpas) module instead.
 - module: cyberark
   corepas:
     enabled: true

--- a/x-pack/filebeat/module/cyberark/_meta/config.yml
+++ b/x-pack/filebeat/module/cyberark/_meta/config.yml
@@ -1,3 +1,5 @@
+# The cyberark module is deprecated and will be removed in future releases.
+# Please use the Cyberark Privileged Account Security (cyberarkpas) module instead.
 - module: cyberark
   corepas:
     enabled: true

--- a/x-pack/filebeat/module/cyberark/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cyberark/_meta/docs.asciidoc
@@ -5,7 +5,7 @@
 
 == Cyberark module
 
-experimental[]
+deprecated::[7.13.0,"This module is deprecated. Use the <<filebeat-module-cyberarkpas,CyberArk Privileged Account Security module.>>"]
 
 This is a module for receiving Cyber-Ark logs over Syslog or a file.
 
@@ -20,7 +20,7 @@ include::../include/config-option-intro.asciidoc[]
 [float]
 ==== `corepas` fileset settings
 
-experimental[]
+deprecated::[7.13.0]
 
 NOTE: This was converted from RSA NetWitness log parser XML "cyberark" device revision 124.
 

--- a/x-pack/filebeat/modules.d/cyberark.yml.disabled
+++ b/x-pack/filebeat/modules.d/cyberark.yml.disabled
@@ -1,6 +1,8 @@
 # Module: cyberark
 # Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-cyberark.html
 
+# The cyberark module is deprecated and will be removed in future releases.
+# Please use the Cyberark Privileged Account Security (cyberarkpas) module instead.
 - module: cyberark
   corepas:
     enabled: true


### PR DESCRIPTION
## What does this PR do?

Marks Filebeat's cyberark module as deprecated.

## Why is it important?

The new cyberarkpas module replaces the RSA2Elk-generated cyberark.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues
- Closes: #25261 

## Screenshots

<img width="768" alt="image" src="https://user-images.githubusercontent.com/15056957/116919723-f9e82080-ac51-11eb-8663-c7e182b6696a.png">
