### PR TITLE
[mergify] set title and allow bp in any direction

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -109,7 +109,6 @@ pull_request_rules:
   - name: backport patches to 7.14 branch
     conditions:
       - merged
-      - base=master
       - label=backport-v7.14.0
     actions:
       backport:
@@ -119,6 +118,7 @@ pull_request_rules:
           - "7.14"
         labels:
           - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: automatic approval for mergify pull requests with changes in bump-rules
     conditions:
       - author=mergify[bot]


### PR DESCRIPTION
## What does this PR do?

Automated backport rule generation didnt 'have the new changes for the title and the any direction.

## Why is it important?

Normalise the configuration that was done with:
- https://github.com/elastic/beats/pull/25396
- https://github.com/elastic/beats/pull/25787

NOTE: Ideally this particular PR should be automatically merged and the branch deleted 🤞 