### PR TITLE
[Filebeat] Mark MISP module deprecated

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -995,6 +995,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Filebeat*
 
+- Deprecate the MISP module. The Threat Intel module should be used instead. {issue}25240[25240]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/misp.asciidoc
+++ b/filebeat/docs/modules/misp.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == MISP module
 
+deprecated::[7.14.0,"This module is deprecated. Use the <<filebeat-module-threatintel,Threat Intel module>> instead."]
+
 beta[]
 
 This is a filebeat module for reading threat intel information from the MISP platform (https://www.circl.lu/doc/misp/). It uses the httpjson input to access the MISP REST API interface.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -1537,6 +1537,8 @@ filebeat.modules:
     # var.tz_offset: local
 
 #--------------------------------- MISP Module ---------------------------------
+# Deprecated in 7.14.0: Recommended to migrate to the Threat Intel module.
+
 - module: misp
   threat:
     enabled: true

--- a/x-pack/filebeat/module/misp/_meta/config.yml
+++ b/x-pack/filebeat/module/misp/_meta/config.yml
@@ -1,3 +1,5 @@
+# Deprecated in 7.14.0: Recommended to migrate to the Threat Intel module.
+
 - module: misp
   threat:
     enabled: true

--- a/x-pack/filebeat/module/misp/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/misp/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == MISP module
 
+deprecated::[7.14.0,"This module is deprecated. Use the <<filebeat-module-threatintel,Threat Intel module>> instead."]
+
 beta[]
 
 This is a filebeat module for reading threat intel information from the MISP platform (https://www.circl.lu/doc/misp/). It uses the httpjson input to access the MISP REST API interface.

--- a/x-pack/filebeat/modules.d/misp.yml.disabled
+++ b/x-pack/filebeat/modules.d/misp.yml.disabled
@@ -1,6 +1,8 @@
 # Module: misp
 # Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-misp.html
 
+# Deprecated in 7.14.0: Recommended to migrate to the Threat Intel module.
+
 - module: misp
   threat:
     enabled: true


### PR DESCRIPTION
## What does this PR do?

Add deprecation notice to docs for the MISP module. The threat intel module should be used instead.

## Why is it important?

Lets users know they should start migrating toward the Threat Intel module

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #25240

## Screenshots

<img width="597" alt="Screen Shot 2021-06-07 at 9 51 09 AM" src="https://user-images.githubusercontent.com/4565752/121031329-3ee30380-c778-11eb-9774-18d7281f31ad.png">
