### PR TITLE
[Heartbeat] use fingerprint processor for screenshots

### DIFF
--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -29,6 +29,7 @@ type SynthEvent struct {
 	Status               string        `json:"status"`
 	RootFields           common.MapStr `json:"root_fields"`
 	index                int
+	PointsTo             string
 }
 
 func (se SynthEvent) ToMap() (m common.MapStr) {


### PR DESCRIPTION
## What does this PR do?

+ Attempt at using the fingerprint processor in ES to de-duplicate fully identical screenshots from the Synthetics agent runs

## Why is it important?

+ To reduce the storage costs in ES for synthetics customers - More details - https://github.com/elastic/synthetics/issues/266

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

