### PR TITLE
[mergify] automate PRs that change the backport rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -119,6 +119,17 @@ pull_request_rules:
           - "7.14"
         labels:
           - "backport"
+  - name: automatic approval for mergify pull requests with changes in bump-rules
+    conditions:
+      - author=mergify[bot]
+      - check-success=beats-ci/pr-merge
+      - label=automation
+      - files~=^\.mergify\.yml$
+      - head~=^add-backport-next.*
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving mergify
   - name: automatic squash and merge with success checks and the files matching the regex ^.mergify.yml is modified.
     conditions:
       - check-success=beats-ci/pr-merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -103,7 +103,7 @@ pull_request_rules:
       - and:
         - label=automation
         - head~=^update-go-version
-        - files~=^.go-version$
+        - files~=^\.go-version$
     actions:
       delete_head_branch:
   - name: backport patches to 7.14 branch
@@ -119,3 +119,24 @@ pull_request_rules:
           - "7.14"
         labels:
           - "backport"
+  - name: automatic squash and merge with success checks and the files matching the regex ^.mergify.yml is modified.
+    conditions:
+      - check-success=beats-ci/pr-merge
+      - label=automation
+      - files~=^\.mergify\.yml$
+      - head~=^add-backport-next.*
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+  - name: delete upstream branch with changes on ^.mergify.yml that has been merged or closed
+    conditions:
+      - or:
+        - merged
+        - closed
+      - and:
+        - label=automation
+        - head~=^add-backport-next.*
+        - files~=^\.mergify\.yml$
+    actions:
+      delete_head_branch:


### PR DESCRIPTION
## What does this PR do?

Delegate the auto-merge for all the PRs that change the backport rules in the mergify. For such, it's also required the auto-review, since the branch protection does not allow to merge automatically.

For instance, https://github.com/elastic/beats/pull/26620 is the candidate to be automatically merged.

## Why is it important?

https://github.com/elastic/beats/pull/26561#issuecomment-872058561