### PR TITLE
Cherry-pick #25825 to 7.x: Improve ES output error insights

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -408,6 +408,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `unit` and `metric_type` properties to fields.yml for populating field metadata in Elasticsearch templates {pull}25419[25419]
 - Add new option `suffix` to `logging.files` to control how log files are rotated. {pull}25464[25464]
 - Validate that required functionality in Elasticsearch is available upon initial connection. {pull}25351[25351]
+- Improve ES output error insights. {pull}25825[25825]
 
 *Auditbeat*
 

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -111,6 +111,9 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 		dialer = transport.StatsDialer(dialer, st)
 		tlsDialer = transport.StatsDialer(tlsDialer, st)
 	}
+	logger := logp.NewLogger("esclientleg")
+	dialer = transport.LoggingDialer(dialer, logger)
+	tlsDialer = transport.LoggingDialer(tlsDialer, logger)
 
 	var encoder BodyEncoder
 	compression := s.CompressionLevel
@@ -163,7 +166,7 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 		ConnectionSettings: s,
 		HTTP:               httpClient,
 		Encoder:            encoder,
-		log:                logp.NewLogger("esclientleg"),
+		log:                logger,
 	}
 
 	if s.APIKey != "" {


### PR DESCRIPTION
Cherry-pick of PR #25825 to 7.x branch. Original message: 

## What does this PR do?
This PR improves ES output insights by:
- do not record EOF as error  in `StatsDialer`
- wrap `StatsDialer`s  with a new dialer wrapper that logs errors

## Why is it important?
To provide [better insights](https://github.com/elastic/sdh-beats/issues/937) on Output errors.
