### PR TITLE
[Heartbeat] redact authorization headers from logger

### DIFF
--- a/libbeat/common/config_test.go
+++ b/libbeat/common/config_test.go
@@ -78,6 +78,28 @@ func TestConfigPrintDebug(t *testing.T) {
 `,
 		},
 		{
+			"config selector redacts authorization headers",
+			"config",
+			map[string]interface{}{
+				"config": map[string]interface{}{
+					"headers": map[string]interface{}{
+						"Authorization": "secret1",
+						"authorization": "secret2",
+					},
+				},
+			},
+			`test:
+{
+  "config": {
+    "headers": {
+      "Authorization": "xxxxx",
+      "authorization": "xxxxx"
+    }
+  }
+}
+`,
+		},
+		{
 			"config-with-passwords does not redact",
 			"config-with-passwords",
 			map[string]interface{}{

--- a/libbeat/common/logging.go
+++ b/libbeat/common/logging.go
@@ -17,6 +17,8 @@
 
 package common
 
+import "strings"
+
 var maskList = MakeStringSet(
 	"password",
 	"passphrase",
@@ -27,13 +29,14 @@ var maskList = MakeStringSet(
 	"urls",
 	"host",
 	"hosts",
+	"authorization",
 )
 
 func applyLoggingMask(c interface{}) {
 	switch cfg := c.(type) {
 	case map[string]interface{}:
 		for k, v := range cfg {
-			if maskList.Has(k) {
+			if maskList.Has(strings.ToLower(k)) {
 				if arr, ok := v.([]interface{}); ok {
 					for i := range arr {
 						arr[i] = "xxxxx"

--- a/libbeat/common/logging.go
+++ b/libbeat/common/logging.go
@@ -30,6 +30,7 @@ var maskList = MakeStringSet(
 	"host",
 	"hosts",
 	"authorization",
+	"proxy-authorization",
 )
 
 func applyLoggingMask(c interface{}) {


### PR DESCRIPTION
+ Heartbeat allows users to pass custom headers for monitors when doing Lightweight HTTP checks. Any errors thrown on the configuration failure would result in configuration printed to the stdout including the sensitive headers (`auth`) in this case. 
+ This PR redacts the `authorization` headers by adding them to the logger and also makes sure we capture both lowercase and uppercase strings as both are allowed for HTTP header checks. Added tests for the same

#### Heartbeat logs after this PR
```
ERROR [autodiscover]	autodiscover/autodiscover.go:212	Auto discover config check failed for config '{
  "headers": {
    "Authorization": "xxxxx",
    "Content-Type": "application/json"
  },
  "hosts": [
    "xxxxx"
  ],
  "id": "test",
  "schedule": "@every 10s",
  "type": "tcp"
}', won't start runner: monitor ID test is configured for multiple monitors! IDs must be unique values.
```