### PR TITLE
[Filebeat] updating cyberarkpas to ecs 1.10.0

### DIFF
--- a/x-pack/filebeat/module/cyberarkpas/audit/config/input.yml
+++ b/x-pack/filebeat/module/cyberarkpas/audit/config/input.yml
@@ -29,4 +29,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.8.0
+        ecs.version: 1.10.0


### PR DESCRIPTION
## What does this PR do?

Updates to ECS 1.10.0. **Changelog entry will come later**, so there is no conflict between the other ECS PR changes

## Why is it important?

Keeps the modules consistent with the current ECS versions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates #25734 