### PR TITLE
Skip flaky test TestFilestreamMetadataUpdatedOnRename

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -80,6 +80,8 @@ func TestFilestreamCloseRenamed(t *testing.T) {
 }
 
 func TestFilestreamMetadataUpdatedOnRename(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/26608")
+
 	if runtime.GOOS == "windows" {
 		t.Skip("renaming files while Filebeat is running is not supported on Windows")
 	}


### PR DESCRIPTION
Skip flaky test, see https://github.com/elastic/beats/issues/26608