### PR TITLE
[Filebeat] Fix file_selectors only using first selector in aws-s3 input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -251,6 +251,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix role_arn to work with access keys for AWS. {pull}25446[25446]
 - Fix `community_id` processor so that ports greater than 65535 aren't valid. {pull}25409[25409]
 - Fix out of date FreeBSD vagrantbox. {pull}25652[25652]
+- Fix handling of `file_selectors` in aws-s3 input. {pull}25792[25792]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/awss3/collector.go
+++ b/x-pack/filebeat/input/awss3/collector.go
@@ -312,8 +312,9 @@ func (c *s3Collector) handleSQSMessage(m sqs.Message) ([]s3Info, error) {
 					readerConfig: fs.ReaderConfig,
 				}
 				s3Infos = append(s3Infos, info)
+
+				break
 			}
-			break
 		}
 	}
 	return s3Infos, nil


### PR DESCRIPTION
## What does this PR do?

Due to a misplaced break statement only the first file_selector was ever being used.

When an S3 notification is received the expected behavior is that every `file_selector`
is checked for a regex match and the first one wins.

## Why is it important?

The config doesn't function as described in docs.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
