### PR TITLE
Add content encoding for S3 GetObject response

### DIFF
--- a/x-pack/filebeat/input/awss3/collector.go
+++ b/x-pack/filebeat/input/awss3/collector.go
@@ -287,7 +287,7 @@ func (c *s3Collector) handleSQSMessage(m sqs.Message) ([]s3Info, error) {
 			return nil, fmt.Errorf("this SQS queue should be dedicated to s3 ObjectCreated event notifications")
 		}
 		// Unescape substrings from s3 log name. For example, convert "%3D" back to "="
-		filename, err := url.QueryUnescape(record.S3.object.Key)
+		filename, err := url.PathUnescape(record.S3.object.Key)
 		if err != nil {
 			return nil, fmt.Errorf("url.QueryUnescape failed for '%s': %w", record.S3.object.Key, err)
 		}
@@ -344,8 +344,9 @@ func (c *s3Collector) createEventsFromS3Info(svc s3iface.ClientAPI, info s3Info,
 
 	// Download the S3 object using GetObjectRequest.
 	s3GetObjectInput := &s3.GetObjectInput{
-		Bucket: awssdk.String(info.name),
-		Key:    awssdk.String(info.key),
+		Bucket:                  awssdk.String(info.name),
+		Key:                     awssdk.String(info.key),
+		ResponseContentEncoding: awssdk.String(string(s3.EncodingTypeUrl)),
 	}
 	req := svc.GetObjectRequest(s3GetObjectInput)
 


### PR DESCRIPTION
## What does this PR do?

This PR adds content encoding header for S3 GetObject response as a workaround for failing to decode S3 XML error response. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
