### PR TITLE
[Elastic Agent] Adjust some naming to fleet-server

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/gateway/fleet/fleet_gateway.go
+++ b/x-pack/elastic-agent/pkg/agent/application/gateway/fleet/fleet_gateway.go
@@ -159,8 +159,8 @@ func (f *fleetGateway) worker() {
 		case <-f.scheduler.WaitTick():
 			f.log.Debug("FleetGateway calling Checkin API")
 
-			// Execute the checkin call and for any errors returned by the fleet API
-			// the function will retry to communicate with fleet with an exponential delay and some
+			// Execute the checkin call and for any errors returned by the fleet-server API
+			// the function will retry to communicate with fleet-server with an exponential delay and some
 			// jitter to help better distribute the load from a fleet of agents.
 			resp, err := f.doExecute()
 			if err != nil {
@@ -199,9 +199,10 @@ func (f *fleetGateway) doExecute() (*fleetapi.CheckinResponse, error) {
 	f.backoff.Reset()
 	for f.bgContext.Err() == nil {
 		// TODO: wrap with timeout context
+		f.log.Debugf("Checking started")
 		resp, err := f.execute(f.bgContext)
 		if err != nil {
-			f.log.Errorf("Could not communicate with Checking API will retry, error: %s", err)
+			f.log.Errorf("Could not communicate with fleet-server Checking API will retry, error: %s", err)
 			if !f.backoff.Wait() {
 				return nil, errors.New(
 					"execute retry loop was stopped",

--- a/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/checkin_cmd.go
@@ -28,7 +28,7 @@ type CheckinRequest struct {
 	Metadata *info.ECSMeta       `json:"local_metadata,omitempty"`
 }
 
-// SerializableEvent is a representation of the event to be send to the Fleet API via the checkin
+// SerializableEvent is a representation of the event to be send to the Fleet Server API via the checkin
 // endpoint, we are liberal into what we accept to be send you only need a type and be able to be
 // serialized into JSON.
 type SerializableEvent interface {
@@ -78,7 +78,7 @@ func NewCheckinCmd(info agentInfo, client client.Sender) *CheckinCmd {
 	}
 }
 
-// Execute enroll the Agent in the Fleet.
+// Execute enroll the Agent in the Fleet Server.
 func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinResponse, error) {
 	if err := r.Validate(); err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (e *CheckinCmd) Execute(ctx context.Context, r *CheckinRequest) (*CheckinRe
 	resp, err := e.client.Send(ctx, "POST", cp, nil, nil, bytes.NewBuffer(b))
 	if err != nil {
 		return nil, errors.New(err,
-			"fail to checkin to fleet",
+			"fail to checkin to fleet-server",
 			errors.TypeNetwork,
 			errors.M(errors.MetaKeyURI, cp))
 	}

--- a/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd.go
@@ -74,7 +74,7 @@ func (p EnrollType) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v)
 }
 
-// EnrollRequest is the data required to enroll the elastic-agent into Fleet.
+// EnrollRequest is the data required to enroll the elastic-agent into Fleet Server.
 //
 // Example:
 // POST /api/fleet/agents/enroll
@@ -167,12 +167,12 @@ func (e *EnrollResponse) Validate() error {
 	return err
 }
 
-// EnrollCmd is the command to be executed to enroll an elastic-agent into Fleet.
+// EnrollCmd is the command to be executed to enroll an elastic-agent into Fleet Server.
 type EnrollCmd struct {
 	client client.Sender
 }
 
-// Execute enroll the Agent in the Fleet.
+// Execute enroll the Agent in the Fleet Server.
 func (e *EnrollCmd) Execute(ctx context.Context, r *EnrollRequest) (*EnrollResponse, error) {
 	const p = "/api/fleet/agents/enroll"
 	const key = "Authorization"


### PR DESCRIPTION
Updates some of the code comments and error messages to use fleet-server instead of Fleet to be more accurate.
