### PR TITLE
[Agent] Fix os.ErrNotExist handling for Agent upgrade marker

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_mark.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_mark.go
@@ -91,13 +91,15 @@ func CleanMarker() error {
 	return nil
 }
 
-// LoadMarker loads marker, if it not exists,it return nil without an error
+// LoadMarker loads the update marker. If the file does not exist it returns nil
+// and no error.
 func LoadMarker() (*UpdateMarker, error) {
 	markerFile := markerFilePath()
 	markerBytes, err := ioutil.ReadFile(markerFile)
-	if err != nil && os.IsNotExist(err) {
-		return nil, err
-	} else if err != nil {
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

The LoadMarker method comment indicates that it should return a nil error when
the file does not exist, but it did return the os.ErrNotExist in this case. So I changed
it to return a nil error when the file does not exist.

This should squelch the benign warnings shown to users like

    16:04:40.160 elastic_agent [elastic_agent][warn] failed to ack update open /opt/Elastic/Agent/data/.update-marker: no such file or directory

## Why is it important?

The warning causes unnecessary alarm for users.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
