### PR TITLE
API keys do not reflect the need for read_pipeline

### DIFF
--- a/libbeat/docs/security/api-keys.asciidoc
+++ b/libbeat/docs/security/api-keys.asciidoc
@@ -29,7 +29,7 @@ POST /_security/api_key
   "name": "{beat_default_index_prefix}_host001", <1>
   "role_descriptors": {
     "{beat_default_index_prefix}_writer": { <2>
-      "cluster": ["monitor", "read_ilm"],
+      "cluster": ["monitor", "read_ilm", "read_pipeline"],
       "index": [
         {
           "names": ["{beat_default_index_prefix}-*"],


### PR DESCRIPTION
## What does this PR do?

As discussed in the PR https://github.com/elastic/beats/pull/26465 the docs should reflect that read_pipeline is needed when using modules. Users usually just copy and paste the JSON payload and might experience failures when running any beat with modules.

Additionally, this change should be reflected on all *beats* API key docs.