### PR TITLE
Add breaking changes for 7.13

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.13.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.13.asciidoc
@@ -1,0 +1,18 @@
+[[breaking-changes-7.13]]
+
+=== Breaking changes in 7.13
+++++
+<titleabbrev>7.13</titleabbrev>
+++++
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+
+coming[7.13]
+
+// end::notable-breaking-changes[]
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.13>>
+
 * <<breaking-changes-7.12>>
 
 * <<breaking-changes-7.11>>
@@ -37,6 +39,7 @@ See the following topics for a description of breaking changes:
 
 * <<breaking-changes-7.0>>
 
+include::breaking-7.13.asciidoc[]
 
 include::breaking-7.12.asciidoc[]
 


### PR DESCRIPTION
Adds a placeholder topic for breaking changes in 7.13.

TODO:

- [ ] After merging, activate the link in the stack upgrade guide.