### PR TITLE
[mergify] allow backports in any direction

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,5 @@
 pull_request_rules:
-  - name: backport patches to master branch
+  - name: forward-port patches to master branch
     conditions:
       - merged
       - label=backport-v8.0.0

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,20 @@
 pull_request_rules:
+  - name: backport patches to master branch
+    conditions:
+      - merged
+      - label=backport-v8.0.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "master"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 7.x branch
     conditions:
       - merged
-      - base=master
       - label=backport-v7.14.0
     actions:
       backport:
@@ -16,7 +28,6 @@ pull_request_rules:
   - name: backport patches to 7.13 branch
     conditions:
       - merged
-      - base=master
       - label=backport-v7.13.0
     actions:
       backport:
@@ -30,7 +41,6 @@ pull_request_rules:
   - name: backport patches to 7.12 branch
     conditions:
       - merged
-      - base=master
       - label=backport-v7.12.0
     actions:
       backport:


### PR DESCRIPTION
## What does this PR do?

Enable backports with mergify in any direction, even to the `master` branch if the backport happens from a release branch.

## Why is it important?

Changes can be in any branch for different reasons. The development branches are `master` and `7.x` (assuming master eventually diverges from 7.x).

Smaller docs changes directly come from release branches, these are normally forward ported to `7.x` and `master`.

Backports can go in any direction



