### PR TITLE
CI: increase timeout

### DIFF
--- a/.ci/scripts/generate_build_table.py
+++ b/.ci/scripts/generate_build_table.py
@@ -5,8 +5,8 @@ import yaml
 
 if __name__ == "__main__":
 
-    print("| Beat  | Stage  | Command  | MODULE  | Platforms  | When |")
-    print("|-------|--------|----------|---------|------------|------|")
+    print("| Beat  | Stage  | Category | Command  | MODULE  | Platforms  | When |")
+    print("|-------|--------|----------|----------|---------|------------|------|")
     for root, dirs, files in os.walk("."):
         dirs.sort()
         for file in files:
@@ -18,6 +18,9 @@ if __name__ == "__main__":
                     withModule = False
                     platforms = [doc["platform"]]
                     when = "mandatory"
+                    category = 'default'
+                    if "stage" in doc["stages"][stage]:
+                        category = doc["stages"][stage]["stage"]
                     if "make" in doc["stages"][stage]:
                         command = doc["stages"][stage]["make"].replace("\n", " ")
                     if "mage" in doc["stages"][stage]:
@@ -33,5 +36,5 @@ if __name__ == "__main__":
                     if "when" in doc["stages"][stage]:
                         if "not_changeset_full_match" not in doc["stages"][stage]["when"]:
                             when = "optional"
-                    print("| {} | {} | `{}` | {} | `{}` | {} |".format(
-                        module, stage, command, withModule, platforms, when))
+                    print("| {} | {} | `{}` | `{}` | {} | `{}` | {} |".format(
+                        module, stage, category, command, withModule, platforms, when))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
   }
   options {
-    timeout(time: 3, unit: 'HOURS')
+    timeout(time: 4, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '60', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
## What does this PR do?

Increase timeout since we have enabled the `retry` to fight some flakiness.

## Why is it important?

Reduce the chances to abort builds for a long build.

## Bonus

I added a minor change to the script to generate the table with the existing list of stages to be run