### PR TITLE
[Elastic Agent] Do not apply config if newer is available during restart 

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator_test.go
@@ -139,9 +139,6 @@ func TestConfigurableRun(t *testing.T) {
 }
 
 func TestConfigurableFailed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("this test is sometimes flaky on the last part, investigating @michal")
-	}
 	p := getProgram("configurable", "1.0")
 
 	operator := getTestOperator(t, downloadPath, installPath, p)

--- a/x-pack/elastic-agent/pkg/core/plugin/process/start.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/start.go
@@ -56,7 +56,7 @@ func (a *Application) start(ctx context.Context, t app.Taggable, cfg map[string]
 	if srvState != nil {
 		a.setState(state.Starting, "Starting", nil)
 		srvState.SetStatus(proto.StateObserved_STARTING, a.state.Message, a.state.Payload)
-		srvState.UpdateConfig(string(cfgStr))
+		srvState.UpdateConfig(srvState.Config())
 	} else {
 		a.srvState, err = a.srv.Register(a, string(cfgStr))
 		if err != nil {

--- a/x-pack/elastic-agent/pkg/core/plugin/process/status.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/status.go
@@ -74,7 +74,7 @@ func (a *Application) startFailedTimer(cfg map[string]interface{}) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			a.restart(a.restartConfig)
+			a.restart()
 		}
 	}()
 }
@@ -91,7 +91,7 @@ func (a *Application) stopFailedTimer() {
 }
 
 // restart restarts the application
-func (a *Application) restart(cfg map[string]interface{}) {
+func (a *Application) restart() {
 	a.appLock.Lock()
 	defer a.appLock.Unlock()
 
@@ -103,7 +103,7 @@ func (a *Application) restart(cfg map[string]interface{}) {
 	ctx := a.startContext
 	tag := a.tag
 
-	err := a.start(ctx, tag, cfg)
+	err := a.start(ctx, tag, a.restartConfig)
 	if err != nil {
 		a.setState(state.Crashed, fmt.Sprintf("failed to restart: %s", err), nil)
 	}

--- a/x-pack/elastic-agent/pkg/core/plugin/service/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/service/app.go
@@ -166,7 +166,7 @@ func (a *Application) Start(ctx context.Context, _ app.Taggable, cfg map[string]
 	if a.srvState != nil {
 		a.setState(state.Starting, "Starting", nil)
 		a.srvState.SetStatus(proto.StateObserved_STARTING, a.state.Message, a.state.Payload)
-		a.srvState.UpdateConfig(string(cfgStr))
+		a.srvState.UpdateConfig(a.srvState.Config())
 	} else {
 		a.setState(state.Starting, "Starting", nil)
 		a.srvState, err = a.srv.Register(a, string(cfgStr))


### PR DESCRIPTION
## What does this PR do?

Theory is that there is a very rare condition when restart and pushConfig has a race and config used in restart overwrites the one used with push. 

## Why is it important?

Fixes: #25637

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
