### PR TITLE
[Heartbeat] Disable default monitor from heartbeat.yml for agent compat

### DIFF
--- a/heartbeat/_meta/config/beat.yml.tmpl
+++ b/heartbeat/_meta/config/beat.yml.tmpl
@@ -22,6 +22,8 @@ heartbeat.config.monitors:
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
+  # Set enabled to true (or delete the following line) to enable this example monitor
+  enabled: false
   # ID used to uniquely identify this monitor in elasticsearch even if the config changes
   id: my-monitor
   # Human readable display name for this service in Uptime UI and elsewhere

--- a/heartbeat/heartbeat.yml
+++ b/heartbeat/heartbeat.yml
@@ -22,6 +22,8 @@ heartbeat.config.monitors:
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
+  # Set enabled to true (or delete the following line) to enable this example monitor
+  enabled: false
   # ID used to uniquely identify this monitor in elasticsearch even if the config changes
   id: my-monitor
   # Human readable display name for this service in Uptime UI and elsewhere

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -22,6 +22,8 @@ heartbeat.config.monitors:
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
+  # Set enabled to true (or delete the following line) to enable this example monitor
+  enabled: false
   # ID used to uniquely identify this monitor in elasticsearch even if the config changes
   id: my-monitor
   # Human readable display name for this service in Uptime UI and elsewhere


### PR DESCRIPTION
Agent will use the default config files, this is a problem as fleet users will have an unwanted "My Monitor" monitor. To solve this we disable this monitor by default now.

I don't believe this really needs a changelog entry, as it is essentially a docs change. No one should be depending on the old file.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
