### PR TITLE
[Elastic Agent] Fix AckBatch to do nothing when no actions passed.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -62,6 +62,7 @@
 - Don't log when upgrade capability doesn't apply {pull}25386[25386]
 - Fixed issue when unversioned home is set and invoked watcher failing with ENOENT {issue}25371[25371]
 - Fixed Elastic Agent: expecting Dict and received *transpiler.Key for '0' {issue}24453[24453]
+- Fix AckBatch to do nothing when no actions passed {pull}25562[25562]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker.go
@@ -79,6 +79,11 @@ func (f *Acker) AckBatch(ctx context.Context, actions []fleetapi.Action) error {
 		ids = append(ids, action.ID())
 	}
 
+	if len(events) == 0 {
+		// no events to send (nothing to do)
+		return nil
+	}
+
 	cmd := fleetapi.NewAckCmd(f.agentInfo, f.client)
 	req := &fleetapi.AckRequest{
 		Events: events,

--- a/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 )
 
-func TestAcker(t *testing.T) {
+func TestAcker_AckCommit(t *testing.T) {
 	type ackRequest struct {
 		Events []fleetapi.AckEvent `json:"events"`
 	}
@@ -66,6 +66,80 @@ func TestAcker(t *testing.T) {
 	}
 	if err := acker.Commit(context.Background()); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestAcker_AckBatch(t *testing.T) {
+	type ackRequest struct {
+		Events []fleetapi.AckEvent `json:"events"`
+	}
+
+	log, _ := logger.New("fleet_acker", false)
+	client := newTestingClient()
+	agentInfo := &testAgentInfo{}
+	acker, err := NewAcker(log, agentInfo, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if acker == nil {
+		t.Fatal("acker not initialized")
+	}
+
+	testID1 := "ack-test-action-id-1"
+	testAction1 := &fleetapi.ActionUnknown{ActionID: testID1}
+	testID2 := "ack-test-action-id-2"
+	testAction2 := &fleetapi.ActionUnknown{ActionID: testID2}
+
+	ch := client.Answer(func(headers http.Header, body io.Reader) (*http.Response, error) {
+		content, err := ioutil.ReadAll(body)
+		assert.NoError(t, err)
+		cr := &ackRequest{}
+		err = json.Unmarshal(content, &cr)
+		assert.NoError(t, err)
+
+		assert.EqualValues(t, 2, len(cr.Events))
+		assert.EqualValues(t, testID1, cr.Events[0].ActionID)
+		assert.EqualValues(t, testID2, cr.Events[1].ActionID)
+
+		resp := wrapStrToResp(http.StatusOK, `{ "actions": [] }`)
+		return resp, nil
+	})
+
+	go func() {
+		for range ch {
+		}
+	}()
+
+	if err := acker.AckBatch(context.Background(), []fleetapi.Action{testAction1, testAction2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := acker.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAcker_AckBatch_Empty(t *testing.T) {
+	log, _ := logger.New("fleet_acker", false)
+	client := newNotCalledClient()
+	agentInfo := &testAgentInfo{}
+	acker, err := NewAcker(log, agentInfo, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if acker == nil {
+		t.Fatal("acker not initialized")
+	}
+
+	if err := acker.AckBatch(context.Background(), []fleetapi.Action{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := acker.Commit(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if client.called {
+		t.Fatal("client should not have been used")
 	}
 }
 
@@ -121,4 +195,31 @@ func wrapStrToResp(code int, body string) *http.Response {
 		ContentLength: int64(len(body)),
 		Header:        make(http.Header),
 	}
+}
+
+type notCalledClient struct {
+	sync.Mutex
+	called bool
+}
+
+func (t *notCalledClient) Send(
+	_ context.Context,
+	method string,
+	path string,
+	params url.Values,
+	headers http.Header,
+	body io.Reader,
+) (*http.Response, error) {
+	t.Lock()
+	defer t.Unlock()
+	t.called = true
+	return nil, fmt.Errorf("should not have been called")
+}
+
+func (t *notCalledClient) URI() string {
+	return "http://localhost"
+}
+
+func newNotCalledClient() *notCalledClient {
+	return &notCalledClient{}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes issue where Elastic Agent errors after un-enrollment. This occurred because `AckBatch` was called and performed an API call even when there were no events to push. The API keys at that point were already invalidated so it placed Elastic Agent in a bad state.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So `AckBatch` doesn't perform an API call when there are no actions to push.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #25561
