### PR TITLE
Increase wait time to stabilize `TestRotateDateSuffix`

### DIFF
--- a/libbeat/common/file/rotator_test.go
+++ b/libbeat/common/file/rotator_test.go
@@ -216,7 +216,7 @@ func TestRotateDateSuffix(t *testing.T) {
 	firstExpectedPattern := fmt.Sprintf("%s-%s.*", logname, time.Now().Format("20060102150405"))
 	AssertDirContentsPattern(t, dir, firstExpectedPattern)
 
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 	secondExpectedPattern := fmt.Sprintf("%s-%s.*", logname, time.Now().Format("20060102150405"))
 
 	Rotate(t, r)
@@ -224,7 +224,7 @@ func TestRotateDateSuffix(t *testing.T) {
 
 	AssertDirContentsPattern(t, dir, firstExpectedPattern, secondExpectedPattern)
 
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(2 * time.Second)
 	thirdExpectedPattern := fmt.Sprintf("%s-%s.*", logname, time.Now().Format("20060102150405"))
 
 	Rotate(t, r)


### PR DESCRIPTION
## What does this PR do?

This PR increases the wait time to make sure files get rotated enough times.

## Why is it important?

The test has been flaky.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

Closes #25868
