### PR TITLE
Cherry-pick #26126 to 7.13: Fix startup with failing configuration 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -70,7 +70,6 @@
 - Fix fleet-server.yml spec to not overwrite existing keys {pull}25741[25741]
 - Agent sends wrong log level to Endpoint {issue}25583[25583]
 - Fix startup with failing configuration {pull}26057[26057]
-- Change timestamp in elatic-agent-json.log to use UTC {issue}25391[25391]
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -69,6 +69,8 @@
 - Handle case where policy doesn't contain Fleet connection information {pull}25707[25707]
 - Fix fleet-server.yml spec to not overwrite existing keys {pull}25741[25741]
 - Agent sends wrong log level to Endpoint {issue}25583[25583]
+- Fix startup with failing configuration {pull}26057[26057]
+- Change timestamp in elatic-agent-json.log to use UTC {issue}25391[25391]
 
 ==== New features
 


### PR DESCRIPTION
Cherry-pick of PR #17391 to 7.13 branch. Original message:

## What does this PR do?

What is going on is a bit weird race.
Basically we start ok but troubles come on restart.

On restart we apply stored config to start MB (`mb1`) with failing configuration, 
MB does not exit just reports Failed state because it cannot apply `system/load` on windows.
At this time 10 second timer to recover is started otherwise we plan a restart.

Then we pull config from fleet and decide MB should be started. 
We start MB `mb2` while `mb1` is still running. We are starting it because check checks for terminal statuses and Failed is one of them. 
This `mb2` starts reports running, timer for killing `mb1` is stopped. Because MB is running and it does not differentiate between processes.
`mb2` fails on `data.path` conflict with `mb1`

watcher detects stopped metricbeat and `mb3` is started, `mb1` is still running, we dont have any information about `mb1` anymore anywhere.
`mb3` fails on same thing `mb2` failed and exits.

`mb1` still running in Failed state and we try `mbX` over and over again.

This PR adds some closers to watcher, some checks on Failure termination and passing proc so watcher and terminator are killing the process they were designed to kill. 

While this fix works, i dont like the whole approach where we handle start/stop/restart from 4-5 places and they can be conflicting. I would like to see this redesigned. But i've spent 5 days chasing this and need some social distancing from the topic so this fix is OK at the moment for me.

How to test:
- Build 
- Create config with fleet-server, system and endpoint integration
- Deploy on windows machine
- Wait for everything to settle and restart a lot of times to check if you see 3 metricbeat processes running in Task Manager. 

How it behaved before the fix: we had 3 metricbeats, 2 with stable PID (one for monitoring, one is `mb1`) and then thirds MB process kept changing PID (crash-restart loop)

## Why is it important?

Fixes #25829 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
