### PR TITLE
Increase timeout to 30secs

### DIFF
--- a/x-pack/metricbeat/module/airflow/statsd/data_test.go
+++ b/x-pack/metricbeat/module/airflow/statsd/data_test.go
@@ -59,7 +59,7 @@ func TestData(t *testing.T) {
 	var events []mb.Event
 	done := make(chan interface{})
 	go func() {
-		events = mbtest.RunPushMetricSetV2(5*time.Second, 1, ms)
+		events = mbtest.RunPushMetricSetV2(30*time.Second, 1, ms)
 		close(done)
 	}()
 


### PR DESCRIPTION
## Flaky Test

* **Test Name:** TestData
* **Link:** https://github.com/elastic/beats/blob/master/x-pack/metricbeat/module/airflow/statsd/data_test.go#L53
* **Branch:** master/7.x
* **Artifact Link:** https://beats-ci.elastic.co/job/Beats/job/beats/job/7.x/837/testReport/junit/github/com_elastic_beats_v7_x-pack_metricbeat_module_airflow_statsd/Build_Test___x_pack_metricbeat_unitTest___TestData/
* **Notes:** An UDP server is started from the module and we send messages to it. We wait up to 5secs in order to receive the messages. after this time we fail the test. Fix will try to wait for a longer time

### Stack Trace

```
=== RUN   TestData
    data_test.go:70: received no events
--- FAIL: TestData (5.01s)
```

fixes #26840 