### PR TITLE
Fix timer failure

### DIFF
--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -82,7 +82,6 @@ func (tq *TimerQueue) Start() {
 	//if tt == nil {
 	//}
 	go func() {
-		t := time.NewTimer(time.Hour * 999999)
 		for {
 			runtime.Gosched()
 			select {

--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -69,9 +69,6 @@ func (tq *TimerQueue) Push(runAt time.Time, fn TimerTaskFn) bool {
 // Start runs a goroutine within the given context that processes items in the queue, spawning a new goroutine
 // for each.
 func (tq *TimerQueue) Start() {
-	//tt := time.NewTimer(time.Second * 5)
-	//if tt == nil {
-	//}
 	go func() {
 		for {
 			select {

--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -104,7 +104,7 @@ func (tq *TimerQueue) pushInternal(tt *timerTask) {
 	heap.Push(&tq.th, tt)
 
 	if tq.nextRunAt == nil || tq.nextRunAt.After(tt.runAt) {
-		if !tq.timer.Stop() {
+		if tq.nextRunAt != nil && !tq.timer.Stop() {
 			<-tq.timer.C
 		}
 		// Originally the line below this comment was

--- a/heartbeat/scheduler/timerqueue/queue.go
+++ b/heartbeat/scheduler/timerqueue/queue.go
@@ -108,7 +108,9 @@ func (tq *TimerQueue) pushInternal(tt *timerTask) {
 			<-tq.timer.C
 		}
 		// Originally the line below this comment was
-		//   tq.timer.Reset(time.Until(tt.runAt))
+		//
+		//  tq.timer.Reset(time.Until(tt.runAt))
+		//
 		// however this broke in go1.16rc1, specifically on the commit b4b014465216790e01aa66f9120d03230e4aff46
 		//, specifically on this line:
 		// https://github.com/golang/go/commit/b4b014465216790e01aa66f9120d03230e4aff46#diff-73699b6edfe5dbb3f6824e66bb3566bce9405e9a8c810cac55c8199459f0ac19R652

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -28,15 +28,17 @@ import (
 )
 
 func TestQueueRunsInOrder(t *testing.T) {
-	t.Skip("flaky test on windows: https://github.com/elastic/beats/issues/26205")
 	// Bugs can show up only occasionally
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 1000000; i++ {
+		if i%1000 == 0 {
+			t.Logf("Runs %d\n", i)
+		}
 		testQueueRunsInOrderOnce(t)
 	}
 }
 
 func testQueueRunsInOrderOnce(t *testing.T) {
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer ctxCancel()
 	tq := NewTimerQueue(ctx)
 

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -59,9 +59,7 @@ func TestStress(t *testing.T) {
 }
 
 func testQueueRunsInOrderOnce(t *testing.T) {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*20)
-	defer ctxCancel()
-	tq := NewTimerQueue(ctx)
+	tq := NewTimerQueue(context.Background())
 
 	// Number of items to test with
 	numItems := 10

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -29,11 +29,31 @@ import (
 
 func TestQueueRunsInOrder(t *testing.T) {
 	// Bugs can show up only occasionally
+	var min time.Duration
+	var max time.Duration
+	var slow int
+	var times = []time.Duration{}
 	for i := 0; i < 1000000; i++ {
-		if i%1000 == 0 {
-			t.Logf("Runs %d\n", i)
-		}
+		start := time.Now()
+
 		testQueueRunsInOrderOnce(t)
+
+		duration := time.Now().Sub(start)
+		if duration < min || min == 0 {
+			min = duration
+		}
+		if duration > max {
+			max = duration
+		}
+		if duration > time.Millisecond*5 {
+			slow++
+		}
+		times = append(times, duration)
+
+		if i%1000 == 0 && i > 0 {
+			ninetyFifth := int(float64(len(times)) * 0.95)
+			t.Logf("count: %07d | min: %s\t | max: %s\t| slow: %d\t| @95th: %s\n", i, min, max, slow, times[ninetyFifth])
+		}
 	}
 }
 

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -60,8 +60,8 @@ func TestStress(t *testing.T) {
 
 func testQueueRunsInOrderOnce(t *testing.T) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
-	tq := NewTimerQueue(ctx)
 	defer ctxCancel()
+	tq := NewTimerQueue(ctx)
 
 	// Number of items to test with
 	numItems := 10

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -59,7 +59,9 @@ func TestStress(t *testing.T) {
 }
 
 func testQueueRunsInOrderOnce(t *testing.T) {
-	tq := NewTimerQueue(context.Background())
+	ctx, ctxCancel := context.WithCancel(context.Background())
+	tq := NewTimerQueue(ctx)
+	defer ctxCancel()
 
 	// Number of items to test with
 	numItems := 10


### PR DESCRIPTION
## What does this PR do?

Fixes #26205

Fixes deadlocks in heartbeat scheduler.

No changelog needed because this bug only exists in go 1.16+ and v7.14.0 is the first affected beats version

The underlying cause is a likely bug in golang, reported here by myself here: https://github.com/golang/go/issues/47329

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

Try replacing the `NewTimer` call with `Reset` per the inline comment and validate that the test goes red.