### PR TITLE
Cherry-pick #26436 to 7.x: disable metricbeat logstash test_node_stats

### DIFF
--- a/metricbeat/module/logstash/test_logstash.py
+++ b/metricbeat/module/logstash/test_logstash.py
@@ -23,6 +23,7 @@ class Test(metricbeat.BaseTest):
         self.check_metricset("logstash", "node", self.get_hosts(), self.FIELDS + ["process"])
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skip("flaky test: https://github.com/elastic/beats/issues/26432")
     def test_node_stats(self):
         """
         logstash node_stats metricset test


### PR DESCRIPTION
Cherry-pick of PR #26436 to 7.x branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to temporarily disable `metricbeat-pythonIntegTest / metricbeat.module.logstash.test_logstash.Test.test_node_stats`.

## Related issues

- Relates https://github.com/elastic/beats/issues/26432
