### PR TITLE
Cherry-pick to 7.13: docs: fix example (#27117)

### DIFF
--- a/libbeat/docs/http-endpoint.asciidoc
+++ b/libbeat/docs/http-endpoint.asciidoc
@@ -56,7 +56,7 @@ curl -XGET 'localhost:5066/?pretty'
 ["source","js",subs="attributes"]
 ----
 {
-  "beat": "metricbeat",
+  "beat": "{beatname_lc}",
   "hostname": "example.lan",
   "name": "example.lan",
   "uuid": "34f6c6e1-45a8-4b12-9125-11b3e6e89866",


### PR DESCRIPTION
Backports the following commits to 7.13:
 - docs: fix example (#27117)