### PR TITLE
Add new parser to filestream input: container

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -816,6 +816,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Enhance GCP module to populate orchestrator.* fields for GKE / K8S logs {pull}25368[25368]
 - http_endpoint: Support multiple documents in a single request by POSTing an array or NDJSON format. {pull}25764[25764]
 - Make `filestream` input GA. {pull}26127[26127]
+- Add new `parser` to `filestream` input: `container`. {pull}26115[26115]
 
 *Heartbeat*
 

--- a/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
@@ -151,6 +151,7 @@ Available parsers:
 
 * `multiline`
 * `ndjson`
+* `container`
 
 In this example, {beatname_uc} is reading multiline messages that consist of 3 lines
 and are encapsulated in single-line JSON objects.
@@ -232,3 +233,28 @@ JSON document and stored in `@metadata._id`
 *`ignore_decoding_error`*:: An optional configuration setting that specifies if
 JSON decoding errors should be logged or not. If set to true, errors will not
 be logged. The default is false.
+
+[float]
+===== `container`
+
+Use the `container` parser to extract information from  containers log files.
+It parses lines into common message lines, extracting timestamps too.
+
+*`stream`*:: Reads from the specified streams only: `all`, `stdout` or `stderr`. The default
+is `all`.
+
+*`format`*:: Use the given format when parsing logs: `auto`, `docker` or `cri`. The
+default is `auto`, it will automatically detect the format. To disable
+autodetection set any of the other options.
+
+The following snippet configures {beatname_uc} to read the `stdout` stream from
+all containers under the default Kubernetes logs path:
+
+[source,yaml]
+----
+  paths:
+    - "/var/log/containers/*.log"
+  parsers:
+    - container:
+      stream: stdout
+----

--- a/filebeat/input/filestream/parser.go
+++ b/filebeat/input/filestream/parser.go
@@ -70,6 +70,14 @@ func newParsers(in reader.Reader, pCfg parserConfig, c []common.ConfigNamespace)
 				return nil, fmt.Errorf("error while parsing ndjson parser config: %+v", err)
 			}
 			p = readjson.NewJSONParser(p, &config)
+		case "container":
+			config := readjson.DefaultContainerConfig()
+			cfg := ns.Config()
+			err := cfg.Unpack(&config)
+			if err != nil {
+				return nil, fmt.Errorf("error while parsing container parser config: %+v", err)
+			}
+			p = readjson.NewContainerParser(p, &config)
 		default:
 			return nil, fmt.Errorf("%s: %s", ErrNoSuchParser, name)
 		}
@@ -95,6 +103,13 @@ func validateParserConfig(pCfg parserConfig, c []common.ConfigNamespace) error {
 			err := cfg.Unpack(&config)
 			if err != nil {
 				return fmt.Errorf("error while parsing ndjson parser config: %+v", err)
+			}
+		case "container":
+			config := readjson.DefaultContainerConfig()
+			cfg := ns.Config()
+			err := cfg.Unpack(&config)
+			if err != nil {
+				return fmt.Errorf("error while parsing container parser config: %+v", err)
 			}
 		default:
 			return fmt.Errorf("%s: %s", ErrNoSuchParser, name)

--- a/libbeat/reader/readjson/docker_json.go
+++ b/libbeat/reader/readjson/docker_json.go
@@ -87,6 +87,33 @@ func New(r reader.Reader, stream string, partial bool, format string, CRIFlags b
 	return &reader
 }
 
+func NewContainerParser(r reader.Reader, config *ContainerJSONConfig) *DockerJSONReader {
+	reader := DockerJSONReader{
+		stream:   config.Stream.String(),
+		partial:  true,
+		reader:   r,
+		criflags: true,
+		logger:   logp.NewLogger("parser_container"),
+	}
+
+	switch config.Format {
+	case Docker, JSONFile:
+		reader.parseLine = reader.parseDockerJSONLog
+	case CRI:
+		reader.parseLine = reader.parseCRILog
+	default:
+		reader.parseLine = reader.parseAuto
+	}
+
+	if runtime.GOOS == "windows" {
+		reader.stripNewLine = stripNewLineWin
+	} else {
+		reader.stripNewLine = stripNewLine
+	}
+
+	return &reader
+}
+
 // parseCRILog parses logs in CRI log format.
 // CRI log format example :
 // 2017-09-12T22:32:21.212861448Z stdout 2017-09-12 22:32:21.212 [INFO][88] table.go 710: Invalidating dataplane cache

--- a/libbeat/reader/readjson/docker_json_config.go
+++ b/libbeat/reader/readjson/docker_json_config.go
@@ -1,0 +1,101 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package readjson
+
+import "fmt"
+
+type ContainerFormat uint8
+
+type Stream uint8
+
+const (
+	Auto ContainerFormat = iota + 1
+	CRI
+	Docker
+	JSONFile
+
+	All Stream = iota + 1
+	Stdout
+	Stderr
+)
+
+var (
+	containerFormats = map[string]ContainerFormat{
+		"auto":      Auto,
+		"cri":       CRI,
+		"docker":    Docker,
+		"json-file": JSONFile,
+	}
+
+	containerStreams = map[string]Stream{
+		"all":    All,
+		"stdout": Stdout,
+		"stderr": Stderr,
+	}
+)
+
+type ContainerJSONConfig struct {
+	Stream Stream          `config:"stream"`
+	Format ContainerFormat `config:"format"`
+}
+
+func DefaultContainerConfig() ContainerJSONConfig {
+	return ContainerJSONConfig{
+		Format: Auto,
+		Stream: All,
+	}
+}
+
+func (f *ContainerFormat) Unpack(v string) error {
+	val, ok := containerFormats[v]
+	if !ok {
+		keys := make([]string, len(containerFormats))
+		i := 0
+		for k := range containerFormats {
+			keys[i] = k
+			i++
+		}
+		return fmt.Errorf("unknown container log format: %s, supported values: %+v", v, keys)
+	}
+	*f = val
+	return nil
+}
+
+func (s *Stream) Unpack(v string) error {
+	val, ok := containerStreams[v]
+	if !ok {
+		keys := make([]string, len(containerStreams))
+		i := 0
+		for k := range containerStreams {
+			keys[i] = k
+			i++
+		}
+		return fmt.Errorf("unknown streams: %s, supported values: %+v", v, keys)
+	}
+	*s = val
+	return nil
+}
+
+func (s *Stream) String() string {
+	for k, v := range containerStreams {
+		if v == *s {
+			return k
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds support for a new parser named `container`. This is the reader that powers the `container` input behind the scenes. Now it is exposed as a parser.

Example configuration for reading container logs with the `filesteam` input:

```yaml
type: filestream
paths:
  - /path/to/containers/*/*.log
parsers:
  - container: ~
```

### Limitations

The PR does not provide feature parity with the `container` input because of the lack of support for separating the states of stdout and strerr streams. It is coming in a follow-up PR.

## Why is it important?

It is a step toward supporting reading container logs from every input that supports `parsers` option.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
