### PR TITLE
[Filebeat] Make set processor with copy_from compatible with ES < 7.13

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -280,6 +280,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix bug in `httpjson` that prevented `first_event` getting updated. {pull}26407[26407]
 - Fix bug in the Syslog input that misparsed rfc5424 days starting with 0. {pull}26419[26419]
 - Do not close filestream harvester if an unexpected error is returned when close.on_state_change.* is enabled. {pull}26411[26411]
+- Fix module pipeline compatability for Elasticsearch versions less than 7.13.0 in modules that use Ingest Node `set` processors with `copy_from`. {pull}26593[26593]
 
 *Filebeat*
 


### PR DESCRIPTION
## What does this PR do?

Automatically rewrite Ingest Node `set` processors that use `copy_from` when connected to
Elasticsearch versions less than 7.13. The copy_from is replaced with `{{{$copy_from value}}}`.
The triple brace ensures the behavior is the same as copy_from in that no escaping is added.

## Why is it important?

Ensures compatibility with earlier ES versions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

