### PR TITLE
[Filebeat] Fix aws-s3 config initialization plus cleanup

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -40,23 +40,21 @@ The `aws-s3` input supports the following configuration options plus the
 
 The maximum duration of the AWS API call. If it exceeds the timeout, the AWS API
 call will be interrupted. The default AWS API call timeout for a message is 120
-seconds. The minimum is 0 seconds. The maximum is half of the visibility timeout
-value.
+seconds. The maximum is half of the visibility timeout value.
 
 [id="input-{type}-buffer_size"]
 [float]
 ==== `buffer_size`
 
 The size in bytes of the buffer that each harvester uses when fetching a file.
-This only applies to non-JSON logs.
-The default is 16384.
+This only applies to non-JSON logs. The default is `16 KiB`.
 
 [id="input-{type}-encoding"]
 [float]
 ==== `encoding`
 
 The file encoding to use for reading data that contains international
-characters. This only applies to non-JSON logs.  See <<_encoding_5>>.
+characters. This only applies to non-JSON logs. See <<_encoding_5>>.
 
 
 [float]
@@ -133,7 +131,7 @@ connecting to the correct service endpoint. For example:
 The maximum number of bytes that a single log message can have. All bytes after
 `max_bytes` are discarded and not sent. This setting is especially useful for
 multiline log messages, which can get large. This only applies to non-JSON logs.
-The default is 10MB (10485760).
+The default is `10 MiB`.
 
 [float]
 ==== `max_number_of_messages`
@@ -164,8 +162,7 @@ The duration that the received messages are hidden from subsequent retrieve
 requests after being retrieved by a ReceiveMessage request. This value needs to
 be a lot bigger than {beatname_uc} collection frequency so if it took too long
 to read the S3 log, this SQS message will not be reprocessed. The default
-visibility timeout for a message is 300 seconds. The minimum is 0 seconds. The
-maximum is 12 hours.
+visibility timeout for a message is 300 seconds. The maximum is 12 hours.
 
 [float]
 ==== `aws credentials`

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -6,77 +6,88 @@ package awss3
 
 import (
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/dustin/go-humanize"
 
+	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
+	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/reader/multiline"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile"
 	awscommon "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 )
 
 type config struct {
-	APITimeout               time.Duration           `config:"api_timeout"`
-	ExpandEventListFromField string                  `config:"expand_event_list_from_field"`
-	FileSelectors            []FileSelectorCfg       `config:"file_selectors"`
-	FipsEnabled              bool                    `config:"fips_enabled"`
-	MaxNumberOfMessages      int                     `config:"max_number_of_messages"`
-	QueueURL                 string                  `config:"queue_url" validate:"nonzero,required"`
-	VisibilityTimeout        time.Duration           `config:"visibility_timeout"`
-	AwsConfig                awscommon.ConfigAWS     `config:",inline"`
-	MaxBytes                 int                     `config:"max_bytes" validate:"min=0,nonzero"`
-	Multiline                *multiline.Config       `config:"multiline"`
-	LineTerminator           readfile.LineTerminator `config:"line_terminator"`
-	Encoding                 string                  `config:"encoding"`
-	BufferSize               int                     `config:"buffer_size"`
-}
-
-// FileSelectorCfg defines type and configuration of FileSelectors
-type FileSelectorCfg struct {
-	RegexString              string                  `config:"regex"`
-	Regex                    *regexp.Regexp          `config:",ignore"`
-	ExpandEventListFromField string                  `config:"expand_event_list_from_field"`
-	MaxBytes                 int                     `config:"max_bytes" validate:"min=0,nonzero"`
-	Multiline                *multiline.Config       `config:"multiline"`
-	LineTerminator           readfile.LineTerminator `config:"line_terminator"`
-	Encoding                 string                  `config:"encoding"`
-	BufferSize               int                     `config:"buffer_size"`
+	APITimeout          time.Duration        `config:"api_timeout"`
+	VisibilityTimeout   time.Duration        `config:"visibility_timeout"`
+	FIPSEnabled         bool                 `config:"fips_enabled"`
+	MaxNumberOfMessages int                  `config:"max_number_of_messages"`
+	QueueURL            string               `config:"queue_url" validate:"required"`
+	AWSConfig           awscommon.ConfigAWS  `config:",inline"`
+	FileSelectors       []fileSelectorConfig `config:"file_selectors"`
+	ReaderConfig        readerConfig         `config:",inline"` // Reader options to apply when no file_selectors are used.
 }
 
 func defaultConfig() config {
-	return config{
+	c := config{
 		APITimeout:          120 * time.Second,
-		FipsEnabled:         false,
-		MaxNumberOfMessages: 5,
 		VisibilityTimeout:   300 * time.Second,
-		LineTerminator:      readfile.AutoLineTerminator,
-		MaxBytes:            10 * humanize.MiByte,
-		BufferSize:          16 * humanize.KiByte,
+		FIPSEnabled:         false,
+		MaxNumberOfMessages: 5,
 	}
+	c.ReaderConfig.InitDefaults()
+	return c
 }
 
 func (c *config) Validate() error {
-	if c.VisibilityTimeout < 0 || c.VisibilityTimeout.Hours() > 12 {
-		return fmt.Errorf("visibility timeout %v is not within the "+
-			"required range 0s to 12h", c.VisibilityTimeout)
+	if c.VisibilityTimeout <= 0 || c.VisibilityTimeout.Hours() > 12 {
+		return fmt.Errorf("visibility_timeout <%v> must be greater than 0 and "+
+			"less than or equal to 12h", c.VisibilityTimeout)
 	}
 
-	if c.APITimeout < 0 || c.APITimeout > c.VisibilityTimeout/2 {
-		return fmt.Errorf("api timeout %v needs to be larger than"+
-			" 0s and smaller than half of the visibility timeout", c.APITimeout)
+	if c.APITimeout <= 0 || c.APITimeout > c.VisibilityTimeout/2 {
+		return fmt.Errorf("api_timeout <%v> must be greater than 0 and less "+
+			"than 1/2 of the visibility_timeout (%v)", c.APITimeout, c.VisibilityTimeout/2)
 	}
 
-	for i := range c.FileSelectors {
-		r, err := regexp.Compile(c.FileSelectors[i].RegexString)
-		if err != nil {
-			return err
-		}
-		c.FileSelectors[i].Regex = r
-	}
-
-	if c.MaxNumberOfMessages > 10 || c.MaxNumberOfMessages < 1 {
-		return fmt.Errorf(" max_number_of_messages %v needs to be between 1 and 10", c.MaxNumberOfMessages)
+	if c.MaxNumberOfMessages <= 0 || c.MaxNumberOfMessages > 10 {
+		return fmt.Errorf("max_number_of_messages <%v> must be greater than "+
+			"0 and less than or equal to 10", c.MaxNumberOfMessages)
 	}
 	return nil
+}
+
+// fileSelectorConfig defines reader configuration that applies to a subset
+// of S3 objects whose URL matches the given regex.
+type fileSelectorConfig struct {
+	Regex        *match.Matcher `config:"regex" validate:"required"`
+	ReaderConfig readerConfig   `config:",inline"`
+}
+
+// readerConfig defines the options for reading the content of an S3 object.
+type readerConfig struct {
+	ExpandEventListFromField string                  `config:"expand_event_list_from_field"`
+	BufferSize               cfgtype.ByteSize        `config:"buffer_size"`
+	MaxBytes                 cfgtype.ByteSize        `config:"max_bytes"`
+	Multiline                *multiline.Config       `config:"multiline"`
+	LineTerminator           readfile.LineTerminator `config:"line_terminator"`
+	Encoding                 string                  `config:"encoding"`
+}
+
+func (f *readerConfig) Validate() error {
+	if f.BufferSize <= 0 {
+		return fmt.Errorf("buffer_size <%v> must be greater than 0", f.BufferSize)
+	}
+
+	if f.MaxBytes <= 0 {
+		return fmt.Errorf("max_bytes <%v> must be greater than 0", f.MaxBytes)
+	}
+
+	return nil
+}
+
+func (f *readerConfig) InitDefaults() {
+	f.BufferSize = 16 * humanize.KiByte
+	f.MaxBytes = 10 * humanize.MiByte
+	f.LineTerminator = readfile.AutoLineTerminator
 }

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -1,0 +1,168 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awss3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/match"
+	"github.com/elastic/beats/v7/libbeat/reader/readfile"
+)
+
+func TestConfig(t *testing.T) {
+	const queueURL = "https://example.com"
+	makeConfig := func() config {
+		// Have a separate copy of defaults in the test to make it clear when
+		// anyone changes the defaults.
+		return config{
+			QueueURL:            queueURL,
+			APITimeout:          120 * time.Second,
+			VisibilityTimeout:   300 * time.Second,
+			FIPSEnabled:         false,
+			MaxNumberOfMessages: 5,
+			ReaderConfig: readerConfig{
+				BufferSize:     16 * humanize.KiByte,
+				MaxBytes:       10 * humanize.MiByte,
+				LineTerminator: readfile.AutoLineTerminator,
+			},
+		}
+	}
+
+	testCases := []struct {
+		name        string
+		config      common.MapStr
+		expectedErr string
+		expectedCfg func() config
+	}{
+		{
+			"input with defaults",
+			common.MapStr{
+				"queue_url": queueURL,
+			},
+			"",
+			makeConfig,
+		},
+		{
+			"input with file_selectors",
+			common.MapStr{
+				"queue_url": queueURL,
+				"file_selectors": []common.MapStr{
+					{
+						"regex": "/CloudTrail/",
+					},
+				},
+			},
+			"",
+			func() config {
+				c := makeConfig()
+				regex := match.MustCompile("/CloudTrail/")
+				c.FileSelectors = []fileSelectorConfig{
+					{
+						Regex:        &regex,
+						ReaderConfig: c.ReaderConfig,
+					},
+				}
+				return c
+			},
+		},
+		{
+			"error on api_timeout == 0",
+			common.MapStr{
+				"queue_url":   queueURL,
+				"api_timeout": "0",
+			},
+			"api_timeout <0s> must be greater than 0 and less than 1/2 of the visibility_timeout (2m30s)",
+			nil,
+		},
+		{
+			"error on api_timeout less than visibility_timeout/2",
+			common.MapStr{
+				"queue_url":   queueURL,
+				"api_timeout": "3m",
+			},
+			"api_timeout <3m0s> must be greater than 0 and less than 1/2 of the visibility_timeout (2m30s)",
+			nil,
+		},
+		{
+			"error on visibility_timeout == 0",
+			common.MapStr{
+				"queue_url":          queueURL,
+				"visibility_timeout": "0",
+			},
+			"visibility_timeout <0s> must be greater than 0 and less than or equal to 12h",
+			nil,
+		},
+		{
+			"error on visibility_timeout > 12h",
+			common.MapStr{
+				"queue_url":          queueURL,
+				"visibility_timeout": "12h1ns",
+			},
+			"visibility_timeout <12h0m0.000000001s> must be greater than 0 and less than or equal to 12h",
+			nil,
+		},
+		{
+			"error on max_number_of_messages == 0",
+			common.MapStr{
+				"queue_url":              queueURL,
+				"max_number_of_messages": "0",
+			},
+			"max_number_of_messages <0> must be greater than 0 and less than or equal to 10",
+			nil,
+		},
+		{
+			"error on max_number_of_messages > 10",
+			common.MapStr{
+				"queue_url":              queueURL,
+				"max_number_of_messages": "11",
+			},
+			"max_number_of_messages <11> must be greater than 0 and less than or equal to 10",
+			nil,
+		},
+		{
+			"error on buffer_size == 0 ",
+			common.MapStr{
+				"queue_url":   queueURL,
+				"buffer_size": "0",
+			},
+			"buffer_size <0> must be greater than 0",
+			nil,
+		},
+		{
+			"error on max_bytes == 0 ",
+			common.MapStr{
+				"queue_url": queueURL,
+				"max_bytes": "0",
+			},
+			"max_bytes <0> must be greater than 0",
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := common.MustNewConfigFrom(tc.config)
+
+			c := defaultConfig()
+			if err := in.Unpack(&c); err != nil {
+				if tc.expectedErr != "" {
+					assert.Contains(t, err.Error(), tc.expectedErr)
+					return
+				}
+				t.Fatal(err)
+			}
+
+			if tc.expectedCfg == nil {
+				t.Fatal("missing expected config in test case")
+			}
+			assert.EqualValues(t, tc.expectedCfg(), c)
+		})
+	}
+}

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -54,7 +54,7 @@ func newInput(config config) (*s3Input, error) {
 func (in *s3Input) Name() string { return inputName }
 
 func (in *s3Input) Test(ctx v2.TestContext) error {
-	_, err := awscommon.GetAWSCredentials(in.config.AwsConfig)
+	_, err := awscommon.GetAWSCredentials(in.config.AWSConfig)
 	if err != nil {
 		return fmt.Errorf("getAWSCredentials failed: %w", err)
 	}
@@ -89,7 +89,7 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 		return nil, err
 	}
 
-	regionName, err := getRegionFromQueueURL(in.config.QueueURL, in.config.AwsConfig.Endpoint)
+	regionName, err := getRegionFromQueueURL(in.config.QueueURL, in.config.AWSConfig.Endpoint)
 	if err != nil {
 		err := fmt.Errorf("getRegionFromQueueURL failed: %w", err)
 		log.Error(err)
@@ -98,7 +98,7 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 		log = log.With("region", regionName)
 	}
 
-	awsConfig, err := awscommon.GetAWSCredentials(in.config.AwsConfig)
+	awsConfig, err := awscommon.GetAWSCredentials(in.config.AWSConfig)
 	if err != nil {
 		return nil, fmt.Errorf("getAWSCredentials failed: %w", err)
 	}
@@ -109,13 +109,13 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 	log.Infof("aws api timeout is set to %v", in.config.APITimeout)
 
 	s3Servicename := "s3"
-	if in.config.FipsEnabled {
+	if in.config.FIPSEnabled {
 		s3Servicename = "s3-fips"
 	}
 
 	log.Debug("s3 service name = ", s3Servicename)
 	log.Debug("s3 input config max_number_of_messages = ", in.config.MaxNumberOfMessages)
-	log.Debug("s3 input config endpoint = ", in.config.AwsConfig.Endpoint)
+	log.Debug("s3 input config endpoint = ", in.config.AWSConfig.Endpoint)
 	metricRegistry := monitoring.GetNamespace("dataset").GetRegistry()
 	return &s3Collector{
 		cancellation:      ctxtool.FromCanceller(ctx.Cancelation),
@@ -123,8 +123,8 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 		config:            &in.config,
 		publisher:         client,
 		visibilityTimeout: visibilityTimeout,
-		sqs:               sqs.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, "sqs", regionName, awsConfig)),
-		s3:                s3.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, s3Servicename, regionName, awsConfig)),
+		sqs:               sqs.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AWSConfig.Endpoint, "sqs", regionName, awsConfig)),
+		s3:                s3.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AWSConfig.Endpoint, s3Servicename, regionName, awsConfig)),
 		metrics:           newInputMetrics(metricRegistry, ctx.ID),
 	}, nil
 }

--- a/x-pack/filebeat/input/awss3/s3_integration_test.go
+++ b/x-pack/filebeat/input/awss3/s3_integration_test.go
@@ -60,7 +60,7 @@ func getConfigForTest(t *testing.T) config {
 	case profileName != "":
 		awsConfig.ProfileName = profileName
 		config.QueueURL = queueURL
-		config.AwsConfig = awsConfig
+		config.AWSConfig = awsConfig
 		return config
 	case secretAccessKey == "":
 		t.Fatal("$AWS_SECRET_ACCESS_KEY not set or set to empty")
@@ -71,7 +71,7 @@ func getConfigForTest(t *testing.T) config {
 	if sessionToken != "" {
 		awsConfig.SessionToken = sessionToken
 	}
-	config.AwsConfig = awsConfig
+	config.AWSConfig = awsConfig
 	return config
 }
 
@@ -134,7 +134,7 @@ func setupCollector(t *testing.T, cfg *common.Config, mock bool) (*s3Collector, 
 	}
 
 	config := getConfigForTest(t)
-	awsConfig, err := awscommon.GetAWSCredentials(config.AwsConfig)
+	awsConfig, err := awscommon.GetAWSCredentials(config.AWSConfig)
 	if err != nil {
 		t.Fatal("failed GetAWSCredentials with AWS Config: ", err)
 	}


### PR DESCRIPTION
## What does this PR do?

The bug was that the FileSelectorCfg values were not being initialized to their defaults prior to config `Unpack`. This caused previously working configs to fail because the new options recently added were uninitialized. This fixes the issue by implementing the ucfg Initializer interface (https://pkg.go.dev/github.com/elastic/go-ucfg#Initializer) to ensure defaults are set.

Other changes:

- Refactoring the config to have a `readerConfig` struct that contained all the S3 object processing options since they were defined in several structs.

- Replaced `int`s used to represent byte sizes with `cfgtype.ByteSize` so that users can write values like `10 MiB` for convenience.

- Changed the validation logic to check that api_timeout and visibility_timeout are > 0. Previously they accepted 0.

- Changed the config structs to use `*match.Matcher` instead of manually initializing and validating regexp values. match.Matcher implements the ucfg interface so there is less work to do here.

- Added tests to cover all of the config validation logic.

## Why is it important?

Fixes an issue added in #25710. It hasn't been released so I didn't add a changelog. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

- Relates #25710

## Logs

This fixes errors like

`Exiting: Failed to start crawler: starting input failed: Error while initializing input: zero value accessing 'filebeat.inputs.0.file_selectors.0.max_bytes' (source:'filebeat.s3.yml')`