### PR TITLE
Change to use one period between start and end time

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -398,7 +398,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change vsphere.datastore.capacity.used.pct value to betweeen 0 and 1. {pull}23148[23148]
 - Allow metric prefix override per service in gcp module. {pull}26960[26960]
 - Change `server_status_path` default setting to `nginx_status` for the `nginx` module. {pull}26642[26642]
-- Fix cloudwatch metricset collecting duplicate data points. {pull}27248[27248]
+- Fix cloudwatch metricset collecting duplicate data points. {pull}27327[27327]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -36,9 +36,10 @@ AWS regions. If `endpoint` is specified, `regions` becomes a required config par
 * *latency*
 
 Some AWS services send monitoring metrics to CloudWatch with a latency to
-process larger than Metricbeat collection period. This case, please specify a
-`latency` parameter so collection start time and end time will be shifted by the
-given latency amount.
+process larger than Metricbeat collection period. This will cause data points missing
+or none get collected by Metricbeat. In this case, please specify a `latency`
+parameter so collection start time and end time will be shifted by the given
+latency amount.
 
 * *endpoint*
 

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -28,9 +28,10 @@ AWS regions. If `endpoint` is specified, `regions` becomes a required config par
 * *latency*
 
 Some AWS services send monitoring metrics to CloudWatch with a latency to
-process larger than Metricbeat collection period. This case, please specify a
-`latency` parameter so collection start time and end time will be shifted by the
-given latency amount.
+process larger than Metricbeat collection period. This will cause data points missing
+or none get collected by Metricbeat. In this case, please specify a `latency`
+parameter so collection start time and end time will be shifted by the given
+latency amount.
 
 * *endpoint*
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1621,5 +1621,5 @@ func TestGetStartTimeEndTime(t *testing.T) {
 	m.MetricSet = &aws.MetricSet{Period: 5 * time.Minute}
 	m.logger = logp.NewLogger("test")
 	startTime, endTime := aws.GetStartTimeEndTime(m.MetricSet.Period, m.MetricSet.Latency)
-	assert.Equal(t, 9*time.Minute+59*time.Second, endTime.Sub(startTime))
+	assert.Equal(t, 5*time.Minute, endTime.Sub(startTime))
 }


### PR DESCRIPTION
## What does this PR do?

This PR is to change startTime and endTime of `GetMetricData` API in `cloudwatch` metricbeat to be only one collection period apart. Bug in previous code is:

- First Metricbeat collection cycle: startTime = 06:50:35 endTime = 07:00:35 -> cloudwatch metric timestamp = 06:55:00

- Second Metricbeat collection cycle: startTime = 06:55:35 endTime = 07:05:35 -> cloudwatch metric timestamp = 06:55:00

The problem is caused by the startTime and endTime parameters in AWS CloudWatch GetMetricData API only look at the hour and minute (e.g: 06:50 and 07:00) in a timestamp. And also the gap between startTime and endTime is double the period, which causes more than one data point gets returned.  

This PR is to first round the timestamps to ignore seconds. Then change startTime to be one collection period ahead of endTime. If no data is collected, which means services have a delay to send metrics into AWS CloudWatch. In this case, `latency` config parameter should be used.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.