### PR TITLE
Reopen journald reader when journal is corrupt

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -390,6 +390,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Journalbeat*
 
+- Reopen journald reader when journal becomes corrupted. {issue}23627[23627] {pull}26116[26116]
 
 *Metricbeat*
 

--- a/journalbeat/input/input.go
+++ b/journalbeat/input/input.go
@@ -18,8 +18,10 @@
 package input
 
 import (
+	"errors"
 	"fmt"
 	"sync"
+	"syscall"
 
 	"github.com/elastic/beats/v7/libbeat/processors/add_formatted_index"
 
@@ -169,6 +171,12 @@ func (i *Input) publishAll() {
 				if event == nil {
 					if err != nil {
 						i.logger.Errorf("Error while reading event: %v", err)
+						if errors.Is(err, syscall.EBADMSG) {
+							reopenErr := r.Reopen()
+							if reopenErr != nil {
+								i.logger.Errorf("Error while reopening journal: %v", reopenErr)
+							}
+						}
 					}
 					continue
 				}


### PR DESCRIPTION
## What does this PR do?

When a Beat encounters a corrupt journal, it reopens the journal reader.

## Why is it important?

When running Journalbeat for a while when it encounters a corrupt journal, it fills up the log with error messages. Now it requires manual intervention to clean up the status.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #23627