### PR TITLE
Add Proxy settings to AWS Common

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -617,6 +617,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Libbeat: report beat version to monitoring. {pull}26214[26214]
 - Ensure common proxy settings support in HTTP clients: proxy_disabled, proxy_url, proxy_headers and typical environment variables HTTP_PROXY, HTTPS_PROXY, NOPROXY. {pull}25219[25219]
 - `add_process_metadata` processor enrich process information with owner name and id. {issue}21068[21068] {pull}21111[21111]
+- Add proxy support for AWS functions. {pull}26832[26832]
 
 *Auditbeat*
 

--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -53,6 +53,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   cloudwatch:
     enabled: false
@@ -66,6 +67,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   ec2:
     enabled: false
@@ -79,6 +81,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   elb:
     enabled: false
@@ -92,6 +95,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   s3access:
     enabled: false
@@ -105,6 +109,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   vpcflow:
     enabled: false
@@ -118,6 +123,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 ----
 
 *`var.queue_url`*::

--- a/libbeat/common/transport/httpcommon/proxy.go
+++ b/libbeat/common/transport/httpcommon/proxy.go
@@ -28,7 +28,7 @@ import (
 //
 // Proxy usage will be disabled in general if Disable is set.
 // If URL is not set, the proxy configuration will default
-// to HTTP_PROXY, HTTPS_PPROXY, and NO_PROXY.
+// to HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
 //
 // The default (and zero) value of HTTPClientProxySettings has Proxy support
 // enabled, and will select the proxy per URL based on the environment variables.

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -107,6 +107,7 @@ func NewInput(cfg *common.Config, connector channel.Connector, context input.Con
 	if err != nil {
 		return nil, errors.Wrap(err, "getAWSCredentials failed")
 	}
+	awsConfig = awscommon.EnrichAWSConfigWithProxy(config.AwsConfig, awsConfig)
 	awsConfig.Region = config.RegionName
 
 	closeChannel := make(chan struct{})

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -103,11 +103,10 @@ func NewInput(cfg *common.Config, connector channel.Connector, context input.Con
 		config.RegionName = regionName
 	}
 
-	awsConfig, err := awscommon.GetAWSCredentials(config.AwsConfig)
+	awsConfig, err := awscommon.InitializeAWSConfig(config.AwsConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "getAWSCredentials failed")
+		return nil, errors.Wrap(err, "InitializeAWSConfig failed")
 	}
-	awsConfig = awscommon.EnrichAWSConfigWithProxy(config.AwsConfig, awsConfig)
 	awsConfig.Region = config.RegionName
 
 	closeChannel := make(chan struct{})

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -54,9 +54,9 @@ func newInput(config config) (*s3Input, error) {
 func (in *s3Input) Name() string { return inputName }
 
 func (in *s3Input) Test(ctx v2.TestContext) error {
-	_, err := awscommon.GetAWSCredentials(in.config.AWSConfig)
+	_, err := awscommon.InitializeAWSConfig(in.config.AWSConfig)
 	if err != nil {
-		return fmt.Errorf("getAWSCredentials failed: %w", err)
+		return fmt.Errorf("InitializeAWSConfig failed: %w", err)
 	}
 	return nil
 }
@@ -98,11 +98,10 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 		log = log.With("region", regionName)
 	}
 
-	awsConfig, err := awscommon.GetAWSCredentials(in.config.AWSConfig)
+	awsConfig, err := awscommon.InitializeAWSConfig(in.config.AWSConfig)
 	if err != nil {
-		return nil, fmt.Errorf("getAWSCredentials failed: %w", err)
+		return nil, fmt.Errorf("InitializeAWSConfig failed: %w", err)
 	}
-	awsConfig = awscommon.EnrichAWSConfigWithProxy(in.config.AWSConfig, awsConfig)
 	awsConfig.Region = regionName
 
 	visibilityTimeout := int64(in.config.VisibilityTimeout.Seconds())

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -102,6 +102,7 @@ func (in *s3Input) createCollector(ctx v2.Context, pipeline beat.Pipeline) (*s3C
 	if err != nil {
 		return nil, fmt.Errorf("getAWSCredentials failed: %w", err)
 	}
+	awsConfig = awscommon.EnrichAWSConfigWithProxy(in.config.AWSConfig, awsConfig)
 	awsConfig.Region = regionName
 
 	visibilityTimeout := int64(in.config.VisibilityTimeout.Seconds())

--- a/x-pack/filebeat/input/awss3/s3_integration_test.go
+++ b/x-pack/filebeat/input/awss3/s3_integration_test.go
@@ -138,9 +138,9 @@ func setupCollector(t *testing.T, cfg *common.Config, mock bool) (*s3Collector, 
 	}
 
 	config := getConfigForTest(t)
-	awsConfig, err := awscommon.GetAWSCredentials(config.AWSConfig)
+	awsConfig, err := awscommon.InitializeAWSConfig(config.AWSConfig)
 	if err != nil {
-		t.Fatal("failed GetAWSCredentials with AWS Config: ", err)
+		t.Fatal("failed InitializeAWSConfig with AWS Config: ", err)
 	}
 
 	s3BucketRegion := os.Getenv("S3_BUCKET_REGION")

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -48,6 +48,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   cloudwatch:
     enabled: false
@@ -61,6 +62,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   ec2:
     enabled: false
@@ -74,6 +76,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   elb:
     enabled: false
@@ -87,6 +90,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   s3access:
     enabled: false
@@ -100,6 +104,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 
   vpcflow:
     enabled: false
@@ -113,6 +118,7 @@ Example config:
     #var.api_timeout: 120s
     #var.endpoint: amazonaws.com
     #var.role_arn: arn:aws:iam::123456789012:role/test-mb
+    #var.proxy_url: http://proxy:8080
 ----
 
 *`var.queue_url`*::

--- a/x-pack/filebeat/module/aws/cloudtrail/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/aws-s3.yml
@@ -59,6 +59,10 @@ fips_enabled: {{ .fips_enabled }}
 max_number_of_messages: {{ .max_number_of_messages }}
 {{ end }}
 
+{{ if .proxy_url }}
+proxy_url: {{ .proxy_url }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
@@ -22,6 +22,7 @@ var:
   - name: process_insight_logs
     default: true
   - name: fips_enabled
+  - name: proxy_url
   - name: max_number_of_messages
 
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/filebeat/module/aws/cloudwatch/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/aws-s3.yml
@@ -45,6 +45,10 @@ fips_enabled: {{ .fips_enabled }}
 max_number_of_messages: {{ .max_number_of_messages }}
 {{ end }}
 
+{{ if .proxy_url }}
+proxy_url: {{ .proxy_url }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
@@ -16,6 +16,7 @@ var:
   - name: tags
     default: [forwarded]
   - name: fips_enabled
+  - name: proxy_url
   - name: max_number_of_messages
 
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/filebeat/module/aws/ec2/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/aws-s3.yml
@@ -45,6 +45,10 @@ fips_enabled: {{ .fips_enabled }}
 max_number_of_messages: {{ .max_number_of_messages }}
 {{ end }}
 
+{{ if .proxy_url }}
+proxy_url: {{ .proxy_url }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/ec2/manifest.yml
+++ b/x-pack/filebeat/module/aws/ec2/manifest.yml
@@ -16,6 +16,7 @@ var:
   - name: tags
     default: [forwarded]
   - name: fips_enabled
+  - name: proxy_url
   - name: max_number_of_messages
 
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/filebeat/module/aws/elb/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/elb/config/aws-s3.yml
@@ -45,6 +45,10 @@ fips_enabled: {{ .fips_enabled }}
 max_number_of_messages: {{ .max_number_of_messages }}
 {{ end }}
 
+{{ if .proxy_url }}
+proxy_url: {{ .proxy_url }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/elb/manifest.yml
+++ b/x-pack/filebeat/module/aws/elb/manifest.yml
@@ -16,6 +16,7 @@ var:
   - name: tags
     default: [forwarded]
   - name: fips_enabled
+  - name: proxy_url
   - name: max_number_of_messages
 
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/filebeat/module/aws/s3access/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/s3access/config/aws-s3.yml
@@ -45,6 +45,10 @@ fips_enabled: {{ .fips_enabled }}
 max_number_of_messages: {{ .max_number_of_messages }}
 {{ end }}
 
+{{ if .proxy_url }}
+proxy_url: {{ .proxy_url }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/s3access/manifest.yml
+++ b/x-pack/filebeat/module/aws/s3access/manifest.yml
@@ -16,6 +16,7 @@ var:
   - name: tags
     default: [forwarded]
   - name: fips_enabled
+  - name: proxy_url
   - name: max_number_of_messages
 
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/filebeat/module/aws/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/config/input.yml
@@ -47,6 +47,10 @@ fips_enabled: {{ .fips_enabled }}
 max_number_of_messages: {{ .max_number_of_messages }}
 {{ end }}
 
+{{ if .proxy_url }}
+proxy_url: {{ .proxy_url }}
+{{ end }}
+
 {{ else if eq .input "file" }}
 
 type: log

--- a/x-pack/filebeat/module/aws/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/manifest.yml
@@ -16,6 +16,7 @@ var:
   - name: tags
     default: [forwarded]
   - name: fips_enabled
+  - name: proxy_url
   - name: max_number_of_messages
 
 ingest_pipeline: ingest/pipeline.yml

--- a/x-pack/functionbeat/manager/aws/cli_manager.go
+++ b/x-pack/functionbeat/manager/aws/cli_manager.go
@@ -214,7 +214,7 @@ func NewCLI(
 	if err := cfg.Unpack(config); err != nil {
 		return nil, err
 	}
-	awsCfg, err := awscommon.GetAWSCredentials(config.Credentials)
+	awsCfg, err := awscommon.InitializeAWSConfig(config.Credentials)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get aws credentials, please check AWS credential in config: %+v", err)
 	}

--- a/x-pack/libbeat/autodiscover/providers/aws/ec2/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/ec2/provider.go
@@ -52,7 +52,7 @@ func AutodiscoverBuilder(
 		return nil, err
 	}
 
-	awsCfg, err := awscommon.GetAWSCredentials(
+	awsCfg, err := awscommon.InitializeAWSConfig(
 		awscommon.ConfigAWS{
 			AccessKeyID:     config.AWSConfig.AccessKeyID,
 			SecretAccessKey: config.AWSConfig.SecretAccessKey,

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -60,6 +60,7 @@ func AutodiscoverBuilder(
 		SessionToken:    config.AWSConfig.SessionToken,
 		ProfileName:     config.AWSConfig.ProfileName,
 	})
+	awsCfg = awscommon.EnrichAWSConfigWithProxy(config.AWSConfig, awsCfg)
 
 	// Construct MetricSet with a full regions list if there is no region specified.
 	if config.Regions == nil {
@@ -85,6 +86,7 @@ func AutodiscoverBuilder(
 		if err != nil {
 			logp.Err("error loading AWS config for aws_elb autodiscover provider: %s", err)
 		}
+		awsCfg = awscommon.EnrichAWSConfigWithProxy(config.AWSConfig, awsCfg)
 		awsCfg.Region = region
 		clients = append(clients, elasticloadbalancingv2.New(awscommon.EnrichAWSConfigWithEndpoint(
 			config.AWSConfig.Endpoint, "elasticloadbalancing", region, awsCfg)))

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -54,13 +54,12 @@ func AutodiscoverBuilder(
 		return nil, err
 	}
 
-	awsCfg, err := awscommon.GetAWSCredentials(awscommon.ConfigAWS{
+	awsCfg, err := awscommon.InitializeAWSConfig(awscommon.ConfigAWS{
 		AccessKeyID:     config.AWSConfig.AccessKeyID,
 		SecretAccessKey: config.AWSConfig.SecretAccessKey,
 		SessionToken:    config.AWSConfig.SessionToken,
 		ProfileName:     config.AWSConfig.ProfileName,
 	})
-	awsCfg = awscommon.EnrichAWSConfigWithProxy(config.AWSConfig, awsCfg)
 
 	// Construct MetricSet with a full regions list if there is no region specified.
 	if config.Regions == nil {
@@ -77,7 +76,7 @@ func AutodiscoverBuilder(
 
 	var clients []elasticloadbalancingv2iface.ClientAPI
 	for _, region := range config.Regions {
-		awsCfg, err := awscommon.GetAWSCredentials(awscommon.ConfigAWS{
+		awsCfg, err := awscommon.InitializeAWSConfig(awscommon.ConfigAWS{
 			AccessKeyID:     config.AWSConfig.AccessKeyID,
 			SecretAccessKey: config.AWSConfig.SecretAccessKey,
 			SessionToken:    config.AWSConfig.SessionToken,
@@ -86,7 +85,6 @@ func AutodiscoverBuilder(
 		if err != nil {
 			logp.Err("error loading AWS config for aws_elb autodiscover provider: %s", err)
 		}
-		awsCfg = awscommon.EnrichAWSConfigWithProxy(config.AWSConfig, awsCfg)
 		awsCfg.Region = region
 		clients = append(clients, elasticloadbalancingv2.New(awscommon.EnrichAWSConfigWithEndpoint(
 			config.AWSConfig.Endpoint, "elasticloadbalancing", region, awsCfg)))

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -17,7 +17,7 @@ Some services, such as IAM, do not support regions. The endpoints for these
 services do not include a region. In `aws` module, `endpoint` config is to set
 the `endpoint-code` part, such as `amazonaws.com`, `amazonaws.com.cn`, `c2s.ic.gov`,
 `sc2s.sgov.gov`.
-* *proxy*: URL of the proxy to use to connect to AWS web services. The syntax is http(s)://<IP/Hostname>:<port>
+* *proxy_url*: URL of the proxy to use to connect to AWS web services. The syntax is http(s)://<IP/Hostname>:<port>
 
 [float]
 ==== Supported Formats

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -17,6 +17,7 @@ Some services, such as IAM, do not support regions. The endpoints for these
 services do not include a region. In `aws` module, `endpoint` config is to set
 the `endpoint-code` part, such as `amazonaws.com`, `amazonaws.com.cn`, `c2s.ic.gov`,
 `sc2s.sgov.gov`.
+* *proxy*: URL of the proxy to use to connect to AWS web services. The syntax is http(s)://<IP/Hostname>:<port>
 
 [float]
 ==== Supported Formats

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -76,11 +76,10 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		return nil, err
 	}
 
-	awsConfig, err := awscommon.GetAWSCredentials(config.AWSConfig)
+	awsConfig, err := awscommon.InitializeAWSConfig(config.AWSConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get aws credentials, please check AWS credential in config: %w", err)
 	}
-	awsConfig = awscommon.EnrichAWSConfigWithProxy(config.AWSConfig, awsConfig)
 
 	_, err = awsConfig.Credentials.Retrieve()
 	if err != nil {

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -80,6 +80,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get aws credentials, please check AWS credential in config: %w", err)
 	}
+	awsConfig = awscommon.EnrichAWSConfigWithProxy(config.AWSConfig, awsConfig)
 
 	_, err = awsConfig.Credentials.Retrieve()
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Adds the ability to set a proxy to the AWS SDK config.

## Why is it important?

This is useful when the Beats outbound connections need to go through a proxy but don't want it to affect other inputs/outputs.  When using the HTTP_PROXY env variable, this also affects the Beats output to Elasticsearch.  Having a dedicated setting allows only the AWS requests to be proxied and not affect any other input/output.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues


## Use cases


## Screenshots


## Logs
