### PR TITLE
[Enhancement] Unifying path variables

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - MacOSX minimum supported version set to 10.14 {issue}24193{24193}
 - Add daemonset.name in pods controlled by DaemonSets {pull}26808[26808], {issue}25816[25816]
 - Kubernetes autodiscover fails in node scope if node name cannot be discovered {pull}26947[26947]
+- unifying path variables in install-service.ps1 template
 
 *Auditbeat*
 

--- a/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
+++ b/dev-tools/packaging/templates/windows/install-service.ps1.tmpl
@@ -11,7 +11,7 @@ $workdir = Split-Path $MyInvocation.MyCommand.Path
 # Create the new service.
 New-Service -name {{.BeatName}} `
   -displayName {{.BeatName | title}} `
-  -binaryPathName "`"$workdir\{{.BeatName}}.exe`" --environment=windows_service -c `"$workdir\{{.BeatName}}.yml`" --path.home `"$workdir`" --path.data `"$env:PROGRAMDATA\{{.BeatName}}`" --path.logs `"$env:PROGRAMDATA\{{.BeatName}}\logs`" -E logging.files.redirect_stderr=true"
+  -binaryPathName "`"$workdir\{{.BeatName}}.exe`" --environment=windows_service -c `"$workdir\{{.BeatName}}.yml`" --path.home `"$workdir`" --path.data `"$workdir`" --path.logs `"$workdir\logs`" -E logging.files.redirect_stderr=true"
 
 # Attempt to set the service to delayed start using sc config.
 Try {


### PR DESCRIPTION
[Enhancement] Unifying path variables

While `path.home` was set to `$workdir`, path.data was in `$env:PROGRAMDATA\{{.BeatName}}` and `path.logs`  in `$env:PROGRAMDATA\{{.BeatName}}\logs`. By default the latter should be located in `$workdir` and not in a seperate directory.

## What does this PR do?

path.home is located in $workdir. This moves path.data and path.logs also into $workdir instead of $env:PROGRAMDATA.

## Why is it important?

If $workdir is configured to something else like c:\ProgramData, logs and data directory would remain there while the rest moves to the location $workdir. By default users would expect to move those along with the changed directory.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
