### PR TITLE
Cherry-pick to 7.x: Add support note (#26283)

### DIFF
--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -11,6 +11,11 @@ This file is generated! See scripts/docs_collector.py
 The +{modulename}+ module parses access and error logs created by the
 Internet Information Services (IIS) HTTP server.
 
+[IMPORTANT]
+=====
+The +{modulename}+ module currently supports only the default W3C log format.
+=====
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -6,6 +6,11 @@
 The +{modulename}+ module parses access and error logs created by the
 Internet Information Services (IIS) HTTP server.
 
+[IMPORTANT]
+=====
+The +{modulename}+ module currently supports only the default W3C log format.
+=====
+
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add support note (#26283)