### PR TITLE
Run base tests when applying module selective testing

### DIFF
--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -179,6 +179,9 @@ func PythonTestForModule(params PythonTestArgs) error {
 		params.Files = []string{
 			fmt.Sprintf("module/%s/test_*.py", module),
 			fmt.Sprintf("module/%s/*/test_*.py", module),
+
+			// Run always the base tests, that include tests for module dashboards.
+			"tests/system/test*_base.py",
 		}
 		params.TestName += "-" + module
 	}


### PR DESCRIPTION
## What does this PR do?

Run base tests when applying module selective testing in python integration tests.

## Why is it important?

Dashboards are not tested at the module level, they are only tested by the base tests. When a single module is modified, selective testing is applied, so dashboard tests were not executed, allowing to introduce issues when single dashboards are modified.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

* Introduce a failure in a dashboard of the kubernetes module (or any other module).
* Run integration tests for this module `MODULE="kubernetes" mage -v pythonIntegTest`, failure should be detected.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/beats/pull/26919 added a dashboard that required 7.14 to work, before it was released, making tests to fail, but not being detected in CI.