### PR TITLE
Disable ILM for overriding index name

### DIFF
--- a/libbeat/docs/howto/load-index-templates.asciidoc
+++ b/libbeat/docs/howto/load-index-templates.asciidoc
@@ -44,6 +44,13 @@ setup.template.fields: "path/to/fields.yml"
 If the template already exists, it’s not overwritten unless you configure
 {beatname_uc} to do so.
 
+Also make sure to disable the index Index Lifecycle Management(ILM) feature in Elasticsearch. ILM is used to manage your Filebeat indices and ```output.elasticsearch.index``` setting that allows to override the index name used for Beats events doesn't work when ILM is enabled.
+
+-----
+setup.ilm.enabled: false
+-----
+
+
 [float]
 [[overwrite-template]]
 === Overwrite an existing index template


### PR DESCRIPTION
Updated docs to disable ILM for overriding index name

```
setup.ilm.enabled: false
```

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Updated the ```load-index-template``` doc with disabling the ILM for ```output.elasticsearch.index``` setting to work

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

```output.elasticsearch.index``` setting won't work with ILM enabled (default behaviour) which is not mentioned in this doc.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->