### PR TITLE
Cherry-pick #25590 to 7.13: Retry deamon reload during enroll

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -252,7 +252,7 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context) (string, error) {
 	var agentSubproc <-chan *os.ProcessState
 	if agentRunning {
 		// reload the already running agent
-		err = c.daemonReload(ctx)
+		err = c.daemonReloadWithBackoff(ctx)
 		if err != nil {
 			return "", errors.New(err, "failed to trigger elastic-agent daemon reload", errors.TypeApplication)
 		}
@@ -320,6 +320,28 @@ func (c *enrollCmd) prepareFleetTLS() error {
 		return errors.New("url is required when a certificate is provided")
 	}
 	return nil
+}
+
+func (c *enrollCmd) daemonReloadWithBackoff(ctx context.Context) error {
+	err := c.daemonReload(ctx)
+	if err == nil {
+		return nil
+	}
+
+	signal := make(chan struct{})
+	backExp := backoff.NewExpBackoff(signal, 10*time.Second, 1*time.Minute)
+
+	for i := 5; i >= 0; i-- {
+		backExp.Wait()
+		c.log.Info("Retrying to restart...")
+		err = c.daemonReload(ctx)
+		if err == nil {
+			break
+		}
+	}
+
+	close(signal)
+	return err
 }
 
 func (c *enrollCmd) daemonReload(ctx context.Context) error {


### PR DESCRIPTION
Cherry-pick of PR #25590 to 7.13 branch. Original message:

## What does this PR do?

Adds retry for daemon reload 

## Why is it important?

https://github.com/elastic/fleet-server/issues/297

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
