### PR TITLE
Packaging: add armv7 platform in the main pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -353,9 +353,9 @@ def packagingLinux(Map args = [:]) {
                 'linux/amd64',
                 'linux/386',
                 'linux/arm64',
+                'linux/armv7',
                 // The platforms above are disabled temporarly as crossbuild images are
                 // not available. See: https://github.com/elastic/golang-crossbuild/issues/71
-                //'linux/armv7',
                 //'linux/ppc64le',
                 //'linux/mips64',
                 //'linux/s390x',


### PR DESCRIPTION
## What does this PR do?

Align the platforms defined in the `.ci/packaging.groovy` in the `Jenkinsfile`

## Why is it important?

Missed platform 