### PR TITLE
[Agent] Support Node and Service autodiscovery in k8s provider

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -117,3 +117,4 @@
 - Set `agent.id` to the Fleet Agent ID in events published from inputs backed by Beats. {issue}21121[21121] {pull}26394[26394]
 - Enable configuring monitoring namespace {issue}26439[26439]
 - Communicate with Fleet Server over HTTP2. {pull}26474[26474]
+- Support Node and Service autodiscovery in k8s provider. {pull}26801[26801]

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -117,4 +117,4 @@
 - Set `agent.id` to the Fleet Agent ID in events published from inputs backed by Beats. {issue}21121[21121] {pull}26394[26394]
 - Enable configuring monitoring namespace {issue}26439[26439]
 - Communicate with Fleet Server over HTTP2. {pull}26474[26474]
-- Support Node and Service autodiscovery in k8s provider. {pull}26801[26801]
+- Support Node and Service autodiscovery in kubernetes dynamic provider. {pull}26801[26801]

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -16,6 +16,7 @@ import (
 // Config for kubernetes provider
 type Config struct {
 	KubeConfig     string        `config:"kube_config"`
+	Namespace      string        `config:"namespace"`
 	SyncPeriod     time.Duration `config:"sync_period"`
 	CleanupTimeout time.Duration `config:"cleanup_timeout" validate:"positive"`
 

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -15,11 +15,11 @@ import (
 
 // Config for kubernetes provider
 type Config struct {
-	Scope    string   `config:"scope"`
-	Resource Resource `config:"resource"`
+	Scope     string    `config:"scope"`
+	Resources Resources `config:"resources"`
 }
 
-type Resource struct {
+type Resources struct {
 	Pod     *ResourceConfig `config:"pod"`
 	Node    *ResourceConfig `config:"node"`
 	Service *ResourceConfig `config:"service"`
@@ -38,18 +38,18 @@ type ResourceConfig struct {
 
 // InitDefaults initializes the default values for the config.
 func (c *Config) InitDefaults() {
-	if c.Resource.Pod == nil {
-		c.Resource.Pod = &ResourceConfig{}
+	if c.Resources.Pod == nil {
+		c.Resources.Pod = &ResourceConfig{}
 	}
-	c.Resource.Pod.SyncPeriod = 10 * time.Minute
-	c.Resource.Pod.CleanupTimeout = 60 * time.Second
+	c.Resources.Pod.SyncPeriod = 10 * time.Minute
+	c.Resources.Pod.CleanupTimeout = 60 * time.Second
 	c.Scope = "node"
 }
 
 // Validate ensures correctness of config
 func (c *Config) Validate() error {
 	// Check if resource is service. If yes then default the scope to "cluster".
-	if c.Resource.Service != nil {
+	if c.Resources.Service != nil {
 		if c.Scope == "node" {
 			logp.L().Warnf("can not set scope to `node` when using resource `Service`. resetting scope to `cluster`")
 		}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -26,7 +26,7 @@ type Resources struct {
 	Service *ResourceConfig `config:"service"`
 }
 
-// Config for kubernetes provider
+// ResourceConfig for kubernetes resource
 type ResourceConfig struct {
 	KubeConfig     string        `config:"kube_config"`
 	Namespace      string        `config:"namespace"`

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -46,9 +46,6 @@ func (c *Config) InitDefaults() {
 	c.CleanupTimeout = 60 * time.Second
 	c.SyncPeriod = 10 * time.Minute
 	c.Scope = "node"
-	c.Resources.Pod = Enabled{true}
-	c.Resources.Node = Enabled{true}
-	c.Resources.Service = Enabled{true}
 	c.LabelsDedot = true
 	c.AnnotationsDedot = true
 }
@@ -61,6 +58,11 @@ func (c *Config) Validate() error {
 			logp.L().Warnf("can not set scope to `node` when using resource `Service`. resetting scope to `cluster`")
 		}
 		c.Scope = "cluster"
+	}
+
+	if !c.Resources.Pod.Enabled && !c.Resources.Node.Enabled && !c.Resources.Service.Enabled {
+		c.Resources.Pod = Enabled{true}
+		c.Resources.Node = Enabled{true}
 	}
 
 	return nil

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Resources Resources `config:"resources"`
 }
 
+// Resources config section for resources' config blocks
 type Resources struct {
 	Pod     *ResourceConfig `config:"pod"`
 	Node    *ResourceConfig `config:"node"`

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -37,6 +37,7 @@ type Resources struct {
 	Service Enabled `config:"service"`
 }
 
+// Enabled config section for resources' config blocks
 type Enabled struct {
 	Enabled bool `config:"enabled"`
 }

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -16,8 +16,16 @@ import (
 // Config for kubernetes provider
 type Config struct {
 	Scope     string    `config:"scope"`
-	ResourceConfig
 	Resources Resources `config:"resources"`
+
+	// expand config settings at root level of config too
+	KubeConfig     string        `config:"kube_config"`
+	Namespace      string        `config:"namespace"`
+	SyncPeriod     time.Duration `config:"sync_period"`
+	CleanupTimeout time.Duration `config:"cleanup_timeout" validate:"positive"`
+
+	// Needed when resource is a Pod or Node
+	Node string `config:"node"`
 }
 
 // Resources config section for resources' config blocks
@@ -34,7 +42,7 @@ type ResourceConfig struct {
 	SyncPeriod     time.Duration `config:"sync_period"`
 	CleanupTimeout time.Duration `config:"cleanup_timeout" validate:"positive"`
 
-	// Needed when resource is a pod
+	// Needed when resource is a Pod or Node
 	Node string `config:"node"`
 }
 
@@ -56,19 +64,16 @@ func (c *Config) Validate() error {
 	}
 	baseCfg := &ResourceConfig{
 		CleanupTimeout: c.CleanupTimeout,
-		SyncPeriod: c.CleanupTimeout,
-		KubeConfig: c.KubeConfig,
-		Namespace: c.Namespace,
-		Node: c.Node,
+		SyncPeriod:     c.CleanupTimeout,
+		KubeConfig:     c.KubeConfig,
+		Namespace:      c.Namespace,
+		Node:           c.Node,
 	}
 	if c.Resources.Pod == nil {
 		c.Resources.Pod = baseCfg
 	}
 	if c.Resources.Node == nil {
 		c.Resources.Node = baseCfg
-	}
-	if c.Resources.Service == nil {
-		c.Resources.Service = baseCfg
 	}
 
 	return nil

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -8,6 +8,7 @@
 package kubernetes
 
 import (
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"time"
 )
 
@@ -22,6 +23,7 @@ type Config struct {
 
 	// Scope of the provider (cluster or node)
 	Scope string `config:"scope"`
+	Resource string `config:"resource"`
 }
 
 // InitDefaults initializes the default values for the config.
@@ -29,4 +31,23 @@ func (c *Config) InitDefaults() {
 	c.SyncPeriod = 10 * time.Minute
 	c.CleanupTimeout = 60 * time.Second
 	c.Scope = "node"
+}
+
+// Validate ensures correctness of config
+func (c *Config) Validate() error {
+	// Check if resource is either node or pod. If yes then default the scope to "node" if not provided.
+	// Default the scope to "cluster" for everything else.
+	switch c.Resource {
+	case "node", "pod":
+		if c.Scope == "" {
+			c.Scope = "node"
+		}
+	default:
+		if c.Scope == "node" {
+			logp.L().Warnf("can not set scope to `node` when using resource %s. resetting scope to `cluster`", c.Resource)
+		}
+		c.Scope = "cluster"
+	}
+
+	return nil
 }

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -16,6 +16,7 @@ import (
 // Config for kubernetes provider
 type Config struct {
 	Scope     string    `config:"scope"`
+	ResourceConfig
 	Resources Resources `config:"resources"`
 }
 
@@ -39,11 +40,8 @@ type ResourceConfig struct {
 
 // InitDefaults initializes the default values for the config.
 func (c *Config) InitDefaults() {
-	if c.Resources.Pod == nil {
-		c.Resources.Pod = &ResourceConfig{}
-	}
-	c.Resources.Pod.SyncPeriod = 10 * time.Minute
-	c.Resources.Pod.CleanupTimeout = 60 * time.Second
+	c.CleanupTimeout = 60 * time.Second
+	c.SyncPeriod = 10 * time.Minute
 	c.Scope = "node"
 }
 
@@ -55,6 +53,22 @@ func (c *Config) Validate() error {
 			logp.L().Warnf("can not set scope to `node` when using resource `Service`. resetting scope to `cluster`")
 		}
 		c.Scope = "cluster"
+	}
+	baseCfg := &ResourceConfig{
+		CleanupTimeout: c.CleanupTimeout,
+		SyncPeriod: c.CleanupTimeout,
+		KubeConfig: c.KubeConfig,
+		Namespace: c.Namespace,
+		Node: c.Node,
+	}
+	if c.Resources.Pod == nil {
+		c.Resources.Pod = baseCfg
+	}
+	if c.Resources.Node == nil {
+		c.Resources.Node = baseCfg
+	}
+	if c.Resources.Service == nil {
+		c.Resources.Service = baseCfg
 	}
 
 	return nil

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -8,8 +8,9 @@
 package kubernetes
 
 import (
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"time"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // Config for kubernetes provider
@@ -22,7 +23,7 @@ type Config struct {
 	Node string `config:"node"`
 
 	// Scope of the provider (cluster or node)
-	Scope string `config:"scope"`
+	Scope    string `config:"scope"`
 	Resource string `config:"resource"`
 }
 

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -25,9 +25,6 @@ type Config struct {
 
 	// Needed when resource is a Pod or Node
 	Node string `config:"node"`
-
-	LabelsDedot      bool `config:"labels.dedot"`
-	AnnotationsDedot bool `config:"annotations.dedot"`
 }
 
 // Resources config section for resources' config blocks
@@ -47,8 +44,6 @@ func (c *Config) InitDefaults() {
 	c.CleanupTimeout = 60 * time.Second
 	c.SyncPeriod = 10 * time.Minute
 	c.Scope = "node"
-	c.LabelsDedot = true
-	c.AnnotationsDedot = true
 }
 
 // Validate ensures correctness of config

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
@@ -124,19 +124,19 @@ func (p *dynamicProvider) newWatcher(
 	config *ResourceConfig) (kubernetes.Watcher, error) {
 	switch resourceType {
 	case "pod":
-		watcher, err := NewPodWatcher(comm, config, p.logger, client)
+		watcher, err := NewPodWatcher(comm, config, p.logger, client, p.config.Scope)
 		if err != nil {
 			return nil, err
 		}
 		return watcher, nil
 	case "node":
-		watcher, err := NewNodeWatcher(comm, config, p.logger, client)
+		watcher, err := NewNodeWatcher(comm, config, p.logger, client, p.config.Scope)
 		if err != nil {
 			return nil, err
 		}
 		return watcher, nil
 	case "service":
-		watcher, err := NewServiceWatcher(comm, config, p.logger, client)
+		watcher, err := NewServiceWatcher(comm, config, p.logger, client, p.config.Scope)
 		if err != nil {
 			return nil, err
 		}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
@@ -51,22 +51,22 @@ func DynamicProviderBuilder(logger *logger.Logger, c *config.Config) (composable
 
 // Run runs the kubernetes context provider.
 func (p *dynamicProvider) Run(comm composable.DynamicProviderComm) error {
-	if p.config.Resource.Pod != nil {
-		resourceConfig := p.config.Resource.Pod
+	if p.config.Resources.Pod != nil {
+		resourceConfig := p.config.Resources.Pod
 		err := p.watchResource(comm, "pod", resourceConfig)
 		if err != nil {
 			return err
 		}
 	}
-	if p.config.Resource.Node != nil {
-		resourceConfig := p.config.Resource.Node
+	if p.config.Resources.Node != nil {
+		resourceConfig := p.config.Resources.Node
 		err := p.watchResource(comm, "node", resourceConfig)
 		if err != nil {
 			return err
 		}
 	}
-	if p.config.Resource.Service != nil {
-		resourceConfig := p.config.Resource.Service
+	if p.config.Resources.Service != nil {
+		resourceConfig := p.config.Resources.Service
 		err := p.watchResource(comm, "service", resourceConfig)
 		if err != nil {
 			return err

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
@@ -21,6 +21,8 @@ const (
 	PodPriority = 0
 	// ContainerPriority is the priority that container mappings are added to the provider.
 	ContainerPriority = 1
+	// NodePriority is the priority that node mappings are added to the provider.
+	NodePriority = 0
 )
 
 func init() {
@@ -64,8 +66,6 @@ func (p *dynamicProvider) Run(comm composable.DynamicProviderComm) error {
 		p.config.Node = ""
 	}
 
-
-
 	watcher, err := p.newWatcher(comm, client)
 	if err != nil {
 		return errors.New(err, "couldn't create kubernetes watcher")
@@ -89,7 +89,11 @@ func (p *dynamicProvider) newWatcher(comm composable.DynamicProviderComm, client
 		}
 		return watcher, nil
 	case "node":
-		return nil, nil
+		watcher, err := NewNodeWatcher(comm, p.config, p.logger, client)
+		if err != nil {
+			return nil, err
+		}
+		return watcher, nil
 	case "service":
 		return nil, nil
 	default:

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
@@ -23,6 +23,8 @@ const (
 	ContainerPriority = 1
 	// NodePriority is the priority that node mappings are added to the provider.
 	NodePriority = 0
+	// ServicePriority is the priority that service mappings are added to the provider.
+	ServicePriority = 0
 )
 
 func init() {
@@ -95,7 +97,11 @@ func (p *dynamicProvider) newWatcher(comm composable.DynamicProviderComm, client
 		}
 		return watcher, nil
 	case "service":
-		return nil, nil
+		watcher, err := NewServiceWatcher(comm, p.config, p.logger, client)
+		if err != nil {
+			return nil, err
+		}
+		return watcher, nil
 	default:
 		return nil, fmt.Errorf("unsupported autodiscover resource %s", p.config.Resource)
 	}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
@@ -183,22 +183,13 @@ func generateNodeData(node *kubernetes.Node, cfg *Config) *nodeData {
 	// Pass annotations to all events so that it can be used in templating and by annotation builders.
 	annotations := common.MapStr{}
 	for k, v := range node.GetObjectMeta().GetAnnotations() {
-		if cfg.AnnotationsDedot {
-			annotation := common.DeDot(k)
-			annotations.Put(annotation, v)
-		} else {
-			safemapstr.Put(annotations, k, v)
-		}
+		safemapstr.Put(annotations, k, v)
 	}
 
 	labels := common.MapStr{}
 	for k, v := range node.GetObjectMeta().GetLabels() {
-		if cfg.LabelsDedot {
-			label := common.DeDot(k)
-			labels.Put(label, v)
-		} else {
-			safemapstr.Put(labels, k, v)
-		}
+		// TODO: add dedoting option
+		safemapstr.Put(labels, k, v)
 	}
 
 	mapping := map[string]interface{}{

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
@@ -32,7 +32,7 @@ type nodeData struct {
 }
 
 // NewNodeWatcher creates a watcher that can discover and process node objects
-func NewNodeWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
+func NewNodeWatcher(comm composable.DynamicProviderComm, cfg *ResourceConfig, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, kubernetes.WatchOptions{
 		SyncTimeout:  cfg.SyncPeriod,
 		Node:         cfg.Node,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
@@ -25,9 +25,9 @@ type node struct {
 	comm           composable.DynamicProviderComm
 }
 
-// NewNodeWatcher creates a watcher that can discover and process pod objects
+// NewNodeWatcher creates a watcher that can discover and process node objects
 func NewNodeWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
-	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
+	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, kubernetes.WatchOptions{
 		SyncTimeout:  cfg.SyncPeriod,
 		Node:         cfg.Node,
 		IsUpdated:    isUpdated,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
@@ -1,0 +1,184 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kubernetes
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+	"github.com/elastic/beats/v7/libbeat/common/safemapstr"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+)
+
+type node struct {
+	logger         *logp.Logger
+	cleanupTimeout time.Duration
+	comm           composable.DynamicProviderComm
+}
+
+// NewNodeWatcher creates a watcher that can discover and process pod objects
+func NewNodeWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
+	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
+		SyncTimeout:  cfg.SyncPeriod,
+		Node:         cfg.Node,
+		IsUpdated:    isUpdated,
+		HonorReSyncs: true,
+	}, nil)
+	if err != nil {
+		return nil, errors.New(err, "couldn't create kubernetes watcher")
+	}
+	watcher.AddEventHandler(&node{logger, cfg.CleanupTimeout, comm})
+
+	return watcher, nil
+}
+
+func (n *node) emitRunning(node *kubernetes.Node) {
+	host := getAddress(node)
+
+	// If a node doesn't have an IP then dont monitor it
+	if host == "" {
+		return
+	}
+
+	// If the node is not in ready state then dont monitor it
+	if !isNodeReady(node) {
+		return
+	}
+
+	//TODO: add metadata here too ie -> meta := n.metagen.Generate(node)
+
+	// Pass annotations to all events so that it can be used in templating and by annotation builders.
+	annotations := common.MapStr{}
+	for k, v := range node.GetObjectMeta().GetAnnotations() {
+		safemapstr.Put(annotations, k, v)
+	}
+
+	mapping := map[string]interface{}{
+		"node": map[string]interface{}{
+			"uid":         string(node.GetUID()),
+			"name":        node.GetName(),
+			"labels":      node.GetLabels(),
+			"annotations": annotations,
+			"ip":          host,
+		},
+	}
+
+	processors := []map[string]interface{}{
+		{
+			"add_fields": map[string]interface{}{
+				"fields": mapping,
+				"target": "kubernetes",
+			},
+		},
+	}
+
+	// Emit the node
+	n.comm.AddOrUpdate(string(node.GetUID()), NodePriority, mapping, processors)
+}
+
+func (n *node) emitStopped(node *kubernetes.Node) {
+	n.comm.Remove(string(node.GetUID()))
+}
+
+// OnAdd ensures processing of node objects that are newly created
+func (n *node) OnAdd(obj interface{}) {
+	n.logger.Debugf("Watcher Node add: %+v", obj)
+	n.emitRunning(obj.(*kubernetes.Node))
+}
+
+// OnUpdate ensures processing of node objects that are updated
+func (n *node) OnUpdate(obj interface{}) {
+	node := obj.(*kubernetes.Node)
+	if node.GetObjectMeta().GetDeletionTimestamp() != nil {
+		n.logger.Debugf("Watcher Node update (terminating): %+v", obj)
+		// Node is terminating, don't reload its configuration and ignore the event as long as node is Ready.
+		if isNodeReady(node) {
+			return
+		}
+		time.AfterFunc(n.cleanupTimeout, func() { n.emitStopped(node) })
+	} else {
+		n.logger.Debugf("Watcher Node update: %+v", obj)
+		n.emitStopped(node)
+		n.emitRunning(node)
+	}
+}
+
+// OnDelete ensures processing of node objects that are deleted
+func (n *node) OnDelete(obj interface{}) {
+	n.logger.Debugf("Watcher Node delete: %+v", obj)
+	node := obj.(*kubernetes.Node)
+	time.AfterFunc(n.cleanupTimeout, func() { n.emitStopped(node) })
+}
+
+func isUpdated(o, n interface{}) bool {
+	old, _ := o.(*kubernetes.Node)
+	new, _ := n.(*kubernetes.Node)
+
+	// Consider as not update in case one of the two objects is not a Node
+	if old == nil || new == nil {
+		return true
+	}
+
+	// This is a resync. It is not an update
+	if old.ResourceVersion == new.ResourceVersion {
+		return false
+	}
+
+	// If the old object and new object are different
+	oldCopy := old.DeepCopy()
+	oldCopy.ResourceVersion = ""
+
+	newCopy := new.DeepCopy()
+	newCopy.ResourceVersion = ""
+
+	// If the old object and new object are different in either meta or spec then there is a valid change
+	if !equality.Semantic.DeepEqual(oldCopy.Spec, newCopy.Spec) || !equality.Semantic.DeepEqual(oldCopy.ObjectMeta, newCopy.ObjectMeta) {
+		return true
+	}
+
+	// If there is a change in the node status then there is a valid change.
+	if isNodeReady(old) != isNodeReady(new) {
+		return true
+	}
+	return false
+}
+
+func getAddress(node *kubernetes.Node) string {
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeExternalIP && address.Address != "" {
+			return address.Address
+		}
+	}
+
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeInternalIP && address.Address != "" {
+			return address.Address
+		}
+	}
+
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1.NodeHostName && address.Address != "" {
+			return address.Address
+		}
+	}
+
+	return ""
+}
+
+func isNodeReady(node *kubernetes.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == v1.NodeReady {
+			return c.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
@@ -19,15 +19,16 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 )
 
-type nodeData struct {
-	node       *kubernetes.Node
-	mapping    map[string]interface{}
-	processors []map[string]interface{}
-}
 type node struct {
 	logger         *logp.Logger
 	cleanupTimeout time.Duration
 	comm           composable.DynamicProviderComm
+}
+
+type nodeData struct {
+	node       *kubernetes.Node
+	mapping    map[string]interface{}
+	processors []map[string]interface{}
 }
 
 // NewNodeWatcher creates a watcher that can discover and process node objects
@@ -47,7 +48,7 @@ func NewNodeWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *lo
 }
 
 func (n *node) emitRunning(node *kubernetes.Node) {
-	data := generateData(node)
+	data := generateNodeData(node)
 	if data == nil {
 		return
 	}
@@ -154,7 +155,7 @@ func isNodeReady(node *kubernetes.Node) bool {
 	return false
 }
 
-func generateData(node *kubernetes.Node) *nodeData {
+func generateNodeData(node *kubernetes.Node) *nodeData {
 	host := getAddress(node)
 
 	// If a node doesn't have an IP then dont monitor it

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node_test.go
@@ -1,0 +1,70 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+)
+
+func TestGenerateNodeData(t *testing.T) {
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
+	node := &kubernetes.Node{
+		ObjectMeta: kubernetes.ObjectMeta{
+			Name: "testnode",
+			UID:  types.UID(uid),
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"baz": "ban",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}},
+			Addresses:  []v1.NodeAddress{{Type: v1.NodeHostName, Address: "node1"}},
+		},
+	}
+
+	data := generateData(node)
+
+	mapping := map[string]interface{}{
+		"node": map[string]interface{}{
+			"uid":    string(node.GetUID()),
+			"name":   node.GetName(),
+			"labels": node.GetLabels(),
+			"annotations": common.MapStr{
+				"baz": "ban",
+			},
+			"ip": "node1",
+		},
+	}
+
+	processors := []map[string]interface{}{
+		{
+			"add_fields": map[string]interface{}{
+				"fields": mapping,
+				"target": "kubernetes",
+			},
+		},
+	}
+
+	assert.Equal(t, node, data.node)
+	assert.Equal(t, mapping, data.mapping)
+	assert.Equal(t, processors, data.processors)
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node_test.go
@@ -41,13 +41,15 @@ func TestGenerateNodeData(t *testing.T) {
 		},
 	}
 
-	data := generateNodeData(node)
+	data := generateNodeData(node, &Config{LabelsDedot: true, AnnotationsDedot: true})
 
 	mapping := map[string]interface{}{
 		"node": map[string]interface{}{
-			"uid":    string(node.GetUID()),
-			"name":   node.GetName(),
-			"labels": node.GetLabels(),
+			"uid":  string(node.GetUID()),
+			"name": node.GetName(),
+			"labels": common.MapStr{
+				"foo": "bar",
+			},
 			"annotations": common.MapStr{
 				"baz": "ban",
 			},

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node_test.go
@@ -41,7 +41,7 @@ func TestGenerateNodeData(t *testing.T) {
 		},
 	}
 
-	data := generateNodeData(node, &Config{LabelsDedot: true, AnnotationsDedot: true})
+	data := generateNodeData(node, &Config{})
 
 	mapping := map[string]interface{}{
 		"node": map[string]interface{}{

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -129,22 +129,13 @@ func generatePodData(pod *kubernetes.Pod, cfg *Config) providerData {
 	// Pass annotations to all events so that it can be used in templating and by annotation builders.
 	annotations := common.MapStr{}
 	for k, v := range pod.GetObjectMeta().GetAnnotations() {
-		if cfg.AnnotationsDedot {
-			annotation := common.DeDot(k)
-			annotations.Put(annotation, v)
-		} else {
-			safemapstr.Put(annotations, k, v)
-		}
+		safemapstr.Put(annotations, k, v)
 	}
 
 	labels := common.MapStr{}
 	for k, v := range pod.GetObjectMeta().GetLabels() {
-		if cfg.LabelsDedot {
-			label := common.DeDot(k)
-			labels.Put(label, v)
-		} else {
-			safemapstr.Put(labels, k, v)
-		}
+		// TODO: add dedoting option
+		safemapstr.Put(labels, k, v)
 	}
 
 	mapping := map[string]interface{}{
@@ -189,12 +180,7 @@ func generateContainerData(
 
 	labels := common.MapStr{}
 	for k, v := range pod.GetObjectMeta().GetLabels() {
-		if cfg.LabelsDedot {
-			label := common.DeDot(k)
-			labels.Put(label, v)
-		} else {
-			safemapstr.Put(labels, k, v)
-		}
+		safemapstr.Put(labels, k, v)
 	}
 
 	for _, c := range containers {

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -1,0 +1,167 @@
+package kubernetes
+
+import (
+	"fmt"
+	"time"
+
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+)
+
+type pod struct {
+	logger         *logp.Logger
+	cleanupTimeout time.Duration
+	comm           composable.DynamicProviderComm
+}
+
+// NewPodEventer creates an eventer that can discover and process pod objects
+func NewPodWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
+	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
+		SyncTimeout: cfg.SyncPeriod,
+		Node:        cfg.Node,
+		//Namespace:   p.config.Namespace,
+	}, nil)
+	if err != nil {
+		return nil, errors.New(err, "couldn't create kubernetes watcher")
+	}
+	watcher.AddEventHandler(&pod{logger, cfg.CleanupTimeout, comm})
+
+	return watcher, nil
+}
+
+func (p *pod) emitRunning(pod *kubernetes.Pod) {
+	mapping := map[string]interface{}{
+		"namespace": pod.GetNamespace(),
+		"pod": map[string]interface{}{
+			"uid":    string(pod.GetUID()),
+			"name":   pod.GetName(),
+			"labels": pod.GetLabels(),
+			"ip":     pod.Status.PodIP,
+		},
+	}
+
+	processors := []map[string]interface{}{
+		{
+			"add_fields": map[string]interface{}{
+				"fields": mapping,
+				"target": "kubernetes",
+			},
+		},
+	}
+
+	// Emit the pod
+	// We emit Pod + containers to ensure that configs matching Pod only
+	// get Pod metadata (not specific to any container)
+	p.comm.AddOrUpdate(string(pod.GetUID()), PodPriority, mapping, processors)
+
+	// Emit all containers in the pod
+	p.emitContainers(pod, pod.Spec.Containers, pod.Status.ContainerStatuses)
+
+	// TODO deal with init containers stopping after initialization
+	p.emitContainers(pod, pod.Spec.InitContainers, pod.Status.InitContainerStatuses)
+}
+
+func (p *pod) emitContainers(pod *kubernetes.Pod, containers []kubernetes.Container, containerstatuses []kubernetes.PodContainerStatus) {
+	// Collect all runtimes from status information.
+	containerIDs := map[string]string{}
+	runtimes := map[string]string{}
+	for _, c := range containerstatuses {
+		cid, runtime := kubernetes.ContainerIDWithRuntime(c)
+		containerIDs[c.Name] = cid
+		runtimes[c.Name] = runtime
+	}
+
+	for _, c := range containers {
+		// If it doesn't have an ID, container doesn't exist in
+		// the runtime, emit only an event if we are stopping, so
+		// we are sure of cleaning up configurations.
+		cid := containerIDs[c.Name]
+		if cid == "" {
+			continue
+		}
+
+		// ID is the combination of pod UID + container name
+		eventID := fmt.Sprintf("%s.%s", pod.GetObjectMeta().GetUID(), c.Name)
+
+		mapping := map[string]interface{}{
+			"namespace": pod.GetNamespace(),
+			"pod": map[string]interface{}{
+				"uid":    string(pod.GetUID()),
+				"name":   pod.GetName(),
+				"labels": pod.GetLabels(),
+				"ip":     pod.Status.PodIP,
+			},
+			"container": map[string]interface{}{
+				"id":      cid,
+				"name":    c.Name,
+				"image":   c.Image,
+				"runtime": runtimes[c.Name],
+			},
+		}
+
+		processors := []map[string]interface{}{
+			{
+				"add_fields": map[string]interface{}{
+					"fields": mapping,
+					"target": "kubernetes",
+				},
+			},
+		}
+
+		// Emit the container
+		p.comm.AddOrUpdate(eventID, ContainerPriority, mapping, processors)
+	}
+}
+
+func (p *pod) emitStopped(pod *kubernetes.Pod) {
+	p.comm.Remove(string(pod.GetUID()))
+
+	for _, c := range pod.Spec.Containers {
+		// ID is the combination of pod UID + container name
+		eventID := fmt.Sprintf("%s.%s", pod.GetObjectMeta().GetUID(), c.Name)
+		p.comm.Remove(eventID)
+	}
+
+	for _, c := range pod.Spec.InitContainers {
+		// ID is the combination of pod UID + container name
+		eventID := fmt.Sprintf("%s.%s", pod.GetObjectMeta().GetUID(), c.Name)
+		p.comm.Remove(eventID)
+	}
+}
+
+// OnAdd ensures processing of pod objects that are newly added
+func (p *pod) OnAdd(obj interface{}) {
+	p.logger.Debugf("pod add: %+v", obj)
+	p.emitRunning(obj.(*kubernetes.Pod))
+}
+
+// OnUpdate emits events for a given pod depending on the state of the pod,
+// if it is terminating, a stop event is scheduled, if not, a stop and a start
+// events are sent sequentially to recreate the resources assotiated to the pod.
+func (p *pod) OnUpdate(obj interface{}) {
+	pod := obj.(*kubernetes.Pod)
+
+	p.logger.Debugf("pod update for pod: %+v, status: %+v", pod.Name, pod.Status.Phase)
+	switch pod.Status.Phase {
+	case kubernetes.PodSucceeded, kubernetes.PodFailed:
+		time.AfterFunc(p.cleanupTimeout, func() { p.emitStopped(pod) })
+		return
+	case kubernetes.PodPending:
+		p.logger.Debugf("pod update (pending): don't know what to do with this pod yet, skipping for now: %+v", obj)
+		return
+	}
+
+	p.logger.Debugf("pod update: %+v", obj)
+	p.emitRunning(pod)
+}
+
+// OnDelete stops pod objects that are deleted
+func (p *pod) OnDelete(obj interface{}) {
+	p.logger.Debugf("pod delete: %+v", obj)
+	pod := obj.(*kubernetes.Pod)
+	time.AfterFunc(p.cleanupTimeout, func() { p.emitStopped(pod) })
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -65,8 +65,9 @@ func (p *pod) emitRunning(pod *kubernetes.Pod) {
 	// Emit all containers in the pod
 	p.emitContainers(pod, pod.Spec.Containers, pod.Status.ContainerStatuses)
 
-	// TODO deal with init containers stopping after initialization
+	// TODO: deal with init containers stopping after initialization
 	p.emitContainers(pod, pod.Spec.InitContainers, pod.Status.InitContainerStatuses)
+	// TODO: deal with ephemeral containers
 }
 
 func (p *pod) emitContainers(pod *kubernetes.Pod, containers []kubernetes.Container, containerstatuses []kubernetes.PodContainerStatus) {
@@ -123,7 +124,7 @@ func (p *pod) OnDelete(obj interface{}) {
 }
 
 func generatePodData(pod *kubernetes.Pod, cfg *Config) providerData {
-	//TODO: add metadata here too ie -> meta := s.metagen.Generate(pod)
+	// TODO: add metadata here too ie -> meta := s.metagen.Generate(pod)
 
 	// Pass annotations to all events so that it can be used in templating and by annotation builders.
 	annotations := common.MapStr{}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package kubernetes
 
 import (
@@ -8,8 +12,8 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 )
 
 type pod struct {
@@ -18,7 +22,7 @@ type pod struct {
 	comm           composable.DynamicProviderComm
 }
 
-// NewPodEventer creates an eventer that can discover and process pod objects
+// NewPodWatcher creates a watcher that can discover and process pod objects
 func NewPodWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 		SyncTimeout: cfg.SyncPeriod,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -32,7 +32,7 @@ type providerData struct {
 }
 
 // NewPodWatcher creates a watcher that can discover and process pod objects
-func NewPodWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
+func NewPodWatcher(comm composable.DynamicProviderComm, cfg *ResourceConfig, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 		SyncTimeout:  cfg.SyncPeriod,
 		Node:         cfg.Node,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -16,15 +16,16 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
 )
 
-type podData struct {
-	pod        *kubernetes.Pod
-	mapping    map[string]interface{}
-	processors []map[string]interface{}
-}
 type pod struct {
 	logger         *logp.Logger
 	cleanupTimeout time.Duration
 	comm           composable.DynamicProviderComm
+}
+
+type podData struct {
+	pod        *kubernetes.Pod
+	mapping    map[string]interface{}
+	processors []map[string]interface{}
 }
 
 // NewPodWatcher creates a watcher that can discover and process pod objects

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -34,9 +34,10 @@ type podData struct {
 // NewPodWatcher creates a watcher that can discover and process pod objects
 func NewPodWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
-		SyncTimeout: cfg.SyncPeriod,
-		Node:        cfg.Node,
-		//Namespace:   p.config.Namespace,
+		SyncTimeout:  cfg.SyncPeriod,
+		Node:         cfg.Node,
+		Namespace:    cfg.Namespace,
+		HonorReSyncs: true,
 	}, nil)
 	if err != nil {
 		return nil, errors.New(err, "couldn't create kubernetes watcher")

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
@@ -43,14 +43,16 @@ func TestGeneratePodData(t *testing.T) {
 		Status: kubernetes.PodStatus{PodIP: "127.0.0.5"},
 	}
 
-	data := generatePodData(pod)
+	data := generatePodData(pod, &Config{LabelsDedot: true, AnnotationsDedot: true})
 
 	mapping := map[string]interface{}{
 		"namespace": pod.GetNamespace(),
 		"pod": map[string]interface{}{
-			"uid":    string(pod.GetUID()),
-			"name":   pod.GetName(),
-			"labels": pod.GetLabels(),
+			"uid":  string(pod.GetUID()),
+			"name": pod.GetName(),
+			"labels": common.MapStr{
+				"foo": "bar",
+			},
 			"annotations": common.MapStr{
 				"app": "production",
 			},
@@ -118,15 +120,22 @@ func TestGenerateContainerPodData(t *testing.T) {
 			ContainerID: "crio://asdfghdeadbeef",
 		},
 	}
-	go generateContainerData(pod, containers, containerStatuses, providerDataChan, done)
+	go generateContainerData(
+		pod,
+		containers,
+		containerStatuses,
+		providerDataChan,
+		done, &Config{LabelsDedot: true, AnnotationsDedot: true})
 
 	mapping := map[string]interface{}{
 		"namespace": pod.GetNamespace(),
 		"pod": map[string]interface{}{
-			"uid":    string(pod.GetUID()),
-			"name":   pod.GetName(),
-			"labels": pod.GetLabels(),
-			"ip":     pod.Status.PodIP,
+			"uid":  string(pod.GetUID()),
+			"name": pod.GetName(),
+			"labels": common.MapStr{
+				"foo": "bar",
+			},
+			"ip": pod.Status.PodIP,
 		},
 		"container": map[string]interface{}{
 			"id":      "asdfghdeadbeef",

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
@@ -1,0 +1,65 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+)
+
+func TestGeneratePodData(t *testing.T) {
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
+	pod := &kubernetes.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod",
+			UID:       types.UID(uid),
+			Namespace: "testns",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"app": "production",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: kubernetes.PodSpec{
+			NodeName: "testnode",
+		},
+		Status: kubernetes.PodStatus{PodIP: "127.0.0.5"},
+	}
+
+	data := generatePodData(pod)
+
+	mapping := map[string]interface{}{
+		"namespace": pod.GetNamespace(),
+		"pod": map[string]interface{}{
+			"uid":    string(pod.GetUID()),
+			"name":   pod.GetName(),
+			"labels": pod.GetLabels(),
+			"ip":     pod.Status.PodIP,
+		},
+	}
+	processors := []map[string]interface{}{
+		{
+			"add_fields": map[string]interface{}{
+				"fields": mapping,
+				"target": "kubernetes",
+			},
+		},
+	}
+
+	assert.Equal(t, pod, data.pod)
+	assert.Equal(t, mapping, data.mapping)
+	assert.Equal(t, processors, data.processors)
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
@@ -7,6 +7,8 @@ package kubernetes
 import (
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/common"
+
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +49,10 @@ func TestGeneratePodData(t *testing.T) {
 			"uid":    string(pod.GetUID()),
 			"name":   pod.GetName(),
 			"labels": pod.GetLabels(),
-			"ip":     pod.Status.PodIP,
+			"annotations": common.MapStr{
+				"app": "production",
+			},
+			"ip": pod.Status.PodIP,
 		},
 	}
 	processors := []map[string]interface{}{

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
@@ -5,12 +5,14 @@
 package kubernetes
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 
 	"github.com/stretchr/testify/assert"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -64,7 +66,95 @@ func TestGeneratePodData(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, pod, data.pod)
+	assert.Equal(t, string(pod.GetUID()), data.uid)
 	assert.Equal(t, mapping, data.mapping)
 	assert.Equal(t, processors, data.processors)
+}
+
+func TestGenerateContainerPodData(t *testing.T) {
+	uid := "005f3b90-4b9d-12f8-acf0-31020a840133"
+	pod := &kubernetes.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testpod",
+			UID:       types.UID(uid),
+			Namespace: "testns",
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+			Annotations: map[string]string{
+				"app": "production",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		Spec: kubernetes.PodSpec{
+			NodeName: "testnode",
+		},
+		Status: kubernetes.PodStatus{PodIP: "127.0.0.5"},
+	}
+
+	providerDataChan := make(chan providerData)
+	done := make(chan bool, 1)
+
+	containers := []kubernetes.Container{
+		{
+			Name:  "nginx",
+			Image: "nginx:1.120",
+			Ports: []kubernetes.ContainerPort{
+				{
+					Name:          "http",
+					Protocol:      v1.ProtocolTCP,
+					ContainerPort: 80,
+				},
+			},
+		},
+	}
+	containerStatuses := []kubernetes.PodContainerStatus{
+		{
+			Name:        "nginx",
+			Ready:       true,
+			ContainerID: "crio://asdfghdeadbeef",
+		},
+	}
+	go generateContainerData(pod, containers, containerStatuses, providerDataChan, done)
+
+	mapping := map[string]interface{}{
+		"namespace": pod.GetNamespace(),
+		"pod": map[string]interface{}{
+			"uid":    string(pod.GetUID()),
+			"name":   pod.GetName(),
+			"labels": pod.GetLabels(),
+			"ip":     pod.Status.PodIP,
+		},
+		"container": map[string]interface{}{
+			"id":      "asdfghdeadbeef",
+			"name":    "nginx",
+			"image":   "nginx:1.120",
+			"runtime": "crio",
+		},
+	}
+
+	processors := []map[string]interface{}{
+		{
+			"add_fields": map[string]interface{}{
+				"fields": mapping,
+				"target": "kubernetes",
+			},
+		},
+	}
+
+	cuid := fmt.Sprintf("%s.%s", pod.GetObjectMeta().GetUID(), "nginx")
+	for {
+		select {
+		case data := <-providerDataChan:
+			assert.Equal(t, cuid, data.uid)
+			assert.Equal(t, mapping, data.mapping)
+			assert.Equal(t, processors, data.processors)
+		case <-done:
+			return
+		}
+	}
+
 }

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
@@ -44,7 +44,7 @@ func TestGeneratePodData(t *testing.T) {
 		Status: kubernetes.PodStatus{PodIP: "127.0.0.5"},
 	}
 
-	data := generatePodData(pod, &Config{LabelsDedot: true, AnnotationsDedot: true})
+	data := generatePodData(pod, &Config{})
 
 	mapping := map[string]interface{}{
 		"namespace": pod.GetNamespace(),
@@ -129,7 +129,7 @@ func TestGenerateContainerPodData(t *testing.T) {
 		pod,
 		containers,
 		containerStatuses,
-		&Config{LabelsDedot: true, AnnotationsDedot: true})
+		&Config{})
 
 	mapping := map[string]interface{}{
 		"namespace": pod.GetNamespace(),

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -105,22 +105,13 @@ func generateServiceData(service *kubernetes.Service, cfg *Config) *serviceData 
 	// Pass annotations to all events so that it can be used in templating and by annotation builders.
 	annotations := common.MapStr{}
 	for k, v := range service.GetObjectMeta().GetAnnotations() {
-		if cfg.AnnotationsDedot {
-			annotation := common.DeDot(k)
-			annotations.Put(annotation, v)
-		} else {
-			safemapstr.Put(annotations, k, v)
-		}
+		safemapstr.Put(annotations, k, v)
 	}
 
 	labels := common.MapStr{}
 	for k, v := range service.GetObjectMeta().GetLabels() {
-		if cfg.LabelsDedot {
-			label := common.DeDot(k)
-			labels.Put(label, v)
-		} else {
-			safemapstr.Put(labels, k, v)
-		}
+		// TODO: add dedoting option
+		safemapstr.Put(labels, k, v)
 	}
 
 	mapping := map[string]interface{}{

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -55,7 +55,7 @@ func (s *service) emitRunning(service *kubernetes.Service) {
 	}
 
 	mapping := map[string]interface{}{
-		"node": map[string]interface{}{
+		"service": map[string]interface{}{
 			"uid":         string(service.GetUID()),
 			"name":        service.GetName(),
 			"labels":      service.GetLabels(),
@@ -73,7 +73,7 @@ func (s *service) emitRunning(service *kubernetes.Service) {
 		},
 	}
 
-	// Emit the node
+	// Emit the service
 	s.comm.AddOrUpdate(string(service.GetUID()), ServicePriority, mapping, processors)
 }
 

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -1,0 +1,109 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package kubernetes
+
+import (
+	"time"
+
+	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+	"github.com/elastic/beats/v7/libbeat/common/safemapstr"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/composable"
+)
+
+type service struct {
+	logger         *logp.Logger
+	cleanupTimeout time.Duration
+	comm           composable.DynamicProviderComm
+}
+
+// NewServiceWatcher creates a watcher that can discover and process service objects
+func NewServiceWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
+	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
+		SyncTimeout:  cfg.SyncPeriod,
+		Node:         cfg.Node,
+		HonorReSyncs: true,
+	}, nil)
+	if err != nil {
+		return nil, errors.New(err, "couldn't create kubernetes watcher")
+	}
+	watcher.AddEventHandler(&service{logger, cfg.CleanupTimeout, comm})
+
+	return watcher, nil
+}
+
+func (s *service) emitRunning(service *kubernetes.Service) {
+	host := service.Spec.ClusterIP
+
+	// If a service doesn't have an IP then dont monitor it
+	if host == "" {
+		return
+	}
+
+	//TODO: add metadata here too ie -> meta := s.metagen.Generate(service)
+
+	// Pass annotations to all events so that it can be used in templating and by annotation builders.
+	annotations := common.MapStr{}
+	for k, v := range service.GetObjectMeta().GetAnnotations() {
+		safemapstr.Put(annotations, k, v)
+	}
+
+	mapping := map[string]interface{}{
+		"node": map[string]interface{}{
+			"uid":         string(service.GetUID()),
+			"name":        service.GetName(),
+			"labels":      service.GetLabels(),
+			"annotations": annotations,
+			"ip":          host,
+		},
+	}
+
+	processors := []map[string]interface{}{
+		{
+			"add_fields": map[string]interface{}{
+				"fields": mapping,
+				"target": "kubernetes",
+			},
+		},
+	}
+
+	// Emit the node
+	s.comm.AddOrUpdate(string(service.GetUID()), ServicePriority, mapping, processors)
+}
+
+func (n *service) emitStopped(service *kubernetes.Service) {
+	n.comm.Remove(string(service.GetUID()))
+}
+
+// OnAdd ensures processing of service objects that are newly created
+func (n *service) OnAdd(obj interface{}) {
+	n.logger.Debugf("Watcher Service add: %+v", obj)
+	n.emitRunning(obj.(*kubernetes.Service))
+}
+
+// OnUpdate ensures processing of service objects that are updated
+func (n *service) OnUpdate(obj interface{}) {
+	service := obj.(*kubernetes.Service)
+	// Once service is in terminated state, mark it for deletion
+	if service.GetObjectMeta().GetDeletionTimestamp() != nil {
+		n.logger.Debugf("Watcher Service update (terminating): %+v", obj)
+		time.AfterFunc(n.cleanupTimeout, func() { n.emitStopped(service) })
+	} else {
+		n.logger.Debugf("Watcher Node update: %+v", obj)
+		n.emitStopped(service)
+		n.emitRunning(service)
+	}
+}
+
+// OnDelete ensures processing of service objects that are deleted
+func (s *service) OnDelete(obj interface{}) {
+	s.logger.Debugf("Watcher Service delete: %+v", obj)
+	service := obj.(*kubernetes.Service)
+	time.AfterFunc(s.cleanupTimeout, func() { s.emitStopped(service) })
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -30,7 +30,7 @@ type serviceData struct {
 }
 
 // NewServiceWatcher creates a watcher that can discover and process service objects
-func NewServiceWatcher(comm composable.DynamicProviderComm, cfg *Config, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
+func NewServiceWatcher(comm composable.DynamicProviderComm, cfg *ResourceConfig, logger *logp.Logger, client k8s.Interface) (kubernetes.Watcher, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
 		SyncTimeout:  cfg.SyncPeriod,
 		Node:         cfg.Node,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -77,27 +77,27 @@ func (s *service) emitRunning(service *kubernetes.Service) {
 	s.comm.AddOrUpdate(string(service.GetUID()), ServicePriority, mapping, processors)
 }
 
-func (n *service) emitStopped(service *kubernetes.Service) {
-	n.comm.Remove(string(service.GetUID()))
+func (s *service) emitStopped(service *kubernetes.Service) {
+	s.comm.Remove(string(service.GetUID()))
 }
 
 // OnAdd ensures processing of service objects that are newly created
-func (n *service) OnAdd(obj interface{}) {
-	n.logger.Debugf("Watcher Service add: %+v", obj)
-	n.emitRunning(obj.(*kubernetes.Service))
+func (s *service) OnAdd(obj interface{}) {
+	s.logger.Debugf("Watcher Service add: %+v", obj)
+	s.emitRunning(obj.(*kubernetes.Service))
 }
 
 // OnUpdate ensures processing of service objects that are updated
-func (n *service) OnUpdate(obj interface{}) {
+func (s *service) OnUpdate(obj interface{}) {
 	service := obj.(*kubernetes.Service)
 	// Once service is in terminated state, mark it for deletion
 	if service.GetObjectMeta().GetDeletionTimestamp() != nil {
-		n.logger.Debugf("Watcher Service update (terminating): %+v", obj)
-		time.AfterFunc(n.cleanupTimeout, func() { n.emitStopped(service) })
+		s.logger.Debugf("Watcher Service update (terminating): %+v", obj)
+		time.AfterFunc(s.cleanupTimeout, func() { s.emitStopped(service) })
 	} else {
-		n.logger.Debugf("Watcher Node update: %+v", obj)
-		n.emitStopped(service)
-		n.emitRunning(service)
+		s.logger.Debugf("Watcher Node update: %+v", obj)
+		s.emitStopped(service)
+		s.emitRunning(service)
 	}
 }
 

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service_test.go
@@ -45,13 +45,15 @@ func TestGenerateServiceData(t *testing.T) {
 		},
 	}
 
-	data := generateServiceData(service)
+	data := generateServiceData(service, &Config{LabelsDedot: true, AnnotationsDedot: true})
 
 	mapping := map[string]interface{}{
 		"service": map[string]interface{}{
-			"uid":    string(service.GetUID()),
-			"name":   service.GetName(),
-			"labels": service.GetLabels(),
+			"uid":  string(service.GetUID()),
+			"name": service.GetName(),
+			"labels": common.MapStr{
+				"foo": "bar",
+			},
 			"annotations": common.MapStr{
 				"baz": "ban",
 			},

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service_test.go
@@ -45,7 +45,7 @@ func TestGenerateServiceData(t *testing.T) {
 		},
 	}
 
-	data := generateServiceData(service, &Config{LabelsDedot: true, AnnotationsDedot: true})
+	data := generateServiceData(service, &Config{})
 
 	mapping := map[string]interface{}{
 		"service": map[string]interface{}{


### PR DESCRIPTION
## What does this PR do?
This PR adds more resources in `kubernetes` dynamic provider.

## Why is it important?
So as to support Node and Service discovery via `kubernetes` dynamic provider of Agent.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally
#### Test with `node` resource`:
1. Use the following config:
```
providers.kubernetes:
  scope: cluster
  kube_config: /Users/chrismark/.kube/config
  cleanup_timeout: 360s
  resources:
    node: 
      enabled: true

inputs:
  - type: logfile
    streams:
      - paths: ${kubernetes.node.name}/another.log
```
2. Run `inspect` command to check what is the compiled configuration (use proper path for the elastic-agent.yml config file :
`./elastic-agent -c /Users/ubuntu/Desktop/elastic-agent.yml inspect output -o default`
3. Verify that something similar to the following is produced:
```
filebeat:
  inputs:
  - index: logs-generic-default
    paths: kind-control-plane/another.log
    processors:
    - add_fields:
        fields:
          node:
            annotations:
              kubeadm:
                alpha:
                  kubernetes:
                    io/cri-socket: unix:///run/containerd/containerd.sock
              node:
                alpha:
                  kubernetes:
                    io/ttl: "0"
              volumes:
                kubernetes:
                  io/controller-managed-attach-detach: "true"
            ip: 172.18.0.3
            labels:
              beta.kubernetes.io/arch: amd64
              beta.kubernetes.io/os: linux
              kubernetes.io/arch: amd64
              kubernetes.io/hostname: kind-control-plane
              kubernetes.io/os: linux
              node-role.kubernetes.io/master: ""
            name: kind-control-plane
            uid: 65e26851-66d2-44f9-948d-37e2c43f50f7
        target: kubernetes
```

### Test with `service` resource.
1.
```
providers.kubernetes:
  scope: cluster
  kube_config: /Users/chrismark/.kube/config
  cleanup_timeout: 360s
  resources:
    service: 
      enabled: true

inputs:
  - type: logfile
    streams:
      - paths: ${kubernetes.service.name}/another.log
```

### Test with `pod`
1.
```
providers.kubernetes:
  scope: cluster
  kube_config: /Users/chrismark/.kube/config
  cleanup_timeout: 360s
  resources:
    pod:
       enabled: true

inputs:
  - type: logfile
    streams:
      - paths: ${kubernetes.pod.name}/another.log
```

### Test with `service` resource and `node` scope.
1.
```
providers.kubernetes:
  scope: node
  kube_config: /Users/chrismark/.kube/config
 cleanup_timeout: 360s
  resources:
    service:
      enabled: true
      

inputs:
  - type: logfile
    streams:
      - paths: ${kubernetes.service.name}/another.log
```
2. Verify from the logs that the scope was enforced to `cluster` scope (`can not set scope to node when using resource Service. resetting scope to cluster`), and that `kubernetes.scope` field is populated with `cluster` value.

### Test with `pod` at node scope and define node
1.
```
providers.kubernetes:
  scope: node
  kube_config: /Users/chrismark/.kube/config
  cleanup_timeout: 360s
  node: "kind-control-plane"
  resources:
    pod:
      enabled: true
      

inputs:
  - type: logfile
    streams:
      - paths: ${kubernetes.pod.name}/another.log
```

## Related issues

- Closes https://github.com/elastic/beats/issues/24496


