### PR TITLE
Osquerybeat: Add osquery client reconnect on broken pipe error

### DIFF
--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -35,6 +35,7 @@ var (
 	ErrAlreadyRunning     = errors.New("already running")
 	ErrQueryExecution     = errors.New("failed query execution")
 	ErrActionRequest      = errors.New("invalid action request")
+	ErrOsquerydExited     = errors.New("osqueryd exited")
 )
 
 const (
@@ -234,6 +235,11 @@ func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.O
 		err := osq.Run(ctx)
 		if err != nil {
 			bt.log.Errorf("Failed to run osqueryd: %v", err)
+		} else {
+			// When osqueryd is killed for example there is no error returned
+			// but we can't continue running. Exiting.
+			bt.log.Info("osqueryd process exited")
+			err = ErrOsquerydExited
 		}
 		return err
 	})

--- a/x-pack/osquerybeat/internal/osqdcli/client.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client.go
@@ -8,13 +8,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
+	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"golang.org/x/sync/semaphore"
 
 	"github.com/kolide/osquery-go"
+	genosquery "github.com/kolide/osquery-go/gen/osquery"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -102,14 +106,24 @@ func New(socketPath string, opts ...Option) *Client {
 func (c *Client) Connect(ctx context.Context) error {
 	c.mx.Lock()
 	defer c.mx.Unlock()
-	c.log.Debugf("connect client: socket_path: %s, retries: %v", c.socketPath, c.connectRetries)
+	c.log.Debugf("connect osquery client: socket_path: %s, retries: %v", c.socketPath, c.connectRetries)
 	if c.cli != nil {
 		err := ErrAlreadyConnected
 		c.log.Error(err)
 		return err
 	}
 
-	var err error
+	err := c.reconnect(ctx)
+	if err != nil {
+		c.log.Errorf("osquery client failed to connect: %v", err)
+		return err
+	}
+	c.log.Info("osquery client is connected")
+	return err
+}
+
+func (c *Client) reconnect(ctx context.Context) error {
+	c.close()
 
 	for i := 0; i < c.connectRetries; i++ {
 		attempt := i + 1
@@ -132,22 +146,48 @@ func (c *Client) Connect(ctx context.Context) error {
 		c.cli = cli
 		break
 	}
-	if err != nil {
-		c.log.Errorf("failed connect: %v", err)
-		return err
-	}
-	c.log.Info("connected")
-	return err
+	return nil
 }
 
 func (c *Client) Close() {
 	c.mx.Lock()
 	defer c.mx.Unlock()
+	c.close()
+}
 
+func (c *Client) close() {
 	if c.cli != nil {
 		c.cli.Close()
 		c.cli = nil
 	}
+}
+
+func (c *Client) withReconnect(ctx context.Context, fn func() error) error {
+	err := fn()
+	if err == nil {
+		return nil
+	}
+
+	var netErr *net.OpError
+
+	// The current osquery go library github.com/osquery/osquery-go uses the older version of thrift library that
+	// doesn't not wrap the original error, so we have to use this ugly check for the error message suffix here.
+	// The latest version of thrift library is wrapping the error, so adding this check first here.
+	if (errors.As(err, &netErr) && (netErr.Err == syscall.EPIPE || netErr.Err ==
+		syscall.ECONNRESET)) ||
+		strings.HasSuffix(err.Error(), " broken pipe") {
+
+		c.log.Infof("osquery error: %v, reconnect", err)
+
+		// reconnect && retry
+		err = c.reconnect(ctx)
+		if err != nil {
+			c.log.Errorf("failed to reconnect: %v", err)
+			return err
+		}
+		return fn()
+	}
+	return nil
 }
 
 // Query executes a given query, resolves the types
@@ -164,7 +204,11 @@ func (c *Client) Query(ctx context.Context, sql string) ([]map[string]interface{
 	}
 	defer c.cliLimiter.Release(limit)
 
-	res, err := c.cli.Client.Query(ctx, sql)
+	var res *genosquery.ExtensionResponse
+	err = c.withReconnect(ctx, func() error {
+		res, err = c.cli.Client.Query(ctx, sql)
+		return err
+	})
 	if err != nil {
 		return nil, fmt.Errorf("osquery failed: %w", err)
 	}
@@ -218,7 +262,16 @@ func (c *Client) queryColumnTypes(ctx context.Context, sql string) (map[string]s
 	}
 
 	if colTypes == nil {
-		exres, err := c.cli.GetQueryColumns(sql)
+		var (
+			exres *genosquery.ExtensionResponse
+			err   error
+		)
+
+		err = c.withReconnect(ctx, func() error {
+			exres, err = c.cli.Client.GetQueryColumns(ctx, sql)
+			return err
+		})
+
 		if err != nil {
 			return nil, fmt.Errorf("osquery get query columns failed: %w", err)
 		}

--- a/x-pack/osquerybeat/internal/osqdcli/client.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client.go
@@ -177,7 +177,7 @@ func (c *Client) withReconnect(ctx context.Context, fn func() error) error {
 		syscall.ECONNRESET)) ||
 		strings.HasSuffix(err.Error(), " broken pipe") {
 
-		c.log.Infof("osquery error: %v, reconnect", err)
+		c.log.Debugf("osquery error: %v, reconnect", err)
 
 		// reconnect && retry
 		err = c.reconnect(ctx)


### PR DESCRIPTION
## What does this PR do?

This addresses the issue observed on linux platforms, where after running osquerybeat for some time the osqueryd client gets the "broken pipe" error from the osqueryd domain socket client:
"Osquerybeat: osquery failed: write unix ->/var/run/642722736/osquery.sock: write: broken pipe
https://github.com/elastic/beats/issues/25297"

Before the change the osqueryd client was connected once at the start of osquerybeat, after the change the client reconnects to osqueryd upon receiving the error.

## Why is it important?

Addresses:
"Osquerybeat: osquery failed: write unix ->/var/run/642722736/osquery.sock: write: broken pipe"
https://github.com/elastic/beats/issues/25297

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

This issue is difficult to reproduce. The only way I was able to reproduce it at the moment is to leave the agent with osquerybeat running overnight. Here is the list of scheduled queries that were scheduled at the test setup, it's not clear at the moment if this affects the reproduction of this issue.
<img width="1247" alt="Screen Shot 2021-08-11 at 7 40 49 AM" src="https://user-images.githubusercontent.com/872351/129029897-e0305e5c-d02e-4294-8310-2218e4bba984.png">

## Related issues

- Closes https://github.com/elastic/beats/issues/25297

## Screenshots

Log shows reconnect on broken pipe error:
<img width="1330" alt="Screen Shot 2021-08-11 at 7 16 33 AM" src="https://user-images.githubusercontent.com/872351/129030133-acd6a158-0f10-4727-8307-a660f5ab7c7a.png">

