### PR TITLE
libbeat: monitor version

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -591,6 +591,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Add support for defining explicitly named dynamic templates without path/type match criteria {pull}25422[25422]
 - Improve ES output error insights. {pull}25825[25825]
+- Libbeat: report beat version to monitoring. {pull}TODO[TODO]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -591,7 +591,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow node/namespace metadata to be disabled on kubernetes metagen and ensure add_kubernetes_metadata honors host {pull}23012[23012]
 - Add support for defining explicitly named dynamic templates without path/type match criteria {pull}25422[25422]
 - Improve ES output error insights. {pull}25825[25825]
-- Libbeat: report beat version to monitoring. {pull}TODO[TODO]
+- Libbeat: report beat version to monitoring. {pull}26214[26214]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/metrics/metrics_common.go
+++ b/libbeat/cmd/instance/metrics/metrics_common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/beats/v7/libbeat/monitoring/report/log"
+	"github.com/elastic/beats/v7/libbeat/version"
 )
 
 var (
@@ -59,4 +60,5 @@ func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
 	})
 
 	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
+	monitoring.ReportString(V, "version", version.GetDefaultVersion())
 }

--- a/libbeat/cmd/instance/metrics/metrics_common_test.go
+++ b/libbeat/cmd/instance/metrics/metrics_common_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package metrics
 
 import (

--- a/libbeat/cmd/instance/metrics/metrics_common_test.go
+++ b/libbeat/cmd/instance/metrics/metrics_common_test.go
@@ -3,11 +3,12 @@ package metrics
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/beats/v7/libbeat/version"
-	"github.com/stretchr/testify/assert"
 )
- 
+
 func TestMonitoring(t *testing.T) {
 	metrics := monitoring.Default.GetRegistry("beat")
 	metricsSnapshot := monitoring.CollectFlatSnapshot(metrics, monitoring.Full, true)

--- a/libbeat/cmd/instance/metrics/metrics_common_test.go
+++ b/libbeat/cmd/instance/metrics/metrics_common_test.go
@@ -1,0 +1,15 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/elastic/beats/v7/libbeat/version"
+	"github.com/stretchr/testify/assert"
+)
+ 
+func TestMonitoring(t *testing.T) {
+	metrics := monitoring.Default.GetRegistry("beat")
+	metricsSnapshot := monitoring.CollectFlatSnapshot(metrics, monitoring.Full, true)
+	assert.Equal(t, version.GetDefaultVersion(), metricsSnapshot.Strings["info.version"])
+}

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -66,6 +66,7 @@ var gauges = map[string]bool{
 // TODO: Change this when gauges are refactored, too.
 var strConsts = map[string]bool{
 	"beat.info.ephemeral_id": true,
+	"beat.info.version": true,
 }
 
 var (

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -66,7 +66,7 @@ var gauges = map[string]bool{
 // TODO: Change this when gauges are refactored, too.
 var strConsts = map[string]bool{
 	"beat.info.ephemeral_id": true,
-	"beat.info.version": true,
+	"beat.info.version":      true,
 }
 
 var (


### PR DESCRIPTION
## What does this PR do?

Expand monitoring to report `beat.info.version`.

## Why is it important?

When monitoring multiple beats version would be a useful dimension to break down metrics.

## Checklist

- [x] My code follows the style guidelines of this project
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Start a beat and note that verison information is reported:

```
INFO	[monitoring]	log/log.go:153	Total non-zero metrics	{"monitoring": {"metrics": {"beat":{"cpu":{"system":{"ticks":40,"time":{"ms":40}},"total":{"ticks":131,"time":{"ms":131},"value":131},"user":{"ticks":91,"time":{"ms":91}}},"info":{"ephemeral_id":"d0703db5-bc9d-45d8-a67b-993e1626339a","uptime":{"ms":5961},"version":"8.0.0"},"memstats":{"gc_next":16014480,"memory_alloc":13199072,"memory_sys":77153288,"memory_total":32009184,"rss":57188352},"runtime":{"goroutines":20}},"libbeat":{"config":{"module":{"running":0},"reloads":1,"scans":1},"output":{"events":{"active":0},"type":"elasticsearch"},"pipeline":{"clients":0,"events":{"active":0},"queue":{"max_events":4096}}},"system":{"cpu":{"cores":16},"load":{"1":11.8486,"15":5.3057,"5":8.9258,"norm":{"1":0.7405,"15":0.3316,"5":0.5579}}}}}}
```
