### PR TITLE
[DOCS] IIS module: clarify supported logFormat

### DIFF
--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -11,6 +11,11 @@ This file is generated! See scripts/docs_collector.py
 The +{modulename}+ module parses access and error logs created by the
 Internet Information Services (IIS) HTTP server.
 
+[IMPORTANT]
+=====
+The +{modulename}+ module currently supports only the default W3C log format.
+=====
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -6,6 +6,11 @@
 The +{modulename}+ module parses access and error logs created by the
 Internet Information Services (IIS) HTTP server.
 
+[IMPORTANT]
+=====
+The +{modulename}+ module currently supports only the default W3C log format.
+=====
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]


### PR DESCRIPTION
### Summary

This PR adds a note to clarify that the IIS module currently only supports the default W3C format.

### Docs preview

https://beats_26283.docs-preview.app.elstc.co/guide/en/beats/filebeat/master/filebeat-module-iis.html

### Related issue

Closes https://github.com/elastic/beats/issues/25456