### PR TITLE
fix: permission resource lease for API group "coordination.k8s.io"

### DIFF
--- a/deploy/kubernetes/elastic-agent-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-kubernetes.yaml
@@ -135,6 +135,15 @@ rules:
       - "/metrics"
     verbs:
       - get
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - get
+    - list
+    - update
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
This config fixes the issue. Tested on EKS, 1.19.
error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"

- Bug

## What does this PR do?

Fixed k8s cluster role permission issue.

## Why is it important?

Not able to run the start the elastic-agent in k8s cluster

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Deploy this in a k8s cluster: curl -L -O https://raw.githubusercontent.com/elastic/beats/7.13/deploy/kubernetes/elastic-agent-kubernetes.yaml
- [ ] Check the deployment logs for error. you can notice this error `error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system`

## How to test this PR locally 

added k8s config solves the permission issue. can be tested with any k8s cluster.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

Follow Logs:
Show timestamp:
Since:
0
Tail:
-1
To terminal:
Filter:
Enter your key words
Wrap lines:
Policy selected for enrollment:  
The Elastic Agent is currently in BETA and should not be used in production

2021-06-12T15:41:21.536Z	INFO	cmd/enroll_cmd.go:201	Elastic Agent might not be running; unable to trigger restart
2021-06-12T15:41:21.536Z	INFO	cmd/enroll_cmd.go:203	Successfully triggered restart on running Elastic Agent.
Successfully enrolled the Elastic Agent.
2021-06-12T15:41:21.641Z	INFO	warn/warn.go:18	The Elastic Agent is currently in BETA and should not be used in production
2021-06-12T15:41:21.641Z	INFO	application/application.go:68	Detecting execution mode
2021-06-12T15:41:21.642Z	INFO	application/application.go:93	Agent is managed by Fleet
2021-06-12T15:41:21.642Z	INFO	capabilities/capabilities.go:59	capabilities file not found in /usr/share/elastic-agent/state/capabilities.yml
2021-06-12T15:41:21.802Z	INFO	[composable]	composable/controller.go:46	EXPERIMENTAL - Inputs with variables are currently experimental and should not be used in production
I0612 15:41:21.905690       6 leaderelection.go:243] attempting to acquire leader lease  kube-system/elastic-agent-cluster-leader...
E0612 15:41:21.915059       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:41:22.008Z	INFO	[composable.providers.docker]	docker/docker.go:43	Docker provider skipped, unable to connect: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2021-06-12T15:41:22.008Z	INFO	[composable.providers.kubernetes]	kubernetes/kubernetes.go:64	Kubernetes provider started with node scope
2021-06-12T15:41:22.008Z	INFO	[composable.providers.kubernetes]	kubernetes/util.go:114	kubernetes: Using pod name agent-ingest-management-clusterscope-5844d8b975-k752w and namespace kube-system to discover kubernetes node
2021-06-12T15:41:22.021Z	INFO	[composable.providers.kubernetes]	kubernetes/util.go:120	kubernetes: Using node ip-172-31-95-22.ec2.internal discovered by in cluster pod node query
2021-06-12T15:41:22.122Z	INFO	[api]	api/server.go:62	Starting stats endpoint
2021-06-12T15:41:22.122Z	INFO	application/managed_mode.go:291	Agent is starting
2021-06-12T15:41:22.123Z	INFO	[api]	api/server.go:64	Metrics endpoint listening on: /usr/share/elastic-agent/state/data/tmp/elastic-agent.sock (configured: unix:///usr/share/elastic-agent/state/data/tmp/elastic-agent.sock)
2021-06-12T15:41:22.223Z	WARN	application/managed_mode.go:304	failed to ack update open /usr/share/elastic-agent/state/data/.update-marker: no such file or directory
2021-06-12T15:41:23.950Z	INFO	stateresolver/stateresolver.go:48	New State ID is MWzKO-IG
2021-06-12T15:41:23.950Z	INFO	stateresolver/stateresolver.go:49	Converging state requires execution of 3 step(s)
E0612 15:41:24.786817       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:41:27.395Z	INFO	log/reporter.go:40	2021-06-12T15:41:27Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:41:29.139466       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:41:29.332Z	INFO	log/reporter.go:40	2021-06-12T15:41:29Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RUNNING: Running - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:41:30.959Z	INFO	log/reporter.go:40	2021-06-12T15:41:30Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:41:31.670Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:32.465Z	INFO	log/reporter.go:40	2021-06-12T15:41:32Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:41:32.556702       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:41:35.914Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:41:36.047Z	INFO	log/reporter.go:40	2021-06-12T15:41:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:41:36.055Z	INFO	stateresolver/stateresolver.go:66	Updating internal state
2021-06-12T15:41:36.403Z	INFO	stateresolver/stateresolver.go:48	New State ID is MWzKO-IG
2021-06-12T15:41:36.403Z	INFO	stateresolver/stateresolver.go:49	Converging state requires execution of 3 step(s)
2021-06-12T15:41:36.406Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:41:36.407Z	ERROR	log/reporter.go:36	2021-06-12T15:41:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to CRASHED: exited with code: -1 - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:41:36.411Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:41:36.412Z	INFO	log/reporter.go:40	2021-06-12T15:41:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:41:36.412Z	INFO	log/reporter.go:40	2021-06-12T15:41:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:41:36.435388       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:41:38.390Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:41:38.390Z	ERROR	log/reporter.go:36	2021-06-12T15:41:38Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to CRASHED: exited with code: -1 - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:41:38.391Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:41:38.391Z	INFO	log/reporter.go:40	2021-06-12T15:41:38Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:41:38.392Z	INFO	log/reporter.go:40	2021-06-12T15:41:38Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:41:39.032Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:41:39.032Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:41:40.314Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:40.314Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
E0612 15:41:40.813524       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:41:41.396Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:41.396Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:42.774Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:41:42.774Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:41:42.776Z	INFO	stateresolver/stateresolver.go:66	Updating internal state
2021-06-12T15:41:42.932Z	INFO	stateresolver/stateresolver.go:48	New State ID is MWzKO-IG
2021-06-12T15:41:42.932Z	INFO	stateresolver/stateresolver.go:49	Converging state requires execution of 2 step(s)
E0612 15:41:43.161021       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:41:44.080Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:44.080Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:45.224Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:45.224Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:41:46.670Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:41:46.670Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:41:46.674Z	INFO	stateresolver/stateresolver.go:66	Updating internal state
E0612 15:41:47.373441       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:41:51.370443       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:41:54.151940       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:41:58.109078       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:01.393070       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:04.903274       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:08.296353       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:10.382660       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:13.571730       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:17.253210       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:19.937246       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:24.191950       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:42:26.769Z	INFO	stateresolver/stateresolver.go:48	New State ID is MWzKO-IG
2021-06-12T15:42:26.773Z	INFO	stateresolver/stateresolver.go:49	Converging state requires execution of 3 step(s)
E0612 15:42:27.759858       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:42:29.209Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:42:29.209Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for metricbeat.7.13.1-SNAPSHOT
E0612 15:42:29.802992       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:42:31.229Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:42:31.236Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:42:31.809Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:42:31.809Z	INFO	log/reporter.go:40	2021-06-12T15:42:31Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:42:31.809Z	INFO	log/reporter.go:40	2021-06-12T15:42:31Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:42:33.213Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:42:33.213Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
E0612 15:42:33.630842       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:42:35.590Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:42:35.595Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:42:35.597Z	INFO	stateresolver/stateresolver.go:66	Updating internal state
2021-06-12T15:42:35.744Z	INFO	stateresolver/stateresolver.go:48	New State ID is MWzKO-IG
2021-06-12T15:42:35.744Z	INFO	stateresolver/stateresolver.go:49	Converging state requires execution of 3 step(s)
2021-06-12T15:42:36.809Z	INFO	log/reporter.go:40	2021-06-12T15:42:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:42:36.809Z	INFO	log/reporter.go:40	2021-06-12T15:42:36Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:42:37.174457       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:42:38.102Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:42:38.102Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for metricbeat.7.13.1-SNAPSHOT
E0612 15:42:39.702378       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:42:40.075Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:42:40.075Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:42:42.158Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for filebeat.7.13.1-SNAPSHOT
2021-06-12T15:42:42.158Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for filebeat.7.13.1-SNAPSHOT
E0612 15:42:43.925527       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:42:44.658Z	INFO	operation/operator.go:259	operation 'operation-install' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:42:44.664Z	INFO	operation/operator.go:259	operation 'operation-start' skipped for metricbeat.7.13.1-SNAPSHOT
2021-06-12T15:42:44.666Z	INFO	stateresolver/stateresolver.go:66	Updating internal state
E0612 15:42:46.919596       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:51.243156       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:54.179473       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:42:57.831210       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:00.034728       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:02.605017       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:05.099979       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:07.388772       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:09.739521       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:12.736637       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:16.734994       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:19.691115       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:23.621366       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:26.373176       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:29.731393       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:43:31.811Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:43:31.811Z	ERROR	log/reporter.go:36	2021-06-12T15:43:31Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:43:31.820Z	ERROR	log/reporter.go:36	2021-06-12T15:43:31Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:43:33.536846       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:43:36.822Z	ERROR	log/reporter.go:36	2021-06-12T15:43:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:43:36.823Z	ERROR	log/reporter.go:36	2021-06-12T15:43:36Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:43:37.424576       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:40.914478       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:43:41.820Z	INFO	log/reporter.go:40	2021-06-12T15:43:41Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:43:41.821Z	INFO	log/reporter.go:40	2021-06-12T15:43:41Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:43:41.879Z	INFO	log/reporter.go:40	2021-06-12T15:43:41Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:43:41.879Z	INFO	log/reporter.go:40	2021-06-12T15:43:41Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:43:45.017054       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:43:46.823Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:43:46.823Z	INFO	log/reporter.go:40	2021-06-12T15:43:46Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:43:46.823Z	INFO	log/reporter.go:40	2021-06-12T15:43:46Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:43:46.823Z	INFO	log/reporter.go:40	2021-06-12T15:43:46Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:43:46.832Z	INFO	log/reporter.go:40	2021-06-12T15:43:46Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:43:47.408189       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:50.130711       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:52.890994       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:56.476729       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:43:59.046865       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:02.272742       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:06.142222       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:08.583029       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:10.994924       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:13.495199       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:16.845577       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:19.983829       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:23.141324       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:27.288978       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:29.427947       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:44:31.825Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:44:31.825Z	INFO	log/reporter.go:40	2021-06-12T15:44:31Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:44:31.913Z	INFO	log/reporter.go:40	2021-06-12T15:44:31Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:44:31.915034       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:34.167583       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:44:36.913Z	INFO	log/reporter.go:40	2021-06-12T15:44:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:44:36.913Z	INFO	log/reporter.go:40	2021-06-12T15:44:36Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:44:37.110641       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:39.225369       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:41.463135       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:43.877308       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:47.927185       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:51.145624       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:53.708696       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:56.516640       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:44:59.049004       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:01.114514       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:05.441831       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:08.924393       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:12.641402       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:15.283700       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:17.494312       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:21.416332       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:24.500574       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:28.035627       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:31.688038       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:45:31.914Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:45:31.914Z	ERROR	log/reporter.go:36	2021-06-12T15:45:31Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:45:31.916Z	ERROR	log/reporter.go:36	2021-06-12T15:45:31Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:45:34.294568       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:36.535227       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:45:36.917Z	ERROR	log/reporter.go:36	2021-06-12T15:45:36Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:45:36.917Z	ERROR	log/reporter.go:36	2021-06-12T15:45:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:45:39.245194       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:45:41.917Z	INFO	log/reporter.go:40	2021-06-12T15:45:41Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:45:41.918Z	INFO	log/reporter.go:40	2021-06-12T15:45:41Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:45:41.919Z	INFO	log/reporter.go:40	2021-06-12T15:45:41Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:45:41.919Z	INFO	log/reporter.go:40	2021-06-12T15:45:41Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:45:42.180024       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:44.966212       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:45:46.918Z	INFO	log/reporter.go:40	2021-06-12T15:45:46Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:45:46.918Z	INFO	log/reporter.go:40	2021-06-12T15:45:46Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:45:46.919Z	INFO	log/reporter.go:40	2021-06-12T15:45:46Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:45:46.919Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:45:46.919Z	INFO	log/reporter.go:40	2021-06-12T15:45:46Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:45:47.379228       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:51.056750       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:53.094584       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:45:57.464089       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:01.006180       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:03.821711       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:07.323636       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:10.012001       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:13.091881       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:17.076711       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:20.312673       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:22.826453       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:26.157023       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:30.206883       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:46:31.919Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:46:31.919Z	INFO	log/reporter.go:40	2021-06-12T15:46:31Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:46:31.919Z	INFO	log/reporter.go:40	2021-06-12T15:46:31Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:46:33.316667       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:46:36.919Z	INFO	log/reporter.go:40	2021-06-12T15:46:36Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:46:36.919Z	INFO	log/reporter.go:40	2021-06-12T15:46:36Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:46:36.985020       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:40.719064       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:45.078812       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:48.298757       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:51.736019       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:55.308285       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:46:57.908299       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:00.149425       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:02.915811       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:07.214225       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:14.705025       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:17.324533       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:20.649885       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:22.740935       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:25.600556       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:27.610254       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:30.425555       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:47:31.921Z	ERROR	log/reporter.go:36	2021-06-12T15:47:31Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:47:31.920Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:47:32.045Z	ERROR	log/reporter.go:36	2021-06-12T15:47:32Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:47:34.433418       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:36.643752       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:47:39.795Z	ERROR	log/reporter.go:36	2021-06-12T15:47:39Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:47:39.796Z	ERROR	log/reporter.go:36	2021-06-12T15:47:39Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:47:40.860718       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:47:42.815Z	INFO	log/reporter.go:40	2021-06-12T15:47:42Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:47:42.815Z	INFO	log/reporter.go:40	2021-06-12T15:47:42Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:47:43.067233       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:47:44.796Z	INFO	log/reporter.go:40	2021-06-12T15:47:44Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:47:44.796Z	INFO	log/reporter.go:40	2021-06-12T15:47:44Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:47:47.007336       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:47:49.796Z	INFO	log/reporter.go:40	2021-06-12T15:47:49Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:47:49.796Z	INFO	log/reporter.go:40	2021-06-12T15:47:49Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:47:49.797Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:47:49.797Z	INFO	log/reporter.go:40	2021-06-12T15:47:49Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:47:49.797Z	INFO	log/reporter.go:40	2021-06-12T15:47:49Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:47:50.042354       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:54.343544       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:56.500434       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:47:59.187739       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:02.630095       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:05.103573       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:07.948338       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:10.182160       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:12.743923       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:14.995710       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:17.435118       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:20.878144       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:23.922425       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:26.216580       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:30.343580       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:32.474184       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:48:34.797Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:48:34.797Z	INFO	log/reporter.go:40	2021-06-12T15:48:34Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:48:34.797Z	INFO	log/reporter.go:40	2021-06-12T15:48:34Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:48:35.907031       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:39.458388       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:48:39.798Z	INFO	log/reporter.go:40	2021-06-12T15:48:39Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:48:39.798Z	INFO	log/reporter.go:40	2021-06-12T15:48:39Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:48:41.899978       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:45.868391       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:49.877351       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:53.361747       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:55.471739       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:48:57.726188       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:00.518559       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:04.195450       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:06.999906       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:09.084955       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:12.025709       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:14.840341       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:19.167013       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:22.839443       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:26.696566       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:28.769456       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:30.993216       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:33.126481       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:49:34.799Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:49:34.799Z	ERROR	log/reporter.go:36	2021-06-12T15:49:34Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:49:34.800Z	ERROR	log/reporter.go:36	2021-06-12T15:49:34Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:49:36.957867       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:39.124944       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:49:39.801Z	ERROR	log/reporter.go:36	2021-06-12T15:49:39Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:49:39.802Z	ERROR	log/reporter.go:36	2021-06-12T15:49:39Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:49:42.003674       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:44.405971       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:49:44.802Z	INFO	log/reporter.go:40	2021-06-12T15:49:44Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:49:44.802Z	INFO	log/reporter.go:40	2021-06-12T15:49:44Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:49:44.803Z	INFO	log/reporter.go:40	2021-06-12T15:49:44Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:49:44.803Z	INFO	log/reporter.go:40	2021-06-12T15:49:44Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:49:47.713210       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:49:49.802Z	INFO	log/reporter.go:40	2021-06-12T15:49:49Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:49:49.802Z	INFO	log/reporter.go:40	2021-06-12T15:49:49Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:49:49.803Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:49:49.803Z	INFO	log/reporter.go:40	2021-06-12T15:49:49Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:49:49.803Z	INFO	log/reporter.go:40	2021-06-12T15:49:49Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:49:50.984420       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:53.873939       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:56.312321       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:49:59.994915       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:02.406486       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:05.395237       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:08.311826       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:11.994008       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:14.025521       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:16.103599       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:20.245076       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:23.380393       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:26.832704       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:29.603645       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:32.979368       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:50:34.803Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:50:34.803Z	INFO	log/reporter.go:40	2021-06-12T15:50:34Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:50:34.803Z	INFO	log/reporter.go:40	2021-06-12T15:50:34Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:50:36.825040       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:50:39.803Z	INFO	log/reporter.go:40	2021-06-12T15:50:39Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:50:39.803Z	INFO	log/reporter.go:40	2021-06-12T15:50:39Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:50:40.147011       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:44.531520       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:48.205966       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:52.088007       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:54.269976       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:50:57.883757       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:00.691729       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:05.005794       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:08.736809       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:10.765123       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:13.121029       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:15.189901       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:17.361624       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:20.065204       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:22.422255       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:26.503019       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:30.283616       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:32.970805       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:51:34.804Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:51:34.804Z	ERROR	log/reporter.go:36	2021-06-12T15:51:34Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:51:34.806Z	ERROR	log/reporter.go:36	2021-06-12T15:51:34Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:51:35.189368       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:39.384949       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:51:39.807Z	ERROR	log/reporter.go:36	2021-06-12T15:51:39Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:51:39.807Z	ERROR	log/reporter.go:36	2021-06-12T15:51:39Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:51:42.772757       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:51:44.807Z	INFO	log/reporter.go:40	2021-06-12T15:51:44Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:51:44.808Z	INFO	log/reporter.go:40	2021-06-12T15:51:44Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:51:44.809Z	INFO	log/reporter.go:40	2021-06-12T15:51:44Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:51:44.809Z	INFO	log/reporter.go:40	2021-06-12T15:51:44Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:51:45.665703       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:47.748074       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:51:49.808Z	INFO	log/reporter.go:40	2021-06-12T15:51:49Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:51:49.808Z	INFO	log/reporter.go:40	2021-06-12T15:51:49Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:51:49.808Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:51:49.808Z	INFO	log/reporter.go:40	2021-06-12T15:51:49Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:51:49.808Z	INFO	log/reporter.go:40	2021-06-12T15:51:49Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:51:51.073721       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:53.132935       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:56.412254       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:51:59.716014       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:03.304471       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:07.262167       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:11.322531       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:14.272809       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:18.472865       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:22.744141       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:26.766608       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:30.650322       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:34.732726       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:52:34.809Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:52:34.809Z	INFO	log/reporter.go:40	2021-06-12T15:52:34Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:52:35.023Z	INFO	log/reporter.go:40	2021-06-12T15:52:35Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:52:38.601884       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:52:40.024Z	INFO	log/reporter.go:40	2021-06-12T15:52:40Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:52:40.024Z	INFO	log/reporter.go:40	2021-06-12T15:52:40Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:52:41.067922       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:43.593710       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:46.754238       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:50.997105       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:53.662012       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:52:57.937719       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:00.630363       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:04.521621       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:07.772577       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:11.840251       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:15.661353       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:18.809518       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:22.250388       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:26.627139       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:29.987260       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:32.136696       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:53:35.024Z	ERROR	log/reporter.go:36	2021-06-12T15:53:35Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:53:35.024Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:53:35.205Z	ERROR	log/reporter.go:36	2021-06-12T15:53:35Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:53:36.191188       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:39.743082       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:53:40.206Z	ERROR	log/reporter.go:36	2021-06-12T15:53:40Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:53:40.206Z	ERROR	log/reporter.go:36	2021-06-12T15:53:40Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:53:42.591875       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:53:45.206Z	INFO	log/reporter.go:40	2021-06-12T15:53:45Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:53:45.206Z	INFO	log/reporter.go:40	2021-06-12T15:53:45Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:53:45.208Z	INFO	log/reporter.go:40	2021-06-12T15:53:45Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:53:45.208Z	INFO	log/reporter.go:40	2021-06-12T15:53:45Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:53:46.100852       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:49.083639       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:53:50.207Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:53:50.210Z	INFO	log/reporter.go:40	2021-06-12T15:53:50Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:53:50.210Z	INFO	log/reporter.go:40	2021-06-12T15:53:50Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:53:50.210Z	INFO	log/reporter.go:40	2021-06-12T15:53:50Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:53:50.210Z	INFO	log/reporter.go:40	2021-06-12T15:53:50Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:53:52.649183       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:56.689595       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:53:59.727550       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:02.549150       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:04.856257       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:08.535247       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:10.933973       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:14.164322       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:16.242816       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:19.492401       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:54:21.360Z	ERROR	fleet/fleet_gateway.go:205	Could not communicate with fleet-server Checking API will retry, error: status code: 0, fleet-server returned an error: , message: backend closed connection
E0612 15:54:23.469001       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:26.936279       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:29.846885       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:32.859448       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:54:35.210Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:54:35.210Z	INFO	log/reporter.go:40	2021-06-12T15:54:35Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:54:35.210Z	INFO	log/reporter.go:40	2021-06-12T15:54:35Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:54:36.409777       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:54:40.211Z	INFO	log/reporter.go:40	2021-06-12T15:54:40Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:54:40.211Z	INFO	log/reporter.go:40	2021-06-12T15:54:40Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:54:40.275964       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:43.593766       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:47.767463       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:51.720814       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:54.976571       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:54:58.847773       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:01.863576       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:05.895748       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:10.159632       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:13.987152       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:17.964065       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:20.811004       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:23.361644       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:26.120258       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:28.768485       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:31.932852       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:34.249793       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:55:35.212Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:55:35.212Z	ERROR	log/reporter.go:36	2021-06-12T15:55:35Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:55:35.476Z	ERROR	log/reporter.go:36	2021-06-12T15:55:35Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:55:37.681307       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:40.257378       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:55:40.476Z	ERROR	log/reporter.go:36	2021-06-12T15:55:40Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:55:40.476Z	ERROR	log/reporter.go:36	2021-06-12T15:55:40Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:55:42.331895       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:55:45.477Z	INFO	log/reporter.go:40	2021-06-12T15:55:45Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:55:45.477Z	INFO	log/reporter.go:40	2021-06-12T15:55:45Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:55:45.478Z	INFO	log/reporter.go:40	2021-06-12T15:55:45Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:55:45.478Z	INFO	log/reporter.go:40	2021-06-12T15:55:45Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:55:45.865897       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:47.984770       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:55:50.477Z	INFO	log/reporter.go:40	2021-06-12T15:55:50Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:55:50.477Z	INFO	log/reporter.go:40	2021-06-12T15:55:50Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:55:50.481Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:55:50.481Z	INFO	log/reporter.go:40	2021-06-12T15:55:50Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:55:50.481Z	INFO	log/reporter.go:40	2021-06-12T15:55:50Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:55:51.186649       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:54.110465       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:55:58.471561       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:02.091087       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:06.049850       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:10.343963       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:13.371993       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:15.833056       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:18.213191       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:20.782117       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:23.674774       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:27.718070       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:31.487363       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:56:35.478Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:56:35.478Z	INFO	log/reporter.go:40	2021-06-12T15:56:35Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:56:35.564Z	INFO	log/reporter.go:40	2021-06-12T15:56:35Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:56:35.813436       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:39.487752       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:56:40.564Z	INFO	log/reporter.go:40	2021-06-12T15:56:40Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:56:40.564Z	INFO	log/reporter.go:40	2021-06-12T15:56:40Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:56:42.307900       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:44.483341       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:46.819446       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:50.553958       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:54.419739       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:56:58.469428       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:01.399577       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:03.424736       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:07.756772       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:11.840917       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:14.078205       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:17.739480       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:21.049922       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:24.543775       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:28.113776       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:30.644390       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:34.075115       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:57:35.565Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:57:35.565Z	ERROR	log/reporter.go:36	2021-06-12T15:57:35Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:57:35.748Z	ERROR	log/reporter.go:36	2021-06-12T15:57:35Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:57:37.663771       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:39.806530       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:57:42.056Z	ERROR	log/reporter.go:36	2021-06-12T15:57:42Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:57:42.056Z	ERROR	log/reporter.go:36	2021-06-12T15:57:42Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:57:42.764197       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:45.731770       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:57:45.749Z	INFO	log/reporter.go:40	2021-06-12T15:57:45Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:57:45.749Z	INFO	log/reporter.go:40	2021-06-12T15:57:45Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:57:47.056Z	INFO	log/reporter.go:40	2021-06-12T15:57:47Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:57:47.056Z	INFO	log/reporter.go:40	2021-06-12T15:57:47Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:57:48.602113       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:57:52.057Z	INFO	log/reporter.go:40	2021-06-12T15:57:52Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:57:52.057Z	INFO	log/reporter.go:40	2021-06-12T15:57:52Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:57:52.057Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:57:52.057Z	INFO	log/reporter.go:40	2021-06-12T15:57:52Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:57:52.058Z	INFO	log/reporter.go:40	2021-06-12T15:57:52Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:57:52.416843       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:55.069854       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:57:58.533886       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:01.521677       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:05.268830       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:07.925133       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:10.616296       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:13.664367       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:17.244368       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:19.951944       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:23.275421       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:26.507871       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:28.669049       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:32.589486       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:35.286108       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:58:37.058Z	INFO	log/reporter.go:40	2021-06-12T15:58:37Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:58:37.058Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T15:58:37.224Z	INFO	log/reporter.go:40	2021-06-12T15:58:37Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:58:39.520019       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:58:42.224Z	INFO	log/reporter.go:40	2021-06-12T15:58:42Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T15:58:42.224Z	INFO	log/reporter.go:40	2021-06-12T15:58:42Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 15:58:42.964901       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:45.912696       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:48.404458       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:52.497822       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:54.941359       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:58:57.233837       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:01.395952       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:05.172519       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:08.970658       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:12.380924       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:16.614295       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:19.789620       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:22.930416       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:25.383583       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:28.384951       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:31.096310       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:34.388185       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:59:37.225Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T15:59:37.225Z	ERROR	log/reporter.go:36	2021-06-12T15:59:37Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:59:37.446Z	ERROR	log/reporter.go:36	2021-06-12T15:59:37Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:59:37.798654       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:41.075639       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:59:42.446Z	ERROR	log/reporter.go:36	2021-06-12T15:59:42Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T15:59:42.447Z	ERROR	log/reporter.go:36	2021-06-12T15:59:42Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 15:59:44.134303       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:46.978632       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:59:47.447Z	INFO	log/reporter.go:40	2021-06-12T15:59:47Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:59:47.447Z	INFO	log/reporter.go:40	2021-06-12T15:59:47Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:59:47.448Z	INFO	log/reporter.go:40	2021-06-12T15:59:47Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:59:47.448Z	INFO	log/reporter.go:40	2021-06-12T15:59:47Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:59:50.699292       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T15:59:52.447Z	INFO	log/reporter.go:40	2021-06-12T15:59:52Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:59:52.447Z	INFO	log/reporter.go:40	2021-06-12T15:59:52Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:59:52.448Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T15:59:52.448Z	INFO	log/reporter.go:40	2021-06-12T15:59:52Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T15:59:52.448Z	INFO	log/reporter.go:40	2021-06-12T15:59:52Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 15:59:54.121360       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:56.388793       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 15:59:58.735199       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:01.091481       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:03.369812       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:07.740053       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:09.985822       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:12.414173       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:16.755433       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:20.956340       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:23.297305       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:25.350338       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:27.487697       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:29.895924       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:33.161632       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:36.446821       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T16:00:37.448Z	WARN	status/reporter.go:236	Elastic Agent status changed to: 'degraded'
2021-06-12T16:00:37.448Z	INFO	log/reporter.go:40	2021-06-12T16:00:37Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T16:00:37.724Z	INFO	log/reporter.go:40	2021-06-12T16:00:37Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 16:00:38.495782       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:42.520533       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T16:00:42.724Z	INFO	log/reporter.go:40	2021-06-12T16:00:42Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2021-06-12T16:00:42.724Z	INFO	log/reporter.go:40	2021-06-12T16:00:42Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
E0612 16:00:46.495922       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:50.197080       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:53.023645       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:56.082770       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:00:58.758276       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:02.943844       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:06.795718       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:10.569642       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:13.915445       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:16.675504       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:19.439300       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:23.500657       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:27.386227       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:31.175664       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:34.567680       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:37.845834       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T16:01:37.725Z	ERROR	status/reporter.go:236	Elastic Agent status changed to: 'error'
2021-06-12T16:01:37.725Z	ERROR	log/reporter.go:36	2021-06-12T16:01:37Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T16:01:37.886Z	ERROR	log/reporter.go:36	2021-06-12T16:01:37Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 16:01:41.234072       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T16:01:42.886Z	ERROR	log/reporter.go:36	2021-06-12T16:01:42Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
2021-06-12T16:01:42.887Z	ERROR	log/reporter.go:36	2021-06-12T16:01:42Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to FAILED: Missed two check-ins - type: 'ERROR' - sub_type: 'FAILED'
E0612 16:01:44.861352       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:47.227811       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T16:01:47.887Z	INFO	log/reporter.go:40	2021-06-12T16:01:47Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T16:01:47.887Z	INFO	log/reporter.go:40	2021-06-12T16:01:47Z - message: Application: filebeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T16:01:47.888Z	INFO	log/reporter.go:40	2021-06-12T16:01:47Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T16:01:47.888Z	INFO	log/reporter.go:40	2021-06-12T16:01:47Z - message: Application: metricbeat--7.13.1-SNAPSHOT[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 16:01:50.167431       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
2021-06-12T16:01:52.887Z	INFO	log/reporter.go:40	2021-06-12T16:01:52Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T16:01:52.887Z	INFO	log/reporter.go:40	2021-06-12T16:01:52Z - message: Application: filebeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T16:01:52.888Z	INFO	status/reporter.go:236	Elastic Agent status changed to: 'online'
2021-06-12T16:01:52.888Z	INFO	log/reporter.go:40	2021-06-12T16:01:52Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to STARTING: Starting - type: 'STATE' - sub_type: 'STARTING'
2021-06-12T16:01:52.888Z	INFO	log/reporter.go:40	2021-06-12T16:01:52Z - message: Application: metricbeat--7.13.1-SNAPSHOT--36643631373035623733363936343635[6ca6f0fa-4f5f-4a1f-919e-68676c9ca5a7]: State changed to RESTARTING: Restarting - type: 'STATE' - sub_type: 'STARTING'
E0612 16:01:53.289641       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:56.443442       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:01:58.667781       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:02:01.490419       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:02:04.292084       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
E0612 16:02:06.706719       6 leaderelection.go:325] error retrieving resource lock kube-system/elastic-agent-cluster-leader: leases.coordination.k8s.io "elastic-agent-cluster-leader" is forbidden: User "system:serviceaccount:kube-system:agent-ingest-management" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
I0612 16:02:10.669954       6 leaderelection.go:253] successfully acquired lease kube-system/elastic-agent-cluster-leader
