### PR TITLE
Remove all docs about  Beats central management

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -16,7 +16,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_default_index_prefix: {beatname_lc}
 :beat_kib_app: {kib} Logs
 :has_ml_jobs: yes
-:has_central_config:
 :has_solutions:
 :ignores_max_retries:
 :has_docker_label_ex:

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -102,10 +102,6 @@ ifdef::apm-server[]
 |Set up ingest pipelines
 endif::apm-server[]
 
-ifdef::has_central_config[]
-|`beats_admin`
-|Enroll and manage configurations in Beats central management
-endif::has_central_config[]
 |====
 +
 Omit any roles that aren't relevant in your environment.
@@ -307,10 +303,6 @@ endif::apm-server[]
 {kib} users typically need to view dashboards and visualizations that contain
 {beatname_uc} data. These users might also need to create and edit dashboards
 and visualizations.
-ifdef::has_central_config[]
-If you're using Beats central management, some of these users might need to
-create and manage configurations.
-endif::has_central_config[]
 
 To grant users the required privileges:
 
@@ -347,12 +339,6 @@ users who need to read {beatname_uc} data:
 | `monitoring_user`
 | Allow users to monitor the health of {beatname_uc} itself. Only assign this role to users who manage {beatname_uc}.
 
-ifdef::has_central_config[]
-|`beats_admin`
-|Create and manage configurations in Beats central management. Only assign this
-role to users who need to use Beats central management.
-+
-endif::[]
 |====
 endif::apm-server[]
 

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -71,6 +71,11 @@ we've provided a migration tool to help you migrate your configurations from
 version 6.6 to 6.7 or later. For more information, see the
 https://www.elastic.co/blog/beats-6-7-0-released[Beats 6.7.0 release blog].
 
+NOTE: {beats} central management has been removed starting in version 7.14.0.
+Looking for a replacement? Refer to the
+{fleet-guide}/index.html[Fleet User Guide] to learn how to deploy and centrally
+manage a single {agent} to monitor and secure each host. 
+
 ==== Upgrade {beats} binaries to 7.0
 
 Before upgrading:

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -17,7 +17,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :beat_kib_app: {kib} Metrics
-:has_central_config:
 :has_solutions:
 :has_docker_label_ex:
 :has_modules_command:


### PR DESCRIPTION
I have a few outstanding questions:

- [x] In the [upgrade docs](https://www.elastic.co/guide/en/beats/metricbeat/master/exported-fields-beat.html), we mention Beats central management. I'd hate for users to go through the process of upgrading their central management indices only to discover they won't work later on when they upgrade to 7.14. Is it OK to just remove this section, or should I add a note saying that support is removed?  
![image](https://user-images.githubusercontent.com/14206422/122840642-645f2980-d2af-11eb-8e27-45d463d773cf.png)

- [x] There is a field called `beat.state.management.enabled` under [exported fields](https://www.elastic.co/guide/en/beats/metricbeat/master/exported-fields-beat.html ) . Should this be removed, or is it being used by Fleet now?
![image](https://user-images.githubusercontent.com/14206422/122841036-28789400-d2b0-11eb-9e39-525509bffe33.png)

## What does this PR do?

Removes remaining references to Beats central management

## Why is it important?

Beats central management has been completely removed in 7.14.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes https://github.com/elastic/observability-docs/issues/783

