### PR TITLE
Allow fields with ip_range datatype

### DIFF
--- a/libbeat/kibana/fields_transformer.go
+++ b/libbeat/kibana/fields_transformer.go
@@ -293,6 +293,7 @@ var (
 		"geo_point":    "geo_point",
 		"date":         "date",
 		"ip":           "ip",
+		"ip_range":     "ip_range",
 		"boolean":      "boolean",
 	}
 )

--- a/libbeat/kibana/fields_transformer_test.go
+++ b/libbeat/kibana/fields_transformer_test.go
@@ -205,6 +205,8 @@ func TestTransformTypes(t *testing.T) {
 		{commonField: mapping.Field{Type: "string"}, expected: nil},
 		{commonField: mapping.Field{Type: "date"}, expected: "date"},
 		{commonField: mapping.Field{Type: "geo_point"}, expected: "geo_point"},
+		{commonField: mapping.Field{Type: "ip"}, expected: "ip"},
+		{commonField: mapping.Field{Type: "ip_range"}, expected: "ip_range"},
 		{commonField: mapping.Field{Type: "invalid"}, expected: nil},
 	}
 	for idx, test := range tests {

--- a/libbeat/mapping/field.go
+++ b/libbeat/mapping/field.go
@@ -153,7 +153,7 @@ func (f *Field) validateType() error {
 		allowedFormatters = []string{"geo_point"}
 	case "date_range":
 		allowedFormatters = []string{"date_range"}
-	case "boolean", "binary", "ip", "alias", "array":
+	case "boolean", "binary", "ip", "alias", "array", "ip_range":
 		// No formatters, metric types, or units allowed.
 	case "object":
 		if f.DynamicTemplate && (len(f.ObjectTypeParams) > 0 || f.ObjectType != "") {

--- a/libbeat/mapping/field_test.go
+++ b/libbeat/mapping/field_test.go
@@ -364,6 +364,11 @@ func TestFieldValidate(t *testing.T) {
 			},
 			err: true,
 		},
+		"allow ip_range": {
+			cfg:   common.MapStr{"type": "ip_range"},
+			err:   false,
+			field: Field{Type: "ip_range"},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## What does this PR do?

Updates libbeat to support fields with `ip_range` type.

## Why is it important?

So that fields with type `ip_range` can be defined in the various `fields.yml`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
