### PR TITLE
Update to "read_pipeline" permission in docs

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -279,7 +279,7 @@ endif::no_ilm[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
 |Cluster
-|`cluster:admin/ingest/pipeline/get`
+|`read_pipeline`
 |Check for ingest pipelines used by modules. Needed when using modules.
 endif::[]
 


### PR DESCRIPTION
## What does this PR do?

I don't know in what version this was updated to be called "read_pipeline". but it is available through the roles settings in Kibana.

This change should be reflected across all *beats* docs.

<img width="853" alt="Screenshot 2021-06-24 at 11 26 17" src="https://user-images.githubusercontent.com/12175559/123238878-26e0e300-d4df-11eb-89c5-9c605e56440a.png">


## Why is it important?

Users might try to copy and paste the permissions and receive errors or incompatibility in the future.