### PR TITLE
[Filebeat] Fix fileset evaluateVars

### DIFF
--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -160,11 +160,22 @@ func (fs *Fileset) evaluateVars(info beat.Info) (map[string]interface{}, error) 
 		return nil, err
 	}
 
+	// init from the config
+	for name, val := range fs.fcfg.Var {
+		vars[name] = val
+	}
+
 	for _, vals := range fs.manifest.Vars {
 		var exists bool
 		name, exists := vals["name"].(string)
 		if !exists {
 			return nil, fmt.Errorf("Variable doesn't have a string 'name' key")
+		}
+
+		// overrides
+		_, exists = vars[name]
+		if exists {
+			continue
 		}
 
 		// Variables are not required to have a default. Templates should
@@ -184,11 +195,6 @@ func (fs *Fileset) evaluateVars(info beat.Info) (map[string]interface{}, error) 
 		if err != nil {
 			return nil, fmt.Errorf("Error resolving variables on %s: %v", name, err)
 		}
-	}
-
-	// overrides from the config
-	for name, val := range fs.fcfg.Var {
-		vars[name] = val
 	}
 
 	return vars, nil

--- a/filebeat/fileset/fileset_test.go
+++ b/filebeat/fileset/fileset_test.go
@@ -145,6 +145,25 @@ func TestEvaluateVarsMySQL(t *testing.T) {
 	assert.Equal(t, expectedPaths, vars["paths"])
 }
 
+func TestEvaluateVarsKafkaOverride(t *testing.T) {
+	modulesPath, err := filepath.Abs("../module")
+	require.NoError(t, err)
+	fs, err := New(modulesPath, "log", &ModuleConfig{Module: "kafka"}, &FilesetConfig{
+		Var: map[string]interface{}{
+			"kafka_home": "/path/to/kafka*",
+		},
+	})
+	require.NoError(t, err)
+
+	fs.manifest, err = fs.readManifest()
+	require.NoError(t, err)
+
+	vars, err := fs.evaluateVars(makeTestInfo("6.6.0"))
+	require.NoError(t, err)
+
+	assert.Contains(t, vars["paths"], "/path/to/kafka*/logs/server.log*")
+}
+
 func TestResolveVariable(t *testing.T) {
 	tests := []struct {
 		Value    interface{}


### PR DESCRIPTION
## What does this PR do?

Fix [[Filebeat] module kafka var.kafka_home not work](https://github.com/elastic/beats/issues/26163)

## Why is it important?

Bug need to fix!

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
```
cd filebeat/fileset && go test -v -run '^\QTestEvaluateVarsKafkaOverride\E$'
```

## Related issues

- Relates #26163

