### PR TITLE
libbeat/cmd/instance: ensure test config file has appropriate permissions

### DIFF
--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -78,16 +78,31 @@ func TestInitKibanaConfig(t *testing.T) {
 	assert.Equal(t, "testidx", b.Info.IndexPrefix)
 	assert.Equal(t, "0.9", b.Info.Version)
 
-	cfg, err := cfgfile.Load("../test/filebeat_test.yml", nil)
+	const configPath = "../test/filebeat_test.yml"
+
+	// Ensure that the config has owner-exclusive write permissions.
+	// This is necessary on some systems which have a default umask
+	// of 0o002, meaning that files are checked out by git with mode
+	// 0o664. This would cause cfgfile.Load to fail.
+	err = os.Chmod(configPath, 0o644)
+	assert.NoError(t, err)
+
+	cfg, err := cfgfile.Load(configPath, nil)
+	assert.NoError(t, err)
 	err = cfg.Unpack(&b.Config)
 	assert.NoError(t, err)
 
 	kibanaConfig := InitKibanaConfig(b.Config)
 	username, err := kibanaConfig.String("username", -1)
+	assert.NoError(t, err)
 	password, err := kibanaConfig.String("password", -1)
+	assert.NoError(t, err)
 	api_key, err := kibanaConfig.String("api_key", -1)
+	assert.NoError(t, err)
 	protocol, err := kibanaConfig.String("protocol", -1)
+	assert.NoError(t, err)
 	host, err := kibanaConfig.String("host", -1)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "elastic-test-username", username)
 	assert.Equal(t, "elastic-test-password", password)


### PR DESCRIPTION
This is arguably a bug fix.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This change ensures that the test config is owner-exclusive write before running the test. It also adds checks to currently ineffective error assignments.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Git does not store r/w permissions, instead depending on the host system's umask. On some systems the default umask is 0o002, meaning that the test config file is checked out with g+w permission, causing the test to fail.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Standard testing

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `go test` in github.com/elastic/beats/libbeat/cmd/instance.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

No related issues.

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

```
Feature: Test initializing kibana config on system with permissive umask

    Scenario Outline: A contributor runs the test suite on the beats repository
        Given a host environment with a umask that is <umask>
        And the contributor clones github.com/elastic/beats
        Then the beats beats/libbeat/cmd/instance.TestInitKibanaConfig test will pass

    Examples:
        | umask |
        | 0o000 |
        | 0o002 |
        | 0o022 |
```

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A