### PR TITLE
[filebeat][fortinet] Use default add_locale for fortinet.firewall

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -842,6 +842,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `uri_parts` and `user_agent` ingest processors to `aws.elb` module. {issue}26435[26435] {pull}26441[26441]
 - Added dataset `recordedfuture` to the `threatintel` module to ingest indicators from Recorded Future Connect API {pull}26481[26481]
 - Update `fortinet` ingest pipelines. {issue}22136[22136] {issue}25254[25254] {pull}24816[24816]
+- Use default add_locale for fortinet.firewall {issue}20300[20300] {pull}26524[26524]
 
 *Heartbeat*
 

--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -27,7 +27,7 @@ include::../include/gs-link.asciidoc[]
 [float]
 === Compatibility
 
-This module has been tested against FortiOS version 6.0.x and 6.2.x. 
+This module has been tested against FortiOS version 6.0.x and 6.2.x.
 Versions above this are expected to work but have not been tested.
 
 include::../include/configuring-intro.asciidoc[]
@@ -50,6 +50,8 @@ include::../include/config-option-intro.asciidoc[]
 ----
 
 include::../include/var-paths.asciidoc[]
+
+include::../include/timezone-support.asciidoc[]
 
 *`var.input`*::
 

--- a/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
@@ -22,7 +22,7 @@ include::../include/gs-link.asciidoc[]
 [float]
 === Compatibility
 
-This module has been tested against FortiOS version 6.0.x and 6.2.x. 
+This module has been tested against FortiOS version 6.0.x and 6.2.x.
 Versions above this are expected to work but have not been tested.
 
 include::../include/configuring-intro.asciidoc[]
@@ -45,6 +45,8 @@ include::../include/config-option-intro.asciidoc[]
 ----
 
 include::../include/var-paths.asciidoc[]
+
+include::../include/timezone-support.asciidoc[]
 
 *`var.input`*::
 

--- a/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/config/firewall.yml
@@ -25,6 +25,7 @@ tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 
 processors:
+  - add_locale: ~
   - add_fields:
       target: ''
       fields:

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -76,27 +76,27 @@ processors:
     target_field: event.start
     formats:
     - UNIX_MS
-    timezone: "{{fortinet.firewall.tz}}"
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
+    timezone: "{{event.timezone}}"
+    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.event?.timezone != null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
 - date:
     field: fortinet.firewall.eventtime
     target_field: event.start
     formats:
     - UNIX
-    timezone: "{{fortinet.firewall.tz}}"
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz != null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
+    timezone: "{{event.timezone}}"
+    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.event?.timezone != null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
 - date:
     field: fortinet.firewall.eventtime
     target_field: event.start
     formats:
     - UNIX_MS
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
+    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.event?.timezone == null && (ctx.fortinet?.firewall?.eventtime).length() > 11"
 - date:
     field: fortinet.firewall.eventtime
     target_field: event.start
     formats:
     - UNIX
-    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.fortinet?.firewall?.tz == null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
+    if: "ctx?.fortinet?.firewall?.eventtime != null && ctx.event?.timezone == null && (ctx.fortinet?.firewall?.eventtime).length() <= 11"
 - script:
     lang: painless
     source: "ctx.event.duration = Long.parseLong(ctx.fortinet.firewall.duration) * 1000000000"

--- a/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/pipeline.yml
@@ -41,12 +41,12 @@ processors:
     ignore_empty_value: true
 - set:
     field: _temp.time
-    value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}} {{fortinet.firewall.tz}}"
-    if: "ctx.fortinet?.firewall?.tz != null"
+    value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}} {{event.timezone}}"
+    if: "ctx.event?.timezone != null"
 - set:
     field: _temp.time
     value: "{{fortinet.firewall.date}} {{fortinet.firewall.time}}"
-    if: "ctx.fortinet?.firewall?.tz == null"
+    if: "ctx.event?.timezone == null"
 - date:
     field: _temp.time
     target_field: "@timestamp"
@@ -55,8 +55,8 @@ processors:
     - yyyy-MM-dd HH:mm:ss Z
     - yyyy-MM-dd HH:mm:ss z
     - ISO8601
-    timezone: "{{fortinet.firewall.tz}}"
-    if: "ctx.fortinet?.firewall?.tz != null"
+    timezone: "{{event.timezone}}"
+    if: "ctx.event?.timezone != null"
 - date:
     field: _temp.time
     target_field: "@timestamp"
@@ -65,7 +65,7 @@ processors:
     - yyyy-MM-dd HH:mm:ss Z
     - yyyy-MM-dd HH:mm:ss z
     - ISO8601
-    if: "ctx.fortinet?.firewall?.tz == null"
+    if: "ctx.event?.timezone == null"
 - gsub:
     field: fortinet.firewall.eventtime
     pattern: "\\d{6}$"

--- a/x-pack/filebeat/module/fortinet/firewall/test/event.log-expected.json
+++ b/x-pack/filebeat/module/fortinet/firewall/test/event.log-expected.json
@@ -635,7 +635,7 @@
         ]
     },
     {
-        "@timestamp": "2020-11-02T08:11:38.000Z",
+        "@timestamp": "2020-11-02T08:11:38.000-02:00",
         "destination.as.number": 15169,
         "destination.as.organization.name": "Google LLC",
         "destination.geo.continent_name": "North America",
@@ -654,6 +654,7 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection"
         ],
@@ -696,7 +697,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-13T11:20:54.000Z",
+        "@timestamp": "2019-05-13T11:20:54.000-02:00",
         "destination.ip": "172.16.200.2",
         "event.action": "login",
         "event.code": "0100032001",
@@ -704,7 +705,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.reason": "none",
-        "event.start": "2019-05-13T18:20:54.587Z",
+        "event.start": "2019-05-13T16:20:54.587-02:00",
+        "event.timezone": "-02:00",
         "fileset.name": "firewall",
         "fortinet.firewall.action": "login",
         "fortinet.firewall.method": "ssh",
@@ -740,7 +742,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-13T14:21:42.000Z",
+        "@timestamp": "2019-05-13T14:21:42.000-02:00",
         "destination.as.number": 7065,
         "destination.as.organization.name": "Sonoma Interconnect",
         "destination.geo.city_name": "North Highlands",
@@ -762,7 +764,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-13T21:21:42.722Z",
+        "event.start": "2019-05-13T19:21:42.722-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection"
         ],
@@ -813,7 +816,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-13T15:55:56.000Z",
+        "@timestamp": "2019-05-13T15:55:56.000-02:00",
         "destination.ip": "172.16.200.55",
         "event.action": "authentication",
         "event.category": [
@@ -823,7 +826,8 @@
         "event.dataset": "fortinet.firewall",
         "event.kind": "event",
         "event.module": "fortinet",
-        "event.start": "2019-05-13T22:55:56.913Z",
+        "event.start": "2019-05-13T20:55:56.913-02:00",
+        "event.timezone": "-02:00",
         "fileset.name": "firewall",
         "fortinet.firewall.action": "authentication",
         "fortinet.firewall.authproto": "TELNET(10.1.100.11)",
@@ -859,13 +863,14 @@
         ]
     },
     {
-        "@timestamp": "2019-05-14T08:32:13.000Z",
+        "@timestamp": "2019-05-14T08:32:13.000-02:00",
         "event.action": "add",
         "event.code": "0107045057",
         "event.dataset": "fortinet.firewall",
         "event.kind": "event",
         "event.module": "fortinet",
-        "event.start": "2019-05-14T15:32:13.900Z",
+        "event.start": "2019-05-14T13:32:13.900-02:00",
+        "event.timezone": "-02:00",
         "fileset.name": "firewall",
         "fortinet.firewall.action": "add",
         "fortinet.firewall.connection_type": "sslvpn",
@@ -898,13 +903,14 @@
         ]
     },
     {
-        "@timestamp": "2019-05-14T08:19:38.000Z",
+        "@timestamp": "2019-05-14T08:19:38.000-02:00",
         "event.action": "close",
         "event.code": "0107045058",
         "event.dataset": "fortinet.firewall",
         "event.kind": "event",
         "event.module": "fortinet",
-        "event.start": "2019-05-14T15:19:39.037Z",
+        "event.start": "2019-05-14T13:19:39.037-02:00",
+        "event.timezone": "-02:00",
         "fileset.name": "firewall",
         "fortinet.firewall.action": "close",
         "fortinet.firewall.connection_type": "sslvpn",

--- a/x-pack/filebeat/module/fortinet/firewall/test/traffic.log-expected.json
+++ b/x-pack/filebeat/module/fortinet/firewall/test/traffic.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2020-04-23T01:16:08.000Z",
+        "@timestamp": "2020-04-23T01:16:08.000-02:00",
         "destination.as.number": 15169,
         "destination.as.organization.name": "Google LLC",
         "destination.bytes": 0,
@@ -21,7 +21,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2020-06-24T01:16:08.000Z",
+        "event.start": "2020-06-23T23:16:08.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection",
             "denied",
@@ -581,7 +582,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-31T06:42:54.000Z",
+        "@timestamp": "2019-03-31T06:42:54.000-02:00",
         "destination.bytes": 0,
         "destination.ip": "230.1.1.2",
         "destination.packets": 0,
@@ -596,7 +597,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-03-31T13:42:52.000Z",
+        "event.start": "2019-03-31T11:42:52.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "allowed",
             "connection",
@@ -644,7 +646,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-10T14:18:54.000Z",
+        "@timestamp": "2019-05-10T14:18:54.000-02:00",
         "destination.as.number": 20940,
         "destination.as.organization.name": "Akamai International B.V.",
         "destination.bytes": 0,
@@ -666,7 +668,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-10T21:18:54.021Z",
+        "event.start": "2019-05-10T19:18:54.021-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection",
             "end"
@@ -732,7 +735,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-13T11:45:04.000Z",
+        "@timestamp": "2019-05-13T11:45:04.000-02:00",
         "destination.bytes": 2286,
         "destination.ip": "172.16.200.55",
         "destination.packets": 6,
@@ -747,7 +750,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-13T18:45:04.815Z",
+        "event.start": "2019-05-13T16:45:04.815-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection",
             "denied",
@@ -819,7 +823,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-13T16:29:50.000Z",
+        "@timestamp": "2019-05-13T16:29:50.000-02:00",
         "destination.as.number": 42831,
         "destination.as.organization.name": "UK Dedicated Servers Limited",
         "destination.bytes": 3138,
@@ -844,7 +848,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-13T23:29:50.452Z",
+        "event.start": "2019-05-13T21:29:50.452-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection",
             "denied",
@@ -906,7 +911,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-15T17:58:10.000Z",
+        "@timestamp": "2019-05-15T17:58:10.000-02:00",
         "destination.bytes": 9112,
         "destination.ip": "172.16.200.55",
         "destination.packets": 8,
@@ -921,7 +926,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-16T00:58:09.000Z",
+        "event.start": "2019-05-15T22:58:09.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection",
             "denied",
@@ -984,7 +990,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-15T17:45:34.000Z",
+        "@timestamp": "2019-05-15T17:45:34.000-02:00",
         "destination.as.number": 16509,
         "destination.as.organization.name": "Amazon.com, Inc.",
         "destination.bytes": 5266,
@@ -1009,7 +1015,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-16T00:45:34.000Z",
+        "event.start": "2019-05-15T22:45:34.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "connection",
             "denied",

--- a/x-pack/filebeat/module/fortinet/firewall/test/utm.log-expected.json
+++ b/x-pack/filebeat/module/fortinet/firewall/test/utm.log-expected.json
@@ -771,7 +771,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-15T18:03:36.000Z",
+        "@timestamp": "2019-05-15T18:03:36.000-02:00",
         "destination.as.number": 41690,
         "destination.as.organization.name": "Dailymotion S.A.",
         "destination.geo.continent_name": "Europe",
@@ -790,7 +790,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-16T01:03:35.000Z",
+        "event.start": "2019-05-15T23:03:35.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "allowed"
         ],
@@ -844,7 +845,7 @@
         "url.path": "/"
     },
     {
-        "@timestamp": "2019-05-13T11:45:03.000Z",
+        "@timestamp": "2019-05-13T11:45:03.000-02:00",
         "destination.ip": "172.16.200.55",
         "destination.port": 80,
         "event.action": "blocked",
@@ -857,7 +858,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reference": "http://www.fortinet.com/ve?vn=EICAR_TEST_FILE",
-        "event.start": "2019-05-13T18:45:03.767Z",
+        "event.start": "2019-05-13T16:45:03.767-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -917,7 +919,7 @@
         "vulnerability.category": "Virus"
     },
     {
-        "@timestamp": "2019-05-13T16:29:45.000Z",
+        "@timestamp": "2019-05-13T16:29:45.000-02:00",
         "destination.as.number": 42831,
         "destination.as.organization.name": "UK Dedicated Servers Limited",
         "destination.bytes": 0,
@@ -940,7 +942,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-13T23:29:44.975Z",
+        "event.start": "2019-05-13T21:29:44.975-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -993,7 +996,7 @@
         "url.path": "/"
     },
     {
-        "@timestamp": "2019-05-15T17:56:41.000Z",
+        "@timestamp": "2019-05-15T17:56:41.000-02:00",
         "destination.ip": "172.16.200.55",
         "destination.port": 80,
         "event.action": "dropped",
@@ -1007,7 +1010,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reference": "http://www.fortinet.com/ids/VID23305",
-        "event.start": "2019-05-16T00:56:41.000Z",
+        "event.start": "2019-05-15T22:56:41.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1062,7 +1066,7 @@
         "url.path": "/ips/sig1.pdf"
     },
     {
-        "@timestamp": "2019-05-13T17:05:59.000Z",
+        "@timestamp": "2019-05-13T17:05:59.000-02:00",
         "destination.ip": "172.16.200.55",
         "event.action": "clear_session",
         "event.category": [
@@ -1074,7 +1078,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reference": "http://www.fortinet.com/ids/VID16777316",
-        "event.start": "2019-05-14T00:05:59.461Z",
+        "event.start": "2019-05-13T22:05:59.461-02:00",
+        "event.timezone": "-02:00",
         "fileset.name": "firewall",
         "fortinet.firewall.action": "clear_session",
         "fortinet.firewall.attack": "icmp_flood",
@@ -1120,7 +1125,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-15T17:45:30.000Z",
+        "@timestamp": "2019-05-15T17:45:30.000-02:00",
         "destination.as.number": 16509,
         "destination.as.organization.name": "Amazon.com, Inc.",
         "destination.geo.city_name": "Ashburn",
@@ -1143,7 +1148,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-16T00:45:28.000Z",
+        "event.start": "2019-05-15T22:45:28.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1202,7 +1208,7 @@
         "user_agent.version": "1.17.1"
     },
     {
-        "@timestamp": "2019-05-15T16:18:17.000Z",
+        "@timestamp": "2019-05-15T16:18:17.000-02:00",
         "destination.ip": "172.16.200.44",
         "destination.port": 22,
         "event.action": "blocked",
@@ -1214,7 +1220,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-15T23:18:16.000Z",
+        "event.start": "2019-05-15T21:18:16.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1255,7 +1262,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T10:44:53.000Z",
+        "@timestamp": "2019-03-28T10:44:53.000-02:00",
         "destination.as.number": 15169,
         "destination.as.organization.name": "Google LLC",
         "destination.geo.continent_name": "North America",
@@ -1277,7 +1284,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "block-cert-invalid",
-        "event.start": "2019-03-28T17:44:52.000Z",
+        "event.start": "2019-03-28T15:44:52.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1316,7 +1324,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T10:51:17.000Z",
+        "@timestamp": "2019-03-28T10:51:17.000-02:00",
         "destination.ip": "172.16.200.99",
         "destination.port": 443,
         "event.action": "blocked",
@@ -1329,7 +1337,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "block-cert-untrusted",
-        "event.start": "2019-03-28T17:51:16.000Z",
+        "event.start": "2019-03-28T15:51:16.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1368,7 +1377,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T10:55:43.000Z",
+        "@timestamp": "2019-03-28T10:55:43.000-02:00",
         "destination.ip": "172.16.200.99",
         "destination.port": 443,
         "event.action": "blocked",
@@ -1381,7 +1390,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "block-cert-req",
-        "event.start": "2019-03-28T17:55:42.000Z",
+        "event.start": "2019-03-28T15:55:42.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1420,7 +1430,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T10:57:42.000Z",
+        "@timestamp": "2019-03-28T10:57:42.000-02:00",
         "destination.ip": "172.16.200.99",
         "destination.port": 8080,
         "event.action": "blocked",
@@ -1433,7 +1443,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "malformed input",
-        "event.start": "2019-03-28T17:57:41.000Z",
+        "event.start": "2019-03-28T15:57:41.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1473,7 +1484,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T11:00:17.000Z",
+        "@timestamp": "2019-03-28T11:00:17.000-02:00",
         "destination.ip": "172.16.200.99",
         "destination.port": 443,
         "event.action": "blocked",
@@ -1486,7 +1497,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "block-cert-sni-mismatch",
-        "event.start": "2019-03-28T18:00:16.000Z",
+        "event.start": "2019-03-28T16:00:16.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1525,7 +1537,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T11:02:07.000Z",
+        "@timestamp": "2019-03-28T11:02:07.000-02:00",
         "destination.ip": "172.16.200.99",
         "destination.port": 443,
         "event.action": "blocked",
@@ -1538,7 +1550,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "Other",
-        "event.start": "2019-03-28T18:02:06.000Z",
+        "event.start": "2019-03-28T16:02:06.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],
@@ -1578,7 +1591,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T11:06:05.000Z",
+        "@timestamp": "2019-03-28T11:06:05.000-02:00",
         "destination.as.number": 16509,
         "destination.as.organization.name": "Amazon.com, Inc.",
         "destination.geo.city_name": "San Jose",
@@ -1601,7 +1614,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "exempt-whitelist",
-        "event.start": "2019-03-28T18:06:03.000Z",
+        "event.start": "2019-03-28T16:06:03.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "allowed"
         ],
@@ -1640,7 +1654,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T11:09:14.000Z",
+        "@timestamp": "2019-03-28T11:09:14.000-02:00",
         "destination.ip": "172.16.200.99",
         "destination.port": 443,
         "event.action": "exempt",
@@ -1653,7 +1667,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "exempt-addr",
-        "event.start": "2019-03-28T18:09:13.000Z",
+        "event.start": "2019-03-28T16:09:13.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "allowed"
         ],
@@ -1692,7 +1707,7 @@
         ]
     },
     {
-        "@timestamp": "2019-03-28T11:10:55.000Z",
+        "@timestamp": "2019-03-28T11:10:55.000-02:00",
         "destination.as.number": 16509,
         "destination.as.organization.name": "Amazon.com, Inc.",
         "destination.geo.city_name": "San Jose",
@@ -1715,7 +1730,8 @@
         "event.module": "fortinet",
         "event.outcome": "success",
         "event.reason": "exempt-ftgd-cat",
-        "event.start": "2019-03-28T18:10:54.000Z",
+        "event.start": "2019-03-28T16:10:54.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "allowed"
         ],
@@ -1754,7 +1770,7 @@
         ]
     },
     {
-        "@timestamp": "2019-05-15T16:28:17.000Z",
+        "@timestamp": "2019-05-15T16:28:17.000-02:00",
         "destination.ip": "172.16.200.44",
         "destination.port": 445,
         "event.action": "blocked",
@@ -1766,7 +1782,8 @@
         "event.kind": "event",
         "event.module": "fortinet",
         "event.outcome": "success",
-        "event.start": "2019-05-15T23:28:15.000Z",
+        "event.start": "2019-05-15T21:28:15.000-02:00",
+        "event.timezone": "-02:00",
         "event.type": [
             "denied"
         ],


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

- Adds a `add_locale` default processor to `fortinet.firewall`
- Uses `event.timezone` on the ingest pipeline
- Adds documentation about how to set a custom timezone

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It has been a recurrent request to be able to set a custom timezone to `fortinet.firewall`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #20300
