### PR TITLE
[Heartbeat] add screenshots config to synthetics

### DIFF
--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -115,4 +115,33 @@ Set this option to `true` to enable the normally disabled chromium sandbox. Defa
 [[monitor-browser-synthetics-args]]
 ==== `synthetics_args`
 
-Extra arguments to pass to the synthetics agent package. Takes a list of strings.
+Extra arguments to pass to the synthetics agent package. Takes a list of
+strings.
+
+[float]
+[[monitor-browser-screenshots]]
+==== `screenshots`
+
+Set this option to manage the screenshots captured by the synthetics agent.
+
+Under `screenshots`, specify one of these options:
+
+*`on`*:: capture screenshots for all steps in a journey (default)
+*`off`*:: do not capture any screenshots
+*`only-on-failure`*:: capture screenshots for all steps when a journey fails
+(any failing step marks the whole journey as failed)
+
+Example configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: browser
+  id: local-journeys
+  name: Local journeys
+  schedule: '@every 1m'
+  screenshots: "on"
+  source:
+    local:
+      path: "/path/to/synthetics/journeys"
+-------------------------------------------------------------------------------
+

--- a/x-pack/heartbeat/monitors/browser/config.go
+++ b/x-pack/heartbeat/monitors/browser/config.go
@@ -13,7 +13,8 @@ import (
 
 func DefaultConfig() *Config {
 	return &Config{
-		Sandbox: false,
+		Sandbox:     false,
+		Screenshots: "on",
 	}
 }
 
@@ -27,6 +28,7 @@ type Config struct {
 	// Id is optional for lightweight checks but required for browsers
 	Id             string   `config:"id"`
 	Sandbox        bool     `config:"sandbox"`
+	Screenshots    string   `config:"screenshots"`
 	SyntheticsArgs []string `config:"synthetics_args"`
 }
 

--- a/x-pack/heartbeat/monitors/browser/suite.go
+++ b/x-pack/heartbeat/monitors/browser/suite.go
@@ -75,6 +75,9 @@ func (s *Suite) extraArgs() []string {
 	if s.suiteCfg.Sandbox {
 		extraArgs = append(extraArgs, "--sandbox")
 	}
+	if s.suiteCfg.Screenshots != "" {
+		extraArgs = append(extraArgs, "--screenshots", s.suiteCfg.Screenshots)
+	}
 
 	return extraArgs
 }

--- a/x-pack/heartbeat/monitors/browser/suite_test.go
+++ b/x-pack/heartbeat/monitors/browser/suite_test.go
@@ -128,9 +128,19 @@ func TestExtraArgs(t *testing.T) {
 			nil,
 		},
 		{
+			"default",
+			DefaultConfig(),
+			[]string{"--screenshots", "on"},
+		},
+		{
 			"sandbox",
 			&Config{Sandbox: true},
 			[]string{"--sandbox"},
+		},
+		{
+			"screenshots",
+			&Config{Screenshots: "off"},
+			[]string{"--screenshots", "off"},
 		},
 		{
 			"capabilities",


### PR DESCRIPTION
+ Counterpart of https://github.com/elastic/synthetics/pull/311
+ Allows users to complete switch screenshots `off|on|only-on-failure` through the `heartbeat.yml` file. 