### PR TITLE
[Elastic Agent] Default to port 80 and 443 for Kibana and Fleet Server connections

### DIFF
--- a/libbeat/common/url.go
+++ b/libbeat/common/url.go
@@ -46,7 +46,10 @@ func MakeURL(defaultScheme string, defaultPath string, rawURL string, defaultPor
 
 	scheme := addr.Scheme
 	host := addr.Host
-	port := strconv.Itoa(defaultPort)
+	port := ""
+	if defaultPort > 0 {
+		port = strconv.Itoa(defaultPort)
+	}
 
 	if host == "" {
 		host = "localhost"
@@ -71,7 +74,10 @@ func MakeURL(defaultScheme string, defaultPath string, rawURL string, defaultPor
 
 	// reconstruct url
 	addr.Scheme = scheme
-	addr.Host = host + ":" + port
+	addr.Host = host
+	if port != "" {
+		addr.Host += ":" + port
+	}
 
 	return addr.String(), nil
 }

--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -91,11 +91,16 @@ func NewKibanaClient(cfg *common.Config) (*Client, error) {
 
 // NewClientWithConfig creates and returns a kibana client using the given config
 func NewClientWithConfig(config *ClientConfig) (*Client, error) {
+	return NewClientWithConfigDefault(config, 5601)
+}
+
+// NewClientWithConfig creates and returns a kibana client using the given config
+func NewClientWithConfigDefault(config *ClientConfig, defaultPort int) (*Client, error) {
 	p := config.Path
 	if config.SpaceID != "" {
 		p = path.Join(p, "s", config.SpaceID)
 	}
-	kibanaURL, err := common.MakeURL(config.Protocol, p, config.Host, 5601)
+	kibanaURL, err := common.MakeURL(config.Protocol, p, config.Host, defaultPort)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Kibana host: %v", err)
 	}

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -11,6 +11,7 @@
 - Read Fleet connection information from `fleet.*` instead of `fleet.kibana.*`. {pull}24713[24713]
 - Beats build for 32Bit Windows or Linux system will refuse to run on a 64bit system. {pull}25186[25186]
 - Remove the `--kibana-url` from `install` and `enroll` command. {pull}25529[25529]
+- Default to port 80 and 443 for Kibana and Fleet Server connections. {pull}25723[25723]
 
 ==== Bugfixes
 - Fix rename *ConfigChange to *PolicyChange to align on changes in the UI. {pull}20779[20779]

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -457,14 +457,14 @@ func kibanaClient(cfg kibanaConfig, headers map[string]string) (*kibana.Client, 
 		}
 	}
 
-	return kibana.NewClientWithConfig(&kibana.ClientConfig{
+	return kibana.NewClientWithConfigDefault(&kibana.ClientConfig{
 		Host:          cfg.Fleet.Host,
 		Username:      cfg.Fleet.Username,
 		Password:      cfg.Fleet.Password,
 		IgnoreVersion: true,
 		TLS:           tls,
 		Headers:       headers,
-	})
+	}, 0)
 }
 
 func findPolicy(cfg setupConfig, policies []kibanaPolicy) (*kibanaPolicy, error) {

--- a/x-pack/elastic-agent/pkg/remote/client_test.go
+++ b/x-pack/elastic-agent/pkg/remote/client_test.go
@@ -44,10 +44,10 @@ func TestPortDefaults(t *testing.T) {
 		ExpectedPort   int
 		ExpectedScheme string
 	}{
-		{"no scheme uri", "test.url", defaultPort, "http"},
-		{"default port", "http://test.url", defaultPort, "http"},
+		{"no scheme uri", "test.url", 0, "http"},
+		{"default port", "http://test.url", 0, "http"},
 		{"specified port", "http://test.url:123", 123, "http"},
-		{"default https port", "https://test.url", defaultPort, "https"},
+		{"default https port", "https://test.url", 0, "https"},
 		{"specified https port", "https://test.url:123", 123, "https"},
 	}
 	for _, tc := range testCases {
@@ -61,7 +61,11 @@ func TestPortDefaults(t *testing.T) {
 			r, err := c.nextRequester().request("GET", "/", nil, strings.NewReader(""))
 			require.NoError(t, err)
 
-			assert.True(t, strings.HasSuffix(r.Host, fmt.Sprintf(":%d", tc.ExpectedPort)))
+			if tc.ExpectedPort > 0 {
+				assert.True(t, strings.HasSuffix(r.Host, fmt.Sprintf(":%d", tc.ExpectedPort)))
+			} else {
+				assert.False(t, strings.HasSuffix(r.Host, fmt.Sprintf(":%d", tc.ExpectedPort)))
+			}
 			assert.Equal(t, tc.ExpectedScheme, r.URL.Scheme)
 		})
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This changes the Elastic Agent to use 80 and 443 as the default ports when providing a URL that doesn't contain a port number. This affects both the connection to Kibana in the container command as well as Elastic Agents communication with Fleet Server.

**NOTE**: This is a breaking change.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So valid http and https connections use the correct port when no port number is given. Without this change Elastic Agent would default to 5601 and 8220 respectively for Kibana and Fleet Server.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #25669 
