### PR TITLE
[CI] Archive test output at the end

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -584,6 +584,15 @@ def target(Map args = [:]) {
   def isPackaging = args.get('package', false)
   def dockerArch = args.get('dockerArch', 'amd64')
   def archive = args.get('archive', true)
+
+  // some command don't generate tests so let's skip the archive post stage in this case.
+  // The args.archive takes precedence.
+  if (!args.containsKey('archive')) {
+    if (command.contains('crosscompile') || command.contains('test-package') || command.contains('stress-tests')) {
+      archive = false
+    }
+  }
+
   withNode(labels: args.label, forceWorkspace: true){
     withGithubNotify(context: "${context}") {
       withBeatsEnv(archive: archive, withModule: withModule, directory: directory, id: args.id) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -588,7 +588,7 @@ def target(Map args = [:]) {
   // some command don't generate tests so let's skip the archive post stage in this case.
   // The args.archive takes precedence.
   if (!args.containsKey('archive')) {
-    if (command.contains('crosscompile') || command.contains('test-package') || command.contains('stress-tests')) {
+    if (command.contains('crosscompile') || command.contains('test-package') || command.contains('stress-tests') || context.endsWith('lint')) {
       archive = false
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -583,9 +583,10 @@ def target(Map args = [:]) {
   def isE2E = args.e2e?.get('enabled', false)
   def isPackaging = args.get('package', false)
   def dockerArch = args.get('dockerArch', 'amd64')
+  def archive = args.get('archive', true)
   withNode(labels: args.label, forceWorkspace: true){
     withGithubNotify(context: "${context}") {
-      withBeatsEnv(archive: true, withModule: withModule, directory: directory, id: args.id) {
+      withBeatsEnv(archive: archive, withModule: withModule, directory: directory, id: args.id) {
         dumpVariables()
         // make commands use -C <folder> while mage commands require the dir(folder)
         // let's support this scenario with the location variable.
@@ -1069,7 +1070,8 @@ class RunCommand extends co.elastic.beats.BeatsFunction {
                            id: args.id,
                            e2e: args.content.get('e2e'),
                            package: true,
-                           dockerArch: 'arm64')
+                           dockerArch: 'arm64',
+                           archive: false)
       }
       if(args?.content?.containsKey('packaging-linux')) {
         steps.packagingLinux(context: args.context,
@@ -1080,7 +1082,8 @@ class RunCommand extends co.elastic.beats.BeatsFunction {
                              id: args.id,
                              e2e: args.content.get('e2e'),
                              package: true,
-                             dockerArch: 'amd64')
+                             dockerArch: 'amd64',
+                             archive: false)
       }
       if(args?.content?.containsKey('k8sTest')) {
         steps.k8sTest(context: args.context, versions: args.content.k8sTest.split(','), label: args.label, id: args.id)


### PR DESCRIPTION
## What does this PR do?

Ensure the semantic is correct in terms of the usability and what the CI test reports, and for such, it stores all the test output in Google Cloud to be consumed later on as part of the top-level-post-stage.

Exclude test results for all those stages that don't generate any test output:
- linting
- cross-compile
- stress-test
- packaging

## Why is it important?

Because the `retry` in the CI does not clean the previous test failures for the same stage, but it creates a new stage and therefore it aggregates the test results

For instance:

![image](https://user-images.githubusercontent.com/2871786/124157803-160d1000-da91-11eb-81ee-328061763b3e.png)

produces

![image](https://user-images.githubusercontent.com/2871786/124157921-389f2900-da91-11eb-8e7d-a06b06d33b9b.png)

and the GitHub message produces some incorrect details

![image](https://user-images.githubusercontent.com/2871786/124161902-dbf23d00-da95-11eb-8688-0462808bf71e.png)


## Tests

Google Storage looks like 

![image](https://user-images.githubusercontent.com/2871786/124162511-70f53600-da96-11eb-9bfb-8ac2f5dba0d1.png)

![image](https://user-images.githubusercontent.com/2871786/124162584-85d1c980-da96-11eb-90cd-f1e2ca6d75bc.png)


## Question

- [ ] If test failures, will the pipeline report them correctly if the test output digestion happened in the top-level post-always step? I think so, since, the make/mage goals report `errorlevel` > 0 when there are test failures.
