### PR TITLE
[Packetbeat] Add `url.extension` to Packetbeat HTTP events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -954,6 +954,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for "http.request.mime_type" and "http.response.mime_type". {pull}22940[22940]
 - Upgrade to ECS 1.8.0. {pull}23783[23783]
 - Add `event.type: [connection]` to flow events and include `end` for final flows. {pull}24564[24564]
+- Add `url.extension` to HTTP events {issue}25990[25990] {pull}25999[25999]
 
 *Functionbeat*
 

--- a/packetbeat/protos/http/event.go
+++ b/packetbeat/protos/http/event.go
@@ -94,8 +94,6 @@ func newURL(host string, port int64, path, query string) *ecs.Url {
 		periodIndex := strings.LastIndex(path, ".")
 		if periodIndex < len(path) {
 			u.Extension = path[(periodIndex + 1):]
-		} else {
-			u.Extension = ""
 		}
 	}
 	u.Full = synthesizeFullURL(u, port)

--- a/packetbeat/protos/http/event.go
+++ b/packetbeat/protos/http/event.go
@@ -90,9 +90,9 @@ func newURL(host string, port int64, path, query string) *ecs.Url {
 	if port != 80 {
 		u.Port = port
 	}
-	if path != "" && strings.Contains(path, ".") {
+	if path != "" {
 		periodIndex := strings.LastIndex(path, ".")
-		if periodIndex < len(path) {
+		if periodIndex != -1 && periodIndex < len(path) {
 			u.Extension = path[(periodIndex + 1):]
 		}
 	}

--- a/packetbeat/protos/http/event.go
+++ b/packetbeat/protos/http/event.go
@@ -90,6 +90,14 @@ func newURL(host string, port int64, path, query string) *ecs.Url {
 	if port != 80 {
 		u.Port = port
 	}
+	if path != "" && strings.Contains(path, ".") {
+		periodIndex := strings.LastIndex(path, ".")
+		if periodIndex < len(path) {
+			u.Extension = path[(periodIndex + 1):]
+		} else {
+			u.Extension = ""
+		}
+	}
 	u.Full = synthesizeFullURL(u, port)
 	return u
 }

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -1845,6 +1845,57 @@ func TestHttpParser_hostHeader(t *testing.T) {
 	}
 }
 
+func TestHttpParser_Extension(t *testing.T) {
+	template := "HEAD %s HTTP/1.1\r\n" +
+		"Host: abc.com\r\n" +
+		"\r\n"
+	var store eventStore
+	http := httpModForTests(&store)
+	for _, test := range []struct {
+		title, path string
+		expected    common.MapStr
+	}{
+		{
+			title: "Zip Extension",
+			path:  "/files.zip",
+			expected: common.MapStr{
+				"url.full":      "http://abc.com/files.zip",
+				"url.extension": "zip",
+			},
+		},
+		{
+			title: "No Extension",
+			path:  "/files",
+			expected: common.MapStr{
+				"url.full":      "http://abc.com/files",
+				"url.extension": nil,
+			},
+		},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			request := fmt.Sprintf(template, test.path)
+			tcptuple := testCreateTCPTuple()
+			packet := protos.Packet{Payload: []byte(request)}
+			private := protos.ProtocolData(&httpConnectionData{})
+			private = http.Parse(&packet, tcptuple, 1, private)
+			http.Expired(tcptuple, private)
+			trans := expectTransaction(t, &store)
+			if !assert.NotNil(t, trans) {
+				t.Fatal("nil transaction")
+			}
+			for field, expected := range test.expected {
+				actual, err := trans.GetValue(field)
+				assert.Equal(t, expected, actual, field)
+				if expected != nil {
+					assert.Nil(t, err, field)
+				} else {
+					assert.Equal(t, common.ErrKeyNotFound, err, field)
+				}
+			}
+		})
+	}
+}
+
 func benchmarkHTTPMessage(b *testing.B, data []byte) {
 	http := httpModForTests(nil)
 	parser := newParser(&http.parserConfig)


### PR DESCRIPTION
## What does this PR do?

Add `url.extension` to Packetbeat HTTP events

## Why is it important?

Adds additional field per ECS spec that can be used for correlation and ML.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- Closes #25990 
- 
## Use cases


## Screenshots


## Logs

