### PR TITLE
[CI] use try to avoid a global abort

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -707,18 +707,17 @@ def tearDown() {
 */
 def fixPermissions(location) {
   if(isUnix()) {
-      try {
-        timeout(5) {
-          sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
-            set +x
-            echo "Cleaning up ${location}"
-            source ./dev-tools/common.bash
-            docker_setup
-            script/fix_permissions.sh ${location}""", returnStatus: true)
-        }
-      } catch (Throwable e) {
-        echo "There were some failures when fixing the permissions. ${e.toString()}"
+    try {
+      timeout(5) {
+        sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+          set +x
+          echo "Cleaning up ${location}"
+          source ./dev-tools/common.bash
+          docker_setup
+          script/fix_permissions.sh ${location}""", returnStatus: true)
       }
+    } catch (Throwable e) {
+      echo "There were some failures when fixing the permissions. ${e.toString()}"
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -707,14 +707,17 @@ def tearDown() {
 */
 def fixPermissions(location) {
   if(isUnix()) {
-    catchError(message: 'There were some failures when fixing the permissions', buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
-      timeout(5) {
-        sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
-          set +x
-          echo "Cleaning up ${location}"
-          source ./dev-tools/common.bash
-          docker_setup
-          script/fix_permissions.sh ${location}""", returnStatus: true)
+      try {
+        timeout(5) {
+          sh(label: 'Fix permissions', script: """#!/usr/bin/env bash
+            set +x
+            echo "Cleaning up ${location}"
+            source ./dev-tools/common.bash
+            docker_setup
+            script/fix_permissions.sh ${location}""", returnStatus: true)
+        }
+      } catch (Throwable e) {
+        echo "There were some failures when fixing the permissions. ${e.toString()}"
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Use try/catch to avoid setting the build to abort

## Why is it important?

I see several aborted builds recently and somehow I thing the catchError + timeout is not doing what it should be.


In addition a put https://beats-ci.elastic.co/computer/worker-c07c6107jyw0/ offline