### PR TITLE
[Metricbeat] gcp: allow service metric prefix override

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -512,6 +512,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix memory leak in SQL module when database is not available. {issue}25840[25840] {pull}26607[26607]
 - Fix aws metric tags with resourcegroupstaggingapi paginator.  {issue}26385[26385] {pull}26443[26443]
 - Fix quoting in GCP billing table name  {issue}26855[26855] {pull}26870[26870]
+- Allow metric prefix override per service in gcp module. {pull}26960[26960]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/gcp.asciidoc
+++ b/metricbeat/docs/modules/gcp.asciidoc
@@ -288,6 +288,20 @@ metricbeat.modules:
 
 - module: gcp
   metricsets:
+    - metrics
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  metrics:
+    - aligner: ALIGN_NONE
+      service: kubernetes
+      service_metric_prefix: kubernetes.io/
+      metric_types:
+        - "container/cpu/core_usage_time"
+
+- module: gcp
+  metricsets:
     - billing
   period: 24h
   project_id: "your project id"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -571,6 +571,20 @@ metricbeat.modules:
 
 - module: gcp
   metricsets:
+    - metrics
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  metrics:
+    - aligner: ALIGN_NONE
+      service: kubernetes
+      service_metric_prefix: kubernetes.io/
+      metric_types:
+        - "container/cpu/core_usage_time"
+
+- module: gcp
+  metricsets:
     - billing
   period: 24h
   project_id: "your project id"

--- a/x-pack/metricbeat/module/gcp/_meta/config.yml
+++ b/x-pack/metricbeat/module/gcp/_meta/config.yml
@@ -43,6 +43,20 @@
 
 - module: gcp
   metricsets:
+    - metrics
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  metrics:
+    - aligner: ALIGN_NONE
+      service: kubernetes
+      service_metric_prefix: kubernetes.io/
+      metric_types:
+        - "container/cpu/core_usage_time"
+
+- module: gcp
+  metricsets:
     - billing
   period: 24h
   project_id: "your project id"

--- a/x-pack/metricbeat/module/gcp/metrics/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/gcp/metrics/_meta/docs.asciidoc
@@ -16,12 +16,6 @@ call.
 [float]
 == Metricset config and parameters
 
-* *metric_types*: Required, a list of metric type strings, or a list of metric
-type prefixes. For example, `instance/cpu` is the prefix for metric type
-`instance/cpu/usage_time`, `instance/cpu/utilization` etc Each call of the
-`ListTimeSeries` API can return any number of time series from a single metric
-type. Metric type is to used for identifying a specific time series.
-
 * *aligner*: A single string with which aggregation operation need to be applied
 onto time series data for ListTimeSeries API. If it's not given, default aligner
 is `ALIGN_NONE`. Google Cloud also supports `ALIGN_DELTA`, `ALIGN_RATE`,
@@ -29,6 +23,27 @@ is `ALIGN_NONE`. Google Cloud also supports `ALIGN_DELTA`, `ALIGN_RATE`,
 Please see
 https://cloud.google.com/monitoring/api/ref_v3/rpc/google.monitoring.v3#aligner[Aggregation Aligner]
 for the full list of aligners.
+
+* *metric_types*: Required, a list of metric type strings, or a list of metric
+type prefixes. For example, `instance/cpu` is the prefix for metric type
+`instance/cpu/usage_time`, `instance/cpu/utilization` etc Each call of the
+`ListTimeSeries` API can return any number of time series from a single metric
+type. Metric type is to used for identifying a specific time series.
+
+* *service*: Required, the name of the service for related metrics. This should
+be a valid Google Cloud service name. Service names may be viewed from the
+corresponding page from https://cloud.google.com/monitoring/api/metrics[GCP Metrics list documentation].
+The `service` field is used to compute the GCP Metric prefix, unless
+`service_metric_prefix` is set.
+
+* *service_metric_prefix*: A string containing the full Metric prefix as
+specified in the GCP documentation.
+All metrics from GCP Monitoring API require a prefix. When
+`service_metric_prefix` is empty, the prefix default to a value computed using
+the `service` value: `<service>.googleapis.com/`. This default works for any
+services under "Google Cloud metrics", but does not work for other services
+(`kubernetes` aka GKE for example).
+This option allow to override the default and specify an arbitrary metric prefix.
 
 [float]
 === Example Configuration
@@ -123,4 +138,28 @@ every minute with no aggregation. The metric types in `compute` service with
       service: compute
       metric_types:
         - "instance/cpu"
+----
+
+* `metrics` metricset is enabled to collect metrics from all zones under
+`europe-west1-c` region in `elastic-observability` project. One set of metrics
+will be collected: core usage time for containers in GCP GKE.
+Note that the is required to use `service_metric_prefix` to override the default
+metric prefix, as for GKE metrics the required prefix is `kubernetes.io/`
+
++
+[source,yaml]
+----
+- module: googlecloud
+  metricsets:
+    - metrics
+  zone: "europe-west1-c"
+  project_id: elastic-observability
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  metrics:
+    - service: kubernetes
+      service_metric_prefix: kubernetes.io/
+      metric_types:
+        - "container/cpu/core_usage_time"
 ----

--- a/x-pack/metricbeat/module/gcp/metrics/metricset_test.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset_test.go
@@ -6,44 +6,39 @@ package metrics
 
 import "testing"
 
-func Test_metricsConfig_MetricPrefix(t *testing.T) {
-	type fields struct {
-		ServiceName         string
-		ServiceMetricPrefix string
-		MetricTypes         []string
-		Aligner             string
-	}
+var fakeMetricsConfig = []metricsConfig{
+	{"billing", "", []string{}, ""},
+	{"billing", "foobar/", []string{}, ""},
+	{"billing", "foobar", []string{}, ""},
+}
+
+func Test_metricsConfig_AddPrefixTo(t *testing.T) {
+	metric := "awesome/metric"
 	tests := []struct {
 		name   string
-		fields fields
+		fields metricsConfig
 		want   string
 	}{
 		{
 			name:   "only service name",
-			fields: fields{"billing", "", []string{}, ""},
-			want:   "billing.googleapis.com/",
+			fields: fakeMetricsConfig[0],
+			want:   "billing.googleapis.com/" + metric,
 		},
 		{
 			name:   "service metric prefix override",
-			fields: fields{"billing", "foobar/", []string{}, ""},
-			want:   "foobar/",
+			fields: fakeMetricsConfig[1],
+			want:   "foobar/" + metric,
 		},
 		{
 			name:   "service metric prefix override (without trailing /)",
-			fields: fields{"billing", "foobar", []string{}, ""},
-			want:   "foobar/",
+			fields: fakeMetricsConfig[2],
+			want:   "foobar/" + metric,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mc := metricsConfig{
-				ServiceName:         tt.fields.ServiceName,
-				ServiceMetricPrefix: tt.fields.ServiceMetricPrefix,
-				MetricTypes:         tt.fields.MetricTypes,
-				Aligner:             tt.fields.Aligner,
-			}
-			if got := mc.MetricPrefix(); got != tt.want {
-				t.Errorf("metricsConfig.MetricPrefix() = %v, want %v", got, tt.want)
+			if got := tt.fields.AddPrefixTo(metric); got != tt.want {
+				t.Errorf("metricsConfig.AddPrefixTo(%s) = %v, want %v", metric, got, tt.want)
 			}
 		})
 	}

--- a/x-pack/metricbeat/module/gcp/metrics/metricset_test.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset_test.go
@@ -1,0 +1,50 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package metrics
+
+import "testing"
+
+func Test_metricsConfig_MetricPrefix(t *testing.T) {
+	type fields struct {
+		ServiceName         string
+		ServiceMetricPrefix string
+		MetricTypes         []string
+		Aligner             string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name:   "only service name",
+			fields: fields{"billing", "", []string{}, ""},
+			want:   "billing.googleapis.com/",
+		},
+		{
+			name:   "service metric prefix override",
+			fields: fields{"billing", "foobar/", []string{}, ""},
+			want:   "foobar/",
+		},
+		{
+			name:   "service metric prefix override (without trailing /)",
+			fields: fields{"billing", "foobar", []string{}, ""},
+			want:   "foobar/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mc := metricsConfig{
+				ServiceName:         tt.fields.ServiceName,
+				ServiceMetricPrefix: tt.fields.ServiceMetricPrefix,
+				MetricTypes:         tt.fields.MetricTypes,
+				Aligner:             tt.fields.Aligner,
+			}
+			if got := mc.MetricPrefix(); got != tt.want {
+				t.Errorf("metricsConfig.MetricPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/x-pack/metricbeat/modules.d/gcp.yml.disabled
+++ b/x-pack/metricbeat/modules.d/gcp.yml.disabled
@@ -46,6 +46,20 @@
 
 - module: gcp
   metricsets:
+    - metrics
+  project_id: "your project id"
+  credentials_file_path: "your JSON credentials file path"
+  exclude_labels: false
+  period: 1m
+  metrics:
+    - aligner: ALIGN_NONE
+      service: kubernetes
+      service_metric_prefix: kubernetes.io/
+      metric_types:
+        - "container/cpu/core_usage_time"
+
+- module: gcp
+  metricsets:
     - billing
   period: 24h
   project_id: "your project id"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

While working at #26824 I found out that some GCP Stackdriver metrics require a prefix which is not in the form `<servicename>.googleapis.com`.

This PR address this by adding a new field in the `manifest.yml`: `service_metric_prefix`. If this field is set, the value is used as metric prefix; if is not set, the previous behaviour is kept for backward compatibility.

Provide tests for the old and new behaviours.

## Why is it important?

This change is required for #26824

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Required for #26824

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

```
Scenario: Set required value for GCP metric collection service prefix
	When a developer adds a new GCP metricset
	Given service_metric_prefix is filled
	Then service_metric_prefix value is used as metric prefix

Scenario: Empty value for GCP metric collection service prefix
	When a developer adds a new GCP metricset
	Given service_metric_prefix is left empty
	Then service_metric_prefix is computed using the provided service name
```

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
