### PR TITLE
Cherry-pick #25656 to 7.13: Disable flaky test 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -139,6 +139,9 @@ func TestConfigurableRun(t *testing.T) {
 }
 
 func TestConfigurableFailed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("this test is sometimes flaky on the last part, investigating @michal")
+	}
 	p := getProgram("configurable", "1.0")
 
 	operator := getTestOperator(t, downloadPath, installPath, p)


### PR DESCRIPTION
Cherry-pick of PR #25656 to 7.13 branch. Original message:

## What does this PR do?

Disable `TestConfigurationFailed` test. i'm working on repro and looking for issue but it is not hitting this condition locally as often as on CI, so disabling to unblock PRs

## Why is it important?

Unblock PRs

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
