### PR TITLE
Fix version placeholder for elastic-agent k8s manifest

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: elastic-agent
-          image: docker.elastic.co/beats/elastic-agent:8.0.0
+          image: docker.elastic.co/beats/elastic-agent:%VERSION%
           env:
             - name: FLEET_ENROLL
               value: "1"


### PR DESCRIPTION
## What does this PR do?
This PR fixes the version placeholder within manifests for managed elastic-agent.