### PR TITLE
Cherry-pick #26439 to 7.x: Enable configuring monitoring namespace 

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -116,4 +116,5 @@
 - Use `filestream` input for internal log collection. {pull}25660[25660]
 - Enable agent to send custom headers to kibana/ES {pull}26275[26275]
 - Set `agent.id` to the Fleet Agent ID in events published from inputs backed by Beats. {issue}21121[21121] {pull}26394[26394]
+- Enable configuring monitoring namespace {issue}26439[26439]
 - Communicate with Fleet Server over HTTP2. {pull}26474[26474]

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/modifiers/monitoring_decorator.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/modifiers/monitoring_decorator.go
@@ -49,6 +49,7 @@ func InjectMonitoring(agentInfo *info.AgentInfo, outputGroup string, rootAst *tr
 			transpiler.NewKey("logs", transpiler.NewBoolVal(true)),
 			transpiler.NewKey("metrics", transpiler.NewBoolVal(true)),
 			transpiler.NewKey("use_output", transpiler.NewStrVal("default")),
+			transpiler.NewKey("namespace", transpiler.NewStrVal("default")),
 		})
 
 		transpiler.Insert(rootAst, transpiler.NewKey("monitoring", monitoringNode), "settings")

--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring_test.go
@@ -215,6 +215,9 @@ func (b *testMonitor) Reload(cfg *config.Config) error { return nil }
 // IsMonitoringEnabled returns true if monitoring is configured.
 func (b *testMonitor) IsMonitoringEnabled() bool { return b.monitorLogs || b.monitorMetrics }
 
+// MonitoringNamespace returns monitoring namespace configured.
+func (b *testMonitor) MonitoringNamespace() string { return "default" }
+
 // WatchLogs return true if monitoring is configured and monitoring logs is enabled.
 func (b *testMonitor) WatchLogs() bool { return b.monitorLogs }
 

--- a/x-pack/elastic-agent/pkg/agent/program/program_test.go
+++ b/x-pack/elastic-agent/pkg/agent/program/program_test.go
@@ -383,6 +383,10 @@ func TestConfiguration(t *testing.T) {
 		empty    bool
 		err      bool
 	}{
+		"namespace": {
+			programs: []string{"filebeat", "fleet-server", "heartbeat", "metricbeat", "endpoint", "packetbeat"},
+			expected: 6,
+		},
 		"single_config": {
 			programs: []string{"filebeat", "fleet-server", "heartbeat", "metricbeat", "endpoint", "packetbeat"},
 			expected: 6,

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-endpoint-security.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-endpoint-security.yml
@@ -1,0 +1,114 @@
+fleet:
+  enabled: true
+  access_api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+  protocol: https
+  hosts: [ localhost:5601 ]
+  timeout: 30s
+  agent:
+    id: fleet-agent-id
+    logging.level: error
+  host:
+    id: host-agent-id
+
+output:
+  elasticsearch:
+    hosts:
+      - "127.0.0.1:9200"
+      - "127.0.0.1:9300"
+    namespace: test_namespace
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=
+
+inputs:
+- id: endpoint-id
+  type: endpoint
+  name: endpoint-1
+  enabled: true
+  package:
+    name: endpoint
+    version: 0.3.0
+  data_stream:
+    namespace: default
+  artifact_manifest:
+    schema_version: v22
+    manifest_version: v21
+    artifacts:
+      - endpoint-allowlist-windows:
+          sha256: 1234
+          size: 2
+          url: /relative/path/to/endpoint-allowlist-windows
+      - endpoint-allowlist-macos:
+          sha256: 1234
+          size: 2
+          url: /relative/path/to/endpoint-allowlist-macos
+      - endpoint-allowlist-linux:
+          sha256: 1234
+          size: 2
+          url: /relative/path/to/endpoint-allowlist-linux
+  policy:
+    linux:
+      advanced:
+        free-form: free-form-value
+      indices:
+        network: logs-endpoint.events.network-default
+        file: logs-endpoint.events.file-default
+        process: logs-endpoint.events.process-default
+        metadata: metrics-endpoint.metadata-default
+        policy: metrics-endpoint.policy-default
+        telemetry: metrics-endpoint.telemetry-default
+      logging:
+        file: info
+        stdout: debug
+      events:
+        process: true
+        file: true
+        network: true
+    windows:
+      malware:
+        mode: prevent
+      advanced:
+        free-form: free-form-value
+      indices:
+        network: logs-endpoint.events.network-default
+        file: logs-endpoint.events.file-default
+        registry: logs-endpoint.events.registry-default
+        process: logs-endpoint.events.process-default
+        driver: logs-endpoint.events.driver-default
+        library: logs-endpoint.events.library-default
+        alerts: logs-endpoint.alerts-default
+        metadata: metrics-endpoint.metadata-default
+        policy: metrics-endpoint.policy-default
+        telemetry: metrics-endpoint.telemetry-default
+      logging:
+        file: info
+        stdout: debug
+      events:
+        registry: true
+        process: true
+        security: true
+        file: true
+        dns: false
+        dll_and_driver_load: false
+        network: true
+    mac:
+      malware:
+        mode: prevent
+      advanced:
+        free-form: free-form-value
+      indices:
+        network: logs-endpoint.events.network-default
+        file: logs-endpoint.events.file-default
+        process: logs-endpoint.events.process-default
+        alerts: logs-endpoint.alerts-default
+        metadata: metrics-endpoint.metadata-default
+        policy: metrics-endpoint.policy-default
+        telemetry: metrics-endpoint.telemetry-default
+      logging:
+        file: info
+        stdout: debug
+      events:
+        process: true
+        file: true
+        network: true

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-filebeat.yml
@@ -1,0 +1,68 @@
+filebeat:
+  inputs:
+  - type: log
+    paths:
+      - /var/log/hello1.log
+      - /var/log/hello2.log
+    index: logs-generic-default
+    vars:
+      var: value
+    processors:
+      - add_fields:
+          target: "data_stream"
+          fields:
+            type: logs
+            dataset: generic
+            namespace: default
+      - add_fields:
+          target: "event"
+          fields:
+            dataset: generic
+      - add_fields:
+          target: "elastic_agent"
+          fields:
+            id: agent-id
+            version: 8.0.0
+            snapshot: false
+      - add_fields:
+          target: "agent"
+          fields:
+            id: agent-id
+  - type: log
+    paths:
+      - /var/log/hello3.log
+      - /var/log/hello4.log
+    index: testtype-generic-default
+    vars:
+      var: value
+    processors:
+      - add_fields:
+          target: "data_stream"
+          fields:
+            type: testtype
+            dataset: generic
+            namespace: default
+      - add_fields:
+          target: "event"
+          fields:
+            dataset: generic
+      - add_fields:
+          target: "elastic_agent"
+          fields:
+            id: agent-id
+            version: 8.0.0
+            snapshot: false
+      - add_fields:
+          target: "agent"
+          fields:
+            id: agent-id
+output:
+  elasticsearch:
+    hosts:
+      - 127.0.0.1:9200
+      - 127.0.0.1:9300
+    namespace: test_namespace
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-fleet-server.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-fleet-server.yml
@@ -1,0 +1,16 @@
+fleet:
+  agent:
+    id: fleet-agent-id
+    logging.level: error
+  host:
+    id: host-agent-id
+
+output:
+  elasticsearch:
+    hosts: [ 127.0.0.1:9200, 127.0.0.1:9300 ]
+    username: fleet
+    password: fleetpassword
+
+inputs:
+  - id: fleet-server-id
+    type: fleet-server

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-heartbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-heartbeat.yml
@@ -1,0 +1,30 @@
+inputs:
+- type: synthetics/http
+  id: unique-http-id
+  name: my-http
+  schedule: '*/5 * * * * * *'
+  host: "http://localhost:80/service/status"
+  timeout: 16s
+  wait: 1s
+  data_stream.namespace: default
+  processors:
+    - add_fields:
+        target: 'elastic_agent'
+        fields:
+          id: agent-id
+          version: 8.0.0
+          snapshot: false
+    - add_fields:
+        target: 'agent'
+        fields:
+          id: agent-id
+output:
+  elasticsearch:
+    hosts:
+      - 127.0.0.1:9200
+      - 127.0.0.1:9300
+    namespace: test_namespace
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-metricbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-metricbeat.yml
@@ -1,0 +1,88 @@
+metricbeat:
+  modules:
+  - module: docker
+    metricsets: [status]
+    index: metrics-docker.status-default
+    hosts: ["http://127.0.0.1:8080"]
+    processors:
+    - add_fields:
+        target: "data_stream"
+        fields:
+          type: metrics
+          dataset: docker.status
+          namespace: default
+    - add_fields:
+        target: "event"
+        fields:
+          dataset: docker.status
+    - add_fields:
+        target: "elastic_agent"
+        fields:
+          id: agent-id
+          version: 8.0.0
+          snapshot: false
+    - add_fields:
+        target: "agent"
+        fields:
+          id: agent-id
+  - module: docker
+    metricsets: [info]
+    index: metrics-generic-default
+    hosts: ["http://127.0.0.1:8080"]
+    processors:
+    - add_fields:
+        target: "data_stream"
+        fields:
+          type: metrics
+          dataset: generic
+          namespace: default
+    - add_fields:
+        target: "event"
+        fields:
+          dataset: generic
+    - add_fields:
+        target: "elastic_agent"
+        fields:
+          id: agent-id
+          version: 8.0.0
+          snapshot: false
+    - add_fields:
+        target: "agent"
+        fields:
+          id: agent-id
+  - module: apache
+    metricsets: [info]
+    index: metrics-generic-testing
+    hosts: ["http://apache.remote"]
+    processors:
+      - add_fields:
+          fields:
+            should_be: first
+      - add_fields:
+          target: "data_stream"
+          fields:
+            type: metrics
+            dataset: generic
+            namespace: testing
+      - add_fields:
+          target: "event"
+          fields:
+            dataset: generic
+      - add_fields:
+          target: "elastic_agent"
+          fields:
+            id: agent-id
+            version: 8.0.0
+            snapshot: false
+      - add_fields:
+          target: "agent"
+          fields:
+            id: agent-id
+output:
+  elasticsearch:
+    hosts: [127.0.0.1:9200, 127.0.0.1:9300]
+    namespace: test_namespace
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-packetbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-packetbeat.yml
@@ -1,0 +1,35 @@
+inputs:
+- type: packet
+  processors:
+    - add_fields:
+        target: 'elastic_agent'
+        fields:
+          id: agent-id
+          version: 8.0.0
+          snapshot: false
+    - add_fields:
+        target: 'agent'
+        fields:
+          id: agent-id
+  streams:
+  - type: flow
+    timeout: 10s
+    period: 10s
+    keep_null: false
+    data_stream:
+      dataset: packet.flow
+      type: logs
+  - type: icmp
+    data_stream:
+      dataset: packet.icmp
+      type: logs
+output:
+  elasticsearch:
+    hosts:
+      - 127.0.0.1:9200
+      - 127.0.0.1:9300
+    namespace: test_namespace
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace.yml
@@ -1,0 +1,201 @@
+name: Production Website DB Servers
+fleet:
+  enabled: true
+  access_api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+  protocol: https
+  hosts: [ localhost:5601 ]
+  timeout: 30s
+  agent:
+    id: fleet-agent-id
+    logging.level: error
+  host:
+    id: host-agent-id
+  server:
+    output:
+      elasticsearch:
+        hosts: [ 127.0.0.1:9200, 127.0.0.1:9300 ]
+        username: fleet
+        password: fleetpassword
+
+outputs:
+  default:
+    type: elasticsearch
+    namespace: test_namespace
+    hosts: [127.0.0.1:9200, 127.0.0.1:9300]
+    username: elastic
+    password: changeme
+    api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+    ca_sha256: 7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=
+
+  monitoring:
+    type: elasticsearch
+    api_key: VuaCfGcBCdbkQm-e5aOx:ui2lp2axTNmsyakw9tvNnw
+    hosts: ["monitoring:9200"]
+    ca_sha256: "7lHLiyp4J8m9kw38SJ7SURJP4bXRZv/BNxyyXkCcE/M="
+
+inputs:
+- id: fleet-server-id
+  type: fleet-server
+  use_output: default
+  data_stream:
+    type: default
+- type: docker/metrics
+  use_output: default
+  streams:
+    - metricset: status
+      processors:
+      - null
+      data_stream:
+        dataset: docker.status
+    - metricset: info
+      data_stream:
+        dataset: ""
+  hosts: ["http://127.0.0.1:8080"]
+- type: logfile
+  use_output: default
+  streams:
+    - paths:
+      - /var/log/hello1.log
+      - /var/log/hello2.log
+  vars:
+    var: value
+- type: logfile
+  data_stream:
+    type: testtype
+  use_output: default
+  streams:
+    - paths:
+      - /var/log/hello3.log
+      - /var/log/hello4.log
+  vars:
+    var: value
+- id: apache-metrics-id
+  type: apache/metrics
+  data_stream:
+    namespace: testing
+  use_output: default
+  processors:
+    - add_fields:
+        fields:
+          should_be: first
+  streams:
+    - enabled: true
+      metricset: info
+      hosts: ["http://apache.remote"]
+  hosts: ["http://apache.local"]
+- type: synthetics/http
+  id: unique-http-id
+  name: my-http
+  schedule: '*/5 * * * * * *'
+  host: "http://localhost:80/service/status"
+  timeout: 16s
+  wait: 1s
+- type: packet
+  streams:
+    - type: flow
+      timeout: 10s
+      period: 10s
+      keep_null: false
+      data_stream:
+        dataset: packet.flow
+        type: logs
+    - type: icmp
+      data_stream:
+        dataset: packet.icmp
+        type: logs
+- id: endpoint-id
+  type: endpoint
+  name: endpoint-1
+  enabled: true
+  package:
+    name: endpoint
+    version: 0.3.0
+  data_stream:
+    namespace: default
+  artifact_manifest:
+    schema_version: v22
+    manifest_version: v21
+    artifacts:
+      - endpoint-allowlist-windows:
+          sha256: 1234
+          size: 2
+          url: /relative/path/to/endpoint-allowlist-windows
+      - endpoint-allowlist-macos:
+          sha256: 1234
+          size: 2
+          url: /relative/path/to/endpoint-allowlist-macos
+      - endpoint-allowlist-linux:
+          sha256: 1234
+          size: 2
+          url: /relative/path/to/endpoint-allowlist-linux
+  policy:
+    linux:
+      advanced:
+        free-form: free-form-value
+      indices:
+        network: logs-endpoint.events.network-default
+        file: logs-endpoint.events.file-default
+        process: logs-endpoint.events.process-default
+        metadata: metrics-endpoint.metadata-default
+        policy: metrics-endpoint.policy-default
+        telemetry: metrics-endpoint.telemetry-default
+      logging:
+        file: info
+        stdout: debug
+      events:
+        process: true
+        file: true
+        network: true
+    windows:
+      malware:
+        mode: prevent
+      advanced:
+        free-form: free-form-value
+      indices:
+        network: logs-endpoint.events.network-default
+        file: logs-endpoint.events.file-default
+        registry: logs-endpoint.events.registry-default
+        process: logs-endpoint.events.process-default
+        driver: logs-endpoint.events.driver-default
+        library: logs-endpoint.events.library-default
+        alerts: logs-endpoint.alerts-default
+        metadata: metrics-endpoint.metadata-default
+        policy: metrics-endpoint.policy-default
+        telemetry: metrics-endpoint.telemetry-default
+      logging:
+        file: info
+        stdout: debug
+      events:
+        registry: true
+        process: true
+        security: true
+        file: true
+        dns: false
+        dll_and_driver_load: false
+        network: true
+    mac:
+      malware:
+        mode: prevent
+      advanced:
+        free-form: free-form-value
+      indices:
+        network: logs-endpoint.events.network-default
+        file: logs-endpoint.events.file-default
+        process: logs-endpoint.events.process-default
+        alerts: logs-endpoint.alerts-default
+        metadata: metrics-endpoint.metadata-default
+        policy: metrics-endpoint.policy-default
+        telemetry: metrics-endpoint.telemetry-default
+      logging:
+        file: info
+        stdout: debug
+      events:
+        process: true
+        file: true
+        network: true
+
+agent.monitoring:
+  use_output: monitoring
+
+agent:
+  reload: 123

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
@@ -21,6 +21,7 @@ import (
 )
 
 const httpPlusPrefix = "http+"
+const defaultMonitoringNamespace = "default"
 
 // Monitor is a monitoring interface providing information about the way
 // how beat is monitored
@@ -68,6 +69,14 @@ func (b *Monitor) Close() {
 
 // IsMonitoringEnabled returns true if monitoring is enabled.
 func (b *Monitor) IsMonitoringEnabled() bool { return b.config.Enabled }
+
+// MonitoringNamespace returns monitoring namespace configured.
+func (b *Monitor) MonitoringNamespace() string {
+	if b.config.Namespace == "" {
+		return defaultMonitoringNamespace
+	}
+	return b.config.Namespace
+}
 
 // WatchLogs returns true if monitoring is enabled and monitor should watch logs.
 func (b *Monitor) WatchLogs() bool { return b.config.Enabled && b.config.MonitorLogs }

--- a/x-pack/elastic-agent/pkg/core/monitoring/config/config.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/config/config.go
@@ -5,6 +5,7 @@
 package config
 
 const defaultPort = 6791
+const defaultNamespace = "default"
 
 // MonitoringConfig describes a configuration of a monitoring
 type MonitoringConfig struct {
@@ -12,6 +13,7 @@ type MonitoringConfig struct {
 	MonitorLogs    bool                  `yaml:"logs" config:"logs"`
 	MonitorMetrics bool                  `yaml:"metrics" config:"metrics"`
 	HTTP           *MonitoringHTTPConfig `yaml:"http" config:"http"`
+	Namespace      string                `yaml:"namespace" config:"namespace"`
 }
 
 // MonitoringHTTPConfig is a config defining HTTP endpoint published by agent
@@ -33,5 +35,6 @@ func DefaultConfig() *MonitoringConfig {
 			Enabled: false,
 			Port:    defaultPort,
 		},
+		Namespace: defaultNamespace,
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/monitoring/monitor.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/monitor.go
@@ -23,6 +23,7 @@ type Monitor interface {
 	Cleanup(spec program.Spec, pipelineID string) error
 	Reload(cfg *config.Config) error
 	IsMonitoringEnabled() bool
+	MonitoringNamespace() string
 	WatchLogs() bool
 	WatchMetrics() bool
 	Close()

--- a/x-pack/elastic-agent/pkg/core/monitoring/noop/noop_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/noop/noop_monitor.go
@@ -66,3 +66,6 @@ func (b *Monitor) WatchLogs() bool { return false }
 
 // WatchMetrics return true if monitoring is configured and monitoring metrics is enabled.
 func (b *Monitor) WatchMetrics() bool { return false }
+
+// MonitoringNamespace returns monitoring namespace configured.
+func (b *Monitor) MonitoringNamespace() string { return "default" }


### PR DESCRIPTION
Cherry-pick of PR #26439 to 7.13 branch. Original message:

## What does this PR do?

This PR adds a config option which is used as monitoring namespace. 
This namespace is injected to `data_stream` section of the event and alters index name as well following our naming convention. 

Config option is also reloadable and will be applied on change without a need of restarting agent

## Why is it important?

Fixes: #25350

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
