### PR TITLE
Add env for http monitor container command

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -67,6 +67,7 @@
 - Add error log entry when listener creation fails {issue}23483[23482]
 - Handle case where policy doesn't contain Fleet connection information {pull}25707[25707]
 - Fix fleet-server.yml spec to not overwrite existing keys {pull}25741[25741]
+- Add env for http monitor container command {pull}25746[25746]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -967,7 +967,7 @@ func defaultAccessConfig() (setupConfig, error) {
 				HTTP: agentMonitoringHTTPConfig{
 					Enabled: envBool("AGENT_MONITORING_HTTP_ENABLE"),
 					Host:    envWithDefault("0.0.0.0", "AGENT_MONITORING_HTTP_HOST"),
-					Port:    envWithDefault("6789", "AGENT_MONITORING_HTTP_PORT"),
+					Port:    envWithDefault("6791", "AGENT_MONITORING_HTTP_PORT"),
 				},
 			},
 		},

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -174,9 +174,9 @@ func logContainerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 func containerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	// set paths early so all action below use the defined paths
-	//if err := setPaths("", "", "", true); err != nil {
-	//	return err
-	//}
+	if err := setPaths("", "", "", true); err != nil {
+		return err
+	}
 
 	elasticCloud := envBool("ELASTIC_AGENT_CLOUD")
 	// if not in cloud mode, always run the agent

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -172,9 +172,9 @@ func logContainerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 
 func containerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 	// set paths early so all action below use the defined paths
-	if err := setPaths("", "", "", true); err != nil {
-		return err
-	}
+	//if err := setPaths("", "", "", true); err != nil {
+	//	return err
+	//}
 
 	elasticCloud := envBool("ELASTIC_AGENT_CLOUD")
 	// if not in cloud mode, always run the agent
@@ -348,7 +348,7 @@ func prepareAgent(cfg setupConfig) error {
 		}{
 			Agent: cfg.Agent,
 		}
-		err = rawConfig.Merge(&agentCfgOnly, config.DefaultOptions)
+		err = rawConfig.Merge(&agentCfgOnly)
 		if err != nil {
 			return err
 		}
@@ -947,7 +947,7 @@ func defaultAccessConfig() (setupConfig, error) {
 		Agent: agentConfig{
 			Monitoring: agentMonitoringConfig{
 				HTTP: agentMonitoringHTTPConfig{
-					Enabled: envBool("AGENT_MONITORING_HTTP_ENABLED"),
+					Enabled: envBool("AGENT_MONITORING_HTTP_ENABLE"),
 					Host:    envWithDefault("0.0.0.0", "AGENT_MONITORING_HTTP_HOST"),
 					Port:    envWithDefault("6789", "AGENT_MONITORING_HTTP_PORT"),
 				},

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -340,7 +340,7 @@ func prepareAgent(cfg setupConfig) error {
 		pathConfigFile := paths.ConfigFile()
 		rawConfig, err := config.LoadFile(pathConfigFile)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed open config for reading: %s", err)
 		}
 
 		agentCfgOnly := struct {
@@ -361,9 +361,9 @@ func prepareAgent(cfg setupConfig) error {
 			return err
 		}
 
-		fp, err := os.Create(pathConfigFile)
+		fp, err := os.OpenFile(pathConfigFile, os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed opening config for writing: %s", err)
 		}
 		defer fp.Close()
 		_, err = fp.Write(dataStr)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds ENV variables for the container command to allow the configuration of the HTTP metrics endpoint of the Elastic Agent.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Allows setting the `agent.monitoring.http` through ENV instead of having to write the `elastic-agent.yml` in a volumn mount that will affect the ability for an Elastic Agent to restart without having to re-enroll.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/obs-dc-team/issues/528
