### PR TITLE
Cherry-pick to 7.x: Add breaking change around licensing (#25832)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.13.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.13.asciidoc
@@ -10,8 +10,18 @@
 
 // tag::notable-breaking-changes[]
 
-coming[7.13]
+[discrete]
+==== Beats may not be sending data to some distributions of {es}
 
+In this release, Elastic is enabling a licensing change that was broadly
+communicated earlier in 2021
+(https://www.elastic.co/pricing/faq/licensing[Licensing FAQ]). This change would
+imply that 7.13 instances of Beats would fail to connect to 7.10 or earlier open
+source distributions of {es} and {kib}.
+
+This licensing change ensures that the {beats} modules are sending data to an
+officially supported versions of {es} and {kib} where Elastic can attest to the
+quality and scale of the products.   
 // end::notable-breaking-changes[]
 
 See the <<release-notes,release notes>> for a complete list of changes,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add breaking change around licensing (#25832)