### PR TITLE
Cherry-pick #26785 to 7.14: Remove symlink.prev from previously failed upgrade

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -75,6 +75,7 @@
 - Fix add support for Logstash output. {pull}24305[24305]
 - Do not log Elasticsearch configuration for monitoring output when running with debug. {pull}26583[26583]
 - Fix issue where proxy enrollment options broke enrollment command. {pull}26749[26749]
+- Remove symlink.prev from previously failed upgrade {pull}26785[26785]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/rollback.go
@@ -73,6 +73,9 @@ func Cleanup(currentHash string, removeMarker bool) error {
 		return err
 	}
 
+	// remove symlink to avoid upgrade failures, ignore error
+	_ = os.Remove(prevSymlinkPath())
+
 	dirPrefix := fmt.Sprintf("%s-", agentName)
 	currentDir := fmt.Sprintf("%s-%s", agentName, currentHash)
 	for _, dir := range subdirs {


### PR DESCRIPTION
Cherry-pick of PR #26785 to 7.14 branch. Original message:

## What does this PR do?

This PR removes symlink prev before starting upgrade procedure

## Why is it important?

In case .prev is left there because of failure in previous upgrades it will fail to upgrade on `cannot create symlink, file already exists` error

Fixes: #26513

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
