### PR TITLE
packaging: retryWithSleep the google storage upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -399,10 +399,13 @@ def publishPackages(beatsFolder){
 * @param beatsFolder the beats folder.
 */
 def uploadPackages(bucketUri, beatsFolder){
-  googleStorageUploadExt(bucket: bucketUri,
-    credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
-    pattern: "${beatsFolder}/build/distributions/**/*",
-    sharedPublicly: true)
+  // sometimes google storage reports ResumableUploadException: 503 Server Error
+  retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+    googleStorageUploadExt(bucket: bucketUri,
+      credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
+      pattern: "${beatsFolder}/build/distributions/**/*",
+      sharedPublicly: true)
+  }
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Retry to upload artifacts

## Why is it important?

Sometimes the google storage is not accessible, let's mitigate the environmental issues

![image](https://user-images.githubusercontent.com/2871786/126758966-4763b762-4318-419d-bbb1-214ced80ea20.png)


[build](https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats/detail/master/961/pipeline)