### PR TITLE
Change link to snapshots in README (#26317)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ your dev environment to build Beats from the source.
 
 ## Snapshots
 
-For testing purposes, we generate snapshot builds that you can find [here](https://beats-ci.elastic.co/job/Beats/job/packaging/job/master/lastSuccessfulBuild/gcsObjects/). Please be aware that these are built on top of master and are not meant for production.
+For testing purposes, we generate snapshot builds that you can find [here](https://artifacts-api.elastic.co/v1/search/7.x-SNAPSHOT/). Please be aware that these are built on top of master and are not meant for production.
 
 ## CI
 


### PR DESCRIPTION
Link to snapshots in the README has pointed to an empty page since some time ago. Change the link to go to the artifacts api list (https://artifacts-api.elastic.co/v1/search/7.x-SNAPSHOT/).

(cherry picked from 41ef134eb1afd643fe1f8b8bc80b21e493aeff94)
