### PR TITLE
Add inttests for the x-pack/metricbeat on a PR/branches basis

### DIFF
--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -24,6 +24,14 @@ stages:
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
+    goIntegTest:
+        mage: "mage goIntegTest"
+        withModule: true
+        stage: mandatory
+    pythonIntegTest:
+        mage: "mage pythonIntegTest"
+        withModule: true
+        stage: mandatory
     cloud:
         cloud: "mage build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.


### PR DESCRIPTION
## What does this PR do?

Enable specific ITs for `x-pack/metricbeats`

## Why is it important?

ITs for `x-pack/metricbeats` were executed on a weekly basis in the CI as part of the cloud stage. See https://github.com/elastic/beats/pull/23186

## Tests

Test failures might need to be reviewed by the team or the build manager in rotation. 
