### PR TITLE
Update breaking changes to mention removal of Beats central management

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.14.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.14.asciidoc
@@ -1,0 +1,24 @@
+[[breaking-changes-7.14]]
+
+=== Breaking changes in 7.14
+++++
+<titleabbrev>7.14</titleabbrev>
+++++
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+
+[discrete]
+==== {beats} central management has been removed
+
+Starting in version 7.14, Beats central management has been removed. If you're
+currently using Beats central management, we recommend that you start using
+{fleet} instead. For more information, refer to the
+{fleet-guide}/index.html[{fleet} documentation].
+
+// end::notable-breaking-changes[]
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.14>>
+
 * <<breaking-changes-7.13>>
 
 * <<breaking-changes-7.12>>
@@ -38,6 +40,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.14.asciidoc[]
 
 include::breaking-7.13.asciidoc[]
 


### PR DESCRIPTION
## What does this PR do?

Documents the removal of Beats central management as a breaking change.

[Click here to preview the documentation](https://beats_26400.docs-preview.app.elstc.co/guide/en/beats/libbeat/master/breaking-changes-7.14.html )

## Related issues

- Closes https://github.com/elastic/observability-docs/issues/783
