### PR TITLE
Logging code cleanup related to Nomad auto-discovery

### DIFF
--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/bus"
@@ -692,9 +693,9 @@ func TestGenerateHints(t *testing.T) {
 	for _, test := range tests {
 		// Configure path for modules access
 		abs, _ := filepath.Abs("../../..")
-		err := paths.InitPaths(&paths.Path{
+		require.NoError(t, paths.InitPaths(&paths.Path{
 			Home: abs,
-		})
+		}))
 
 		l, err := NewLogHints(test.config)
 		if err != nil {
@@ -927,9 +928,9 @@ func TestGenerateHintsWithPaths(t *testing.T) {
 
 		// Configure path for modules access
 		abs, _ := filepath.Abs("../../..")
-		err := paths.InitPaths(&paths.Path{
+		require.NoError(t, paths.InitPaths(&paths.Path{
 			Home: abs,
-		})
+		}))
 
 		l, err := NewLogHints(cfg)
 		if err != nil {
@@ -937,7 +938,7 @@ func TestGenerateHintsWithPaths(t *testing.T) {
 		}
 
 		cfgs := l.CreateConfig(test.event)
-		assert.Equal(t, test.len, len(cfgs), test.msg)
+		require.Equal(t, test.len, len(cfgs), test.msg)
 		if test.len != 0 {
 			config := common.MapStr{}
 			err := cfgs[0].Unpack(&config)

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -314,3 +314,48 @@ meta {
   "co.elastic.logs/multiline.match"   = "after"
 }
 -----
+
+If you are using autodiscover then in most cases you will want to use the
+<<add-nomad-metadata,`add_nomad_metadata`>> processor to enrich events with
+Nomad metadata. This example configures {{beatname_uc}} to connect to the local
+Nomad agent over HTTPS and adds the Nomad allocation ID to all events from the
+input. Later in the pipeline the `add_nomad_metadata` processor will use that ID
+to enrich the event.
+
+[source,yaml]
+-----
+filebeat.autodiscover:
+  providers:
+    - type: nomad
+      address: https://localhost:4646
+      hints.enabled: true
+      hints.default_config:
+        enabled: false <1>
+        type: log
+        paths:
+          - /opt/nomad/alloc/${data.nomad.allocation.id}/alloc/logs/${data.nomad.task.name}.*
+        processors:
+          - add_fields: <2>
+              target: nomad
+              fields:
+                allocation.id: ${data.nomad.allocation.id}
+
+processors:
+  - add_nomad_metadata: <3>
+      when.has_fields.fields: [nomad.allocation.id]
+      address: https://localhost:4646
+      default_indexers.enabled: false
+      default_matchers.enabled: false
+      indexers:
+        - allocation_uuid:
+      matchers:
+        - fields:
+            lookup_fields:
+              - 'nomad.allocation.id'
+-----
+<1> The default config is disabled meaning any task without the
+`"co.elastic.logs/enabled" = "true"` metadata will be ignored.
+<2> The `add_fields` processor populates the `nomad.allocation.id` field with
+the Nomad allocation UUID.
+<3> The `add_nomad_metadata` processor is configured at the global level so
+that it is only instantiated one time which saves resources.

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -259,7 +259,9 @@ You can label Docker containers with useful info to decode logs structured as JS
 [float]
 ==== Nomad
 
-Nomad autodiscover provider supports hints using the https://www.nomadproject.io/docs/job-specification/meta.html[`meta` stanza]. To enable it just set `hints.enabled`:
+Nomad autodiscover provider supports hints using the
+https://www.nomadproject.io/docs/job-specification/meta.html[`meta` stanza]. To
+enable it just set `hints.enabled`:
 
 [source,yaml]
 -----
@@ -269,7 +271,8 @@ filebeat.autodiscover:
       hints.enabled: true
 -----
 
-You can configure the default config that will be launched when a new job is seen, like this:
+You can configure the default config that will be launched when a new job is
+seen, like this:
 
 [source,yaml]
 -----
@@ -278,13 +281,13 @@ filebeat.autodiscover:
     - type: nomad
       hints.enabled: true
       hints.default_config:
-        type: nomad
+        type: log
         paths:
-          - /var/lib/nomad/alloc/${data.nomad.allocation.id}/alloc/logs/${data.nomad.task.name}.*
+          - /opt/nomad/alloc/${data.nomad.allocation.id}/alloc/logs/${data.nomad.task.name}.*
 -----
 
-You can also disable default settings entirely, so only Jobs annotated like `co.elastic.logs/enabled: true`
-will be retrieved:
+You can also disable the default config such that only logs from jobs explicitly
+annotated with `"co.elastic.logs/enabled" = "true"` will be collected:
 
 [source,yaml]
 -----
@@ -292,17 +295,22 @@ filebeat.autodiscover:
   providers:
     - type: nomad
       hints.enabled: true
-      hints.default_config.enabled: false
+      hints.default_config:
+        enabled: false
+        type: log
+        paths:
+          - /opt/nomad/alloc/${data.nomad.allocation.id}/alloc/logs/${data.nomad.task.name}.*
 -----
 
-You can annotate Nomad Jobs using the `meta` stanza with useful info to spin up {beatname_uc} inputs
-or modules:
+You can annotate Nomad Jobs using the `meta` stanza with useful info to spin up
+{beatname_uc} inputs or modules:
 
 [source,hcl]
 -----
 meta {
-  "co.elastic.logs/multiline.pattern" = "^\["
-  "co.elastic.logs/multiline.negate"  = true
-  "co.elastic.logs/multiline.match"   = after
+  "co.elastic.logs/enabled"           = "true"
+  "co.elastic.logs/multiline.pattern" = "^\\["
+  "co.elastic.logs/multiline.negate"  = "true"
+  "co.elastic.logs/multiline.match"   = "after"
 }
 -----

--- a/filebeat/docs/autodiscover-nomad-config.asciidoc
+++ b/filebeat/docs/autodiscover-nomad-config.asciidoc
@@ -43,6 +43,6 @@ filebeat.autodiscover:
                     - /var/lib/nomad/alloc/${data.nomad.allocation.id}/alloc/logs/${data.nomad.task.name}.*
 -------------------------------------------------------------------------------------
 
-WARNING: The `docker` input is currently not supported. Nomad doesn't expose the container id
-associated with the allocation. Without the container id, there is no way of generating the proper
+WARNING: The `docker` input is currently not supported. Nomad doesn't expose the container ID
+associated with the allocation. Without the container ID, there is no way of generating the proper
 path for reading the container's logs.

--- a/heartbeat/tests/system/test_autodiscovery.py
+++ b/heartbeat/tests/system/test_autodiscovery.py
@@ -40,7 +40,7 @@ class TestAutodiscover(BaseTest):
         proc = self.start_beat()
 
         self.wait_until(lambda: self.log_contains(
-            re.compile('autodiscover.+Got a start event:', re.I)))
+            re.compile('autodiscover.+Got a start event', re.I)))
 
         self.wait_until(lambda: self.output_count(lambda x: x >= 1))
 

--- a/libbeat/autodiscover/autodiscover.go
+++ b/libbeat/autodiscover/autodiscover.go
@@ -169,7 +169,7 @@ func (a *Autodiscover) worker() {
 }
 
 func (a *Autodiscover) handleStart(event bus.Event) bool {
-	a.logger.Debugf("Got a start event: %v", event)
+	a.logger.Debugw("Got a start event.", "autodiscover.event", event)
 
 	eventID := getID(event)
 	if eventID == "" {

--- a/libbeat/autodiscover/builder/plugin.go
+++ b/libbeat/autodiscover/builder/plugin.go
@@ -29,7 +29,7 @@ type builderPlugin struct {
 	builder autodiscover.BuilderConstructor
 }
 
-var pluginKey = "libbeat.autodiscover.builder"
+const pluginKey = "libbeat.autodiscover.builder"
 
 // Plugin accepts a BuilderConstructor to be registered as a plugin
 func Plugin(name string, b autodiscover.BuilderConstructor) map[string][]interface{} {

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -482,7 +482,18 @@ The `nomad` autodiscover provider has the following configuration settings:
 
 `namespace`:: (Optional) Namespace to use. If not provided the `default` namespace is used.
 
-`secret_id`:: (Optional) SecretID to use if ACL is enabled in Nomad.
+`secret_id`:: (Optional) SecretID to use if ACL is enabled in Nomad. A minimal
+ACL policy is:
+
+[source,hcl]
+----
+node {
+  policy = "read"
+}
+agent {
+  policy = "read"
+}
+----
 
 `node`:: (Optional) Specify the node to scope {beatname_lc} to in case it
   cannot be accurately detected when `node` scope is used.

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -482,11 +482,14 @@ The `nomad` autodiscover provider has the following configuration settings:
 
 `namespace`:: (Optional) Namespace to use. If not provided the `default` namespace is used.
 
-`secret_id`:: (Optional) SecretID to use if ACL is enabled in Nomad. A minimal
-ACL policy is:
+`secret_id`:: (Optional) SecretID to use if ACL is enabled in Nomad. This is an
+example ACL policy to apply to the token.
 
 [source,hcl]
 ----
+namespace "*" {
+  policy = "read"
+}
 node {
   policy = "read"
 }

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -496,6 +496,7 @@ The `nomad` autodiscover provider has the following configuration settings:
 
 `allow_stale`:: (Optional) allows any Nomad server (non-leader) to service a read. This normally
   means that the local node where filebeat is allocated will service filebeat's requests.
+  Defaults to `true`.
 
 include::../../{beatname_lc}/docs/autodiscover-nomad-config.asciidoc[]
 

--- a/x-pack/libbeat/autodiscover/providers/nomad/config.go
+++ b/x-pack/libbeat/autodiscover/providers/nomad/config.go
@@ -41,9 +41,6 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		Address:        "http://127.0.0.1:4646",
-		Region:         "",
-		Namespace:      "",
-		SecretID:       "",
 		Scope:          ScopeNode,
 		allowStale:     true,
 		waitTime:       15 * time.Second,
@@ -53,7 +50,7 @@ func defaultConfig() *Config {
 	}
 }
 
-// Validate ensures correctness of config
+// Validate ensures correctness of config.
 func (c *Config) Validate() error {
 	// Make sure that prefix doesn't ends with a '.'
 	if c.Prefix[len(c.Prefix)-1] == '.' && c.Prefix != "." {

--- a/x-pack/libbeat/common/nomad/metadata.go
+++ b/x-pack/libbeat/common/nomad/metadata.go
@@ -82,7 +82,7 @@ func (g *metaGenerator) ResourceMetadata(obj Resource) common.MapStr {
 // Returns an array of per-task metadata aggregating the group metadata into the
 // task metadata
 func (g *metaGenerator) GroupMeta(job *Job) []common.MapStr {
-	tasksMeta := []common.MapStr{}
+	var tasksMeta []common.MapStr
 
 	for _, group := range job.TaskGroups {
 		meta := make(map[string]string, len(job.Meta))
@@ -131,7 +131,7 @@ func (g *metaGenerator) GroupMeta(job *Job) []common.MapStr {
 
 // Returns per-task metadata
 func (g *metaGenerator) tasksMeta(group *TaskGroup) []common.MapStr {
-	tasks := []common.MapStr{}
+	var tasks []common.MapStr
 
 	for _, task := range group.Tasks {
 		var svcNames, svcTags, svcCanaryTags []string
@@ -201,7 +201,7 @@ func generateMapSubset(input common.MapStr, keys []string, dedot bool) common.Ma
 }
 
 // AllocationNodeName returns Name of the node where the task is allocated. It
-// does one additional API call to circunvent the empty NodeName property of
+// does one additional API call to circumvent the empty NodeName property of
 // older Nomad versions (up to v0.8)
 func (g *metaGenerator) AllocationNodeName(id string) (string, error) {
 	if name, ok := g.nodesCache[id]; ok {

--- a/x-pack/libbeat/processors/add_nomad_metadata/docs/add_nomad_metadata.asciidoc
+++ b/x-pack/libbeat/processors/add_nomad_metadata/docs/add_nomad_metadata.asciidoc
@@ -32,7 +32,18 @@ uses `http://127.0.0.1:4646` by default.
 in this namespace will be annotated.
 `region`:: (Optional) Region to watch. If set, only events for allocations in
 this region will be annotated.
-`secretID`:: (Optional) SecretID to use when connecting with the agent API.
+`secret_id`:: (Optional) SecretID to use when connecting with the agent API.  A
+minimal ACL policy is:
+
+[source,hcl]
+----
+node {
+  policy = "read"
+}
+agent {
+  policy = "read"
+}
+----
 `refresh_interval`:: (Optional) Interval used to updated the cached metadata. It
 defaults to 30 seconds.
 `cleanup_timeout`:: (Optional) After an allocation has been removed, time to

--- a/x-pack/libbeat/processors/add_nomad_metadata/docs/add_nomad_metadata.asciidoc
+++ b/x-pack/libbeat/processors/add_nomad_metadata/docs/add_nomad_metadata.asciidoc
@@ -32,11 +32,14 @@ uses `http://127.0.0.1:4646` by default.
 in this namespace will be annotated.
 `region`:: (Optional) Region to watch. If set, only events for allocations in
 this region will be annotated.
-`secret_id`:: (Optional) SecretID to use when connecting with the agent API.  A
-minimal ACL policy is:
+`secret_id`:: (Optional) SecretID to use when connecting with the agent API.
+This is an example ACL policy to apply to the token.
 
 [source,hcl]
 ----
+namespace "*" {
+  policy = "read"
+}
 node {
   policy = "read"
 }


### PR DESCRIPTION
## What does this PR do?

This does some minor clean up of the logging code and docs related to Nomad. I removed some statements that were providing duplicate information and switched a few over to using the structured logger to improve log readability.

A log message about `enabled` not being parsed was always being logged despite no actual error.

The doc examples were trying to start a Filebeat input with `type: nomad`.

Fixed some typos in code comments.

## Why is it important?

This make debugging a little more enjoyable 😆 .

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

- Closes #26456
