### PR TITLE
Don't include full ES index template in errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -242,6 +242,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix handling of `file_selectors` in aws-s3 input. {pull}25792[25792]
 - Fix ILM alias creation when write alias exists and initial index does not exist {pull}26143[26143]
 - Include date separator in the filename prefix of `dateRotator` to make sure nothing gets purged accidentally {pull}26176[26176]
+- Omit full index template from errors that occur while loading the template. {pull}25743[25743]
 
 *Auditbeat*
 

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -40,7 +40,7 @@ var (
 	}
 )
 
-//Loader interface for loading templates
+// Loader interface for loading templates.
 type Loader interface {
 	Load(config TemplateConfig, info beat.Info, fields []byte, migration bool) error
 }
@@ -94,15 +94,15 @@ func newTemplateBuilder() *templateBuilder {
 	return &templateBuilder{log: logp.NewLogger("template")}
 }
 
-// Load checks if the index mapping template should be loaded
+// Load checks if the index mapping template should be loaded.
 // In case the template is not already loaded or overwriting is enabled, the
-// template is built and written to index
+// template is built and written to index.
 func (l *ESLoader) Load(config TemplateConfig, info beat.Info, fields []byte, migration bool) error {
 	if l.client == nil {
 		return errors.New("can not load template without active Elasticsearch client")
 	}
 
-	//build template from config
+	// build template from config
 	tmpl, err := l.builder.template(config, info, l.client.GetVersion(), migration)
 	if err != nil || tmpl == nil {
 		return err
@@ -120,19 +120,19 @@ func (l *ESLoader) Load(config TemplateConfig, info beat.Info, fields []byte, mi
 	}
 
 	if exists && !config.Overwrite {
-		l.log.Infof("Template %s already exists and will not be overwritten.", templateName)
+		l.log.Infof("Template %q already exists and will not be overwritten.", templateName)
 		return nil
 	}
 
-	//loading template to ES
+	// loading template to ES
 	body, err := l.builder.buildBody(tmpl, config, fields)
 	if err != nil {
 		return err
 	}
 	if err := l.loadTemplate(templateName, config.Type, body); err != nil {
-		return fmt.Errorf("could not load template. Elasticsearch returned: %v. Template is: %s", err, body.StringToPrint())
+		return fmt.Errorf("failed to load template: %w", err)
 	}
-	l.log.Infof("template with name '%s' loaded.", templateName)
+	l.log.Infof("Template with name %q loaded.", templateName)
 	return nil
 }
 

--- a/libbeat/tests/system/test_template.py
+++ b/libbeat/tests/system/test_template.py
@@ -107,7 +107,7 @@ class Test(BaseTest):
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
         self.wait_until(lambda: self.log_contains("Loading json template from file"))
-        self.wait_until(lambda: self.log_contains("template with name 'bla' loaded"))
+        self.wait_until(lambda: self.log_contains('Template with name "bla" loaded.'))
         proc.check_kill_and_wait()
 
         result = es.transport.perform_request('GET', '/_template/' + template_name)
@@ -149,7 +149,7 @@ class TestRunTemplate(BaseTest):
         self.render_config()
         proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("mockbeat start running."))
-        self.wait_until(lambda: self.log_contains("template with name 'mockbeat-9.9.9' loaded"))
+        self.wait_until(lambda: self.log_contains('Template with name "mockbeat-9.9.9" loaded.'))
         self.wait_until(lambda: self.log_contains("PublishEvents: 1 events have been published"))
         proc.check_kill_and_wait()
 


### PR DESCRIPTION
## What does this PR do?

Index templates in some beats can be very large (~1MB) and including the data in errors can use a lot of memory and also makes for very large log lines. If the error is recurring then this makes the effects worse. So this change removes the index template body from the error. Users that need to see the index template for debugging can use `<beatname> export template --es.version=1.2.3`.

Fixes #25540

## Why is it important?

~1MB log lines are difficult to work with.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Fixes #25540
