### PR TITLE
Refactor kubelet metricsets to share response from endpoint

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -992,6 +992,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Refactor state_* metricsets to share response from endpoint. {pull}25640[25640]
 - Add server id to zookeeper events. {pull}25550[25550]
 - Add additional network metrics to docker/network {pull}25354[25354]
+- [Kubernetes] Refactor kubelet metricsets to share response from endpoint. {pull}25782[25782]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -992,7 +992,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Refactor state_* metricsets to share response from endpoint. {pull}25640[25640]
 - Add server id to zookeeper events. {pull}25550[25550]
 - Add additional network metrics to docker/network {pull}25354[25354]
-- [Kubernetes] Refactor kubelet metricsets to share response from endpoint. {pull}25782[25782]
+- Reduce number of requests done by kubernetes metricsets to kubelet. {pull}25782[25782]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -90,7 +90,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	body, err := m.mod.GetSharedKubeletStats(m.http)
+	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'container' Metricset data")
 

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -18,12 +18,15 @@
 package container
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
+	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
@@ -58,6 +61,7 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	http     *helper.HTTP
 	enricher util.Enricher
+	mod      k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -68,10 +72,15 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
+	mod, ok := base.Module().(k8smod.Module)
+	if !ok {
+		return nil, fmt.Errorf("must be child of kubernetes module")
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
 		enricher:      util.NewContainerMetadataEnricher(base, true),
+		mod:           mod,
 	}, nil
 }
 
@@ -81,7 +90,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	body, err := m.http.FetchContent()
+	body, err := m.mod.GetSharedKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'container' Metricset data")
 

--- a/metricbeat/module/kubernetes/kubernetes.go
+++ b/metricbeat/module/kubernetes/kubernetes.go
@@ -39,8 +39,8 @@ func init() {
 
 type Module interface {
 	mb.Module
-	GetSharedFamilies(prometheus p.Prometheus) ([]*dto.MetricFamily, error)
-	GetSharedKubeletStats(http *helper.HTTP) ([]byte, error)
+	GetStateMetricsFamilies(prometheus p.Prometheus) ([]*dto.MetricFamily, error)
+	GetKubeletStats(http *helper.HTTP) ([]byte, error)
 }
 
 type familiesCache struct {
@@ -109,7 +109,7 @@ func ModuleBuilder() func(base mb.BaseModule) (mb.Module, error) {
 	}
 }
 
-func (m *module) GetSharedFamilies(prometheus p.Prometheus) ([]*dto.MetricFamily, error) {
+func (m *module) GetStateMetricsFamilies(prometheus p.Prometheus) ([]*dto.MetricFamily, error) {
 	m.kubeStateMetricsCache.lock.Lock()
 	defer m.kubeStateMetricsCache.lock.Unlock()
 
@@ -127,7 +127,7 @@ func (m *module) GetSharedFamilies(prometheus p.Prometheus) ([]*dto.MetricFamily
 	return familiesCache.sharedFamilies, familiesCache.lastFetchErr
 }
 
-func (m *module) GetSharedKubeletStats(http *helper.HTTP) ([]byte, error) {
+func (m *module) GetKubeletStats(http *helper.HTTP) ([]byte, error) {
 	m.kubeletStatsCache.lock.Lock()
 	defer m.kubeletStatsCache.lock.Unlock()
 

--- a/metricbeat/module/kubernetes/kubernetes.go
+++ b/metricbeat/module/kubernetes/kubernetes.go
@@ -18,7 +18,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -116,7 +115,6 @@ func (m *module) GetSharedFamilies(prometheus p.Prometheus) ([]*dto.MetricFamily
 	defer m.kubeStateMetricsCache.lock.Unlock()
 
 	now := time.Now()
-	fmt.Println("hahahah")
 	// NOTE: These entries will be never removed, this can be a leak if
 	// metricbeat is used to monitor clusters dynamically created.
 	// (https://github.com/elastic/beats/pull/25640#discussion_r633395213)
@@ -134,7 +132,6 @@ func (m *module) GetSharedKubeletStats(http *helper.HTTP) ([]byte, error) {
 	m.kubeletStatsCache.lock.Lock()
 	defer m.kubeletStatsCache.lock.Unlock()
 
-	fmt.Println("hehehehe")
 	now := time.Now()
 
 	// NOTE: These entries will be never removed, this can be a leak if

--- a/metricbeat/module/kubernetes/kubernetes.go
+++ b/metricbeat/module/kubernetes/kubernetes.go
@@ -21,12 +21,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/beats/v7/metricbeat/helper"
-
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/elastic/beats/v7/metricbeat/helper"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )

--- a/metricbeat/module/kubernetes/kubernetes.go
+++ b/metricbeat/module/kubernetes/kubernetes.go
@@ -18,6 +18,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -56,8 +57,6 @@ type kubeStateMetricsCache struct {
 }
 
 func (c *kubeStateMetricsCache) getCacheMapEntry(hash uint64) *familiesCache {
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	if _, ok := c.cacheMap[hash]; !ok {
 		c.cacheMap[hash] = &familiesCache{}
 	}
@@ -76,8 +75,6 @@ type kubeletStatsCache struct {
 }
 
 func (c *kubeletStatsCache) getCacheMapEntry(hash uint64) *statsCache {
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	if _, ok := c.cacheMap[hash]; !ok {
 		c.cacheMap[hash] = &statsCache{}
 	}
@@ -119,7 +116,7 @@ func (m *module) GetSharedFamilies(prometheus p.Prometheus) ([]*dto.MetricFamily
 	defer m.kubeStateMetricsCache.lock.Unlock()
 
 	now := time.Now()
-
+	fmt.Println("hahahah")
 	// NOTE: These entries will be never removed, this can be a leak if
 	// metricbeat is used to monitor clusters dynamically created.
 	// (https://github.com/elastic/beats/pull/25640#discussion_r633395213)
@@ -137,6 +134,7 @@ func (m *module) GetSharedKubeletStats(http *helper.HTTP) ([]byte, error) {
 	m.kubeletStatsCache.lock.Lock()
 	defer m.kubeletStatsCache.lock.Unlock()
 
+	fmt.Println("hehehehe")
 	now := time.Now()
 
 	// NOTE: These entries will be never removed, this can be a leak if

--- a/metricbeat/module/kubernetes/kubernetes.go
+++ b/metricbeat/module/kubernetes/kubernetes.go
@@ -18,9 +18,10 @@
 package kubernetes
 
 import (
-	"github.com/elastic/beats/v7/metricbeat/helper"
 	"sync"
 	"time"
+
+	"github.com/elastic/beats/v7/metricbeat/helper"
 
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
@@ -87,8 +88,8 @@ type module struct {
 	mb.BaseModule
 
 	kubeStateMetricsCache *kubeStateMetricsCache
-	kubeletStatsCache *kubeletStatsCache
-	cacheHash uint64
+	kubeletStatsCache     *kubeletStatsCache
+	cacheHash             uint64
 }
 
 func ModuleBuilder() func(base mb.BaseModule) (mb.Module, error) {
@@ -106,8 +107,8 @@ func ModuleBuilder() func(base mb.BaseModule) (mb.Module, error) {
 		m := module{
 			BaseModule:            base,
 			kubeStateMetricsCache: kubeStateMetricsCache,
-			kubeletStatsCache: kubeletStatsCache,
-			cacheHash: hash,
+			kubeletStatsCache:     kubeletStatsCache,
+			cacheHash:             hash,
 		}
 		return &m, nil
 	}

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -18,6 +18,7 @@
 package node
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -26,6 +27,7 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
+	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
@@ -60,6 +62,7 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	http     *helper.HTTP
 	enricher util.Enricher
+	mod        k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -70,11 +73,15 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	mod, ok := base.Module().(k8smod.Module)
+	if !ok {
+		return nil, fmt.Errorf("must be child of kubernetes module")
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
 		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Node{}, false),
+		mod: mod,
 	}, nil
 }
 
@@ -84,7 +91,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	body, err := m.http.FetchContent()
+	body, err := m.mod.GetSharedKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'node' Metricset data")
 

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -92,7 +92,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	body, err := m.mod.GetSharedKubeletStats(m.http)
+	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'node' Metricset data")
 

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -19,6 +19,7 @@ package node
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -62,7 +63,7 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	http     *helper.HTTP
 	enricher util.Enricher
-	mod        k8smod.Module
+	mod      k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -81,7 +82,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		BaseMetricSet: base,
 		http:          http,
 		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Node{}, false),
-		mod: mod,
+		mod:           mod,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -18,6 +18,7 @@
 package pod
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
@@ -25,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
+	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
@@ -59,6 +61,7 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	http     *helper.HTTP
 	enricher util.Enricher
+	mod        k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -69,11 +72,15 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	mod, ok := base.Module().(k8smod.Module)
+	if !ok {
+		return nil, fmt.Errorf("must be child of kubernetes module")
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
 		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Pod{}, true),
+		mod: mod,
 	}, nil
 }
 
@@ -83,9 +90,9 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	body, err := m.http.FetchContent()
+	body, err := m.mod.GetSharedKubeletStats(m.http)
 	if err != nil {
-		return errors.Wrap(err, "error doing HTTP request to fetch 'pod' Metricset data")
+		return errors.Wrap(err, "error fetching shared data for 'pod' Metricset")
 	}
 
 	events, err := eventMapping(body, util.PerfMetrics)

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -19,6 +19,7 @@ package pod
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
@@ -61,7 +62,7 @@ type MetricSet struct {
 	mb.BaseMetricSet
 	http     *helper.HTTP
 	enricher util.Enricher
-	mod        k8smod.Module
+	mod      k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -80,7 +81,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		BaseMetricSet: base,
 		http:          http,
 		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Pod{}, true),
-		mod: mod,
+		mod:           mod,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -91,7 +91,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	body, err := m.mod.GetSharedKubeletStats(m.http)
+	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error fetching shared data for 'pod' Metricset")
 	}

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -120,7 +120,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return errors.Wrap(err, "error getting families")
 	}

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
@@ -87,7 +87,7 @@ func NewCronJobMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 //
 // Copied from other kube state metrics.
 func (m *CronJobMetricSet) Fetch(reporter mb.ReporterV2) error {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return errors.Wrap(err, "error getting family metrics")
 	}

--- a/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
+++ b/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
@@ -101,7 +101,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment.go
@@ -102,7 +102,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -113,7 +113,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'state_node' Metricset data")
 	}

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
@@ -77,7 +77,7 @@ func NewPersistentVolumeMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
 // module rooted fields at the event that gets reported
 func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
@@ -82,7 +82,7 @@ func NewpersistentvolumeclaimMetricSet(base mb.BaseMetricSet) (mb.MetricSet, err
 // module rooted fields at the event that gets reported
 func (m *persistentvolumeclaimMetricSet) Fetch(reporter mb.ReporterV2) error {
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return err
 	}

--- a/metricbeat/module/kubernetes/state_pod/state_pod.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod.go
@@ -104,7 +104,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
@@ -102,7 +102,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_resourcequota/state_resourcequota.go
+++ b/metricbeat/module/kubernetes/state_resourcequota/state_resourcequota.go
@@ -76,7 +76,7 @@ func NewResourceQuotaMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
 // module rooted fields at the event that gets reported
 func (m *ResourceQuotaMetricSet) Fetch(reporter mb.ReporterV2) {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_service/state_service.go
+++ b/metricbeat/module/kubernetes/state_service/state_service.go
@@ -95,7 +95,7 @@ func NewServiceMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *ServiceMetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_statefulset/state_statefulset.go
+++ b/metricbeat/module/kubernetes/state_statefulset/state_statefulset.go
@@ -101,7 +101,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_storageclass/state_storageclass.go
+++ b/metricbeat/module/kubernetes/state_storageclass/state_storageclass.go
@@ -78,7 +78,7 @@ func NewStorageClassMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
 // module rooted fields at the event that gets reported
 func (m *StorageClassMetricSet) Fetch(reporter mb.ReporterV2) {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -18,12 +18,14 @@
 package system
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
+	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 )
 
 const (
@@ -56,6 +58,7 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
+	mod        k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -66,9 +69,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
+	mod, ok := base.Module().(k8smod.Module)
+	if !ok {
+		return nil, fmt.Errorf("must be child of kubernetes module")
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
+		mod: mod,
 	}, nil
 }
 
@@ -76,7 +84,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
-	body, err := m.http.FetchContent()
+	body, err := m.mod.GetSharedKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'system' Metricset data")
 	}

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -85,7 +85,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
-	body, err := m.mod.GetSharedKubeletStats(m.http)
+	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'system' Metricset data")
 	}

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -19,6 +19,7 @@ package system
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -58,7 +59,7 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
-	mod        k8smod.Module
+	mod  k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -76,7 +77,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
-		mod: mod,
+		mod:           mod,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -85,7 +85,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
-	body, err := m.mod.GetSharedKubeletStats(m.http)
+	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'volume' Metricset data")
 	}

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -19,6 +19,7 @@ package volume
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -58,7 +59,7 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
-	mod        k8smod.Module
+	mod  k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -76,7 +77,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
-		mod: mod,
+		mod:           mod,
 	}, nil
 }
 

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -18,12 +18,14 @@
 package volume
 
 import (
+	"fmt"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
+	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 )
 
 const (
@@ -56,6 +58,7 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
+	mod        k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -66,9 +69,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
+	mod, ok := base.Module().(k8smod.Module)
+	if !ok {
+		return nil, fmt.Errorf("must be child of kubernetes module")
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
+		mod: mod,
 	}, nil
 }
 
@@ -76,7 +84,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
-	body, err := m.http.FetchContent()
+	body, err := m.mod.GetSharedKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'volume' Metricset data")
 	}


### PR DESCRIPTION
## What does this PR do?
Follow up of https://github.com/elastic/beats/pull/25640. This PR changes how kubernetes module handle metricsets which collect metrics from kubelet's API and which share same target endpoint.
Metricsets affected:
- `system`
- `pod`
- `node`
- `volume`
- `container`

## Why is it important?
To improve the performance of the module by avoid fetching same content multiple times.

## How to test this PR locally

1. Deploy Metricbeat on k8s with https://github.com/elastic/beats/blob/master/deploy/kubernetes/metricbeat-kubernetes.yaml using the proper docker image (ie a BC, snapshot etc). Modify the configmaps accordingly using the configs below.
2. state_* config using leaderelection:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      scope: cluster
      node: ${NODE_NAME}
      unique: true
      templates:
        - config:
            - module: kubernetes
              hosts: ["kube-state-metrics:8080"]
              period: 10s
              add_metadata: true
              metricsets:
                - state_node
                - state_deployment
                - state_daemonset
                - state_replicaset
                - state_pod
            - module: kubernetes
              hosts: ["kube-state-metrics:8080"]
              period: 10s
              add_metadata: true
              metricsets:
                - state_container
                - state_cronjob
                - state_service
                - state_resourcequota
                - state_statefulset
```
2. Kubelet's metricsets' config:
```
- module: kubernetes
  metricsets:
    - container
    - volume
  period: 10s
  host: ${NODE_NAME}
  hosts: ["https://${NODE_NAME}:10250"]
  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
  ssl.verification_mode: "none" 
- module: kubernetes
  metricsets:
    - node
    - system
    - pod
  period: 10s
  host: ${NODE_NAME}
  hosts: ["https://${NODE_NAME}:10250"]
  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
  ssl.verification_mode: "none"
```
4. Verify that all metricsets are being populated (like in the screenshot below) and that k8s metadata are properly attached on the events.

## Related issues
Closes #24869


## Screenshots
![Screenshot 2021-05-20 at 1 47 18 PM](https://user-images.githubusercontent.com/11754898/118966016-f357e980-b971-11eb-9652-18c59c7238b3.png)

