### PR TITLE
Revert "Add env for http monitor container command (#25746)"

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -67,7 +67,6 @@
 - Add error log entry when listener creation fails {issue}23483[23482]
 - Handle case where policy doesn't contain Fleet connection information {pull}25707[25707]
 - Fix fleet-server.yml spec to not overwrite existing keys {pull}25741[25741]
-- Add env for http monitor container command {pull}25746[25746]
 
 ==== New features
 


### PR DESCRIPTION

This reverts commit 6b61c9692c0daaf5608550bc05609c47673fb25b. As its no longer needed and we should find a cleaner way of doing this in 7.14.
