### PR TITLE
cyberarkpas: Link to official docs on how to setup syslog over TLS

### DIFF
--- a/filebeat/docs/modules/cyberarkpas.asciidoc
+++ b/filebeat/docs/modules/cyberarkpas.asciidoc
@@ -83,8 +83,9 @@ protocol connections from all interfaces:
     # var.paths:
 ----
 
-For encrypted communications, use the `TLS` protocol in the Vault's `DBPARM.ini` and use `tcp` input
-with `var.ssl` settings in Filebeat:
+For encrypted communications, follow the
+https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/PASIMP/DV-Integrating-with-SIEM-Applications.htm#ConfigureSIEMintegration[CyberArk documentation]
+to configure encrypted protocol in the Vault server and use `tcp` input with `var.ssl` settings in Filebeat:
 
 [source,yaml]
 ----

--- a/x-pack/filebeat/module/cyberarkpas/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cyberarkpas/_meta/docs.asciidoc
@@ -78,8 +78,9 @@ protocol connections from all interfaces:
     # var.paths:
 ----
 
-For encrypted communications, use the `TLS` protocol in the Vault's `DBPARM.ini` and use `tcp` input
-with `var.ssl` settings in Filebeat:
+For encrypted communications, follow the
+https://docs.cyberark.com/Product-Doc/OnlineHelp/PAS/Latest/en/Content/PASIMP/DV-Integrating-with-SIEM-Applications.htm#ConfigureSIEMintegration[CyberArk documentation]
+to configure encrypted protocol in the Vault server and use `tcp` input with `var.ssl` settings in Filebeat:
 
 [source,yaml]
 ----


### PR DESCRIPTION
## What does this PR do?

Update Filebeat's cyberarkpas module docs to include a link CyberArk's documentation on how to set up encrypted syslog.

## Why is it important?

Better to link to the official docs instead of provide a short explanation that doesn't cover all cases.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Screenshots

Before:

<img width="758" alt="Screen Shot 2021-06-30 at 16 36 09" src="https://user-images.githubusercontent.com/15056957/123980489-dfb48f80-d9c1-11eb-8103-fc122bf252d4.png">

After:

<img width="791" alt="Screen Shot 2021-06-30 at 16 35 54" src="https://user-images.githubusercontent.com/15056957/123980537-e9d68e00-d9c1-11eb-9499-502ca2a05ad5.png">
