### PR TITLE
[Filebeat] Kafka input, json payload

### DIFF
--- a/filebeat/docs/inputs/input-kafka.asciidoc
+++ b/filebeat/docs/inputs/input-kafka.asciidoc
@@ -168,6 +168,10 @@ Configuration options for Kerberos authentication.
 
 See <<configuration-kerberos>> for more information.
 
+===== `payload_type`
+
+This configures how the input will handle the payload. Defaults to `"string"` which puts the payload into message field. Other option `json` will attempt to parse the payload and merge the structure with the top level of the event.
+
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../inputs/input-common-options.asciidoc[]
 

--- a/filebeat/input/kafka/config.go
+++ b/filebeat/input/kafka/config.go
@@ -53,6 +53,7 @@ type kafkaInputConfig struct {
 	Username                 string            `config:"username"`
 	Password                 string            `config:"password"`
 	ExpandEventListFromField string            `config:"expand_event_list_from_field"`
+	PayloadType              string            `config:"payload_type"`
 }
 
 type kafkaFetch struct {
@@ -127,6 +128,7 @@ func defaultConfig() kafkaInputConfig {
 			MaxRetries:   4,
 			RetryBackoff: 2 * time.Second,
 		},
+		PayloadType: "string",
 	}
 }
 
@@ -142,6 +144,10 @@ func (c *kafkaInputConfig) Validate() error {
 
 	if c.Username != "" && c.Password == "" {
 		return fmt.Errorf("password must be set when username is configured")
+	}
+
+	if !stringInSlice(c.PayloadType, []string{"string", "json"}) {
+		return fmt.Errorf("invalid value for payload_type: %s, supported values are: string, json", c.PayloadType)
 	}
 	return nil
 }
@@ -271,4 +277,13 @@ func (is *isolationLevel) Unpack(value string) error {
 	}
 	*is = isolationLevel
 	return nil
+}
+
+func stringInSlice(str string, list []string) bool {
+	for _, v := range list {
+		if v == str {
+			return true
+		}
+	}
+	return false
 }

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -256,6 +256,153 @@ func TestInputWithMultipleEvents(t *testing.T) {
 	}
 }
 
+func TestInputWithJsonPayload(t *testing.T) {
+	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
+	testTopic := fmt.Sprintf("Filebeat-TestInput-%s", id)
+	context := input.Context{
+		Done:     make(chan struct{}),
+		BeatDone: make(chan struct{}),
+	}
+
+	// Send test message to the topic for the input to read.
+	message := testMessage{
+		message: "{\"val\":\"val1\"}",
+		headers: []sarama.RecordHeader{
+			recordHeader("X-Test-Header", "test header value"),
+		},
+	}
+	writeToKafkaTopic(t, testTopic, message.message, message.headers, time.Second*20)
+
+	// Setup the input config
+	config := common.MustNewConfigFrom(common.MapStr{
+		"hosts":        getTestKafkaHost(),
+		"topics":       []string{testTopic},
+		"group_id":     "filebeat",
+		"wait_close":   0,
+		"payload_type": "json",
+	})
+
+	// Route input events through our capturer instead of sending through ES.
+	events := make(chan beat.Event, 100)
+	defer close(events)
+	capturer := NewEventCapturer(events)
+	defer capturer.Close()
+	connector := channel.ConnectorFunc(func(_ *common.Config, _ beat.ClientConfig) (channel.Outleter, error) {
+		return channel.SubOutlet(capturer), nil
+	})
+
+	input, err := NewInput(config, connector, context)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the input and wait for finalization
+	input.Run()
+
+	timeout := time.After(30 * time.Second)
+	select {
+	case event := <-events:
+		text, err := event.Fields.GetValue("val")
+		if err != nil {
+			t.Fatal(err)
+		}
+		msgs := []string{"val1"}
+		assert.Contains(t, msgs, text)
+		checkMatchingHeaders(t, event, message.headers)
+	case <-timeout:
+		t.Fatal("timeout waiting for incoming events")
+	}
+
+	// Close the done channel and make sure the beat shuts down in a reasonable
+	// amount of time.
+	close(context.Done)
+	didClose := make(chan struct{})
+	go func() {
+		input.Wait()
+		close(didClose)
+	}()
+
+	select {
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for beat to shut down")
+	case <-didClose:
+	}
+}
+
+func TestInputWithJsonPayloadAndMultipleEvents(t *testing.T) {
+	id := strconv.Itoa(rand.New(rand.NewSource(int64(time.Now().Nanosecond()))).Int())
+	testTopic := fmt.Sprintf("Filebeat-TestInput-%s", id)
+	context := input.Context{
+		Done:     make(chan struct{}),
+		BeatDone: make(chan struct{}),
+	}
+
+	// Send test messages to the topic for the input to read.
+	message := testMessage{
+		message: "{\"records\": [{\"val\":\"val1\"}, {\"val\":\"val2\"}]}",
+		headers: []sarama.RecordHeader{
+			recordHeader("X-Test-Header", "test header value"),
+		},
+	}
+	writeToKafkaTopic(t, testTopic, message.message, message.headers, time.Second*20)
+
+	// Setup the input config
+	config := common.MustNewConfigFrom(common.MapStr{
+		"hosts":                        getTestKafkaHost(),
+		"topics":                       []string{testTopic},
+		"group_id":                     "filebeat",
+		"wait_close":                   0,
+		"expand_event_list_from_field": "records",
+		"payload_type":                 "json",
+	})
+
+	// Route input events through our capturer instead of sending through ES.
+	events := make(chan beat.Event, 100)
+	defer close(events)
+	capturer := NewEventCapturer(events)
+	defer capturer.Close()
+	connector := channel.ConnectorFunc(func(_ *common.Config, _ beat.ClientConfig) (channel.Outleter, error) {
+		return channel.SubOutlet(capturer), nil
+	})
+
+	input, err := NewInput(config, connector, context)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the input and wait for finalization
+	input.Run()
+
+	timeout := time.After(30 * time.Second)
+	select {
+	case event := <-events:
+		text, err := event.Fields.GetValue("val")
+		if err != nil {
+			t.Fatal(err)
+		}
+		msgs := []string{"val1", "val2"}
+		assert.Contains(t, msgs, text)
+		checkMatchingHeaders(t, event, message.headers)
+	case <-timeout:
+		t.Fatal("timeout waiting for incoming events")
+	}
+
+	// Close the done channel and make sure the beat shuts down in a reasonable
+	// amount of time.
+	close(context.Done)
+	didClose := make(chan struct{})
+	go func() {
+		input.Wait()
+		close(didClose)
+	}()
+
+	select {
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for beat to shut down")
+	case <-didClose:
+	}
+}
+
 func findMessage(t *testing.T, text string, msgs []testMessage) *testMessage {
 	var msg *testMessage
 	for _, m := range msgs {

--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -227,17 +227,19 @@ func TestInputWithMultipleEvents(t *testing.T) {
 	input.Run()
 
 	timeout := time.After(30 * time.Second)
-	select {
-	case event := <-events:
-		text, err := event.Fields.GetValue("message")
-		if err != nil {
-			t.Fatal(err)
+	for i := 0; i < 2; i++ {
+		select {
+		case event := <-events:
+			text, err := event.Fields.GetValue("message")
+			if err != nil {
+				t.Fatal(err)
+			}
+			msgs := []string{"{\"val\":\"val1\"}", "{\"val\":\"val2\"}"}
+			assert.Contains(t, msgs, text)
+			checkMatchingHeaders(t, event, message.headers)
+		case <-timeout:
+			t.Fatal("timeout waiting for incoming events")
 		}
-		msgs := []string{"{\"val\":\"val1\"}", "{\"val\":\"val2\"}"}
-		assert.Contains(t, msgs, text)
-		checkMatchingHeaders(t, event, message.headers)
-	case <-timeout:
-		t.Fatal("timeout waiting for incoming events")
 	}
 
 	// Close the done channel and make sure the beat shuts down in a reasonable
@@ -374,17 +376,19 @@ func TestInputWithJsonPayloadAndMultipleEvents(t *testing.T) {
 	input.Run()
 
 	timeout := time.After(30 * time.Second)
-	select {
-	case event := <-events:
-		text, err := event.Fields.GetValue("val")
-		if err != nil {
-			t.Fatal(err)
+	for i := 0; i < 2; i++ {
+		select {
+		case event := <-events:
+			text, err := event.Fields.GetValue("val")
+			if err != nil {
+				t.Fatal(err)
+			}
+			msgs := []string{"val1", "val2"}
+			assert.Contains(t, msgs, text)
+			checkMatchingHeaders(t, event, message.headers)
+		case <-timeout:
+			t.Fatal("timeout waiting for incoming events")
 		}
-		msgs := []string{"val1", "val2"}
-		assert.Contains(t, msgs, text)
-		checkMatchingHeaders(t, event, message.headers)
-	case <-timeout:
-		t.Fatal("timeout waiting for incoming events")
 	}
 
 	// Close the done channel and make sure the beat shuts down in a reasonable


### PR DESCRIPTION
## What does this PR do?

It allows the Filebeat Kafka input to handle json. Specifically this enables picking up structured data and exposing it under top level fields in stead of having escaped json in the message field.

## Why is it important?

Kafka is often used to pull data away from the log sources as fast as possible to avoid disks filling up and to allow the 'backend of the pipeline to be serviced / incidents be handled, without dropping events on the floor. 

This avoid the need for one to apply the [decode-json-fields processor](https://www.elastic.co/guide/en/beats/filebeat/current/decode-json-fields.html) immediately after the input to be able to process any of the fields in the structured data.

In the context of modules this change can be a big advantage; right now we can override the input but not change the processors used by the module easy or inject a processor between the input and the module. While this doesn't solve the issue of mismatched structure, it at least allows one to transform the data before it's stored in Kafka so that modules can be used post Kafka.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.