### PR TITLE
[Heartbeat] Fix broken invocation of synth package

### DIFF
--- a/x-pack/heartbeat/monitors/browser/source/validatepackage.go
+++ b/x-pack/heartbeat/monitors/browser/source/validatepackage.go
@@ -75,6 +75,11 @@ func validatePackageJSON(path string) error {
 	if synthVersion == "" {
 		synthVersion = pkgJson.DevDependencies.SynthVersion
 	}
+
+	if strings.HasPrefix(synthVersion, "file://") {
+		return nil
+	}
+
 	err = validateVersion(ExpectedSynthVersion, synthVersion)
 	if err != nil {
 		return fmt.Errorf("could not validate @elastic/synthetics version: '%s' %w", synthVersion, err)

--- a/x-pack/heartbeat/monitors/browser/source/validatepackage.go
+++ b/x-pack/heartbeat/monitors/browser/source/validatepackage.go
@@ -42,6 +42,10 @@ func parseVersion(version string) string {
 }
 
 func validateVersion(expected string, current string) error {
+	if strings.HasPrefix(current, "file://") {
+		return nil
+	}
+
 	expectedRange, err := semver.NewConstraint(expected)
 	if err != nil {
 		return err
@@ -74,10 +78,6 @@ func validatePackageJSON(path string) error {
 	synthVersion := pkgJson.Dependencies.SynthVersion
 	if synthVersion == "" {
 		synthVersion = pkgJson.DevDependencies.SynthVersion
-	}
-
-	if strings.HasPrefix(synthVersion, "file://") {
-		return nil
 	}
 
 	err = validateVersion(ExpectedSynthVersion, synthVersion)

--- a/x-pack/heartbeat/monitors/browser/source/validatepackage_test.go
+++ b/x-pack/heartbeat/monitors/browser/source/validatepackage_test.go
@@ -70,6 +70,11 @@ func TestValidateVersion(t *testing.T) {
 			current:   "0.0.1-alpha.11",
 			shouldErr: false,
 		},
+		{
+			expected:  "",
+			current:   "file://blahblahblah",
+			shouldErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -30,7 +30,7 @@ const debugSelector = "synthexec"
 func SuiteJob(ctx context.Context, suitePath string, params common.MapStr, extraArgs ...string) (jobs.Job, error) {
 	// Run the command in the given suitePath, use '.' as the first arg since the command runs
 	// in the correct dir
-	newCmd, err := suiteCommandFactory(suitePath, append(extraArgs, ".")...)
+	newCmd, err := suiteCommandFactory(suitePath, append([]string{suitePath}, extraArgs...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -30,12 +30,12 @@ const debugSelector = "synthexec"
 func SuiteJob(ctx context.Context, suitePath string, params common.MapStr, extraArgs ...string) (jobs.Job, error) {
 	// Run the command in the given suitePath, use '.' as the first arg since the command runs
 	// in the correct dir
-	newCmd, err := suiteCommandFactory(suitePath, append([]string{suitePath}, extraArgs...)...)
+	cmdFactory, err := suiteCommandFactory(suitePath, extraArgs...)
 	if err != nil {
 		return nil, err
 	}
 
-	return startCmdJob(ctx, newCmd, nil, params), nil
+	return startCmdJob(ctx, cmdFactory, nil, params), nil
 }
 
 func suiteCommandFactory(suitePath string, args ...string) (func() *exec.Cmd, error) {
@@ -46,7 +46,11 @@ func suiteCommandFactory(suitePath string, args ...string) (func() *exec.Cmd, er
 
 	newCmd := func() *exec.Cmd {
 		bin := filepath.Join(npmRoot, "node_modules/.bin/elastic-synthetics")
-		cmd := exec.Command(bin, args...)
+		// Always put the suite path first to prevent conflation with variadic args!
+		// See https://github.com/tj/commander.js/blob/master/docs/options-taking-varying-arguments.md
+		// Note, we don't use the -- approach because it's cleaner to always know we can add new options
+		// to the end.
+		cmd := exec.Command(bin, append([]string{suitePath}, args...)...)
 		cmd.Dir = npmRoot
 		return cmd
 	}


### PR DESCRIPTION
Fixes invocation of synthetics broken in #26188 

Additionally, for dev purposes, this lets accepts a synthetics version of `file:///` as valid to help with debugging development versions of the synthetics agent.

Never released, so no changelog needed

Still just sticking with unit tests here since testing more deeply with synthetics (esp. master where this is a problem) is a larger problem than we're equipped to handle ATM.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


## How to test this PR locally

Can be done with `file://` deps in package.json used to run the latest synthetics master branch
