### PR TITLE
disable metricbeat logstash test_node_stats

### DIFF
--- a/metricbeat/module/logstash/test_logstash.py
+++ b/metricbeat/module/logstash/test_logstash.py
@@ -25,6 +25,7 @@ class Test(metricbeat.BaseTest):
         self.check_metricset("logstash", "node", self.get_hosts(), self.FIELDS + ["process"])
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skip("flaky test: https://github.com/elastic/beats/issues/26432")
     def test_node_stats(self):
         """
         logstash node_stats metricset test


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to temporarily disable `metricbeat-pythonIntegTest / metricbeat.module.logstash.test_logstash.Test.test_node_stats`.

## Related issues

- Relates https://github.com/elastic/beats/issues/26432
