### PR TITLE
Pass correct config to standalone

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/application.go
+++ b/x-pack/elastic-agent/pkg/agent/application/application.go
@@ -73,7 +73,7 @@ func createApplication(
 
 	if configuration.IsStandalone(cfg.Fleet) {
 		log.Info("Agent is managed locally")
-		return newLocal(ctx, log, pathConfigFile, rawConfig, reexec, statusCtrl, uc, agentInfo)
+		return newLocal(ctx, log, paths.ConfigFile(), rawConfig, reexec, statusCtrl, uc, agentInfo)
 	}
 
 	// not in standalone; both modes require reading the fleet.yml configuration file


### PR DESCRIPTION
## What does this PR do?

Passes the correct config file into local mode.
PR https://github.com/elastic/beats/pull/27118 changed how path is retrieved in `run.go`
and went from 
`pathConfigFile := paths.ConfigFile()`
to 
`pathConfigFile := paths.AgentConfigFile()`

while `ConfigFile()` checks for config file defined using `-c` and if not found it falls back to `elastic-agent.yml` 
`AgentConfigFile()` just retrieves an absolute path to `fleet.yml`

in this PR i pass result of `paths.ConfigFile()` into standalone code path so it behaves like it was before.

As standalone agent needs to read `elastic-agent.yml` because this is where the config is, `fleet.yml` is still created and it contains agent.id 

Possible workaround is to COPY config into `fleet.yml`. renaming will lead to agent failing on initial config load. 
Then agent will append agent id into `fleet.yml` while preserving inputs and outputs. Just tested it.
 
## Why is it important?

WIthout this standalone does not work as it tries to read fleet.yml 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
