### PR TITLE
Disable armv7 packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -352,9 +352,9 @@ def packagingLinux(Map args = [:]) {
                 'linux/amd64',
                 'linux/386',
                 'linux/arm64',
-                'linux/armv7',
                 // The platforms above are disabled temporarly as crossbuild images are
                 // not available. See: https://github.com/elastic/golang-crossbuild/issues/71
+                //'linux/armv7',
                 //'linux/ppc64le',
                 //'linux/mips64',
                 //'linux/s390x',


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Bug

## What does this PR do?

Disable linux/armv7 packaging.

## Why is it important?

We only produce artifacts for aarch64. Don't build and package binaries we do not test or provide for download.