### PR TITLE
Cherry-pick #26852 to 7.14: Use aws sdk paginator for FilterLogEvents and GetMetricData

### DIFF
--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -222,11 +222,6 @@ func (in *awsCloudWatchInput) getLogGroupNames(svc cloudwatchlogsiface.ClientAPI
 
 // getLogEventsFromCloudWatch uses FilterLogEvents API to collect logs from CloudWatch
 func (in *awsCloudWatchInput) getLogEventsFromCloudWatch(svc cloudwatchlogsiface.ClientAPI) error {
-	ctx, cancelFn := context.WithTimeout(in.inputCtx, in.config.APITimeout)
-	defer cancelFn()
-
-	init := true
-	nextToken := ""
 	currentTime := time.Now()
 	startTime, endTime := getStartPosition(in.config.StartPosition, currentTime, in.prevEndTime, in.config.ScanFrequency)
 	in.logger.Debugf("start_position = %s, startTime = %v, endTime = %v", in.config.StartPosition, time.Unix(startTime/1000, 0), time.Unix(endTime/1000, 0))
@@ -234,45 +229,36 @@ func (in *awsCloudWatchInput) getLogEventsFromCloudWatch(svc cloudwatchlogsiface
 	// overwrite prevEndTime using new endTime
 	in.prevEndTime = endTime
 
-	for nextToken != "" || init {
-		// construct FilterLogEventsInput
-		filterLogEventsInput := in.constructFilterLogEventsInput(startTime, endTime, nextToken)
+	// construct FilterLogEventsInput
+	filterLogEventsInput := in.constructFilterLogEventsInput(startTime, endTime)
 
-		// make API request
-		req := svc.FilterLogEventsRequest(filterLogEventsInput)
-		resp, err := req.Send(ctx)
-		if err != nil {
-			in.logger.Error("failed FilterLogEventsRequest", err)
-			return err
-		}
+	// make API request
+	req := svc.FilterLogEventsRequest(filterLogEventsInput)
+	paginator := cloudwatchlogs.NewFilterLogEventsPaginator(req)
+	for paginator.Next(context.TODO()) {
+		page := paginator.CurrentPage()
 
-		// get token for next API call, if resp.NextToken is nil, nextToken set to ""
-		nextToken = ""
-		if resp.NextToken != nil {
-			nextToken = *resp.NextToken
-		}
-
-		logEvents := resp.Events
+		logEvents := page.Events
 		in.logger.Debugf("Processing #%v events", len(logEvents))
-
-		err = in.processLogEvents(logEvents)
+		err := in.processLogEvents(logEvents)
 		if err != nil {
 			err = errors.Wrap(err, "processLogEvents failed")
 			in.logger.Error(err)
-			cancelFn()
 		}
-
-		init = false
-
-		// This sleep is to avoid hitting the FilterLogEvents API limit(5 transactions per second (TPS)/account/Region).
-		in.logger.Debugf("sleeping for %v before making FilterLogEvents API call again", in.config.APISleep)
-		time.Sleep(in.config.APISleep)
-		in.logger.Debug("done sleeping")
 	}
+
+	if err := paginator.Err(); err != nil {
+		return errors.Wrap(err, "error FilterLogEvents with Paginator")
+	}
+
+	// This sleep is to avoid hitting the FilterLogEvents API limit(5 transactions per second (TPS)/account/Region).
+	in.logger.Debugf("sleeping for %v before making FilterLogEvents API call again", in.config.APISleep)
+	time.Sleep(in.config.APISleep)
+	in.logger.Debug("done sleeping")
 	return nil
 }
 
-func (in *awsCloudWatchInput) constructFilterLogEventsInput(startTime int64, endTime int64, nextToken string) *cloudwatchlogs.FilterLogEventsInput {
+func (in *awsCloudWatchInput) constructFilterLogEventsInput(startTime int64, endTime int64) *cloudwatchlogs.FilterLogEventsInput {
 	filterLogEventsInput := &cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName: awssdk.String(in.config.LogGroupName),
 		StartTime:    awssdk.Int64(startTime),
@@ -285,10 +271,6 @@ func (in *awsCloudWatchInput) constructFilterLogEventsInput(startTime int64, end
 
 	if in.config.LogStreamPrefix != "" {
 		filterLogEventsInput.LogStreamNamePrefix = awssdk.String(in.config.LogStreamPrefix)
-	}
-
-	if nextToken != "" {
-		filterLogEventsInput.NextToken = awssdk.String(nextToken)
 	}
 	return filterLogEventsInput
 }

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1241,7 +1241,13 @@ func (m *MockCloudWatchClient) GetMetricDataRequest(input *cloudwatch.GetMetricD
 	httpReq, _ := http.NewRequest("", "", nil)
 
 	return cloudwatch.GetMetricDataRequest{
+		Input: input,
+		Copy:  m.GetMetricDataRequest,
 		Request: &awssdk.Request{
+			Operation: &awssdk.Operation{
+				Name:      "GetMetricData",
+				Paginator: nil,
+			},
 			Data: &cloudwatch.GetMetricDataOutput{
 				MetricDataResults: []cloudwatch.MetricDataResult{
 					{
@@ -1284,7 +1290,13 @@ func (m *MockCloudWatchClientWithoutDim) GetMetricDataRequest(input *cloudwatch.
 	httpReq, _ := http.NewRequest("", "", nil)
 
 	return cloudwatch.GetMetricDataRequest{
+		Input: input,
+		Copy:  m.GetMetricDataRequest,
 		Request: &awssdk.Request{
+			Operation: &awssdk.Operation{
+				Name:      "GetMetricData",
+				Paginator: nil,
+			},
 			Data: &cloudwatch.GetMetricDataOutput{
 				MetricDataResults: []cloudwatch.MetricDataResult{
 					{

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -39,69 +39,58 @@ func GetStartTimeEndTime(period time.Duration, latency time.Duration) (time.Time
 // to obtain statistical data.
 func GetListMetricsOutput(namespace string, regionName string, svcCloudwatch cloudwatchiface.ClientAPI) ([]cloudwatch.Metric, error) {
 	var metricsTotal []cloudwatch.Metric
-	init := true
 	var nextToken *string
 
-	for init || nextToken != nil {
-		init = false
-		listMetricsInput := &cloudwatch.ListMetricsInput{
-			NextToken: nextToken,
-		}
-		if namespace != "*" {
-			listMetricsInput.Namespace = &namespace
-		}
-		reqListMetrics := svcCloudwatch.ListMetricsRequest(listMetricsInput)
-
-		// List metrics of a given namespace for each region
-		listMetricsOutput, err := reqListMetrics.Send(context.TODO())
-		if err != nil {
-			return nil, errors.Wrap(err, "ListMetricsRequest failed, skipping region "+regionName)
-		}
-		metricsTotal = append(metricsTotal, listMetricsOutput.Metrics...)
-		nextToken = listMetricsOutput.NextToken
+	listMetricsInput := &cloudwatch.ListMetricsInput{
+		NextToken: nextToken,
+	}
+	if namespace != "*" {
+		listMetricsInput.Namespace = &namespace
 	}
 
+	// List metrics of a given namespace for each region
+	req := svcCloudwatch.ListMetricsRequest(listMetricsInput)
+	paginator := cloudwatch.NewListMetricsPaginator(req)
+	for paginator.Next(context.TODO()) {
+		page := paginator.CurrentPage()
+		metricsTotal = append(metricsTotal, page.Metrics...)
+	}
+
+	if err := paginator.Err(); err != nil {
+		return metricsTotal, errors.Wrap(err, "error ListMetrics with Paginator, skipping region "+regionName)
+	}
 	return metricsTotal, nil
-}
-
-func getMetricDataPerRegion(metricDataQueries []cloudwatch.MetricDataQuery, nextToken *string, svc cloudwatchiface.ClientAPI, startTime time.Time, endTime time.Time) (*cloudwatch.GetMetricDataOutput, error) {
-	getMetricDataInput := &cloudwatch.GetMetricDataInput{
-		NextToken:         nextToken,
-		StartTime:         &startTime,
-		EndTime:           &endTime,
-		MetricDataQueries: metricDataQueries,
-	}
-
-	reqGetMetricData := svc.GetMetricDataRequest(getMetricDataInput)
-	getMetricDataResponse, err := reqGetMetricData.Send(context.TODO())
-	if err != nil {
-		return nil, errors.Wrap(err, "Error GetMetricDataInput")
-	}
-	return getMetricDataResponse.GetMetricDataOutput, nil
 }
 
 // GetMetricDataResults function uses MetricDataQueries to get metric data output.
 func GetMetricDataResults(metricDataQueries []cloudwatch.MetricDataQuery, svc cloudwatchiface.ClientAPI, startTime time.Time, endTime time.Time) ([]cloudwatch.MetricDataResult, error) {
-	init := true
 	maxQuerySize := 100
 	getMetricDataOutput := &cloudwatch.GetMetricDataOutput{NextToken: nil}
-	for init || getMetricDataOutput.NextToken != nil {
-		init = false
-		// Split metricDataQueries into smaller slices that length no longer than 100.
-		// 100 is defined in maxQuerySize.
-		// To avoid ValidationError: The collection MetricDataQueries must not have a size greater than 100.
-		for i := 0; i < len(metricDataQueries); i += maxQuerySize {
-			metricDataQueriesPartial := metricDataQueries[i:int(math.Min(float64(i+maxQuerySize), float64(len(metricDataQueries))))]
-			if len(metricDataQueriesPartial) == 0 {
-				return getMetricDataOutput.MetricDataResults, nil
-			}
 
-			output, err := getMetricDataPerRegion(metricDataQueriesPartial, getMetricDataOutput.NextToken, svc, startTime, endTime)
-			if err != nil {
-				return getMetricDataOutput.MetricDataResults, errors.Wrap(err, "getMetricDataPerRegion failed")
-			}
+	// Split metricDataQueries into smaller slices that length no longer than 100.
+	// 100 is defined in maxQuerySize.
+	// To avoid ValidationError: The collection MetricDataQueries must not have a size greater than 100.
+	for i := 0; i < len(metricDataQueries); i += maxQuerySize {
+		metricDataQueriesPartial := metricDataQueries[i:int(math.Min(float64(i+maxQuerySize), float64(len(metricDataQueries))))]
+		if len(metricDataQueriesPartial) == 0 {
+			return getMetricDataOutput.MetricDataResults, nil
+		}
 
-			getMetricDataOutput.MetricDataResults = append(getMetricDataOutput.MetricDataResults, output.MetricDataResults...)
+		getMetricDataInput := &cloudwatch.GetMetricDataInput{
+			StartTime:         &startTime,
+			EndTime:           &endTime,
+			MetricDataQueries: metricDataQueriesPartial,
+		}
+
+		req := svc.GetMetricDataRequest(getMetricDataInput)
+		paginator := cloudwatch.NewGetMetricDataPaginator(req)
+		for paginator.Next(context.TODO()) {
+			page := paginator.CurrentPage()
+			getMetricDataOutput.MetricDataResults = append(getMetricDataOutput.MetricDataResults, page.MetricDataResults...)
+		}
+
+		if err := paginator.Err(); err != nil {
+			return getMetricDataOutput.MetricDataResults, errors.Wrap(err, "error GetMetricData with Paginator")
 		}
 	}
 	return getMetricDataOutput.MetricDataResults, nil


### PR DESCRIPTION
Cherry-pick of PR #26852 to 7.14 branch. Original message: 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR refactors AWS related code to use AWS SDK paginators instead. 
1. In Filebeat `aws-cloudwatch` input, change `FilterLogEvents` API to use `NewFilterLogEventsPaginator`.
2. In Metricbeat, change `GetMetricData` to use `NewGetMetricDataPaginator`.
3. In Metricbeat, change `ListMetrics` to use `NewListMetricsPaginator`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes  https://github.com/elastic/beats/issues/26401