### PR TITLE
Osquerybeat: Set the raw index name to suppress the timestamp suffix

### DIFF
--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/beat/events"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors"
@@ -430,7 +431,7 @@ func (bt *osquerybeat) publishEvents(index, actionID, responseID string, hits []
 			event.Fields["response_id"] = responseID
 		}
 		if index != "" {
-			event.Meta = common.MapStr{"index": index}
+			event.Meta = common.MapStr{events.FieldMetaRawIndex: index}
 		}
 
 		bt.client.Publish(event)


### PR DESCRIPTION
## What does this PR do?

Set the raw index name to suppress the timestamp suffix
This fixes the issue where the osquerybeat can't create the index for the result data, due to recent permissions tightening in kibana:
```
(status=403): {\"type\":\"security_exception\",\"reason\":\"action [indices:admin/auto_create] is unauthorized for API key id [uEnGPnoB_V-56sCMhHs-] of user [elastic] on indices [logs-osquery_manager.result-default-2021.06.24], this action is granted by the index privileges [auto_configure,create_index,manage,all]\"}
```

Also eliminates the need for special casing for osquerybeat https://github.com/elastic/kibana/pull/103319.

Based on discussion:
https://groups.google.com/a/elastic.co/g/agent-team/c/Syc0bE12aK4/m/uuYWmILkBgAJ

## Why is it important?

Fixes the breakage due to permissions tightening in kibana.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

