### PR TITLE
run processors, defined in the block overriding the input, before the module.

### DIFF
--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -373,7 +373,7 @@ func (fs *Fileset) getInputConfig() (*common.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error creating config from input overrides: %v", err)
 		}
-		cfg, err = common.MergeConfigsWithOptions([]*common.Config{cfg, overrides}, ucfg.FieldReplaceValues("**.paths"), ucfg.FieldAppendValues("**.processors"))
+		cfg, err = common.MergeConfigsWithOptions([]*common.Config{cfg, overrides}, ucfg.FieldReplaceValues("**.paths"), ucfg.FieldPrependValues("**.processors"))
 		if err != nil {
 			return nil, fmt.Errorf("Error applying config overrides: %v", err)
 		}


### PR DESCRIPTION
## What does this PR do?

Changing the order of processors when defining processors on the (overriding) input block, to be run before the module.

## Why is it important?

When overriding the input on a module https://www.elastic.co/guide/en/beats/filebeat/7.13/advanced-settings.html .
https://www.elastic.co/guide/en/beats/filebeat/7.13/defining-processors.html#where-valid describes how it's a valid location but is ambiguous about the order, other then that it runs after the input. This change makes the processors defined there, run right after the input, thus before the module. This is useful in the case where input is overiden as the structure might have changed due to using a different input/transport. 

For example, when adding a buffer to ingest pipeline, kafka is often introduced. Currently even if json is posted to kafka it is read back as json (escaped) string into the message field. Due to the modules having a log input with https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-log.html#filebeat-input-log-config-json setup this breaks / disallows kafka being used. As it iether expects json fields as root or json parsed and placed under the json field.  

## Checklist

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] Discuss breaking change
- [ ] Discuss adding processor at module level to reintroduce old behaviour

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Relates #26833
- Competes #27154

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

As one of the reasons to introduce a buffer in the ingest pipeline is to allow quick draining of the logsources / reduce backpressure. parsing and processing is best done after the buffer. A beat / elastic agent -> kafka -> filebeat -> es is a preferred setup where logstash is not needed.

In other causes where a different intermediate is introduced this change will also help to smooth out any structural changes introduced by going through that intermediate. (for example syslog server or logging to s3 bucket.)
