### PR TITLE
Cherry-pick #25516 to 7.13: Fix Insert when array is empty 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -62,6 +62,7 @@
 - Delay the restart of application when a status report of failure is given {pull}25339[25339]
 - Don't log when upgrade capability doesn't apply {pull}25386[25386]
 - Fixed issue when unversioned home is set and invoked watcher failing with ENOENT {issue}25371[25371]
+- Fixed Elastic Agent: expecting Dict and received *transpiler.Key for '0' {issue}24453[24453]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/controller.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/controller.go
@@ -142,7 +142,7 @@ func (e *Controller) update() error {
 		}
 		err = transpiler.Insert(ast, renderedInputs, "inputs")
 		if err != nil {
-			return err
+			return errors.New(err, "inserting rendered inputs failed")
 		}
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/install/uninstall.go
+++ b/x-pack/elastic-agent/pkg/agent/install/uninstall.go
@@ -253,7 +253,7 @@ func applyDynamics(ctx context.Context, log *logger.Logger, cfg *config.Config) 
 		}
 		err = transpiler.Insert(ast, renderedInputs, "inputs")
 		if err != nil {
-			return nil, err
+			return nil, errors.New("inserting rendered inputs failed", err)
 		}
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/transpiler/ast_test.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/ast_test.go
@@ -375,6 +375,184 @@ func TestAST(t *testing.T) {
 	})
 }
 
+func TestInsert(t *testing.T) {
+	testcases := map[string]struct {
+		hashmap  map[string]interface{}
+		selector Selector
+		node     Node
+		expected *AST
+	}{
+		"insert root": {
+			selector: "inputs",
+			node: NewList([]Node{
+				NewDict([]Node{
+					NewKey("type", NewStrVal("test-key")),
+				}),
+			}),
+			hashmap: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"type": "elasticsearch",
+					"host": "demo.host.co",
+				},
+			},
+			expected: &AST{
+				root: &Dict{
+					value: []Node{
+						&Key{
+							name: "inputs",
+							value: NewList([]Node{
+								NewDict([]Node{
+									NewKey("type", NewStrVal("test-key")),
+								}),
+							}),
+						},
+						&Key{
+							name: "outputs",
+							value: NewDict(
+								[]Node{
+									&Key{name: "host", value: &StrVal{value: "demo.host.co"}},
+									&Key{name: "type", value: &StrVal{value: "elasticsearch"}},
+								}),
+						},
+					},
+				},
+			},
+		},
+		"insert sub key": {
+			selector: "outputs.sub",
+			node: NewList([]Node{
+				NewDict([]Node{
+					NewKey("type", NewStrVal("test-key")),
+				}),
+			}),
+			hashmap: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"type": "elasticsearch",
+					"host": "demo.host.co",
+				},
+			},
+			expected: &AST{
+				root: &Dict{
+					value: []Node{
+						&Key{
+							name: "outputs",
+							value: NewDict(
+								[]Node{
+									&Key{name: "host", value: &StrVal{value: "demo.host.co"}},
+									&Key{name: "sub", value: NewList([]Node{
+										NewDict([]Node{
+											NewKey("type", NewStrVal("test-key")),
+										}),
+									})},
+									&Key{name: "type", value: &StrVal{value: "elasticsearch"}},
+								}),
+						},
+					},
+				},
+			},
+		},
+		"insert at index": {
+			selector: "inputs.0.sub",
+			node: NewList([]Node{
+				NewDict([]Node{
+					NewKey("type", NewStrVal("test-key")),
+				}),
+			}),
+			hashmap: map[string]interface{}{
+				"inputs": []interface{}{
+					map[string]interface{}{
+						"type":         "log/docker",
+						"ignore_older": "20s",
+					},
+				},
+			},
+			expected: &AST{
+				root: &Dict{
+					value: []Node{
+						&Key{
+							name: "inputs",
+							value: NewList(
+								[]Node{
+									NewDict([]Node{
+										NewKey("ignore_older", NewStrVal("20s")),
+										NewKey("sub", NewList([]Node{
+											NewDict([]Node{
+												NewKey("type", NewStrVal("test-key")),
+											}),
+										})),
+										NewKey("type", NewStrVal("log/docker")),
+									}),
+								}),
+						},
+					},
+				},
+			},
+		},
+
+		"insert at index when array empty": {
+			selector: "inputs.0.sub",
+			node: NewList([]Node{
+				NewDict([]Node{
+					NewKey("type", NewStrVal("test-key")),
+				}),
+			}),
+			hashmap: map[string]interface{}{
+				"inputs": make([]interface{}, 0),
+				"outputs": map[string]interface{}{
+					"type": "elasticsearch",
+					"host": "demo.host.co",
+				},
+			},
+			expected: &AST{
+				root: &Dict{
+					value: []Node{
+						&Key{
+							name: "inputs",
+							value: NewList(
+								[]Node{
+									NewDict(
+										[]Node{
+											NewKey("sub", NewList([]Node{
+												NewDict([]Node{
+													NewKey("type", NewStrVal("test-key")),
+												}),
+											})),
+										},
+									),
+								}),
+						},
+						&Key{
+							name: "outputs",
+							value: NewDict(
+								[]Node{
+									NewKey("host", &StrVal{value: "demo.host.co"}),
+									NewKey("type", &StrVal{value: "elasticsearch"}),
+								}),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range testcases {
+		t.Run(name, func(t *testing.T) {
+			ast, err := NewAST(test.hashmap)
+			require.NoError(t, err)
+
+			err = Insert(ast, test.node, test.selector)
+			require.NoError(t, err)
+
+			if !assert.True(t, reflect.DeepEqual(test.expected, ast)) {
+				t.Logf(
+					`received: %+v
+					 expected: %+v`, ast, test.expected)
+			}
+
+		})
+	}
+}
+
 func TestSelector(t *testing.T) {
 	testcases := map[string]struct {
 		hashmap  map[string]interface{}

--- a/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
@@ -192,7 +192,12 @@ type SelectIntoRule struct {
 }
 
 // Apply applies select into rule.
-func (r *SelectIntoRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *SelectIntoRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to select data into configuration")
+		}
+	}()
 	target := &Dict{}
 
 	for _, selector := range r.Selectors {
@@ -225,7 +230,13 @@ type RemoveKeyRule struct {
 }
 
 // Apply applies remove key rule.
-func (r *RemoveKeyRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *RemoveKeyRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to remove key from configuration")
+		}
+	}()
+
 	sourceMap, ok := ast.root.(*Dict)
 	if !ok {
 		return nil
@@ -261,7 +272,13 @@ type MakeArrayRule struct {
 }
 
 // Apply applies make array rule.
-func (r *MakeArrayRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *MakeArrayRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to create Dictionary out of configuration")
+		}
+	}()
+
 	sourceNode, found := Lookup(ast, r.Item)
 	if !found {
 		return nil
@@ -297,7 +314,13 @@ type CopyToListRule struct {
 }
 
 // Apply copies specified node into every item of the list.
-func (r *CopyToListRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *CopyToListRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to copy segment into configuration")
+		}
+	}()
+
 	sourceNode, found := Lookup(ast, r.Item)
 	if !found {
 		// nothing to copy
@@ -358,7 +381,13 @@ type CopyAllToListRule struct {
 }
 
 // Apply copies all nodes into every item of the list.
-func (r *CopyAllToListRule) Apply(agentInfo AgentInfo, ast *AST) error {
+func (r *CopyAllToListRule) Apply(agentInfo AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to copy all nodes into a list")
+		}
+	}()
+
 	// get list of nodes
 	astMap, err := ast.Map()
 	if err != nil {
@@ -404,7 +433,13 @@ type FixStreamRule struct {
 }
 
 // Apply stream fixes.
-func (r *FixStreamRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *FixStreamRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to fix stream section of configuration")
+		}
+	}()
+
 	const defaultDataset = "generic"
 	const defaultNamespace = "default"
 
@@ -537,7 +572,13 @@ type InjectIndexRule struct {
 }
 
 // Apply injects index into input.
-func (r *InjectIndexRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *InjectIndexRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to inject index into configuration")
+		}
+	}()
+
 	inputsNode, found := Lookup(ast, "inputs")
 	if !found {
 		return nil
@@ -594,7 +635,13 @@ type InjectStreamProcessorRule struct {
 }
 
 // Apply injects processor into input.
-func (r *InjectStreamProcessorRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *InjectStreamProcessorRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to add stream processor to configuration")
+		}
+	}()
+
 	inputsNode, found := Lookup(ast, "inputs")
 	if !found {
 		return nil
@@ -680,7 +727,13 @@ func InjectStreamProcessor(onMerge, streamType string) *InjectStreamProcessorRul
 type InjectAgentInfoRule struct{}
 
 // Apply injects index into input.
-func (r *InjectAgentInfoRule) Apply(agentInfo AgentInfo, ast *AST) error {
+func (r *InjectAgentInfoRule) Apply(agentInfo AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to inject agent information into configuration")
+		}
+	}()
+
 	inputsNode, found := Lookup(ast, "inputs")
 	if !found {
 		return nil
@@ -747,7 +800,13 @@ type ExtractListItemRule struct {
 }
 
 // Apply extracts items from array.
-func (r *ExtractListItemRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *ExtractListItemRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to extract items from configuration")
+		}
+	}()
+
 	node, found := Lookup(ast, r.Path)
 	if !found {
 		return nil
@@ -808,7 +867,13 @@ type RenameRule struct {
 
 // Apply renames the last items of a Selector to a new name and keep all the other values and will
 // return an error on failure.
-func (r *RenameRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *RenameRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to rename section of configuration")
+		}
+	}()
+
 	// Skip rename when node is not found.
 	node, ok := Lookup(ast, r.From)
 	if !ok {
@@ -841,7 +906,13 @@ func Copy(from, to Selector) *CopyRule {
 }
 
 // Apply copy a part of a tree into a new destination.
-func (r CopyRule) Apply(_ AgentInfo, ast *AST) error {
+func (r CopyRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to copy section of configuration")
+		}
+	}()
+
 	node, ok := Lookup(ast, r.From)
 	// skip when the `from` node is not found.
 	if !ok {
@@ -868,7 +939,13 @@ func Translate(path Selector, mapper map[string]interface{}) *TranslateRule {
 }
 
 // Apply translates matching elements of a translation table for a specific selector.
-func (r *TranslateRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *TranslateRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to translate elements of configuration")
+		}
+	}()
+
 	// Skip translate when node is not found.
 	node, ok := Lookup(ast, r.Path)
 	if !ok {
@@ -941,7 +1018,13 @@ func TranslateWithRegexp(path Selector, re *regexp.Regexp, with string) *Transla
 }
 
 // Apply translates matching elements of a translation table for a specific selector.
-func (r *TranslateWithRegexpRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *TranslateWithRegexpRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to translate elements of configuration using regex")
+		}
+	}()
+
 	// Skip translate when node is not found.
 	node, ok := Lookup(ast, r.Path)
 	if !ok {
@@ -982,7 +1065,13 @@ func Map(path Selector, rules ...Rule) *MapRule {
 }
 
 // Apply maps multiples rules over a subset of the tree.
-func (r *MapRule) Apply(agentInfo AgentInfo, ast *AST) error {
+func (r *MapRule) Apply(agentInfo AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to apply multiple rules on configuration")
+		}
+	}()
+
 	node, ok := Lookup(ast, r.Path)
 	// Skip map  when node is not found.
 	if !ok {
@@ -1119,9 +1208,14 @@ func Filter(selectors ...Selector) *FilterRule {
 }
 
 // Apply filters a Tree based on list of selectors.
-func (r *FilterRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *FilterRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to filter subset of configuration")
+		}
+	}()
+
 	mergedAST := &AST{root: &Dict{}}
-	var err error
 	for _, selector := range r.Selectors {
 		newAST, ok := Select(ast.Clone(), selector)
 		if !ok {
@@ -1149,7 +1243,13 @@ func FilterValues(selector Selector, key Selector, values ...interface{}) *Filte
 }
 
 // Apply filters a Tree based on list of selectors.
-func (r *FilterValuesRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *FilterValuesRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to filter section based on values from configuration")
+		}
+	}()
+
 	node, ok := Lookup(ast, r.Selector)
 	// Skip map  when node is not found.
 	if !ok {
@@ -1262,7 +1362,13 @@ func (r *FilterValuesWithRegexpRule) UnmarshalYAML(unmarshal func(interface{}) e
 }
 
 // Apply filters a Tree based on list of selectors.
-func (r *FilterValuesWithRegexpRule) Apply(_ AgentInfo, ast *AST) error {
+func (r *FilterValuesWithRegexpRule) Apply(_ AgentInfo, ast *AST) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.New(err, "failed to filter section of configuration using regex")
+		}
+	}()
+
 	node, ok := Lookup(ast, r.Selector)
 	// Skip map  when node is not found.
 	if !ok {


### PR DESCRIPTION
Cherry-pick of PR #25516 to 7.13 branch. Original message:

## What does this PR do?

Calling Insert on `inputs.0.sub` fails when array we're inserting into is empty. 
This PRs handles this and creates a node instead.
If the inserted node is not needed it's excluded using type filter later on. 

## Why is it important?

https://github.com/elastic/beats/issues/24453

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


cc @michel-laterman 
