### PR TITLE
[Uptime] Document `params` browser option, fix docs hierarchy.

### DIFF
--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -112,7 +112,7 @@ Example configuration:
 Set this option to add user defined parameters for your scripts. This value takes
 arbitrary YAML that is then converted to JSON which is then passed into synthetics
 via the `--params` option. See {observability-guide}/synthetics-params-secrets.html[Working with Params]
-for more information
+for more information.
 
 Example:
 

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -111,7 +111,7 @@ Example configuration:
 
 Set this option to add user defined parameters for your scripts. This value takes
 arbitrary YAML that is then converted to JSON which is then passed into synthetics
-via the `--params` option. See https://www.elastic.co/guide/en/observability/current/synthetics-params-secrets.html[Working with Params]
+via the `--params` option. See {observability-guide}/synthetics-params-secrets.html[Working with Params]
 for more information
 
 Example:
@@ -169,4 +169,3 @@ Set this option to `true` to enable the normally disabled chromium sandbox. Defa
 
 Extra arguments to pass to the synthetics agent package. Takes a list of
 strings.
-

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -106,17 +106,28 @@ Example configuration:
 -------------------------------------------------------------------------------
 
 [float]
-[[monitor-browser-sandbox]]
-==== `sandbox`
+[[monitor-browser-params]]
+==== `params`
 
-Set this option to `true` to enable the normally disabled chromium sandbox. Defaults to false.
+Set this option to add user defined parameters for your scripts. This value takes
+arbitrary YAML that is then converted to JSON which is then passed into synthetics
+via the `--params` option. See https://www.elastic.co/guide/en/observability/current/synthetics-params-secrets.html[Working with Params]
+for more information
 
-[float]
-[[monitor-browser-synthetics-args]]
-==== `synthetics_args`
+Example:
 
-Extra arguments to pass to the synthetics agent package. Takes a list of
-strings.
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: browser
+  id: local-journeys
+  name: Local journeys
+  schedule: '@every 1m'
+  source: # Omitted in this example for brevity
+  params:
+    root_url: http://example.net
+    my_custom_object:
+      a_key: ["a value"]
+-------------------------------------------------------------------------------
 
 [float]
 [[monitor-browser-screenshots]]
@@ -144,4 +155,18 @@ Example configuration:
     local:
       path: "/path/to/synthetics/journeys"
 -------------------------------------------------------------------------------
+
+[float]
+[[monitor-browser-sandbox]]
+==== `sandbox`
+
+Set this option to `true` to enable the normally disabled chromium sandbox. Defaults to false.
+
+
+[float]
+[[monitor-browser-synthetics-args]]
+==== `synthetics_args`
+
+Extra arguments to pass to the synthetics agent package. Takes a list of
+strings.
 


### PR DESCRIPTION
Fixes #27217 and also improves the ordering of documentation here, putting the most used options first, and the least used last.