### PR TITLE
Preserve annotations in a kubernetes namespace metadata

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -245,6 +245,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Omit full index template from errors that occur while loading the template. {pull}25743[25743]
 - In the script processor, the `decode_xml` and `decode_xml_wineventlog` processors are now available as `DecodeXML` and `DecodeXMLWineventlog` respectively.
 - Fix encoding errors when using the disk queue on nested data with multi-byte characters {pull}26484[26484]
+- Preserve annotations in a kubernetes namespace metadata {pull}27045[27045]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/metadata/namespace.go
+++ b/libbeat/common/kubernetes/metadata/namespace.go
@@ -114,15 +114,17 @@ func flattenMetadata(in common.MapStr) common.MapStr {
 		}
 	}
 
-	rawLabels, err := in.GetValue("labels")
-	if err != nil {
-		return out
+	populateFromKeys := []string{"labels", "annotations"}
+	for _, key := range populateFromKeys {
+		rawValues, err := in.GetValue(key)
+		if err != nil {
+			continue
+		}
+		values, ok := rawValues.(common.MapStr)
+		if ok {
+			out[resource+"_"+key] = values
+		}
 	}
-	labels, ok := rawLabels.(common.MapStr)
-	if !ok {
-		return out
-	}
-	out[resource+"_labels"] = labels
 
 	return out
 }

--- a/libbeat/common/kubernetes/metadata/namespace_test.go
+++ b/libbeat/common/kubernetes/metadata/namespace_test.go
@@ -52,7 +52,9 @@ func TestNamespace_Generate(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "bar",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						"spam": "baz",
+					},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Namespace",
@@ -78,11 +80,20 @@ func TestNamespace_Generate(t *testing.T) {
 				"namespace_labels": common.MapStr{
 					"foo": "bar",
 				},
+				"namespace_annotations": common.MapStr{
+					"spam": "baz",
+				},
 			}},
 		},
 	}
 
-	cfg := common.NewConfig()
+	cfg, err := common.NewConfigFrom(Config{
+		IncludeAnnotations: []string{"spam"},
+	})
+	if err != nil {
+		t.Fatalf("Could not merge configs")
+	}
+
 	metagen := NewNamespaceMetadataGenerator(cfg, nil, client)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -109,7 +120,9 @@ func TestNamespace_GenerateFromName(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "bar",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						"spam": "baz",
+					},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Namespace",
@@ -133,12 +146,21 @@ func TestNamespace_GenerateFromName(t *testing.T) {
 				"namespace_labels": common.MapStr{
 					"foo": "bar",
 				},
+				"namespace_annotations": common.MapStr{
+					"spam": "baz",
+				},
 			},
 		},
 	}
 
 	for _, test := range tests {
-		cfg := common.NewConfig()
+		cfg, err := common.NewConfigFrom(Config{
+			IncludeAnnotations: []string{"spam"},
+		})
+		if err != nil {
+			t.Fatalf("Could not merge configs")
+		}
+
 		namespaces := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		namespaces.Add(test.input)
 		metagen := NewNamespaceMetadataGenerator(cfg, namespaces, client)


### PR DESCRIPTION
## What does this PR do?

When kubernetes is used as autodiscover provider, we can use metadata in processors of filebeat.
But after #16834 we lost access to 'annotations' section. This PR fix it.

## Why is it important?

We have custom tags in namespace annotations but have no access to them from the latest versions of filebeat. But we still have access to labels what is contradictory.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

As usual: `go test ./...`

## Related issues

- Relates #16834

## Use cases

```yaml
kind: Namespace
metadata:
  annotations:
    sage/group: foo_bar # We lost this without fix
```
