### PR TITLE
Update agent managed manifest to include enrolment token variable

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -28,13 +28,13 @@ spec:
               value: "1"
               # Set to true in case of insecure or unverified HTTP
             - name: FLEET_INSECURE
-              value: "false"
+              value: "true"
               # The ip:port pair of fleet server
             - name: FLEET_URL
               value: "https://fleet-server:8220"
               # If left empty KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
             - name: FLEET_ENROLLMENT_TOKEN
-              value: "token"
+              value: ""
             - name: KIBANA_HOST
               value: "http://kibana:5601"
             - name: KIBANA_FLEET_USERNAME

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -28,10 +28,13 @@ spec:
               value: "1"
               # Set to true in case of insecure or unverified HTTP
             - name: FLEET_INSECURE
-              value: false
+              value: "false"
               # The ip:port pair of fleet server
             - name: FLEET_URL
               value: "https://fleet-server:8220"
+              # If left empty KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
+            - name: FLEET_ENROLLMENT_TOKEN
+              value: "token"
             - name: KIBANA_HOST
               value: "http://kibana:5601"
             - name: KIBANA_FLEET_USERNAME

--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -26,7 +26,7 @@ spec:
           env:
             - name: FLEET_ENROLL
               value: "1"
-              # Set to true in case of insecure or unverified HTTP
+            # Set to true in case of insecure or unverified HTTP
             - name: FLEET_INSECURE
               value: "true"
               # The ip:port pair of fleet server

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -28,13 +28,13 @@ spec:
               value: "1"
             # Set to true in case of insecure or unverified HTTP
             - name: FLEET_INSECURE
-              value: "false"
+              value: "true"
               # The ip:port pair of fleet server
             - name: FLEET_URL
               value: "https://fleet-server:8220"
               # If left empty KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
             - name: FLEET_ENROLLMENT_TOKEN
-              value: "token"
+              value: ""
             - name: KIBANA_HOST
               value: "http://kibana:5601"
             - name: KIBANA_FLEET_USERNAME

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -26,12 +26,15 @@ spec:
           env:
             - name: FLEET_ENROLL
               value: "1"
-              # Set to true in case of insecure or unverified HTTP
+            # Set to true in case of insecure or unverified HTTP
             - name: FLEET_INSECURE
-              value: false
+              value: "false"
               # The ip:port pair of fleet server
             - name: FLEET_URL
               value: "https://fleet-server:8220"
+              # If left empty KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
+            - name: FLEET_ENROLLMENT_TOKEN
+              value: "token"
             - name: KIBANA_HOST
               value: "http://kibana:5601"
             - name: KIBANA_FLEET_USERNAME


### PR DESCRIPTION
## What does this PR do?

This PR adds _FLEET_ENROLLMENT_TOKEN_ in managed elastic-agent manifest.

## Why is it important?

Agent can enrol to fleet server  policy either by specifying an enrolment token for a specific policy or by
connecting to Kibana and getting the default one.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

