### PR TITLE
Fix cyberarkpas XSLT handling of TAB and Carriage Return special chars

### DIFF
--- a/x-pack/filebeat/module/cyberarkpas/_meta/assets/elastic-json-v1.0.xsl
+++ b/x-pack/filebeat/module/cyberarkpas/_meta/assets/elastic-json-v1.0.xsl
@@ -127,9 +127,23 @@
       <xsl:with-param name="to" select="'\n'"/>
     </xsl:call-template>
   </xsl:variable>
+  <xsl:variable name="tmp3">
+    <xsl:call-template name="string-replace">
+      <xsl:with-param name="string" select="$tmp2"/>
+      <xsl:with-param name="from" select="'&#xd;'"/>
+      <xsl:with-param name="to" select="'\r'"/>
+    </xsl:call-template>
+  </xsl:variable>
+  <xsl:variable name="tmp4">
+    <xsl:call-template name="string-replace">
+      <xsl:with-param name="string" select="$tmp3"/>
+      <xsl:with-param name="from" select="'&#x09;'"/>
+      <xsl:with-param name="to" select="'\t'"/>
+    </xsl:call-template>
+  </xsl:variable>
   <xsl:text>&quot;</xsl:text>
   <xsl:call-template name="string-replace">
-    <xsl:with-param name="string" select="translate($tmp2,'&#9;&#xd;','  ')"/>
+    <xsl:with-param name="string" select="$tmp4"/>
     <xsl:with-param name="from" select="'&quot;'"/>
     <xsl:with-param name="to" select="'\&quot;'"/>
   </xsl:call-template>


### PR DESCRIPTION
## What does this PR do?

Fixes how the XSLT translator converts TAB (&#x9;) and CARRIAGE RETURN (&#xD) special characters when embedded inside a JSON string.

## Why is it important?

Before, those two characters were simply translated to a space. This patch translates them to the appropriate escape sequence (`\t` and `\r`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
