### PR TITLE
[fix][metricbeat] Change default value for server_status_path in nginx module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -514,6 +514,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix aws metric tags with resourcegroupstaggingapi paginator.  {issue}26385[26385] {pull}26443[26443]
 - Fix quoting in GCP billing table name  {issue}26855[26855] {pull}26870[26870]
 - Allow metric prefix override per service in gcp module. {pull}26960[26960]
+- Change `server_status_path` default setting to `nginx_status` for the `nginx` module. {pull}26642[26642]
 
 *Packetbeat*
 

--- a/metricbeat/module/nginx/_meta/Dockerfile
+++ b/metricbeat/module/nginx/_meta/Dockerfile
@@ -2,5 +2,5 @@ ARG NGINX_VERSION
 FROM nginx:${NGINX_VERSION}
 RUN sed -i "/jessie-updates/d" /etc/apt/sources.list
 RUN apt-get update && apt-get install -y curl
-HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost/server-status
+HEALTHCHECK --interval=1s --retries=90 CMD curl -f http://localhost/nginx_status
 COPY ./nginx.conf /etc/nginx/

--- a/metricbeat/module/nginx/_meta/config.yml
+++ b/metricbeat/module/nginx/_meta/config.yml
@@ -6,8 +6,8 @@
   # Nginx hosts
   hosts: ["http://127.0.0.1"]
 
-  # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  # Path to server status. Default nginx_status
+  #server_status_path: "nginx_status"
 
   #username: "user"
   #password: "secret"

--- a/metricbeat/module/nginx/_meta/nginx.conf
+++ b/metricbeat/module/nginx/_meta/nginx.conf
@@ -24,7 +24,7 @@ http {
         listen 80;
         server_name localhost;
 
-        location /server-status {
+        location /nginx_status {
             stub_status on;
         }
     }

--- a/metricbeat/module/nginx/stubstatus/stubstatus.go
+++ b/metricbeat/module/nginx/stubstatus/stubstatus.go
@@ -33,7 +33,7 @@ const (
 	defaultScheme = "http"
 
 	// defaultPath is the default path to the ngx_http_stub_status_module endpoint on Nginx.
-	defaultPath = "/server-status"
+	defaultPath = "/nginx_status"
 )
 
 var (

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -9,8 +9,8 @@
   # Nginx hosts
   hosts: ["http://127.0.0.1"]
 
-  # Path to server status. Default server-status
-  #server_status_path: "server-status"
+  # Path to server status. Default nginx_status
+  #server_status_path: "nginx_status"
 
   #username: "user"
   #password: "secret"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the default path for the nginx module from `server-status` to `nginx_status`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

If set by default the endpoint will return a 404

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
