### PR TITLE
Populate the agent action result if there is no matching action handlers

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
@@ -41,7 +41,11 @@ func (h *AppAction) Handle(ctx context.Context, a fleetapi.Action, acker store.F
 
 	appState, ok := h.srv.FindByInputType(action.InputType)
 	if !ok {
-		return fmt.Errorf("matching app is not found for action input: %s", action.InputType)
+		// If the matching action is not found ack the action with the error for action result document
+		action.StartedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		action.CompletedAt = action.StartedAt
+		action.Error = fmt.Sprintf("matching app is not found for action input: %s", action.InputType)
+		return acker.Ack(ctx, action)
 	}
 
 	params, err := action.MarshalMap()


### PR DESCRIPTION
## What does this PR do?

Acknowledge the agent action and send the action result back if there is no matching action input supported by the agent.
This could happen in two cases:
1. Action input type is not supported
2. The policy update didn't reach the agent yet and the user tries to send the action, for example sending osquery query while the osquery was not enabled on the agent yet. 

## Why is it important?

Without this change the .fleet-actions-results document is not be created for the action with unsupported input type, giving no feedback to the user about the result of the action.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

1. Create an action document with unsupported action input type, for example "foobar":
<img width="529" alt="Screen Shot 2021-06-04 at 12 29 27 PM" src="https://user-images.githubusercontent.com/872351/120847315-53898680-c541-11eb-8b53-1a1c19f27951.png">

Observe the .fleet-actions-results document with the error
<img width="658" alt="Screen Shot 2021-06-04 at 11 54 55 AM" src="https://user-images.githubusercontent.com/872351/120846868-b7f81600-c540-11eb-9af6-6aa346142595.png">

2. Create an action document with `osquery` input type, while osquery manager IS NOT added to the policy. 
Observe the .fleet-actions-results document with the error.

<img width="660" alt="Screen Shot 2021-06-04 at 11 57 51 AM" src="https://user-images.githubusercontent.com/872351/120846797-a0209200-c540-11eb-8f8f-a04bb645f815.png">

