### PR TITLE
Include date separator in the filename prefix of `dateRotator` to make sure nothing gets purged accidentally

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -238,6 +238,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix 'make setup' instructions for a new beat {pull}24944[24944]
 - Fix out of date FreeBSD vagrantbox. {pull}25652[25652]
 - Fix handling of `file_selectors` in aws-s3 input. {pull}25792[25792]
+- Include date separator in the filename prefix of `dateRotator` to make sure nothing gets purged accidentally {pull}26176[26176]
 
 *Auditbeat*
 

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -436,7 +436,7 @@ func newDateRotater(log Logger, filename string) rotater {
 	d := &dateRotator{
 		log:            log,
 		filenamePrefix: filename + "-",
-		format:         filename + "-20060102150405",
+		format:         "20060102150405",
 	}
 
 	d.currentFilename = d.filenamePrefix + time.Now().Format(d.format)
@@ -493,7 +493,7 @@ func (d *dateRotator) SortModTimeLogs(strings []string) {
 }
 
 func (d *dateRotator) OrderLog(filename string) time.Time {
-	ts, err := time.Parse(d.format, filepath.Base(filename))
+	ts, err := time.Parse(d.filenamePrefix+d.format, filepath.Base(filename))
 	if err != nil {
 		return time.Time{}
 	}

--- a/libbeat/common/file/rotator.go
+++ b/libbeat/common/file/rotator.go
@@ -435,11 +435,11 @@ func newRotater(log Logger, s SuffixType, filename string, maxBackups uint, inte
 func newDateRotater(log Logger, filename string) rotater {
 	d := &dateRotator{
 		log:            log,
-		filenamePrefix: filename,
-		format:         "20060102150405",
+		filenamePrefix: filename + "-",
+		format:         filename + "-20060102150405",
 	}
 
-	d.currentFilename = d.filenamePrefix + "-" + time.Now().Format(d.format)
+	d.currentFilename = d.filenamePrefix + time.Now().Format(d.format)
 	files, err := filepath.Glob(d.filenamePrefix + "*")
 	if err != nil {
 		return d
@@ -467,7 +467,7 @@ func (d *dateRotator) Rotate(reason rotateReason, rotateTime time.Time) error {
 		d.log.Debugw("Rotating file", "filename", d.currentFilename, "reason", reason)
 	}
 
-	d.currentFilename = d.filenamePrefix + "-" + rotateTime.Format(d.format)
+	d.currentFilename = d.filenamePrefix + rotateTime.Format(d.format)
 	return nil
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR changes the log file prefix when using date rotation in Beats. Previously the `-` was not included, so in the list of rotated files every file that started with the configured file prefix were included.

## Why is it important?

If the binary is under the same path as the value configured in `logging.files.path` and `logging.files.name`, when the number of rotated log files gets bigger than the one configured in `loggin.files.keepfiles`, the binary is purged on rotation.

The workaround is to put the log files in a separate folder.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.