### PR TITLE
Add sha256 digests to RPM packages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -619,6 +619,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Ensure common proxy settings support in HTTP clients: proxy_disabled, proxy_url, proxy_headers and typical environment variables HTTP_PROXY, HTTPS_PROXY, NOPROXY. {pull}25219[25219]
 - `add_process_metadata` processor enrich process information with owner name and id. {issue}21068[21068] {pull}21111[21111]
 - Add proxy support for AWS functions. {pull}26832[26832]
+- Add sha256 digests to RPM packages. {issue}23670[23670]
 
 *Auditbeat*
 

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -721,7 +721,10 @@ func runFPM(spec PackageSpec, packageType PackageType) error {
 		"--architecture", spec.Arch,
 	)
 	if packageType == RPM {
-		args = append(args, "--rpm-rpmbuild-define", "_build_id_links none")
+		args = append(args,
+			"--rpm-rpmbuild-define", "_build_id_links none",
+			"--rpm-digest", "sha256",
+		)
 	}
 	if spec.Version != "" {
 		args = append(args, "--version", spec.Version)

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	fpmVersion = "1.11.0"
+	fpmVersion = "1.13.1"
 
 	// Docker images. See https://github.com/elastic/golang-crossbuild.
 	beatsFPMImage = "docker.elastic.co/beats-dev/fpm"


### PR DESCRIPTION
## What does this PR do?

Adds sha256 digests to RPM packages.

```
# rpm --checksig -v filebeat-8.0.0-SNAPSHOT-x86_64.rpm
filebeat-8.0.0-SNAPSHOT-x86_64.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
```

Fixes #23670

## Why is it important?

This allows the RPMs to be installed on RHEL8 without any additional flags to disable digest checks. RHEL8 no longer trust the sha1 and md5 we were adding.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Install unsigned RPM on centos:8
- [x] Install unsigned RPM on centos:6

## How to test this PR locally



## Related issues

- Closes #23670
- Requires https://github.com/elastic/golang-crossbuild/pull/118
