### PR TITLE
Cherry-pick #26520 to 7.x: Improper casting of int64

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/transpiler/ast.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/ast.go
@@ -716,8 +716,10 @@ func load(val reflect.Value) (Node, error) {
 		return loadSliceOrArray(val)
 	case reflect.String:
 		return &StrVal{value: val.Interface().(string)}, nil
-	case reflect.Int, reflect.Int64:
+	case reflect.Int:
 		return &IntVal{value: val.Interface().(int)}, nil
+	case reflect.Int64:
+		return &IntVal{value: int(val.Interface().(int64))}, nil
 	case reflect.Uint:
 		return &UIntVal{value: uint64(val.Interface().(uint))}, nil
 	case reflect.Uint64:

--- a/x-pack/elastic-agent/pkg/agent/transpiler/ast_test.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/ast_test.go
@@ -105,6 +105,7 @@ func TestAST(t *testing.T) {
 		"support integers": {
 			hashmap: map[string]interface{}{
 				"timeout": 12,
+				"zero":    int64(0),
 				"range":   []int{20, 30, 40},
 			},
 			ast: &AST{
@@ -121,6 +122,7 @@ func TestAST(t *testing.T) {
 							),
 						},
 						&Key{name: "timeout", value: &IntVal{value: 12}},
+						&Key{name: "zero", value: &IntVal{value: 0}},
 					},
 				},
 			},


### PR DESCRIPTION
Cherry-pick of PR #26520 to 7.13 branch. Original message:

## What does this PR do?

When int64 is encountered during load agent crashes on improper casting. 
Decision tree is updated so it casts correctly

## Why is it important?

Bug

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
