### PR TITLE
[Heartbeat]: capture error from journey/end events

### DIFF
--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -102,6 +102,15 @@ func (je *journeyEnricher) enrich(event *beat.Event, se *SynthEvent) error {
 }
 
 func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent) error {
+	var jobErr error
+	if se.Error != nil {
+		jobErr = stepError(se.Error)
+		je.errorCount++
+		if je.firstError == nil {
+			je.firstError = jobErr
+		}
+	}
+
 	switch se.Type {
 	case "journey/end":
 		je.journeyComplete = true
@@ -133,16 +142,6 @@ func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent) e
 			}
 		}
 	}
-
-	var jobErr error
-	if se.Error != nil {
-		jobErr = stepError(se.Error)
-		je.errorCount++
-		if je.firstError == nil {
-			je.firstError = jobErr
-		}
-	}
-
 	return jobErr
 }
 


### PR DESCRIPTION
+ fix #26780 
+ When move the error handling logic before looking for type to make sure we always capture the errors from the top level without having to worry about the event types and can assure the summary event always have the error payload. 


### Before
<img width="1177" alt="Screen Shot 2021-07-07 at 17 06 58" src="https://user-images.githubusercontent.com/3902525/124843491-e2c1f980-df46-11eb-9403-71df5dbb6382.png">



### After

<img width="1186" alt="Screen Shot 2021-07-07 at 17 04 52" src="https://user-images.githubusercontent.com/3902525/124843495-e6558080-df46-11eb-8983-5dfadc7abcd0.png">
