### PR TITLE
[CI] Add check-headers and a metadata make goal to simplify the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,13 +202,7 @@ def runLinting() {
       mapParallelTasks["${k}"] = v
     }
   }
-  mapParallelTasks['default'] = {
-                                cmd(label: "make check-python", script: "make check-python")
-                                cmd(label: "make notice", script: "make notice")
-                                // `make check-go` must follow `make notice` to ensure that the lint checks can be satisfied
-                                cmd(label: "make check-go", script: "make check-go")
-                                cmd(label: "Check for changes", script: "make check-no-changes")
-                              }
+  mapParallelTasks['default'] = { cmd(label: "make check-python", script: "make check-default") }
 
   parallel(mapParallelTasks)
 }

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,15 @@ check:
 	@$(MAKE) check-go
 	@$(MAKE) check-no-changes
 
+## check : Run some checks similar to what the default check validation runs in the CI.
+.PHONY: check-default
+check-default:
+	@$(MAKE) check-python
+	@$(MAKE) notice
+	@$(MAKE) check-headers
+	@$(MAKE) check-go
+	@$(MAKE) check-no-changes
+
 ## ccheck-go : Check there is no changes in Go modules.
 .PHONY: check-go
 check-go:


### PR DESCRIPTION
## What does this PR do?

Check-header is not executed and therefore PRs can get merged without validating whether the headers have been changed.

## Why is it important?

Only doc changes run the top level make check. 