### PR TITLE
Cherry-pick #25782 to 7.x: Refactor kubelet metricsets to share response from endpoint

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -616,6 +616,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Refactor state_* metricsets to share response from endpoint. {pull}25640[25640]
 - Add server id to zookeeper events. {pull}25550[25550]
 - Add additional network metrics to docker/network {pull}25354[25354]
+- Reduce number of requests done by kubernetes metricsets to kubelet. {pull}25782[25782]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -120,7 +120,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return errors.Wrap(err, "error getting families")
 	}

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
@@ -87,7 +87,7 @@ func NewCronJobMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 //
 // Copied from other kube state metrics.
 func (m *CronJobMetricSet) Fetch(reporter mb.ReporterV2) error {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return errors.Wrap(err, "error getting family metrics")
 	}

--- a/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
+++ b/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
@@ -101,7 +101,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment.go
@@ -102,7 +102,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -113,7 +113,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'state_node' Metricset data")
 	}

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
@@ -77,7 +77,7 @@ func NewPersistentVolumeMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
 // module rooted fields at the event that gets reported
 func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
@@ -82,7 +82,7 @@ func NewpersistentvolumeclaimMetricSet(base mb.BaseMetricSet) (mb.MetricSet, err
 // module rooted fields at the event that gets reported
 func (m *persistentvolumeclaimMetricSet) Fetch(reporter mb.ReporterV2) error {
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		return err
 	}

--- a/metricbeat/module/kubernetes/state_pod/state_pod.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod.go
@@ -104,7 +104,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
@@ -102,7 +102,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_resourcequota/state_resourcequota.go
+++ b/metricbeat/module/kubernetes/state_resourcequota/state_resourcequota.go
@@ -76,7 +76,7 @@ func NewResourceQuotaMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
 // module rooted fields at the event that gets reported
 func (m *ResourceQuotaMetricSet) Fetch(reporter mb.ReporterV2) {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_service/state_service.go
+++ b/metricbeat/module/kubernetes/state_service/state_service.go
@@ -95,7 +95,7 @@ func NewServiceMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *ServiceMetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_statefulset/state_statefulset.go
+++ b/metricbeat/module/kubernetes/state_statefulset/state_statefulset.go
@@ -101,7 +101,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 	m.enricher.Start()
 
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/state_storageclass/state_storageclass.go
+++ b/metricbeat/module/kubernetes/state_storageclass/state_storageclass.go
@@ -78,7 +78,7 @@ func NewStorageClassMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
 // module rooted fields at the event that gets reported
 func (m *StorageClassMetricSet) Fetch(reporter mb.ReporterV2) {
-	families, err := m.mod.GetSharedFamilies(m.prometheus)
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -18,12 +18,15 @@
 package volume
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
+	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 )
 
 const (
@@ -56,6 +59,7 @@ func init() {
 type MetricSet struct {
 	mb.BaseMetricSet
 	http *helper.HTTP
+	mod  k8smod.Module
 }
 
 // New create a new instance of the MetricSet
@@ -66,9 +70,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
+	mod, ok := base.Module().(k8smod.Module)
+	if !ok {
+		return nil, fmt.Errorf("must be child of kubernetes module")
+	}
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
+		mod:           mod,
 	}, nil
 }
 
@@ -76,7 +85,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // format. It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
-	body, err := m.http.FetchContent()
+	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'volume' Metricset data")
 	}


### PR DESCRIPTION
Cherry-pick of PR #25782 to 7.x branch. Original message: 

## What does this PR do?
Follow up of https://github.com/elastic/beats/pull/25640. This PR changes how kubernetes module handle metricsets which collect metrics from kubelet's API and which share same target endpoint.
Metricsets affected:
- `system`
- `pod`
- `node`
- `volume`
- `container`

## Why is it important?
To improve the performance of the module by avoid fetching same content multiple times.

## How to test this PR locally

1. Deploy Metricbeat on k8s with https://github.com/elastic/beats/blob/master/deploy/kubernetes/metricbeat-kubernetes.yaml using the proper docker image (ie a BC, snapshot etc). Modify the configmaps accordingly using the configs below.
2. state_* config using leaderelection:
```
metricbeat.autodiscover:
  providers:
    - type: kubernetes
      scope: cluster
      node: ${NODE_NAME}
      unique: true
      templates:
        - config:
            - module: kubernetes
              hosts: ["kube-state-metrics:8080"]
              period: 10s
              add_metadata: true
              metricsets:
                - state_node
                - state_deployment
                - state_daemonset
                - state_replicaset
                - state_pod
            - module: kubernetes
              hosts: ["kube-state-metrics:8080"]
              period: 10s
              add_metadata: true
              metricsets:
                - state_container
                - state_cronjob
                - state_service
                - state_resourcequota
                - state_statefulset
```
2. Kubelet's metricsets' config:
```
- module: kubernetes
  metricsets:
    - container
    - volume
  period: 10s
  host: ${NODE_NAME}
  hosts: ["https://${NODE_NAME}:10250"]
  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
  ssl.verification_mode: "none" 
- module: kubernetes
  metricsets:
    - node
    - system
    - pod
  period: 10s
  host: ${NODE_NAME}
  hosts: ["https://${NODE_NAME}:10250"]
  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
  ssl.verification_mode: "none"
```
4. Verify that all metricsets are being populated (like in the screenshot below) and that k8s metadata are properly attached on the events.

## Related issues
Closes #24869


## Screenshots
![Screenshot 2021-05-20 at 1 47 18 PM](https://user-images.githubusercontent.com/11754898/118966016-f357e980-b971-11eb-9652-18c59c7238b3.png)

