### PR TITLE
Fix path indentation (file_integrity module)

### DIFF
--- a/auditbeat/docs/auditbeat-modules-config.asciidoc
+++ b/auditbeat/docs/auditbeat-modules-config.asciidoc
@@ -23,11 +23,11 @@ auditbeat.modules:
 
 - module: file_integrity
   paths:
-  - /bin
-  - /usr/bin
-  - /sbin
-  - /usr/sbin
-  - /etc
+    - /bin
+    - /usr/bin
+    - /sbin
+    - /usr/sbin
+    - /etc
 ----
 
 The configuration details vary by module. See the


### PR DESCRIPTION
## What does this PR do?

Apply correct indentation to a configuration example.

## Why is it important?

It's not :)

## Checklist

N/A

## Author's Checklist

N/A

## How to test this PR locally

N/A

## Related issues

N/A

## Use cases

N/A

## Screenshots

N/A

## Logs

N/A
