### PR TITLE
Allow conditional processing in `decode_xml`

### DIFF
--- a/libbeat/processors/decode_xml/decode_xml.go
+++ b/libbeat/processors/decode_xml/decode_xml.go
@@ -56,7 +56,7 @@ func init() {
 				"field", "target_field",
 				"overwrite_keys", "document_id",
 				"to_lower", "ignore_missing",
-				"ignore_failure",
+				"ignore_failure", "when",
 			)))
 	jsprocessor.RegisterPlugin("DecodeXML", New)
 }


### PR DESCRIPTION
## What does this PR do?

This PR allows `when` in the accepted fields of `decode_xml`.

## Why is it important?

Without this conditionals are not allowed when using `decode_xml`.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
