### PR TITLE
Cherry-pick #26412 to 7.x: [Metricbeat] Change Account ID to Project ID in `gcp.billing` module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -379,6 +379,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix copy-paste error in libbeat docs. {pull}25448[25448]
 - Fix azure billing dashboard. {pull}25554[25554]
 - Major refactor of system/cpu and system/core metrics. {pull}25771[25771]
+- Fix GCP Project ID being ingested as `cloud.account.id` in `gcp.billing` module {issue}26357[26357] {pull}26412[26412]
 
 *Packetbeat*
 


### PR DESCRIPTION
Cherry-pick of PR #26412 to 7.x branch. Original message: 

## What does this PR do?

Currently the GCP Project ID is being ingested as `cloud.account.id` instead of `cloud.project.id`.  This PR fixes that.

## Why is it important?

See above

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues

- Closes #26357 

## Use cases


## Screenshots


## Logs
