### PR TITLE
Osquerybeat: Update ECS mapping implementation based on the latest developers feedback

### DIFF
--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -208,9 +208,6 @@ func traverseTree(depth int, ecsm ecs.Mapping, path []string, v interface{}) err
 		if len(path) == 1 {
 			return fmt.Errorf("unexpected top level key '%s': %w", keyValue, ErrECSMappingIsInvalid)
 		}
-		if len(path) == 1 {
-			return ErrECSMappingIsInvalid
-		}
 		ecsm[strings.Join(path[:len(path)-1], ".")] = ecs.MappingInfo{
 			Value: v,
 		}

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -6,15 +6,16 @@ package beater
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
+	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
-
-	"github.com/google/go-cmp/cmp"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/config"
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/ecs"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/testutil"
+	"github.com/google/go-cmp/cmp"
 )
 
 func renderFullConfig(inputs []config.InputConfig) (map[string]string, error) {
@@ -87,62 +88,197 @@ func TestConfigPluginNew(t *testing.T) {
 	}
 }
 
-var testInputConfigs = []config.InputConfig{
-	{
-		Name: "osquery_manager-1",
-		Type: "osquery",
-		Streams: []config.StreamConfig{
-			{
-				ID:       "users",
-				Query:    "select * from users",
-				Interval: 60,
-			},
-		},
-	},
-	{
-		Name: "osquery_manager-2",
-		Type: "osquery",
-		Streams: []config.StreamConfig{
-			{
-				ID:       "uptime",
-				Query:    "select * from uptime",
-				Interval: 30,
-			},
-			{
-				ID:       "processes",
-				Query:    "select * from processes",
-				Interval: 45,
-			},
-		},
-	},
-}
-
-func TestConfigPluginWithConfig(t *testing.T) {
-	validLogger := logp.NewLogger("config_test")
-	tempDirPath, err := ioutil.TempDir("", "")
+func TestFlattenECSMapping(t *testing.T) {
+	const mapping = `{"user":{"custom":{"shoeSize":{"value":45}},"id":{"field":"uid"},"name":{"field":"username"}}}`
+	var m map[string]interface{}
+	err := json.Unmarshal([]byte(mapping), &m)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		os.RemoveAll(tempDirPath)
-	}()
-
-	p := NewConfigPlugin(validLogger)
-
-	p.Set(testInputConfigs)
-
-	generatedConfig, err := p.GenerateConfig(context.Background())
+	ecsm, err := flattenECSMapping(m)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Test the expected configuration
-	expectedConfig, err := renderFullConfig(testInputConfigs)
-	if err != nil {
-		t.Fatal(err)
-	}
-	diff := cmp.Diff(expectedConfig, generatedConfig)
+	diff := cmp.Diff(ecsm["user.custom.shoeSize"].Value, float64(45))
 	if diff != "" {
 		t.Error(diff)
+	}
+
+	diff = cmp.Diff(ecsm["user.id"].Field, "uid")
+	if diff != "" {
+		t.Error(diff)
+	}
+
+	diff = cmp.Diff(ecsm["user.name"].Field, "username")
+	if diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestFlattenECSMappingTooDeep(t *testing.T) {
+	const mapping = `{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{"j":{"k":{"value": 1}}}}}}}}}}}}`
+	var m map[string]interface{}
+	err := json.Unmarshal([]byte(mapping), &m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = flattenECSMapping(m)
+	if err != ErrECSMappingIsTooDeep {
+		t.Fatalf("expected error: %v", ErrECSMappingIsTooDeep)
+	}
+}
+
+func TestSet(t *testing.T) {
+	logger := logp.NewLogger("config_test")
+
+	const noQueriesConfig = `{
+    "options": {
+        "schedule_splay_percent": 10
+    }
+}`
+
+	const oneInputConfig = `{
+    "options": {
+        "schedule_splay_percent": 10
+    },
+    "packs": {
+        "osquery-manager-1": {
+            "queries": {
+                "users": {
+                    "query": "select * from users limit 2",
+                    "interval": 60,
+                    "snapshot": true
+                }
+            }
+        }
+    }
+}`
+
+	tests := []struct {
+		name   string
+		inputs []config.InputConfig
+		err    error
+		scfg   string
+		ecsm   ecs.Mapping
+	}{
+		{
+			name: "nil",
+			scfg: noQueriesConfig,
+		},
+		{
+			name:   "empty",
+			inputs: []config.InputConfig{},
+			scfg:   noQueriesConfig,
+		},
+		{
+			name: "one input",
+			inputs: []config.InputConfig{
+				{
+					Name: "osquery-manager-1",
+					Type: "osquery",
+					Streams: []config.StreamConfig{
+						{
+							ID:       "users",
+							Query:    "select * from users limit 2",
+							Interval: 60,
+							ECSMapping: map[string]interface{}{
+								"user": map[string]interface{}{
+									"custom": map[string]interface{}{
+										"shoeSize": map[string]interface{}{
+											"value": 45,
+										},
+									},
+									"id": map[string]interface{}{
+										"field": "uid",
+									},
+									"name": map[string]interface{}{
+										"field": "username",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			scfg: oneInputConfig,
+			ecsm: ecs.Mapping{
+				"user.custom.shoeSize": ecs.MappingInfo{
+					Value: 45,
+				},
+				"user.id": ecs.MappingInfo{
+					Field: "uid",
+				},
+				"user.name": ecs.MappingInfo{
+					Field: "username",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgp := NewConfigPlugin(logger)
+
+			err := cfgp.Set(tc.inputs)
+			diff := cmp.Diff(tc.err, err)
+			if diff != "" {
+				t.Fatal(diff)
+			}
+
+			// test generate config
+			mcfg, err := cfgp.GenerateConfig(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			scfg, ok := mcfg[configName]
+			if !ok {
+				t.Errorf("missing %v configuration name", configName)
+			}
+
+			diff = cmp.Diff(tc.scfg, scfg)
+			if diff != "" {
+				fmt.Println(scfg)
+				t.Error(diff)
+			}
+
+			// test the count matches the number of inputs
+			diff = cmp.Diff(len(tc.inputs), cfgp.Count())
+			if diff != "" {
+				t.Error(diff)
+			}
+
+			// test that the queries can be resolved
+			for _, input := range tc.inputs {
+				for _, stream := range input.Streams {
+					name := strings.Join([]string{"pack", input.Name, stream.ID}, "_")
+					sql, ok := cfgp.ResolveName(name)
+					if !ok {
+						t.Fatalf("failed to resolve name %v", name)
+					}
+					diff = cmp.Diff(sql, stream.Query)
+					if diff != "" {
+						t.Error(diff)
+					}
+					if len(stream.ECSMapping) == 0 {
+						continue
+					}
+
+					// test that the query ecs mapping lookup succeeds
+					ecsm, ok := cfgp.LookupECSMapping(name)
+					if !ok {
+						t.Fatalf("failed to lookup ecs mapping for %v", name)
+					}
+					diff = cmp.Diff(tc.ecsm, ecsm)
+				}
+			}
+
+			// test that unknown query can't be resolved
+			_, ok = cfgp.ResolveName("unknown query name")
+			if ok {
+				t.Fatalf("unexpectedly resolved unknown query")
+			}
+		})
 	}
 }

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -278,7 +278,11 @@ func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.O
 				bt.log.Info("context cancelled, exiting")
 				return ctx.Err()
 			case inputConfigs := <-inputCh:
-				configPlugin.Set(inputConfigs)
+				err = configPlugin.Set(inputConfigs)
+				if err != nil {
+					bt.log.Errorf("failed to set configuration from inputs: %v", err)
+					return err
+				}
 				cache.Resize(configPlugin.Count())
 			}
 		}

--- a/x-pack/osquerybeat/internal/config/config.go
+++ b/x-pack/osquerybeat/internal/config/config.go
@@ -22,12 +22,12 @@ import (
 const DefaultStreamIndex = "logs-osquery_manager.result-default"
 
 type StreamConfig struct {
-	ID         string            `config:"id"`
-	Query      string            `config:"query"`       // the SQL query to run
-	Interval   int               `config:"interval"`    // an interval in seconds to run the query (subject to splay/smoothing). It has a maximum value of 604,800 (1 week).
-	Platform   string            `config:"platform"`    // restrict this query to a given platform, default is 'all' platforms; you may use commas to set multiple platforms
-	Version    string            `config:"version"`     // only run on osquery versions greater than or equal-to this version string
-	ECSMapping map[string]string `config:"ecs_mapping"` // ECS mapping definition where the key is the source field in osquery result and the value is the destination fields in ECS
+	ID         string                 `config:"id"`
+	Query      string                 `config:"query"`       // the SQL query to run
+	Interval   int                    `config:"interval"`    // an interval in seconds to run the query (subject to splay/smoothing). It has a maximum value of 604,800 (1 week).
+	Platform   string                 `config:"platform"`    // restrict this query to a given platform, default is 'all' platforms; you may use commas to set multiple platforms
+	Version    string                 `config:"version"`     // only run on osquery versions greater than or equal-to this version string
+	ECSMapping map[string]interface{} `config:"ecs_mapping"` // ECS mapping definition where the key is the source field in osquery result and the value is the destination fields in ECS
 }
 
 type InputConfig struct {

--- a/x-pack/osquerybeat/internal/ecs/mapping.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping.go
@@ -5,14 +5,25 @@ import "strings"
 const keySeparator = "."
 
 type Doc map[string]interface{}
-type Mapping map[string]string
+
+type MappingInfo struct {
+	Field string      `json:"field,omitempty" config:"field,omitempty"`
+	Value interface{} `json:"value,omitempty" config:"value,omitempty"`
+}
+
+// Mapping is ECS mapping definition where the key is the dotted ECS field name
+type Mapping map[string]MappingInfo
 
 // Map creates the copy of the values from the doc[src] key to the doc[dst] key where the dst can be nested '.' delimited key
 // Source is expected to be a simple key name, the destination could be nested child node
 func (m Mapping) Map(doc Doc) Doc {
 	res := make(Doc)
-	for src, dst := range m {
-		val, ok := doc[src]
+	for dst, mi := range m {
+		if mi.Value != nil {
+			res.Set(dst, mi.Value)
+			continue
+		}
+		val, ok := doc[mi.Field]
 		if !ok {
 			continue
 		}

--- a/x-pack/osquerybeat/internal/ecs/mapping_test.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping_test.go
@@ -1,6 +1,10 @@
 package ecs
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 var testOsqueryResult = Doc{
 	"uid":         275,
@@ -19,42 +23,64 @@ var testOsqueryResult = Doc{
 
 func TestMap(t *testing.T) {
 	mapping := Mapping{
-		"uid":         "user.id",
-		"gid":         "user.group.id",
-		"username":    "user.name",
-		"description": "description",
-		"uuid":        "a.b.c.d.e.f",
-		"uid_signed":  "a.b.c.d.g",
+		"user.id":       {Field: "uid"},
+		"user.group.id": {Field: "gid"},
+		"user.name":     {Field: "username"},
+		"description":   {Field: "description"},
+		"a.b.c.d.e.f":   {Field: "uuid"},
+		"a.b.c.d.g":     {Field: "uid_signed"},
 	}
 
 	doc := mapping.Map(testOsqueryResult)
 
-	for src, dst := range mapping {
+	for dst, mi := range mapping {
 		val, ok := doc.Get(dst)
 		if !ok {
 			t.Errorf("key [%v] not found", dst)
 			break
 		}
-		if testOsqueryResult[src] != val {
-			t.Errorf("key [%v]=[%v], expected [%v]", src, val, testOsqueryResult[src])
+		if testOsqueryResult[mi.Field] != val {
+			t.Errorf("key [%v]=[%v], expected [%v]", mi.Field, val, testOsqueryResult[mi.Field])
 		}
 	}
 }
 
 func TestMapBadKeys(t *testing.T) {
 	mapping := Mapping{
-		"":           "",
-		"foo":        "",
-		"test":       "..",
-		"uid_signed": "",
+		"":   {Field: ""},
+		"..": {Field: "test"},
 	}
 
 	doc := mapping.Map(testOsqueryResult)
 
-	for _, dst := range mapping {
-		_, ok := doc.Get(dst)
+	for _, mi := range mapping {
+		_, ok := doc.Get(mi.Field)
 		if ok {
-			t.Errorf("key [%v] is expected to be not found", dst)
+			t.Errorf("key [%v] is expected to be not found", mi.Field)
+		}
+	}
+}
+
+func TestMapValue(t *testing.T) {
+	mapping := Mapping{
+		"value.empty":  {Value: ""},
+		"value.zero":   {Value: 0},
+		"value.number": {Value: 42},
+		"value.map":    {Value: map[string]interface{}{"foo": "bar"}},
+		"value.array":  {Value: []interface{}{"1234", "test", 42}},
+	}
+
+	doc := mapping.Map(testOsqueryResult)
+
+	for dst, mi := range mapping {
+		val, ok := doc.Get(dst)
+		if !ok {
+			t.Errorf("key [%v] not found", dst)
+			break
+		}
+		diff := cmp.Diff(mi.Value, val)
+		if diff != "" {
+			t.Errorf("key [%v]=[%v], expected [%v]", dst, val, mi.Value)
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?
Changes the format of ECS mapping configuration for the queries:
1. The mapping keys are the ECS key path
2. The mapping value is an object that allows to define the static value or the field which is the name of the osquery result column.

Improves test coverage for configuration plugin.

Current format example:
```
                        "ecs_mapping": {
                                "user.custom.shoeSize": {
                                    "value": 45
                                },
                                "user.id": {
                                    "field": "uid"
                                },
                                "user.name": {
                                    "field": "username"
                                }
                        }
```

## Why is it important?

ECS mapping support for Osquerybeat

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Requires https://github.com/elastic/integrations/pull/1360

## Screenshots

The fragment of the document showing and example of the ECS fields mapped:

<img width="326" alt="Screen Shot 2021-07-27 at 3 19 42 PM" src="https://user-images.githubusercontent.com/872351/127231388-3d2e91a6-a345-4ca5-ac14-2678bb49b99d.png">
