### PR TITLE
Cherry-pick to 7.x: Add redirect pages for removed central management docs (#27239)

### DIFF
--- a/filebeat/docs/index.asciidoc
+++ b/filebeat/docs/index.asciidoc
@@ -64,4 +64,4 @@ include::{libbeat-dir}/contributing-to-beats.asciidoc[]
 
 include::redirects.asciidoc[]
 
-
+include::{libbeat-dir}/redirects.asciidoc[]

--- a/libbeat/docs/redirects.asciidoc
+++ b/libbeat/docs/redirects.asciidoc
@@ -1,0 +1,25 @@
+["appendix",role="exclude",id="redirects-global"]
+= Deleted pages
+
+The following pages have moved or been deleted.
+
+[role="exclude",id="configuration-central-management"]
+== {beats} central management
+
+Starting in version 7.14, {beats} central management has been removed.
+
+// tag::fleet-redirect[]
+Elastic now provides simpler and faster data onboarding with secure,
+centralized agent management through {agent} and {fleet}. For more information,
+refer to {fleet-guide}/fleet-overview.html[{fleet} and {agent} overview].
+// end::fleet-redirect[]
+
+[role="exclude",id="how-central-managment-works"]
+== How central management works
+
+include::redirects.asciidoc[tag=fleet-redirect]
+
+[role="exclude",id="enroll-beats"]
+== Enroll {beats} in central management
+
+include::redirects.asciidoc[tag=fleet-redirect]

--- a/metricbeat/docs/index.asciidoc
+++ b/metricbeat/docs/index.asciidoc
@@ -62,4 +62,5 @@ include::./faq.asciidoc[]
 
 include::{libbeat-dir}/contributing-to-beats.asciidoc[]
 
+include::{libbeat-dir}/redirects.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add redirect pages for removed central management docs (#27239)