### PR TITLE
[Packetbeat] Fix index to raw_index override for agent

### DIFF
--- a/packetbeat/publish/publish.go
+++ b/packetbeat/publish/publish.go
@@ -112,7 +112,7 @@ func (p *TransactionPublisher) CreateReporter(
 		clientConfig.PublishMode = beat.DropIfFull
 	}
 	if meta.Index != "" {
-		clientConfig.Processing.Meta = common.MapStr{"index": meta.Index}
+		clientConfig.Processing.Meta = common.MapStr{"raw_index": meta.Index}
 	}
 
 	client, err := p.pipeline.ConnectWith(clientConfig)


### PR DESCRIPTION
## What does this PR do?

Previously, when we were overwriting the index to which packetbeat published data while being controlled by agent, we were running into the per-day index code [here](https://github.com/elastic/beats/blob/794df17de660e84fb2e03e47946607b8fd30ed8e/libbeat/idxmgmt/std.go#L356-L360) which was unintentionally appending a timestamp onto the name of the data stream being created.

Instead, we want to leverage [this code](https://github.com/elastic/beats/blob/794df17de660e84fb2e03e47946607b8fd30ed8e/libbeat/idxmgmt/std.go#L366-L368) which doesn't append the date.

Since this currently isn't in use anywhere, no changelog entry required.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Screenshots

The attached screenshot shows the difference in the change. The top data stream is using `raw_index`, the bottom is using the old value, `index`

<img width="1029" alt="Screen Shot 2021-06-22 at 3 25 03 PM" src="https://user-images.githubusercontent.com/3577250/122987069-2ecd4580-d36e-11eb-9b77-ded2fee009f6.png">
