### PR TITLE
upstream.response.status_code handling fix

### DIFF
--- a/filebeat/module/nginx/ingress_controller/ingest/pipeline.yml
+++ b/filebeat/module/nginx/ingress_controller/ingest/pipeline.yml
@@ -125,7 +125,7 @@ processors:
           ctx.nginx.ingress_controller.upstream.response.status_code = last_status_code;
         }
         catch (Exception e) {
-          ctx.nginx.ingress_controller.upstream.response.time = null;
+          ctx.nginx.ingress_controller.upstream.response.status_code = null;
         }
   - script:
       if: ctx.nginx?.ingress_controller?.upstream_address_list != null && ctx.nginx.ingress_controller.upstream_address_list.length > 0


### PR DESCRIPTION
Apparently there was a copy & paste issue in the modified line.
Please reject if you believe we are mistaken :)

## What does this PR do?

Fixes a copy&paste issue on the nginx module --> ingest_controller fileset pipeline
