### PR TITLE
[Elastic Agent] Use http2 to connect to Fleet Server.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -115,3 +115,4 @@
 - Use `filestream` input for internal log collection. {pull}25660[25660]
 - Enable agent to send custom headers to kibana/ES {pull}26275[26275]
 - Set `agent.id` to the Fleet Agent ID in events published from inputs backed by Beats. {issue}21121[21121] {pull}26394[26394]
+- Communicate with Fleet Server over HTTP2. {pull}26474[26474]

--- a/x-pack/elastic-agent/pkg/remote/client.go
+++ b/x-pack/elastic-agent/pkg/remote/client.go
@@ -6,7 +6,6 @@ package remote
 
 import (
 	"context"
-	"golang.org/x/net/http2"
 	"io"
 	"net/http"
 	"net/url"
@@ -16,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/http2"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/transport"

--- a/x-pack/elastic-agent/pkg/remote/client.go
+++ b/x-pack/elastic-agent/pkg/remote/client.go
@@ -6,6 +6,7 @@ package remote
 
 import (
 	"context"
+	"golang.org/x/net/http2"
 	"io"
 	"net/http"
 	"net/url"
@@ -113,8 +114,16 @@ func NewWithConfig(log *logger.Logger, cfg Config, wrapper wrapperFunc) (*Client
 	hosts := cfg.GetHosts()
 	clients := make([]*requestClient, len(hosts))
 	for i, host := range cfg.GetHosts() {
-		var transport http.RoundTripper
-		transport, err := makeTransport(cfg.Timeout, cfg.TLS)
+		connStr, err := common.MakeURL(string(cfg.Protocol), p, host, 0)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid fleet-server endpoint")
+		}
+		addr, err := url.Parse(connStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid fleet-server endpoint")
+		}
+
+		transport, err := makeTransport(addr.Scheme, cfg.Timeout, cfg.TLS)
 		if err != nil {
 			return nil, err
 		}
@@ -136,12 +145,8 @@ func NewWithConfig(log *logger.Logger, cfg Config, wrapper wrapperFunc) (*Client
 			Timeout:   cfg.Timeout,
 		}
 
-		url, err := common.MakeURL(string(cfg.Protocol), p, host, 0)
-		if err != nil {
-			return nil, errors.Wrap(err, "invalid fleet-server endpoint")
-		}
 		clients[i] = &requestClient{
-			request: prefixRequestFactory(url),
+			request: prefixRequestFactory(connStr),
 			client:  httpClient,
 		}
 	}
@@ -272,17 +277,18 @@ func prefixRequestFactory(URL string) requestFunc {
 }
 
 // makeTransport create a transport object based on the TLS configuration.
-func makeTransport(timeout time.Duration, tls *tlscommon.Config) (*http.Transport, error) {
+func makeTransport(scheme string, timeout time.Duration, tls *tlscommon.Config) (http.RoundTripper, error) {
+	dialer := transport.NetDialer(timeout)
+	if scheme == "http" {
+		return &http.Transport{Dial: dialer.Dial}, nil
+	}
 	tlsConfig, err := tlscommon.LoadTLSConfig(tls)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid TLS configuration")
 	}
-	dialer := transport.NetDialer(timeout)
-	tlsDialer, err := transport.TLSDialer(dialer, tlsConfig, timeout)
+	tlsDialer, err := transport.TLSDialerH2(dialer, tlsConfig, timeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "fail to create TLS dialer")
 	}
-
-	// TODO: Dial is deprecated we need to move to DialContext.
-	return &http.Transport{Dial: dialer.Dial, DialTLS: tlsDialer.Dial}, nil
+	return &http2.Transport{DialTLS: tlsDialer.Dial}, nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Changes Elastic Agent to connect to Fleet Server using HTTP2.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

HTTP2 providers better performance and scale.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #23205

