### PR TITLE
Osquerybeat: Fix the configuration poll interval setting

### DIFF
--- a/x-pack/osquerybeat/internal/osqd/osqueryd.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd.go
@@ -65,7 +65,7 @@ func WithBinaryPath(binPath string) Option {
 
 func WithConfigRefresh(refreshInterval int) Option {
 	return func(q *OSQueryD) {
-		q.extensionsTimeout = refreshInterval
+		q.configRefreshInterval = refreshInterval
 	}
 }
 

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_test.go
@@ -1,0 +1,48 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package osqd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNew(t *testing.T) {
+
+	socketPath := "/var/run/foobar"
+
+	extensionsTimeout := 5
+	configurationRefreshIntervalSecs := 12
+	configPluginName := "config_plugin_test"
+	loggerPluginName := "logger_plugin_test"
+
+	osq := New(
+		socketPath,
+		WithExtensionsTimeout(extensionsTimeout),
+		WithConfigRefresh(configurationRefreshIntervalSecs),
+		WithConfigPlugin(configPluginName),
+		WithLoggerPlugin(loggerPluginName),
+	)
+
+	diff := cmp.Diff(extensionsTimeout, osq.extensionsTimeout)
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	diff = cmp.Diff(configurationRefreshIntervalSecs, osq.configRefreshInterval)
+	if diff != "" {
+		t.Error(diff)
+	}
+	diff = cmp.Diff(configPluginName, osq.configPlugin)
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	diff = cmp.Diff(loggerPluginName, osq.loggerPlugin)
+	if diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the typo, setting the osquery configuration plugin poll interval correctly. 
It's a minor bug, the osquery still functions without this change for typical use cases, but it will use the default refresh interval and will set the extensions timeouts to the larger than expected value. 

## Why is it important?

Otherwise the configuration poll interval would use a default hardcoded value.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

