### PR TITLE
Osquerybeat: ECS mapping for scheduled queries

### DIFF
--- a/x-pack/osquerybeat/beater/action_handler.go
+++ b/x-pack/osquerybeat/beater/action_handler.go
@@ -95,6 +95,6 @@ func (a *actionHandler) executeQuery(ctx context.Context, index, id, query, resp
 	if err != nil {
 		return err
 	}
-	a.bt.publishEvents(index, id, responseID, hits, req["data"])
+	a.bt.publishEvents(index, id, responseID, hits, nil, req["data"])
 	return nil
 }

--- a/x-pack/osquerybeat/internal/config/config.go
+++ b/x-pack/osquerybeat/internal/config/config.go
@@ -22,11 +22,12 @@ import (
 const DefaultStreamIndex = "logs-osquery_manager.result-default"
 
 type StreamConfig struct {
-	ID       string `config:"id"`
-	Query    string `config:"query"`    // the SQL query to run
-	Interval int    `config:"interval"` // an interval in seconds to run the query (subject to splay/smoothing). It has a maximum value of 604,800 (1 week).
-	Platform string `config:"platform"` // restrict this query to a given platform, default is 'all' platforms; you may use commas to set multiple platforms
-	Version  string `config:"version"`  // only run on osquery versions greater than or equal-to this version string
+	ID         string            `config:"id"`
+	Query      string            `config:"query"`       // the SQL query to run
+	Interval   int               `config:"interval"`    // an interval in seconds to run the query (subject to splay/smoothing). It has a maximum value of 604,800 (1 week).
+	Platform   string            `config:"platform"`    // restrict this query to a given platform, default is 'all' platforms; you may use commas to set multiple platforms
+	Version    string            `config:"version"`     // only run on osquery versions greater than or equal-to this version string
+	ECSMapping map[string]string `config:"ecs_mapping"` // ECS mapping definition where the key is the source field in osquery result and the value is the destination fields in ECS
 }
 
 type InputConfig struct {

--- a/x-pack/osquerybeat/internal/ecs/mapping.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping.go
@@ -1,0 +1,80 @@
+package ecs
+
+import "strings"
+
+const keySeparator = "."
+
+type Doc map[string]interface{}
+type Mapping map[string]string
+
+// Map creates the copy of the values from the doc[src] key to the doc[dst] key where the dst can be nested '.' delimited key
+// Source is expected to be a simple key name, the destination could be nested child node
+func (m Mapping) Map(doc Doc) Doc {
+	res := make(Doc)
+	for src, dst := range m {
+		val, ok := doc[src]
+		if !ok {
+			continue
+		}
+		res.Set(dst, val)
+	}
+	return res
+}
+
+func (d Doc) Get(key string) (val interface{}, ok bool) {
+	keys := getKeys(key)
+	node := d
+
+	for i := 0; i < len(keys)-1; i++ {
+		if keys[i] == "" {
+			return nil, false
+		}
+		val, ok = node[keys[i]]
+		if ok {
+			node, ok = val.(Doc)
+			if ok {
+				continue
+			} else {
+				break
+			}
+		} else {
+			break
+		}
+	}
+
+	if node != nil {
+		val, ok = node[keys[len(keys)-1]]
+	}
+	return
+}
+
+func (d Doc) Set(key string, val interface{}) {
+	keys := getKeys(key)
+	node := d
+
+	// Create nested keys if needed
+	for i := 0; i < len(keys)-1; i++ {
+		if keys[i] == "" {
+			return
+		}
+
+		inode, ok := node[keys[i]]
+		if ok {
+			node, ok = inode.(Doc)
+		} else {
+			d := make(Doc)
+			node[keys[i]] = d
+			node = d
+		}
+	}
+
+	key = keys[len(keys)-1]
+	if key == "" {
+		return
+	}
+	node[key] = val
+}
+
+func getKeys(key string) []string {
+	return strings.Split(key, keySeparator)
+}

--- a/x-pack/osquerybeat/internal/ecs/mapping_test.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping_test.go
@@ -1,0 +1,60 @@
+package ecs
+
+import "testing"
+
+var testOsqueryResult = Doc{
+	"uid":         275,
+	"gid_signed":  275,
+	"gid":         275,
+	"shell":       "/usr/bin/false",
+	"uid_signed":  275,
+	"is_hidden":   0,
+	"description": "Demo Daemon",
+	"directory":   "/var/empty",
+	"uuid":        "FFFFEEEE-DDDD-CCCC-BBBB-AAAA00000113",
+	"username":    "_demod",
+	"foo":         "bar",
+	"test":        "testval",
+}
+
+func TestMap(t *testing.T) {
+	mapping := Mapping{
+		"uid":         "user.id",
+		"gid":         "user.group.id",
+		"username":    "user.name",
+		"description": "description",
+		"uuid":        "a.b.c.d.e.f",
+		"uid_signed":  "a.b.c.d.g",
+	}
+
+	doc := mapping.Map(testOsqueryResult)
+
+	for src, dst := range mapping {
+		val, ok := doc.Get(dst)
+		if !ok {
+			t.Errorf("key [%v] not found", dst)
+			break
+		}
+		if testOsqueryResult[src] != val {
+			t.Errorf("key [%v]=[%v], expected [%v]", src, val, testOsqueryResult[src])
+		}
+	}
+}
+
+func TestMapBadKeys(t *testing.T) {
+	mapping := Mapping{
+		"":           "",
+		"foo":        "",
+		"test":       "..",
+		"uid_signed": "",
+	}
+
+	doc := mapping.Map(testOsqueryResult)
+
+	for _, dst := range mapping {
+		_, ok := doc.Get(dst)
+		if ok {
+			t.Errorf("key [%v] is expected to be not found", dst)
+		}
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Optional ECS mapping for scheduled queries. The ```ecs_mapping``` can be provided per query/stream configuration. The mapping consists of pairs of source and destination keys for example:
```
"ecs_mapping": {
    "value": {
        "uid" : "user.id",
        "gid" : "user.group.id",
        "username" : "user.name"
    }
}

```

## Why is it important?

This is the first step to move osquerybeat towards ECS format for the query results.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation


## Related issues

- Relates https://github.com/elastic/security-team/issues/1380
- Requires https://github.com/elastic/integrations/pull/1318

## Screenshots
Example of the mapping parameters provided with the stream configuration:
<img width="502" alt="Screen Shot 2021-07-09 at 7 10 23 PM" src="https://user-images.githubusercontent.com/872351/125203616-22d6f400-e247-11eb-985b-d0b807d104ec.png">

Example of the result with the ECS mapping applied:
<img width="489" alt="Screen Shot 2021-07-09 at 4 52 10 PM" src="https://user-images.githubusercontent.com/872351/125203651-5023a200-e247-11eb-97d9-bf4315f43be7.png">


