### PR TITLE
backport: Add 6.8 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "upstream": "elastic/beats",
-  "branches": [ { "name": "7.x", "checked": true }, "7.14", "7.13", "7.12" ],
+  "branches": [ { "name": "7.x", "checked": true }, "6.8", "7.14", "7.13", "7.12" ],
   "labels": ["backport"],
   "autoAssign": true,
   "prTitle": "Cherry-pick to {targetBranch}: {commitMessages}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -151,3 +151,16 @@ pull_request_rules:
         - files~=^\.mergify\.yml$
     actions:
       delete_head_branch:
+  - name: backport patches to 6.8 branch
+    conditions:
+      - merged
+      - label=backport-v6.8.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "6.8"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 6.8 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821