### PR TITLE
[7.x](backport #27192) [Elastic Agent] Do not watch monitors

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/app"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/monitoring/noop"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/process"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/plugin/service"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/server"
@@ -293,6 +294,13 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 	// TODO: (michal) join args into more compact options version
 	var a Application
 	var err error
+
+	monitor := o.monitor
+	if app.IsSidecar(p) {
+		// make watchers unmonitorable
+		monitor = noop.NewMonitor()
+	}
+
 	if p.ServicePort() == 0 {
 		// Applications without service ports defined are ran as through the process application type.
 		a, err = process.NewApplication(
@@ -306,7 +314,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 			o.config,
 			o.logger,
 			o.reporter,
-			o.monitor,
+			monitor,
 			o.statusController)
 	} else {
 		// Service port is defined application is ran with service application type, with it fetching
@@ -323,7 +331,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 			o.config,
 			o.logger,
 			o.reporter,
-			o.monitor,
+			monitor,
 			o.statusController)
 	}
 


### PR DESCRIPTION
This is an automatic backport of pull request #27192 done by [Mergify](https://mergify.io).


---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://docs.mergify.io/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR on its base branch
- `@Mergifyio update` will merge the base branch into this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the config editor.

Finally, you can contact us on https://mergify.io/
</details>
