### PR TITLE
[filebeat] Add preserve_original_event option to o365audit input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -821,6 +821,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Make `filestream` input GA. {pull}26127[26127]
 - Add new `parser` to `filestream` input: `container`. {pull}26115[26115]
 - Add support for ISO8601 timestamps in Zeek fileset {pull}25564[25564]
+- Add `preserve_original_event` option to `o365audit` input. {pull}26273[26273]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-o365audit.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-o365audit.asciidoc
@@ -133,6 +133,11 @@ default is `2000`, as this is the server-side limit per tenant.
 The maximum time window that API allows in a single query. Defaults to `24h`
 to match Microsoft's documented limit.
 
+===== `api.preserve_original_event`
+
+Controls whether the original o365 audit object will be kept in `event.original`
+ or not. Defaults to `false`.
+
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]
 

--- a/x-pack/filebeat/input/o365audit/config.go
+++ b/x-pack/filebeat/input/o365audit/config.go
@@ -83,6 +83,10 @@ type APIConfig struct {
 	// duplicates.
 	SetIDFromAuditRecord bool `config:"set_id_from_audit_record"`
 
+	// PreserveOriginalEvent controls whether the original o365 audit object
+	// will be kept in `event.original` or not.
+	PreserveOriginalEvent bool `config:"preserve_original_event"`
+
 	// MaxQuerySize is the maximum time window that can be queried. The default
 	// is 24h.
 	MaxQuerySize time.Duration `config:"max_query_size" validate:"positive"`

--- a/x-pack/filebeat/input/o365audit/input.go
+++ b/x-pack/filebeat/input/o365audit/input.go
@@ -6,8 +6,6 @@ package o365audit
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -256,12 +254,7 @@ func (env apiEnvironment) toBeatEvent(doc common.MapStr) beat.Event {
 		}
 	}
 	if env.Config.PreserveOriginalEvent {
-		o, err := json.Marshal(doc)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed generating event.original: %w", err))
-		} else {
-			b.PutValue("event.original", string(o))
-		}
+		b.PutValue("event.original", doc.String())
 	}
 	if len(errs) > 0 {
 		msgs := make([]string, len(errs))

--- a/x-pack/filebeat/input/o365audit/input.go
+++ b/x-pack/filebeat/input/o365audit/input.go
@@ -6,6 +6,8 @@ package o365audit
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
@@ -251,6 +253,14 @@ func (env apiEnvironment) toBeatEvent(doc common.MapStr) beat.Event {
 	if env.Config.SetIDFromAuditRecord {
 		if id, err := getString(doc, "Id"); err == nil && len(id) > 0 {
 			b.SetID(id)
+		}
+	}
+	if env.Config.PreserveOriginalEvent {
+		o, err := json.Marshal(doc)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed generating event.original: %w", err))
+		} else {
+			b.PutValue("event.original", string(o))
 		}
 	}
 	if len(errs) > 0 {

--- a/x-pack/filebeat/input/o365audit/input_test.go
+++ b/x-pack/filebeat/input/o365audit/input_test.go
@@ -1,0 +1,38 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package o365audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestPreserveOriginalEvent(t *testing.T) {
+	env := apiEnvironment{
+		Config: APIConfig{PreserveOriginalEvent: false},
+	}
+
+	doc := common.MapStr{
+		"field1": "val1",
+	}
+
+	event := env.toBeatEvent(doc)
+
+	v, err := event.GetValue("event.original")
+	require.EqualError(t, err, "key not found")
+	assert.Nil(t, v)
+
+	env.Config.PreserveOriginalEvent = true
+
+	event = env.toBeatEvent(doc)
+
+	v, err = event.GetValue("event.original")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"field1":"val1"}`, v.(string))
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds `preserve_original_event` option to `o365audit` input.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Being able to opt in to have `event.original` populate adds consistency with other inputs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
