### PR TITLE
[Filebeat] updating zeek to ecs 1.10.0

### DIFF
--- a/x-pack/filebeat/module/zeek/capture_loss/config/capture_loss.yml
+++ b/x-pack/filebeat/module/zeek/capture_loss/config/capture_loss.yml
@@ -22,4 +22,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/connection/config/connection.yml
+++ b/x-pack/filebeat/module/zeek/connection/config/connection.yml
@@ -102,4 +102,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
+++ b/x-pack/filebeat/module/zeek/dce_rpc/config/dce_rpc.yml
@@ -58,4 +58,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
+++ b/x-pack/filebeat/module/zeek/dhcp/config/dhcp.yml
@@ -120,4 +120,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
+++ b/x-pack/filebeat/module/zeek/dnp3/config/dnp3.yml
@@ -68,4 +68,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/dns/config/dns.yml
+++ b/x-pack/filebeat/module/zeek/dns/config/dns.yml
@@ -210,4 +210,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
+++ b/x-pack/filebeat/module/zeek/dpd/config/dpd.yml
@@ -57,4 +57,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/files/config/files.yml
+++ b/x-pack/filebeat/module/zeek/files/config/files.yml
@@ -42,4 +42,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
+++ b/x-pack/filebeat/module/zeek/ftp/config/ftp.yml
@@ -86,4 +86,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/http/config/http.yml
+++ b/x-pack/filebeat/module/zeek/http/config/http.yml
@@ -94,4 +94,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/intel/config/intel.yml
+++ b/x-pack/filebeat/module/zeek/intel/config/intel.yml
@@ -67,4 +67,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/irc/config/irc.yml
+++ b/x-pack/filebeat/module/zeek/irc/config/irc.yml
@@ -72,4 +72,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
+++ b/x-pack/filebeat/module/zeek/kerberos/config/kerberos.yml
@@ -104,4 +104,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
+++ b/x-pack/filebeat/module/zeek/modbus/config/modbus.yml
@@ -73,4 +73,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
+++ b/x-pack/filebeat/module/zeek/mysql/config/mysql.yml
@@ -72,4 +72,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/notice/config/notice.yml
+++ b/x-pack/filebeat/module/zeek/notice/config/notice.yml
@@ -104,4 +104,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
+++ b/x-pack/filebeat/module/zeek/ntlm/config/ntlm.yml
@@ -86,4 +86,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/ntp/config/ntp.yml
+++ b/x-pack/filebeat/module/zeek/ntp/config/ntp.yml
@@ -54,4 +54,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/ocsp/config/ocsp.yml
+++ b/x-pack/filebeat/module/zeek/ocsp/config/ocsp.yml
@@ -64,4 +64,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/pe/config/pe.yml
+++ b/x-pack/filebeat/module/zeek/pe/config/pe.yml
@@ -33,4 +33,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/radius/config/radius.yml
+++ b/x-pack/filebeat/module/zeek/radius/config/radius.yml
@@ -58,4 +58,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
+++ b/x-pack/filebeat/module/zeek/rdp/config/rdp.yml
@@ -88,4 +88,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
+++ b/x-pack/filebeat/module/zeek/rfb/config/rfb.yml
@@ -73,4 +73,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/signature/config/signature.yml
+++ b/x-pack/filebeat/module/zeek/signature/config/signature.yml
@@ -47,4 +47,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/sip/config/sip.yml
+++ b/x-pack/filebeat/module/zeek/sip/config/sip.yml
@@ -95,4 +95,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
+++ b/x-pack/filebeat/module/zeek/smb_cmd/config/smb_cmd.yml
@@ -101,4 +101,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
+++ b/x-pack/filebeat/module/zeek/smb_files/config/smb_files.yml
@@ -61,4 +61,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
+++ b/x-pack/filebeat/module/zeek/smb_mapping/config/smb_mapping.yml
@@ -57,4 +57,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
+++ b/x-pack/filebeat/module/zeek/smtp/config/smtp.yml
@@ -67,4 +67,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
+++ b/x-pack/filebeat/module/zeek/snmp/config/snmp.yml
@@ -69,4 +69,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/socks/config/socks.yml
+++ b/x-pack/filebeat/module/zeek/socks/config/socks.yml
@@ -67,4 +67,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
+++ b/x-pack/filebeat/module/zeek/ssh/config/ssh.yml
@@ -76,4 +76,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
+++ b/x-pack/filebeat/module/zeek/ssl/config/ssl.yml
@@ -94,4 +94,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/stats/config/stats.yml
+++ b/x-pack/filebeat/module/zeek/stats/config/stats.yml
@@ -97,4 +97,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
+++ b/x-pack/filebeat/module/zeek/syslog/config/syslog.yml
@@ -57,4 +57,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/traceroute/config/traceroute.yml
+++ b/x-pack/filebeat/module/zeek/traceroute/config/traceroute.yml
@@ -45,4 +45,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/tunnel/config/tunnel.yml
+++ b/x-pack/filebeat/module/zeek/tunnel/config/tunnel.yml
@@ -56,4 +56,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/weird/config/weird.yml
+++ b/x-pack/filebeat/module/zeek/weird/config/weird.yml
@@ -56,4 +56,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/x-pack/filebeat/module/zeek/x509/config/x509.yml
+++ b/x-pack/filebeat/module/zeek/x509/config/x509.yml
@@ -67,4 +67,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0


### PR DESCRIPTION
## What does this PR do?

Updates to ECS 1.10.0. **Changelog entry will come later**, so there is no conflict between the other ECS PR changes

## Why is it important?

Keeps the modules consistent with the current ECS versions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates #25734 