### PR TITLE
[Docs] Typo in exported field description

### DIFF
--- a/metricbeat/docs/fields.asciidoc
+++ b/metricbeat/docs/fields.asciidoc
@@ -40973,7 +40973,7 @@ format: bytes
 *`redis.info.memory.allocator_stats.active`*::
 +
 --
-Active memeory
+Active memory
 
 
 type: long


### PR DESCRIPTION
This is a no-brainer: memeory => memory
