### PR TITLE
[Winlogbeat] Fixes for wineventlog experimental api

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -521,6 +521,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
 - Protect against accessing an undefined variable in Security module. {pull}22937[22937]
 - Fix related.ip field in renameCommonAuthFields {pull}24892[24892]
+- Fix an issue with message template caching in the `wineventlog-experimental` API implementation. {pull}26826[26826]
 
 *Functionbeat*
 

--- a/winlogbeat/sys/wineventlog/format_message.go
+++ b/winlogbeat/sys/wineventlog/format_message.go
@@ -45,7 +45,7 @@ func getMessageString(metadata *PublisherMetadata, eventHandle EvtHandle, messag
 	var flags EvtFormatMessageFlag
 	if eventHandle > 0 {
 		flags = EvtFormatMessageEvent
-	} else if messageID > 0 {
+	} else {
 		flags = EvtFormatMessageId
 	}
 

--- a/winlogbeat/sys/wineventlog/stringinserts.go
+++ b/winlogbeat/sys/wineventlog/stringinserts.go
@@ -30,6 +30,9 @@ const (
 	// maxInsertStrings is the maximum number of parameters supported in a
 	// Windows event message.
 	maxInsertStrings = 99
+
+	leftTemplateDelim  = "[{{"
+	rightTemplateDelim = "}}]"
 )
 
 // templateInserts contains EvtVariant values that can be used to substitute
@@ -45,7 +48,7 @@ type stringInserts struct {
 	evtVariants   [maxInsertStrings]EvtVariant
 }
 
-// Pointer returns a pointer the EvtVariant array.
+// Slice returns a slice of the full EvtVariant array.
 func (si *stringInserts) Slice() []EvtVariant {
 	return si.evtVariants[:]
 }
@@ -66,7 +69,8 @@ func newTemplateStringInserts() *stringInserts {
 
 	for i := 0; i < len(si.evtVariants); i++ {
 		// Use i+1 to keep our inserts numbered the same as Window's inserts.
-		strSlice, err := windows.UTF16FromString(`{{eventParam $ ` + strconv.Itoa(i+1) + `}}`)
+		templateParam := leftTemplateDelim + `eventParam $ ` + strconv.Itoa(i+1) + rightTemplateDelim
+		strSlice, err := windows.UTF16FromString(templateParam)
 		if err != nil {
 			// This will never happen.
 			panic(err)

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -661,3 +661,5 @@ func EvtClearLog(session EvtHandle, channelPath string, targetFilePath string) e
 //sys   _EvtNextEventMetadata(enumerator EvtHandle, flags uint32) (handle EvtHandle, err error) = wevtapi.EvtNextEventMetadata
 //sys   _EvtGetObjectArrayProperty(objectArray EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, arrayIndex uint32, flags uint32, bufferSize uint32, evtVariant *EvtVariant, bufferUsed *uint32) (err error) = wevtapi.EvtGetObjectArrayProperty
 //sys   _EvtGetObjectArraySize(objectArray EvtObjectArrayPropertyHandle, arraySize *uint32) (err error) = wevtapi.EvtGetObjectArraySize
+//sys   _EvtOpenPublisherEnum(session EvtHandle, flags uint32) (handle EvtHandle, err error) = wevtapi.EvtOpenPublisherEnum
+//sys   _EvtNextPublisherId(enumerator EvtHandle, bufferSize uint32, buffer *byte, bufferUsed *uint32) (err error) = wevtapi.EvtNextPublisherId

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -662,4 +662,4 @@ func EvtClearLog(session EvtHandle, channelPath string, targetFilePath string) e
 //sys   _EvtGetObjectArrayProperty(objectArray EvtObjectArrayPropertyHandle, propertyID EvtPublisherMetadataPropertyID, arrayIndex uint32, flags uint32, bufferSize uint32, evtVariant *EvtVariant, bufferUsed *uint32) (err error) = wevtapi.EvtGetObjectArrayProperty
 //sys   _EvtGetObjectArraySize(objectArray EvtObjectArrayPropertyHandle, arraySize *uint32) (err error) = wevtapi.EvtGetObjectArraySize
 //sys   _EvtOpenPublisherEnum(session EvtHandle, flags uint32) (handle EvtHandle, err error) = wevtapi.EvtOpenPublisherEnum
-//sys   _EvtNextPublisherId(enumerator EvtHandle, bufferSize uint32, buffer *byte, bufferUsed *uint32) (err error) = wevtapi.EvtNextPublisherId
+//sys   _EvtNextPublisherId(enumerator EvtHandle, bufferSize uint32, buffer *uint16, bufferUsed *uint32) (err error) = wevtapi.EvtNextPublisherId

--- a/winlogbeat/sys/wineventlog/template.go
+++ b/winlogbeat/sys/wineventlog/template.go
@@ -22,12 +22,13 @@ import (
 )
 
 type eventTemplate struct {
-	Data []eventData `xml:"data"`
+	Data []EventData `xml:"data"`
 }
 
-type eventData struct {
-	Name string `xml:"name,attr"`
-	Type string `xml:"outType,attr"`
+type EventData struct {
+	Name    string `xml:"name,attr"`
+	InType  string `xml:"inType,attr"`
+	OutType string `xml:"outType,attr"`
 }
 
 func (t *eventTemplate) Unmarshal(xmlData []byte) error {

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"reflect"
 	"runtime"
+	"sort"
 	"syscall"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -417,6 +418,46 @@ func FormatEventString(
 	// This assumes there is only a single string value to read. This will
 	// not work to read keys (when messageFlag == EvtFormatMessageKeyword).
 	return common.UTF16ToUTF8Bytes(buffer[:bufferUsed], out)
+}
+
+// Publishers returns a sort list of event publishers on the local computer.
+func Publishers() ([]string, error) {
+	publisherEnumerator, err := _EvtOpenPublisherEnum(NilHandle, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed in EvtOpenPublisherEnum: %w", err)
+	}
+	defer Close(publisherEnumerator)
+
+	var (
+		publishers []string
+		bufferUsed uint32
+		buffer     = make([]byte, 1024)
+	)
+
+loop:
+	for {
+		if err = _EvtNextPublisherId(publisherEnumerator, uint32(len(buffer)), &buffer[0], &bufferUsed); err != nil {
+			switch err {
+			case ERROR_NO_MORE_ITEMS:
+				break loop
+			case ERROR_INSUFFICIENT_BUFFER:
+				buffer = make([]byte, 2*bufferUsed)
+				continue loop
+			default:
+				return nil, fmt.Errorf("failed in EvtNextPublisherId: %w", err)
+			}
+		}
+
+		provider, err := sys.UTF16BytesToString(buffer)
+		if err != nil {
+			return nil, err
+		}
+
+		publishers = append(publishers, provider)
+	}
+
+	sort.Strings(publishers)
+	return publishers, nil
 }
 
 // offset reads a pointer value from the reader then calculates an offset from

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -431,7 +431,7 @@ func Publishers() ([]string, error) {
 	var (
 		publishers []string
 		bufferUsed uint32
-		buffer     = make([]byte, 1024)
+		buffer     = make([]uint16, 1024)
 	)
 
 loop:
@@ -441,18 +441,14 @@ loop:
 			case ERROR_NO_MORE_ITEMS:
 				break loop
 			case ERROR_INSUFFICIENT_BUFFER:
-				buffer = make([]byte, 2*bufferUsed)
+				buffer = make([]uint16, bufferUsed)
 				continue loop
 			default:
 				return nil, fmt.Errorf("failed in EvtNextPublisherId: %w", err)
 			}
 		}
 
-		provider, err := sys.UTF16BytesToString(buffer)
-		if err != nil {
-			return nil, err
-		}
-
+		provider := windows.UTF16ToString(buffer)
 		publishers = append(publishers, provider)
 	}
 

--- a/winlogbeat/sys/wineventlog/wineventlog_windows_test.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows_test.go
@@ -108,3 +108,15 @@ func TestChannels(t *testing.T) {
 		}
 	}
 }
+
+func TestPublishers(t *testing.T) {
+	publishers, err := Publishers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NotEmpty(t, publishers)
+	for _, p := range publishers {
+		t.Log(p)
+	}
+}

--- a/winlogbeat/sys/wineventlog/zsyscall_windows.go
+++ b/winlogbeat/sys/wineventlog/zsyscall_windows.go
@@ -69,9 +69,11 @@ var (
 	procEvtNext                         = modwevtapi.NewProc("EvtNext")
 	procEvtNextChannelPath              = modwevtapi.NewProc("EvtNextChannelPath")
 	procEvtNextEventMetadata            = modwevtapi.NewProc("EvtNextEventMetadata")
+	procEvtNextPublisherId              = modwevtapi.NewProc("EvtNextPublisherId")
 	procEvtOpenChannelEnum              = modwevtapi.NewProc("EvtOpenChannelEnum")
 	procEvtOpenEventMetadataEnum        = modwevtapi.NewProc("EvtOpenEventMetadataEnum")
 	procEvtOpenLog                      = modwevtapi.NewProc("EvtOpenLog")
+	procEvtOpenPublisherEnum            = modwevtapi.NewProc("EvtOpenPublisherEnum")
 	procEvtOpenPublisherMetadata        = modwevtapi.NewProc("EvtOpenPublisherMetadata")
 	procEvtQuery                        = modwevtapi.NewProc("EvtQuery")
 	procEvtRender                       = modwevtapi.NewProc("EvtRender")
@@ -179,6 +181,14 @@ func _EvtNextEventMetadata(enumerator EvtHandle, flags uint32) (handle EvtHandle
 	return
 }
 
+func _EvtNextPublisherId(enumerator EvtHandle, bufferSize uint32, buffer *byte, bufferUsed *uint32) (err error) {
+	r1, _, e1 := syscall.Syscall6(procEvtNextPublisherId.Addr(), 4, uintptr(enumerator), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), 0, 0)
+	if r1 == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
 func _EvtOpenChannelEnum(session EvtHandle, flags uint32) (handle EvtHandle, err error) {
 	r0, _, e1 := syscall.Syscall(procEvtOpenChannelEnum.Addr(), 2, uintptr(session), uintptr(flags), 0)
 	handle = EvtHandle(r0)
@@ -199,6 +209,15 @@ func _EvtOpenEventMetadataEnum(publisherMetadata EvtHandle, flags uint32) (handl
 
 func _EvtOpenLog(session EvtHandle, path *uint16, flags uint32) (handle EvtHandle, err error) {
 	r0, _, e1 := syscall.Syscall(procEvtOpenLog.Addr(), 3, uintptr(session), uintptr(unsafe.Pointer(path)), uintptr(flags))
+	handle = EvtHandle(r0)
+	if handle == 0 {
+		err = errnoErr(e1)
+	}
+	return
+}
+
+func _EvtOpenPublisherEnum(session EvtHandle, flags uint32) (handle EvtHandle, err error) {
+	r0, _, e1 := syscall.Syscall(procEvtOpenPublisherEnum.Addr(), 2, uintptr(session), uintptr(flags), 0)
 	handle = EvtHandle(r0)
 	if handle == 0 {
 		err = errnoErr(e1)
@@ -233,12 +252,10 @@ func _EvtRender(context EvtHandle, fragment EvtHandle, flags EvtRenderFlag, buff
 }
 
 func _EvtSeek(resultSet EvtHandle, position int64, bookmark EvtHandle, timeout uint32, flags uint32) (success bool, err error) {
-
 	var (
 		r0 uintptr
 		e1 syscall.Errno
 	)
-
 	if unsafe.Sizeof(uintptr(0)) == unsafe.Sizeof(uint64(0)) {
 		r0, _, e1 = syscall.Syscall6(procEvtSeek.Addr(), 5, uintptr(resultSet), uintptr(position), uintptr(bookmark), uintptr(timeout), uintptr(flags), 0)
 	} else {

--- a/winlogbeat/sys/wineventlog/zsyscall_windows.go
+++ b/winlogbeat/sys/wineventlog/zsyscall_windows.go
@@ -181,7 +181,7 @@ func _EvtNextEventMetadata(enumerator EvtHandle, flags uint32) (handle EvtHandle
 	return
 }
 
-func _EvtNextPublisherId(enumerator EvtHandle, bufferSize uint32, buffer *byte, bufferUsed *uint32) (err error) {
+func _EvtNextPublisherId(enumerator EvtHandle, bufferSize uint32, buffer *uint16, bufferUsed *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procEvtNextPublisherId.Addr(), 4, uintptr(enumerator), uintptr(bufferSize), uintptr(unsafe.Pointer(buffer)), uintptr(unsafe.Pointer(bufferUsed)), 0, 0)
 	if r1 == 0 {
 		err = errnoErr(e1)


### PR DESCRIPTION
## What does this PR do?

Some valid message strings have a "message ID" of 0. So set the EvtFormatMessageId flag when we don't have a valid event handle when calling EvtFormatMessage.

Change the delimiters used in message templates. There were a few cases were the template failed to parse because the raw message used the same delims in some way.

EventMetadata is an exported type, but its EventData field was using an unexported type called `eventData`. To make external usage easier make that type exported as well.

Add winevetlog.Publishers() to list all registered event publishers on the system.

## Why is it important?

This fixes errors initializing the metadata cache for some message publishers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

