### PR TITLE
Add action timeout. Use previously defined default of 1 minute if the action timeout is not specified.

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
@@ -9,13 +9,19 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/storage/store"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 )
 
-const defaultActionTimeout = time.Minute
+const (
+	defaultActionTimeout = time.Minute
+	maxActionTimeout     = time.Hour
+)
+
+var ErrActionTimeoutInvalid = errors.New("action timeout is invalid")
 
 // AppAction is a handler for application actions.
 type AppAction struct {
@@ -54,11 +60,25 @@ func (h *AppAction) Handle(ctx context.Context, a fleetapi.Action, acker store.F
 	}
 
 	start := time.Now().UTC()
-	res, err := appState.PerformAction(action.InputType, params, defaultActionTimeout)
+	timeout := defaultActionTimeout
+	if action.Timeout > 0 {
+		timeout = time.Duration(action.Timeout) * time.Second
+		if timeout > maxActionTimeout {
+			h.log.Debugf("handlerAppAction: action '%v' timeout exceeds maximum allowed %v", action.InputType, maxActionTimeout)
+			err = ErrActionTimeoutInvalid
+		}
+	}
+
+	var res map[string]interface{}
+	if err == nil {
+		h.log.Debugf("handlerAppAction: action '%v' started with timeout: %v", action.InputType, timeout)
+		res, err = appState.PerformAction(action.InputType, params, timeout)
+	}
 	end := time.Now().UTC()
 
 	startFormatted := start.Format(time.RFC3339Nano)
 	endFormatted := end.Format(time.RFC3339Nano)
+	h.log.Debugf("handlerAppAction: action '%v' finished, startFormatted: %v, endFormatted: %v, err: %v", action.InputType, startFormatted, endFormatted, err)
 	if err != nil {
 		action.StartedAt = startFormatted
 		action.CompletedAt = endFormatted

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_application.go
@@ -21,7 +21,7 @@ const (
 	maxActionTimeout     = time.Hour
 )
 
-var ErrActionTimeoutInvalid = errors.New("action timeout is invalid")
+var errActionTimeoutInvalid = errors.New("action timeout is invalid")
 
 // AppAction is a handler for application actions.
 type AppAction struct {
@@ -65,7 +65,7 @@ func (h *AppAction) Handle(ctx context.Context, a fleetapi.Action, acker store.F
 		timeout = time.Duration(action.Timeout) * time.Second
 		if timeout > maxActionTimeout {
 			h.log.Debugf("handlerAppAction: action '%v' timeout exceeds maximum allowed %v", action.InputType, maxActionTimeout)
-			err = ErrActionTimeoutInvalid
+			err = errActionTimeoutInvalid
 		}
 	}
 

--- a/x-pack/elastic-agent/pkg/fleetapi/action.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/action.go
@@ -211,6 +211,7 @@ type ActionApp struct {
 	ActionID    string          `json:"id" mapstructure:"id"`
 	ActionType  string          `json:"type" mapstructure:"type"`
 	InputType   string          `json:"input_type" mapstructure:"input_type"`
+	Timeout     int64           `json:"timeout" mapstructure:"timeout"`
 	Data        json.RawMessage `json:"data" mapstructure:"data"`
 	StartedAt   string          `json:"started_at,omitempty" mapstructure:"started_at,omitempty"`
 	CompletedAt string          `json:"completed_at,omitempty" mapstructure:"completed_at,omitempty"`
@@ -284,6 +285,7 @@ func (a *Actions) UnmarshalJSON(data []byte) error {
 				ActionID:   response.ActionID,
 				ActionType: response.ActionType,
 				InputType:  response.InputType,
+				Timeout:    response.Timeout,
 				Data:       response.Data,
 			}
 		case ActionTypeUnenroll:

--- a/x-pack/elastic-agent/pkg/fleetapi/action.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/action.go
@@ -211,7 +211,7 @@ type ActionApp struct {
 	ActionID    string          `json:"id" mapstructure:"id"`
 	ActionType  string          `json:"type" mapstructure:"type"`
 	InputType   string          `json:"input_type" mapstructure:"input_type"`
-	Timeout     int64           `json:"timeout" mapstructure:"timeout"`
+	Timeout     int64           `json:"timeout,omitempty" mapstructure:"timeout,omitempty"`
 	Data        json.RawMessage `json:"data" mapstructure:"data"`
 	StartedAt   string          `json:"started_at,omitempty" mapstructure:"started_at,omitempty"`
 	CompletedAt string          `json:"completed_at,omitempty" mapstructure:"completed_at,omitempty"`


### PR DESCRIPTION
## What does this PR do?

Add action timeout. Use previously defined default of 1 minute if the action timeout is not specified.

## Why is it important?

This should allow the actions such as the endpoint containment to set the individual timeout if they expect the action to take longer than one minute.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## Related issues

- Relates https://github.com/elastic/kibana/issues/105477
- Requires https://github.com/elastic/fleet-server/pull/575

## Screenshots
When timeout exceeds 1 hour
<img width="460" alt="Screen Shot 2021-07-20 at 1 21 57 PM" src="https://user-images.githubusercontent.com/872351/126383314-139a002e-ee6e-4909-8f36-6ccf59b7d835.png">

results in error:
<img width="606" alt="Screen Shot 2021-07-20 at 1 17 55 PM" src="https://user-images.githubusercontent.com/872351/126383201-56676d3b-20e0-4e60-9bb5-b99d6df763f2.png">

