### PR TITLE
[Metricbeat] gcp: use ServiceMetrixPrefix in field extractor too

### DIFF
--- a/x-pack/metricbeat/module/gcp/metrics/metricset.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset.go
@@ -7,7 +7,6 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 	"time"
 
@@ -64,13 +63,21 @@ type metricsConfig struct {
 
 // prefix returns the service metric prefix, falling back to the Google Cloud
 // monitoring service prefix when not specified.
+// The prefix is normalized to always end with '/'.
 func (mc metricsConfig) prefix() string {
 	prefix := mc.ServiceMetricPrefix
+
 	// NOTE: fallback to Google Cloud prefix for backward compatibility
 	// Prefix <service>.googleapis.com/ works only for Google Cloud metrics
 	// List: https://cloud.google.com/monitoring/api/metrics_gcp
 	if prefix == "" {
-		prefix = mc.ServiceName + ".googleapis.com"
+		prefix = mc.ServiceName + ".googleapis.com/"
+	}
+
+	// Final slash is part of prefix. Creating a prefix with final slash
+	// normalize the prefix for other use cases
+	if !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
 	}
 
 	return prefix
@@ -78,7 +85,7 @@ func (mc metricsConfig) prefix() string {
 
 // AddPrefixTo adds the required service metric prefix to the given metric
 func (mc metricsConfig) AddPrefixTo(metric string) string {
-	return path.Join(mc.prefix(), metric)
+	return mc.prefix() + metric
 }
 
 // RemovePrefixFrom removes service metric prefix from the given metric

--- a/x-pack/metricbeat/module/gcp/metrics/metricset_test.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset_test.go
@@ -43,3 +43,39 @@ func Test_metricsConfig_AddPrefixTo(t *testing.T) {
 		})
 	}
 }
+
+func Test_metricsConfig_RemovePrefixFrom(t *testing.T) {
+	metric := "awesome/metric"
+	tests := []struct {
+		name   string
+		fields metricsConfig
+		metric string
+		want   string
+	}{
+		{
+			name:   "only service name",
+			fields: fakeMetricsConfig[0],
+			metric: "billing.googleapis.com/" + metric,
+			want:   metric,
+		},
+		{
+			name:   "service metric prefix override",
+			fields: fakeMetricsConfig[1],
+			metric: "foobar/" + metric,
+			want:   metric,
+		},
+		{
+			name:   "service metric prefix override (without trailing /)",
+			fields: fakeMetricsConfig[2],
+			metric: "foobar/" + metric,
+			want:   metric,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fields.RemovePrefixFrom(metric); got != tt.want {
+				t.Errorf("metricsConfig.RemovePrefixFrom(%s) = %v, want %v", metric, got, tt.want)
+			}
+		})
+	}
+}

--- a/x-pack/metricbeat/module/gcp/metrics/response_parser_test.go
+++ b/x-pack/metricbeat/module/gcp/metrics/response_parser_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestCleanMetricNameString(t *testing.T) {
+	computeMC := metricsConfig{"compute", "", []string{}, ""}
+
 	cases := []struct {
 		title              string
 		metricType         string
@@ -33,7 +35,7 @@ func TestCleanMetricNameString(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			metricName := cleanMetricNameString(c.metricType, c.aligner)
+			metricName := cleanMetricNameString(c.metricType, c.aligner, computeMC)
 			assert.Equal(t, c.expectedMetricName, metricName)
 		})
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes a bug introduced with #26960 

## Why is it important?

#26960 was a partial implementation of the feature: it was missing a code change to use `ServiceMetricPrefix` in `incomingFieldExtractor`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Run `go test -v ./module/gcp/metrics/`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
