### PR TITLE
docs(heartbeat): add browser monitor configuration

### DIFF
--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -105,3 +105,5 @@ include::monitors/monitor-icmp.asciidoc[]
 include::monitors/monitor-tcp.asciidoc[]
 
 include::monitors/monitor-http.asciidoc[]
+
+include::monitors/monitor-browser.asciidoc[]

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -1,0 +1,74 @@
+[[monitor-browser-options]]
+=== Browser options
+
+Also see <<monitor-options>>.
+
+The options described here configure {beatname_uc} to run the synthetic
+monitoring test suites via Synthetic Agent on the chromium browser.
+
+Example configuration:
+
+[source,yaml]
+----
+- type: browser
+  id: synthetic-inline-suites
+  name: Elastic website
+  schedule: '@every 1m'
+  source:
+    inline:
+      script: |-
+        step("load homepage", async () => {
+          await page.goto('https://www.elastic.co');
+        });
+        step("hover over products menu", async () => {
+          await page.hover('css=[data-nav-item=products]');
+        });
+----
+
+[float]
+[[monitor-browser-source]]
+==== `Source`
+
+Details about the how to run the synthetic test suites.
+
+[float]
+[[monitor-source-inline]]
+==== `Inline`
+
+Runs the Synthetic test scripts that are defined inline in the configuration.
+See <<synthetics-syntax>> for more information.
+
+
+[float]
+[[monitor-source-zipendpoint]]
+==== `Zip endpoint`
+
+Remote zip endpoint configuration allows users to specify the location
+where the synthetics tests are located.
+
+Under `zip_url`, specify these options
+
+*`url`*:: Location of the synthetics project repository.
+*`folder`*:: Relative directory path where the synthetic journey files are
+located in the repository.
+*`username`*:: The username for authenticating with the zip endpoint. This setting is optional.
+*`password`*:: The password for authenticating with the zip endpoint. This setting is optional.
+
+Username and password if provided will be sent as HTTP Basic Authentication
+headers to the remote zip endpoint.
+
+Example configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: browser
+  id: todos-suites
+  name: Todos Journeys
+  schedule: '@every 1m'
+  source:
+    zip_url:
+      url: "https://github.com/elastic/synthetics/archive/refs/heads/master.zip"
+      folder: "examples/todos"
+      username: ""
+      password: ""
+-------------------------------------------------------------------------------

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -4,7 +4,7 @@
 Also see <<monitor-options>>.
 
 The options described here configure {beatname_uc} to run the synthetic
-monitoring test suites via Synthetic Agent on the chromium browser.
+monitoring test suites via Synthetic Agent on the Chromium browser.
 
 Example configuration:
 
@@ -39,9 +39,9 @@ Runs the Synthetic test scripts that are defined inline in the configuration.
 See {observability-guide}/synthetics-create-test.html[Synthetics syntax] for
 more information.
 
-The mmost convinient way to get the Synthetic test up and running, however it becomes
-harder to maintain and share code once the number of test file increases.
-Recommended way to run Synthetic suites is to create an https://docs.npmjs.com/cli/v7/commands/npm-init[NPM project] and
+This is the most convenient way to get Synthetic tests up and running, however, it becomes
+harder to maintain and share code as the number of test files increases.
+The recommended way to run Synthetic suites is to create an https://docs.npmjs.com/cli/v7/commands/npm-init[NPM project] and
 start writing individual tests for all the user journeys and save them as JavaScript or
 TypeScript files. Once the project is created, the tests can be invoked either by
 <<monitor-source-zipurl,Zip Url>> or <<monitor-source-local,Local directory>> method.
@@ -103,4 +103,3 @@ Example configuration:
     local:
       path: "/path/to/synthetics/journeys"
 -------------------------------------------------------------------------------
-

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -1,11 +1,12 @@
 [[monitor-browser-options]]
 === Browser options
 
-Also see <<monitor-options>>.
+TIP: Want to get started with synthetic monitoring?
+See the {observability-guide}/synthetics-quickstart.html[quick start guide].
 
 The options described here configure {beatname_uc} to run the synthetic
 monitoring test suites via Synthetic Agent on the Chromium browser.
-
+Additional shared options are defined in <<monitor-options>>.
 Example configuration:
 
 [source,yaml]

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -29,22 +29,33 @@ Example configuration:
 [[monitor-browser-source]]
 ==== `source`
 
-Details about the how to run the synthetic test suites.
+Contains information on how to run the synthetic test suites.
 
 [float]
 [[monitor-source-inline]]
 ===== `inline`
 
 Runs the Synthetic test scripts that are defined inline in the configuration.
-See {observability-guide}/synthetics-create-test.html[Synthetics syntax] for more information.
+See {observability-guide}/synthetics-create-test.html[Synthetics syntax] for
+more information.
 
+The mmost convinient way to get the Synthetic test up and running, however it becomes
+harder to maintain and share code once the number of test file increases.
+Recommended way to run Synthetic suites is to create an https://docs.npmjs.com/cli/v7/commands/npm-init[NPM project] and
+start writing individual tests for all the user journeys and save them as JavaScript or
+TypeScript files. Once the project is created, the tests can be invoked either by
+<<monitor-source-zipurl,Zip Url>> or <<monitor-source-local,Local directory>> method.
+
+NOTE: {beatname_uc} will use the latest compatible version(^1.0.0) of the
+https://www.npmjs.com/package/@elastic/synthetics[Synthetics NPM library] to run
+the inline journeys.
 
 [float]
-[[monitor-source-zipendpoint]]
+[[monitor-source-zipurl]]
 ===== `Zip URL`
 
 Remote zip endpoint configuration allows users to specify the location
-of a ZIP file where the synthetics tests are located.
+of a synthetics test project ZIP file.
 
 Under `zip_url`, specify these options:
 
@@ -72,3 +83,24 @@ Example configuration:
       username: ""
       password: ""
 -------------------------------------------------------------------------------
+
+
+[float]
+[[monitor-source-local]]
+===== `Local directory`
+
+Local directory where the synthetic test files are located.
+
+Example configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: browser
+  id: local-journeys
+  name: Local journeys
+  schedule: '@every 1m'
+  source:
+    local:
+      path: "/path/to/synthetics/journeys"
+-------------------------------------------------------------------------------
+

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -27,26 +27,26 @@ Example configuration:
 
 [float]
 [[monitor-browser-source]]
-==== `Source`
+==== `source`
 
 Details about the how to run the synthetic test suites.
 
 [float]
 [[monitor-source-inline]]
-==== `Inline`
+===== `inline`
 
 Runs the Synthetic test scripts that are defined inline in the configuration.
-See <<synthetics-syntax>> for more information.
+See {observability-guide}/synthetics-create-test.html[Synthetics syntax] for more information.
 
 
 [float]
 [[monitor-source-zipendpoint]]
-==== `Zip endpoint`
+===== `Zip endpoint`
 
 Remote zip endpoint configuration allows users to specify the location
-where the synthetics tests are located.
+of a ZIP file where the synthetics tests are located.
 
-Under `zip_url`, specify these options
+Under `zip_url`, specify these options:
 
 *`url`*:: Location of the synthetics project repository.
 *`folder`*:: Relative directory path where the synthetic journey files are
@@ -54,7 +54,7 @@ located in the repository.
 *`username`*:: The username for authenticating with the zip endpoint. This setting is optional.
 *`password`*:: The password for authenticating with the zip endpoint. This setting is optional.
 
-Username and password if provided will be sent as HTTP Basic Authentication
+If `username` and `password` are provided, they will be sent as HTTP Basic Authentication
 headers to the remote zip endpoint.
 
 Example configuration:

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -41,7 +41,7 @@ See {observability-guide}/synthetics-create-test.html[Synthetics syntax] for mor
 
 [float]
 [[monitor-source-zipendpoint]]
-===== `Zip endpoint`
+===== `Zip URL`
 
 Remote zip endpoint configuration allows users to specify the location
 of a ZIP file where the synthetics tests are located.


### PR DESCRIPTION
## What does this PR do?

+  Adds the new monitor type `browser` to the heartbeat docs
 
## Why is it important?

+ We have moved from Experimental to Beta and its a good time to have these docs going forward. 
