### PR TITLE
[filebeat] Populate event.original with the original json bytes

### DIFF
--- a/x-pack/filebeat/input/o365audit/input_test.go
+++ b/x-pack/filebeat/input/o365audit/input_test.go
@@ -5,6 +5,7 @@
 package o365audit
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,11 +19,12 @@ func TestPreserveOriginalEvent(t *testing.T) {
 		Config: APIConfig{PreserveOriginalEvent: false},
 	}
 
+	raw := json.RawMessage(`{"field1":"val1"}`)
 	doc := common.MapStr{
 		"field1": "val1",
 	}
 
-	event := env.toBeatEvent(doc)
+	event := env.toBeatEvent(raw, doc)
 
 	v, err := event.GetValue("event.original")
 	require.EqualError(t, err, "key not found")
@@ -30,7 +32,7 @@ func TestPreserveOriginalEvent(t *testing.T) {
 
 	env.Config.PreserveOriginalEvent = true
 
-	event = env.toBeatEvent(doc)
+	event = env.toBeatEvent(raw, doc)
 
 	v, err = event.GetValue("event.original")
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Use original json bytes to populate `event.original` instead of serializing the object.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
