### PR TITLE
[Elastic Agent] Fix broken enrollment command

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -73,6 +73,7 @@
 - Change timestamp in elatic-agent-json.log to use UTC {issue}25391[25391]
 - Fix add support for Logstash output. {pull}24305[24305]
 - Do not log Elasticsearch configuration for monitoring output when running with debug. {pull}26583[26583]
+- Fix issue where proxy enrollment options broke enrollment command. {pull}26749[26749]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -200,6 +200,15 @@ func (c *enrollCmd) Execute(ctx context.Context) error {
 	// will communicate to the internal fleet server on localhost only.
 	// Connection setup should disable proxies in that case.
 	localFleetServer := c.options.FleetServer.ConnStr != ""
+	if localFleetServer {
+		token, err := c.fleetServerBootstrap(ctx)
+		if err != nil {
+			return err
+		}
+		if c.options.EnrollAPIKey == "" && token != "" {
+			c.options.EnrollAPIKey = token
+		}
+	}
 
 	c.remoteConfig, err = c.options.remoteConfig()
 	if err != nil {
@@ -208,19 +217,10 @@ func (c *enrollCmd) Execute(ctx context.Context) error {
 			errors.TypeConfig,
 			errors.M(errors.MetaKeyURI, c.options.URL))
 	}
-
 	if localFleetServer {
 		// Ensure that the agent does not use a proxy configuration
 		// when connecting to the local fleet server.
 		c.remoteConfig.Transport.Proxy.Disable = true
-
-		token, err := c.fleetServerBootstrap(ctx)
-		if err != nil {
-			return err
-		}
-		if c.options.EnrollAPIKey == "" && token != "" {
-			c.options.EnrollAPIKey = token
-		}
 	}
 
 	c.client, err = fleetclient.NewWithConfig(c.log, c.remoteConfig)

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -420,7 +420,7 @@ func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[
 			break
 		}
 		backExp.Wait()
-		c.log.Infof("Retrying to enrollment to URL: %s", c.client.URI())
+		c.log.Infof("Retrying enrollment to URL: %s", c.client.URI())
 		err = c.enroll(ctx, persistentConfig)
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -402,6 +402,7 @@ func (c *enrollCmd) daemonReload(ctx context.Context) error {
 func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[string]interface{}) error {
 	delay(ctx, enrollDelay)
 
+	c.log.Infof("Starting enrollment to URL: %s", c.client.URI())
 	err := c.enroll(ctx, persistentConfig)
 	signal := make(chan struct{})
 	backExp := backoff.NewExpBackoff(signal, 60*time.Second, 10*time.Minute)
@@ -419,7 +420,7 @@ func (c *enrollCmd) enrollWithBackoff(ctx context.Context, persistentConfig map[
 			break
 		}
 		backExp.Wait()
-		c.log.Info("Retrying to enroll...")
+		c.log.Infof("Retrying to enrollment to URL: %s", c.client.URI())
 		err = c.enroll(ctx, persistentConfig)
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

The proxy work broke the `enroll` command that prevents enrollment from working when running Fleet Server with default options.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Otherwise the enrollment command will not work also breaking the container.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #26721
