### PR TITLE
Cherry-pick #25784 to 7.x: Fix license header for osquery-extension

### DIFF
--- a/x-pack/osquerybeat/ext/osquery-extension/main.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/main.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 // Borrowed from https://github.com/kolide/launcher/blob/master/cmd/osquery-extension/osquery-extension.go
 // Original license from the kolide launcher repository
 


### PR DESCRIPTION
Cherry-pick of PR #25784 to 7.x branch. Original message: 

## What does this PR do?

Updates the license header for osquery-extention main.go file.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
