### PR TITLE
Revert "[CI] fight the flakiness with some retry option in the CI only for the Pull Requests"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,12 +2,6 @@
 
 @Library('apm@current') _
 
-def numberOfRetries = 1
-// Only Pull Requests can rerun the build&test stages
-if (env.CHANGE_ID?.trim()) {
-    numberOfRetries = 3
-}
-
 pipeline {
   agent { label 'ubuntu-18 && immutable' }
   environment {
@@ -107,10 +101,7 @@ pipeline {
       }
     }
     stage('Build&Test') {
-      options {
-        skipDefaultCheckout()
-        retry(numberOfRetries)
-      }
+      options { skipDefaultCheckout() }
       when {
         // Always when running builds on branches/tags
         // On a PR basis, skip if changes are only related to docs.
@@ -129,10 +120,7 @@ pipeline {
       }
     }
     stage('Extended') {
-      options {
-        skipDefaultCheckout()
-        retry(numberOfRetries)
-      }
+      options { skipDefaultCheckout() }
       when {
         // Always when running builds on branches/tags
         // On a PR basis, skip if changes are only related to docs.


### PR DESCRIPTION
Reverts elastic/beats#26617

### Why

Unfortunately, there are a couple of issues:
1) Test population with the retry does not reset the test failures.
2) Dynamic stage does not reset the overall build status.

Somehow the tests I ran with the original PR always worked, so I could not detect this behaviour.

Alternative for this approach:

- https://github.com/elastic/beats/pull/26574 in addition to the test result validation for duplicated tests