### PR TITLE
[libbeat] Remove experimental flags from decode_xml processor

### DIFF
--- a/libbeat/processors/decode_xml/decode_xml.go
+++ b/libbeat/processors/decode_xml/decode_xml.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/common/encoding/xml"
 	"github.com/elastic/beats/v7/libbeat/common/jsontransform"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -74,8 +73,6 @@ func New(c *common.Config) (processors.Processor, error) {
 }
 
 func newDecodeXML(config decodeXMLConfig) (processors.Processor, error) {
-	cfgwarn.Experimental("The " + procName + " processor is experimental.")
-
 	// Default target to overwriting field.
 	if config.Target == nil {
 		config.Target = &config.Field

--- a/libbeat/processors/decode_xml/docs/decode_xml.asciidoc
+++ b/libbeat/processors/decode_xml/docs/decode_xml.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>decode_xml</titleabbrev>
 ++++
 
-experimental[]
-
 The `decode_xml` processor decodes XML data that is stored under the `field`
 key. It outputs the result into the `target_field`.
 
@@ -97,12 +95,11 @@ value (`target_field:`) is treated as if the field was not set at all.
 exist in the event are overwritten by keys from the decoded XML object. The
 default value is `true`.
 
-`to_lower`:: (Optional) Converts all keys to lowercase. Accepts either true or
-false. The default value is `true`.
+`to_lower`:: (Optional) Converts all keys to lowercase. Accepts either `true` or
+`false`. The default value is `true`.
 
 `document_id`:: (Optional) XML key to use as the document ID. If configured, the
-field will be removed from the original XML document and stored in
-`@metadata._id`.
+field will be removed from the original XML document and stored in `@metadata._id`.
 
 `ignore_missing`:: (Optional) If `true` the processor will not return an error
 when a specified field does not exist. Defaults to `false`.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Removes experimental flags from the decode_xml processor.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The processor is already in a state that is safe to move to GA so users can use with with confidence.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
