### PR TITLE
Heartbeat: add datastream fields to synthetics

### DIFF
--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -120,6 +120,10 @@ func newCommonPublishConfigs(info beat.Info, cfg *common.Config) (pipetool.Confi
 		fields := clientCfg.Processing.Fields.Clone()
 		fields.Put("event.dataset", dataset)
 
+		if settings.DataStream != nil {
+			fields.Put("data_stream", settings.DataStream)
+		}
+
 		meta := clientCfg.Processing.Meta.Clone()
 		if settings.Pipeline != "" {
 			meta.Put("pipeline", settings.Pipeline)


### PR DESCRIPTION
+ fixes https://github.com/elastic/kibana/issues/102651
+ Adds `data_stream.*` fields to all heartbeat events when data stream is enabled on the monitors. 

```json
{
  "_index": ".ds-synthetics-http-default-2021.07.07-000001",
  "_id": "9SJfgnoBUSsHvkuw1eQu",
  "_version": 1,
  "_score": null,
  "fields": {
    "monitor.status": [
      "up"
    ],
    "http.response.headers.X-Elastic-Product": [
      "Elasticsearch"
    ],
    "http.rtt.validate.us": [
      2431
    ],
    "url.scheme": [
      "http"
    ],
    "monitor.id": [
      "my-monitor"
    ],
    "tcp.rtt.connect.us": [
      249
    ],
    "resolve.ip": [
      "127.0.0.1"
    ],
    "monitor.name": [
      "My Monitor"
    ],
    "agent.type": [
      "heartbeat"
    ],
    "http.rtt.content.us": [
      89
    ],
    "summary.up": [
      1
    ],
    "resolve.rtt.us": [
      1017
    ],
    "url.port": [
      9200
    ],
    "monitor.ip": [
      "127.0.0.1"
    ],
    "agent.name": [
      "Vignesh.local"
    ],
    "observer.mac": [
     
    ],
    "http.response.status_code": [
      200
    ],
    "http.response.headers.Content-Length": [
      "551"
    ],
    "url.full": [
      "http://localhost:9200"
    ],
    "monitor.duration.us": [
      3811
    ],
    "monitor.timespan.gte": [
      "2021-07-07T19:09:15.383Z"
    ],
    "monitor.type": [
      "http"
    ],
    "monitor.timespan.lt": [
      "2021-07-07T19:09:25.383Z"
    ],
    "http.response.mime_type": [
      "application/json"
    ],
    "data_stream.namespace": [
      "default"
    ],
    "http.rtt.write_request.us": [
      43
    ],
    "http.rtt.total.us": [
      2750
    ],
    "data_stream.type": [
      "synthetics"
    ],
    "observer.hostname": [
      "Vigneshs-MacBook-Pro.local"
    ],
    "summary.down": [
      0
    ],
    "http.response.body.bytes": [
      551
    ],
    "http.response.body.hash": [
      "1733414713f1f365fc373e84272a9b0de92c6e1bcfcb41f38262df1490f7cbbf"
    ],
    "@timestamp": [
      "2021-07-07T19:09:15.379Z"
    ],
    "agent.id": [
      "7090ecca-326f-4b11-abe9-b036b4f5a375"
    ],
    "ecs.version": [
      "1.10.0"
    ],
    "http.response.headers.Content-Type": [
      "application/json"
    ],
    "data_stream.dataset": [
      "http"
    ],
    "http.rtt.response_header.us": [
      2341
    ],
    "url.domain": [
      "localhost"
    ],
    "monitor.check_group": [
      "d253645c-df56-11eb-87c0-f21898a15015"
    ],
    "agent.ephemeral_id": [
      "4b721f94-526a-47a8-a23e-36acfafe814b"
    ],
    "agent.version": [
      "8.0.0"
    ],
    "observer.ip": [
    ],
    "event.dataset": [
      "http"
    ]
  },
  "sort": [
    1625684955379
  ]
}

```