### PR TITLE
CI: use withMageEnv

### DIFF
--- a/.ci/scripts/install-go.bat
+++ b/.ci/scripts/install-go.bat
@@ -1,0 +1,57 @@
+set GOPATH=%WORKSPACE%
+set MAGEFILE_CACHE=%WORKSPACE%\.magefile
+
+set PATH=%WORKSPACE%\bin;C:\ProgramData\chocolatey\bin;%PATH%
+
+curl --version >nul 2>&1 && (
+    echo found curl
+) || (
+    choco install curl -y --no-progress --skipdownloadcache
+)
+
+mkdir %WORKSPACE%\bin
+
+IF EXIST "%PROGRAMFILES(X86)%" (
+    REM Force the gvm installation.
+    SET GVM_BIN=gvm.exe
+    curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-windows-amd64.exe
+    IF ERRORLEVEL 1 (
+        REM gvm installation has failed.
+        del bin\gvm.exe /s /f /q
+        exit /b 1
+    )
+) ELSE (
+    REM Windows 7 workers got a broken gvm installation.
+    curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-windows-386.exe
+    IF ERRORLEVEL 1 (
+        REM gvm installation has failed.
+        del bin\gvm.exe /s /f /q
+        exit /b 1
+    )
+)
+
+SET GVM_BIN=gvm.exe
+WHERE /q %GVM_BIN%
+%GVM_BIN% version
+
+REM Install the given go version
+%GVM_BIN% --debug install %GO_VERSION%
+
+REM Configure the given go version
+FOR /f "tokens=*" %%i IN ('"%GVM_BIN%" use %GO_VERSION% --format=batch') DO %%i
+
+go env
+IF ERRORLEVEL 1 (
+    REM go is not configured correctly.
+    rmdir %WORKSPACE%\.gvm /s /q
+    exit /b 1
+)
+
+where mage
+mage -version
+IF ERRORLEVEL 1 (
+    go get github.com/magefile/mage
+    IF ERRORLEVEL 1 (
+        exit /b 1
+    )
+)

--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -52,11 +52,13 @@ IF ERRORLEVEL 1 (
     exit /b 1
 )
 
-go get github.com/magefile/mage
 where mage
 mage -version
 IF ERRORLEVEL 1 (
-    exit /b 1
+    go get github.com/magefile/mage
+    IF ERRORLEVEL 1 (
+        exit /b 1
+    )
 )
 
 REM Set the USERPROFILE to the previous location to fix issues with chocolatey in windows 2019

--- a/.ci/scripts/install-tools.bat
+++ b/.ci/scripts/install-tools.bat
@@ -1,6 +1,3 @@
-set GOPATH=%WORKSPACE%
-set MAGEFILE_CACHE=%WORKSPACE%\.magefile
-
 REM Configure GCC for either 32 or 64 bits
 set MINGW_ARCH=64
 IF NOT EXIST "%PROGRAMFILES(X86)%" (
@@ -12,53 +9,6 @@ curl --version >nul 2>&1 && (
     echo found curl
 ) || (
     choco install curl -y --no-progress --skipdownloadcache
-)
-
-mkdir %WORKSPACE%\bin
-
-IF EXIST "%PROGRAMFILES(X86)%" (
-    REM Force the gvm installation.
-    SET GVM_BIN=gvm.exe
-    curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-windows-amd64.exe
-    IF ERRORLEVEL 1 (
-        REM gvm installation has failed.
-        del bin\gvm.exe /s /f /q
-        exit /b 1
-    )
-) ELSE (
-    REM Windows 7 workers got a broken gvm installation.
-    curl -L -o %WORKSPACE%\bin\gvm.exe https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-windows-386.exe
-    IF ERRORLEVEL 1 (
-        REM gvm installation has failed.
-        del bin\gvm.exe /s /f /q
-        exit /b 1
-    )
-)
-
-SET GVM_BIN=gvm.exe
-WHERE /q %GVM_BIN%
-%GVM_BIN% version
-
-REM Install the given go version
-%GVM_BIN% --debug install %GO_VERSION%
-
-REM Configure the given go version
-FOR /f "tokens=*" %%i IN ('"%GVM_BIN%" use %GO_VERSION% --format=batch') DO %%i
-
-go env
-IF ERRORLEVEL 1 (
-    REM go is not configured correctly.
-    rmdir %WORKSPACE%\.gvm /s /q
-    exit /b 1
-)
-
-where mage
-mage -version
-IF ERRORLEVEL 1 (
-    go get github.com/magefile/mage
-    IF ERRORLEVEL 1 (
-        exit /b 1
-    )
 )
 
 REM Set the USERPROFILE to the previous location to fix issues with chocolatey in windows 2019

--- a/.ci/scripts/install-tools.sh
+++ b/.ci/scripts/install-tools.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
-.ci/scripts/install-go.sh
 .ci/scripts/install-docker-compose.sh
 .ci/scripts/install-terraform.sh

--- a/.ci/scripts/install-tools.sh
+++ b/.ci/scripts/install-tools.sh
@@ -4,4 +4,3 @@ set -exuo pipefail
 .ci/scripts/install-go.sh
 .ci/scripts/install-docker-compose.sh
 .ci/scripts/install-terraform.sh
-make mage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -640,7 +640,7 @@ def withBeatsEnv(Map args = [:], Closure body) {
       dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: 'docker.io')
     }
-    withMageEnv() {
+    withMageEnv(version: "${env.GO_VERSION}"){
       dir("${env.BASE_DIR}") {
         // Go/Mage installation is not anymore configured with env variables and installed
         // with installTools but delegated to the parent closure withMageEnv.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -711,7 +711,7 @@ def fixPermissions(location) {
 def installTools(args) {
   def stepHeader = "${args.id?.trim() ? args.id : env.STAGE_NAME}"
   if(isUnix()) {
-    retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "${stepHeader} - Install Go/Python/Docker/Terraform ${GO_VERSION}", script: '.ci/scripts/install-tools.sh') }
+    retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "${stepHeader} - Install Python/Docker/Terraform", script: '.ci/scripts/install-tools.sh') }
     // TODO (2020-04-07): This is a work-around to fix the Beat generator tests.
     // See https://github.com/elastic/beats/issues/17787.
     sh(label: 'check git config', script: '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -642,6 +642,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
     }
     withMageEnv() {
       dir("${env.BASE_DIR}") {
+        // Go/Mage installation is not anymore configured with env variables and installed
+        // with installTools but delegated to the parent closure withMageEnv.
         installTools(args)
         // Skip to upload the generated files by default.
         def upload = false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -718,7 +718,7 @@ def installTools(args) {
         git config --global user.name "beatsmachine"
       fi''')
   } else {
-    retryWithSleep(retries: 3, seconds: 5, backoff: true){ bat(label: "${stepHeader} - Install Go/Mage/Python ${GO_VERSION}", script: ".ci/scripts/install-tools.bat") }
+    retryWithSleep(retries: 3, seconds: 5, backoff: true){ bat(label: "${stepHeader} - Install Python", script: ".ci/scripts/install-tools.bat") }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

- Use `withMageEnv` closure
- Remove go installation for Windows (though I created a new script with the go installation for windows in case someone needs it)

## Why is it important?

Stop setting env variables and use the step in charges to prepare the context for go using GVM.

## Follow ups

- Let' see if the `gvm` installation is not corrupted in all the OS versions we use, if not we could potentially remove the GVM installation from the `sh/bat` installation scripts.