### PR TITLE
Improve ES output error insights

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -630,6 +630,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `unit` and `metric_type` properties to fields.yml for populating field metadata in Elasticsearch templates {pull}25419[25419]
 - Add new option `suffix` to `logging.files` to control how log files are rotated. {pull}25464[25464]
 - Validate that required functionality in Elasticsearch is available upon initial connection. {pull}25351[25351]
+- Improve ES output error insights. {pull}25825[25825]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -584,10 +584,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added new `rate_limit` processor for enforcing rate limits on event throughput. {pull}22883[22883]
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Add support for defining explicitly named dynamic templates without path/type match criteria {pull}25422[25422]
-- Add new setting `gc_percent` for tuning the garbage collector limits via configuration file. {pull}25394[25394]
-- Add `unit` and `metric_type` properties to fields.yml for populating field metadata in Elasticsearch templates {pull}25419[25419]
-- Add new option `suffix` to `logging.files` to control how log files are rotated. {pull}25464[25464]
-- Validate that required functionality in Elasticsearch is available upon initial connection. {pull}25351[25351]
 - Improve ES output error insights. {pull}25825[25825]
 
 *Auditbeat*

--- a/libbeat/common/transport/logging.go
+++ b/libbeat/common/transport/logging.go
@@ -30,8 +30,16 @@ type loggingConn struct {
 }
 
 func LoggingDialer(d Dialer, logger *logp.Logger) Dialer {
-	return ConnWrapper(d, func(c net.Conn) net.Conn {
-		return &loggingConn{c, logger}
+	return DialerFunc(func(network, addr string) (net.Conn, error) {
+		logger := logger.With("network", network, "address", addr)
+		c, err := d.Dial(network, addr)
+		if err != nil {
+			logger.Errorf("error dialing", err)
+			return nil, err
+		}
+
+		logger.Debugf("dialing done")
+		return &loggingConn{c, logger}, nil
 	})
 }
 

--- a/libbeat/common/transport/logging.go
+++ b/libbeat/common/transport/logging.go
@@ -37,26 +37,16 @@ func LoggingDialer(d Dialer, logger *logp.Logger) Dialer {
 
 func (l *loggingConn) Read(b []byte) (int, error) {
 	n, err := l.Conn.Read(b)
-	if err != nil {
-		// ignore EOF error
-		if err == io.EOF {
-			err = nil
-		} else {
-			l.logger.Debugf("error reading from connection: %v", err)
-		}
+	if err != nil && err != io.EOF {
+		l.logger.Debugf("error reading from connection: %v", err)
 	}
 	return n, err
 }
 
 func (l *loggingConn) Write(b []byte) (int, error) {
 	n, err := l.Conn.Write(b)
-	if err != nil {
-		// ignore EOF error
-		if err == io.EOF {
-			err = nil
-		} else {
-			l.logger.Debugf("error writing to connection: %v", err)
-		}
+	if err != nil && err != io.EOF {
+		l.logger.Debugf("error writing to connection: %v", err)
 	}
 	return n, err
 }

--- a/libbeat/common/transport/logging.go
+++ b/libbeat/common/transport/logging.go
@@ -46,7 +46,7 @@ func LoggingDialer(d Dialer, logger *logp.Logger) Dialer {
 func (l *loggingConn) Read(b []byte) (int, error) {
 	n, err := l.Conn.Read(b)
 	if err != nil && err != io.EOF {
-		l.logger.Debugf("error reading from connection: %v", err)
+		l.logger.Debugf("Error reading from connection: %v", err)
 	}
 	return n, err
 }
@@ -54,7 +54,7 @@ func (l *loggingConn) Read(b []byte) (int, error) {
 func (l *loggingConn) Write(b []byte) (int, error) {
 	n, err := l.Conn.Write(b)
 	if err != nil && err != io.EOF {
-		l.logger.Debugf("error writing to connection: %v", err)
+		l.logger.Debugf("Error writing to connection: %v", err)
 	}
 	return n, err
 }

--- a/libbeat/common/transport/logging.go
+++ b/libbeat/common/transport/logging.go
@@ -34,11 +34,11 @@ func LoggingDialer(d Dialer, logger *logp.Logger) Dialer {
 		logger := logger.With("network", network, "address", addr)
 		c, err := d.Dial(network, addr)
 		if err != nil {
-			logger.Errorf("error dialing", err)
+			logger.Errorf("Error dialing %v", err)
 			return nil, err
 		}
 
-		logger.Debugf("dialing done")
+		logger.Debugf("Completed dialing successfully")
 		return &loggingConn{c, logger}, nil
 	})
 }

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -110,10 +110,10 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 	if st := s.Observer; st != nil {
 		dialer = transport.StatsDialer(dialer, st)
 		tlsDialer = transport.StatsDialer(tlsDialer, st)
-		logger := logp.NewLogger("esclientleg")
-		dialer = transport.LoggingDialer(dialer, logger)
-		tlsDialer = transport.LoggingDialer(tlsDialer, logger)
 	}
+	logger := logp.NewLogger("esclientleg")
+	dialer = transport.LoggingDialer(dialer, logger)
+	tlsDialer = transport.LoggingDialer(tlsDialer, logger)
 
 	var encoder BodyEncoder
 	compression := s.CompressionLevel
@@ -166,7 +166,7 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 		ConnectionSettings: s,
 		HTTP:               httpClient,
 		Encoder:            encoder,
-		log:                logp.NewLogger("esclientleg"),
+		log:                logger,
 	}
 
 	if s.APIKey != "" {

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -110,6 +110,9 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 	if st := s.Observer; st != nil {
 		dialer = transport.StatsDialer(dialer, st)
 		tlsDialer = transport.StatsDialer(tlsDialer, st)
+		logger := logp.NewLogger("esclientleg")
+		dialer = transport.LoggingDialer(dialer, logger)
+		tlsDialer = transport.LoggingDialer(tlsDialer, logger)
 	}
 
 	var encoder BodyEncoder


### PR DESCRIPTION
## What does this PR do?
This PR improves ES output insights by:
- do not record EOF as error  in `StatsDialer`
- wrap `StatsDialer`s  with a new dialer wrapper that logs errors

## Why is it important?
To provide [better insights](https://github.com/elastic/sdh-beats/issues/937) on Output errors.
