### PR TITLE
Close monitored files after 5 minutes of inactivity

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/monitoring.go
@@ -220,6 +220,11 @@ func (o *Operator) getMonitoringFilebeatConfig(outputType string, output interfa
 	inputs := []interface{}{
 		map[string]interface{}{
 			"type": "filestream",
+			"close": map[string]interface{}{
+				"on_state_change": map[string]interface{}{
+					"inactive": "5m",
+				},
+			},
 			"parsers": []map[string]interface{}{
 				{
 					"ndjson": map[string]interface{}{
@@ -288,6 +293,11 @@ func (o *Operator) getMonitoringFilebeatConfig(outputType string, output interfa
 		for name, paths := range logPaths {
 			inputs = append(inputs, map[string]interface{}{
 				"type": "filestream",
+				"close": map[string]interface{}{
+					"on_state_change": map[string]interface{}{
+						"inactive": "5m",
+					},
+				},
 				"parsers": []map[string]interface{}{
 					{
 						"ndjson": map[string]interface{}{


### PR DESCRIPTION
## What does this PR do?

This PR sets `close.on_state_change.inactive` to 5 minutes, so every monitored file is closed after 5 minutes of inactivity. If the log file is updated, it will be picked up in 10 seconds because of the default value of `prospector.scanner.check_interval`.

## Why is it important?

Filebeat keeps log files open indefinitely by default. However, on Windows, log files cannot be cleaned up if Filebeat keeps the handles. This prevented Endpoint from cleaning up its own logs on Windows. Not anymore.

The original issue comes from Endpoint, however, it makes sense to enable this option for all log files of Agent as they are following the same log writing and log rotation method: adding the date to the end of the log file name.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes https://github.com/elastic/beats/issues/26941
