### PR TITLE
Add max_content_size as a mechanism to throttle large prometheus endpoints

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -617,6 +617,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ensure common proxy settings support in HTTP clients: proxy_disabled, proxy_url, proxy_headers and typical environment variables HTTP_PROXY, HTTPS_PROXY, NOPROXY. {pull}25219[25219]
 - `add_process_metadata` processor enrich process information with owner name and id. {issue}21068[21068] {pull}21111[21111]
 - Add proxy support for AWS functions. {pull}26832[26832]
+- Add max_content_size as a mechanism to throttle large prometheus endpoints {pull}27087[27087]
 
 *Auditbeat*
 

--- a/metricbeat/helper/prometheus/config.go
+++ b/metricbeat/helper/prometheus/config.go
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package prometheus
+
+import (
+	"math"
+
+	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
+)
+
+type config struct {
+	// MaxContentSize is the byte size after which we should stop reading a prometheus endpoint's HTTP Response Body
+	MaxContentSize cfgtype.ByteSize `config:"max_content_size" validate:"nonzero,positive"`
+}
+
+func defaultConfig() *config {
+	return &config{
+		MaxContentSize: math.MaxInt64,
+	}
+}

--- a/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
+++ b/metricbeat/module/prometheus/collector/_meta/docs.asciidoc
@@ -134,3 +134,18 @@ To keep only specific metrics, anchor the start and the end of the regexp of eac
   metrics_filters:
     include: ["^node_network_net_dev_group$", "^node_network_up$"]
 -------------------------------------------------------------------------------------
+
+[float]
+=== Setting limits on endpoint sizes
+
+Sometimes endpoints can get too large that they become detrimental to the agent's memory consumption or the underlying storage's stability.
+`max_content_size` can be set to ensure that an endpoint that is larger than a certain size would not get parsed at at. By default there is no set limit.
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+- module: prometheus
+  period: 10s
+  hosts: ["localhost:9090"]
+  metrics_path: /metrics
+  max_content_size: 1MB
+-------------------------------------------------------------------------------------


### PR DESCRIPTION

Enhancement

## What does this PR do?

Allows setting a max_content_length field on prometheus metricsets so that we can throttle the parsing of the endpoint in case its over the set limit

## Why is it important?
Excessively large endpoints can not only kill beats but also spam the storage layer with garbage in case there is rogue instrumentation

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this PR locally

Set max_content_length on a metricbeat module collector metricset to 0 and it should reject any endpoint it attempts to parse. 

## Related issues
