### PR TITLE
Osquerybeat: Fix osqueryd binary on linux executable permissions

### DIFF
--- a/x-pack/osquerybeat/scripts/mage/package.go
+++ b/x-pack/osquerybeat/scripts/mage/package.go
@@ -5,7 +5,7 @@
 package mage
 
 import (
-	"io/fs"
+	"os"
 	"path/filepath"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
@@ -17,9 +17,9 @@ func CustomizePackaging() {
 		distFile := distro.OsquerydDistroPlatformFilename(args.OS)
 
 		// The minimal change to fix the issue for 7.13
-		// https://github.com/elastic/security-team/issues/1162
+		// https://github.com/elastic/beats/issues/25762
 		// TODO: this could be moved to dev-tools/packaging/packages.yml for the next release
-		var mode fs.FileMode = 0644
+		var mode os.FileMode = 0644
 		// If distFile is osqueryd binary then it should be executable
 		if distFile == distro.OsquerydFilename() {
 			mode = 0750

--- a/x-pack/osquerybeat/scripts/mage/package.go
+++ b/x-pack/osquerybeat/scripts/mage/package.go
@@ -5,6 +5,7 @@
 package mage
 
 import (
+	"io/fs"
 	"path/filepath"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
@@ -15,8 +16,16 @@ func CustomizePackaging() {
 	for _, args := range devtools.Packages {
 		distFile := distro.OsquerydDistroPlatformFilename(args.OS)
 
+		// The minimal change to fix the issue for 7.13
+		// https://github.com/elastic/security-team/issues/1162
+		// TODO: this could be moved to dev-tools/packaging/packages.yml for the next release
+		var mode fs.FileMode = 0644
+		// If distFile is osqueryd binary then it should be executable
+		if distFile == distro.OsquerydFilename() {
+			mode = 0750
+		}
 		packFile := devtools.PackageFile{
-			Mode:   0644,
+			Mode:   mode,
 			Source: filepath.Join(distro.DataInstallDir, distFile),
 		}
 		args.Spec.Files[distFile] = packFile


### PR DESCRIPTION
## What does this PR do?

The osquerybeat package for linux contains the osqueryd binary that doesn't have executable permissions

```
-rw-r--r-- 1 root root 45460912 May 18 12:37 osqueryd
```

which causes osquerybeat to fail to run osqueryd as a child process:
```
{"log.level":"error","@timestamp":"2021-05-18T12:38:47.368Z","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquerybeat.go","file.line":173},"message":"Failed to start osqueryd process: fork/exec /opt/Elastic/Agent/data/elastic-agent-64ec73/install/osquerybeat-7
.13.0-SNAPSHOT-linux-x86_64/osqueryd: permission denied","ecs.version":"1.6.0"}
```


**Desktop (please complete the following information):**
 - OS: Linux (Ubuntu tested)


## Why is it important?

This fixes the issue on linux when osqueryd can not be started: https://github.com/elastic/security-team/issues/1162 https://github.com/elastic/beats/issues/25762

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/security-team/issues/1162
https://github.com/elastic/beats/issues/25762

## Screenshots
Confirmed the osqueryd has executable permissions out of the box and is running on linux:
![Screen Shot 2021-05-18 at 9 58 55 AM](https://user-images.githubusercontent.com/872351/118666482-3757bc80-b7c1-11eb-9cb2-b9f0ccf885f5.png)

