### PR TITLE
[Filebeat] updating elasticsearch to ecs 1.10.0

### DIFF
--- a/filebeat/module/elasticsearch/audit/config/audit.yml
+++ b/filebeat/module/elasticsearch/audit/config/audit.yml
@@ -10,7 +10,7 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0
   - if:
       regexp:
         message: "^{"

--- a/filebeat/module/elasticsearch/deprecation/config/log.yml
+++ b/filebeat/module/elasticsearch/deprecation/config/log.yml
@@ -15,4 +15,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.9.0
+      ecs.version: 1.10.0

--- a/filebeat/module/elasticsearch/gc/config/gc.yml
+++ b/filebeat/module/elasticsearch/gc/config/gc.yml
@@ -13,4 +13,4 @@ processors:
   - add_fields:
       target: ''
       fields:
-        ecs.version: 1.9.0
+        ecs.version: 1.10.0

--- a/filebeat/module/elasticsearch/server/config/log.yml
+++ b/filebeat/module/elasticsearch/server/config/log.yml
@@ -15,4 +15,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.9.0
+      ecs.version: 1.10.0

--- a/filebeat/module/elasticsearch/slowlog/config/slowlog.yml
+++ b/filebeat/module/elasticsearch/slowlog/config/slowlog.yml
@@ -16,4 +16,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-      ecs.version: 1.9.0
+      ecs.version: 1.10.0


### PR DESCRIPTION
## What does this PR do?

Updates to ECS 1.10.0. **Changelog entry will come later**, so there is no conflict between the other ECS PR changes

## Why is it important?

Keeps the modules consistent with the current ECS versions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates #25734 