### PR TITLE
Fix cloudwatch metricset collecting duplicate data points

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -396,6 +396,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change vsphere.datastore.capacity.used.pct value to betweeen 0 and 1. {pull}23148[23148]
 - Allow metric prefix override per service in gcp module. {pull}26960[26960]
 - Change `server_status_path` default setting to `nginx_status` for the `nginx` module. {pull}26642[26642]
+- Fix cloudwatch metricset collecting duplicate data points. {pull}27248[27248]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1614,3 +1614,12 @@ func TestCreateEventsTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, timestamp, events[regionName+accountID+namespace].Timestamp)
 }
+
+func TestGetStartTimeEndTime(t *testing.T) {
+	m := MetricSet{}
+	m.CloudwatchConfigs = []Config{{Statistic: []string{"Average"}}}
+	m.MetricSet = &aws.MetricSet{Period: 5 * time.Minute}
+	m.logger = logp.NewLogger("test")
+	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period, m.MetricSet.Latency)
+	assert.Equal(t, 9*time.Minute+59*time.Second, endTime.Sub(startTime))
+}

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -29,9 +29,11 @@ func GetStartTimeEndTime(period time.Duration, latency time.Duration) (time.Time
 		endTime = endTime.Add(latency * -1)
 	}
 
-	// Set startTime double the period earlier than the endtime in order to
-	// make sure GetMetricDataRequest gets the latest data point for each metric.
-	return endTime.Add(period * -2), endTime
+	// Set startTime double the period plus one second earlier than the endTime in order to
+	// make sure GetMetricDataRequest gets the latest data point for each metric. The plus
+	// one second is to make sure the startTime of the next collect period is one second later
+	// than the endTime of last collection period. This is to avoid collecting duplicate data.
+	return endTime.Add(period*-2 + time.Second), endTime
 }
 
 // GetListMetricsOutput function gets listMetrics results from cloudwatch per namespace for each region.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When a CloudWatch data point lands on the start time or end time, it gets collected twice. This PR is to fix this bug by moving the start time by one second so the end time of the first collection period does not overlap with the start time of the second collection period.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/19126


