### PR TITLE
Cherry-pick to master: API keys do not reflect the need for read_pipeline (#26466)

### DIFF
--- a/libbeat/docs/security/api-keys.asciidoc
+++ b/libbeat/docs/security/api-keys.asciidoc
@@ -29,7 +29,7 @@ POST /_security/api_key
   "name": "{beat_default_index_prefix}_host001", <1>
   "role_descriptors": {
     "{beat_default_index_prefix}_writer": { <2>
-      "cluster": ["monitor", "read_ilm"],
+      "cluster": ["monitor", "read_ilm", "read_pipeline"],
       "index": [
         {
           "names": ["{beat_default_index_prefix}-*"],


### PR DESCRIPTION
Backports the following commits to master:
 - API keys do not reflect the need for read_pipeline (#26466)