### PR TITLE
Upgrade PyYAML test dependency to 5.4.1

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -33,7 +33,7 @@ pyrsistent==0.16.0
 pytest==6.2.4
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
-PyYAML==5.3.1
+PyYAML==5.4.1
 redis==2.10.6
 requests==2.25.1
 semver==2.8.1


### PR DESCRIPTION
## What does this PR do?

This upgrades the PyYAML package used for tests from 5.3.1 to 5.4.1.
## Why is it important?

The package is being flagged as being vulnerable. This doesn't affect Beats at all as the dependency is only used during testing in our CI.