### PR TITLE
Disable test processors system test for windows 10

### DIFF
--- a/metricbeat/tests/system/test_lightmodules.py
+++ b/metricbeat/tests/system/test_lightmodules.py
@@ -2,6 +2,7 @@ import http.server
 import metricbeat
 import os
 import os.path
+import platform
 import shutil
 import sys
 import threading
@@ -12,6 +13,8 @@ from contextlib import contextmanager
 
 
 class Test(metricbeat.BaseTest):
+    @unittest.skipIf(platform.platform().startswith("Windows-10"),
+                     "flaky test: https://github.com/elastic/beats/issues/26181")
     def test_processors(self):
         shutil.copytree(
             os.path.join(self.beat_path, "mb/testing/testdata/lightmodules"),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to disable test processors system test for windows 10 in 7.x branch.

## How to test this PR locally

- Relates #26181
