### PR TITLE
[Heartbeat] use --params flag for synthetics

### DIFF
--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -118,7 +118,7 @@ func runCmd(
 
 	if len(params) > 0 {
 		paramsBytes, _ := json.Marshal(params)
-		cmd.Args = append(cmd.Args, "--suite-params", string(paramsBytes))
+		cmd.Args = append(cmd.Args, "--params", string(paramsBytes))
 	}
 
 	// We need to pass both files in here otherwise we get a broken pipe, even


### PR DESCRIPTION
+ Synthetics agent deprecated `--suite-params` in favor of `--params`. https://github.com/elastic/synthetics/pull/331
+ We dont have integration tests in beats repo, instead they are on the Synthetics agent repo. 