### PR TITLE
Do not fail TLS config load if at least one CA loads

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,8 +33,9 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for SCRAM-SHA-512 and SCRAM-SHA-256 in Kafka output. {pull}12867[12867]
 - Remove id_field_data {pull}25239[25239]
 - Removed beats central management {pull}25696[25696], {issue}23908[23908]
-- MacOSX minimum supported version set to 10.14 {issue}24193{24193}
+- MacOSX minimum supported version set to 10.14 {issue}24193[24193]
 - Add daemonset.name in pods controlled by DaemonSets {pull}26808[26808], {issue}25816[25816]
+- TLS config will succeed if at least one of the specified Certificate Authorities loads correctly {issue}24796[24796]
 
 *Auditbeat*
 

--- a/libbeat/common/transport/tlscommon/config.go
+++ b/libbeat/common/transport/tlscommon/config.go
@@ -68,7 +68,9 @@ func LoadTLSConfig(config *Config) (*TLSConfig, error) {
 	logFail(err)
 
 	cas, errs := LoadCertificateAuthorities(config.CAs)
-	logFail(errs...)
+	if cas == nil || len(cas.Subjects()) == 0 {
+		logFail(errs...)
+	}
 
 	// fail, if any error occurred when loading certificate files
 	if err = fail.Err(); err != nil {

--- a/libbeat/common/transport/tlscommon/tls_test.go
+++ b/libbeat/common/transport/tlscommon/tls_test.go
@@ -493,6 +493,27 @@ supported_protocols: null
 			assert.NotNil(t, tlsC)
 		})
 
+		t.Run("multiple cas one will error", func(t *testing.T) {
+			// Create a dummy configuration and append the CA after.
+			cfg, err := load(`
+enabled: true
+verification_mode: null
+certificate: null
+key: null
+key_passphrase: null
+certificate_authorities:
+cipher_suites: null
+curve_types: null
+supported_protocols: null
+  `)
+
+			cfg.CAs = []string{f.Name(), "does-not-exist.crt"}
+			tlsC, err := LoadTLSConfig(cfg)
+			assert.NoError(t, err)
+
+			assert.NotNil(t, tlsC)
+		})
+
 		t.Run("mixed from disk and embed", func(t *testing.T) {
 			// Create a dummy configuration and append the CA after.
 			cfg, err := load(`


### PR DESCRIPTION
## What does this PR do?

Allow the TLS config settings to load if at least on CA cert succeeds.
Current behaviour will expect all passed CAs to load without error.

## Why is it important?

Allowing for a CA to fail can allow the agent to use a cross-platform list for the CA certs in fleet.

However, there are no messages entries by the agent during startup if one of the CA certs fails to load as config is parsed before the logger is set.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #24796