### PR TITLE
libbeat/processors/timestamp: use time/tzdata to embed tzdata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/elastic/beats/v7
 go 1.16
 
 require (
-	4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b
 	cloud.google.com/go v0.51.0
 	cloud.google.com/go/bigquery v1.0.1
 	cloud.google.com/go/pubsub v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-4d63.com/embedfiles v0.0.0-20190311033909-995e0740726f h1:oyYjGRBNq1TxAIG8aHqtxlvqUfzdZf+MbcRb/oweNfY=
-4d63.com/embedfiles v0.0.0-20190311033909-995e0740726f/go.mod h1:HxEsUxoVZyRxsZML/S6e2xAuieFMlGO0756ncWx1aXE=
-4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b h1:+TO4EgK74+Qo/ilRDiF2WpY09Jk9VSJSLe3wEn+dJBw=
-4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b/go.mod h1:SHGqVdL7hd2ZaX2T9uEiOZ/OFAUfCCLURdLPJsd8ZNs=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/libbeat/processors/timestamp/timestamp.go
+++ b/libbeat/processors/timestamp/timestamp.go
@@ -20,8 +20,8 @@ package timestamp
 import (
 	"fmt"
 	"time"
+	_ "time/tzdata" // Imported to embed the timezone database.
 
-	"4d63.com/tz"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -96,7 +96,7 @@ func loadLocation(timezone string) (*time.Location, error) {
 	}
 
 	// Rest of location formats
-	return tz.LoadLocation(timezone)
+	return time.LoadLocation(timezone)
 }
 
 func (p *processor) String() string {


### PR DESCRIPTION
This is a cleanup.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This change replaces 4d63.com/tz [which is no longer maintained](https://github.com/leighmcculloch/go-tz) with the standard library time/tzdata package for embedding the tzdata asset for systems that do not hold their own.

Note that time/tzdata conditionally uses the embedded asset only when there is no timezone database available on the system. This is a difference compared to 4d63.com/tz which is unconditional.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

4d63.com/tz is no longer maintained and the conditional use of the embedded asset means that users can maintain an up-to-date tz database rather than being pinned to the embedded asset.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Please let me know if this requires text to be added to the CHANGELOG and whether there should be documentation added (I suspect not).

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

No new feature is added, and existing tests already cover the change. I have run tests on a platform with tzdata though, so testing on a Windows env is recommended.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Standard test suite.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

No related issues.


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

N/A

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A