### PR TITLE
Update generated file linux/memory.asciidoc

### DIFF
--- a/metricbeat/docs/modules/linux/memory.asciidoc
+++ b/metricbeat/docs/modules/linux/memory.asciidoc
@@ -9,7 +9,6 @@ beta[]
 
 include::../../../module/linux/memory/_meta/docs.asciidoc[]
 
-This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.
 
 ==== Fields
 


### PR DESCRIPTION
## What does this PR do?

This PR was just a run of `make update`, since the generated file `metricbeat/docs/modules/linux/memory.asciidoc` is out of sync at head.
