### PR TITLE
Fix flaky test `TestAddCounterInvalidArgWhenQueryClosed`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -399,6 +399,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Allow metric prefix override per service in gcp module. {pull}26960[26960]
 - Change `server_status_path` default setting to `nginx_status` for the `nginx` module. {pull}26642[26642]
 - Fix cloudwatch metricset collecting duplicate data points. {pull}27248[27248]
+- Fix flaky test TestAddCounterInvalidArgWhenQueryClosed. {issue}27312[27312] {pull}27313[27313]
 
 *Packetbeat*
 

--- a/metricbeat/helper/windows/pdh/pdh_query_windows.go
+++ b/metricbeat/helper/windows/pdh/pdh_query_windows.go
@@ -225,7 +225,11 @@ func (q *Query) ExpandWildCardPath(wildCardPath string) ([]string, error) {
 		return UTF16ToStringArray(expdPaths), nil
 	} else {
 		if expdPaths, err = PdhExpandWildCardPath(utfPath); err != nil {
-			return nil, err
+			if err == PDH_MORE_DATA {
+				expdPaths, err = PdhExpandWildCardPath(utfPath)
+			} else {
+				return nil, err
+			}
 		}
 		paths := UTF16ToStringArray(expdPaths)
 		// in several cases ExpandWildCardPath win32 api seems to return initial wildcard without any errors, adding some waiting time between the 2 ExpandWildCardPath api calls seems to be succesfull but that will delay data retrieval

--- a/metricbeat/helper/windows/pdh/pdh_query_windows.go
+++ b/metricbeat/helper/windows/pdh/pdh_query_windows.go
@@ -226,7 +226,9 @@ func (q *Query) ExpandWildCardPath(wildCardPath string) ([]string, error) {
 	} else {
 		if expdPaths, err = PdhExpandWildCardPath(utfPath); err != nil {
 			if err == PDH_MORE_DATA {
-				expdPaths, err = PdhExpandWildCardPath(utfPath)
+				if expdPaths, err = PdhExpandWildCardPath(utfPath); err != nil {
+					return nil, err
+				}
 			} else {
 				return nil, err
 			}


### PR DESCRIPTION
## What does this PR do?

Fix flaky test `TestAddCounterInvalidArgWhenQueryClosed`
## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/beats/issues/27312


