### PR TITLE
Osquerybeat: Align with the rest of the beats, set the ECS version

### DIFF
--- a/x-pack/osquerybeat/cmd/root.go
+++ b/x-pack/osquerybeat/cmd/root.go
@@ -9,18 +9,33 @@ import (
 
 	cmd "github.com/elastic/beats/v7/libbeat/cmd"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 
 	_ "github.com/elastic/beats/v7/x-pack/libbeat/include"
 )
 
 // Name of this beat
-var Name = "osquerybeat"
+const (
+	Name = "osquerybeat"
+
+	// ecsVersion specifies the version of ECS that this beat is implementing.
+	ecsVersion = "1.10.0"
+)
+
+// withECSVersion is a modifier that adds ecs.version to events.
+var withECSVersion = processing.WithFields(common.MapStr{
+	"ecs": common.MapStr{
+		"version": ecsVersion,
+	},
+})
 
 var RootCmd = Osquerybeat()
 
 func Osquerybeat() *cmd.BeatsRootCmd {
 	settings := instance.Settings{
 		Name:            Name,
+		Processing:      processing.MakeDefaultSupport(true, withECSVersion, processing.WithAgentMeta()),
 		ElasticLicensed: true,
 	}
 	command := cmd.GenRootCmdWithSettings(beater.New, settings)


### PR DESCRIPTION
## What does this PR do?

Align with the rest of the beats with setting the ECS version. 
This was missing and noticed by @P1llus.

## Why is it important?

Follows the beats ECS recommendation

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Screenshots

<img width="654" alt="Screen Shot 2021-06-15 at 9 16 46 AM" src="https://user-images.githubusercontent.com/872351/122088293-96661c80-cdd3-11eb-9c13-7eea72d57b12.png">

