### PR TITLE
[DOCS] Hint for the error "Error extracting container id"

### DIFF
--- a/filebeat/docs/faq.asciidoc
+++ b/filebeat/docs/faq.asciidoc
@@ -5,6 +5,13 @@ This section describes common problems you might encounter with
 {beatname_uc}. Also check out the
 https://discuss.elastic.co/c/beats/{beatname_lc}[{beatname_uc} discussion forum].
 
+[[filebeat-kubernetes-metadata-error-extracting-container-id]]
+=== Error extracting container id while using Kubernetes metadata
+
+The `add_kubernetes_metadata` processor might throw the error `Error extracting container id - source value does not contain matcher's logs_path`.
+There might be some issues with the matchers definitions or the location of `logs_path`.
+Please verify the Kubernetes pod is healthy.
+
 [[filebeat-network-volumes]]
 === Can't read log files from network volumes
 


### PR DESCRIPTION
## What does this PR do?

When using the Kubernetes add metadata processor, the error `Error extracting container id - source value does not contain matcher's logs_path` might be reported in some cases.
Typical issues:
- The `logs_path` is incorrect
- We had some problems in the past (7.7.0) due to a change in behavior (https://github.com/elastic/beats/pull/18818), which was restored in 7.7.2 onwards.
- The Kubernetes pod is crashing

## Why is it important?

It can provide a possible explanation of a common issue

## Checklist

- [x] I have made corresponding changes to the documentation

## Maintainer's Checklist

- [ ] Please review the syntax and apply changes in the wording
- [ ] Determine if it is worth mentioning a regression we got once on 7.7.0/7.7.1 about this issue
