### PR TITLE
Add log.flags and object metadata to aws-s3 input events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -824,6 +824,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add new `parser` to `filestream` input: `container`. {pull}26115[26115]
 - Add support for ISO8601 timestamps in Zeek fileset {pull}25564[25564]
 - Add `preserve_original_event` option to `o365audit` input. {pull}26273[26273]
+- Add `log.flags` to events created by the `aws-s3` input. {pull}26267[26267]
+- Add `include_s3_metadata` config option to the `aws-s3` input for including object metadata in events. {pull}26267[26267]
 
 *Heartbeat*
 

--- a/filebeat/docs/fields.asciidoc
+++ b/filebeat/docs/fields.asciidoc
@@ -125697,7 +125697,7 @@ S3 fields from s3 input.
 
 
 
-*`bucket_name`*::
+*`bucket.name`*::
 +
 --
 Name of the S3 bucket that this log retrieved from.
@@ -125707,13 +125707,32 @@ type: keyword
 
 --
 
-*`object_key`*::
+*`bucket.arn`*::
++
+--
+ARN of the S3 bucket that this log retrieved from.
+
+
+type: keyword
+
+--
+
+*`object.key`*::
 +
 --
 Name of the S3 object that this log retrieved from.
 
 
 type: keyword
+
+--
+
+*`metadata`*::
++
+--
+AWS S3 object metadata values.
+
+type: flattened
 
 --
 

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -73,3 +73,6 @@
   # The duration (in seconds) that the received messages are hidden from subsequent
   # retrieve requests after being retrieved by a ReceiveMessage request.
   #visibility_timeout: 300
+
+  # List of S3 object metadata keys to include in events.
+  #include_s3_metadata: []

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -112,9 +112,10 @@ setting.  If `file_selectors` is given, then any global
 `expand_event_list_from_field` value is ignored in favor of the ones
 specified in the `file_selectors`.  Regex syntax is the same as the Go
 language.  Files that don't match one of the regexes won't be
-processed.  <<input-aws-s3-content_type>>, <<input-aws-s3-multiline>>,
-<<input-aws-s3-max_bytes>>, <<input-aws-s3-buffer_size>>, and
-<<input-aws-s3-encoding>> may also be set for each file selector.
+processed.  <<input-aws-s3-content_type>>, <<input-aws-s3-include_s3_metadata>>,
+<<input-aws-s3-multiline>>, <<input-aws-s3-max_bytes>>,
+<<input-aws-s3-buffer_size>>, and <<input-aws-s3-encoding>> may also be set for
+each file selector.
 
 ["source", "yml"]
 ----
@@ -132,6 +133,22 @@ file_selectors:
 Enabling this option changes the service name from `s3` to `s3-fips` for
 connecting to the correct service endpoint. For example:
 `s3-fips.us-gov-east-1.amazonaws.com`.
+
+[id="input-{type}-include_s3_metadata"]
+[float]
+==== `include_s3_metadata`
+
+This input can include S3 object metadata in the generated events for use in
+follow-on processing. You must specify the list of keys to include. By default
+none are included. If the key exists in the S3 response then it will be included
+in the event as `aws.s3.metadata.<key>` where the key name as been normalized
+to all lowercase.
+
+----
+include_s3_metadata:
+  - last-modified
+  - x-amz-version-id
+----
 
 [id="input-{type}-max_bytes"]
 [float]

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3056,6 +3056,9 @@ filebeat.inputs:
   # retrieve requests after being retrieved by a ReceiveMessage request.
   #visibility_timeout: 300
 
+  # List of S3 object metadata keys to include in events.
+  #include_s3_metadata: []
+
 # =========================== Filebeat autodiscover ============================
 
 # Autodiscover allows you to detect changes in the system and spawn new modules

--- a/x-pack/filebeat/input/awss3/_meta/fields.yml
+++ b/x-pack/filebeat/input/awss3/_meta/fields.yml
@@ -4,11 +4,19 @@
     S3 fields from s3 input.
   release: ga
   fields:
-    - name: bucket_name
+    - name: bucket.name
       type: keyword
       description: >
         Name of the S3 bucket that this log retrieved from.
-    - name: object_key
+    - name: bucket.arn
+      type: keyword
+      description: >
+        ARN of the S3 bucket that this log retrieved from.
+    - name: object.key
       type: keyword
       description: >
         Name of the S3 object that this log retrieved from.
+    - name: metadata
+      type: flattened
+      description:
+        AWS S3 object metadata values.

--- a/x-pack/filebeat/input/awss3/collector_test.go
+++ b/x-pack/filebeat/input/awss3/collector_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/reader"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile/encoding"
@@ -324,12 +323,12 @@ func TestCreateEvent(t *testing.T) {
 			break
 		}
 		if err == io.EOF {
-			event := createEvent(log, int64(len(log)), s3Info, s3ObjectHash, s3Context, common.MapStr{})
+			event := createEvent(log, int64(len(log)), s3Info, s3ObjectHash, s3Context)
 			events = append(events, event)
 			break
 		}
 
-		event := createEvent(log, int64(len(log)), s3Info, s3ObjectHash, s3Context, common.MapStr{})
+		event := createEvent(log, int64(len(log)), s3Info, s3ObjectHash, s3Context)
 		events = append(events, event)
 	}
 

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -73,6 +73,7 @@ type readerConfig struct {
 	LineTerminator           readfile.LineTerminator `config:"line_terminator"`
 	Encoding                 string                  `config:"encoding"`
 	ContentType              string                  `config:"content_type"`
+	IncludeS3Metadata        []string                `config:"include_s3_metadata"`
 }
 
 func (f *readerConfig) Validate() error {

--- a/x-pack/filebeat/input/awss3/fields.go
+++ b/x-pack/filebeat/input/awss3/fields.go
@@ -19,5 +19,5 @@ func init() {
 // AssetAwss3 returns asset data.
 // This is the base64 encoded gzipped contents of input/awss3.
 func AssetAwss3() string {
-	return "eJykjrFuhDAQRHt/xYgeGncu8glp8gHI4AEcDEb2koi/PxloTjrpittipR3tzJsaMw+DrBUgXgINqqwrBTjmPvlNfFwNvhQA/GgMnsFlDCkuyBp+3XZpFJAYaDMNRqtwf5nTVGO1Cw26vZ8pbTlOHZBjoyn8/5jcrb2glvm2CxEHyMTS4sqCTLYsnxHiiERJnn90Z7vmCR67X/bSzjw+Zl9Rb9iPAAAA//+ahmgy"
+	return "eJykz7FuwyAQBuCdp/iVPV68MVTqC2Rohs4X8zuhxmDBOZXfvsJJ1UbyEoUBiRP3f3d7DFwsSmsA9RposSvtzgCOpct+Up+ixZsBgGOL3jO4gj6nEaWFj9OsjQEyA6XQ4iwG9192bdojykiL09wN1KY+1jqgy0Rb/e+U3b22odZzkJFIPfTCOsUtC3qRevmCkM7I1Ox5pVuna7ZwyfF5+/3j8AqdTl/stBm4vLz2LeoJe6SKE5UHuQ+iysgt+2/pz+M/8TcHVwkzS2N+AgAA//8B6arF"
 }


### PR DESCRIPTION
## What does this PR do?

This adds the `log.flags` field created by the line readers to aws-s3 events. `log.flags` contains metadata like `multiline` and `truncated` to indicate how the data was processed.

This also adds a config option to include S3 object metadata in the event if it exists. The use case for me was to get the `Last-Modified` timestamp for cases where the log does not have a timestamp or it cannot be parsed. Then this can be used as a fallback.

## Why is it important?

It makes the S3 log reader behave more similar to the log reader. And having access to the S3 headers gives users a bit more flexibility in their use-cases.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

