### PR TITLE
Osquerybeat: Add support for input/integration level osquery platform/version/discovery configuration

### DIFF
--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -110,7 +110,10 @@ type query struct {
 }
 
 type pack struct {
-	Queries map[string]query `json:"queries,omitempty"`
+	Discovery []string         `json:"discovery,omitempty"`
+	Platform  string           `json:"platform,omitempty"`
+	Version   string           `json:"version,omitempty"`
+	Queries   map[string]query `json:"queries,omitempty"`
 }
 
 type osqueryConfig struct {
@@ -151,7 +154,10 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) error {
 	p.packs = make(map[string]pack)
 	for _, input := range inputs {
 		pack := pack{
-			Queries: make(map[string]query),
+			Queries:   make(map[string]query),
+			Platform:  input.Platform,
+			Version:   input.Version,
+			Discovery: input.Discovery,
 		}
 		for _, stream := range input.Streams {
 			id := "pack_" + input.Name + "_" + stream.ID

--- a/x-pack/osquerybeat/internal/config/config.go
+++ b/x-pack/osquerybeat/internal/config/config.go
@@ -35,6 +35,9 @@ type InputConfig struct {
 	Type       string                  `config:"type"`
 	Streams    []StreamConfig          `config:"streams"`
 	Processors processors.PluginConfig `config:"processors"`
+	Platform   string                  `config:"iplatform"` // restrict all queries to a given platform, default is 'all' platforms; you may use commas to set multiple platforms
+	Version    string                  `config:"iversion"`  // only run the queries with osquery versions greater than or equal-to this version string
+	Discovery  []string                `config:"discovery"` // a list of discovery queries https://osquery.readthedocs.io/en/stable/deployment/configuration/#discovery-queries
 }
 
 type Config struct {


### PR DESCRIPTION
## What does this PR do?

Add support for input/integration level osquery platform/version/discovery configuration.
This allows to map the integration configuration to the osquery packs 1:1.
The ```platform``` and ```version``` constraints at the input level had to have a different name currently in order to avoid these values to be injected in every stream instead, that's why the names are ```iplatform``` and ```iversion``` as abbreviation for the ```input platform``` and the ```input version```.

This change requires the updated osquery_manager integration https://github.com/elastic/integrations/pull/1441
and is also couple of more fixes on kibana side:
1. kibana needs to be able to create integration configuration with empty vars, currently it returns error when you try to add updated osquery_manager integration into the policy.
2. the configuration page for osquery maanger needs to remove compiled_input from the payload from the input request payload when updating the integrations configurations

This change can be merged before the work mentioned above, the new constraints just would get propagated with the the policy and would not apply to the osquery configuration without those changes.

Here is an example of the request payload with the new constraints:
```
{
    "name": "osquery_manager-1",
    "description": "",
    "policy_id": "548a3940-df4e-11eb-8fdd-b98cebb63257",
    "namespace": "default",
    "inputs": [
        {
            "type": "osquery",
            "enabled": true,
            "streams": [
                {
                    "data_stream": {
                        "type": "logs",
                        "dataset": "osquery_manager.result"
                    },
                    "id": "osquery-osquery_manager.result-ce361ed0-559c-4549-a71c-c48dd64a12d3",
                    "vars": {
                        "query": {
                            "type": "text",
                            "value": "select * from users limit 5"
                        },
                        "interval": {
                            "type": "integer",
                            "value": "60"
                        },
                        "id": {
                            "type": "text",
                            "value": "users"
                        }
                    },
                    "enabled": true
                }
            ],
            "policy_template": "osquery_manager",
            "vars": {
                "iplatform": {
                    "type": "text",
                    "value": "posix"
                },
                "discovery": {
                    "type": "text",
                    "value": [
                        "SELECT pid FROM processes WHERE name = 'osquerybeat';",
                        "SELECT 1 FROM users WHERE username like 'amau%';"
                    ]
                },
                "iversion": {
                    "type": "text",
                    "value": "4.7.0"
                }
            }
        }
    ],
    "enabled": true,
    "output_id": "",
    "package": {
        "name": "osquery_manager",
        "title": "Osquery Manager",
        "version": "0.5.1"
    }
}
```

Here is the screenshot of the policy configuration with the new ```input level``` constraints
<img width="563" alt="Screen Shot 2021-08-04 at 8 38 20 AM" src="https://user-images.githubusercontent.com/872351/128193790-7eab247a-bad1-40d4-bddd-4b789970de97.png">

## Why is it important?

This is needed in order to support the osquery packs further configuration options.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] have added tests that prove my fix is effective or that my feature works


## Related issues
- Requires https://github.com/elastic/integrations/pull/1441


Special thanks to @nchaulet for working with me yesterday through undocumented obstacles of integration package changes and kibana errors. 

