### PR TITLE
Cherry-pick to 7.13: Fix UBI source URL (#26384)

### DIFF
--- a/dev-tools/dependencies-report
+++ b/dev-tools/dependencies-report
@@ -47,8 +47,8 @@ go list -m -json all $@ | go run go.elastic.co/go-licence-detector \
 # Check headers in $SRCPATH/notice/dependencies.csv.tmpl:
 # name,url,version,revision,license
 ubi8url='https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8'
-ubi8source='https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz'
+ubi8source='https://oss-dependencies.elastic.co/red-hat-universal-base-image-minimal/8/ubi-minimal-8-source.tar.gz'
 ubilicense='Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf'
 cat <<EOF >> $outfile
-Red Hat Universal Base Image,$ubi8url,8,,$ubilicense,$ubi8source
+Red Hat Universal Base Image minimal,$ubi8url,8,,$ubilicense,$ubi8source
 EOF


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Fix UBI source URL (#26384)