### PR TITLE
[fix][httpjson] Fix incorrect key for template data

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -398,6 +398,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix Elasticsearch compatibility for modules that use the `network_direction` processor. {issue}26629[26629] {pull}26676[26676]
 - Fix Elasticsearch compatibility for modules that use the `registered_domain` processor. {issue}26629[26629] {pull}26676[26676]
 - Fix Suricata metadata fields breaking visualizations, moved out of flattened datatype. {pull}26710[26710]
+- Fix `httpjson` template data key for `url.params`. {pull}26848[26848]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/httpjson/internal/v2/response.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/response.go
@@ -175,10 +175,10 @@ func (resp *response) templateValues() common.MapStr {
 		return common.MapStr{}
 	}
 	return common.MapStr{
-		"header":    resp.header.Clone(),
-		"page":      resp.page,
-		"url.value": resp.url.String(),
-		"params":    resp.url.Query(),
-		"body":      resp.body,
+		"header":     resp.header.Clone(),
+		"page":       resp.page,
+		"url.value":  resp.url.String(),
+		"url.params": resp.url.Query(),
+		"body":       resp.body,
 	}
 }

--- a/x-pack/filebeat/input/httpjson/internal/v2/response_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/response_test.go
@@ -1,0 +1,42 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package v2
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestTemplateValues(t *testing.T) {
+	resp := &response{
+		page: 1,
+		url:  newURL("http://test?p1=v1"),
+		header: http.Header{
+			"Authorization": []string{"Bearer token"},
+		},
+		body: common.MapStr{
+			"param": "value",
+		},
+	}
+
+	vals := resp.templateValues()
+
+	assert.Equal(t, resp.page, vals["page"])
+	assert.Equal(t, resp.url.String(), vals["url.value"])
+	assert.EqualValues(t, resp.url.Query(), vals["url.params"])
+	assert.EqualValues(t, resp.header, vals["header"])
+	assert.EqualValues(t, resp.body, vals["body"])
+
+	resp = nil
+
+	vals = resp.templateValues()
+
+	assert.NotNil(t, vals)
+	assert.Equal(t, 0, len(vals))
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the key used for the url parameters in the transform context from `params` to `url.params` which was documented in https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-httpjson.html#input-state

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Users wanting to access using `url.params` will not be able to do it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
