### PR TITLE
Cherry-pick to 7.14: Add Beats central management removal to BCs (#26400)

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.14.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.14.asciidoc
@@ -1,0 +1,24 @@
+[[breaking-changes-7.14]]
+
+=== Breaking changes in 7.14
+++++
+<titleabbrev>7.14</titleabbrev>
+++++
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+
+[discrete]
+==== {beats} central management has been removed
+
+Starting in version 7.14, Beats central management has been removed. If you're
+currently using Beats central management, we recommend that you start using
+{fleet} instead. For more information, refer to the
+{fleet-guide}/index.html[{fleet} documentation].
+
+// end::notable-breaking-changes[]
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.14>>
+
 * <<breaking-changes-7.13>>
 
 * <<breaking-changes-7.12>>
@@ -38,6 +40,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.14.asciidoc[]
 
 include::breaking-7.13.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - Add Beats central management removal to BCs (#26400)