### PR TITLE
[Build] Disable armv7 packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,7 +365,11 @@ def packagingLinux(Map args = [:]) {
                 'linux/amd64',
                 'linux/386',
                 'linux/arm64',
-                'linux/armv7',
+                // armv7 packaging isn't working, and we don't currently
+                // need it for release. Do not re-enable it without
+                // confirming it is fixed, you will break the packaging
+                // pipeline!
+                //'linux/armv7',
                 // The platforms above are disabled temporarly as crossbuild images are
                 // not available. See: https://github.com/elastic/golang-crossbuild/issues/71
                 //'linux/ppc64le',


### PR DESCRIPTION
## What does this PR do?

Disables the `linux/armv7` platform in the packaging pipeline, since it is currently broken. See https://github.com/elastic/beats/issues/26677.