### PR TITLE
[httpjson] Add value_type parameter to httpjson transforms

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -854,6 +854,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Added dataset `recordedfuture` to the `threatintel` module to ingest indicators from Recorded Future Connect API {pull}26481[26481]
 - Update `fortinet` ingest pipelines. {issue}22136[22136] {issue}25254[25254] {pull}24816[24816]
 - Use default add_locale for fortinet.firewall {issue}20300[20300] {pull}26524[26524]
+- Add new template functions and `value_type` parameter to `httpjson` transforms. {pull}26847[26847]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -134,6 +134,7 @@ Appends a value to an array. If the field does not exist, the first entry will c
 - `target` defines the destination field where the value is stored.
 - `value` defines the value that will be stored and it is a <<value-templates,value template>>.
 - `default` defines the fallback value whenever `value` is empty or the template parsing fails. Default templates do not have access to any state, only to functions.
+- `value_type` defines the type of the resulting value. Possible values are: `string`, `json`, and `int`. Default is `string`.
 - `fail_on_template_error` if set to `true` an error will be returned and the request will be aborted when the template evaluation fails. Default is `false`.
 
 [float]
@@ -165,6 +166,7 @@ Sets a value.
 - `target` defines the destination field where the value is stored.
 - `value` defines the value that will be stored and it is a <<value-templates,value template>>.
 - `default` defines the fallback value whenever `value` is empty or the template parsing fails. Default templates do not have access to any state, only to functions.
+- `value_type` defines how the resulting value will be treated. Possible values are: `string`, `json`, and `int`. Default is `string`.
 - `fail_on_template_error` if set to `true` an error will be returned and the request will be aborted when the template evaluation fails. Default is `false`.
 
 [[value-templates]]
@@ -197,10 +199,12 @@ Some built-in helper functions are provided to work with the input state inside 
 - `parseDate`: parses a date string and returns a `time.Time` in UTC. By default the expected layout is `RFC3339` but optionally can accept any of the Golang predefined layouts or a custom one. Example: `[[ parseDate "2020-11-05T12:25:32Z" ]]`, `[[ parseDate "2020-11-05T12:25:32.1234567Z" "RFC3339Nano" ]]`, `[[ (parseDate "Thu Nov  5 12:25:32 +0000 2020" "Mon Jan _2 15:04:05 -0700 2006").UTC ]]`.
 - `formatDate`: formats a `time.Time`. By default the format layout is `RFC3339` but optionally can accept any of the Golang predefined layouts or a custom one. It will default to UTC timezone when formatting, but you can specify a different timezone. If the timezone is incorrect, it will default to UTC. Example: `[[ formatDate (now) "UnixDate" ]]`, `[[ formatDate (now) "UnixDate" "America/New_York" ]]`.
 - `getRFC5988Link`: extracts a specific relation from a list of https://tools.ietf.org/html/rfc5988[RFC5988] links. It is useful when parsing header values for pagination. Example: `[[ getRFC5988Link "next" .last_response.header.Link ]]`.
-- `toInt`: converts a string to an integer. Returns 0 if the conversion fails.
+- `toInt`: converts a value of any type to an integer when possible. Returns 0 if the conversion fails.
 - `add`: adds a list of integers and returns their sum.
+- `mul`: multiplies two integers.
+- `div`: does the integer division of two integer values.
 
-In addition to the provided functions, any of the native functions for `time.Time` and `http.Header` types can be used on the corresponding objects. Examples: `[[(now).Day]]`, `[[.last_response.header.Get "key"]]`
+In addition to the provided functions, any of the native functions for https://golang.org/pkg/time/#Time[`time.Time`], https://golang.org/pkg/net/http/#Header[`http.Header`], and https://golang.org/pkg/net/url/#Values[`url.Values`] types can be used on the corresponding objects. Examples: `[[(now).Day]]`, `[[.last_response.header.Get "key"]]`
 
 ==== Configuration options
 

--- a/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
@@ -92,7 +92,7 @@ type pageIterator struct {
 	isFirst bool
 	done    bool
 
-	n int
+	n int64
 }
 
 func (p *pagination) newPageIterator(stdCtx context.Context, trCtx *transformContext, resp *http.Response) *pageIterator {

--- a/x-pack/filebeat/input/httpjson/internal/v2/response.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/response.go
@@ -22,7 +22,7 @@ func registerResponseTransforms() {
 }
 
 type response struct {
-	page   int
+	page   int64
 	url    url.URL
 	header http.Header
 	body   interface{}

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_append_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_append_test.go
@@ -9,8 +9,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 func TestNewAppend(t *testing.T) {
@@ -129,7 +131,7 @@ func TestNewAppend(t *testing.T) {
 func TestAppendFunctions(t *testing.T) {
 	cases := []struct {
 		name        string
-		tfunc       func(ctx *transformContext, transformable transformable, key, val string) error
+		tfunc       func(ctx *transformContext, transformable transformable, key string, val interface{}) error
 		paramCtx    *transformContext
 		paramTr     transformable
 		paramKey    string
@@ -193,4 +195,82 @@ func TestAppendFunctions(t *testing.T) {
 			assert.EqualValues(t, tcase.expectedTr, tcase.paramTr)
 		})
 	}
+}
+
+func TestDifferentAppendValueTypes(t *testing.T) {
+	c1 := map[string]interface{}{
+		"target":     "body.p1",
+		"value":      `{"param":"value"}`,
+		"value_type": "json",
+	}
+
+	cfg, err := common.NewConfigFrom(c1)
+	require.NoError(t, err)
+
+	transform, err := newAppendResponse(cfg, logp.NewLogger("test"))
+	require.NoError(t, err)
+
+	testAppend := transform.(*appendt)
+
+	trCtx := emptyTransformContext()
+	tr := transformable{}
+
+	tr, err = testAppend.run(trCtx, tr)
+	require.NoError(t, err)
+
+	exp := common.MapStr{
+		"p1": []interface{}{
+			map[string]interface{}{
+				"param": "value",
+			},
+		},
+	}
+
+	assert.EqualValues(t, exp, tr.body())
+
+	c2 := map[string]interface{}{
+		"target":     "body.p1",
+		"value":      "1",
+		"value_type": "int",
+	}
+
+	cfg, err = common.NewConfigFrom(c2)
+	require.NoError(t, err)
+
+	transform, err = newAppendResponse(cfg, logp.NewLogger("test"))
+	require.NoError(t, err)
+
+	testAppend = transform.(*appendt)
+
+	tr = transformable{}
+
+	tr, err = testAppend.run(trCtx, tr)
+	require.NoError(t, err)
+
+	exp = common.MapStr{
+		"p1": []interface{}{int64(1)},
+	}
+
+	assert.EqualValues(t, exp, tr.body())
+
+	c2["value_type"] = "string"
+
+	cfg, err = common.NewConfigFrom(c2)
+	require.NoError(t, err)
+
+	transform, err = newAppendResponse(cfg, logp.NewLogger("test"))
+	require.NoError(t, err)
+
+	testAppend = transform.(*appendt)
+
+	tr = transformable{}
+
+	tr, err = testAppend.run(trCtx, tr)
+	require.NoError(t, err)
+
+	exp = common.MapStr{
+		"p1": []interface{}{"1"},
+	}
+
+	assert.EqualValues(t, exp, tr.body())
 }

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_test.go
@@ -93,6 +93,7 @@ func TestNewTransformsFromConfig(t *testing.T) {
 			expectedTransforms: transforms{
 				&set{
 					targetInfo: targetInfo{Name: "foo", Type: "body"},
+					valueType:  valueTypeString,
 				},
 			},
 		},

--- a/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
@@ -7,6 +7,7 @@ package v2
 import (
 	"bytes"
 	"errors"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -45,6 +46,8 @@ func (t *valueTpl) Unpack(in string) error {
 			"getRFC5988Link":      getRFC5988Link,
 			"toInt":               toInt,
 			"add":                 add,
+			"mul":                 mul,
+			"div":                 div,
 		}).
 		Delims(leftDelim, rightDelim).
 		Parse(in)
@@ -201,15 +204,35 @@ func getRFC5988Link(rel string, links []string) string {
 	return ""
 }
 
-func toInt(s string) int {
-	i, _ := strconv.ParseInt(s, 10, 64)
-	return int(i)
+func toInt(v interface{}) int64 {
+	vv := reflect.ValueOf(v)
+	switch vv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return int64(vv.Int())
+	case reflect.Float32, reflect.Float64:
+		return int64(vv.Float())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(vv.Uint())
+	case reflect.String:
+		f, _ := strconv.ParseFloat(vv.String(), 64)
+		return int64(f)
+	default:
+		return 0
+	}
 }
 
-func add(vs ...int) int {
-	var sum int
+func add(vs ...int64) int64 {
+	var sum int64
 	for _, v := range vs {
 		sum += v
 	}
 	return sum
+}
+
+func mul(a, b int64) int64 {
+	return a * b
+}
+
+func div(a, b int64) int64 {
+	return a / b
 }

--- a/x-pack/filebeat/input/httpjson/internal/v2/value_tpl_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/value_tpl_test.go
@@ -224,6 +224,34 @@ func TestValueTpl(t *testing.T) {
 			paramTr:     transformable{},
 			expectedVal: "2020-11-05T12:25:32Z",
 		},
+		{
+			name:        "func toInt",
+			value:       `[[(toInt "1")]] [[(toInt 1.0)]] [[(toInt "1,0")]] [[(toInt 2)]]`,
+			paramCtx:    emptyTransformContext(),
+			paramTr:     transformable{},
+			expectedVal: "1 1 0 2",
+		},
+		{
+			name:        "func add",
+			value:       `[[add 1 2 3 4]]`,
+			paramCtx:    emptyTransformContext(),
+			paramTr:     transformable{},
+			expectedVal: "10",
+		},
+		{
+			name:        "func mul",
+			value:       `[[mul 4 4]]`,
+			paramCtx:    emptyTransformContext(),
+			paramTr:     transformable{},
+			expectedVal: "16",
+		},
+		{
+			name:        "func div",
+			value:       `[[div 16 4]]`,
+			paramCtx:    emptyTransformContext(),
+			paramTr:     transformable{},
+			expectedVal: "4",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Adds `value_type` parameter to the transforms.
Adds `mul` and `div` template functions.
Modifies `toInt` to accept more types other than `string`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This allows to use the output from the `value` templates as other value types different than string. Initially `int` and `json` types have been added, allowing to define the output of the templates to be used as integer literals eg `0` vs `"0"` or JSON objects `{"foo":"bar"}` or `["foo","bar"}` vs `"{\"foo\":\"bar\"}"` or `"[\"foo\":\"bar\"]"`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
