### PR TITLE
Heartbeat: add browser monitor docs

### DIFF
--- a/heartbeat/docs/heartbeat-options.asciidoc
+++ b/heartbeat/docs/heartbeat-options.asciidoc
@@ -94,6 +94,8 @@ receiving a custom payload.
 *<<monitor-http-options,`http`>>*:: Connects via HTTP and optionally verifies that the host returns the
 expected response. Will use `Elastic-Heartbeat` as
 the user agent product.
+*<<monitor-browser-options,`browser`>>*:: Allows users to run the synthetic
+monitoring test suites via Synthetic Agent on the Chromium browser.
 
 The `tcp` and `http` monitor types both support SSL/TLS and some proxy
 settings.

--- a/heartbeat/docs/heartbeat-scheduler.asciidoc
+++ b/heartbeat/docs/heartbeat-scheduler.asciidoc
@@ -39,3 +39,24 @@ specify for `limit` should be below the configured ulimit.
 
 The time zone for the scheduler. By default the scheduler uses localtime.
 
+
+[float]
+[[heartbeat-job-limit]]
+==== `job.limit`
+
+On top of the scheduler level limit, {beatname_uc} allows limiting the number of
+concurrent tasks per monitor/job type.
+
+Example configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+heartbeat.jobs:
+  http:
+    limit: 10
+  browser:
+    limit: 5
+-------------------------------------------------------------------------------
+
+In the example, at any given time {beatname_uc} guarantees that only 10
+concurrent `http` tasks and only 5 concurrent `browser` tasks will be active.

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -160,7 +160,34 @@ Example configuration:
 [[monitor-browser-sandbox]]
 ==== `sandbox`
 
-Set this option to `true` to enable the normally disabled chromium sandbox. Defaults to false.
+Set this option to `true` to enable the normally disabled chromium sandbox.
+Defaults to false.
+
+[float]
+[[monitor-browser-filter-journeys]]
+==== `filter_journeys`
+
+Set this option to filter journeys based on journey tags and names.
+
+
+Example configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------
+- type: browser
+  id: local-journeys
+  name: Local journeys
+  schedule: '@every 1m'
+  filter_journeys:
+    tags: ["browse", "checkout"]
+    match: "login*"
+  source:
+    local:
+      path: "/path/to/synthetics/journeys"
+-------------------------------------------------------------------------------
+
+*`tags`*:: run only journeys with the given tag(s), or globs
+*`match`*:: run only journeys with a name or tags that matches the configured glob
 
 
 [float]


### PR DESCRIPTION
+ Adds docs for the new scheduled job limit option that is added via https://github.com/elastic/beats/pull/27160/
+ Also added new browser monitor options `filter_journeys` that is added here - https://github.com/elastic/beats/pull/27347