### PR TITLE
Add multiline support to awss3 input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -854,6 +854,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update PanOS module to parse Global Protect & User ID logs. {issue}24722[24722] {issue}24724[24724] {pull}24927[24927]
 - Add HMAC signature validation support for http_endpoint input. {pull}24918[24918]
 - Add new grok pattern for iptables module for Ubiquiti UDM {issue}25615[25615] {pull}25616[25616]
+- Add multiline support to aws-s3 input. {issue}25249[25249] {pull}25710[25710]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -47,14 +47,14 @@ is 0 seconds. The maximum is half of the visibility timeout value.
 ==== `buffer_size`
 
 The size in bytes of the buffer that each harvester uses when fetching a file.
-This only applies to non JSON logs.
+This only applies to non-JSON logs.
 The default is 16384.
 
 [float]
 ==== `encoding`
 
 The file encoding to use for reading data that contains international
-characters. This only applies to non JSON logs.  See <<_encoding_5>>.
+characters. This only applies to non-JSON logs.  See <<_encoding_5>>.
 
 
 [float]
@@ -126,7 +126,7 @@ Enabling this option changes the service name from `s3` to `s3-fips` for connect
 The maximum number of bytes that a single log message can have. All
 bytes after `max_bytes` are discarded and not sent. This setting is
 especially useful for multiline log messages, which can get
-large. This only applies to non JSON logs.  The default is 10MB
+large. This only applies to non-JSON logs.  The default is 10MB
 (10485760).
 
 [float]
@@ -138,8 +138,10 @@ Valid values: 1 to 10. Default: 5.
 [float]
 ==== `multiline`
 
+beta[]
+
 Options that control how {beatname_uc} deals with log messages that
-span multiple lines. This only applies to non JSON logs.  See
+span multiple lines. This only applies to non-JSON logs.  See
 <<multiline-examples>> for more information about configuring
 multiline options.
 

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -44,6 +44,20 @@ The default AWS API call timeout for a message is 120 seconds. The minimum
 is 0 seconds. The maximum is half of the visibility timeout value.
 
 [float]
+==== `buffer_size`
+
+The size in bytes of the buffer that each harvester uses when fetching a file.
+This only applies to non JSON logs.
+The default is 16384.
+
+[float]
+==== `encoding`
+
+The file encoding to use for reading data that contains international
+characters. This only applies to non JSON logs.  See <<_encoding_5>>.
+
+
+[float]
 ==== `expand_event_list_from_field`
 
 If the fileset using this input expects to receive multiple messages bundled
@@ -107,10 +121,27 @@ file_selectors:
 Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint. For example: `s3-fips.us-gov-east-1.amazonaws.com`.
 
 [float]
+==== `max_bytes`
+
+The maximum number of bytes that a single log message can have. All
+bytes after `max_bytes` are discarded and not sent. This setting is
+especially useful for multiline log messages, which can get
+large. This only applies to non JSON logs.  The default is 10MB
+(10485760).
+
+[float]
 ==== `max_number_of_messages`
 The maximum number of messages to return. Amazon SQS never returns more messages
 than this value (however, fewer messages might be returned).
 Valid values: 1 to 10. Default: 5.
+
+[float]
+==== `multiline`
+
+Options that control how {beatname_uc} deals with log messages that
+span multiple lines. This only applies to non JSON logs.  See
+<<multiline-examples>> for more information about configuring
+multiline options.
 
 [float]
 ==== `queue_url`

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -43,6 +43,7 @@ call will be interrupted.
 The default AWS API call timeout for a message is 120 seconds. The minimum
 is 0 seconds. The maximum is half of the visibility timeout value.
 
+[id="input-{type}-buffer_size"]
 [float]
 ==== `buffer_size`
 
@@ -50,6 +51,7 @@ The size in bytes of the buffer that each harvester uses when fetching a file.
 This only applies to non-JSON logs.
 The default is 16384.
 
+[id="input-{type}-encoding"]
 [float]
 ==== `encoding`
 
@@ -105,7 +107,9 @@ setting.  If `file_selectors` is given, then any global
 `expand_event_list_from_field` value is ignored in favor of the ones
 specified in the `file_selectors`.  Regex syntax is the same as the Go
 language.  Files that don't match one of the regexes won't be
-processed.
+processed.  <<input-aws-s3-multiline>>, <<input-aws-s3-max_bytes>>,
+<<input-aws-s3-buffer_size>> and <<input-aws-s3-encoding>> may also be
+set for each file selector.
 
 ["source", "yml"]
 ----
@@ -120,6 +124,7 @@ file_selectors:
 
 Enabling this option changes the service name from `s3` to `s3-fips` for connecting to the correct service endpoint. For example: `s3-fips.us-gov-east-1.amazonaws.com`.
 
+[id="input-{type}-max_bytes"]
 [float]
 ==== `max_bytes`
 
@@ -135,6 +140,7 @@ The maximum number of messages to return. Amazon SQS never returns more messages
 than this value (however, fewer messages might be returned).
 Valid values: 1 to 10. Default: 5.
 
+[id="input-{type}-multiline"]
 [float]
 ==== `multiline`
 

--- a/x-pack/filebeat/input/awss3/collector.go
+++ b/x-pack/filebeat/input/awss3/collector.go
@@ -416,7 +416,7 @@ func (c *s3Collector) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info,
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("Error reading message: %v", err)
+			return fmt.Errorf("error reading message: %w", err)
 		}
 		event := createEvent(string(message.Content), offset, info, objectHash, s3Ctx)
 		offset += int64(message.Bytes)

--- a/x-pack/filebeat/input/awss3/collector.go
+++ b/x-pack/filebeat/input/awss3/collector.go
@@ -422,7 +422,7 @@ func (c *s3Collector) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info,
 		offset += int64(message.Bytes)
 		err = c.forwardEvent(event)
 		if err != nil {
-			return fmt.Errorf("forwardEvent failed: %v", err)
+			return fmt.Errorf("forwardEvent failed: %w", err)
 		}
 	}
 	return nil

--- a/x-pack/filebeat/input/awss3/collector.go
+++ b/x-pack/filebeat/input/awss3/collector.go
@@ -420,8 +420,7 @@ func (c *s3Collector) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info,
 		}
 		event := createEvent(string(message.Content), offset, info, objectHash, s3Ctx)
 		offset += int64(message.Bytes)
-		err = c.forwardEvent(event)
-		if err != nil {
+		if err = c.forwardEvent(event); err != nil {
 			return fmt.Errorf("forwardEvent failed: %w", err)
 		}
 	}

--- a/x-pack/filebeat/input/awss3/collector.go
+++ b/x-pack/filebeat/input/awss3/collector.go
@@ -297,7 +297,7 @@ func (c *s3Collector) handleSQSMessage(m sqs.Message) ([]s3Info, error) {
 				continue
 			}
 			if fs.Regex.MatchString(filename) {
-				s3Infos = append(s3Infos, s3Info{
+				info := s3Info{
 					region:                   record.AwsRegion,
 					name:                     record.S3.bucket.Name,
 					key:                      filename,
@@ -308,9 +308,19 @@ func (c *s3Collector) handleSQSMessage(m sqs.Message) ([]s3Info, error) {
 					lineTerminator:           fs.LineTerminator,
 					encoding:                 fs.Encoding,
 					bufferSize:               fs.BufferSize,
-				})
-				break
+				}
+				if info.bufferSize == 0 {
+					info.bufferSize = c.config.BufferSize
+				}
+				if info.maxBytes == 0 {
+					info.maxBytes = c.config.MaxBytes
+				}
+				if info.lineTerminator == 0 {
+					info.lineTerminator = c.config.LineTerminator
+				}
+				s3Infos = append(s3Infos, info)
 			}
+			break
 		}
 	}
 	return s3Infos, nil

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -33,9 +33,14 @@ type config struct {
 
 // FileSelectorCfg defines type and configuration of FileSelectors
 type FileSelectorCfg struct {
-	RegexString              string         `config:"regex"`
-	Regex                    *regexp.Regexp `config:",ignore"`
-	ExpandEventListFromField string         `config:"expand_event_list_from_field"`
+	RegexString              string                  `config:"regex"`
+	Regex                    *regexp.Regexp          `config:",ignore"`
+	ExpandEventListFromField string                  `config:"expand_event_list_from_field"`
+	MaxBytes                 int                     `config:"max_bytes" validate:"min=0,nonzero"`
+	Multiline                *multiline.Config       `config:"multiline"`
+	LineTerminator           readfile.LineTerminator `config:"line_terminator"`
+	Encoding                 string                  `config:"encoding"`
+	BufferSize               int                     `config:"buffer_size"`
 }
 
 func defaultConfig() config {

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+
 	"github.com/elastic/beats/v7/libbeat/reader/multiline"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile"
 	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -9,18 +9,26 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/dustin/go-humanize"
+	"github.com/elastic/beats/v7/libbeat/reader/multiline"
+	"github.com/elastic/beats/v7/libbeat/reader/readfile"
 	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 )
 
 type config struct {
-	APITimeout               time.Duration       `config:"api_timeout"`
-	ExpandEventListFromField string              `config:"expand_event_list_from_field"`
-	FileSelectors            []FileSelectorCfg   `config:"file_selectors"`
-	FipsEnabled              bool                `config:"fips_enabled"`
-	MaxNumberOfMessages      int                 `config:"max_number_of_messages"`
-	QueueURL                 string              `config:"queue_url" validate:"nonzero,required"`
-	VisibilityTimeout        time.Duration       `config:"visibility_timeout"`
-	AwsConfig                awscommon.ConfigAWS `config:",inline"`
+	APITimeout               time.Duration           `config:"api_timeout"`
+	ExpandEventListFromField string                  `config:"expand_event_list_from_field"`
+	FileSelectors            []FileSelectorCfg       `config:"file_selectors"`
+	FipsEnabled              bool                    `config:"fips_enabled"`
+	MaxNumberOfMessages      int                     `config:"max_number_of_messages"`
+	QueueURL                 string                  `config:"queue_url" validate:"nonzero,required"`
+	VisibilityTimeout        time.Duration           `config:"visibility_timeout"`
+	AwsConfig                awscommon.ConfigAWS     `config:",inline"`
+	MaxBytes                 int                     `config:"max_bytes" validate:"min=0,nonzero"`
+	Multiline                *multiline.Config       `config:"multiline"`
+	LineTerminator           readfile.LineTerminator `config:"line_terminator"`
+	Encoding                 string                  `config:"encoding"`
+	BufferSize               int                     `config:"buffer_size"`
 }
 
 // FileSelectorCfg defines type and configuration of FileSelectors
@@ -36,6 +44,9 @@ func defaultConfig() config {
 		FipsEnabled:         false,
 		MaxNumberOfMessages: 5,
 		VisibilityTimeout:   300 * time.Second,
+		LineTerminator:      readfile.AutoLineTerminator,
+		MaxBytes:            10 * humanize.MiByte,
+		BufferSize:          16 * humanize.KiByte,
 	}
 }
 

--- a/x-pack/filebeat/input/awss3/ftest/sample2.txt
+++ b/x-pack/filebeat/input/awss3/ftest/sample2.txt
@@ -1,0 +1,8 @@
+<Event><Data>
+	A
+	B
+	C</Data></Event>
+<Event><Data>
+	D
+	E
+	F</Data</Event>


### PR DESCRIPTION
## What does this PR do?

Adds multiline and encoding reader support to aws-s3 input.  This does
not change the processing of JSON logs by aws-s3 input.

## Why is it important?

This is needed so you can read logs that have embedded new lines.  For
example XML Windows events.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Need S3 bucket & SQS queue, then upload multiline logs.

## Related issues

- Closes #25249