### PR TITLE
Osquerybeat: Add event.module into the result data

### DIFF
--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -48,6 +48,8 @@ const (
 	configurationRefreshIntervalSecs = 60
 
 	osqueryTimeout = 60 * time.Second
+
+	eventModule = "osquery_manager"
 )
 
 const (
@@ -439,6 +441,11 @@ func (bt *osquerybeat) publishEvents(index, actionID, responseID string, hits []
 			fields = ecsFields[i]
 		} else {
 			fields = common.MapStr{}
+		}
+
+		// Add event.module for ECS
+		fields["event"] = map[string]string{
+			"module": eventModule,
 		}
 
 		fields["type"] = bt.b.Info.Name


### PR DESCRIPTION
## What does this PR do?

Adds event.module into the result data

## Why is it important?
Addresses https://github.com/elastic/security-team/issues/1555

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/security-team/issues/1555

## Screenshots
<img width="613" alt="Screen Shot 2021-08-05 at 12 49 44 PM" src="https://user-images.githubusercontent.com/872351/128390014-bc1f55c6-8ab1-4d6a-adc5-4fdcf0da18bd.png">

