### PR TITLE
[Metricbeat] gcp: refactor service based metric filter creation

### DIFF
--- a/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
@@ -7,7 +7,6 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -36,14 +35,14 @@ type timeSeriesWithAligner struct {
 	aligner    string
 }
 
-func (r *metricsRequester) Metric(ctx context.Context, metricType string, timeInterval *monitoringpb.TimeInterval, aligner string) (out timeSeriesWithAligner) {
+func (r *metricsRequester) Metric(ctx context.Context, serviceName, metricType string, timeInterval *monitoringpb.TimeInterval, aligner string) (out timeSeriesWithAligner) {
 	timeSeries := make([]*monitoringpb.TimeSeries, 0)
 
 	req := &monitoringpb.ListTimeSeriesRequest{
 		Name:     "projects/" + r.config.ProjectID,
 		Interval: timeInterval,
 		View:     monitoringpb.ListTimeSeriesRequest_FULL,
-		Filter:   r.getFilterForMetric(metricType),
+		Filter:   r.getFilterForMetric(serviceName, metricType),
 		Aggregation: &monitoringpb.Aggregation{
 			PerSeriesAligner: gcp.AlignersMapToGCP[aligner],
 			AlignmentPeriod:  r.config.period,
@@ -85,7 +84,7 @@ func (r *metricsRequester) Metrics(ctx context.Context, sdc metricsConfig, metri
 
 			r.logger.Debugf("For metricType %s, metricMeta = %d", mt, metricMeta)
 			interval, aligner := getTimeIntervalAligner(metricMeta.ingestDelay, metricMeta.samplePeriod, r.config.period, aligner)
-			ts := r.Metric(ctx, mt, interval, aligner)
+			ts := r.Metric(ctx, sdc.ServiceName, mt, interval, aligner)
 			lock.Lock()
 			defer lock.Unlock()
 			results = append(results, ts)
@@ -96,19 +95,15 @@ func (r *metricsRequester) Metrics(ctx context.Context, sdc metricsConfig, metri
 	return results, nil
 }
 
-var serviceRegexp = regexp.MustCompile(`^(?P<service>[a-z]+)\.googleapis.com.*`)
-
 // getFilterForMetric returns the filter associated with the corresponding filter. Some services like Pub/Sub fails
 // if they have a region specified.
-func (r *metricsRequester) getFilterForMetric(m string) (f string) {
+func (r *metricsRequester) getFilterForMetric(serviceName, m string) (f string) {
 	f = fmt.Sprintf(`metric.type="%s"`, m)
 	if r.config.Zone == "" && r.config.Region == "" {
 		return
 	}
 
-	service := serviceRegexp.ReplaceAllString(m, "${service}")
-
-	switch service {
+	switch serviceName {
 	case gcp.ServicePubsub, gcp.ServiceLoadBalancing, gcp.ServiceCloudFunctions:
 		return
 	case gcp.ServiceStorage:

--- a/x-pack/metricbeat/module/gcp/metrics/metrics_requester_test.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metrics_requester_test.go
@@ -18,78 +18,91 @@ func TestGetFilterForMetric(t *testing.T) {
 	var logger = logp.NewLogger("test")
 	cases := []struct {
 		title          string
+		s              string
 		m              string
 		r              metricsRequester
 		expectedFilter string
 	}{
 		{
 			"compute service with zone in config",
+			"compute",
 			"compute.googleapis.com/firewall/dropped_bytes_count",
 			metricsRequester{config: config{Zone: "us-central1-a"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\" AND resource.labels.zone = starts_with(\"us-central1-a\")",
 		},
 		{
 			"pubsub service with zone in config",
+			"pubsub",
 			"pubsub.googleapis.com/subscription/ack_message_count",
 			metricsRequester{config: config{Zone: "us-central1-a"}, logger: logger},
 			"metric.type=\"pubsub.googleapis.com/subscription/ack_message_count\"",
 		},
 		{
 			"loadbalancing service with zone in config",
+			"loadbalancing",
 			"loadbalancing.googleapis.com/https/backend_latencies",
 			metricsRequester{config: config{Zone: "us-central1-a"}, logger: logger},
 			"metric.type=\"loadbalancing.googleapis.com/https/backend_latencies\"",
 		},
 		{
 			"compute service with region in config",
+			"compute",
 			"compute.googleapis.com/firewall/dropped_bytes_count",
 			metricsRequester{config: config{Region: "us-east1"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\" AND resource.labels.zone = starts_with(\"us-east1\")",
 		},
 		{
 			"pubsub service with region in config",
+			"pubsub",
 			"pubsub.googleapis.com/subscription/ack_message_count",
 			metricsRequester{config: config{Region: "us-east1"}, logger: logger},
 			"metric.type=\"pubsub.googleapis.com/subscription/ack_message_count\"",
 		},
 		{
 			"loadbalancing service with region in config",
+			"loadbalancing",
 			"loadbalancing.googleapis.com/https/backend_latencies",
 			metricsRequester{config: config{Region: "us-east1"}, logger: logger},
 			"metric.type=\"loadbalancing.googleapis.com/https/backend_latencies\"",
 		},
 		{
 			"compute service with both region and zone in config",
+			"compute",
 			"compute.googleapis.com/firewall/dropped_bytes_count",
 			metricsRequester{config: config{Region: "us-central1", Zone: "us-central1-a"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\" AND resource.labels.zone = starts_with(\"us-central1\")",
 		},
 		{
 			"compute uptime with partial region",
+			"compute",
 			"compute.googleapis.com/instance/uptime",
 			metricsRequester{config: config{Region: "us-west"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-west\")",
 		},
 		{
 			"compute uptime with partial zone",
+			"compute",
 			"compute.googleapis.com/instance/uptime",
 			metricsRequester{config: config{Zone: "us-west1-"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-west1-\")",
 		},
 		{
 			"compute uptime with wildcard in region",
+			"compute",
 			"compute.googleapis.com/instance/uptime",
 			metricsRequester{config: config{Region: "us-*"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-\")",
 		},
 		{
 			"compute uptime with wildcard in zone",
+			"compute",
 			"compute.googleapis.com/instance/uptime",
 			metricsRequester{config: config{Zone: "us-west1-*"}, logger: logger},
 			"metric.type=\"compute.googleapis.com/instance/uptime\" AND resource.labels.zone = starts_with(\"us-west1-\")",
 		},
 		{
 			"compute service with no region/zone in config",
+			"compute",
 			"compute.googleapis.com/firewall/dropped_bytes_count",
 			metricsRequester{config: config{}, logger: logger},
 			"metric.type=\"compute.googleapis.com/firewall/dropped_bytes_count\"",
@@ -98,7 +111,7 @@ func TestGetFilterForMetric(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			filter := c.r.getFilterForMetric(c.m)
+			filter := c.r.getFilterForMetric(c.s, c.m)
 			assert.Equal(t, c.expectedFilter, filter)
 		})
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

`metricsRequester.getFilterForMetric` was using a regexp logic to
extract the service name from the metric name.

The service name is used to adapt the metric filter creation based on
the service the metric belongs to, as different services require
different filters and some are not supported.

With the changes required to supporting GKE, that has a different metric
prefix than other Google Cloud metrics, the logic was broken, creating a
filter that was always returning an empty metric set.

This commit change the logic to rely on `metricsConfig.ServiceName`
instead, removing the inference on the metric name.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The implemented Regexp inference on the metric name does not work when the metric prefix is not in the form `<servicename>.googleapis.com`. This prevent adding metricsets not related to [Google Cloud](https://cloud.google.com/monitoring/api/metrics_gcp) metrics.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related to #26960
- Required for #26824  

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

```
Scenario: add new metricsets to gcp module

	As a gcp Beat module developer
	Given I want to add a metricset not related to "Google Cloud" metrics
	Then I may need to control the metric filter creation logic
```

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
