### PR TITLE
fix: build elastic agent dependencies only on amd64 architecture

### DIFF
--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -444,10 +444,23 @@ shared:
         mode: 0644
 
   - &agent_docker_arm_spec
-    <<: *agent_docker_spec
+    <<: *agent_binary_files
     extra_vars:
       from: 'arm64v8/centos:7'
       buildFrom: 'arm64v8/centos:7'
+      dockerfile: 'Dockerfile.elastic-agent.tmpl'
+      docker_entrypoint: 'docker-entrypoint.elastic-agent.tmpl'
+      user: '{{ .BeatName }}'
+      linux_capabilities: ''
+    files:
+      'elastic-agent.yml':
+        source: 'elastic-agent.docker.yml'
+        mode: 0600
+        config: true
+      '.elastic-agent.active.commit':
+        content: >
+          {{ commit }}
+        mode: 0644
 
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -445,7 +445,6 @@ shared:
 
   - &agent_docker_arm_spec
     <<: *common
-    <<: *agent_binary_files
     extra_vars:
       from: 'arm64v8/centos:7'
       buildFrom: 'arm64v8/centos:7'
@@ -454,6 +453,7 @@ shared:
       user: '{{ .BeatName }}'
       linux_capabilities: ''
     files:
+      <<: *agent_binary_files
       'elastic-agent.yml':
         source: 'elastic-agent.docker.yml'
         mode: 0600

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -444,6 +444,7 @@ shared:
         mode: 0644
 
   - &agent_docker_arm_spec
+    <<: *common
     <<: *agent_binary_files
     extra_vars:
       from: 'arm64v8/centos:7'

--- a/x-pack/elastic-agent/magefile.go
+++ b/x-pack/elastic-agent/magefile.go
@@ -566,7 +566,8 @@ func packageAgent(requiredPackages []string, packagingFn func()) {
 	}
 
 	// build deps only when drop is not provided
-	if dropPathEnv, found := os.LookupEnv(agentDropPath); !found || len(dropPathEnv) == 0 {
+	// build dependencies only if your are running on a amd64 architecture.
+	if dropPathEnv, found := os.LookupEnv(agentDropPath); runtime.GOARCH == "amd64" && (!found || len(dropPathEnv) == 0) {
 		// prepare new drop
 		dropPath := filepath.Join("build", "distributions", "elastic-agent-drop")
 		dropPath, err := filepath.Abs(dropPath)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
It does not build Elastic Agent beats dependencies if you are not running on amd64 architecture.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
The current code tries to build amd64 packages in ARM architecture, we only support cross-compile for all architectures on amd64 machines. This causes that the mage package fails when you make it on an ARM host. The change in this PR skip dependencies in other architectures other than amd64.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ X I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
* Launch a ubuntu-18.04/amd64 VM 
* Enter on x-pack/elastic-agent
* Run mage package
* It will build filebeat, metricbeat, heartbeat, and elastic-agent

* Launch a ubuntu-18.04/arm64 VM 
* Enter on x-pack/elastic-agent
* Run mage package
* It will build Elastic-Agent only

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- closes https://github.com/elastic/beats/issues/26246

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
