### PR TITLE
Cherry-pick #26616 to 6.8.10: [Metricbeat] Fix jvm old / young collector

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -70,19 +70,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Move service config under metrics and simplify metric types. {pull}18691[18691]
 - Fix ECS compliance of user.id field in system/users  metricset {pull}19019[19019]
 - Remove "invalid zero" metrics on Windows and Darwin, don't report linux-only memory and diskio metrics when running under agent. {pull}21457[21457]
-- Change cloud.provider from googlecloud to gcp. {pull}21775[21775]
-- API address and shard ID are required settings in the Cloud Foundry module. {pull}21759[21759]
-- Rename googlecloud module to gcp module. {pull}22246[22246]
-- Use ingress/egress instead of inbound/outbound for system/socket metricset. {pull}22992[22992]
-- Change types of numeric metrics from Kubelet summary api to double so as to cover big numbers. {pull}23335[23335]
-- Add container.image.name and containe.name ECS fields for state_container. {pull}23802[23802]
-- Add support for Consul 1.9. {pull}24123[24123]
-- Add support for the MemoryPressure, DiskPressure, OutOfDisk and PIDPressure status conditions in state_node. {pull}23905[23905]
-- Store `cloudfoundry.container.cpu.pct` in decimal form and as `scaled_float`. {pull}24219[24219]
-- Remove `index_stats.created` field from Elasticsearch/index Metricset {pull}25113[25113]
-- Adjust host fields to adopt new names from 1.9.0 ECS. {pull}24312[24312]
-- Add replicas.ready field to state_statefulset in Kubernetes module{pull}26088[26088]
-- Fix Elasticsearch jvm.gc.collectors.old being exposed as young {issue}19636[19636] {pull}26616[26616]
 
 *Packetbeat*
 
@@ -279,6 +266,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Set tags correctly if the dimension value is ARN {issue}19111[19111] {pull}19433[19433]
 - Fix bug incorrect parsing of float numbers as integers in Couchbase module {issue}18949[18949] {pull}19055[19055]
 - Add missing info about the rest of the azure metricsets in the documentation. {pull}19601[19601]
+- Fix Elasticsearch jvm.gc.collectors.old being exposed as young {issue}19636[19636] {pull}26616[26616]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -69,7 +69,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Tomcat overview dashboard {pull}14026[14026]
 - Move service config under metrics and simplify metric types. {pull}18691[18691]
 - Fix ECS compliance of user.id field in system/users  metricset {pull}19019[19019]
-- Remove "invalid zero" metrics on Windows and Darwin, don't report linux-only memory and diskio metrics when running under agent. {pull}21457[21457]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -69,6 +69,20 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add Tomcat overview dashboard {pull}14026[14026]
 - Move service config under metrics and simplify metric types. {pull}18691[18691]
 - Fix ECS compliance of user.id field in system/users  metricset {pull}19019[19019]
+- Remove "invalid zero" metrics on Windows and Darwin, don't report linux-only memory and diskio metrics when running under agent. {pull}21457[21457]
+- Change cloud.provider from googlecloud to gcp. {pull}21775[21775]
+- API address and shard ID are required settings in the Cloud Foundry module. {pull}21759[21759]
+- Rename googlecloud module to gcp module. {pull}22246[22246]
+- Use ingress/egress instead of inbound/outbound for system/socket metricset. {pull}22992[22992]
+- Change types of numeric metrics from Kubelet summary api to double so as to cover big numbers. {pull}23335[23335]
+- Add container.image.name and containe.name ECS fields for state_container. {pull}23802[23802]
+- Add support for Consul 1.9. {pull}24123[24123]
+- Add support for the MemoryPressure, DiskPressure, OutOfDisk and PIDPressure status conditions in state_node. {pull}23905[23905]
+- Store `cloudfoundry.container.cpu.pct` in decimal form and as `scaled_float`. {pull}24219[24219]
+- Remove `index_stats.created` field from Elasticsearch/index Metricset {pull}25113[25113]
+- Adjust host fields to adopt new names from 1.9.0 ECS. {pull}24312[24312]
+- Add replicas.ready field to state_statefulset in Kubernetes module{pull}26088[26088]
+- Fix Elasticsearch jvm.gc.collectors.old being exposed as young {issue}19636[19636] {pull}26616[26616]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/node_stats/data_xpack.go
+++ b/metricbeat/module/elasticsearch/node_stats/data_xpack.go
@@ -134,7 +134,7 @@ var (
 						"collection_count":          c.Int("collection_count"),
 						"collection_time_in_millis": c.Int("collection_time_in_millis"),
 					}),
-					"old": c.Dict("young", s.Schema{
+					"old": c.Dict("old", s.Schema{
 						"collection_count":          c.Int("collection_count"),
 						"collection_time_in_millis": c.Int("collection_time_in_millis"),
 					}),


### PR DESCRIPTION
Cherry-pick of PR #26616 to 6.8.10 branch. Original message: 

A field on node stats metricset had a wrong value. It was fixed in master along many other changes so it has been done here for compatibility too