### PR TITLE
Osquerybeat: Add ECS Mapping support for ad-hoc/live queries

### DIFF
--- a/x-pack/osquerybeat/beater/action_handler.go
+++ b/x-pack/osquerybeat/beater/action_handler.go
@@ -7,10 +7,13 @@ package beater
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/config"
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/ecs"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/osqdcli"
 )
 
@@ -26,8 +29,9 @@ func (a *actionHandler) Name() string {
 }
 
 type actionData struct {
-	Query string
-	ID    string
+	Query      string
+	ID         string
+	ECSMapping ecs.Mapping
 }
 
 func actionDataFromRequest(req map[string]interface{}) (ad actionData, err error) {
@@ -46,9 +50,63 @@ func actionDataFromRequest(req map[string]interface{}) (ad actionData, err error
 					ad.Query = query
 				}
 			}
+			if v, ok := m["ecs_mapping"]; ok {
+				m, ok := v.(map[string]interface{})
+				if !ok {
+					return ad, ErrActionRequest
+				}
+				ecsm, err := convertActionDataECSMapping(m)
+				if err != nil {
+					return ad, err
+				}
+				ad.ECSMapping = ecsm
+			}
 		}
 	}
 	return ad, nil
+}
+
+func convertActionDataECSMapping(m map[string]interface{}) (ecsm ecs.Mapping, err error) {
+	ecsm = make(ecs.Mapping)
+	for k, v := range m {
+		k = strings.TrimSpace(k)
+		if k == "" {
+			return ecsm, ErrActionRequest
+		}
+		valmap, ok := v.(map[string]interface{})
+		if !ok {
+			return ecsm, ErrActionRequest
+		}
+
+		var (
+			val   interface{}
+			field string
+		)
+
+		if val, ok = valmap["field"]; ok {
+			// "field" can only be string
+			field, ok = val.(string)
+			if !ok {
+				return ecsm, ErrActionRequest
+			}
+			field = strings.TrimSpace(field)
+		}
+
+		value := valmap["value"]
+		if field != "" && value != nil {
+			return ecsm, ErrActionRequest
+		}
+
+		// Should have at field or value defined in the mapping object
+		if field == "" && value == nil {
+			return ecsm, ErrActionRequest
+		}
+		ecsm[k] = ecs.MappingInfo{
+			Field: field,
+			Value: value,
+		}
+	}
+	return
 }
 
 // Execute handles the action request.
@@ -74,16 +132,16 @@ func (a *actionHandler) execute(ctx context.Context, req map[string]interface{})
 	if err != nil {
 		return fmt.Errorf("%v: %w", err, ErrQueryExecution)
 	}
-	return a.executeQuery(ctx, config.DefaultStreamIndex, ad.ID, ad.Query, "", req)
+	return a.executeQuery(ctx, config.DefaultStreamIndex, ad, "", req)
 }
 
-func (a *actionHandler) executeQuery(ctx context.Context, index, id, query, responseID string, req map[string]interface{}) error {
+func (a *actionHandler) executeQuery(ctx context.Context, index string, ad actionData, responseID string, req map[string]interface{}) error {
 
-	a.log.Debugf("Execute query: %s", query)
+	a.log.Debugf("Execute query: %s", ad.Query)
 
 	start := time.Now()
 
-	hits, err := a.cli.Query(ctx, query)
+	hits, err := a.cli.Query(ctx, ad.Query)
 
 	if err != nil {
 		a.log.Errorf("Failed to execute query, err: %v", err)
@@ -92,9 +150,17 @@ func (a *actionHandler) executeQuery(ctx context.Context, index, id, query, resp
 
 	a.log.Debugf("Completed query in: %v", time.Since(start))
 
+	var ecsFields []common.MapStr
+	// If non-empty result and the ECSMapping is present
+	if len(hits) > 0 && len(ad.ECSMapping) > 0 {
+		ecsFields = make([]common.MapStr, len(hits))
+		for i, hit := range hits {
+			ecsFields[i] = common.MapStr(ad.ECSMapping.Map(ecs.Doc(hit)))
+		}
+	}
 	if err != nil {
 		return err
 	}
-	a.bt.publishEvents(index, id, responseID, hits, nil, req["data"])
+	a.bt.publishEvents(index, ad.ID, responseID, hits, ecsFields, req["data"])
 	return nil
 }

--- a/x-pack/osquerybeat/beater/action_handler_test.go
+++ b/x-pack/osquerybeat/beater/action_handler_test.go
@@ -1,0 +1,217 @@
+package beater
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/ecs"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestActionDataFromRequest(t *testing.T) {
+
+	tests := []struct {
+		Name       string
+		Req        map[string]interface{}
+		ActionData actionData
+		Err        error
+	}{
+		{
+			Name: "nil",
+			Req:  nil,
+			Err:  ErrActionRequest,
+		},
+		{
+			Name: "empty",
+			Req:  map[string]interface{}{},
+			Err:  ErrActionRequest,
+		},
+		{
+			Name: "valid",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+				},
+			},
+			ActionData: actionData{
+				ID:    "214f219d-d67c-4744-8eb1-0a812594263f",
+				Query: "select * from users limit 2",
+			},
+		},
+		{
+			Name: "ECS mapping nil",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query":       "select * from users limit 2",
+					"ecs_mapping": nil,
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping empty string",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query":       "select * from users limit 2",
+					"ecs_mapping": "",
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping empty",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query":       "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{},
+				},
+			},
+			ActionData: actionData{
+				ID:         "214f219d-d67c-4744-8eb1-0a812594263f",
+				Query:      "select * from users limit 2",
+				ECSMapping: ecs.Mapping{},
+			},
+		},
+		{
+			Name: "ECS mapping invalid",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping invalid, field spaces string",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{
+						"user.custom.shoeSize": map[string]interface{}{
+							"field": "      ",
+						},
+					},
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping invalid, key empty",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{
+						"": map[string]interface{}{
+							"field": "uid",
+						},
+					},
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping invalid, key spaces",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{
+						"  ": map[string]interface{}{
+							"field": "uid",
+						},
+					},
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping invalid, field non-string",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{
+						"user.custom.shoeSize": map[string]interface{}{
+							"field": 123,
+						},
+					},
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping invalid, both field and value defined",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{
+						"user.custom.shoeSize": map[string]interface{}{
+							"value": 48,
+							"field": "uid",
+						},
+					},
+				},
+			},
+			Err: ErrActionRequest,
+		},
+		{
+			Name: "ECS mapping valid",
+			Req: map[string]interface{}{
+				"id": "214f219d-d67c-4744-8eb1-0a812594263f",
+				"data": map[string]interface{}{
+					"query": "select * from users limit 2",
+					"ecs_mapping": map[string]interface{}{
+						"user.custom.shoeSize": map[string]interface{}{
+							"value": 48,
+						},
+						"user.id": map[string]interface{}{
+							"field": "uid",
+						},
+					},
+				},
+			},
+			ActionData: actionData{
+				ID:    "214f219d-d67c-4744-8eb1-0a812594263f",
+				Query: "select * from users limit 2",
+				ECSMapping: ecs.Mapping{
+					"user.custom.shoeSize": ecs.MappingInfo{
+						Value: int(48),
+					},
+					"user.id": ecs.MappingInfo{
+						Field: "uid",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			ad, err := actionDataFromRequest(tc.Req)
+			if tc.Err != nil {
+				if !errors.Is(err, tc.Err) {
+					t.Fatalf("unexpected error, want:%v, got %v", tc.Err, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal("unexpected error:", err)
+				}
+				diff := cmp.Diff(tc.ActionData, ad)
+				if diff != "" {
+					t.Fatal(diff)
+				}
+			}
+		})
+	}
+}

--- a/x-pack/osquerybeat/beater/action_handler_test.go
+++ b/x-pack/osquerybeat/beater/action_handler_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package beater
 
 import (


### PR DESCRIPTION
## What does this PR do?

Adds ECS Mapping support for ad-hoc/live queries for osquerybeat.

## Why is it important?

Support the use case where the customer can run/test the live query results with ECS mapping applied.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


Example of action with ecs_mapping:
```
POST .fleet-actions/_doc/
{
  "action_id": "214f219d-d67c-4744-8eb1-0a812594263f",
  "@timestamp": "2021-07-20T19:15:31.124Z",
  "expiration": "2021-12-25T00:36:30Z",
  "type" : "INPUT_ACTION",
  "input_type": "osquery",
  "timeout": 60,
  "agents": [
    "9c149708-54b6-4a5b-b818-ecadfd583e95"
  ],
  "data" : {
    "query" : "select * from users limit 2",
    "ecs_mapping" : {
      "user.custom.shoeSize": {
          "value": 48
      },
      "user.id": {
          "field": "uid"
      },
      "user.name": {
          "field": "username"
      }
    }
  },
  "user_id": "user-aleksmaus"
}
```

## Screenshots

Part of the result document for the action above with ECS mapping applied:

<img width="563" alt="Screen Shot 2021-08-05 at 3 11 49 PM" src="https://user-images.githubusercontent.com/872351/128412720-970a5b28-0aba-474d-bf14-4149ae7e93d8.png">
