### PR TITLE
[Filebeat] decode_cef - allow MACs without separators

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -865,6 +865,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use default add_locale for fortinet.firewall {issue}20300[20300] {pull}26524[26524]
 - Add new template functions and `value_type` parameter to `httpjson` transforms. {pull}26847[26847]
 - Add support to merge registry updates in the filestream input across multiple ACKed batches in case of backpressure in the registry or disk. {pull}25976[25976]
+- Add support to `decode_cef` for MAC addresses that do not contain separator characters. {issue}27050[27050] {pull}27109[27109]
 - Update Elasticsearch module's ingest pipeline for parsing new deprecation logs {issue}26857[26857] {pull}26880[26880]
 
 *Heartbeat*

--- a/x-pack/filebeat/processors/decode_cef/cef/types.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types.go
@@ -7,6 +7,7 @@ package cef
 import (
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -93,11 +94,38 @@ func toIP(v string) (string, error) {
 func toMACAddress(v string) (string, error) {
 	// CEF specifies that MAC addresses are colon separated, but this will be a
 	// little more liberal.
-	hw, err := net.ParseMAC(v)
+	hw, err := net.ParseMAC(insertMACSeparators(v))
 	if err != nil {
 		return "", err
 	}
 	return hw.String(), nil
+}
+
+// insertMACSeparators adds colon separators to EUI-48 and EUI-64 addresses that
+// have no separators.
+func insertMACSeparators(v string) string {
+	const (
+		eui48HexLength                 = 48 / 4
+		eui64HexLength                 = 64 / 4
+		eui64HexWithSeparatorMaxLength = eui64HexLength + eui64HexLength/2 - 1
+	)
+
+	// Check that the length is correct for a MAC address without separators.
+	// And check that there isn't already a separator in the string.
+	if len(v) != eui48HexLength && len(v) != eui64HexLength || v[2] == ':' || v[2] == '-' || v[4] == '.' {
+		return v
+	}
+
+	var sb strings.Builder
+	sb.Grow(eui64HexWithSeparatorMaxLength)
+
+	for i := 0; i < len(v); i++ {
+		sb.WriteByte(v[i])
+		if i < len(v)-1 && i%2 != 0 {
+			sb.WriteByte(':')
+		}
+	}
+	return sb.String()
 }
 
 var timeLayouts = []string{

--- a/x-pack/filebeat/processors/decode_cef/cef/types_test.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types_test.go
@@ -65,3 +65,24 @@ func TestToTimestamp(t *testing.T) {
 		assert.NoError(t, err, timeValue)
 	}
 }
+
+func TestToMACAddress(t *testing.T) {
+	var macs = []string{
+		// EUI-48 (with and without separators).
+		"00:0D:60:AF:1B:61",
+		"00-0D-60-AF-1B-61",
+		"000D.60AF.1B61",
+		"000D60AF1B61",
+
+		// EUI-64 (with and without separators).
+		"00:0D:60:FF:FE:AF:1B:61",
+		"00-0D-60-FF-FE-AF-1B-61",
+		"000D.60FF.FEAF.1B61",
+		"000D60FFEEAF1B61",
+	}
+
+	for _, mac := range macs {
+		_, err := toMACAddress(mac)
+		assert.NoError(t, err, mac)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Accept MAC addresses that do not contain separators (i.e. `000D60AF1B61`).

Fixes #27050

## Why is it important?

Some log sources do not comply with the CEF spec and send valid MACs but without separators. The processor should identify these and accept them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #27050
