### PR TITLE
[mergify] automerge PRs for mergify prs with auto-bumps

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,7 +55,17 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
-  - name: Automatic squash and merge with success checks and the files matching the regex ^testing/environments/snapshot* are modified.
+  - name: automatic approval for mergify pull requests with bump updates
+    conditions:
+      - author~=^mergify(|-preview)\[bot\]$
+      - check-success=beats-ci/pr-merge
+      - label=automation
+      - files~=^testing/environments/snapshot.*\.yml$
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving mergify
+  - name: automatic squash and merge with success checks and the files matching the regex ^testing/environments/snapshot* are modified.
     conditions:
       - check-success=beats-ci/pr-merge
       - label=automation

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -57,7 +57,7 @@ pull_request_rules:
             ```
   - name: automatic approval for mergify pull requests with bump updates
     conditions:
-      - author~=^mergify(|-preview)\[bot\]$
+      - author=mergify[bot]
       - check-success=beats-ci/pr-merge
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$


### PR DESCRIPTION
## What does this PR do?

Enable auto-merge when the branch protection requires a review. See [review example](https://docs.mergify.io/actions/review/) in mergify.

The suggested approach was also to enable `mergify` in the list of users to merge -> https://docs.mergify.io/faq/#mergify-is-unable-to-merge-my-pull-request-due-to-my-branch-protection-settings. But it might somehow the other users to be restricted, so let's avoid that particular case

## Why is it important?

Otherwise the bump update automation will require manual actions anyway
