### PR TITLE
Reduce Winlogbeat info log level verbosity

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -1020,6 +1020,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add dns.question.subdomain fields for sysmon DNS events. {pull}22999[22999]
 - Add dns.question.top_level_domain fields for sysmon DNS events. {pull}23046[23046]
 - Add support for sysmon v13 events 24 and 25. {issue}24217[24217] {pull}24945[24945]
+- Changed the log level of the "Successfully published events" message from `info` to `debug` to reduce verbosity of the `info` logging level. To track event log reader activity use the `published_events` metric. {pull}25617[25617]
 
 *Elastic Log Driver*
 

--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -39,6 +39,7 @@ type eventLogger struct {
 	eventMeta  common.EventMetadata
 	processors beat.ProcessorList
 	keepNull   bool
+	log        *logp.Logger
 }
 
 type eventLoggerConfig struct {
@@ -55,6 +56,7 @@ func newEventLogger(
 	beatInfo beat.Info,
 	source eventlog.EventLog,
 	options *common.Config,
+	log *logp.Logger,
 ) (*eventLogger, error) {
 	config := eventLoggerConfig{}
 	if err := options.Unpack(&config); err != nil {
@@ -70,11 +72,11 @@ func newEventLogger(
 		source:     source,
 		eventMeta:  config.EventMetadata,
 		processors: processors,
+		log:        log.With("id", source.Name()),
 	}, nil
 }
 
 func (e *eventLogger) connect(pipeline beat.Pipeline) (beat.Client, error) {
-	api := e.source.Name()
 	return pipeline.ConnectWith(beat.ClientConfig{
 		PublishMode: beat.GuaranteedSend,
 		Processing: beat.ProcessingConfig{
@@ -84,8 +86,8 @@ func (e *eventLogger) connect(pipeline beat.Pipeline) (beat.Client, error) {
 			KeepNull:      e.keepNull,
 		},
 		ACKHandler: acker.Counting(func(n int) {
-			addPublished(api, n)
-			logp.Info("EventLog[%s] successfully published %d events", api, n)
+			addPublished(e.source.Name(), n)
+			e.log.Debugw("Successfully published events.", "event.count", n)
 		}),
 	})
 }
@@ -107,8 +109,7 @@ func (e *eventLogger) run(
 
 	client, err := e.connect(pipeline)
 	if err != nil {
-		logp.Warn("EventLog[%s] Pipeline error. Failed to connect to publisher pipeline",
-			api.Name())
+		e.log.Warnw("Pipeline error. Failed to connect to publisher pipeline", "error", err)
 		return
 	}
 
@@ -121,20 +122,19 @@ func (e *eventLogger) run(
 
 	err = api.Open(state)
 	if err != nil {
-		logp.Warn("EventLog[%s] Open() error. No events will be read from "+
-			"this source. %v", api.Name(), err)
+		e.log.Warnw("Open() error. No events will be read from this source.", "error", err)
 		return
 	}
 	defer func() {
-		logp.Info("EventLog[%s] Stop processing.", api.Name())
+		e.log.Info("Stop processing.")
 
 		if err := api.Close(); err != nil {
-			logp.Warn("EventLog[%s] Close() error. %v", api.Name(), err)
+			e.log.Warnw("Close() error.", "error", err)
 			return
 		}
 	}()
 
-	debugf("EventLog[%s] opened successfully", api.Name())
+	e.log.Debug("Opened successfully.")
 
 	for stop := false; !stop; {
 		select {
@@ -151,11 +151,11 @@ func (e *eventLogger) run(
 			// Graceful stop.
 			stop = true
 		default:
-			logp.Warn("EventLog[%s] Read() error: %v", api.Name(), err)
+			e.log.Warnw("Read() error.", "error", err)
 			return
 		}
 
-		debugf("EventLog[%s] Read() returned %d records", api.Name(), len(records))
+		e.log.Debugf("Read() returned %d records.", len(records))
 		if len(records) == 0 {
 			time.Sleep(time.Second)
 			continue

--- a/winlogbeat/tests/system/test_config.py
+++ b/winlogbeat/tests/system/test_config.py
@@ -62,7 +62,7 @@ class Test(BaseTest, common_tests.TestExportsMixin):
             ]
         )
         self.run_config_tst(exit_code=1)
-        assert self.log_contains("Failed to create new event log. "
+        assert self.log_contains("failed to create new event log: "
                                  "file API is not available")
 
     def run_config_tst(self, pcap=None, exit_code=0):


### PR DESCRIPTION
## What does this PR do?

Change the logging level of "Successfully published %d events" from info to debug.
If you want to track progress of an event logger you can enable debug for the
`winlogbeat` selector. Or the preferred method is to use the `published_events`
metric that is visible in the logs periodically or through the HTTP monitoring endpoint.

This also updates the code in the beater package to use a package level logger instead
of the deprecated global logp functions.

## Why is it important?

The info log level was extremely verbose on systems with lots of Windows event logs. Monitoring metrics is the preferred way to track logger activity. It also created logging loop when the `logging.to_eventlog: true` option was used.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

