### PR TITLE
[Filebeat] Additional utfbom fixes

### DIFF
--- a/libbeat/reader/readfile/encode.go
+++ b/libbeat/reader/readfile/encode.go
@@ -52,10 +52,16 @@ func NewEncodeReader(r io.ReadCloser, config Config) (EncoderReader, error) {
 // This converts a io.Reader to a reader.reader
 func (r EncoderReader) Next() (reader.Message, error) {
 	c, sz, err := r.reader.Next()
+	// remove UTF8 mark
+	ct := bytes.Trim(c, "\xef\xbb\xbf")
+	// remove UTF16BE mark
+	ct = bytes.Trim(ct, "\xfe\xff")
+	// remove UTF16LE mark
+	ct = bytes.Trim(ct, "\xff\xfe")
 	// Creating message object
 	return reader.Message{
 		Ts:      time.Now(),
-		Content: bytes.Trim(c, "\xef\xbb\xbf"),
+		Content: ct,
 		Bytes:   sz,
 	}, err
 }

--- a/libbeat/reader/readfile/encode_test.go
+++ b/libbeat/reader/readfile/encode_test.go
@@ -32,11 +32,17 @@ func TestEncodeLines(t *testing.T) {
 		Input  []byte
 		Output []string
 	}{
-		"simple":            {[]byte("testing simple line\n"), []string{"testing simple line\n"}},
-		"multiline":         {[]byte("testing\nmultiline\n"), []string{"testing\n", "multiline\n"}},
-		"bom-on-first":      {[]byte("\xef\xbb\xbftesting simple line\n"), []string{"testing simple line\n"}},
-		"bom-on-each":       {[]byte("\xef\xbb\xbftesting\n\xef\xbb\xbfmultiline\n"), []string{"testing\n", "multiline\n"}},
-		"bom-in-the-middle": {[]byte("testing simple \xef\xbb\xbfline\n"), []string{"testing simple \xef\xbb\xbfline\n"}},
+		"simple":                {[]byte("testing simple line\n"), []string{"testing simple line\n"}},
+		"multiline":             {[]byte("testing\nmultiline\n"), []string{"testing\n", "multiline\n"}},
+		"bom-on-first":          {[]byte("\xef\xbb\xbftesting simple line\n"), []string{"testing simple line\n"}},
+		"bom-on-each":           {[]byte("\xef\xbb\xbftesting\n\xef\xbb\xbfmultiline\n"), []string{"testing\n", "multiline\n"}},
+		"bom-in-the-middle":     {[]byte("testing simple \xef\xbb\xbfline\n"), []string{"testing simple \xef\xbb\xbfline\n"}},
+		"bom16be-on-first":      {[]byte("\xfe\xfftesting simple line\n"), []string{"testing simple line\n"}},
+		"bom16be-on-each":       {[]byte("\xfe\xfftesting\n\xfe\xffmultiline\n"), []string{"testing\n", "multiline\n"}},
+		"bom16be-in-the-middle": {[]byte("testing simple \xfe\xffline\n"), []string{"testing simple \xfe\xffline\n"}},
+		"bom16le-on-first":      {[]byte("\xff\xfetesting simple line\n"), []string{"testing simple line\n"}},
+		"bom16le-on-each":       {[]byte("\xff\xfetesting\n\xff\xfemultiline\n"), []string{"testing\n", "multiline\n"}},
+		"bom16le-in-the-middle": {[]byte("testing simple \xff\xfeline\n"), []string{"testing simple \xff\xfeline\n"}},
 	}
 
 	bufferSize := 1000


### PR DESCRIPTION
Please label this PR with one of the following labels, depending on the scope:
- Bug
- Enhancement

## What does this PR do?

Removes additional UTF marks in logs files:
* UTF16BE
* UTF16LE 

## Why is it important?

This fix several errors with some microsoft log files (ex. MS SQL Server 2019).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Relates #1349 
