### PR TITLE
Change fleetmode detection to only use management.enabled

### DIFF
--- a/libbeat/common/fleetmode/fleet_mode.go
+++ b/libbeat/common/fleetmode/fleet_mode.go
@@ -25,11 +25,10 @@ import (
 
 // Enabled checks to see if filebeat/metricbeat is running under Agent
 // The management setting is stored in the main Beat runtime object, but we can't see that from a module
-// So instead we check the CLI flags, since Agent starts filebeat/metricbeat with "-E", "management.mode=x-pack-fleet", "-E", "management.enabled=true"
+// So instead we check the CLI flags, since Agent starts filebeat/metricbeat with "-E", "management.enabled=true"
 func Enabled() bool {
 	type management struct {
-		Mode    string `config:"management.mode"`
-		Enabled bool   `config:"management.enabled"`
+		Enabled bool `config:"management.enabled"`
 	}
 	var managementSettings management
 
@@ -46,8 +45,5 @@ func Enabled() bool {
 		return false
 	}
 
-	if managementSettings.Enabled == true && managementSettings.Mode == "x-pack-fleet" {
-		return true
-	}
-	return false
+	return managementSettings.Enabled
 }


### PR DESCRIPTION
## What does this PR do?

Fleetmode detection has been changed ton only use the enabled flag as
fleet is now the only management mode available.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Closes #26120 