### PR TITLE
update data.json for gcp billing

### DIFF
--- a/x-pack/metricbeat/module/gcp/billing/_meta/data.json
+++ b/x-pack/metricbeat/module/gcp/billing/_meta/data.json
@@ -1,7 +1,8 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
-    "cloud.account.id": "elastic-bi",
-    "cloud.account.name": "elastic-bi",
+    "cloud.account.id": "01475F-5B1080-1137E7",
+    "cloud.project.id": "elastic-bi",
+    "cloud.project.name": "elastic-containerlib-prod",
     "cloud.provider": "gcp",
     "event": {
         "dataset": "gcp.billing",
@@ -10,10 +11,12 @@
     },
     "gcp": {
         "billing": {
+            "billing_account_id": "01475F-5B1080-1137E7",
             "cost_type": "regular",
-            "invoice_month": "202010",
-            "project_id": "elastic-fin-bi",
-            "total": 77.897328
+            "invoice_month": "202106",
+            "project_id": "containerlib-prod-12763",
+            "project_name": "elastic-containerlib-prod",
+            "total": 4717.170681
         }
     },
     "metricset": {

--- a/x-pack/metricbeat/module/gcp/billing/billing_integration_test.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing_integration_test.go
@@ -10,9 +10,26 @@ package billing
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/gcp/metrics"
 )
+
+func TestFetch(t *testing.T) {
+	config := metrics.GetConfigForTest(t, "billing")
+	config["period"] = "24h"
+	config["dataset_id"] = "master_gcp"
+
+	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
+	events, errs := mbtest.ReportingFetchV2Error(metricSet)
+	if len(errs) > 0 {
+		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
+	}
+
+	assert.NotEmpty(t, events)
+	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
+}
 
 func TestData(t *testing.T) {
 	config := metrics.GetConfigForTest(t, "billing")


### PR DESCRIPTION
## What does this PR do?

This PR is an addition to https://github.com/elastic/beats/pull/26412 for updating `data.json` in `gcp.billing`. 