### PR TITLE
[Elastic Agent] Add support for the --delay-enroll command flag.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -124,3 +124,4 @@
 - Enable configuring monitoring namespace {issue}26439[26439]
 - Communicate with Fleet Server over HTTP2. {pull}26474[26474]
 - Support Node and Service autodiscovery in kubernetes dynamic provider. {pull}26801[26801]
+- Add new --enroll-delay option for install and enroll commands. {pull}27118[27118]

--- a/x-pack/elastic-agent/pkg/agent/application/paths/files.go
+++ b/x-pack/elastic-agent/pkg/agent/application/paths/files.go
@@ -11,25 +11,37 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/filelock"
 )
 
-// defaultAgentConfigFile is a name of file used to store agent information
+// defaultAgentCapabilitiesFile is a name of file used to store agent capabilities
 const defaultAgentCapabilitiesFile = "capabilities.yml"
-const defaultAgentConfigFile = "fleet.yml"
+
+// defaultAgentFleetFile is a name of file used to store agent information
+const defaultAgentFleetFile = "fleet.yml"
+
+// defaultAgentEnrollFile is a name of file used to enroll agent on first-start
+const defaultAgentEnrollFile = "enroll.yml"
 
 // defaultAgentActionStoreFile is the file that will contains the action that can be replayed after restart.
 const defaultAgentActionStoreFile = "action_store.yml"
+
+// defaultAgentStateStoreFile is the file that will contains the action that can be replayed after restart.
 const defaultAgentStateStoreFile = "state.yml"
 
 // AgentConfigFile is a name of file used to store agent information
 func AgentConfigFile() string {
-	return filepath.Join(Config(), defaultAgentConfigFile)
+	return filepath.Join(Config(), defaultAgentFleetFile)
 }
 
 // AgentConfigFileLock is a locker for agent config file updates.
 func AgentConfigFileLock() *filelock.AppLocker {
 	return filelock.NewAppLocker(
 		Config(),
-		fmt.Sprintf("%s.lock", defaultAgentConfigFile),
+		fmt.Sprintf("%s.lock", defaultAgentFleetFile),
 	)
+}
+
+// AgentEnrollFile is a name of file used to enroll agent on first-start
+func AgentEnrollFile() string {
+	return filepath.Join(Config(), defaultAgentEnrollFile)
 }
 
 // AgentCapabilitiesPath is a name of file used to store agent capabilities

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -9,12 +9,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 
 	"gopkg.in/yaml.v2"
 
@@ -85,23 +88,23 @@ type enrollCmdFleetServerOption struct {
 	Insecure        bool
 	SpawnAgent      bool
 	Headers         map[string]string
-	ProxyURL        string
-	ProxyDisabled   bool
-	ProxyHeaders    map[string]string
 }
 
 // enrollCmdOption define all the supported enrollment option.
 type enrollCmdOption struct {
-	ID                   string
-	URL                  string
-	CAs                  []string
-	CASha256             []string
-	Insecure             bool
-	UserProvidedMetadata map[string]interface{}
-	EnrollAPIKey         string
-	Staging              string
-	FixPermissions       bool
-	FleetServer          enrollCmdFleetServerOption
+	URL                  string                     `yaml:"url,omitempty"`
+	CAs                  []string                   `yaml:"ca,omitempty"`
+	CASha256             []string                   `yaml:"ca_sha256,omitempty"`
+	Insecure             bool                       `yaml:"insecure,omitempty"`
+	EnrollAPIKey         string                     `yaml:"enrollment_key,omitempty"`
+	Staging              string                     `yaml:"staging,omitempty"`
+	ProxyURL             string                     `yaml:"proxy_url,omitempty"`
+	ProxyDisabled        bool                       `yaml:"proxy_disabled,omitempty"`
+	ProxyHeaders         map[string]string          `yaml:"proxy_headers,omitempty"`
+	UserProvidedMetadata map[string]interface{}     `yaml:"-"`
+	FixPermissions       bool                       `yaml:"-"`
+	DelayEnroll          bool                       `yaml:"-"`
+	FleetServer          enrollCmdFleetServerOption `yaml:"-"`
 }
 
 func (e *enrollCmdOption) remoteConfig() (remote.Config, error) {
@@ -127,24 +130,24 @@ func (e *enrollCmdOption) remoteConfig() (remote.Config, error) {
 	cfg.Transport.TLS = &tlsCfg
 
 	var proxyURL *url.URL
-	if e.FleetServer.ProxyURL != "" {
-		proxyURL, err = common.ParseURL(e.FleetServer.ProxyURL)
+	if e.ProxyURL != "" {
+		proxyURL, err = common.ParseURL(e.ProxyURL)
 		if err != nil {
 			return remote.Config{}, err
 		}
 	}
 
 	var headers http.Header
-	if len(e.FleetServer.ProxyHeaders) > 0 {
+	if len(e.ProxyHeaders) > 0 {
 		headers = http.Header{}
-		for k, v := range e.FleetServer.ProxyHeaders {
+		for k, v := range e.ProxyHeaders {
 			headers.Add(k, v)
 		}
 	}
 
 	cfg.Transport.Proxy = httpcommon.HTTPClientProxySettings{
 		URL:     proxyURL,
-		Disable: e.FleetServer.ProxyDisabled,
+		Disable: e.ProxyDisabled,
 		Headers: headers,
 	}
 
@@ -189,7 +192,7 @@ func newEnrollCmdWithStore(
 }
 
 // Execute tries to enroll the agent into Fleet.
-func (c *enrollCmd) Execute(ctx context.Context) error {
+func (c *enrollCmd) Execute(ctx context.Context, streams *cli.IOStreams) error {
 	var err error
 	defer c.stopAgent() // ensure its stopped no matter what
 
@@ -202,7 +205,7 @@ func (c *enrollCmd) Execute(ctx context.Context) error {
 	// will communicate to the internal fleet server on localhost only.
 	// Connection setup should disable proxies in that case.
 	localFleetServer := c.options.FleetServer.ConnStr != ""
-	if localFleetServer {
+	if localFleetServer && !c.options.DelayEnroll {
 		token, err := c.fleetServerBootstrap(ctx)
 		if err != nil {
 			return err
@@ -233,6 +236,13 @@ func (c *enrollCmd) Execute(ctx context.Context) error {
 			errors.M(errors.MetaKeyURI, c.options.URL))
 	}
 
+	if c.options.DelayEnroll {
+		if c.options.FleetServer.Host != "" {
+			return errors.New("--delay-enroll cannot be used with --fleet-server-es", errors.TypeConfig)
+		}
+		return c.writeDelayEnroll(streams)
+	}
+
 	err = c.enrollWithBackoff(ctx, persistentConfig)
 	if err != nil {
 		return errors.New(err, "fail to enroll")
@@ -245,14 +255,41 @@ func (c *enrollCmd) Execute(ctx context.Context) error {
 		}
 	}
 
+	defer func() {
+		fmt.Fprintln(streams.Out, "Successfully enrolled the Elastic Agent.")
+	}()
+
 	if c.agentProc == nil {
 		if c.daemonReload(ctx) != nil {
 			c.log.Info("Elastic Agent might not be running; unable to trigger restart")
+		} else {
+			c.log.Info("Successfully triggered restart on running Elastic Agent.")
 		}
-		c.log.Info("Successfully triggered restart on running Elastic Agent.")
 		return nil
 	}
 	c.log.Info("Elastic Agent has been enrolled; start Elastic Agent")
+	return nil
+}
+
+func (c *enrollCmd) writeDelayEnroll(streams *cli.IOStreams) error {
+	enrollPath := paths.AgentEnrollFile()
+	data, err := yaml.Marshal(c.options)
+	if err != nil {
+		return errors.New(
+			err,
+			"failed to marshall enrollment options",
+			errors.TypeConfig,
+			errors.M("path", enrollPath))
+	}
+	err = ioutil.WriteFile(enrollPath, data, 0600)
+	if err != nil {
+		return errors.New(
+			err,
+			"failed to write enrollment options file",
+			errors.TypeFilesystem,
+			errors.M("path", enrollPath))
+	}
+	fmt.Fprintf(streams.Out, "Successfully wrote %s for delayed enrollment of the Elastic Agent.\n", enrollPath)
 	return nil
 }
 
@@ -283,9 +320,9 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context) (string, error) {
 		c.options.FleetServer.Host, c.options.FleetServer.Port,
 		c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA,
 		c.options.FleetServer.Headers,
-		c.options.FleetServer.ProxyURL,
-		c.options.FleetServer.ProxyDisabled,
-		c.options.FleetServer.ProxyHeaders,
+		c.options.ProxyURL,
+		c.options.ProxyDisabled,
+		c.options.ProxyHeaders,
 	)
 	if err != nil {
 		return "", err
@@ -447,7 +484,6 @@ func (c *enrollCmd) enroll(ctx context.Context, persistentConfig map[string]inte
 
 	r := &fleetapi.EnrollRequest{
 		EnrollAPIKey: c.options.EnrollAPIKey,
-		SharedID:     c.options.ID,
 		Type:         fleetapi.PermanentEnroll,
 		Metadata: fleetapi.Metadata{
 			Local:        metadata,
@@ -480,7 +516,7 @@ func (c *enrollCmd) enroll(ctx context.Context, persistentConfig map[string]inte
 			c.options.FleetServer.Host, c.options.FleetServer.Port,
 			c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA,
 			c.options.FleetServer.Headers,
-			c.options.FleetServer.ProxyURL, c.options.FleetServer.ProxyDisabled, c.options.FleetServer.ProxyHeaders)
+			c.options.ProxyURL, c.options.ProxyDisabled, c.options.ProxyHeaders)
 		if err != nil {
 			return err
 		}

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -17,8 +17,6 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
-
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -36,6 +34,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/install"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/storage"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/authority"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd_test.go
@@ -17,12 +17,11 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/authority"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd_test.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/cli"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
@@ -84,7 +86,6 @@ func TestEnroll(t *testing.T) {
 			cmd, err := newEnrollCmdWithStore(
 				log,
 				&enrollCmdOption{
-					ID:                   "my-id",
 					URL:                  url,
 					CAs:                  []string{caFile},
 					EnrollAPIKey:         "my-enrollment-token",
@@ -95,7 +96,8 @@ func TestEnroll(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = cmd.Execute(context.Background())
+			streams, _, _, _ := cli.NewTestingIOStreams()
+			err = cmd.Execute(context.Background(), streams)
 			require.Error(t, err)
 		},
 	))
@@ -137,7 +139,6 @@ func TestEnroll(t *testing.T) {
 			cmd, err := newEnrollCmdWithStore(
 				log,
 				&enrollCmdOption{
-					ID:                   "my-id",
 					URL:                  url,
 					CAs:                  []string{caFile},
 					EnrollAPIKey:         "my-enrollment-api-key",
@@ -148,7 +149,8 @@ func TestEnroll(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = cmd.Execute(context.Background())
+			streams, _, _, _ := cli.NewTestingIOStreams()
+			err = cmd.Execute(context.Background(), streams)
 			require.NoError(t, err)
 
 			config, err := readConfig(store.Content)
@@ -194,7 +196,6 @@ func TestEnroll(t *testing.T) {
 			cmd, err := newEnrollCmdWithStore(
 				log,
 				&enrollCmdOption{
-					ID:                   "my-id",
 					URL:                  url,
 					CAs:                  []string{},
 					EnrollAPIKey:         "my-enrollment-api-key",
@@ -206,7 +207,8 @@ func TestEnroll(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = cmd.Execute(context.Background())
+			streams, _, _, _ := cli.NewTestingIOStreams()
+			err = cmd.Execute(context.Background(), streams)
 			require.NoError(t, err)
 
 			require.True(t, store.Called)
@@ -254,7 +256,6 @@ func TestEnroll(t *testing.T) {
 			cmd, err := newEnrollCmdWithStore(
 				log,
 				&enrollCmdOption{
-					ID:                   "my-id",
 					URL:                  url,
 					CAs:                  []string{},
 					EnrollAPIKey:         "my-enrollment-api-key",
@@ -266,7 +267,8 @@ func TestEnroll(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = cmd.Execute(context.Background())
+			streams, _, _, _ := cli.NewTestingIOStreams()
+			err = cmd.Execute(context.Background(), streams)
 			require.NoError(t, err)
 
 			require.True(t, store.Called)
@@ -299,7 +301,6 @@ func TestEnroll(t *testing.T) {
 			cmd, err := newEnrollCmdWithStore(
 				log,
 				&enrollCmdOption{
-					ID:                   "my-id",
 					URL:                  url,
 					CAs:                  []string{},
 					EnrollAPIKey:         "my-enrollment-token",
@@ -311,7 +312,8 @@ func TestEnroll(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = cmd.Execute(context.Background())
+			streams, _, _, _ := cli.NewTestingIOStreams()
+			err = cmd.Execute(context.Background(), streams)
 			require.Error(t, err)
 			require.False(t, store.Called)
 		},

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -7,10 +7,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
 
@@ -74,36 +77,29 @@ func run(streams *cli.IOStreams, override cfgOverrider) error { // Windows: Mark
 
 	// register as a service
 	stop := make(chan bool)
-	_, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 	var stopBeat = func() {
 		close(stop)
 	}
 	service.HandleSignals(stopBeat, cancel)
 
-	pathConfigFile := paths.ConfigFile()
-	rawConfig, err := config.LoadFile(pathConfigFile)
+	cfg, err := loadConfig(override)
 	if err != nil {
-		return errors.New(err,
-			fmt.Sprintf("could not read configuration file %s", pathConfigFile),
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, pathConfigFile))
+		return err
 	}
 
-	if err := getOverwrites(rawConfig); err != nil {
-		return errors.New(err, "could not read overwrites")
-	}
-
-	cfg, err := configuration.NewFromConfig(rawConfig)
+	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig, true)
 	if err != nil {
-		return errors.New(err,
-			fmt.Sprintf("could not parse configuration file %s", pathConfigFile),
-			errors.TypeFilesystem,
-			errors.M(errors.MetaKeyPath, pathConfigFile))
+		return err
 	}
 
-	if override != nil {
-		override(cfg)
+	cfg, err = tryDelayEnroll(ctx, logger, cfg, override)
+	if err != nil {
+		err = errors.New(err, "failed to perform delayed enrollment")
+		logger.Error(err)
+		return err
 	}
+	pathConfigFile := paths.AgentConfigFile()
 
 	// agent ID needs to stay empty in bootstrap mode
 	createAgentID := true
@@ -118,15 +114,10 @@ func run(streams *cli.IOStreams, override cfgOverrider) error { // Windows: Mark
 			errors.M(errors.MetaKeyPath, pathConfigFile))
 	}
 
-	logger, err := logger.NewFromConfig("", cfg.Settings.LoggingConfig, true)
-	if err != nil {
-		return err
-	}
-
 	// initiate agent watcher
 	if err := upgrade.InvokeWatcher(logger); err != nil {
 		// we should not fail because watcher is not working
-		logger.Error("failed to invoke rollback watcher", err)
+		logger.Error(errors.New(err, "failed to invoke rollback watcher"))
 	}
 
 	if allowEmptyPgp, _ := release.PGP(); allowEmptyPgp {
@@ -199,6 +190,35 @@ func run(streams *cli.IOStreams, override cfgOverrider) error { // Windows: Mark
 	}
 	rex.ShutdownComplete()
 	return err
+}
+
+func loadConfig(override cfgOverrider) (*configuration.Configuration, error) {
+	pathConfigFile := paths.ConfigFile()
+	rawConfig, err := config.LoadFile(pathConfigFile)
+	if err != nil {
+		return nil, errors.New(err,
+			fmt.Sprintf("could not read configuration file %s", pathConfigFile),
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, pathConfigFile))
+	}
+
+	if err := getOverwrites(rawConfig); err != nil {
+		return nil, errors.New(err, "could not read overwrites")
+	}
+
+	cfg, err := configuration.NewFromConfig(rawConfig)
+	if err != nil {
+		return nil, errors.New(err,
+			fmt.Sprintf("could not parse configuration file %s", pathConfigFile),
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, pathConfigFile))
+	}
+
+	if override != nil {
+		override(cfg)
+	}
+
+	return cfg, err
 }
 
 func reexecPath() (string, error) {
@@ -295,4 +315,53 @@ func setupMetrics(agentInfo *info.AgentInfo, logger *logger.Logger, operatingSys
 
 func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringHTTPConfig) bool {
 	return cfg != nil && cfg.Enabled
+}
+
+func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configuration.Configuration, override cfgOverrider) (*configuration.Configuration, error) {
+	enrollPath := paths.AgentEnrollFile()
+	if _, err := os.Stat(enrollPath); os.IsNotExist(err) {
+		// no enrollment file exists; nothing to do
+		return cfg, nil
+	}
+	contents, err := ioutil.ReadFile(enrollPath)
+	if err != nil {
+		return nil, errors.New(
+			err,
+			"failed to read delay enrollment file",
+			errors.TypeFilesystem,
+			errors.M("path", enrollPath))
+	}
+	var options enrollCmdOption
+	err = yaml.Unmarshal(contents, &options)
+	if err != nil {
+		return nil, errors.New(
+			err,
+			"failed to parse delay enrollment file",
+			errors.TypeConfig,
+			errors.M("path", enrollPath))
+	}
+	options.DelayEnroll = false
+	options.FleetServer.SpawnAgent = false
+	c, err := newEnrollCmd(
+		logger,
+		&options,
+		paths.ConfigFile(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	err = c.Execute(ctx, cli.NewIOStreams())
+	if err != nil {
+		return nil, err
+	}
+	err = os.Remove(enrollPath)
+	if err != nil {
+		logger.Warn(errors.New(
+			err,
+			"failed to remove delayed enrollment file",
+			errors.TypeFilesystem,
+			errors.M("path", enrollPath)))
+	}
+	logger.Info("Successfully performed delayed enrollment of this Elastic Agent.")
+	return loadConfig(override)
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -13,11 +13,8 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"gopkg.in/yaml.v2"
-
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
-
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/beats/v7/libbeat/api"
 	"github.com/elastic/beats/v7/libbeat/cmd/instance/metrics"
@@ -39,6 +36,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/beats"
 	monitoringCfg "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/config"
 	monitoringServer "github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/server"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/status"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
 )
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -216,7 +216,7 @@ func loadConfig(override cfgOverrider) (*configuration.Configuration, error) {
 		override(cfg)
 	}
 
-	return cfg, err
+	return cfg, nil
 }
 
 func reexecPath() (string, error) {
@@ -317,8 +317,8 @@ func isProcessStatsEnabled(cfg *monitoringCfg.MonitoringHTTPConfig) bool {
 
 func tryDelayEnroll(ctx context.Context, logger *logger.Logger, cfg *configuration.Configuration, override cfgOverrider) (*configuration.Configuration, error) {
 	enrollPath := paths.AgentEnrollFile()
-	if _, err := os.Stat(enrollPath); os.IsNotExist(err) {
-		// no enrollment file exists; nothing to do
+	if _, err := os.Stat(enrollPath); err != nil {
+		// no enrollment file exists or failed to stat it; nothing to do
 		return cfg, nil
 	}
 	contents, err := ioutil.ReadFile(enrollPath)

--- a/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd.go
@@ -88,7 +88,6 @@ func (p EnrollType) MarshalJSON() ([]byte, error) {
 type EnrollRequest struct {
 	EnrollAPIKey string     `json:"-"`
 	Type         EnrollType `json:"type"`
-	SharedID     string     `json:"sharedId,omitempty"`
 	Metadata     Metadata   `json:"metadata"`
 }
 

--- a/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd_test.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/enroll_cmd_test.go
@@ -38,7 +38,6 @@ func TestEnroll(t *testing.T) {
 				require.NoError(t, err)
 
 				require.Equal(t, PermanentEnroll, req.Type)
-				require.Equal(t, "im-a-beat", req.SharedID)
 				require.Equal(t, make(map[string]interface{}), req.Metadata.UserProvided)
 				require.Equal(t, "linux", req.Metadata.Local.OS.Name)
 
@@ -73,7 +72,6 @@ func TestEnroll(t *testing.T) {
 			req := &EnrollRequest{
 				Type:         PermanentEnroll,
 				EnrollAPIKey: "my-enrollment-api-key",
-				SharedID:     "im-a-beat",
 				Metadata: Metadata{
 					Local:        testMetadata(),
 					UserProvided: make(map[string]interface{}),
@@ -109,7 +107,6 @@ func TestEnroll(t *testing.T) {
 			req := &EnrollRequest{
 				Type:         PermanentEnroll,
 				EnrollAPIKey: "my-enrollment-api-key",
-				SharedID:     "im-a-beat",
 				Metadata: Metadata{
 					Local:        testMetadata(),
 					UserProvided: make(map[string]interface{}),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds support for the `--delay-enroll` flag for the `install` and `enroll` command. On next start of the Elastic Agent service the Elastic Agent will enroll before running in managed mode.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This supports the use-case for setting up a golden image, sysprep, or VDI image that will enroll into Fleet on first start.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #26667