### PR TITLE
[Filebeat]support maxBytes for DockerJSONReader

### DIFF
--- a/filebeat/input/log/harvester.go
+++ b/filebeat/input/log/harvester.go
@@ -687,7 +687,7 @@ func (h *Harvester) newLogFileReader() (reader.Reader, error) {
 
 	if h.config.DockerJSON != nil {
 		// Docker json-file format, add custom parsing to the pipeline
-		r = readjson.New(r, h.config.DockerJSON.Stream, h.config.DockerJSON.Partial, h.config.DockerJSON.Format, h.config.DockerJSON.CRIFlags)
+		r = readjson.New(r, h.config.DockerJSON.Stream, h.config.DockerJSON.Partial, h.config.DockerJSON.Format, h.config.DockerJSON.CRIFlags, h.config.MaxBytes)
 	}
 
 	if h.config.JSON != nil {

--- a/libbeat/reader/parser/parser.go
+++ b/libbeat/reader/parser/parser.go
@@ -101,6 +101,7 @@ func NewConfig(pCfg CommonConfig, parsers []common.ConfigNamespace) (*Config, er
 			}
 		case "container":
 			config := readjson.DefaultContainerConfig()
+			config.MaxBytes = pCfg.MaxBytes
 			cfg := ns.Config()
 			err := cfg.Unpack(&config)
 			if err != nil {

--- a/libbeat/reader/readjson/docker_json_config.go
+++ b/libbeat/reader/readjson/docker_json_config.go
@@ -17,7 +17,13 @@
 
 package readjson
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/dustin/go-humanize"
+
+	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
+)
 
 type ContainerFormat uint8
 
@@ -50,14 +56,16 @@ var (
 )
 
 type ContainerJSONConfig struct {
-	Stream Stream          `config:"stream"`
-	Format ContainerFormat `config:"format"`
+	Stream   Stream           `config:"stream"`
+	Format   ContainerFormat  `config:"format"`
+	MaxBytes cfgtype.ByteSize `config:"max_bytes"`
 }
 
 func DefaultContainerConfig() ContainerJSONConfig {
 	return ContainerJSONConfig{
-		Format: Auto,
-		Stream: All,
+		Format:   Auto,
+		Stream:   All,
+		MaxBytes: 10 * humanize.MiByte,
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Make config option `max_bytes` take effect to DockerJSONReader, which can ignore partial log when the sum of parital log's size exceeded.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
DockerJSONReader wil always merge partial into one message when configed. 
But, when encounter a huge log event, the sum of partial log may exceed the memory limit which can result in OOM.
So we need to use the config option `max_bytes` to handle with partial log

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
#26464 

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
