### PR TITLE
ECS 1.9 user.changes.*, user.effective.*, user.target.*

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -991,6 +991,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add dns.question.subdomain fields for sysmon DNS events. {pull}22999[22999]
 - Add dns.question.top_level_domain fields for sysmon DNS events. {pull}23046[23046]
 - Add Audit and Authentication Polixy Change Events and related.ip information {pull}20684[20684]
+- Add ECS 1.9 Fields user.changes.* , user.effective.* and user.target.* {pull}25754[25754]
 
 *Elastic Log Driver*
 

--- a/winlogbeat/docs/modules/security.asciidoc
+++ b/winlogbeat/docs/modules/security.asciidoc
@@ -16,6 +16,7 @@ The module has transformations for the following event IDs:
 * 4634 - An account was logged off.
 * 4647 - User initiated logoff (interactive logon types).
 * 4648 - A logon was attempted using explicit credentials.
+* 4670 - Permissions on an object were changed.
 * 4672 - Special privileges assigned to new logon.
 * 4673 - A privileged service was called.
 * 4674 - An operation was attempted on a privileged object.
@@ -27,6 +28,12 @@ The module has transformations for the following event IDs:
 * 4700 - A scheduled task was enabled.
 * 4701 - A scheduled task was disabled.
 * 4702 - A scheduled task was updated.
+* 4706 - A new trust was created to a domain.
+* 4707 - A trust to a domain was removed.
+* 4713 - Kerberos policy was changed.
+* 4716 - Trusted domain information was modified.
+* 4717 - System security access was granted to an account.
+* 4718 - System security access was removed from an account.
 * 4719 - System audit policy was changed.
 * 4720 - A user account was created.
 * 4722 - A user account was enabled.
@@ -45,6 +52,7 @@ The module has transformations for the following event IDs:
 * 4735 - A security-enabled local group was changed.
 * 4737 - A security-enabled global group was changed.
 * 4738 - An user account was changed.
+* 4739 - Domain Policy was changed.
 * 4740 - An user account was locked out.
 * 4741 - A computer account was created.
 * 4742 - A computer account was changed.
@@ -105,6 +113,14 @@ The module has transformations for the following event IDs:
 * 4781 - The name of an account was changed.
 * 4798 - A user's local group membership was enumerated.
 * 4799 - A security-enabled local group membership was enumerated.
+* 4817 - Auditing settings on object were changed.
+* 4902 - The Per-user audit policy table was created.
+* 4904 - An attempt was made to register a security event source.
+* 4905 - An attempt was made to unregister a security event source.
+* 4906 - The CrashOnAuditFail value has changed.
+* 4907 - Auditing settings on object were changed.
+* 4908 - Special Groups Logon table modified.
+* 4912 - Per User Audit Policy was changed.
 * 4964 - Special groups have been assigned to a new logon.
 
 More event IDs will be added.


### PR DESCRIPTION
## What does this PR do?

In ECS 1.9 user.changes.\*,  user.effective.\*,  and user.target.* were introduced in order to capture better those events in where many users are involved. This fields allows us to model complex user's relationships.

See improvements sections in  https://github.com/elastic/ecs/releases

## Why is it important?

According to the usage described in  https://www.elastic.co/guide/en/ecs/current/ecs-user-usage.html  modifications to the winlogbeat security module are introduced in this PR in order to model  user's relationship in an event.

## Checklist 

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] In the modified copyTargetUser I could simplify the code adding only {from: "winlog.event_data.TargetSid", to: "user.id"} but instead of that I check later for the existence of the field. If its better to do int in the .Convert please let me know

## Use cases
The events affected are

<!--table
	{mso-displayed-decimal-separator:"\,";
	mso-displayed-thousand-separator:"\.";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{background:#92D050;
	mso-pattern:black none;}
.xl66
	{color:red;}
.xl67
	{color:white;
	background:black;
	mso-pattern:black none;}
.xl68
	{white-space:normal;}
.xl69
	{color:white;
	background:black;
	mso-pattern:black none;
	white-space:normal;}
.xl70
	{vertical-align:middle;
	white-space:normal;}
-->

EventID | User Field | Comments
-- | -- | --
4648 | user.effective.* | This event captures the semantic  of **RunAs**.  Originally the user.* was completed with the information of the winlog.event_data.TargetUser.\*,  but according to the documentation _user.* is the actual user who is   executing the RunAs,_ so I've change to the user.* to be complete with the  winlog.event_data.SubjectUser and the winlog.event_data.TargetUser.* copied to user.effective.*.     From the doc   _Use the user fields at the root to capture who is requesting the privilege   change, and user.effective to capture the requested privilege level, whether   or not the privilege change was successful_
4688 | user.effective.* | In Windows 10/ Windows Server   2016 the some fields (winlog.event_data.TargetUser.*) where added in order to   capture when a process is started under a different account. By default, a   new process runs under the same account and logon session as the creator   process
4720 | user.target.* | User Management Events where the   winlog.event_data.TargetUser.\*&nbsp;   -&gt;&nbsp; user.target.\*
4722 | user.target.* | User Management Events where the   winlog.event_data.TargetUser.\*&nbsp;   -&gt;&nbsp; user.target.\*
4723 | user.target.* | User Management Events where the   winlog.event_data.TargetUser.\*&nbsp;   -&gt;&nbsp; user.target.\*
4724 | user.target.* | User Management Events where the   winlog.event_data.TargetUser.\*&nbsp;   -&gt;&nbsp; user.target.\*
4725 | user.target.* | User Management Events where the   winlog.event_data.TargetUser\.*&nbsp;   -&gt;&nbsp; user.target.\*
4726 | user.target.* | User Management Events where the   winlog.event_data.TargetUser.\*&nbsp;   -&gt;&nbsp; user.target.\*
4728 | user.target.* | Group Management Events   user.target.\* is completed with member information
4729 | user.target.* | Group Management Events   user.target.\* is completed with member information
4732 | user.target.* | Group Management Events   user.target.\* is completed with member information
4733 | user.target.* | Group Management Events   user.target.\* is completed with member information
4738 | user.target.* | User Management Events where the   winlog.event_data.TargetUser\.*&nbsp;   -&gt;&nbsp; user.target.\*
4740 | user.target.* | User Management Events where the   winlog.event_data.TargetUser.\*&nbsp;   -&gt;&nbsp; user.target.\*
4746 | user.target.* | Group Management Events   user.target.* is completed with member information
4747 | user.target.* | Group Management Events   user.target.* is completed with member information
4751 | user.target.* | Group Management Events   user.target.* is completed with member information
4752 | user.target.* | Group Management Events   user.target.* is completed with member information
4756 | user.target.* | Group Management Events   user.target.* is completed with member information
4757 | user.target.* | Group Management Events   user.target.* is completed with member information
4761 | user.target.* | Group Management Events   user.target.* is completed with member information
4762 | user.target.* | Group Management Events   user.target.* is completed with member information
4767 | user.target.* | User Management Events where the   winlog.event_data.TargetUser\.*&nbsp;   -&gt;&nbsp; user.target.\*
4768 | fix | Fixed targetSid Field
4771 | fix | Fixed targetSid Field
4781 | user.target.\* and user.changes.\* | User Management Events where the   winlog.event_data.OldTargetUser.*&nbsp;   -&gt;&nbsp; user.target.\* and   winlog.event_data.NewTargetUser.\*
















