### PR TITLE
Cherry-pick to 7.x: Remove all docs about  Beats central management (#26399)

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -16,7 +16,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_default_index_prefix: {beatname_lc}
 :beat_kib_app: {kib} Logs
 :has_ml_jobs: yes
-:has_central_config:
 :has_solutions:
 :ignores_max_retries:
 :has_docker_label_ex:

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -111,10 +111,6 @@ ifdef::apm-server[]
 |Set up ingest pipelines
 endif::apm-server[]
 
-ifdef::has_central_config[]
-|`beats_admin`
-|Enroll and manage configurations in Beats central management
-endif::has_central_config[]
 |====
 +
 Omit any roles that aren't relevant in your environment.
@@ -316,10 +312,6 @@ endif::apm-server[]
 {kib} users typically need to view dashboards and visualizations that contain
 {beatname_uc} data. These users might also need to create and edit dashboards
 and visualizations.
-ifdef::has_central_config[]
-If you're using Beats central management, some of these users might need to
-create and manage configurations.
-endif::has_central_config[]
 
 To grant users the required privileges:
 
@@ -356,12 +348,6 @@ users who need to read {beatname_uc} data:
 | `monitoring_user`
 | Allow users to monitor the health of {beatname_uc} itself. Only assign this role to users who manage {beatname_uc}.
 
-ifdef::has_central_config[]
-|`beats_admin`
-|Create and manage configurations in Beats central management. Only assign this
-role to users who need to use Beats central management.
-+
-endif::[]
 |====
 endif::apm-server[]
 

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -71,6 +71,11 @@ we've provided a migration tool to help you migrate your configurations from
 version 6.6 to 6.7 or later. For more information, see the
 https://www.elastic.co/blog/beats-6-7-0-released[Beats 6.7.0 release blog].
 
+NOTE: {beats} central management has been removed starting in version 7.14.0.
+Looking for a replacement? Refer to the
+{fleet-guide}/index.html[Fleet User Guide] to learn how to deploy and centrally
+manage a single {agent} to monitor and secure each host. 
+
 ==== Upgrade {beats} binaries to 7.0
 
 Before upgrading:

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -17,7 +17,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: beats/{beatname_lc}
 :beat_default_index_prefix: {beatname_lc}
 :beat_kib_app: {kib} Metrics
-:has_central_config:
 :has_solutions:
 :has_docker_label_ex:
 :has_modules_command:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove all docs about  Beats central management (#26399)