### PR TITLE
[Heartbeat] Skip flakey timer queue test

### DIFF
--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -20,7 +20,6 @@ package timerqueue
 import (
 	"context"
 	"math/rand"
-	"runtime"
 	"sort"
 	"testing"
 	"time"
@@ -29,9 +28,7 @@ import (
 )
 
 func TestQueueRunsInOrder(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky test on windows: https://github.com/elastic/beats/issues/26205")
-	}
+	t.Skip("flaky test on windows: https://github.com/elastic/beats/issues/26205")
 	// Bugs can show up only occasionally
 	for i := 0; i < 100; i++ {
 		testQueueRunsInOrderOnce(t)


### PR DESCRIPTION
Addresses the flakey test failure mentioned in https://github.com/elastic/beats/issues/26205#issuecomment-870741053

We're skipping for now, but we need to fix this in the future.