### PR TITLE
Report dataset metrics in monitoring log reporter

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -498,6 +498,12 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add proxy support for AWS functions. {pull}26832[26832]
 - Added policies to the elasticsearch output for non indexible events {pull}26952[26952]
 - Add sha256 digests to RPM packages. {issue}23670[23670]
+- Add support for defining explicitly named dynamic templates without path/type match criteria {pull}25422[25422]
+- Improve ES output error insights. {pull}25825[25825]
+- Add orchestrator.cluster.name/url fields as k8s metadata {pull}26056[26056]
+- Libbeat: report beat version to monitoring. {pull}26214[26214]
+- Ensure common proxy settings support in HTTP clients: proxy_disabled, proxy_url, proxy_headers and typical environment variables HTTP_PROXY, HTTPS_PROXY, NOPROXY. {pull}25219[25219]
+- Add `logging.metrics.namespaces` config option to control what metric groups are reported in logs. {pull}25727[25727]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -497,13 +497,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Add proxy support for AWS functions. {pull}26832[26832]
 - Added policies to the elasticsearch output for non indexible events {pull}26952[26952]
-- Add sha256 digests to RPM packages. {issue}23670[23670]
-- Add support for defining explicitly named dynamic templates without path/type match criteria {pull}25422[25422]
-- Improve ES output error insights. {pull}25825[25825]
-- Add orchestrator.cluster.name/url fields as k8s metadata {pull}26056[26056]
-- Libbeat: report beat version to monitoring. {pull}26214[26214]
-- Ensure common proxy settings support in HTTP clients: proxy_disabled, proxy_url, proxy_headers and typical environment variables HTTP_PROXY, HTTPS_PROXY, NOPROXY. {pull}25219[25219]
 - Add `logging.metrics.namespaces` config option to control what metric groups are reported in logs. {pull}25727[25727]
+- Add sha256 digests to RPM packages. {issue}23670[23670]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1405,6 +1405,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -161,14 +161,14 @@ auditbeat.modules:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1405,8 +1405,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2317,6 +2317,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1073,14 +1073,14 @@ filebeat.inputs:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -2317,8 +2317,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1536,6 +1536,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -292,14 +292,14 @@ heartbeat.scheduler:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1536,8 +1536,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1348,6 +1348,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -104,14 +104,14 @@ setup.template.settings:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1348,8 +1348,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/libbeat/_meta/config/general.reference.yml.tmpl
+++ b/libbeat/_meta/config/general.reference.yml.tmpl
@@ -41,14 +41,14 @@
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -30,6 +30,9 @@
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -30,8 +30,10 @@
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -194,8 +194,9 @@ The period after which to log the internal metrics. The default is 30s.
 [float]
 ==== `logging.metrics.namespaces`
 
-A list of metrics namespaces to report in the logs. Defaults to
-`[stats, dataset]`.
+A list of metrics namespaces to report in the logs. Defaults to `[stats]`.
+`stats` contains general Beat metrics. `dataset` may be present in some
+Beats and contains module or input metrics.
 
 ifndef::serverless[]
 [float]

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -173,7 +173,7 @@ endif::serverless[]
 By default, {beatname_uc} periodically logs its internal metrics that have
 changed in the last period. For each metric that changed, the delta from the
 value at the beginning of the period is logged. Also, the total values for all
-non-zero internal metrics are logged on shutdown. Set this to false to disable 
+non-zero internal metrics are logged on shutdown. Set this to false to disable
 this behavior. The default is true.
 
 Here is an example log line:
@@ -190,6 +190,12 @@ metrics and for this reason they are also not documented.
 ==== `logging.metrics.period`
 
 The period after which to log the internal metrics. The default is 30s.
+
+[float]
+==== `logging.metrics.namespaces`
+
+A list of metrics namespaces to report in the logs. Defaults to
+`[stats, dataset]`.
 
 ifndef::serverless[]
 [float]

--- a/libbeat/monitoring/report/log/config.go
+++ b/libbeat/monitoring/report/log/config.go
@@ -29,6 +29,6 @@ type config struct {
 func defaultConfig() config {
 	return config{
 		Period:     30 * time.Second,
-		Namespaces: []string{"stats", "dataset"},
+		Namespaces: []string{"stats"},
 	}
 }

--- a/libbeat/monitoring/report/log/config.go
+++ b/libbeat/monitoring/report/log/config.go
@@ -22,9 +22,13 @@ import (
 )
 
 type config struct {
-	Period time.Duration `config:"period"`
+	Period     time.Duration `config:"period"`
+	Namespaces []string      `config:"namespaces"`
 }
 
-var defaultConfig = config{
-	Period: 30 * time.Second,
+func defaultConfig() config {
+	return config{
+		Period:     30 * time.Second,
+		Namespaces: []string{"stats", "dataset"},
+	}
 }

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -216,7 +216,7 @@ func makeDeltaSnapshot(prev, cur monitoring.FlatSnapshot) monitoring.FlatSnapsho
 	}
 
 	for k, i := range cur.Ints {
-		if _, found := gauges[k]; found {
+		if isGauge(k) {
 			delta.Ints[k] = i
 		} else {
 			if p := prev.Ints[k]; p != i {
@@ -226,7 +226,7 @@ func makeDeltaSnapshot(prev, cur monitoring.FlatSnapshot) monitoring.FlatSnapsho
 	}
 
 	for k, f := range cur.Floats {
-		if _, found := gauges[k]; found {
+		if isGauge(k) {
 			delta.Floats[k] = f
 		} else if p := prev.Floats[k]; p != f {
 			delta.Floats[k] = f - p

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -18,6 +18,7 @@
 package log
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -63,6 +64,18 @@ var gauges = map[string]bool{
 	"system.load.norm.15":            true,
 }
 
+// isGauge returns true when the given metric key name represents a gauge value.
+// Any metric name suffixed in '_gauge' or containing '.histogram.' is
+// treated as a gauge. Other metrics can specifically be marked as gauges
+// through the list maintained in this package.
+func isGauge(key string) bool {
+	if strings.HasSuffix(key, "_gauge") || strings.Contains(key, ".histogram.") {
+		return true
+	}
+	_, found := gauges[key]
+	return found
+}
+
 // TODO: Change this when gauges are refactored, too.
 var strConsts = map[string]bool{
 	"beat.info.ephemeral_id": true,
@@ -75,10 +88,10 @@ var (
 )
 
 type reporter struct {
-	wg       sync.WaitGroup
-	done     chan struct{}
-	period   time.Duration
-	registry *monitoring.Registry
+	config
+	wg         sync.WaitGroup
+	done       chan struct{}
+	registries map[string]*monitoring.Registry
 
 	// output
 	logger *logp.Logger
@@ -87,7 +100,7 @@ type reporter struct {
 // MakeReporter returns a new Reporter that periodically reports metrics via
 // logp. If cfg is nil defaults will be used.
 func MakeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
-	config := defaultConfig
+	config := defaultConfig()
 	if cfg != nil {
 		if err := cfg.Unpack(&config); err != nil {
 			return nil, err
@@ -95,10 +108,21 @@ func MakeReporter(beat beat.Info, cfg *common.Config) (report.Reporter, error) {
 	}
 
 	r := &reporter{
-		done:     make(chan struct{}),
-		period:   config.Period,
-		logger:   logp.NewLogger("monitoring"),
-		registry: monitoring.Default,
+		config:     config,
+		done:       make(chan struct{}),
+		logger:     logp.NewLogger("monitoring"),
+		registries: map[string]*monitoring.Registry{},
+	}
+
+	for _, ns := range r.config.Namespaces {
+		reg := monitoring.GetNamespace(ns).GetRegistry()
+
+		// That 'stats' namespace is reported as 'metrics' in the Elasticsearch
+		// reporter so use the same name for consistency.
+		if ns == "stats" {
+			ns = "metrics"
+		}
+		r.registries[ns] = reg
 	}
 
 	r.wg.Add(1)
@@ -115,16 +139,21 @@ func (r *reporter) Stop() {
 }
 
 func (r *reporter) snapshotLoop() {
-	r.logger.Infof("Starting metrics logging every %v", r.period)
+	r.logger.Infof("Starting metrics logging every %v", r.Period)
 	defer r.logger.Infof("Stopping metrics logging.")
 	defer func() {
-		r.logTotals(makeDeltaSnapshot(monitoring.MakeFlatSnapshot(), makeSnapshot(r.registry)))
+		snaps := map[string]monitoring.FlatSnapshot{}
+		for name, reg := range r.registries {
+			snap := makeSnapshot(reg)
+			snaps[name] = snap
+		}
+		r.logTotals(snaps)
 	}()
 
-	ticker := time.NewTicker(r.period)
+	ticker := time.NewTicker(r.Period)
 	defer ticker.Stop()
 
-	var last monitoring.FlatSnapshot
+	lastSnaps := map[string]monitoring.FlatSnapshot{}
 	for {
 		select {
 		case <-r.done:
@@ -132,31 +161,41 @@ func (r *reporter) snapshotLoop() {
 		case <-ticker.C:
 		}
 
-		cur := makeSnapshot(r.registry)
-		delta := makeDeltaSnapshot(last, cur)
-		last = cur
+		snaps := make(map[string]monitoring.FlatSnapshot, len(r.registries))
+		for name, reg := range r.registries {
+			snap := makeSnapshot(reg)
+			lastSnap := lastSnaps[name]
+			lastSnaps[name] = snap
+			delta := makeDeltaSnapshot(lastSnap, snap)
+			snaps[name] = delta
+		}
 
-		r.logSnapshot(delta)
+		r.logSnapshot(snaps)
 	}
 }
 
-func (r *reporter) logSnapshot(s monitoring.FlatSnapshot) {
-	if snapshotLen(s) > 0 {
-		r.logger.Infow("Non-zero metrics in the last "+r.period.String(), toKeyValuePairs(s)...)
+func (r *reporter) logSnapshot(snaps map[string]monitoring.FlatSnapshot) {
+	var snapsLen int
+	for _, s := range snaps {
+		snapsLen += snapshotLen(s)
+	}
+
+	if snapsLen > 0 {
+		r.logger.Infow("Non-zero metrics in the last "+r.Period.String(), toKeyValuePairs(snaps)...)
 		return
 	}
 
-	r.logger.Infof("No non-zero metrics in the last %v", r.period)
+	r.logger.Infof("No non-zero metrics in the last %v", r.Period)
 }
 
-func (r *reporter) logTotals(s monitoring.FlatSnapshot) {
-	r.logger.Infow("Total non-zero metrics", toKeyValuePairs(s)...)
+func (r *reporter) logTotals(snaps map[string]monitoring.FlatSnapshot) {
+	r.logger.Infow("Total metrics", toKeyValuePairs(snaps)...)
 	r.logger.Infof("Uptime: %v", time.Since(StartTime))
 }
 
 func makeSnapshot(R *monitoring.Registry) monitoring.FlatSnapshot {
 	mode := monitoring.Full
-	return monitoring.CollectFlatSnapshot(R, mode, true)
+	return monitoring.CollectFlatSnapshot(R, mode, false)
 }
 
 func makeDeltaSnapshot(prev, cur monitoring.FlatSnapshot) monitoring.FlatSnapshot {
@@ -201,20 +240,27 @@ func snapshotLen(s monitoring.FlatSnapshot) int {
 	return len(s.Bools) + len(s.Floats) + len(s.Ints) + len(s.Strings)
 }
 
-func toKeyValuePairs(s monitoring.FlatSnapshot) []interface{} {
-	data := make(common.MapStr, snapshotLen(s))
-	for k, v := range s.Bools {
-		data.Put(k, v)
-	}
-	for k, v := range s.Floats {
-		data.Put(k, v)
-	}
-	for k, v := range s.Ints {
-		data.Put(k, v)
-	}
-	for k, v := range s.Strings {
-		data.Put(k, v)
+func toKeyValuePairs(snaps map[string]monitoring.FlatSnapshot) []interface{} {
+	args := []interface{}{logp.Namespace("monitoring")}
+
+	for name, snap := range snaps {
+		data := make(common.MapStr, snapshotLen(snap))
+		for k, v := range snap.Bools {
+			data.Put(k, v)
+		}
+		for k, v := range snap.Floats {
+			data.Put(k, v)
+		}
+		for k, v := range snap.Ints {
+			data.Put(k, v)
+		}
+		for k, v := range snap.Strings {
+			data.Put(k, v)
+		}
+		if len(data) > 0 {
+			args = append(args, logp.Reflect(name, data))
+		}
 	}
 
-	return []interface{}{logp.Namespace("monitoring"), logp.Reflect("metrics", data)}
+	return args
 }

--- a/libbeat/monitoring/report/log/log_test.go
+++ b/libbeat/monitoring/report/log/log_test.go
@@ -31,22 +31,26 @@ import (
 var (
 	prevSnap = monitoring.FlatSnapshot{
 		Ints: map[string]int64{
-			"count": 10,
-			"gone":  1,
+			"count":        10,
+			"gone":         1,
+			"active_gauge": 6,
 		},
 		Floats: map[string]float64{
-			"system.load.1": 2.0,
-			"float_counter": 1,
+			"system.load.1":     2.0,
+			"float_counter":     1,
+			"foo.histogram.p99": 4.0,
 		},
 	}
 	curSnap = monitoring.FlatSnapshot{
 		Ints: map[string]int64{
-			"count": 20,
-			"new":   1,
+			"count":        20,
+			"new":          1,
+			"active_gauge": 5,
 		},
 		Floats: map[string]float64{
-			"system.load.1": 1.2,
-			"float_counter": 3,
+			"system.load.1":     1.2,
+			"float_counter":     3,
+			"foo.histogram.p99": 4.1,
 		},
 	}
 )
@@ -66,6 +70,8 @@ func TestMakeDeltaSnapshot(t *testing.T) {
 	assert.EqualValues(t, 1, delta.Ints["new"])
 	assert.EqualValues(t, 1.2, delta.Floats["system.load.1"])
 	assert.EqualValues(t, 2, delta.Floats["float_counter"])
+	assert.EqualValues(t, 5, delta.Ints["active_gauge"])
+	assert.EqualValues(t, 4.1, delta.Floats["foo.histogram.p99"])
 	assert.NotContains(t, delta.Ints, "gone")
 }
 

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -216,8 +216,8 @@ func (res *MiekgResolver) getOrCreateNameserverStats(ns string) *nameserverStats
 		failure:     monitoring.NewInt(reg, "failure"),
 		ptrResponse: metrics.NewUniformSample(1028),
 	}
-	adapter.NewGoMetrics(reg, "response", adapter.Accept).
-		Register("ptr", metrics.NewHistogram(stats.ptrResponse))
+	adapter.NewGoMetrics(reg, "response.ptr", adapter.Accept).
+		Register("histogram", metrics.NewHistogram(stats.ptrResponse))
 	res.nsStats[ns] = stats
 
 	return stats

--- a/libbeat/tests/system/test_base.py
+++ b/libbeat/tests/system/test_base.py
@@ -138,7 +138,7 @@ class Test(BaseTest, common_tests.TestExportsMixin):
             max_timeout=2)
         proc.check_kill_and_wait()
         self.wait_until(
-            lambda: self.log_contains("Total non-zero metrics"),
+            lambda: self.log_contains("Total metrics"),
             max_timeout=2)
 
     def test_persistent_uuid(self):

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -973,14 +973,14 @@ metricbeat.modules:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -2217,8 +2217,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2217,6 +2217,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -656,14 +656,14 @@ packetbeat.ignore_outgoing: false
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1900,8 +1900,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1900,6 +1900,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -84,14 +84,14 @@ winlogbeat.event_logs:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1328,8 +1328,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1328,6 +1328,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -217,14 +217,14 @@ auditbeat.modules:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1461,8 +1461,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1461,6 +1461,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3292,14 +3292,14 @@ filebeat.inputs:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -4536,8 +4536,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -4536,6 +4536,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -447,14 +447,14 @@ functionbeat.provider.gcp.functions:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1307,8 +1307,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1307,6 +1307,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1536,6 +1536,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -292,14 +292,14 @@ heartbeat.scheduler:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1536,8 +1536,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1494,14 +1494,14 @@ metricbeat.modules:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -2738,8 +2738,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2738,6 +2738,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -920,6 +920,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -60,14 +60,14 @@ seccomp.enabled: false
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -920,8 +920,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -656,14 +656,14 @@ packetbeat.ignore_outgoing: false
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1900,8 +1900,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -1900,6 +1900,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1371,6 +1371,9 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
+# A list of metrics namespaces to report in the logs.
+#logging.metrics.namespaces: [stats, dataset]
+
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.
 logging.to_files: true

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -127,14 +127,14 @@ winlogbeat.event_logs:
     # Maximum duration after which events are available to the outputs,
     # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
-  
+
   # The disk queue stores incoming events on disk until the output is
   # ready for them. This allows a higher event limit than the memory-only
   # queue and lets pending events persist through a restart.
   #disk:
     # The directory path to store the queue's data.
     #path: "${path.data}/diskqueue"
-    
+
     # The maximum space the queue should occupy on disk. Depending on
     # input settings, events that exceed this limit are delayed or discarded.
     #max_size: 10GB
@@ -1371,8 +1371,10 @@ setup.kibana:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# A list of metrics namespaces to report in the logs.
-#logging.metrics.namespaces: [stats, dataset]
+# A list of metrics namespaces to report in the logs. Defaults to [stats].
+# `stats` contains general Beat metrics. `dataset` may be present in some
+# Beats and contains module or input metrics.
+#logging.metrics.namespaces: [stats]
 
 # Logging to rotating files. Set logging.to_files to false to disable logging to
 # files.


### PR DESCRIPTION
## What does this PR do?

This adds periodic reporting of "dataset" metrics to the logs. This can be disabled by configuring `logging.metrics.namespaces`. These are the same metrics available from the HTTP monitoring endpoint under the /dataset path. This primarily improves visibility of Filebeat and Metricbeat because they make use of the "dataset" namespace for input and metricset instance metrics.

## Why is it important?

Prior to 7.10 the Filebeat input metrics were reported in the logged metrics, but this was lost when the metrics moved to the "dataset" namespace. It was a useful feature to have for remote debugging.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/beats/pull/19977
- Relates https://github.com/elastic/beats/pull/6836

## Logs

```
2021-05-16T14:20:17.885-0400    INFO    [monitoring]    log/log.go:183  Non-zero metrics in the last 30s        {"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":60,"time":{"ms":60}},"total":{"ticks":250,"time":{"ms":250},"value":250},"user":{"ticks":190,"time":{"ms":190}}},"info":{"ephemeral_id":"caa6d941-b4ad-44fa-a5b2-6b07e41427d2","uptime":{"ms":30055}},"memstats":{"gc_next":35415664,"memory_alloc":17979752,"memory_sys":77415424,"memory_total":75690904,"rss":86929408},"runtime":{"goroutines":62}},"filebeat":{"events":{"active":534,"added":543,"done":9},"harvester":{"open_files":8,"running":8,"started":8}},"libbeat":{"config":{"module":{"running":0}},"output":{"events":{"active":0},"type":"elasticsearch"},"pipeline":{"clients":1,"events":{"active":528,"filtered":15,"published":528,"retry":150,"total":543},"queue":{"max_events":4096}}},"registrar":{"states":{"current":9,"update":9},"writes":{"success":9,"total":9}},"system":{"cpu":{"cores":12},"load":{"1":1.6616,"15":2.3765,"5":2.1978,"norm":{"1":0.1385,"15":0.198,"5":0.1831}}}}, "dataset": {"069dc32a-b71f-4344-a600-fa06d5071036":{"last_event_published_time":"2021-05-16T14:19:47.918Z","last_event_timestamp":"2021-05-16T14:19:47.918Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_traffic_ietf.log","read_offset":51624,"size":51624,"start_time":"2021-05-16T14:19:47.886Z"},"0a414085-71c7-4e62-86c8-d4ef09a2292b":{"last_event_published_time":"2021-05-16T14:19:47.888Z","last_event_timestamp":"2021-05-16T14:19:47.888Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_other.log","read_offset":6217,"size":6217,"start_time":"2021-05-16T14:19:47.884Z"},"12be14ea-a067-480f-9b3a-7f043a826068":{"last_event_published_time":"2021-05-16T14:19:47.886Z","last_event_timestamp":"2021-05-16T14:19:47.885Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/global_protect.log","read_offset":1641,"size":1641,"start_time":"2021-05-16T14:19:47.884Z"},"12cf5432-b0ff-4cb6-8db3-098e54b9cc4b":{"last_event_published_time":"2021-05-16T14:19:47.898Z","last_event_timestamp":"2021-05-16T14:19:47.898Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/userid.log","read_offset":2626,"size":2626,"start_time":"2021-05-16T14:19:47.890Z"},"8c19b7d1-a670-4e91-9950-6a96e0c49457":{"last_event_published_time":"2021-05-16T14:19:47.920Z","last_event_timestamp":"2021-05-16T14:19:47.920Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/traffic.log","read_offset":46385,"size":46385,"start_time":"2021-05-16T14:19:47.888Z"},"926dd152-78a7-45e8-abea-778e22794590":{"last_event_published_time":"2021-05-16T14:19:47.906Z","last_event_timestamp":"2021-05-16T14:19:47.905Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_traffic.log","read_offset":36298,"size":36298,"start_time":"2021-05-16T14:19:47.885Z"},"c089fcd5-1822-4017-9739-4890d65ca098":{"last_event_published_time":"2021-05-16T14:19:47.915Z","last_event_timestamp":"2021-05-16T14:19:47.915Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/threat.log","read_offset":41586,"size":41586,"start_time":"2021-05-16T14:19:47.887Z"},"ddec21fc-29fb-4ed5-b23c-2cc6f6f09d12":{"last_event_published_time":"2021-05-16T14:19:47.914Z","last_event_timestamp":"2021-05-16T14:19:47.914Z","name":"/Users/akroh/go/src/github.com/elastic/beats/x-pack/filebeat/module/panw/panos/test/pan_inc_threat.log","read_offset":39870,"size":39870,"start_time":"2021-05-16T14:19:47.884Z"}}}}
2021-05-16T14:20:47.883-0400    INFO    [monitoring]    log/log.go:183  Non-zero metrics in the last 30s        {"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":66,"time":{"ms":6}},"total":{"ticks":262,"time":{"ms":12},"value":262},"user":{"ticks":196,"time":{"ms":6}}},"info":{"ephemeral_id":"caa6d941-b4ad-44fa-a5b2-6b07e41427d2","uptime":{"ms":60054}},"memstats":{"gc_next":35415664,"memory_alloc":19664576,"memory_total":77375728,"rss":87179264},"runtime":{"goroutines":62}},"filebeat":{"harvester":{"open_files":8,"running":8}},"libbeat":{"config":{"module":{"running":0}},"output":{"events":{"active":0}},"pipeline":{"clients":1,"events":{"active":528,"retry":50}}},"registrar":{"states":{"current":9}},"system":{"load":{"1":1.6016,"15":2.3442,"5":2.1299,"norm":{"1":0.1335,"15":0.1954,"5":0.1775}}}}}}
2021-05-16T14:23:35.401-0400    INFO    [monitoring]    log/log.go:191  Total metrics   {"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":107,"time":{"ms":107}},"total":{"ticks":375,"time":{"ms":375},"value":375},"user":{"ticks":268,"time":{"ms":268}}},"info":{"ephemeral_id":"caa6d941-b4ad-44fa-a5b2-6b07e41427d2","uptime":{"ms":227570}},"memstats":{"gc_next":35912432,"memory_alloc":22875816,"memory_sys":77415424,"memory_total":86230296,"rss":92229632},"runtime":{"goroutines":10}},"filebeat":{"events":{"active":535,"added":544,"done":9},"harvester":{"closed":8,"open_files":0,"running":0,"skipped":0,"started":8},"input":{"log":{"files":{"renamed":0,"truncated":0}},"netflow":{"flows":0,"packets":{"dropped":0,"received":0}}}},"libbeat":{"config":{"module":{"running":0,"starts":0,"stops":0},"reloads":0,"scans":0},"output":{"events":{"acked":0,"active":0,"batches":0,"dropped":0,"duplicates":0,"failed":0,"toomany":0,"total":0},"read":{"bytes":0,"errors":0},"type":"elasticsearch","write":{"bytes":0,"errors":0}},"pipeline":{"clients":0,"events":{"active":529,"dropped":0,"failed":0,"filtered":15,"published":529,"retry":400,"total":544},"queue":{"acked":0,"max_events":4096}}},"registrar":{"states":{"cleanup":0,"current":9,"update":9},"writes":{"fail":0,"success":9,"total":9}},"system":{"cpu":{"cores":12},"load":{"1":3.0503,"15":2.4072,"5":2.4136,"norm":{"1":0.2542,"15":0.2006,"5":0.2011}}}}}}
```

