### PR TITLE
Disable packaging-arm in elastic-agent

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -208,7 +208,8 @@ pipeline {
                   'packetbeat',
                   'x-pack/auditbeat',
                   'x-pack/dockerlogbeat',
-                  'x-pack/elastic-agent',
+                  // See https://github.com/elastic/beats/issues/26239
+                  // 'x-pack/elastic-agent',
                   'x-pack/filebeat',
                   'x-pack/heartbeat',
                   'x-pack/metricbeat',

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -95,10 +95,10 @@ stages:
         e2e:
             enabled: false
         stage: packaging
-    packaging-arm:
-        packaging-arm: "mage package"
-        e2e:
-            enabled: false
-        platforms:             ## override default label in this specific stage.
-          - "arm"
-        stage: packaging
+#    packaging-arm: See https://github.com/elastic/beats/issues/26239
+#        packaging-arm: "mage package"
+#        e2e:
+#            enabled: false
+#        platforms:             ## override default label in this specific stage.
+#          - "arm"
+#        stage: packaging


### PR DESCRIPTION
## What does this PR do?

This PR is to disable arm packaging in elastic-agent.

## Why is it important?

Skipping this so `mage package` can pass in CI.

## Related issues

- Relates https://github.com/elastic/beats/issues/26239
