### PR TITLE
Enable TestConfigurableFailed as logging behaviour has changed

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -139,10 +139,6 @@ func TestConfigurableRun(t *testing.T) {
 }
 
 func TestConfigurableFailed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Flaky test (windows): https://github.com/elastic/beats/issues/25424")
-	}
-
 	p := getProgram("configurable", "1.0")
 
 	operator := getTestOperator(t, downloadPath, installPath, p)


### PR DESCRIPTION
## What does this PR do?

This PR enables the flaky test `TestConfigurableFailed` as the source of the problem has been eliminated. Now Agent does not renames rotated log files, but creates a new one and adds the date as the suffix.

## Why is it important?

Tests should not be flaky.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes #25424
