### PR TITLE
[automation] update elastic stack version for testing 7.14.0-8ba10577

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.14.0-5b4d7537-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.14.0-8ba10577-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -15,7 +15,7 @@ services:
     - "http.host=0.0.0.0"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.14.0-5b4d7537-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.14.0-8ba10577-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -25,7 +25,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.14.0-5b4d7537-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.14.0-8ba10577-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-5b4d7537-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-8ba10577-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -19,7 +19,7 @@ services:
     - "ingest.geoip.downloader.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.14.0-5b4d7537-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.14.0-8ba10577-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -29,7 +29,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.14.0-5b4d7537-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.14.0-8ba10577-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 6 May 2021 05:20:40 GMT, release_branch:7.x, prefix:, end_time:Thu, 6 May 2021 10:30:52 GMT, manifest_version:2.0.0, version:7.14.0-SNAPSHOT, branch:7.x, build_id:7.14.0-8ba10577, build_duration_seconds:18612]