### PR TITLE
Update FreeBSD vagrantbox

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -250,6 +250,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix panic when overwriting metadata {pull}24741[24741]
 - Fix role_arn to work with access keys for AWS. {pull}25446[25446]
 - Fix `community_id` processor so that ports greater than 65535 aren't valid. {pull}25409[25409]
+- Fix out of date FreeBSD vagrantbox. {pull}25652[25652]
 
 *Auditbeat*
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -121,7 +121,7 @@ SCRIPT
 
 
 # Linux GVM
-def linuxGvmProvision(arch="amd64", os="linux")
+def GvmProvision(arch="amd64", os="linux")
   return <<SCRIPT
 mkdir -p ~/bin
 if [ ! -e "~/bin/gvm" ]; then
@@ -182,7 +182,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2223, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: "yum install -y make gcc git rpm-devel epel-release"
     c.vm.provision "shell", inline: "yum install -y python34 python34-pip"
   end
@@ -192,7 +192,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2224, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: "yum install -y make gcc python3 python3-pip git rpm-devel"
   end
 
@@ -201,7 +201,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2225, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: "yum install -y make gcc python3 python3-pip git rpm-devel"
   end
 
@@ -210,7 +210,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2226, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: "apt-get update && apt-get install -y make gcc python3 python3-pip python3.4-venv git"
   end
 
@@ -219,7 +219,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2227, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: linuxDebianProvision
   end
 
@@ -228,7 +228,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2228, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: linuxDebianProvision
   end
 
@@ -237,7 +237,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2229, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: linuxDebianProvision
   end
 
@@ -246,7 +246,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2231, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: linuxDebianProvision
   end
 
@@ -255,7 +255,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2232, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: linuxDebianProvision
   end
 
@@ -264,7 +264,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2233, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: linuxDebianProvision
   end
 
@@ -273,7 +273,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2234, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: "yum install -y make gcc python3 python3-pip git rpm-devel"
   end
 
@@ -282,7 +282,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2235, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: "yum install -y make gcc python3 python3-pip git rpm-devel"
   end
 
@@ -306,7 +306,7 @@ Vagrant.configure("2") do |config|
     c.vm.hostname = "beats-tester"
     c.vm.provision "shell", inline: $unixProvision, privileged: false
     c.vm.provision "shell", inline: $freebsdShellUpdate, privileged: true
-    c.vm.provision "shell", inline: linuxGvmProvision(arch="amd64", os="freebsd"), privileged: false
+    c.vm.provision "shell", inline: GvmProvision(arch="amd64", os="freebsd"), privileged: false
   end
 
   # OpenBSD 5.9-stable
@@ -328,7 +328,7 @@ Vagrant.configure("2") do |config|
     c.vm.network :forwarded_port, guest: 22, host: 2239, id: "ssh", auto_correct: true
 
     c.vm.provision "shell", inline: $unixProvision, privileged: false
-    c.vm.provision "shell", inline: linuxGvmProvision, privileged: false
+    c.vm.provision "shell", inline: GvmProvision, privileged: false
     c.vm.provision "shell", inline: "pacman -Sy && pacman -S --noconfirm make gcc python python-pip git"
   end
 end


### PR DESCRIPTION
## What does this PR do?

The FreeBSD vagrantbox is borderline broken and very out of date. I've started a major refactor of the system integration, so I need an easy way to test against a variety of OSes.

This both updates to a newer version of FreeBSD, and fixes the weird non-working NFS share in favor of an rsync share. I spent the better part of my day trying, and failing to get NFS working on this, so the most I can do is update this with my workaround.

## Why is it important?

FreeBSD should work.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

- Pull down on a host with Vagrant installed
- In the beats directory, run `vagrant up freebsd`
- Make sure everything comes up happily, and the BSD vm has a working go install.
