### PR TITLE
Packaging: linux/armv7 is not supported

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -138,7 +138,11 @@ pipeline {
                     'linux/amd64',
                     'linux/386',
                     'linux/arm64',
-                    'linux/armv7',
+                    // armv7 packaging isn't working, and we don't currently
+                    // need it for release. Do not re-enable it without
+                    // confirming it is fixed, you will break the packaging
+                    // pipeline!
+                    //'linux/armv7',
                     // The platforms above are disabled temporarly as crossbuild images are
                     // not available. See: https://github.com/elastic/golang-crossbuild/issues/71
                     //'linux/ppc64le',


### PR DESCRIPTION
## What does this PR do?

Disable linux/armv7 packaging.

## Why is it important?

We only produce artifacts for aarch64. Don't build and package binaries we do not test or provide for download.

## Related issues

- Closes https://github.com/elastic/beats/issues/26677
- Relates https://github.com/elastic/beats/pull/25977
- Relates https://github.com/elastic/beats/pull/26679