### PR TITLE
Set agent.id to Fleet Agent ID for each metric/log monitoring input

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -265,6 +265,14 @@ func (o *Operator) getMonitoringFilebeatConfig(outputType string, output interfa
 					},
 				},
 				{
+					"add_fields": map[string]interface{}{
+						"target": "agent",
+						"fields": map[string]interface{}{
+							"id": o.agentInfo.AgentID(),
+						},
+					},
+				},
+				{
 					"drop_fields": map[string]interface{}{
 						"fields": []string{
 							"ecs.version", //coming from logger, already added by libbeat
@@ -320,6 +328,14 @@ func (o *Operator) getMonitoringFilebeatConfig(outputType string, output interfa
 						},
 					},
 					{
+						"add_fields": map[string]interface{}{
+							"target": "agent",
+							"fields": map[string]interface{}{
+								"id": o.agentInfo.AgentID(),
+							},
+						},
+					},
+					{
 						"drop_fields": map[string]interface{}{
 							"fields": []string{
 								"ecs.version", //coming from logger, already added by libbeat
@@ -338,16 +354,6 @@ func (o *Operator) getMonitoringFilebeatConfig(outputType string, output interfa
 		},
 		"output": map[string]interface{}{
 			outputType: output,
-		},
-		"processors": []map[string]interface{}{
-			{
-				"add_fields": map[string]interface{}{
-					"target": "agent",
-					"fields": map[string]interface{}{
-						"id": o.agentInfo.AgentID(),
-					},
-				},
-			},
 		},
 	}
 
@@ -398,6 +404,14 @@ func (o *Operator) getMonitoringMetricbeatConfig(outputType string, output inter
 						},
 					},
 				},
+				{
+					"add_fields": map[string]interface{}{
+						"target": "agent",
+						"fields": map[string]interface{}{
+							"id": o.agentInfo.AgentID(),
+						},
+					},
+				},
 			},
 		}, map[string]interface{}{
 			"module":     "http",
@@ -434,6 +448,14 @@ func (o *Operator) getMonitoringMetricbeatConfig(outputType string, output inter
 							"version":  o.agentInfo.Version(),
 							"snapshot": o.agentInfo.Snapshot(),
 							"process":  name,
+						},
+					},
+				},
+				{
+					"add_fields": map[string]interface{}{
+						"target": "agent",
+						"fields": map[string]interface{}{
+							"id": o.agentInfo.AgentID(),
 						},
 					},
 				},
@@ -521,6 +543,14 @@ func (o *Operator) getMonitoringMetricbeatConfig(outputType string, output inter
 				},
 			},
 			{
+				"add_fields": map[string]interface{}{
+					"target": "agent",
+					"fields": map[string]interface{}{
+						"id": o.agentInfo.AgentID(),
+					},
+				},
+			},
+			{
 				"copy_fields": map[string]interface{}{
 					"fields": []map[string]interface{}{
 						// I should be able to see the CPU Usage on the running machine. Am using too much CPU?
@@ -570,16 +600,6 @@ func (o *Operator) getMonitoringMetricbeatConfig(outputType string, output inter
 		},
 		"output": map[string]interface{}{
 			outputType: output,
-		},
-		"processors": []map[string]interface{}{
-			{
-				"add_fields": map[string]interface{}{
-					"target": "agent",
-					"fields": map[string]interface{}{
-						"id": o.agentInfo.AgentID(),
-					},
-				},
-			},
 		},
 	}
 


### PR DESCRIPTION
## What does this PR do?

An earlier commit #26548 set the same value using a single global processor,
but that doesn't seem to make it into the final config so it had no effect. So this
sets the agent.id at the same places where elastic_agent.id is added.

## Why is it important?

It makes `elastic_agent.id` and `agent.id` contain the same Fleet Agent ID.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #26548

## Screenshots

Screenshot showing that `agent.id` matches `elastic_agent.id` for monitoring indices.

<img width="1104" alt="Screen Shot 2021-07-07 at 7 53 53 PM" src="https://user-images.githubusercontent.com/4565752/124842310-422b0400-df5d-11eb-93a6-8a4574efb952.png">
