### PR TITLE
Update getting-started.asciidoc

### DIFF
--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -68,10 +68,10 @@ configured output:
       - log_group_name: /aws/lambda/my-lambda-function
 -------------------------------------------------------------------------------------
 <1> A unique name for the S3 bucket to which the functions will be
-uploaded.
+uploaded. 
 <2> Details about the function you want to deploy, including the name of the
 function, the type of service to monitor, and the log groups that trigger the
-function.
+function. (Try to keep the length of the function name < 11 characters)
 +
 See <<configuration-{beatname_lc}-options>> for more examples.
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Breaking change
- Deprecation
- Docs
-->

## What does this PR do?

The AWS cloud formation wasn't creating the stack because role name was exceeding the character count limit of 64. Thus after all the things that filebeat adds for creating the stack, it was found that keeping the function name (in .yml file) length < 11 characters makes the thing work properly.

This PR will add some info to `quick start guide of File Beats `

## Why is it important?
Without these changes the AWS doesn't create a stack for the Filebeat and the deploying the function to fetch logs generates an deploy error

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
 try following the link [Quick Start - Filebeat Installation](https://www.elastic.co/guide/en/beats/functionbeat/7.12/configuration-functionbeat-options.html) 
For the AWS, try to put the function name, in the filebeat.yml, having a length of more than 11 characters. This function cannot be deployed.




