### PR TITLE
Do not add all contextual information to the same logger in `filestream` prospector

### DIFF
--- a/filebeat/input/filestream/copytruncate_prospector.go
+++ b/filebeat/input/filestream/copytruncate_prospector.go
@@ -238,6 +238,7 @@ func (p *copyTruncateFileProspector) Run(ctx input.Context, s loginp.StateMetada
 			if fe.Op == loginp.OpDone {
 				return nil
 			}
+
 			p.onFSEvent(log, ctx, fe, s, hg, ignoreInactiveSince)
 
 		}

--- a/filebeat/input/filestream/logger.go
+++ b/filebeat/input/filestream/logger.go
@@ -25,7 +25,7 @@ import (
 
 func loggerWithEvent(logger *logp.Logger, event loginp.FSEvent, src loginp.Source) *logp.Logger {
 	log := logger.With(
-		"operation", event.Op,
+		"operation", event.Op.String(),
 		"source_name", src.Name(),
 	)
 	if event.Info != nil && event.Info.Sys() != nil {

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -165,7 +165,7 @@ func (p *fileProspector) onFSEvent(
 		}
 
 		if p.isFileIgnored(evtLog, fe, ignoreSince) {
-			break
+			return
 		}
 
 		hg.Start(ctx, src)

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -129,46 +129,46 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 			}
 
 			src := p.identifier.GetSource(fe)
-			log = loggerWithEvent(log, fe, src)
+			evtLog := loggerWithEvent(log, fe, src)
 
 			switch fe.Op {
 			case loginp.OpCreate, loginp.OpWrite:
 				if fe.Op == loginp.OpCreate {
-					log.Debugf("A new file %s has been found", fe.NewPath)
+					evtLog.Debugf("A new file %s has been found", fe.NewPath)
 
 					err := s.UpdateMetadata(src, fileMeta{Source: fe.NewPath, IdentifierName: p.identifier.Name()})
 					if err != nil {
-						log.Errorf("Failed to set cursor meta data of entry %s: %v", src.Name(), err)
+						evtLog.Errorf("Failed to set cursor meta data of entry %s: %v", src.Name(), err)
 					}
 
 				} else if fe.Op == loginp.OpWrite {
-					log.Debugf("File %s has been updated", fe.NewPath)
+					evtLog.Debugf("File %s has been updated", fe.NewPath)
 				}
 
-				if p.isFileIgnored(log, fe, ignoreInactiveSince) {
+				if p.isFileIgnored(evtLog, fe, ignoreInactiveSince) {
 					break
 				}
 
 				hg.Start(ctx, src)
 
 			case loginp.OpTruncate:
-				log.Debugf("File %s has been truncated", fe.NewPath)
+				evtLog.Debugf("File %s has been truncated", fe.NewPath)
 
 				s.ResetCursor(src, state{Offset: 0})
 				hg.Restart(ctx, src)
 
 			case loginp.OpDelete:
-				log.Debugf("File %s has been removed", fe.OldPath)
+				evtLog.Debugf("File %s has been removed", fe.OldPath)
 
-				p.onRemove(log, fe, src, s, hg)
+				p.onRemove(evtLog, fe, src, s, hg)
 
 			case loginp.OpRename:
-				log.Debugf("File %s has been renamed to %s", fe.OldPath, fe.NewPath)
+				evtLog.Debugf("File %s has been renamed to %s", fe.OldPath, fe.NewPath)
 
-				p.onRename(log, ctx, fe, src, s, hg)
+				p.onRename(evtLog, ctx, fe, src, s, hg)
 
 			default:
-				log.Error("Unkown return value %v", fe.Op)
+				evtLog.Error("Unkown return value %v", fe.Op)
 			}
 		}
 		return nil

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -128,7 +128,8 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 				return nil
 			}
 
-			p.onFSEvent(log, ctx, fe, s, hg, ignoreInactiveSince)
+			src := p.identifier.GetSource(fe)
+			p.onFSEvent(loggerWithEvent(log, fe, src), ctx, fe, src, s, hg, ignoreInactiveSince)
 		}
 		return nil
 	})
@@ -142,52 +143,51 @@ func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, h
 func (p *fileProspector) onFSEvent(
 	log *logp.Logger,
 	ctx input.Context,
-	fe loginp.FSEvent,
-	s loginp.StateMetadataUpdater,
-	hg loginp.HarvesterGroup,
+	event loginp.FSEvent,
+	src loginp.Source,
+	updater loginp.StateMetadataUpdater,
+	group loginp.HarvesterGroup,
 	ignoreSince time.Time,
 ) {
-	src := p.identifier.GetSource(fe)
-	evtLog := loggerWithEvent(log, fe, src)
 
-	switch fe.Op {
+	switch event.Op {
 	case loginp.OpCreate, loginp.OpWrite:
-		if fe.Op == loginp.OpCreate {
-			evtLog.Debugf("A new file %s has been found", fe.NewPath)
+		if event.Op == loginp.OpCreate {
+			log.Debugf("A new file %s has been found", event.NewPath)
 
-			err := s.UpdateMetadata(src, fileMeta{Source: fe.NewPath, IdentifierName: p.identifier.Name()})
+			err := updater.UpdateMetadata(src, fileMeta{Source: event.NewPath, IdentifierName: p.identifier.Name()})
 			if err != nil {
-				evtLog.Errorf("Failed to set cursor meta data of entry %s: %v", src.Name(), err)
+				log.Errorf("Failed to set cursor meta data of entry %s: %v", src.Name(), err)
 			}
 
-		} else if fe.Op == loginp.OpWrite {
-			evtLog.Debugf("File %s has been updated", fe.NewPath)
+		} else if event.Op == loginp.OpWrite {
+			log.Debugf("File %s has been updated", event.NewPath)
 		}
 
-		if p.isFileIgnored(evtLog, fe, ignoreSince) {
+		if p.isFileIgnored(log, event, ignoreSince) {
 			return
 		}
 
-		hg.Start(ctx, src)
+		group.Start(ctx, src)
 
 	case loginp.OpTruncate:
-		evtLog.Debugf("File %s has been truncated", fe.NewPath)
+		log.Debugf("File %s has been truncated", event.NewPath)
 
-		s.ResetCursor(src, state{Offset: 0})
-		hg.Restart(ctx, src)
+		updater.ResetCursor(src, state{Offset: 0})
+		group.Restart(ctx, src)
 
 	case loginp.OpDelete:
-		evtLog.Debugf("File %s has been removed", fe.OldPath)
+		log.Debugf("File %s has been removed", event.OldPath)
 
-		p.onRemove(evtLog, fe, src, s, hg)
+		p.onRemove(log, event, src, updater, group)
 
 	case loginp.OpRename:
-		evtLog.Debugf("File %s has been renamed to %s", fe.OldPath, fe.NewPath)
+		log.Debugf("File %s has been renamed to %s", event.OldPath, event.NewPath)
 
-		p.onRename(evtLog, ctx, fe, src, s, hg)
+		p.onRename(log, ctx, event, src, updater, group)
 
 	default:
-		evtLog.Error("Unkown return value %v", fe.Op)
+		log.Error("Unkown return value %v", event.Op)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR creates a separate logger for every FSEvent the prospector encounters to make sure contextual metadata of different files does not get mixed together.

Furthermore, now the human-readable format of the file system event is added to the metadata.

## Why is it important?

Previously after getting more than one file system event through the file watcher metadata started to pile up in the logger. Notice the duplicated keys "operation", "source_name", "os_id", "new_path" after accepting the second event form the channel:
```json
{
    "id": " 2248D961AFA2E8F",
    "prospector": "file_prospector",
    "operation": "create",
    "source_name": "native::8786365-65029",
    "os_id": "8786365-65029",
    "new_path": "/home/n/go/src/github.com/elastic/beats/filebeat/test.log",
    "operation": "write",
    "source_name": "native::8786363-65029",
    "os_id": "8786363-65029",
    "new_path": "/home/n/go/src/github.com/elastic/beats/filebeat/test.log",
    "old_path": "/home/n/go/src/github.com/elastic/beats/filebeat/test.log"
}
```


## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~