### PR TITLE
Update urllib to 1.26.5.

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -43,7 +43,7 @@ stomp.py==4.1.22
 termcolor==1.1.0
 texttable==0.9.1
 toml==0.10.1
-urllib3==1.24.2
+urllib3==1.26.5
 wcwidth==0.2.5
 websocket-client==0.47.0
 zipp>=1.2.0,<=3.1.0

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -31,11 +31,11 @@ pycodestyle==2.6.0
 pyparsing==2.4.7
 pyrsistent==0.16.0
 pytest==6.2.4
-pytest-timeout==1.4.2
 pytest-rerunfailures==9.1.1
+pytest-timeout==1.4.2
 PyYAML==5.3.1
 redis==2.10.6
-requests==2.20.0
+requests==2.25.1
 semver==2.8.1
 setuptools==47.3.2
 six==1.15.0

--- a/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
+++ b/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
@@ -9,4 +9,4 @@ PyYAML==5.4.1
 rsa==4.7.2
 s3transfer==0.3.3
 six==1.14.0
-urllib3==1.25.9
+urllib3==1.26.5


### PR DESCRIPTION
Update urllib3 to 1.26.5 in python tests requirements file.

Fixes [dependabot alert](https://github.com/elastic/beats/security/dependabot/libbeat/tests/system/requirements.txt/urllib3/open).