### PR TITLE
Set the default value for KIBANA_FLEET_PASSWORD in elastic-agent-managed-daemonset

### DIFF
--- a/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-managed-kubernetes.yaml
@@ -40,7 +40,7 @@ spec:
             - name: KIBANA_FLEET_USERNAME
               value: "elastic"
             - name: KIBANA_FLEET_PASSWORD
-              value: ""
+              value: "changeme"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
+++ b/deploy/kubernetes/elastic-agent-managed/elastic-agent-managed-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             - name: KIBANA_FLEET_USERNAME
               value: "elastic"
             - name: KIBANA_FLEET_PASSWORD
-              value: ""
+              value: "changeme"
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION


## What does this PR do?

Sets `KIBANA_FLEET_PASSWORD` value to `changeme` instead of `""` in `elastic-agent-managed-daemonset.yaml`.
This is the default value according to [documentation](https://www.elastic.co/guide/en/fleet/current/agent-environment-variables.html)

