### PR TITLE
Add host ID attribute to info and agent provider

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -127,3 +127,4 @@
 - Support Node and Service autodiscovery in kubernetes dynamic provider. {pull}26801[26801]
 - Increase Agent's mem limits in k8s. {pull}27153[27153]
 - Add new --enroll-delay option for install and enroll commands. {pull}27118[27118]
+- Add `host_id` to application info to allow the persistent identification for underlying hosts. {issue}26572[26572]

--- a/x-pack/elastic-agent/pkg/agent/application/info/agent_info.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/agent_info.go
@@ -12,6 +12,7 @@ import (
 // AgentInfo is a collection of information about agent.
 type AgentInfo struct {
 	agentID  string
+	hostID   string
 	logLevel string
 	headers  map[string]string
 }
@@ -28,8 +29,14 @@ func NewAgentInfoWithLog(level string, createAgentID bool) (*AgentInfo, error) {
 		return nil, err
 	}
 
+	hostID, err := loadHostID()
+	if err != nil {
+		return nil, err
+	}
+
 	return &AgentInfo{
 		agentID:  agentInfo.ID,
+		hostID:   hostID,
 		logLevel: agentInfo.LogLevel,
 		headers:  agentInfo.Headers,
 	}, nil
@@ -75,6 +82,11 @@ func (i *AgentInfo) ReloadID() error {
 // AgentID returns an agent identifier.
 func (i *AgentInfo) AgentID() string {
 	return i.agentID
+}
+
+// HostID returns a host identifier.
+func (i *AgentInfo) HostID() string {
+	return i.hostID
 }
 
 // Version returns the version for this Agent.

--- a/x-pack/elastic-agent/pkg/agent/application/info/host_id.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/host_id.go
@@ -2,10 +2,18 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+// +build !linux
+// +build !windows
+// +build !darwin
+// +build !freebsd
+// +build !netbsd
+// +build !openbsd
+
 package info
 
 import "errors"
 
+// loadHostID will return an error on systems that do not have a specific implementation.
 func loadHostID() (string, error) {
 	return "", errors.New("loadHostID unimplemented")
 }

--- a/x-pack/elastic-agent/pkg/agent/application/info/host_id.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/host_id.go
@@ -1,0 +1,11 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package info
+
+import "errors"
+
+func loadHostID() (string, error) {
+	return "", errors.New("loadHostID unimplemented")
+}

--- a/x-pack/elastic-agent/pkg/agent/application/info/host_id_bsd.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/host_id_bsd.go
@@ -1,0 +1,28 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+// +build freebsd netbsd openbsd
+
+package info
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+func loadHostID() (string, error) {
+	var mErr error
+	p, err := os.ReadFile("/etc/machine-id")
+	if err != nil {
+		mErr = multierror.Append(mErr, err)
+		c := exec.Command("kenv", "-q", "smbios.system.uuid")
+		p, err = c.Output()
+		if err != nil {
+			return "", multierror.Append(mErr, err)
+		}
+	}
+	return string(p), nil
+}

--- a/x-pack/elastic-agent/pkg/agent/application/info/host_id_darwin.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/host_id_darwin.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package info
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+)
+
+var macReg = regexp.MustCompile(`[\s]+"IOPlatformUUID" = "([\S]+)"`)
+
+func loadHostID() (string, error) {
+	c := exec.Command("Ioreg", "-rd1", "-c", "IOPlatformExpertDevice")
+	out, err := c.Output()
+	if err != nil {
+		return "", err
+	}
+	matches := macReg.FindSubmatch(out)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("unable to find IOPLatformUUID in %q", out)
+	}
+	return string(matches[1]), nil
+}

--- a/x-pack/elastic-agent/pkg/agent/application/info/host_id_linux.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/host_id_linux.go
@@ -1,0 +1,30 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package info
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+func loadHostID() (string, error) {
+	var mErr error
+	p, err := os.ReadFile("/var/lib/dbus/machine-id")
+	if err != nil {
+		mErr = multierror.Append(mErr, err)
+		p, err = os.ReadFile("/etc/machine-id")
+		if err != nil {
+			mErr = multierror.Append(mErr, err)
+			c := exec.Command("hostid") // used for rhel/centos6
+			p, err = c.Output()
+			if err != nil {
+				return "", multierror.Append(mErr, err)
+			}
+		}
+	}
+	return string(p), nil
+}

--- a/x-pack/elastic-agent/pkg/agent/application/info/host_id_windows.go
+++ b/x-pack/elastic-agent/pkg/agent/application/info/host_id_windows.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package info
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+)
+
+var winReg = regexp.MustCompile("[\\s]+MachineGuid[\\s]+REG_SZ[\\s]+([\\S]+)")
+
+func loadHostID() (string, error) {
+	c := exec.Command("Reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography", "/v", "MachineGuid")
+	out, err := c.Output()
+	if err != nil {
+		return "", err
+	}
+	matches := winReg.FindSubmatch(out)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("unable to find MachineGuid in output %q", out)
+	}
+	return string(matches[1]), nil
+}

--- a/x-pack/elastic-agent/pkg/composable/providers/agent/agent.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/agent/agent.go
@@ -27,7 +27,8 @@ func (*contextProvider) Run(comm corecomp.ContextProviderComm) error {
 		return err
 	}
 	err = comm.Set(map[string]interface{}{
-		"id": a.AgentID(),
+		"id":      a.AgentID(),
+		"host_id": a.HostID(),
 		"version": map[string]interface{}{
 			"version":    release.Version(),
 			"commit":     release.Commit(),


### PR DESCRIPTION
## What does this PR do?

Add a host identifier to the application info struct which is also used
by the agent provider.

## Why is it important?

Allows the host that the elastic-agent runs on to be identified in case of an unenroll + re-enrollment.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #26572 