### PR TITLE
[Elastic Agent] Fix leaking connections and timers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/eapache/go-resiliency v1.2.0
 	github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200121105743-0d940dd29fd2
 	github.com/elastic/ecs v1.10.0
-	github.com/elastic/elastic-agent-client/v7 v7.0.0-20210308165121-7dd05ee2b5a5
+	github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6
 	github.com/elastic/go-concert v0.1.0
 	github.com/elastic/go-libaudit/v2 v2.2.0
 	github.com/elastic/go-licenser v0.3.1
@@ -199,7 +199,6 @@ replace (
 	github.com/docker/go-plugins-helpers => github.com/elastic/go-plugins-helpers v0.0.0-20200207104224-bdf17607b79f
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
-	github.com/elastic/elastic-agent-client/v7 => ./x-pack/elastic-agent/elastic-agent-client
 	github.com/fsnotify/fsevents => github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270
 	github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d
 	github.com/google/gopacket => github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41

--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,7 @@ replace (
 	github.com/docker/go-plugins-helpers => github.com/elastic/go-plugins-helpers v0.0.0-20200207104224-bdf17607b79f
 	github.com/dop251/goja => github.com/andrewkroh/goja v0.0.0-20190128172624-dd2ac4456e20
 	github.com/dop251/goja_nodejs => github.com/dop251/goja_nodejs v0.0.0-20171011081505-adff31b136e6
+	github.com/elastic/elastic-agent-client/v7 => ./x-pack/elastic-agent/elastic-agent-client
 	github.com/fsnotify/fsevents => github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270
 	github.com/fsnotify/fsnotify => github.com/adriansr/fsnotify v0.0.0-20180417234312-c9bbe1f46f1d
 	github.com/google/gopacket => github.com/adriansr/gopacket v1.1.18-0.20200327165309-dd62abfa8a41

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 h1:lnDkqiRFKm0rxdljqr
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3/go.mod h1:aPqzac6AYkipvp4hufTyMj5PDIphF3+At8zr7r51xjY=
 github.com/elastic/ecs v1.10.0 h1:C+0ZidF/eh5DKYAZBir3Hq9Q6aMXcwpgEuQnj4bRzKA=
 github.com/elastic/ecs v1.10.0/go.mod h1:pgiLbQsijLOJvFR8OTILLu0Ni/R/foUNg0L+T6mU9b4=
+github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6 h1:nFvXHBjYK3e9+xF0WKDeAKK4aOO51uC28s+L9rBmilo=
+github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6/go.mod h1:uh/Gj9a0XEbYoM4NYz4LvaBVARz3QXLmlNjsrKY9fTc=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQVCpGSRXmLqjEHpJKbR60rxh1nQZY4=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/go-concert v0.1.0 h1:gz/yvA3bseuHzoF/lNMltkL30XdPqMo+bg5o2mBx2EE=

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,6 @@ github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 h1:lnDkqiRFKm0rxdljqr
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3/go.mod h1:aPqzac6AYkipvp4hufTyMj5PDIphF3+At8zr7r51xjY=
 github.com/elastic/ecs v1.10.0 h1:C+0ZidF/eh5DKYAZBir3Hq9Q6aMXcwpgEuQnj4bRzKA=
 github.com/elastic/ecs v1.10.0/go.mod h1:pgiLbQsijLOJvFR8OTILLu0Ni/R/foUNg0L+T6mU9b4=
-github.com/elastic/elastic-agent-client/v7 v7.0.0-20210308165121-7dd05ee2b5a5 h1:n4VHMzwk4o8+0zTCDej1M6uUR9rkzScpSeZXi0B8y1w=
-github.com/elastic/elastic-agent-client/v7 v7.0.0-20210308165121-7dd05ee2b5a5/go.mod h1:uh/Gj9a0XEbYoM4NYz4LvaBVARz3QXLmlNjsrKY9fTc=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQVCpGSRXmLqjEHpJKbR60rxh1nQZY4=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdboCbArMF/nSCDUXgQuWTeoMmE/z8607X+k7ng=
 github.com/elastic/go-concert v0.1.0 h1:gz/yvA3bseuHzoF/lNMltkL30XdPqMo+bg5o2mBx2EE=

--- a/x-pack/elastic-agent/pkg/agent/application/periodic.go
+++ b/x-pack/elastic-agent/pkg/agent/application/periodic.go
@@ -34,9 +34,7 @@ func (p *periodic) Start() error {
 			t := time.NewTimer(p.period)
 			select {
 			case <-p.done:
-				if !t.Stop() {
-					<-t.C
-				}
+				t.Stop()
 				break WORK
 			case <-t.C:
 			}

--- a/x-pack/elastic-agent/pkg/agent/application/periodic.go
+++ b/x-pack/elastic-agent/pkg/agent/application/periodic.go
@@ -31,10 +31,14 @@ func (p *periodic) Start() error {
 
 	WORK:
 		for {
+			t := time.NewTimer(p.period)
 			select {
 			case <-p.done:
+				if !t.Stop() {
+					<-t.C
+				}
 				break WORK
-			case <-time.After(p.period):
+			case <-t.C:
 			}
 
 			if err := p.work(); err != nil {

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
@@ -145,14 +145,15 @@ func (h *PolicyChange) handleFleetServerHosts(ctx context.Context, c *config.Con
 	ctx, cancel := context.WithTimeout(ctx, apiStatusTimeout)
 	defer cancel()
 	resp, err := client.Send(ctx, "GET", "/api/status", nil, nil, nil)
-	// discard body for proper cancellation and connection reuse
-	io.Copy(ioutil.Discard, resp.Body)
-	resp.Body.Close()
 	if err != nil {
 		return errors.New(
 			err, "fail to communicate with updated API client hosts",
 			errors.TypeNetwork, errors.M("hosts", h.config.Fleet.Client.Hosts))
 	}
+	// discard body for proper cancellation and connection reuse
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+
 	reader, err := fleetToReader(h.agentInfo, h.config)
 	if err != nil {
 		return errors.New(

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_policy_change.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"sort"
 	"time"
 
@@ -143,7 +144,10 @@ func (h *PolicyChange) handleFleetServerHosts(ctx context.Context, c *config.Con
 	}
 	ctx, cancel := context.WithTimeout(ctx, apiStatusTimeout)
 	defer cancel()
-	_, err = client.Send(ctx, "GET", "/api/status", nil, nil, nil)
+	resp, err := client.Send(ctx, "GET", "/api/status", nil, nil, nil)
+	// discard body for proper cancellation and connection reuse
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
 	if err != nil {
 		return errors.New(
 			err, "fail to communicate with updated API client hosts",

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker.go
@@ -66,10 +66,15 @@ func (ch *CrashChecker) Run(ctx context.Context) {
 	ch.log.Debug("Crash checker started")
 	for {
 		ch.log.Debugf("watcher having PID: %d", os.Getpid())
+		t := time.NewTimer(ch.checkPeriod)
+
 		select {
 		case <-ctx.Done():
+			if !t.Stop() {
+				<-t.C
+			}
 			return
-		case <-time.After(ch.checkPeriod):
+		case <-t.C:
 			pid, err := ch.sc.PID(ctx)
 			if err != nil {
 				ch.log.Error(err)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/crash_checker.go
@@ -70,9 +70,7 @@ func (ch *CrashChecker) Run(ctx context.Context) {
 
 		select {
 		case <-ctx.Done():
-			if !t.Stop() {
-				<-t.C
-			}
+			t.Stop()
 			return
 		case <-t.C:
 			pid, err := ch.sc.PID(ctx)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/error_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/error_checker.go
@@ -52,9 +52,7 @@ func (ch *ErrorChecker) Run(ctx context.Context) {
 		t := time.NewTimer(statusCheckPeriod)
 		select {
 		case <-ctx.Done():
-			if !t.Stop() {
-				<-t.C
-			}
+			t.Stop()
 			return
 		case <-t.C:
 			err := ch.agentClient.Connect(ctx)

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/error_checker.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/error_checker.go
@@ -49,10 +49,14 @@ func NewErrorChecker(ch chan error, log *logger.Logger) (*ErrorChecker, error) {
 func (ch *ErrorChecker) Run(ctx context.Context) {
 	ch.log.Debug("Error checker started")
 	for {
+		t := time.NewTimer(statusCheckPeriod)
 		select {
 		case <-ctx.Done():
+			if !t.Stop() {
+				<-t.C
+			}
 			return
-		case <-time.After(statusCheckPeriod):
+		case <-t.C:
 			err := ch.agentClient.Connect(ctx)
 			if err != nil {
 				ch.failuresCounter++

--- a/x-pack/elastic-agent/pkg/agent/cmd/watch.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/watch.go
@@ -144,6 +144,7 @@ func watch(ctx context.Context, tilGrace time.Duration, log *logger.Logger) erro
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGKILL, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP)
 
 	t := time.NewTimer(tilGrace)
+	defer t.Stop()
 
 WATCHLOOP:
 	for {
@@ -168,9 +169,6 @@ WATCHLOOP:
 		}
 	}
 
-	if !t.Stop() {
-		<-t.C
-	}
 	return nil
 }
 

--- a/x-pack/elastic-agent/pkg/composable/controller.go
+++ b/x-pack/elastic-agent/pkg/composable/controller.go
@@ -130,6 +130,7 @@ func (c *controller) Run(ctx context.Context, cb VarsCallback) error {
 		for {
 			// performs debounce of notifies; accumulates them into 100 millisecond chunks
 			changed := false
+			t := time.NewTimer(100 * time.Millisecond)
 			for {
 				exitloop := false
 				select {
@@ -138,13 +139,16 @@ func (c *controller) Run(ctx context.Context, cb VarsCallback) error {
 					return
 				case <-notify:
 					changed = true
-				case <-time.After(100 * time.Millisecond):
+				case <-t.C:
 					exitloop = true
-					break
 				}
 				if exitloop {
 					break
 				}
+			}
+
+			if !t.Stop() {
+				<-t.C
 			}
 			if !changed {
 				continue

--- a/x-pack/elastic-agent/pkg/composable/controller.go
+++ b/x-pack/elastic-agent/pkg/composable/controller.go
@@ -147,9 +147,7 @@ func (c *controller) Run(ctx context.Context, cb VarsCallback) error {
 				}
 			}
 
-			if !t.Stop() {
-				<-t.C
-			}
+			t.Stop()
 			if !changed {
 				continue
 			}

--- a/x-pack/elastic-agent/pkg/composable/providers/host/host.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/host/host.go
@@ -55,9 +55,7 @@ func (c *contextProvider) Run(comm corecomp.ContextProviderComm) error {
 			t := time.NewTimer(c.CheckInterval)
 			select {
 			case <-comm.Done():
-				if !t.Stop() {
-					<-t.C
-				}
+				t.Stop()
 				return
 			case <-t.C:
 			}

--- a/x-pack/elastic-agent/pkg/composable/providers/host/host.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/host/host.go
@@ -52,11 +52,14 @@ func (c *contextProvider) Run(comm corecomp.ContextProviderComm) error {
 	// Update context when any host information changes.
 	go func() {
 		for {
+			t := time.NewTimer(c.CheckInterval)
 			select {
 			case <-comm.Done():
+				if !t.Stop() {
+					<-t.C
+				}
 				return
-			case <-time.After(c.CheckInterval):
-				break
+			case <-t.C:
 			}
 
 			updated, err := c.fetcher()

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process.go
@@ -123,7 +123,11 @@ func processMetrics(ctx context.Context, id string) ([]byte, int, error) {
 		)
 	}
 
-	resp, err := client.Do(req.WithContext(ctx))
+	req.Close = true
+	cctx, cancelFn := context.WithCancel(ctx)
+	defer cancelFn()
+
+	resp, err := client.Do(req.WithContext(cctx))
 	if err != nil {
 		statusCode := http.StatusInternalServerError
 		if errors.Is(err, syscall.ENOENT) {

--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -299,9 +299,7 @@ func gracefulKill(proc *process.Info) {
 	t := time.NewTimer(procExitTimeout)
 	select {
 	case <-doneChan:
-		if !t.Stop() {
-			<-t.C
-		}
+		t.Stop()
 	case <-t.C:
 		_ = proc.Process.Kill()
 	}

--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -296,9 +296,13 @@ func gracefulKill(proc *process.Info) {
 	wg.Wait()
 
 	// kill in case it's still running after timeout
+	t := time.NewTimer(procExitTimeout)
 	select {
 	case <-doneChan:
-	case <-time.After(procExitTimeout):
+		if !t.Stop() {
+			<-t.C
+		}
+	case <-t.C:
 		_ = proc.Process.Kill()
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -297,9 +297,9 @@ func gracefulKill(proc *process.Info) {
 
 	// kill in case it's still running after timeout
 	t := time.NewTimer(procExitTimeout)
+	defer t.Stop()
 	select {
 	case <-doneChan:
-		t.Stop()
 	case <-t.C:
 		_ = proc.Process.Kill()
 	}

--- a/x-pack/elastic-agent/pkg/core/plugin/process/watch_posix.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/watch_posix.go
@@ -21,16 +21,11 @@ func (a *Application) externalProcess(proc *os.Process) {
 		return
 	}
 
-	for range time.After(1 * time.Second) {
-
-	}
 	for {
-		select {
-		case <-time.After(1 * time.Second):
-			if proc.Signal(syscall.Signal(0)) != nil {
-				// failed to contact process, return
-				return
-			}
+		<-time.After(1 * time.Second)
+		if proc.Signal(syscall.Signal(0)) != nil {
+			// failed to contact process, return
+			return
 		}
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/process/watch_windows.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/watch_windows.go
@@ -26,11 +26,9 @@ func (a *Application) externalProcess(proc *os.Process) {
 	}
 
 	for {
-		select {
-		case <-time.After(1 * time.Second):
-			if isWindowsProcessExited(proc.Pid) {
-				return
-			}
+		<-time.After(1 * time.Second)
+		if isWindowsProcessExited(proc.Pid) {
+			return
 		}
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/retry/retrystrategy.go
+++ b/x-pack/elastic-agent/pkg/core/retry/retrystrategy.go
@@ -56,9 +56,7 @@ RETRY_LOOP:
 			select {
 			case <-t.C:
 			case <-ctx.Done():
-				if !t.Stop() {
-					<-t.C
-				}
+				t.Stop()
 				break RETRY_LOOP
 			}
 		}

--- a/x-pack/elastic-agent/pkg/core/retry/retrystrategy.go
+++ b/x-pack/elastic-agent/pkg/core/retry/retrystrategy.go
@@ -36,6 +36,7 @@ func Do(ctx context.Context, config *Config, fn func(ctx context.Context) error,
 	retryCount := getRetryCount(config)
 	var err error
 
+RETRY_LOOP:
 	for retryNo := 0; retryNo <= retryCount; retryNo++ {
 		if ctx.Err() != nil {
 			break
@@ -51,10 +52,14 @@ func Do(ctx context.Context, config *Config, fn func(ctx context.Context) error,
 		}
 
 		if retryNo < retryCount {
+			t := time.NewTimer(getDelayDuration(config, retryNo))
 			select {
-			case <-time.After(getDelayDuration(config, retryNo)):
+			case <-t.C:
 			case <-ctx.Done():
-				break
+				if !t.Stop() {
+					<-t.C
+				}
+				break RETRY_LOOP
 			}
 		}
 	}

--- a/x-pack/elastic-agent/pkg/core/server/server.go
+++ b/x-pack/elastic-agent/pkg/core/server/server.go
@@ -864,9 +864,7 @@ func (s *Server) watchdog() {
 		t := time.NewTimer(s.watchdogCheckInterval)
 		select {
 		case <-s.watchdogDone:
-			if !t.Stop() {
-				<-t.C
-			}
+			t.Stop()
 			return
 		case <-t.C:
 		}

--- a/x-pack/elastic-agent/pkg/core/server/server.go
+++ b/x-pack/elastic-agent/pkg/core/server/server.go
@@ -861,10 +861,14 @@ func (as *ApplicationState) destroyCheckinStream() {
 func (s *Server) watchdog() {
 	defer s.watchdogWG.Done()
 	for {
+		t := time.NewTimer(s.watchdogCheckInterval)
 		select {
 		case <-s.watchdogDone:
+			if !t.Stop() {
+				<-t.C
+			}
 			return
-		case <-time.After(s.watchdogCheckInterval):
+		case <-t.C:
 		}
 
 		now := time.Now().UTC()

--- a/x-pack/elastic-agent/pkg/remote/client.go
+++ b/x-pack/elastic-agent/pkg/remote/client.go
@@ -191,7 +191,10 @@ func (c *Client) Send(
 	}
 
 	requester.lastUsed = time.Now().UTC()
-	resp, err := requester.client.Do(req.WithContext(ctx))
+	cctx, cancelFn := context.WithCancel(ctx)
+	defer cancelFn()
+
+	resp, err := requester.client.Do(req.WithContext(cctx))
 	if err != nil {
 		requester.lastErr = err
 		requester.lastErrOcc = time.Now().UTC()


### PR DESCRIPTION
## What does this PR do?

This PR update `elastic-agent-client` dependency which fixes some issues in how grpc connections are closed and other small leak issues.

Also updates patterns of time.After usage in elastic-agent.
Also closes connection explicitly and guarding connections with context.WithCancel where it makes sense

## Why is it important?

Without this we're eating too much memory over time.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

TODO:
figure out tests to catch these kind of issues