### PR TITLE
[Elastic Agent] Do not watch monitors

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/app"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/noop"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/service"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
@@ -293,6 +294,13 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 	// TODO: (michal) join args into more compact options version
 	var a Application
 	var err error
+
+	monitor := o.monitor
+	if app.IsSidecar(p) {
+		// make watchers unmonitorable
+		monitor = noop.NewMonitor()
+	}
+
 	if p.ServicePort() == 0 {
 		// Applications without service ports defined are ran as through the process application type.
 		a, err = process.NewApplication(
@@ -306,7 +314,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 			o.config,
 			o.logger,
 			o.reporter,
-			o.monitor,
+			monitor,
 			o.statusController)
 	} else {
 		// Service port is defined application is ran with service application type, with it fetching
@@ -323,7 +331,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 			o.config,
 			o.logger,
 			o.reporter,
-			o.monitor,
+			monitor,
 			o.statusController)
 	}
 


### PR DESCRIPTION
## What does this PR do?

WHen monitors were enabled monitoring of simple filebeat and metricbeat was configured and should not.
This resulted in socket not found because metricbeat was told to keep an eye on metricbeat.sock but it was not available as simple metricbeat was not running.

This PR does not configure monitoring beat to watch for simple beat if simple beat is not actually running

## Why is it important?

Fixes: https://github.com/elastic/beats/issues/27127

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
