### PR TITLE
Add disk queue unit tests based on the queuetest package

### DIFF
--- a/libbeat/publisher/queue/diskqueue/queue.go
+++ b/libbeat/publisher/queue/diskqueue/queue.go
@@ -111,7 +111,7 @@ func queueFactory(
 
 // NewQueue returns a disk-based queue configured with the given logger
 // and settings, creating it if it doesn't exist.
-func NewQueue(logger *logp.Logger, settings Settings) (queue.Queue, error) {
+func NewQueue(logger *logp.Logger, settings Settings) (*diskQueue, error) {
 	logger = logger.Named("diskqueue")
 	logger.Debugf(
 		"Initializing disk queue at path %v", settings.directoryPath())
@@ -275,5 +275,5 @@ func (dq *diskQueue) Producer(cfg queue.ProducerConfig) queue.Producer {
 }
 
 func (dq *diskQueue) Consumer() queue.Consumer {
-	return &diskQueueConsumer{queue: dq}
+	return &diskQueueConsumer{queue: dq, done: make(chan struct{})}
 }

--- a/libbeat/publisher/queue/diskqueue/queue_test.go
+++ b/libbeat/publisher/queue/diskqueue/queue_test.go
@@ -1,0 +1,100 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"flag"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/queuetest"
+)
+
+var seed int64
+
+type testQueue struct {
+	*diskQueue
+	teardown func()
+}
+
+func init() {
+	flag.Int64Var(&seed, "seed", time.Now().UnixNano(), "test random seed")
+}
+
+func TestProduceConsumer(t *testing.T) {
+	maxEvents := 1024
+	minEvents := 32
+
+	rand.Seed(seed)
+	events := rand.Intn(maxEvents-minEvents) + minEvents
+	batchSize := rand.Intn(events-8) + 4
+	bufferSize := rand.Intn(batchSize*2) + 4
+
+	// events := 4
+	// batchSize := 1
+	// bufferSize := 2
+
+	t.Log("seed: ", seed)
+	t.Log("events: ", events)
+	t.Log("batchSize: ", batchSize)
+	t.Log("bufferSize: ", bufferSize)
+
+	testWith := func(factory queuetest.QueueFactory) func(t *testing.T) {
+		return func(t *testing.T) {
+			t.Run("single", func(t *testing.T) {
+				t.Parallel()
+				queuetest.TestSingleProducerConsumer(t, events, batchSize, factory)
+			})
+			t.Run("multi", func(t *testing.T) {
+				t.Parallel()
+				queuetest.TestMultiProducerConsumer(t, events, batchSize, factory)
+			})
+		}
+	}
+
+	t.Run("direct", testWith(makeTestQueue()))
+}
+
+func makeTestQueue() queuetest.QueueFactory {
+	return func(t *testing.T) queue.Queue {
+		dir, err := ioutil.TempDir("", "diskqueue_test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		settings := DefaultSettings()
+		settings.Path = dir
+		queue, _ := NewQueue(logp.L(), settings)
+		return testQueue{
+			diskQueue: queue,
+			teardown: func() {
+				os.RemoveAll(dir)
+			},
+		}
+	}
+}
+
+func (t testQueue) Close() error {
+	err := t.diskQueue.Close()
+	t.teardown()
+	return err
+}


### PR DESCRIPTION
## What does this PR do?

Wraps the common `queuetest` framework used by the memory queue and disk spool to add additional unit tests to the disk queue. The only non-test change is allowing disk queue consumers to be safely closed from a different thread than they're read from, which is required by the `queuetest` helpers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
