### PR TITLE
[Elastic Agent] Remove deprecated --kibana-url.

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -50,7 +50,6 @@ func newEnrollCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command
 
 func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("url", "", "", "URL to enroll Agent into Fleet")
-	cmd.Flags().StringP("kibana-url", "k", "", "URL of Fleet-Server to enroll Agent into Fleet-Server (deprecated)")
 	cmd.Flags().StringP("enrollment-token", "t", "", "Enrollment token to use to enroll Agent into Fleet")
 	cmd.Flags().StringP("fleet-server-es", "", "", "Start and run a Fleet Server along side this Elastic Agent connecting to the provided elasticsearch")
 	cmd.Flags().StringP("fleet-server-es-ca", "", "", "Path to certificate authority to use with communicate with elasticsearch")
@@ -70,9 +69,6 @@ func addEnrollFlags(cmd *cobra.Command) {
 func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string {
 	if url == "" {
 		url, _ = cmd.Flags().GetString("url")
-	}
-	if url == "" {
-		url, _ = cmd.Flags().GetString("kibana-url")
 	}
 	if token == "" {
 		token, _ = cmd.Flags().GetString("enrollment-token")
@@ -212,9 +208,6 @@ func enroll(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
 
 	insecure, _ := cmd.Flags().GetBool("insecure")
 	url, _ := cmd.Flags().GetString("url")
-	if url == "" {
-		url, _ = cmd.Flags().GetString("kibana-url")
-	}
 	enrollmentToken, _ := cmd.Flags().GetString("enrollment-token")
 	fServer, _ := cmd.Flags().GetString("fleet-server-es")
 	fElasticSearchCA, _ := cmd.Flags().GetString("fleet-server-es-ca")

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -94,9 +94,6 @@ func installCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error
 	enroll := true
 	askEnroll := true
 	url, _ := cmd.Flags().GetString("url")
-	if url == "" {
-		url, _ = cmd.Flags().GetString("kibana-url")
-	}
 	token, _ := cmd.Flags().GetString("enrollment-token")
 	if url != "" && token != "" {
 		askEnroll = false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Removes the `--kibana-url` from the `install` and `enroll` commands. This was original kept in to not break everyone as we switched to Fleet Server. Now with complete transition to Fleet Server this should be removed because it is confusing as it can now never point to Kibana.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So its not confusing and so that `--url` is the only way forward.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

