### PR TITLE
[Heartbeat] Skip flaky windows scheduler test

### DIFF
--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -29,9 +29,8 @@ import (
 )
 
 func TestQueueRunsInOrder(t *testing.T) {
-	// Skip on windows per: https://github.com/elastic/beats/issues/26205
 	if runtime.GOOS == "windows" {
-		return
+		t.Skip("flaky test on windows: https://github.com/elastic/beats/issues/26205")
 	}
 	// Bugs can show up only occasionally
 	for i := 0; i < 100; i++ {

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -20,6 +20,7 @@ package timerqueue
 import (
 	"context"
 	"math/rand"
+	"runtime"
 	"sort"
 	"testing"
 	"time"
@@ -28,6 +29,10 @@ import (
 )
 
 func TestQueueRunsInOrder(t *testing.T) {
+	// Skip on windows per: https://github.com/elastic/beats/issues/26205
+	if runtime.GOOS == "windows" {
+		return
+	}
 	// Bugs can show up only occasionally
 	for i := 0; i < 100; i++ {
 		testQueueRunsInOrderOnce(t)


### PR DESCRIPTION
Temporarily addresses https://github.com/elastic/beats/issues/26205 by disabling the test on windows. We need a real fix at some point in the future.
