### PR TITLE
Update change-index-name.asciidoc

### DIFF
--- a/libbeat/docs/howto/change-index-name.asciidoc
+++ b/libbeat/docs/howto/change-index-name.asciidoc
@@ -3,7 +3,8 @@
 
 ifndef::no_ilm[]
 TIP: If you're sending events to a cluster that supports index lifecycle
-management, see <<ilm>> to learn how to change the index name.
+management, you need to change the index name in the ILM policy to new one.
+See <<ilm>> to learn how to change it.
 endif::no_ilm[]
 
 {beatname_uc} uses time series indices, by default, when index lifecycle

--- a/libbeat/docs/howto/change-index-name.asciidoc
+++ b/libbeat/docs/howto/change-index-name.asciidoc
@@ -3,7 +3,7 @@
 
 ifndef::no_ilm[]
 TIP: If you're sending events to a cluster that supports index lifecycle
-management, you need to change the index name in the ILM policy to new one.
+management, you need to change the index name in the ILM policy.
 See <<ilm>> to learn how to change it.
 endif::no_ilm[]
 


### PR DESCRIPTION
The current doc can be misread like the user need to visit the ILM page to learn how to change the index name. But the TIP is saying they should visit the ILM page and change the index name in the existing ILM policy with the new index name. Need to be more clear sentence. Feel free to suggest better comments.


## What does this PR do?
Fixing confusing comment.

## Why is it important?
It can lead the user to visit the ILM page to check how to change the index name.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
