### PR TITLE
[Metricbeat] Fix jvm old / young collector

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -103,6 +103,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove `index_stats.created` field from Elasticsearch/index Metricset {pull}25113[25113]
 - Adjust host fields to adopt new names from 1.9.0 ECS. {pull}24312[24312]
 - Add replicas.ready field to state_statefulset in Kubernetes module{pull}26088[26088]
+- Fix Elasticsearch jvm.gc.collectors.old being exposed as young {issue}19636[19636] {pull}26616[26616]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -134,7 +134,7 @@ var (
 						"collection_count":          c.Int("collection_count"),
 						"collection_time_in_millis": c.Int("collection_time_in_millis"),
 					}),
-					"old": c.Dict("young", s.Schema{
+					"old": c.Dict("old", s.Schema{
 						"collection_count":          c.Int("collection_count"),
 						"collection_time_in_millis": c.Int("collection_time_in_millis"),
 					}),


### PR DESCRIPTION
A field on node stats metricset had a wrong value. It was fixed in master along many other changes so it has been done here for compatibility too