### PR TITLE
[Elastic Agent] Handle case where policy doesn't contain Fleet connection information

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -65,6 +65,7 @@
 - Fixed Elastic Agent: expecting Dict and received *transpiler.Key for '0' {issue}24453[24453]
 - Fix AckBatch to do nothing when no actions passed {pull}25562[25562]
 - Add error log entry when listener creation fails {issue}23483[23482]
+- Handle case where policy doesn't contain Fleet connection information {pull}25707[25707]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
@@ -100,6 +100,14 @@ func (h *PolicyChange) handleFleetServerHosts(ctx context.Context, c *config.Con
 	if len(h.setters) == 0 {
 		return nil
 	}
+	data, err := c.ToMapStr()
+	if err != nil {
+		return errors.New(err, "could not convert the configuration from the policy", errors.TypeConfig)
+	}
+	if _, ok := data["fleet"]; !ok {
+		// no fleet information in the configuration (skip checking client)
+		return nil
+	}
 
 	cfg, err := configuration.NewFromConfig(c)
 	if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Ensures that the client connection to Fleet Server is only updated if the policy has `fleet.*`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Fixes #25586 because of kibana issue https://github.com/elastic/kibana/issues/100050

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #25586 
