### PR TITLE
Osquerybeat: Improve logging for osqueryd log messages captured in our logging plugin

### DIFF
--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -459,5 +459,5 @@ func (bt *osquerybeat) publishEvents(index, actionID, responseID string, hits []
 
 		bt.client.Publish(event)
 	}
-	bt.log.Infof("The %d events sent to index %s", len(hits), index)
+	bt.log.Infof("%d events sent to index %s", len(hits), index)
 }


### PR DESCRIPTION
## What does this PR do?

Improves the logging of the log messages osquerybeat captures from osqueryd. 

Before the change the log message was logged as is (in json format) that made it difficult to consume/search also all the logs from osqueryd were logged at debug level. 

After the change the osquerybeat logging plugin converts the log severity from osqueryd into better matching libbeat logger level. It also parses JSON message and enriches the log with "osquery." prefixed parameters. 

## Why is it important?

Helps to analyze the osquery scheduled queries failures on Kibana side in this particular case.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Screenshots

The log failure messages before the change, notice the debug level logging and raw JSON string as a message:
![image](https://user-images.githubusercontent.com/872351/126515887-4cf335df-1a4d-4aff-aab5-fd86ead5bcf6.png)

After this change, notice the better logging level match, the error log level in this case
<img width="1429" alt="Screen Shot 2021-07-21 at 8 51 03 AM" src="https://user-images.githubusercontent.com/872351/126515920-2ab5402d-002e-4018-b4d3-7c45994429ed.png">

also parsed osqueryd log message and "osquery." prefixed fields derived from the osqueryd JSON log status message
<img width="811" alt="Screen Shot 2021-07-21 at 8 49 37 AM" src="https://user-images.githubusercontent.com/872351/126516178-bb33fc14-a36e-4a8b-b6e9-7e66185516fb.png">

