### PR TITLE
Introducing preprocessors on the module input override

### DIFF
--- a/filebeat/docs/filebeat-modules-options.asciidoc
+++ b/filebeat/docs/filebeat-modules-options.asciidoc
@@ -121,4 +121,39 @@ You can also enable `close_eof` for all inputs created by any of the modules:
 -M "*.*.input.close_eof=true"
 ----------------------------------------------------------------------
 
+==== Processors
+
+As described in <<defining-processors.html#where-valid,Where are processors valid?>> you can define `processors`
+under the input section of the module definition. These processors are run _after_ any processors defined in the
+module.
+
+[source,yaml]
+----------------------------------------------------------------------
+- module: nginx
+  access:
+    input:
+      processors:
+        - drop_event:
+            when:
+              contains:
+                source: "test"
+----------------------------------------------------------------------
+
+Alternatively you can define `preprocessors` which are run after the input but _before_ the processors defined
+in the module. Preprocessors can be useful if we don't retrieve the data directly from the log source and the
+intermediate channel introduces additional 'wrapping'.
+
+[source,yaml]
+----------------------------------------------------------------------
+- module: nginx
+  access:
+    input:
+      preprocessors:
+        - drop_event:
+            when:
+               contains:
+                 source: "test"
+----------------------------------------------------------------------
+
+
 :modulename!:

--- a/filebeat/fileset/fileset.go
+++ b/filebeat/fileset/fileset.go
@@ -373,7 +373,21 @@ func (fs *Fileset) getInputConfig() (*common.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error creating config from input overrides: %v", err)
 		}
+
 		cfg, err = common.MergeConfigsWithOptions([]*common.Config{cfg, overrides}, ucfg.FieldReplaceValues("**.paths"), ucfg.FieldAppendValues("**.processors"))
+		if overrides.HasField("preprocessors") {
+			preprocessors, err := overrides.Child("preprocessors", -1)
+			if err != nil {
+				return nil, fmt.Errorf("Error creating config from input overrides: %v", err)
+			}
+			overrides, err = common.NewConfigFrom(map[string]interface{}{
+				"processors": preprocessors,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("Error creating config from input overrides: %v", err)
+			}
+			cfg, err = common.MergeConfigsWithOptions([]*common.Config{cfg, overrides}, ucfg.FieldReplaceValues("**.paths"), ucfg.FieldPrependValues("**.processors"))
+		}
 		if err != nil {
 			return nil, fmt.Errorf("Error applying config overrides: %v", err)
 		}


### PR DESCRIPTION
Introducing preprocessors on the module input override which are run after the input but before the processors in the module so some pre transformation can occur.

## What does this PR do?

Allows `preprocessors` to be defined on the module input override which are run after the input but before the processors in the module as opposed to the processors defined at this level which are run after the module. The `preprocessors` are normal processors and after merging the config don't exist as a separate property but are merged with the processors.

## Why is it important?

This PR introduces flexibility to filebeat and allows more module reuse vs local forking (breaking updates) and can simplify the ingest pipeline requiring fewer components

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Competes with #26862

## Use cases

When intermediate transport is used, for example syslog shipped over syslog, leading to double syslog headers which the module doesn't expect.

