### PR TITLE
Restore support for Elasticsearch OSS distributions 7.0.x-7.10.2

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -243,6 +243,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix ILM alias creation when write alias exists and initial index does not exist {pull}26143[26143]
 - Include date separator in the filename prefix of `dateRotator` to make sure nothing gets purged accidentally {pull}26176[26176]
 - In the script processor, the `decode_xml` and `decode_xml_wineventlog` processors are now available as `DecodeXML` and `DecodeXMLWineventlog` respectively.
+- Restore support for Elasticsearch OSS distributions 7.0.x-7.10.2
 
 *Auditbeat*
 

--- a/libbeat/cmd/root.go
+++ b/libbeat/cmd/root.go
@@ -59,9 +59,8 @@ type BeatsRootCmd struct {
 // run command, which will be called if no args are given (for backwards compatibility),
 // and beat settings
 func GenRootCmdWithSettings(beatCreator beat.Creator, settings instance.Settings) *BeatsRootCmd {
-	// Add global Elasticsearch license endpoint check.
-	// Check we are actually talking with Elasticsearch, to ensure that used features actually exist.
-	elasticsearch.RegisterGlobalCallback(licenser.FetchAndVerify)
+	// Check we are actually talking with any of the Elasticsearch
+	elasticsearch.RegisterGlobalCallback(licenser.IsElasticsearch)
 
 	if err := platformcheck.CheckNativePlatformCompat(); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to initialize: %v\n", err)

--- a/libbeat/licenser/elastic_fetcher.go
+++ b/libbeat/licenser/elastic_fetcher.go
@@ -60,7 +60,7 @@ func NewElasticFetcher(client esclient) *ElasticFetcher {
 }
 
 // Fetch retrieves the license information from an Elasticsearch Client, it will call the `_license`
-// endpoint and will return a parsed license. If the `_license` endpoint is unreacheable we will
+// endpoint and will return a parsed license. If the `_license` endpoint is unreachable we will
 // return the OSS License otherwise we return an error.
 func (f *ElasticFetcher) Fetch() (License, error) {
 	status, body, err := f.client.Request("GET", licenseURL, "", params, nil)

--- a/libbeat/licenser/elastic_fetcher.go
+++ b/libbeat/licenser/elastic_fetcher.go
@@ -60,8 +60,7 @@ func NewElasticFetcher(client esclient) *ElasticFetcher {
 }
 
 // Fetch retrieves the license information from an Elasticsearch Client, it will call the `_license`
-// endpoint and will return a parsed license. If the `_license` endpoint is unreachable we will
-// return the OSS License otherwise we return an error.
+// endpoint and will return a parsed license. If the `_license` endpoint is unreachable, we will return an error.
 func (f *ElasticFetcher) Fetch() (License, error) {
 	status, body, err := f.client.Request("GET", licenseURL, "", params, nil)
 	if status == http.StatusUnauthorized {

--- a/libbeat/licenser/oss_license.go
+++ b/libbeat/licenser/oss_license.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package licenser
+
+import (
+	"github.com/google/uuid"
+)
+
+// GenerateOSSLicense generates Active License of type OSS
+func GenerateOSSLicense() License {
+	return License{
+		UUID:   uuid.New().String(),
+		Type:   OSS,
+		Status: Active,
+	}
+}


### PR DESCRIPTION
## What does this PR do?
This PR restores the support for Elasticsearch OSS distributions 7.0.x-7.10.2

## Why is it important?

Change #25351 had a side effect of removing compatibility with OSS distributions of Elasticsearch 7.0.x-7.10.2. This change restores Beats compatibility outlined in the product compatibility matrix by adding version-awareness into the license check. Also resolves #25865


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes #25865
- Relates #25351
