### PR TITLE
Add username to ASA Security negotiation log

### DIFF
--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -638,7 +638,7 @@ processors:
       if: "ctx._temp_.cisco.message_id == '713049'"
       field: "message"
       description: "713049"
-      pattern: "Group = %{}, IP = %{source.address}, Security negotiation complete for LAN-to-LAN Group (%{}) %{}, Inbound SPI = %{}, Outbound SPI = %{}"
+      pattern: "Group = %{}, Username = %{user.name}, IP = %{source.address}, Security negotiation complete for LAN-to-LAN Group (%{}) %{}, Inbound SPI = %{}, Outbound SPI = %{}"
   - grok:
       if: "ctx._temp_.cisco.message_id == '716002'"
       field: "message"


### PR DESCRIPTION
## What does this PR do?

I added the username user.name field to ASA Security negotiation log line.

## Why is it important?

The dissect function fails without it.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

`Unable to find match for dissect pattern: Group = %{}, IP = %{source.address}, Security negotiation complete for LAN-to-LAN Group (%{}) %{}, Inbound SPI = %{}, Outbound SPI = %{} against source: Group = xxxx, Username = xxxx_xxxx, IP = 1.2.3.4, Security negotiation complete for User (xxxx_xxxx)  Responder, Inbound SPI = 0x0000000, Outbound SPI = 0x0000000`