### PR TITLE
Fix UBI source URL

### DIFF
--- a/dev-tools/dependencies-report
+++ b/dev-tools/dependencies-report
@@ -47,8 +47,8 @@ go list -m -json all $@ | go run go.elastic.co/go-licence-detector \
 # Check headers in $SRCPATH/notice/dependencies.csv.tmpl:
 # name,url,version,revision,license
 ubi8url='https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8'
-ubi8source='https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz'
+ubi8source='https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz'
 ubilicense='Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf'
 cat <<EOF >> $outfile
-Red Hat Universal Base Image,$ubi8url,8,,$ubilicense,$ubi8source
+Red Hat Universal Base Image minimal,$ubi8url,8,,$ubilicense,$ubi8source
 EOF


### PR DESCRIPTION
## What does this PR do?

This commit fix the source URL for UBI image to ensure that it stays
consistent with the URL generated in
https://artifacts.elastic.co/reports/dependencies/dependencies-current.html

## Why is it important?

The `sourceURL` column contains a pointer to the source code, which is optional for most dependencies,
but a requirement for some, such as the Red Hat Universal Base Image.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~