### PR TITLE
fix: support unpadded base64 input data in decode_base64_field

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -252,6 +252,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `community_id` processor so that ports greater than 65535 aren't valid. {pull}25409[25409]
 - Fix out of date FreeBSD vagrantbox. {pull}25652[25652]
 - Fix handling of `file_selectors` in aws-s3 input. {pull}25792[25792]
+- Allow non-padded base64 data to be decoded by decode_base64_field
 
 *Auditbeat*
 

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -110,6 +110,12 @@ func (f *decodeBase64Field) decodeField(event *beat.Event) error {
 		return fmt.Errorf("invalid type for `from`, expecting a string received %T", value)
 	}
 
+	if remainder := len([]byte(base64String)) % 4; remainder != 0 {
+		for i := 0; i < 4-remainder; i++ {
+			base64String += "="
+		}
+	}
+
 	decodedData, err := base64.StdEncoding.DecodeString(base64String)
 	if err != nil {
 		return fmt.Errorf("error trying to decode %s: %v", base64String, err)

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -88,6 +88,23 @@ func TestDecodeBase64Run(t *testing.T) {
 			error: false,
 		},
 		{
+			description: "unpadded input data decodes successfully",
+			config: base64Config{
+				Field: fromTo{
+					From: "field1", To: "field1",
+				},
+				IgnoreMissing: false,
+				FailOnError:   true,
+			},
+			Input: common.MapStr{
+				"field1": "dW5wYWRkZWQgZGF0YQ",
+			},
+			Output: common.MapStr{
+				"field1": "unpadded data",
+			},
+			error: false,
+		},
+		{
 			description: "simple field bad data - fail on error",
 			config: base64Config{
 				Field: fromTo{


### PR DESCRIPTION
## Type of change
- Bugfix

## What does this PR do?
Adds support for decoding base64 strings that were encoded without padding.

## Why is it important?
Increases compatibility and flexibility for users attempting to decode base64 strings that were encoded without padding.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
```go test ./...```

## Related issues
N/A

## Use cases
This change allows decoding of any raw base64 input strings that were previously encoded without standard padding character (`=`).

When attempting to decode the payload (middle) section of a JWT token, it was discovered that the decode was failing, because padding characters are not included in a JWT token string.

By adding padding to the string to be decoded, we properly prepare the string for successful decoding.
