### PR TITLE
Update Cisco Umbrella pipeline with Version 5 logs

### DIFF
--- a/x-pack/filebeat/module/cisco/umbrella/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/cisco/umbrella/ingest/pipeline.yml
@@ -86,6 +86,9 @@ processors:
       - cisco.umbrella.amp_score
       - cisco.umbrella.identity_types
       - cisco.umbrella.blocked_categories
+      - cisco.umbrella.all_identities
+      - cisco.umbrella.all_identity_types
+      - http.request.method
     if: ctx?.log?.file?.path.contains('proxylogs')
 
 - set:


### PR DESCRIPTION
## What does this PR do?

Cisco Umbrella released a new log format dubbed "Version 5". This adds three new fields to the proxy logs. 
[https://docs.umbrella.com/deployment-umbrella/docs/log-formats-and-versioning]

The fields are added to the csv processor for the proxy logs.

## Why is it important?

This is especially important because of the http method field which is important to understand proxy logs.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

This PR has not been tested. 
Maybe @P1llus can help.

## Related issues

- No related issues