### PR TITLE
[Metricbeat] Change Account ID to Project ID in `gcp.billing` module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -491,6 +491,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update config in `windows.yml` file. {issue}23027[23027]{pull}23327[23327]
 - Fix metric grouping for windows/perfmon module {issue}23489[23489] {pull}23505[23505]
 - Major refactor of system/cpu and system/core metrics. {pull}25771[25771]
+- Fix GCP Project ID being ingested as `cloud.account.id` in `gcp.billing` module {issue}26357[26357] {pull}26412[26412]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -268,7 +268,7 @@ func (m *MetricSet) queryBigQuery(ctx context.Context, client *bigquery.Client, 
 	return events, nil
 }
 
-func createEvents(rowItems []bigquery.Value, accountID string) mb.Event {
+func createEvents(rowItems []bigquery.Value, projectID string) mb.Event {
 	event := mb.Event{}
 	event.MetricSetFields = common.MapStr{
 		"invoice_month": rowItems[0],
@@ -279,8 +279,8 @@ func createEvents(rowItems []bigquery.Value, accountID string) mb.Event {
 
 	event.RootFields = common.MapStr{
 		"cloud.provider":     "gcp",
-		"cloud.account.id":   accountID,
-		"cloud.account.name": accountID,
+		"cloud.project.id":   projectID,
+		"cloud.project.name": projectID,
 	}
 
 	// create eventID for each current_date + invoice_month + project_id + cost_type

--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -219,8 +219,8 @@ func (m *MetricSet) queryBigQuery(ctx context.Context, client *bigquery.Client, 
 			WHERE project.id IS NOT NULL
 			AND invoice.month = '%s'
 			AND cost_type = '%s'
-			GROUP BY 1, 2, 3
-			ORDER BY 1 ASC, 2 ASC, 3 ASC;`, tableMeta.tableFullID, month, costType)
+			GROUP BY 1, 2, 3, 4, 5
+			ORDER BY 1 ASC, 2 ASC, 3 ASC, 4 ASC, 5 ASC;`, tableMeta.tableFullID, month, costType)
 
 	q := client.Query(query)
 	m.logger.Debug("bigquery query = ", query)

--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -275,17 +275,17 @@ func createEvents(rowItems []bigquery.Value, projectID string) mb.Event {
 	event.MetricSetFields = common.MapStr{
 		"invoice_month":      rowItems[0],
 		"project_id":         rowItems[1],
-		"project_name":       rowItems[3],
-		"billing_account_id": rowItems[4],
-		"cost_type":          rowItems[5],
-		"total":              rowItems[9],
+		"project_name":       rowItems[2],
+		"billing_account_id": rowItems[3],
+		"cost_type":          rowItems[4],
+		"total":              rowItems[5],
 	}
 
 	event.RootFields = common.MapStr{
 		"cloud.provider":     "gcp",
 		"cloud.project.id":   projectID,
-		"cloud.project.name": rowItems[3],
-		"cloud.account.id":   rowItems[4],
+		"cloud.project.name": rowItems[2],
+		"cloud.account.id":   rowItems[3],
 	}
 
 	// create eventID for each current_date + invoice_month + project_id + cost_type


### PR DESCRIPTION
## What does this PR do?

Currently the GCP Project ID is being ingested as `cloud.account.id` instead of `cloud.project.id`.  This PR fixes that.

## Why is it important?

See above

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- Closes #26357 

## Use cases


## Screenshots


## Logs
