### PR TITLE
[Filebeat] Update Threatinteal Anomali pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -744,6 +744,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support to `decode_cef` for MAC addresses that do not contain separator characters. {issue}27050[27050] {pull}27109[27109]
 - Update Elasticsearch module's ingest pipeline for parsing new deprecation logs {issue}26857[26857] {pull}26880[26880]
 - Add new `hmac` template function for httpjson input {pull}27168[27168]
+- Update `tags` and `threatintel.indicator.provider` fields in `threatintel.anomali` ingest pipeline {issue}24746[24746] {pull}27141[27141]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/threatintel/anomali/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/threatintel/anomali/ingest/pipeline.yml
@@ -100,6 +100,20 @@ processors:
     field: threatintel.indicator.type
     value: unknown
     if: ctx?.threatintel?.indicator?.type == null
+- foreach:
+    field: threatintel.anomali.labels
+    ignore_missing: true
+    processor:
+      append:
+        field: tags
+        value: "{{_ingest._value}}"
+        allow_duplicates: false
+- grok:
+    field: threatintel.anomali.description
+    patterns:
+      - "^%{GREEDYDATA}Source: %{GREEDYDATA:threatintel.indicator.provider}"
+    ignore_missing: true
+    ignore_failure: true
 ######################
 # Cleanup processors #
 ######################

--- a/x-pack/filebeat/module/threatintel/anomali/test/anomali_limo.ndjson.log-expected.json
+++ b/x-pack/filebeat/module/threatintel/anomali/test/anomali_limo.ndjson.log-expected.json
@@ -11,7 +11,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-76",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332361; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--44c85d4f-45ca-4977-b693-c810bbfb7a28",
@@ -28,6 +31,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://chol.cc/Work6/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:58:57.431Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "chol.cc",
         "threatintel.indicator.url.extension": "php",
@@ -48,7 +52,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-68",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332307; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--f9fe5c81-6869-4247-af81-62b7c8aba209",
@@ -65,6 +72,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://worldatdoor.in/lewis/Panel/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:58:57.503Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "worldatdoor.in",
         "threatintel.indicator.url.extension": "php",
@@ -85,7 +93,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-71",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332302; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--b0e14122-9005-4776-99fc-00872476c6d1",
@@ -102,6 +113,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0387770.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:58:57.570Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0387770.xsph.ru",
         "threatintel.indicator.url.full": "http://f0387770.xsph.ru/login",
@@ -121,7 +133,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-50",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332312; iType: mal_url; State: active; Org: Digital Ocean; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--111ec76f-616d-4aa8-80fd-e11ef0066aba",
@@ -138,6 +153,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://178.62.187.103/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:58:59.366Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "178.62.187.103",
         "threatintel.indicator.url.full": "http://178.62.187.103/login",
@@ -157,7 +173,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-66",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332386; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--189ce776-6d7e-4e85-9222-de5876644988",
@@ -174,6 +193,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://appareluea.com/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:58:59.457Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "appareluea.com",
         "threatintel.indicator.url.extension": "php",
@@ -194,7 +214,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-93",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332391; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--a4144d34-b86d-475e-8047-eb46b48ee325",
@@ -211,6 +234,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://nkpotu.xyz/Kpot3/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:06.402Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "nkpotu.xyz",
         "threatintel.indicator.url.extension": "php",
@@ -231,7 +255,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-49",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332372; iType: mal_ip; State: active; Org: Unified Layer; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--983d9c3d-b7f8-4345-b643-b1d18e6ac6b2",
@@ -249,6 +276,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:19.990Z",
         "threatintel.indicator.ip": "162.144.128.116",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -263,7 +291,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-79",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332313; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--f9c6386b-dba2-41f9-8160-d307671e5c8e",
@@ -280,6 +311,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://ntrcgroup.com/nze/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:20.155Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "ntrcgroup.com",
         "threatintel.indicator.url.extension": "php",
@@ -300,7 +332,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-76",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332350; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--98fad53e-5389-47f7-a3ff-44d334af2d6b",
@@ -317,6 +352,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://chol.cc/Work8/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:25.521Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "chol.cc",
         "threatintel.indicator.url.extension": "php",
@@ -337,7 +373,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-68",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332291; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--76c01735-fb76-463d-9609-9ea3aedf3f4f",
@@ -354,6 +393,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0390764.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:25.626Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0390764.xsph.ru",
         "threatintel.indicator.url.full": "http://f0390764.xsph.ru/login",
@@ -373,7 +413,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-85",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332343; iType: mal_ip; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--e0a812dc-63c8-4949-b038-2241b2dbfcdc",
@@ -391,6 +434,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:36.461Z",
         "threatintel.indicator.ip": "45.143.138.39",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -405,7 +449,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-82",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332316; iType: mal_url; State: active; Org: Sksa Technology Sdn Bhd; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--6f0d8607-21cb-4738-9712-f4fd91a37f7d",
@@ -422,6 +469,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://aglfreight.com.my/inc/js/jstree/biu/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:41.193Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "aglfreight.com.my",
         "threatintel.indicator.url.extension": "php",
@@ -442,7 +490,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-61",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332284; iType: mal_url; State: active; Org: Oltelecom Jsc; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--c649d6d4-87c4-4b76-bfc2-75a509ccb187",
@@ -459,6 +510,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://95.182.122.184/']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:41.228Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "95.182.122.184",
         "threatintel.indicator.url.full": "http://95.182.122.184/",
@@ -478,7 +530,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-62",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332337; iType: mal_ip; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--408ebd2d-063f-4646-b2e7-c00519869736",
@@ -496,6 +551,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:51.313Z",
         "threatintel.indicator.ip": "198.54.115.121",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -510,7 +566,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-38",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332324; iType: mal_ip; State: active; Org: CyrusOne LLC; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--e1d215cb-c7a5-40e0-bc53-8f92a2bcaba8",
@@ -528,6 +587,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:51.372Z",
         "threatintel.indicator.ip": "192.185.119.172",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -542,7 +602,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-61",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332296; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--6f3a4a2b-62e3-48ef-94ae-70103f09cf7e",
@@ -559,6 +622,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0389246.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T02:59:51.442Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0389246.xsph.ru",
         "threatintel.indicator.url.full": "http://f0389246.xsph.ru/login",
@@ -578,7 +642,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-66",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332400; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--213519c9-f511-4188-89c8-159f35f08008",
@@ -595,6 +662,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://appareluea.com/server/cp.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:01.563Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "appareluea.com",
         "threatintel.indicator.url.extension": "php",
@@ -615,7 +683,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-93",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332396; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--5a563c85-c528-4e33-babe-2dcff34f73c4",
@@ -632,6 +703,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://nkpotu.xyz/Kpot2/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:03.138Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "nkpotu.xyz",
         "threatintel.indicator.url.extension": "php",
@@ -652,7 +724,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-76",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332363; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--f3e33aab-e2af-4c15-8cb9-f008a37cf986",
@@ -669,6 +744,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://chol.cc/Work5/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:03.396Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "chol.cc",
         "threatintel.indicator.url.extension": "php",
@@ -689,7 +765,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-87",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332320; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--f03f098d-2fa9-49e1-a7dd-02518aa105fa",
@@ -706,6 +785,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://mecharnise.ir/ca4/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:03.642Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "mecharnise.ir",
         "threatintel.indicator.url.extension": "php",
@@ -726,7 +806,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-76",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332367; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--e72e3ba0-7de5-46bb-ab1e-efdf3e0a0b3b",
@@ -743,6 +826,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://chol.cc/Work4/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:27.534Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "chol.cc",
         "threatintel.indicator.url.extension": "php",
@@ -763,7 +847,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-78",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332317; iType: mal_url; State: active; Org: SoftLayer Technologies; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--d6b59b66-5020-4368-85a7-196026856ea9",
@@ -780,6 +867,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://kironofer.com/webpanel/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:27.591Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "kironofer.com",
         "threatintel.indicator.url.extension": "php",
@@ -800,7 +888,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-68",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332309; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--aff7b07f-acc7-4bec-ab19-1fce972bfd09",
@@ -817,6 +908,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://worldatdoor.in/panel2/Panel/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:45.787Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "worldatdoor.in",
         "threatintel.indicator.url.extension": "php",
@@ -837,7 +929,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-91",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332286; iType: mal_url; State: active; Org: Garanntor-Hosting; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--ba71ba3a-1efd-40da-ab0d-f4397d6fc337",
@@ -854,6 +949,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://smartlinktelecom.top/kings/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:45.841Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "smartlinktelecom.top",
         "threatintel.indicator.url.extension": "php",
@@ -874,7 +970,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-64",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332339; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--17777e7f-3e91-4446-a43d-79139de8a948",
@@ -891,6 +990,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://carirero.net/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:45.959Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "carirero.net",
         "threatintel.indicator.url.extension": "php",
@@ -911,7 +1011,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-30",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332319; iType: mal_ip; State: active; Org: SoftLayer Technologies; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--f6be1804-cfe4-4f41-9338-2b65f5b1dda1",
@@ -929,6 +1032,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:46.025Z",
         "threatintel.indicator.ip": "74.116.84.20",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -943,7 +1047,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-43",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332305; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--b4fd8489-9589-4f70-996c-84989245a21b",
@@ -960,6 +1067,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://tuu.nu/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:00:57.729Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "tuu.nu",
         "threatintel.indicator.url.full": "http://tuu.nu/login",
@@ -979,7 +1087,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-36",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332346; iType: mal_url; State: active; Org: Ifx Networks Colombia; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--bc50c62f-a015-4460-87df-2137626877e3",
@@ -996,6 +1107,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://dulfix.com/cgi-bins/dulfix/gustav57/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:01:02.696Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "dulfix.com",
         "threatintel.indicator.url.extension": "php",
@@ -1016,7 +1128,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-65",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332323; iType: mal_url; State: active; Org: CyrusOne LLC; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--2765af4b-bfb7-4ac8-82d2-ab6ed8a52461",
@@ -1033,6 +1148,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://deliciasdvally.com.pe/includes/gter/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:01:02.807Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "deliciasdvally.com.pe",
         "threatintel.indicator.url.extension": "php",
@@ -1053,7 +1169,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-93",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332399; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--9c0e63a1-c32a-470a-bf09-51488e239c63",
@@ -1070,6 +1189,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://nkpotu.xyz/Kpot1/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:01:24.810Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "nkpotu.xyz",
         "threatintel.indicator.url.extension": "php",
@@ -1090,7 +1210,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-87",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332328; iType: mal_ip; State: active; Org: RUCloud; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--8047678e-20be-4116-9bc4-7bb7c26554e0",
@@ -1108,6 +1231,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:01:41.158Z",
         "threatintel.indicator.ip": "194.87.147.80",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -1122,7 +1246,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-85",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332377; iType: mal_url; State: active; Org: A100 ROW GmbH; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--c57a880c-1ce0-45de-9bab-fb2910454a61",
@@ -1139,6 +1266,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://35.158.92.3/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:01:57.189Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "35.158.92.3",
         "threatintel.indicator.url.extension": "php",
@@ -1159,7 +1287,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-42",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332101; iType: mal_ip; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--6056152c-0fa5-4e34-871a-3c8990f1ee46",
@@ -1177,6 +1308,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:01:57.279Z",
         "threatintel.indicator.ip": "45.95.168.70",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -1191,7 +1323,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-76",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332357; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--23215acb-4989-4434-ac6d-8f9367734f0f",
@@ -1208,6 +1343,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://chol.cc/Work7/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:02:50.570Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "chol.cc",
         "threatintel.indicator.url.extension": "php",
@@ -1228,7 +1364,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-26",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332289; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--452ece92-9ff2-4f99-8a7f-fd614ebea8cf",
@@ -1245,6 +1384,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0391600.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:02:52.496Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0391600.xsph.ru",
         "threatintel.indicator.url.full": "http://f0391600.xsph.ru/login",
@@ -1264,7 +1404,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-94",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332334; iType: mal_url; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--10958d74-ec60-41af-a1ab-1613257e670f",
@@ -1281,6 +1424,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://extraclick.space/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:03:42.819Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "extraclick.space",
         "threatintel.indicator.url.extension": "php",
@@ -1301,7 +1445,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-87",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332326; iType: mal_url; State: active; Org: RUCloud; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--19556daa-6293-400d-8706-d0baa6b16b7a",
@@ -1318,6 +1465,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://petrogarmani.pw/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:03:52.044Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "petrogarmani.pw",
         "threatintel.indicator.url.extension": "php",
@@ -1338,7 +1486,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-68",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332311; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--b09d9be9-6703-4a7d-a066-2baebb6418fc",
@@ -1355,6 +1506,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://worldatdoor.in/mighty/32/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:04:01.650Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "worldatdoor.in",
         "threatintel.indicator.url.extension": "php",
@@ -1375,7 +1527,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-92",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332341; iType: mal_url; State: active; Org: Institute of Philosophy, Russian Academy of Scienc; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--43febf7d-4185-4a12-a868-e7be690b14aa",
@@ -1392,6 +1547,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://zanlma.com/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:04:32.717Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "zanlma.com",
         "threatintel.indicator.url.full": "http://zanlma.com/login",
@@ -1411,7 +1567,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-84",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332303; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--a34728e6-f91d-47e6-a4d8-a69176299e45",
@@ -1428,6 +1587,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0369688.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:04:56.858Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0369688.xsph.ru",
         "threatintel.indicator.url.full": "http://f0369688.xsph.ru/login",
@@ -1447,7 +1607,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-76",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55241332380; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--ac821704-5eb2-4f8f-a8b6-2a168dbd0e54",
@@ -1464,6 +1627,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://chol.cc/Work2/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-22T03:04:59.245Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "chol.cc",
         "threatintel.indicator.url.extension": "php",
@@ -1484,7 +1648,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-57",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868747; iType: mal_ip; State: active; Org: CyrusOne LLC; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--0d3e1bd8-0f16-4c22-b8a1-663ec255ad79",
@@ -1502,6 +1669,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:00:22.287Z",
         "threatintel.indicator.ip": "192.185.214.199",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -1516,7 +1684,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-24",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868770; iType: mal_url; State: active; Org: Mills College; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--2cdd130a-c884-402d-b63c-e03f9448f5d9",
@@ -1533,6 +1704,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://softtouchcollars.com/Loki/Panel/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:01:11.329Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "softtouchcollars.com",
         "threatintel.indicator.url.extension": "php",
@@ -1553,7 +1725,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-61",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868769; iType: mal_url; State: active; Org: CyrusOne LLC; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--88e98e13-4bfd-4188-941a-f696a7b86b71",
@@ -1570,6 +1745,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://imobiliariatirol.com/gh/panelnew/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:01:36.682Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "imobiliariatirol.com",
         "threatintel.indicator.url.extension": "php",
@@ -1590,7 +1766,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-93",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868772; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--27323b7d-85d3-4e89-8249-b7696925a772",
@@ -1607,6 +1786,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://deliveryexpressworld.xyz/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:02:15.854Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "deliveryexpressworld.xyz",
         "threatintel.indicator.url.extension": "php",
@@ -1627,7 +1807,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-62",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868766; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--b0639721-de55-48c6-b237-3859d61aecfb",
@@ -1644,6 +1827,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0392261.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:02:47.364Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0392261.xsph.ru",
         "threatintel.indicator.url.full": "http://f0392261.xsph.ru/login",
@@ -1663,7 +1847,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-80",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868749; iType: mal_url; State: active; Org: ColoCrossing; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--677e714d-c237-42a1-b6b7-9145acd13eee",
@@ -1680,6 +1867,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://104.168.99.168/panel/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:03:05.048Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "104.168.99.168",
         "threatintel.indicator.url.extension": "php",
@@ -1700,7 +1888,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-69",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868767; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--5baa1dbd-d74e-408c-92b5-0a9f97e4b87a",
@@ -1717,6 +1908,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0387404.xsph.ru/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:03:15.734Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0387404.xsph.ru",
         "threatintel.indicator.url.extension": "php",
@@ -1737,7 +1929,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-72",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55245868768; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--4563241e-5d2f-41a7-adb9-3925a5eeb1b1",
@@ -1754,6 +1949,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://a0386457.xsph.ru/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-23T03:03:42.599Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "a0386457.xsph.ru",
         "threatintel.indicator.url.extension": "php",
@@ -1774,7 +1970,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-74",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078037; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--70cb5d42-91d3-4efe-8c47-995fc0ac4141",
@@ -1791,6 +1990,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://defenseisrael.com/dis/index.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:04.821Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "defenseisrael.com",
         "threatintel.indicator.url.extension": "php",
@@ -1811,7 +2011,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-83",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078030; iType: mal_ip; State: active; Org: Best-Hoster Group Co. Ltd.; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--3aa712bb-b5d4-4632-bf50-48a4aeeaeb6d",
@@ -1829,6 +2032,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:04.857Z",
         "threatintel.indicator.ip": "91.215.170.249",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -1843,7 +2047,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-79",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078019; iType: mal_url; State: active; Org: MoreneHost; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--64227c7d-86ea-4146-a868-3decb5aa5f1d",
@@ -1860,6 +2067,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://lbfb3f03.justinstalledpanel.com/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:04.883Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "lbfb3f03.justinstalledpanel.com",
         "threatintel.indicator.url.full": "http://lbfb3f03.justinstalledpanel.com/login",
@@ -1879,7 +2087,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-93",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078035; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--37fcf9a7-1a90-4d81-be0a-e824a4fa938e",
@@ -1896,6 +2107,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://byedtronchgroup.yt/jik/Panel/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:12.997Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "byedtronchgroup.yt",
         "threatintel.indicator.url.extension": "php",
@@ -1916,7 +2128,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-87",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078008; iType: mal_url; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--5a38786f-107e-4060-a7c9-ea8a5ded6aac",
@@ -1933,6 +2148,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://199.192.28.11/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:13.025Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "199.192.28.11",
         "threatintel.indicator.url.extension": "php",
@@ -1953,7 +2169,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-82",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078038; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--3eb79b31-1d6d-438c-a848-24a3407f6e32",
@@ -1970,6 +2189,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://217.8.117.51/aW8bVds1/login.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:32.901Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "217.8.117.51",
         "threatintel.indicator.url.extension": "php",
@@ -1990,7 +2210,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-93",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078026; iType: mal_url; State: active; Org: IT DeLuxe Ltd.; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--a050832c-db6e-49a0-8470-7a3cd8f17178",
@@ -2007,6 +2230,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://lansome.site/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:32.929Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "lansome.site",
         "threatintel.indicator.url.full": "http://lansome.site/login",
@@ -2026,7 +2250,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-83",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078034; iType: mal_url; State: active; Org: Branch of BachKim Network solutions jsc; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--e88008f4-76fc-428d-831a-4b389e48b712",
@@ -2043,6 +2270,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://iplusvietnam.com.vn/jo/playbook/onelove/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:57:49.028Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "iplusvietnam.com.vn",
         "threatintel.indicator.url.extension": "php",
@@ -2063,7 +2291,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-94",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078032; iType: mal_url; State: active; Org: ColoCrossing; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--dafe91cf-787c-471c-9afe-f7bb20a1b93f",
@@ -2080,6 +2311,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://leakaryadeen.com/parl/id345/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:58:03.345Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "leakaryadeen.com",
         "threatintel.indicator.url.extension": "php",
@@ -2100,7 +2332,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-81",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078031; iType: mal_url; State: active; Org: IT House, Ltd; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--232bdc34-44cb-4f41-af52-f6f1cd28818e",
@@ -2117,6 +2352,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://oaa-my.com/clap/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:58:16.318Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "oaa-my.com",
         "threatintel.indicator.url.extension": "php",
@@ -2137,7 +2373,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-66",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078027; iType: mal_url; State: active; Org: Branch of BachKim Network solutions jsc; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--4adabe80-3be4-401a-948a-f9724c872374",
@@ -2154,6 +2393,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://thaubenuocngam.com/go/playbook/onelove/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:58:16.358Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "thaubenuocngam.com",
         "threatintel.indicator.url.extension": "php",
@@ -2174,7 +2414,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-82",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078013; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--1d7051c0-a42b-4801-bd7f-f0abf2cc125c",
@@ -2191,6 +2434,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://suspiciousactivity.xyz/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:58:32.126Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "suspiciousactivity.xyz",
         "threatintel.indicator.url.full": "http://suspiciousactivity.xyz/login",
@@ -2210,7 +2454,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-82",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078017; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--fb06856c-8aad-4fae-92fc-b73aae4f6dc7",
@@ -2227,6 +2474,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://217.8.117.8/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:58:37.603Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "217.8.117.8",
         "threatintel.indicator.url.full": "http://217.8.117.8/login",
@@ -2246,7 +2494,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-71",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078012; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--33e674f5-a64a-48f4-9d8c-248348356135",
@@ -2263,6 +2514,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0387550.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:58:37.643Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0387550.xsph.ru",
         "threatintel.indicator.url.full": "http://f0387550.xsph.ru/login",
@@ -2282,7 +2534,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-84",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078018; iType: mal_url; State: active; Org: MoreneHost; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--6311f539-1d5d-423f-a238-d0c1dc167432",
@@ -2299,6 +2554,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://lf4e4abf.justinstalledpanel.com/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:58:39.465Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "lf4e4abf.justinstalledpanel.com",
         "threatintel.indicator.url.full": "http://lf4e4abf.justinstalledpanel.com/login",
@@ -2318,7 +2574,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-81",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078033; iType: mal_ip; State: active; Org: ColoCrossing; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--1c91f219-cfa6-44c7-a5ee-1c760489b43c",
@@ -2336,6 +2595,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:02.031Z",
         "threatintel.indicator.ip": "206.217.131.245",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -2350,7 +2610,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-52",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078010; iType: mal_url; State: active; Org: QuadraNet; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--c58983e2-18fd-47b8-aab4-6c8a2e2dcb35",
@@ -2367,6 +2630,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://67.215.224.101/a1/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:15.878Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "67.215.224.101",
         "threatintel.indicator.url.extension": "php",
@@ -2387,7 +2651,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-58",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078000; iType: mal_ip; State: active; Org: CyrusOne LLC; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--1ab178a8-7991-4879-b9aa-8da49f40e92e",
@@ -2405,6 +2672,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:29.155Z",
         "threatintel.indicator.ip": "162.241.73.163",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -2419,7 +2687,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-78",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078020; iType: mal_url; State: active; Org: MoreneHost; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--d5bdff38-6939-4a47-8e11-b910520565c4",
@@ -2436,6 +2707,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://l60bdd58.justinstalledpanel.com/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:50.233Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "l60bdd58.justinstalledpanel.com",
         "threatintel.indicator.url.full": "http://l60bdd58.justinstalledpanel.com/login",
@@ -2455,7 +2727,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-25",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078009; iType: mal_url; State: active; Org: ColoCrossing; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--1be74977-5aa6-4175-99dd-32b54863a06b",
@@ -2472,6 +2747,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://107.175.150.73/~giftioz/.azma/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:50.255Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "107.175.150.73",
         "threatintel.indicator.url.extension": "php",
@@ -2492,7 +2768,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-78",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078023; iType: mal_url; State: active; Org: MoreneHost; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--eacc25ce-584c-4b40-98ab-7935dabd5cb1",
@@ -2509,6 +2788,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://5.188.60.52/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:52.536Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "5.188.60.52",
         "threatintel.indicator.url.full": "http://5.188.60.52/login",
@@ -2528,7 +2808,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-85",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078025; iType: mal_url; State: active; Org: Cloudflare; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--504f4011-eaea-4921-aad5-f102bef7c798",
@@ -2545,6 +2828,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://trotdeiman.ga/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:54.784Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "trotdeiman.ga",
         "threatintel.indicator.url.full": "http://trotdeiman.ga/login",
@@ -2564,7 +2848,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-82",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078014; iType: mal_ip; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--e3ffb953-6c59-461a-8242-0d26c2b5c358",
@@ -2582,6 +2869,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T02:59:54.815Z",
         "threatintel.indicator.ip": "217.8.117.8",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -2596,7 +2884,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-83",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078036; iType: mal_ip; State: active; Org: Global Frag Networks; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--3a47ad46-930d-4ced-b0e7-dc9d0776153e",
@@ -2614,6 +2905,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:00:01.726Z",
         "threatintel.indicator.ip": "104.223.170.113",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -2628,7 +2920,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-58",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078011; iType: mal_url; State: active; Org: CyrusOne LLC; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--0e10924c-745c-4a58-8e27-ab3a6bacd666",
@@ -2645,6 +2940,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://tavim.org/includes/firmino/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:00:01.762Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "tavim.org",
         "threatintel.indicator.url.extension": "php",
@@ -2665,7 +2961,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-84",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078015; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--c3fb816a-cc3b-4442-be4d-d62113ae5168",
@@ -2682,6 +2981,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://onlinesecuritycenter.xyz/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:00:10.928Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "onlinesecuritycenter.xyz",
         "threatintel.indicator.url.full": "http://onlinesecuritycenter.xyz/login",
@@ -2701,7 +3001,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-81",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078029; iType: mal_url; State: active; Org: IT House, Ltd; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--9159e46d-f3a4-464b-ac68-8beaf87e1a8f",
@@ -2718,6 +3021,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://oaa-my.com/cutter/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:00:20.166Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "oaa-my.com",
         "threatintel.indicator.url.extension": "php",
@@ -2738,7 +3042,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-90",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078016; iType: mal_url; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--fefa8e76-ae0f-41ab-84e7-ea43ab055573",
@@ -2755,6 +3062,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://jumbajumbadun.fun/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:00:24.048Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "jumbajumbadun.fun",
         "threatintel.indicator.url.full": "http://jumbajumbadun.fun/login",
@@ -2774,7 +3082,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-58",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078024; iType: mal_url; State: active; Org: CyrusOne LLC; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--6a76fa89-4d5f-40d0-9b03-671bdb2d5b4b",
@@ -2791,6 +3102,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://tavim.org/includes/salah/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:00:55.816Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "tavim.org",
         "threatintel.indicator.url.extension": "php",
@@ -2811,7 +3123,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-80",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078022; iType: mal_url; State: active; Org: MoreneHost; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--21055dfd-d0cb-42ec-93bd-ffaeadd11d80",
@@ -2828,6 +3143,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://l0c23205.justinstalledpanel.com/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:01:10.501Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "l0c23205.justinstalledpanel.com",
         "threatintel.indicator.url.full": "http://l0c23205.justinstalledpanel.com/login",
@@ -2847,7 +3163,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-83",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078021; iType: mal_url; State: active; Org: MoreneHost; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--7471a595-e8b0-4c41-be4c-0a3e55675630",
@@ -2864,6 +3183,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://l535e9e5.justinstalledpanel.com/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:01:10.518Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "l535e9e5.justinstalledpanel.com",
         "threatintel.indicator.url.full": "http://l535e9e5.justinstalledpanel.com/login",
@@ -2883,7 +3203,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-76",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55250078007; iType: mal_ip; State: active; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--ead1e7e5-fdb3-47c2-9476-aa82741c038e",
@@ -2901,6 +3224,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-24T03:01:14.843Z",
         "threatintel.indicator.ip": "217.8.117.47",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -2915,7 +3239,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-67",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484365; iType: mal_url; State: active; Org: Petersburg Internet Network ltd.; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--b0aee6bf-32f4-4f65-8de6-f65e04e92b15",
@@ -2932,6 +3259,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://46.161.27.57/northon/']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:12.699Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "46.161.27.57",
         "threatintel.indicator.url.full": "http://46.161.27.57/northon/",
@@ -2951,7 +3279,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-90",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484350; iType: mal_url; State: active; Org: ColoCrossing; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--54afbceb-72f3-484e-aee4-904f77beeff6",
@@ -2968,6 +3299,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://104.168.99.170/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:28.034Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "104.168.99.170",
         "threatintel.indicator.url.full": "http://104.168.99.170/login",
@@ -2987,7 +3319,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-89",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484356; iType: mal_url; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--da030e10-af9f-462d-bda8-33abb223e950",
@@ -3004,6 +3339,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://officelog.org/inc/js/jstree/scan/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:38.187Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "officelog.org",
         "threatintel.indicator.url.extension": "php",
@@ -3024,7 +3360,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-65",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484343; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--d38e051a-bc5b-4723-884a-65e017d98299",
@@ -3041,6 +3380,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0391587.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:38.214Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0391587.xsph.ru",
         "threatintel.indicator.url.full": "http://f0391587.xsph.ru/login",
@@ -3060,7 +3400,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-67",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484367; iType: mal_url; State: active; Org: Petersburg Internet Network ltd.; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--46491826-6ba1-4217-a35e-1eb0081a9e6a",
@@ -3077,6 +3420,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://46.161.27.57:8080/northon/']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:47.281Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "46.161.27.57",
         "threatintel.indicator.url.full": "http://46.161.27.57:8080/northon/",
@@ -3097,7 +3441,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-79",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484342; iType: mal_url; State: active; Org: SPRINTHOST.RU - shared/premium hosting, VDS, dedic; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--b9715fd5-b89a-4859-b19f-55e052709227",
@@ -3114,6 +3461,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://f0393086.xsph.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:51.296Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "f0393086.xsph.ru",
         "threatintel.indicator.url.full": "http://f0393086.xsph.ru/login",
@@ -3133,7 +3481,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-87",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484363; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--e3177515-f481-46c8-bad8-582ba0858ef3",
@@ -3150,6 +3501,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://insuncos.com/files1/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:56.007Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "insuncos.com",
         "threatintel.indicator.url.extension": "php",
@@ -3170,7 +3522,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-89",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484339; iType: mal_url; State: active; Org: DDoS-GUARD GmbH; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--33cdeaeb-5201-4fbb-b9ae-9c23377e7533",
@@ -3187,6 +3542,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://tg-h.ru/login']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:57:56.044Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "tg-h.ru",
         "threatintel.indicator.url.full": "http://tg-h.ru/login",
@@ -3206,7 +3562,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-86",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484351; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--2baaa5f0-c2f6-4bd1-b59d-3a75931da735",
@@ -3223,6 +3582,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://wusetwo.xyz/public_html/file/five/inc/class/pCharts/info/Panel/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:58:11.038Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "wusetwo.xyz",
         "threatintel.indicator.url.extension": "php",
@@ -3243,7 +3603,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-64",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484366; iType: mal_url; State: active; Org: World Hosting Farm Limited; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--f1bdef49-666f-46b5-a323-efa1f1446b62",
@@ -3260,6 +3623,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://185.234.217.36/northon/']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:58:20.420Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "185.234.217.36",
         "threatintel.indicator.url.full": "http://185.234.217.36/northon/",
@@ -3279,7 +3643,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-84",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484354; iType: mal_url; State: active; Org: McHost.Ru; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--a173f4b1-67ce-44f8-a6d0-bd8a24e8c593",
@@ -3296,6 +3663,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://topik07.mcdir.ru/papka/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:58:20.448Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "topik07.mcdir.ru",
         "threatintel.indicator.url.extension": "php",
@@ -3316,7 +3684,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-87",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484362; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--b53dded1-d293-4cd1-9e63-b6e0cbd850f0",
@@ -3333,6 +3704,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://insuncos.com/files2/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:58:33.189Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "insuncos.com",
         "threatintel.indicator.url.extension": "php",
@@ -3353,7 +3725,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-47",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484364; iType: mal_url; State: active; Org: World Hosting Farm Limited; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--2b30f8fe-13e8-4a7d-8eba-3e59c288bef7",
@@ -3370,6 +3745,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://185.234.218.68/kaspersky/']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:58:49.056Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "185.234.218.68",
         "threatintel.indicator.url.full": "http://185.234.218.68/kaspersky/",
@@ -3389,7 +3765,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-89",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484357; iType: mal_url; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--f502199a-17a4-404b-a114-fb5eda28c32c",
@@ -3406,6 +3785,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://officelog.org/inc/js/jstree/mh/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:58:59.472Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "officelog.org",
         "threatintel.indicator.url.extension": "php",
@@ -3426,7 +3806,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-89",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484359; iType: mal_url; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--af7422eb-5d8e-4878-bdd1-395313434dae",
@@ -3443,6 +3826,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://officelog.org/inc/js/jstree/ch/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:59:27.070Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "officelog.org",
         "threatintel.indicator.url.extension": "php",
@@ -3463,7 +3847,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-89",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484358; iType: mal_url; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--71b36c05-86dd-4685-81c0-5a99e2e14c23",
@@ -3480,6 +3867,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://officelog.org/inc/js/jstree/dar/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:59:28.967Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "officelog.org",
         "threatintel.indicator.url.extension": "php",
@@ -3500,7 +3888,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-81",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484352; iType: mal_url; State: active; Org: Best-Hoster Group Co. Ltd.; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--9d948509-dfb4-45b6-b8bc-780df88a213f",
@@ -3517,6 +3908,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://oaa-my.com/cage/five/PvqDq929BSx_A_D_M1n_a.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:59:37.661Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "oaa-my.com",
         "threatintel.indicator.url.extension": "php",
@@ -3537,7 +3929,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-53",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484224; iType: mal_ip; State: active; Org: Namecheap; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--9f613f8e-2040-4eee-8044-044023a8093e",
@@ -3555,6 +3950,7 @@
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:59:37.692Z",
         "threatintel.indicator.ip": "192.64.118.56",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "ipv4-addr"
     },
     {
@@ -3569,7 +3965,10 @@
         "service.type": "threatintel",
         "tags": [
             "forwarded",
-            "threatintel-anomali"
+            "malicious-activity",
+            "threatintel-anomali",
+            "threatstream-confidence-87",
+            "threatstream-severity-medium"
         ],
         "threatintel.anomali.description": "TS ID: 55253484361; iType: mal_url; State: active; Org: ServerMania; Source: CyberCrime",
         "threatintel.anomali.id": "indicator--518c3959-6c26-413f-9a5f-c8f76d86185a",
@@ -3586,6 +3985,7 @@
         "threatintel.anomali.pattern": "[url:value = 'http://insuncos.com/files3/panel/admin.php']",
         "threatintel.anomali.type": "indicator",
         "threatintel.anomali.valid_from": "2020-01-25T02:59:54.296Z",
+        "threatintel.indicator.provider": "CyberCrime",
         "threatintel.indicator.type": "url",
         "threatintel.indicator.url.domain": "insuncos.com",
         "threatintel.indicator.url.extension": "php",


### PR DESCRIPTION
## What does this PR do?

Populates the `tags` field the same way the MISP dataset is populated and populates the `threatintel.indicator.provider` field like the Abuse URL dataset.

## Why is it important?

Standardizes the Threat Intel datasets

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

```
cd beats/x-pack/filebeat
TESTING_FILEBEAT_MODULES=threatintel TESTING_FILEBEAT_FILESETS=anomali mage -v pythonIntegTest
```

## Related issues

- Closes #24746

## Use cases


## Screenshots



## Logs


