### PR TITLE
Cherry-pick to master: Update to "read_pipeline" permission (#26465)

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -266,7 +266,7 @@ endif::no_ilm[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
 |Cluster
-|`cluster:admin/ingest/pipeline/get`
+|`read_pipeline`
 |Check for ingest pipelines used by modules. Needed when using modules.
 endif::[]
 


### PR DESCRIPTION
Backports the following commits to master:
 - Update to "read_pipeline" permission (#26465)