### PR TITLE
Change xml processor names in script processor to match convention

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -242,6 +242,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix handling of `file_selectors` in aws-s3 input. {pull}25792[25792]
 - Fix ILM alias creation when write alias exists and initial index does not exist {pull}26143[26143]
 - Include date separator in the filename prefix of `dateRotator` to make sure nothing gets purged accidentally {pull}26176[26176]
+- In the script processor, the `decode_xml` and `decode_xml_wineventlog` processors are now available as `DecodeXML` and `DecodeXMLWineventlog` respectively.
 
 *Auditbeat*
 

--- a/libbeat/processors/decode_xml/decode_xml.go
+++ b/libbeat/processors/decode_xml/decode_xml.go
@@ -59,7 +59,7 @@ func init() {
 				"to_lower", "ignore_missing",
 				"ignore_failure",
 			)))
-	jsprocessor.RegisterPlugin(procName, New)
+	jsprocessor.RegisterPlugin("DecodeXML", New)
 }
 
 // New constructs a new decode_xml processor.

--- a/libbeat/processors/decode_xml_wineventlog/processor.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor.go
@@ -51,7 +51,7 @@ func init() {
 				"overwrite_keys", "map_ecs_fields",
 				"ignore_missing", "ignore_failure",
 			)))
-	jsprocessor.RegisterPlugin(procName, New)
+	jsprocessor.RegisterPlugin("DecodeXMLWineventlog", New)
 }
 
 type processor struct {


### PR DESCRIPTION
## What does this PR do?

In the script processor, the `decode_xml` and `decode_xml_wineventlog` processors are now available as `DecodeXML` and `DecodeXMLWineventlog` respectively. This follows the same naming conventions as other processors exposed though the `script` processor. For example you can write `new processor.DecodeXML({...})`.

## Why is it important?

This keeps the naming consistent in the script processor.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

