### PR TITLE
[gcp/billing] always quote table name identifier

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -510,6 +510,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix GCP Project ID being ingested as `cloud.account.id` in `gcp.billing` module {issue}26357[26357] {pull}26412[26412]
 - Fix memory leak in SQL module when database is not available. {issue}25840[25840] {pull}26607[26607]
 - Fix aws metric tags with resourcegroupstaggingapi paginator.  {issue}26385[26385] {pull}26443[26443]
+- Fix quoting in GCP billing table name  {issue}26855[26855] {pull}26870[26870]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -298,6 +298,11 @@ func generateEventID(currentDate string, rowItems []bigquery.Value) string {
 // generateQuery returns the query to be used by the BigQuery client to retrieve monthly
 // cost types breakdown.
 func generateQuery(tableName, month, costType string) string {
+	// The table name is user provided, so it may contains special characters.
+	// In order to allow any character in the table identifier, use the Quoted identifier format.
+	// See https://github.com/elastic/beats/issues/26855
+	// NOTE: is not possible to escape backtics (`) in a multiline string
+	escapedTableName := fmt.Sprintf("`%s`", tableName)
 	query := fmt.Sprintf(`
 SELECT
 	invoice.month,
@@ -313,6 +318,6 @@ WHERE project.id IS NOT NULL
 AND invoice.month = '%s'
 AND cost_type = '%s'
 GROUP BY 1, 2, 3, 4, 5
-ORDER BY 1 ASC, 2 ASC, 3 ASC, 4 ASC, 5 ASC;`, tableName, month, costType)
+ORDER BY 1 ASC, 2 ASC, 3 ASC, 4 ASC, 5 ASC;`, escapedTableName, month, costType)
 	return query
 }

--- a/x-pack/metricbeat/module/gcp/billing/billing_test.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing_test.go
@@ -5,6 +5,8 @@
 package billing
 
 import (
+	"io/ioutil"
+	"log"
 	"strconv"
 	"testing"
 
@@ -15,4 +17,16 @@ func TestGetCurrentMonth(t *testing.T) {
 	currentMonth := getCurrentMonth()
 	_, err := strconv.ParseInt(currentMonth, 0, 64)
 	assert.NoError(t, err)
+}
+
+func TestGenerateQuery(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	query := generateQuery("my-table", "jan", "cost")
+	log.Println(query)
+
+	// verify the group by is preserved
+	assert.Contains(t, query, "GROUP BY 1, 2, 3, 4, 5")
+	// verify the order by is preserved
+	assert.Contains(t, query, "ORDER BY 1 ASC, 2 ASC, 3 ASC, 4 ASC, 5 ASC")
 }

--- a/x-pack/metricbeat/module/gcp/billing/billing_test.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing_test.go
@@ -25,6 +25,8 @@ func TestGenerateQuery(t *testing.T) {
 	query := generateQuery("my-table", "jan", "cost")
 	log.Println(query)
 
+	// verify that table name quoting is in effect
+	assert.Contains(t, query, "`my-table`")
 	// verify the group by is preserved
 	assert.Contains(t, query, "GROUP BY 1, 2, 3, 4, 5")
 	// verify the order by is preserved


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Extract query generation and use quoted identifiers when querying BigQuery from GCP Billing module.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
When users specify a table name containing special characters (not `A-Z a-z _`) the query would fail.

This is because the code is using an Unquoted identifier for the table name that may contain only a limited characters set.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] This change wrap the entire identifier, this is the expected usage from my understanding. Is it?

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/26855

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
