### PR TITLE
[Metricbeat] gcp: fix instance machineType reporting

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -407,7 +407,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix cloudwatch metricset collecting duplicate data points. {pull}27248[27248]
 - Fix flaky test TestAddCounterInvalidArgWhenQueryClosed. {issue}27312[27312] {pull}27313[27313]
 - Add percent formatters to system/process {pull}27374[27374]
-- Fix instance machineType reporting {pull}27363[27363]
+- Fix instance machineType reporting in compute metricset of GCP module {pull}27363[27363]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -407,6 +407,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix cloudwatch metricset collecting duplicate data points. {pull}27248[27248]
 - Fix flaky test TestAddCounterInvalidArgWhenQueryClosed. {issue}27312[27312] {pull}27313[27313]
 - Add percent formatters to system/process {pull}27374[27374]
+- Fix instance machineType reporting {pull}27363[27363]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/gcp/metrics/compute/metadata.go
+++ b/x-pack/metricbeat/module/gcp/metrics/compute/metadata.go
@@ -61,11 +61,11 @@ type metadataCollector struct {
 
 // Metadata implements googlecloud.MetadataCollector to the known set of labels from a Compute TimeSeries single point of data.
 func (s *metadataCollector) Metadata(ctx context.Context, resp *monitoringpb.TimeSeries) (gcp.MetadataCollectorData, error) {
-	if s.computeMetadata == nil {
-		_, err := s.instanceMetadata(ctx, s.instanceID(resp), s.instanceZone(resp))
-		if err != nil {
-			return gcp.MetadataCollectorData{}, err
-		}
+	// NOTE: ignoring the return value because instanceMetadata changes s.computeMetadata in place.
+	// This is probably not thread safe.
+	_, err := s.instanceMetadata(ctx, s.instanceID(resp), s.instanceZone(resp))
+	if err != nil {
+		return gcp.MetadataCollectorData{}, err
 	}
 
 	stackdriverLabels := gcp.NewStackdriverMetadataServiceForTimeSeries(resp)
@@ -107,6 +107,7 @@ func (s *metadataCollector) Metadata(ctx context.Context, resp *monitoringpb.Tim
 
 // instanceMetadata returns the labels of an instance
 func (s *metadataCollector) instanceMetadata(ctx context.Context, instanceID, zone string) (*computeMetadata, error) {
+	// FIXME: remove side effect on metadataCollector instance and use return value instead
 	i, err := s.instance(ctx, instanceID, zone)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error trying to get data from instance '%s' in zone '%s'", instanceID, zone)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Refresh instance metadata for each incoming response by updating the `s.computeMetadata` field in the `metadataCollector` struct.

## Why is it important?

The code was applying a sort of caching to the `computeMetadata`, but in the wrong place. Most probably it was a leftover, as a proper caching for instance metadata is implemented in the `instance` function on line 146.
Due to this check `computeMetadata` were not refreshed for each response.
`metadataCollector` is instanciated only once for the entire module.
Thus by not overriding `computeMetadata` the metadata of the first response handled was used for all subsequent events.

Removing the check make the code update the `s.computeMetadata` property for each new response. With this update the correct metadata based on the instance ID reported in the response are used.

Fixes a bug were all metrics were being reported with the same `machineType`.

NOTE: the code update the same struct field at each iteration; this is most probably not safe in a parallel execution context; this code is not running multiple times in different threads so for the moment this change should not have negative side effects.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
	I would like to add an integration test (as I have been able to reproduce it in a pristine environment)
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
