### PR TITLE
[CI] fight the flakiness with some retry option in the CI only for the Pull Requests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,12 @@
 
 @Library('apm@current') _
 
+def numberOfRetries = 1
+// Only Pull Requests can rerun the build&test stages
+if (env.CHANGE_ID?.trim()) {
+    numberOfRetries = 3
+}
+
 pipeline {
   agent { label 'ubuntu-18 && immutable' }
   environment {
@@ -101,7 +107,10 @@ pipeline {
       }
     }
     stage('Build&Test') {
-      options { skipDefaultCheckout() }
+      options {
+        skipDefaultCheckout()
+        retry(numberOfRetries)
+      }
       when {
         // Always when running builds on branches/tags
         // On a PR basis, skip if changes are only related to docs.
@@ -120,7 +129,10 @@ pipeline {
       }
     }
     stage('Extended') {
-      options { skipDefaultCheckout() }
+      options {
+        skipDefaultCheckout()
+        retry(numberOfRetries)
+      }
       when {
         // Always when running builds on branches/tags
         // On a PR basis, skip if changes are only related to docs.


### PR DESCRIPTION
## What does this PR do?

A declarative approach instead a hacking approach.

## Why is it important?

Retry stages that failed for some flakiness, this is normally happening in the stages that are running on Windows or on Mac.

This approach works quite well with the feature we added back in the days with https://github.com/elastic/beats/pull/24780 . Since the caching happens in the dynamic stages, and the retry option in the static stages.

## Issues

Supersedes https://github.com/elastic/beats/pull/26574