### PR TITLE
Fix serialization/deserialization of proxy URI

### DIFF
--- a/libbeat/common/transport/httpcommon/httpcommon.go
+++ b/libbeat/common/transport/httpcommon/httpcommon.go
@@ -241,7 +241,7 @@ func (settings *HTTPTransportSettings) httpRoundTripper(
 	t.TLSClientConfig = tls.ToConfig()
 	t.ForceAttemptHTTP2 = false
 	t.Proxy = settings.Proxy.ProxyFunc()
-	t.ProxyConnectHeader = settings.Proxy.Headers
+	t.ProxyConnectHeader = settings.Proxy.Headers.Headers()
 
 	//  reset some internal timeouts to not change old Beats defaults
 	t.TLSHandshakeTimeout = 0

--- a/libbeat/common/transport/httpcommon/httpcommon.go
+++ b/libbeat/common/transport/httpcommon/httpcommon.go
@@ -352,7 +352,7 @@ func WithNOProxy() TransportOption {
 // NO_PROXY envionrment variables. Explicitely configured proxy URLs will still applied.
 func WithoutProxyEnvironmentVariables() TransportOption {
 	return transportOptFunc(func(settings *HTTPTransportSettings, t *http.Transport) {
-		if settings.Proxy.Disable || settings.Proxy.URL == nil {
+		if settings.Proxy.Disable || settings.Proxy.URL == "" {
 			t.Proxy = nil
 		}
 	})

--- a/libbeat/common/transport/httpcommon/httpcommon.go
+++ b/libbeat/common/transport/httpcommon/httpcommon.go
@@ -352,7 +352,7 @@ func WithNOProxy() TransportOption {
 // NO_PROXY envionrment variables. Explicitely configured proxy URLs will still applied.
 func WithoutProxyEnvironmentVariables() TransportOption {
 	return transportOptFunc(func(settings *HTTPTransportSettings, t *http.Transport) {
-		if settings.Proxy.Disable || settings.Proxy.URL == "" {
+		if settings.Proxy.Disable || settings.Proxy.URL == nil {
 			t.Proxy = nil
 		}
 	})

--- a/libbeat/common/transport/httpcommon/proxy.go
+++ b/libbeat/common/transport/httpcommon/proxy.go
@@ -49,19 +49,13 @@ type HTTPClientProxySettings struct {
 
 // NewHTTPClientProxySettings creates a new proxy settings based on provided proxy information.
 func NewHTTPClientProxySettings(url string, headers map[string]string, disable bool) (*HTTPClientProxySettings, error) {
-	proxyURI, err := common.ParseURL(url)
+	proxyURI, err := NewProxyURIFromString(url)
 	if err != nil {
 		return nil, err
 	}
 
-	var uri *ProxyURI
-	if proxyURI != nil {
-		pu := ProxyURI(*proxyURI)
-		uri = &pu
-	}
-
 	return &HTTPClientProxySettings{
-		URL:     uri,
+		URL:     proxyURI,
 		Headers: ProxyHeaders(headers),
 		Disable: disable,
 	}, nil

--- a/libbeat/common/transport/httpcommon/proxy.go
+++ b/libbeat/common/transport/httpcommon/proxy.go
@@ -40,7 +40,7 @@ type HTTPClientProxySettings struct {
 
 	// Headers configures additonal headers that are send to the proxy
 	// during CONNECT requests.
-	Headers http.Header `config:"proxy_headers" yaml:"proxy_headers,omitempty"`
+	Headers ProxyHeaders `config:"proxy_headers" yaml:"proxy_headers,omitempty"`
 
 	// Disable HTTP proxy support. Configured URLs and environment variables
 	// are ignored.
@@ -54,14 +54,6 @@ func NewHTTPClientProxySettings(url string, headers map[string]string, disable b
 		return nil, err
 	}
 
-	var httpHeaders http.Header
-	if len(headers) > 0 {
-		httpHeaders = http.Header{}
-		for k, v := range headers {
-			httpHeaders.Add(k, v)
-		}
-	}
-
 	var uri *ProxyURI
 	if proxyURI != nil {
 		pu := ProxyURI(*proxyURI)
@@ -70,7 +62,7 @@ func NewHTTPClientProxySettings(url string, headers map[string]string, disable b
 
 	return &HTTPClientProxySettings{
 		URL:     uri,
-		Headers: httpHeaders,
+		Headers: ProxyHeaders(headers),
 		Disable: disable,
 	}, nil
 }

--- a/libbeat/common/transport/httpcommon/proxy.go
+++ b/libbeat/common/transport/httpcommon/proxy.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
+// ProxyURI is a URL used for proxy serialized as a string.
 type ProxyURI url.URL
 
 // HTTPClientProxySettings provides common HTTP proxy setup support.

--- a/libbeat/common/transport/httpcommon/proxy.go
+++ b/libbeat/common/transport/httpcommon/proxy.go
@@ -63,7 +63,9 @@ func NewHTTPClientProxySettings(url string, headers map[string]string, disable b
 
 // DefaultHTTPClientProxySettings returns the default HTTP proxy setting.
 func DefaultHTTPClientProxySettings() HTTPClientProxySettings {
-	return HTTPClientProxySettings{}
+	return HTTPClientProxySettings{
+		Headers: make(ProxyHeaders),
+	}
 }
 
 // Unpack sets the proxy settings from a config object.

--- a/libbeat/common/transport/httpcommon/proxy.go
+++ b/libbeat/common/transport/httpcommon/proxy.go
@@ -24,9 +24,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-// ProxyURI is a URL used for proxy serialized as a string.
-type ProxyURI url.URL
-
 // HTTPClientProxySettings provides common HTTP proxy setup support.
 //
 // Proxy usage will be disabled in general if Disable is set.
@@ -48,18 +45,6 @@ type HTTPClientProxySettings struct {
 	// Disable HTTP proxy support. Configured URLs and environment variables
 	// are ignored.
 	Disable bool `config:"proxy_disable" yaml:"proxy_disable,omitempty"`
-}
-
-// MarshalYAML serializes URI as a string.
-func (p ProxyURI) MarshalYAML() (interface{}, error) {
-	u := url.URL(p)
-	return u.String(), nil
-}
-
-// URI returns conventional url.URL structure.
-func (p ProxyURI) URI() *url.URL {
-	uri := url.URL(p)
-	return &uri
 }
 
 // NewHTTPClientProxySettings creates a new proxy settings based on provided proxy information.

--- a/libbeat/common/transport/httpcommon/proxy.go
+++ b/libbeat/common/transport/httpcommon/proxy.go
@@ -50,16 +50,19 @@ type HTTPClientProxySettings struct {
 	Disable bool `config:"proxy_disable" yaml:"proxy_disable,omitempty"`
 }
 
+// MarshalYAML serializes URI as a string.
 func (p ProxyURI) MarshalYAML() (interface{}, error) {
 	u := url.URL(p)
 	return u.String(), nil
 }
 
+// URI returns conventional url.URL structure.
 func (p ProxyURI) URI() *url.URL {
 	uri := url.URL(p)
 	return &uri
 }
 
+// NewHTTPClientProxySettings creates a new proxy settings based on provided proxy information.
 func NewHTTPClientProxySettings(url string, headers map[string]string, disable bool) (*HTTPClientProxySettings, error) {
 	proxyURI, err := common.ParseURL(url)
 	if err != nil {

--- a/libbeat/common/transport/httpcommon/proxy_headers.go
+++ b/libbeat/common/transport/httpcommon/proxy_headers.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package httpcommon
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+// ProxyHeaders is a headers for proxy serialized as a map[string]string.
+type ProxyHeaders map[string]string
+
+// MarshalYAML serializes URI as a string.
+func (p ProxyHeaders) MarshalYAML() (interface{}, error) {
+	return p, nil
+}
+
+// MarshalJSON serializes URI as a string.
+func (p ProxyHeaders) MarshalJSON() ([]byte, error) {
+	var m map[string]string = p
+	return json.Marshal(m)
+}
+
+// Unpack unpacks string into an proxy URI.
+func (p *ProxyHeaders) Unpack(cfg *common.Config) error {
+	m := make(map[string]string)
+	if err := cfg.Unpack(&m); err != nil {
+		return err
+	}
+
+	*p = m
+	return nil
+}
+
+// UnmarshalJSON unpacks string into an proxy URI.
+func (p *ProxyHeaders) UnmarshalJSON(b []byte) error {
+	m := make(map[string]string)
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return err
+	}
+
+	*p = m
+	return nil
+}
+
+// UnmarshalYAML unpacks string into an proxy URI.
+func (p *ProxyHeaders) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	m := make(map[string]string)
+	if err := unmarshal(&m); err != nil {
+		return err
+	}
+
+	*p = m
+	return nil
+}
+
+// URI returns conventional url.URL structure.
+func (p ProxyHeaders) Headers() http.Header {
+	var httpHeaders http.Header
+	if p != nil && len(p) > 0 {
+		httpHeaders = http.Header{}
+		for k, v := range p {
+			httpHeaders.Add(k, v)
+		}
+	}
+
+	return httpHeaders
+}

--- a/libbeat/common/transport/httpcommon/proxy_headers_test.go
+++ b/libbeat/common/transport/httpcommon/proxy_headers_test.go
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package httpcommon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestYamlSerializeDeserializeProxyHeaders(t *testing.T) {
+	raw := `key1: value1
+key2: value2
+`
+	var proxyHeaders ProxyHeaders
+	err := yaml.Unmarshal([]byte(raw), &proxyHeaders)
+	require.NoError(t, err)
+
+	out, err := yaml.Marshal(proxyHeaders)
+	require.NoError(t, err)
+	require.Equal(t, raw, string(out))
+}
+
+func TestJSONSerializeDeserializeProxyHeaders(t *testing.T) {
+	raw := `{"key1":"value1","key2":"value2"}`
+
+	var proxyHeaders ProxyHeaders
+	err := json.Unmarshal([]byte(raw), &proxyHeaders)
+	require.NoError(t, err)
+
+	out, err := json.Marshal(proxyHeaders)
+	require.NoError(t, err)
+	require.Equal(t, raw, string(out))
+}

--- a/libbeat/common/transport/httpcommon/proxy_uri.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri.go
@@ -18,11 +18,9 @@
 package httpcommon
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/url"
 	"strings"
-
-	"github.com/elastic/beats/v7/libbeat/common"
 )
 
 // ProxyURI is a URL used for proxy serialized as a string.
@@ -43,38 +41,36 @@ func NewProxyURIFromURL(u url.URL) *ProxyURI {
 }
 
 // MarshalYAML serializes URI as a string.
-func (p ProxyURI) MarshalYAML() (interface{}, error) {
-	u := url.URL(p)
+func (p *ProxyURI) MarshalYAML() (interface{}, error) {
+	u := url.URL(*p)
 	return u.String(), nil
 }
 
 // MarshalJSON serializes URI as a string.
-func (p ProxyURI) MarshalJSON() ([]byte, error) {
-	u := url.URL(p)
-	fmt.Println(u.String())
-	return []byte(fmt.Sprintf("\"%s\"", u.String())), nil
+func (p *ProxyURI) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
 }
 
 // Unpack unpacks string into an proxy URI.
 func (p *ProxyURI) Unpack(s string) error {
-	uri, err := stringToProxyURI(s)
+	uri, err := NewProxyURIFromString(s)
 	if err != nil {
 		return err
 	}
 
-	*p = uri
+	*p = *uri
 	return nil
 }
 
 // UnmarshalJSON unpacks string into an proxy URI.
 func (p *ProxyURI) UnmarshalJSON(b []byte) error {
 	unqoted := strings.Trim(string(b), `"`)
-	uri, err := stringToProxyURI(unqoted)
+	uri, err := NewProxyURIFromString(unqoted)
 	if err != nil {
 		return err
 	}
 
-	*p = uri
+	*p = *uri
 	return nil
 }
 
@@ -85,12 +81,12 @@ func (p *ProxyURI) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	uri, err := stringToProxyURI(rawURI)
+	uri, err := NewProxyURIFromString(rawURI)
 	if err != nil {
 		return err
 	}
 
-	*p = uri
+	*p = *uri
 	return nil
 }
 
@@ -99,11 +95,7 @@ func (p *ProxyURI) URI() *url.URL {
 	return (*url.URL)(p)
 }
 
-func stringToProxyURI(s string) (ProxyURI, error) {
-	proxyURI, err := common.ParseURL(s)
-	if err != nil {
-		return ProxyURI{}, err
-	}
-
-	return ProxyURI(*proxyURI), nil
+// MarshalJSON serializes URI as a string.
+func (p *ProxyURI) String() string {
+	return p.URI().String()
 }

--- a/libbeat/common/transport/httpcommon/proxy_uri.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri.go
@@ -81,9 +81,8 @@ func (p *ProxyURI) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // URI returns conventional url.URL structure.
-func (p ProxyURI) URI() *url.URL {
-	uri := url.URL(p)
-	return &uri
+func (p *ProxyURI) URI() *url.URL {
+	return (*url.URL)(p)
 }
 
 func stringToProxyURI(s string) (ProxyURI, error) {

--- a/libbeat/common/transport/httpcommon/proxy_uri.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri.go
@@ -28,8 +28,8 @@ type ProxyURI url.URL
 
 func NewProxyURIFromString(s string) (*ProxyURI, error) {
 	u, err := url.Parse(s)
-	if err != nil {
-		return &ProxyURI{}, err
+	if err != nil || u == nil {
+		return nil, err
 	}
 
 	return NewProxyURIFromURL(*u), nil

--- a/libbeat/common/transport/httpcommon/proxy_uri.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri.go
@@ -1,0 +1,96 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package httpcommon
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+// ProxyURI is a URL used for proxy serialized as a string.
+type ProxyURI url.URL
+
+// MarshalYAML serializes URI as a string.
+func (p ProxyURI) MarshalYAML() (interface{}, error) {
+	u := url.URL(p)
+	return u.String(), nil
+}
+
+// MarshalJSON serializes URI as a string.
+func (p ProxyURI) MarshalJSON() ([]byte, error) {
+	u := url.URL(p)
+	fmt.Println(u.String())
+	return []byte(fmt.Sprintf("\"%s\"", u.String())), nil
+}
+
+// Unpack unpacks string into an proxy URI.
+func (p *ProxyURI) Unpack(s string) error {
+	uri, err := stringToProxyURI(s)
+	if err != nil {
+		return err
+	}
+
+	*p = uri
+	return nil
+}
+
+// UnmarshalJSON unpacks string into an proxy URI.
+func (p *ProxyURI) UnmarshalJSON(b []byte) error {
+	unqoted := strings.Trim(string(b), `"`)
+	uri, err := stringToProxyURI(unqoted)
+	if err != nil {
+		return err
+	}
+
+	*p = uri
+	return nil
+}
+
+// UnmarshalYAML unpacks string into an proxy URI.
+func (p *ProxyURI) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	rawURI := ""
+	if err := unmarshal(&rawURI); err != nil {
+		return err
+	}
+
+	uri, err := stringToProxyURI(rawURI)
+	if err != nil {
+		return err
+	}
+
+	*p = uri
+	return nil
+}
+
+// URI returns conventional url.URL structure.
+func (p ProxyURI) URI() *url.URL {
+	uri := url.URL(p)
+	return &uri
+}
+
+func stringToProxyURI(s string) (ProxyURI, error) {
+	proxyURI, err := common.ParseURL(s)
+	if err != nil {
+		return ProxyURI{}, err
+	}
+
+	return ProxyURI(*proxyURI), nil
+}

--- a/libbeat/common/transport/httpcommon/proxy_uri.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri.go
@@ -27,6 +27,10 @@ import (
 type ProxyURI url.URL
 
 func NewProxyURIFromString(s string) (*ProxyURI, error) {
+	if s == "" {
+		return nil, nil
+	}
+
 	u, err := url.Parse(s)
 	if err != nil || u == nil {
 		return nil, err
@@ -36,6 +40,10 @@ func NewProxyURIFromString(s string) (*ProxyURI, error) {
 }
 
 func NewProxyURIFromURL(u url.URL) *ProxyURI {
+	if u == (url.URL{}) {
+		return nil
+	}
+
 	p := ProxyURI(u)
 	return &p
 }

--- a/libbeat/common/transport/httpcommon/proxy_uri.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri.go
@@ -28,6 +28,20 @@ import (
 // ProxyURI is a URL used for proxy serialized as a string.
 type ProxyURI url.URL
 
+func NewProxyURIFromString(s string) (*ProxyURI, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return &ProxyURI{}, err
+	}
+
+	return NewProxyURIFromURL(*u), nil
+}
+
+func NewProxyURIFromURL(u url.URL) *ProxyURI {
+	p := ProxyURI(u)
+	return &p
+}
+
 // MarshalYAML serializes URI as a string.
 func (p ProxyURI) MarshalYAML() (interface{}, error) {
 	u := url.URL(p)

--- a/libbeat/common/transport/httpcommon/proxy_uri_test.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri_test.go
@@ -52,3 +52,19 @@ func TestJSONSerializeDeserialize(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, raw, string(out))
 }
+
+func TestYamlSerializeDeserializeSettings(t *testing.T) {
+	raw := `proxy_url: http://localhost:8080/path
+proxy_headers:
+  key: val
+proxy_disable: true
+`
+
+	s := &HTTPClientProxySettings{}
+	err := yaml.Unmarshal([]byte(raw), &s)
+	require.NoError(t, err)
+
+	out, err := yaml.Marshal(s)
+	require.NoError(t, err)
+	require.Equal(t, raw, string(out))
+}

--- a/libbeat/common/transport/httpcommon/proxy_uri_test.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestYamlSerializeDeserialize(t *testing.T) {
 	raw := "http://localhost:8080/path\n"
-	var proxyURI ProxyURI
+	var proxyURI *ProxyURI
 	err := yaml.Unmarshal([]byte(raw), &proxyURI)
 	require.NoError(t, err)
 
@@ -38,10 +38,10 @@ func TestYamlSerializeDeserialize(t *testing.T) {
 
 func TestJSONSerializeDeserialize(t *testing.T) {
 	raw := `{"proxy_uri":"http://localhost:8080/path"}`
-	proxyURI, err := stringToProxyURI("http://localhost:8080/path")
+	proxyURI, err := NewProxyURIFromString("http://localhost:8080/path")
 	require.NoError(t, err)
 	s := struct {
-		P ProxyURI `json:"proxy_uri"`
+		P *ProxyURI `json:"proxy_uri"`
 	}{
 		P: proxyURI,
 	}

--- a/libbeat/common/transport/httpcommon/proxy_uri_test.go
+++ b/libbeat/common/transport/httpcommon/proxy_uri_test.go
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package httpcommon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestYamlSerializeDeserialize(t *testing.T) {
+	raw := "http://localhost:8080/path\n"
+	var proxyURI ProxyURI
+	err := yaml.Unmarshal([]byte(raw), &proxyURI)
+	require.NoError(t, err)
+
+	out, err := yaml.Marshal(proxyURI)
+	require.NoError(t, err)
+	require.Equal(t, raw, string(out))
+}
+
+func TestJSONSerializeDeserialize(t *testing.T) {
+	raw := `{"proxy_uri":"http://localhost:8080/path"}`
+	proxyURI, err := stringToProxyURI("http://localhost:8080/path")
+	require.NoError(t, err)
+	s := struct {
+		P ProxyURI `json:"proxy_uri"`
+	}{
+		P: proxyURI,
+	}
+	err = json.Unmarshal([]byte(raw), &s)
+	require.NoError(t, err)
+
+	out, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.Equal(t, raw, string(out))
+}

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -167,7 +167,7 @@ func NewClients(cfg *common.Config) ([]Connection, error) {
 	}
 
 	if proxyURL := config.Transport.Proxy.URL; proxyURL != nil {
-		logp.Info("using proxy URL: %s", proxyURL)
+		logp.Info("using proxy URL: %s", proxyURL.URI().String())
 	}
 
 	params := config.Params

--- a/libbeat/esleg/eslegclient/connection_integration_test.go
+++ b/libbeat/esleg/eslegclient/connection_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegtest"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 )
@@ -116,9 +117,9 @@ func connectTestEs(t *testing.T, cfg interface{}) (*Connection, error) {
 	s.Transport.Timeout = time.Duration(timeout) * time.Second
 
 	if proxy != "" {
-		p, err := url.Parse(proxy)
+		proxyURI, err := httpcommon.NewProxyURIFromString(proxy)
 		require.NoError(t, err)
-		s.Transport.Proxy.URL = p
+		s.Transport.Proxy.URL = proxyURI
 	}
 
 	return NewConnection(s)

--- a/libbeat/outputs/elasticsearch/client_proxy_test.go
+++ b/libbeat/outputs/elasticsearch/client_proxy_test.go
@@ -198,9 +198,11 @@ func doClientPing(t *testing.T) {
 		Index: outil.MakeSelector(outil.ConstSelectorExpr("test", outil.SelectorLowerCase)),
 	}
 	if proxy != "" {
-		proxyURL, err := url.Parse(proxy)
+		u, err := url.Parse(proxy)
 		require.NoError(t, err)
-		clientSettings.Transport.Proxy.URL = proxyURL
+		proxyURL := httpcommon.ProxyURI(*u)
+
+		clientSettings.Transport.Proxy.URL = &proxyURL
 	}
 	client, err := NewClient(clientSettings, nil)
 	require.NoError(t, err)

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -11,15 +11,12 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
-	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"time"
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/backoff"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
@@ -128,27 +125,12 @@ func (e *enrollCmdOption) remoteConfig() (remote.Config, error) {
 
 	cfg.Transport.TLS = &tlsCfg
 
-	var proxyURL *url.URL
-	if e.ProxyURL != "" {
-		proxyURL, err = common.ParseURL(e.ProxyURL)
-		if err != nil {
-			return remote.Config{}, err
-		}
+	proxySettings, err := httpcommon.NewHTTPClientProxySettings(e.ProxyURL, e.ProxyHeaders, e.ProxyDisabled)
+	if err != nil {
+		return remote.Config{}, err
 	}
 
-	var headers http.Header
-	if len(e.ProxyHeaders) > 0 {
-		headers = http.Header{}
-		for k, v := range e.ProxyHeaders {
-			headers.Add(k, v)
-		}
-	}
-
-	cfg.Transport.Proxy = httpcommon.HTTPClientProxySettings{
-		URL:     proxyURL,
-		Disable: e.ProxyDisabled,
-		Headers: headers,
-	}
+	cfg.Transport.Proxy = *proxySettings
 
 	return cfg, nil
 }


### PR DESCRIPTION
## What does this PR do?

This PR makes sure proxy URI is serialized as string as it is expected to be a string when unpacking value from config

## Why is it important?

Fixes: https://github.com/elastic/beats/issues/27187

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
