### PR TITLE
Fix application.Stop on windows

### DIFF
--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -149,12 +149,9 @@ func (a *Application) Stop() {
 		return
 	}
 
-	stopSig := os.Interrupt
 	if srvState != nil {
-		if err := srvState.Stop(a.processConfig.StopTimeout); err != nil {
-			// kill the process if stop through GRPC doesn't work
-			stopSig = os.Kill
-		}
+		// signal stop through GRPC, wait and kill is performed later in gracefulKill
+		srvState.Stop(a.processConfig.StopTimeout)
 	}
 
 	a.appLock.Lock()
@@ -164,10 +161,8 @@ func (a *Application) Stop() {
 	if a.state.ProcessInfo != nil {
 		// stop and clean watcher
 		a.stopWatcher(a.state.ProcessInfo)
-		if err := a.state.ProcessInfo.Process.Signal(stopSig); err == nil {
-			// no error on signal, so wait for it to stop
-			_, _ = a.state.ProcessInfo.Process.Wait()
-		}
+		a.gracefulKill(a.state.ProcessInfo)
+
 		a.state.ProcessInfo = nil
 
 		// cleanup drops
@@ -207,7 +202,7 @@ func (a *Application) watch(ctx context.Context, p app.Taggable, proc *process.I
 		defer a.appLock.Unlock()
 		if a.state.ProcessInfo != proc {
 			// already another process started, another watcher is watching instead
-			gracefulKill(proc)
+			a.gracefulKill(proc)
 			return
 		}
 
@@ -275,7 +270,7 @@ func (a *Application) cleanUp() {
 	a.monitor.Cleanup(a.desc.Spec(), a.pipelineID)
 }
 
-func gracefulKill(proc *process.Info) {
+func (a *Application) gracefulKill(proc *process.Info) {
 	if proc == nil || proc.Process == nil {
 		return
 	}
@@ -288,7 +283,11 @@ func gracefulKill(proc *process.Info) {
 	wg.Add(1)
 	go func() {
 		wg.Done()
-		_, _ = proc.Process.Wait()
+
+		if _, err := proc.Process.Wait(); err != nil {
+			// process is not a child - some OSs requires process to be child
+			a.externalProcess(proc.Process)
+		}
 		close(doneChan)
 	}()
 


### PR DESCRIPTION
## What does this PR do?

This PR handles the cases in windows where there's different behaviour in Wait and Signal commands.
Wait-kill commands in Stop func were replaced by existing gracefullKill functionality which handles OS differences already.

This needs to be backported to 7.14 as well and released together with the cancellation fixes 
## Why is it important?

https://github.com/elastic/beats/issues/27259

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
