### PR TITLE
macos for metricbeat to run in the extended meta-stage

### DIFF
--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -48,6 +48,7 @@ stages:
                 - "macosTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
+        stage: extended
     windows:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

Cosmetic change to run the `macos` for metricbeats in the extended stage since it runs as part of the linting stage instead.

## Why is it important?

Semantic