### PR TITLE
[automation] update elastic stack version for testing 7.13.3-dbdefa2a

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.13.3-280f3dca-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.13.3-dbdefa2a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -15,7 +15,7 @@ services:
     - "http.host=0.0.0.0"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.13.3-280f3dca-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.13.3-dbdefa2a-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -25,7 +25,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.13.3-280f3dca-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.13.3-dbdefa2a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3-280f3dca-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3-dbdefa2a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -19,7 +19,7 @@ services:
     - "ingest.geoip.downloader.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.13.3-280f3dca-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.13.3-dbdefa2a-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -29,7 +29,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.13.3-280f3dca-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.13.3-dbdefa2a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 30 Jun 2021 12:16:03 GMT, release_branch:7.13, prefix:, end_time:Wed, 30 Jun 2021 17:13:44 GMT, manifest_version:2.0.0, version:7.13.3-SNAPSHOT, branch:7.13, build_id:7.13.3-dbdefa2a, build_duration_seconds:17861]