### PR TITLE
[Heartbeat] Fix Timerqueue initialization / maintainability

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -397,6 +397,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixed excessive memory usage introduced in 7.5 due to over-allocating memory for HTTP checks. {pull}15639[15639]
 - Fixed TCP TLS checks to properly validate hostnames, this broke in 7.x and only worked for IP SANs. {pull}17549[17549]
 - Add Context to otherwise ambiguous HTTP body read errors. {pull}25499[25499]
+- Fix rare scheduler bug. {pull}26303[26303]
 
 *Journalbeat*
 

--- a/heartbeat/scheduler/scheduler_test.go
+++ b/heartbeat/scheduler/scheduler_test.go
@@ -139,7 +139,7 @@ func TestScheduler_Start(t *testing.T) {
 		select {
 		case got := <-executed:
 			received = append(received, got)
-		case <-time.After(5 * time.Second):
+		case <-time.After(10 * time.Second):
 			require.Fail(t, fmt.Sprintf("Timed out waitingTasks for schedule job to execute, got %d of %d: %v",
 				len(received), totalExpected, received))
 		}

--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -123,8 +123,8 @@ func (tq *TimerQueue) pushInternal(tt *timerTask) {
 				<-tq.timer.C
 			}
 			tq.timer.Reset(time.Until(tt.runAt))
+			tq.nextRunAt = &tt.runAt
 		}
-		tq.nextRunAt = &tt.runAt
 	}
 }
 

--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -122,7 +122,8 @@ func (tq *TimerQueue) pushInternal(tt *timerTask) {
 			if !tq.timer.Stop() {
 				<-tq.timer.C
 			}
-			tq.timer.Reset(time.Until(tt.runAt))
+			tq.timer = time.NewTimer(time.Until(tt.runAt))
+			//tq.timer.Reset(time.Until(tt.runAt))
 			tq.nextRunAt = &tt.runAt
 		}
 	}

--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -95,7 +95,7 @@ func (tq *TimerQueue) Start() {
 				if tq.th.Len() > 0 {
 					nr := tq.th[0].runAt
 					tq.nextRunAt = &nr
-					tq.timer.Reset(nr.Sub(time.Now()))
+					tq.timer.Reset(time.Until(nr))
 				} else {
 					tq.timer.Stop()
 					tq.nextRunAt = nil
@@ -120,7 +120,7 @@ func (tq *TimerQueue) pushInternal(tt *timerTask) {
 		if tq.nextRunAt != nil && !tq.timer.Stop() {
 			<-tq.timer.C
 		}
-		tq.timer.Reset(tt.runAt.Sub(time.Now()))
+		tq.timer.Reset(time.Until(tt.runAt))
 
 		tq.nextRunAt = &tt.runAt
 	}

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -19,7 +19,6 @@ package timerqueue
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"sort"
 	"testing"
@@ -31,7 +30,6 @@ import (
 func TestQueueRunsInOrder(t *testing.T) {
 	// Bugs can show up only occasionally
 	for i := 0; i < 10000; i++ {
-		fmt.Printf("%d\n", i)
 		testQueueRunsInOrderOnce(t)
 	}
 }

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -18,6 +18,7 @@
 package timerqueue
 
 import (
+	"container/heap"
 	"context"
 	"math/rand"
 	"sort"
@@ -29,7 +30,7 @@ import (
 
 func TestQueueRunsInOrder(t *testing.T) {
 	// Bugs can show up only occasionally
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 100; i++ {
 		testQueueRunsInOrderOnce(t)
 	}
 }
@@ -70,7 +71,7 @@ func testQueueRunsInOrderOnce(t *testing.T) {
 	// using Push() may result in tasks being executed before all are inserted.
 	// This private method is not threadsafe, so is kept private.
 	for _, tt := range tasks {
-		tq.pushInternal(tt)
+		heap.Push(&tq.th, tt)
 	}
 
 	tq.Start()

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -19,6 +19,7 @@ package timerqueue
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sort"
 	"testing"
@@ -29,13 +30,14 @@ import (
 
 func TestQueueRunsInOrder(t *testing.T) {
 	// Bugs can show up only occasionally
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 10000; i++ {
+		fmt.Printf("%d\n", i)
 		testQueueRunsInOrderOnce(t)
 	}
 }
 
 func testQueueRunsInOrderOnce(t *testing.T) {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*15)
 	tq := NewTimerQueue(ctx)
 	defer func() {
 		ctxCancel()

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -30,10 +30,14 @@ import (
 
 func TestQueueRunsInOrder(t *testing.T) {
 	// Bugs can show up only occasionally
-	for i := 0; i < 100; i++ {
+	totalStart := time.Now()
+	for i := 0; i < 100000; i++ {
 		fmt.Print("%%")
+		start := time.Now()
 		testQueueRunsInOrderOnce(t)
-		fmt.Print("$\n")
+		end := time.Now()
+		dur := end.Sub(start)
+		fmt.Printf("$ %v %v %v\n", i, dur, time.Now().Sub(totalStart))
 	}
 }
 
@@ -59,6 +63,7 @@ func testQueueRunsInOrderOnce(t *testing.T) {
 			schedFor := time.Unix(0, 0).Add(time.Duration(i))
 			tasks = append(tasks, &timerTask{runAt: schedFor, fn: func(now time.Time) {
 				taskResCh <- i
+				fmt.Printf(".")
 				if i == numItems {
 					close(taskResCh)
 				}

--- a/heartbeat/tests/system/test_icmp.py
+++ b/heartbeat/tests/system/test_icmp.py
@@ -44,9 +44,7 @@ class Test(BaseTest):
         # we should run pings on those machines and make sure they work.
         self.wait_until(lambda: has_started_message() or has_failed_message(), 30)
 
-        if has_failed_message:
-            proc.check_kill_and_wait()
-        else:
+        if not has_failed_message:
             # Check that documents are moving through
             self.wait_until(lambda: self.output_has(lines=1))
-            proc.check_kill_and_wait()
+        proc.kill_and_wait()

--- a/heartbeat/tests/system/test_icmp.py
+++ b/heartbeat/tests/system/test_icmp.py
@@ -44,7 +44,9 @@ class Test(BaseTest):
         # we should run pings on those machines and make sure they work.
         self.wait_until(lambda: has_started_message() or has_failed_message(), 30)
 
-        if not has_failed_message():
+        if has_failed_message:
+            proc.check_kill_and_wait(1)
+        else:
             # Check that documents are moving through
             self.wait_until(lambda: self.output_has(lines=1))
-        proc.check_kill_and_wait()
+            proc.check_kill_and_wait()

--- a/heartbeat/tests/system/test_icmp.py
+++ b/heartbeat/tests/system/test_icmp.py
@@ -44,8 +44,7 @@ class Test(BaseTest):
         # we should run pings on those machines and make sure they work.
         self.wait_until(lambda: has_started_message() or has_failed_message(), 30)
 
-        if has_failed_message():
-            proc.check_kill_and_wait(1)
-        else:
+        if not has_failed_message():
             # Check that documents are moving through
             self.wait_until(lambda: self.output_has(lines=1))
+        proc.check_kill_and_wait()

--- a/heartbeat/tests/system/test_icmp.py
+++ b/heartbeat/tests/system/test_icmp.py
@@ -45,7 +45,7 @@ class Test(BaseTest):
         self.wait_until(lambda: has_started_message() or has_failed_message(), 30)
 
         if has_failed_message:
-            proc.check_kill_and_wait(1)
+            proc.check_kill_and_wait()
         else:
             # Check that documents are moving through
             self.wait_until(lambda: self.output_has(lines=1))


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/26205

This PR changes our strategy from resetting timers to using a ticker with 250ms resolution. For whatever reason, reset seems to now be unstable (maybe a go runtime change?) on windows.

This PR also switches some hard to read parts of the code to using the `time.Until` syntax. I'm including this in this change to make the code easier to read in the future, which will help in future debugging. It also restructures some confusing code to make it easier to read.

I do suspect that there was a change in the go runtime implementation that caused this issue to service now since it's been around for a year and 1/2.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

`go test -timeout 30s -run '^TestQueueRunsInOrder$' github.com/elastic/beats/v7/heartbeat/scheduler/timerqueue -count=8000` should reproduce this locally on master. It should never happen on this branch


