### PR TITLE
Change timestamp in elastic-agent-json.log ut UTC

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -68,6 +68,7 @@
 - Handle case where policy doesn't contain Fleet connection information {pull}25707[25707]
 - Fix fleet-server.yml spec to not overwrite existing keys {pull}25741[25741]
 - Agent sends wrong log level to Endpoint {issue}25583[25583]
+- Change timestamp in elatic-agent-json.log to use UTC {issue}25391[25391]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/core/logger/logger.go
+++ b/x-pack/elastic-agent/pkg/core/logger/logger.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"go.elastic.co/ecszap"
 	"go.uber.org/zap/zapcore"
@@ -22,6 +23,8 @@ import (
 )
 
 const agentName = "elastic-agent"
+
+const iso8601Format = "2006-01-02T15:04:05.000Z0700"
 
 // DefaultLogLevel used in agent and its processes.
 const DefaultLogLevel = logp.InfoLevel
@@ -127,6 +130,20 @@ func makeInternalFileOutput(cfg *Config) (zapcore.Core, error) {
 		return nil, errors.New("failed to create internal file rotator")
 	}
 
-	encoder := zapcore.NewJSONEncoder(ecszap.ECSCompatibleEncoderConfig(logp.JSONEncoderConfig()))
+	encoderConfig := ecszap.ECSCompatibleEncoderConfig(logp.JSONEncoderConfig())
+	encoderConfig.EncodeTime = utcTimestampEncode
+	encoder := zapcore.NewJSONEncoder(encoderConfig)
 	return ecszap.WrapCore(zapcore.NewCore(encoder, rotator, cfg.Level.ZapLevel())), nil
+}
+
+// utcTimestampEncode is a zapcore.TimeEncoder that formats time.Time in ISO-8601 in UTC.
+func utcTimestampEncode(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+	type appendTimeEncoder interface {
+		AppendTimeLayout(time.Time, string)
+	}
+	if enc, ok := enc.(appendTimeEncoder); ok {
+		enc.AppendTimeLayout(t.UTC(), iso8601Format)
+		return
+	}
+	enc.AppendString(t.UTC().Format(iso8601Format))
 }


### PR DESCRIPTION
## What does this PR do?

Change encoder to force UTC timestamps in RFC3339 for the json.log
entries.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #25391

## Logs

```
elastic-agent-8.0.0-SNAPSHOT-darwin-x86_64|⇒ sudo ./elastic-agent
2021-05-31T17:40:45.099-0700	INFO	cmd/run.go:133	Artifact has been built with security disabled. Elastic Agent will not verify signatures of the artifacts.
2021-05-31T17:40:45.100-0700	INFO	warn/warn.go:18	The Elastic Agent is currently in BETA and should not be used in production
2021-05-31T17:40:45.101-0700	INFO	application/application.go:68	Detecting execution mode
```

```
elastic-agent-8.0.0-SNAPSHOT-darwin-x86_64|⇒ sudo head data/elastic-agent-5bcdff/logs/elastic-agent-json.log-20210531174045
{"log.level":"info","@timestamp":"2021-06-01T00:40:45.099Z","log.origin":{"file.name":"cmd/run.go","file.line":133},"message":"Artifact has been built with security disabled. Elastic Agent will not verify signatures of the artifacts.","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2021-06-01T00:40:45.100Z","log.origin":{"file.name":"warn/warn.go","file.line":18},"message":"The Elastic Agent is currently in BETA and should not be used in production","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2021-06-01T00:40:45.101Z","log.origin":{"file.name":"application/application.go","file.line":68},"message":"Detecting execution mode","ecs.version":"1.6.0"}
```
