### PR TITLE
CI: resilience with the new MacOS workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -710,12 +710,16 @@ def tearDown() {
 */
 def fixPermissions(location) {
   if(isUnix()) {
-    sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
-      set +x
-      echo "Cleaning up ${location}"
-      source ./dev-tools/common.bash
-      docker_setup
-      script/fix_permissions.sh ${location}""", returnStatus: true)
+    catchError(message: 'There were some failures when fixing the permissions', buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
+      timeout(5) {
+        sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+          set +x
+          echo "Cleaning up ${location}"
+          source ./dev-tools/common.bash
+          docker_setup
+          script/fix_permissions.sh ${location}""", returnStatus: true)
+      }
+    }
   }
 }
 

--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -106,6 +106,9 @@ docker_setup() {
   OS="$(uname)"
   case $OS in
     'Darwin')
+      if ! command -v docker-machine ; then
+        echo "docker-machine is not installed but most likely docker desktop"
+      fi
       # Start the docker machine VM (ignore error if it's already running).
       docker-machine start default || true
       eval $(docker-machine env default)

--- a/script/fix_permissions.sh
+++ b/script/fix_permissions.sh
@@ -2,7 +2,7 @@
 set +e
 readonly LOCATION="${1?Please define the path where the fix permissions should run from}"
 
-if ! docker version ; then
+if ! docker version 2>&1 >/dev/null ; then
   echo "It requires Docker daemon to be installed and running"
 else
   ## Detect architecture to support ARM specific docker images.
@@ -14,6 +14,7 @@ else
   fi
   set -e
   echo "Change ownership of all files inside the specific folder from root/root to current user/group"
+  set -x
   docker run -v "${LOCATION}":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
 fi
 


### PR DESCRIPTION
## What does this PR do?

Ensure new MacOS workers docker environments don't get stalled when fixing the permissions.

## Why is it important?

Builds are getting stalled with https://beats-ci.elastic.co/computer/worker-c07c6107jyw0/

![image](https://user-images.githubusercontent.com/2871786/124897890-a047fd80-dfd6-11eb-9513-14368f877f00.png)

![image](https://user-images.githubusercontent.com/2871786/124898024-bce43580-dfd6-11eb-9d53-34723b6f2ca5.png)

```
06:25:04  Cleaning up /var/lib/jenkins/workspace/master-906-3416391f-c083-40f9-8a2c-18c268765c29
06:25:04  ./dev-tools/common.bash: line 110: docker-machine: command not found
06:25:04  ./dev-tools/common.bash: line 111: docker-machine: command not found
```