### PR TITLE
[Heartbeat] Re-enable windows 32 bit TLS tests

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/bits"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -124,6 +126,13 @@ func TLSChecks(chainIndex, certIndex int, certificate *x509.Certificate) validat
 	}, time.Duration(1))
 
 	expected.Put("tls.rtt.handshake.us", isdef.IsDuration)
+
+	// Generally, the exact cipher will match, but on windows 7 32bit this is not true!
+	// We don't actually care about the exact cipher matching, since we're not testing the TLS
+	// implementation, we trust go there, just that most of the metadata is present
+	if runtime.GOOS == "windows" && bits.UintSize == 32 {
+		expected.Put("tls.cipher", isdef.IsString)
+	}
 
 	return lookslike.MustCompile(expected)
 }

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -402,9 +402,6 @@ func runHTTPSServerCheck(
 }
 
 func TestHTTPSServer(t *testing.T) {
-	if runtime.GOOS == "windows" && bits.UintSize == 32 {
-		t.Skip("flaky test: https://github.com/elastic/beats/issues/25857")
-	}
 	server := httptest.NewTLSServer(hbtest.HelloWorldHandler(http.StatusOK))
 	runHTTPSServerCheck(t, server, nil)
 }

--- a/heartbeat/monitors/active/tcp/tls_test.go
+++ b/heartbeat/monitors/active/tcp/tls_test.go
@@ -67,9 +67,6 @@ func TestTLSSANIPConnection(t *testing.T) {
 }
 
 func TestTLSHostname(t *testing.T) {
-	if runtime.GOOS == "windows" && bits.UintSize == 32 {
-		t.Skip("flaky test: https://github.com/elastic/beats/issues/25857")
-	}
 	ip, port, cert, certFile, teardown := setupTLSTestServer(t)
 	defer teardown()
 


### PR DESCRIPTION
## What does this PR do?

Provides a better fix than https://github.com/elastic/beats/pull/25859 , re-enabled win32 TLS tests, using a less precise cipher match.


fixes https://github.com/elastic/beats/issues/25857