### PR TITLE
backport: Add 7.13 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "upstream": "elastic/beats",
-  "branches": [ { "name": "7.x", "checked": true }, "7.14", "7.13", "7.12" ],
+  "branches": [ { "name": "7.x", "checked": true }, "7.13", "7.14", "7.13", "7.12" ],
   "labels": ["backport"],
   "autoAssign": true,
   "prTitle": "Cherry-pick to {targetBranch}: {commitMessages}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,7 +28,7 @@ pull_request_rules:
   - name: backport patches to 7.13 branch
     conditions:
       - merged
-      - label=backport-v7.13.0
+      - label=backport-v7.14.0
     actions:
       backport:
         assignees:
@@ -151,3 +151,16 @@ pull_request_rules:
         - files~=^\.mergify\.yml$
     actions:
       delete_head_branch:
+  - name: backport patches to 7.13 branch
+    conditions:
+      - merged
+      - label=backport-v7.13.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.13"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 7.13 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821