### PR TITLE
[Elastic Agent] Fix issue where extraction into installation for hostPath would fail

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -77,6 +77,7 @@
 - Remove symlink.prev from previously failed upgrade {pull}26785[26785]
 - Fix apm-server supported outputs not being in sync with supported output types. {pull}26885[26885]
 - Set permissions during installation {pull}26665[26665]
+- Fix issue with atomic extract running in K8s {pull}27375[27375]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/program"
 )
 
@@ -37,7 +36,7 @@ func NewInstaller(i embeddedInstaller) (*Installer, error) {
 // Install performs installation of program in a specific version.
 func (i *Installer) Install(ctx context.Context, spec program.Spec, version, installDir string) error {
 	// tar installer uses Dir of installDir to determine location of unpack
-	tempDir, err := ioutil.TempDir(paths.TempDir(), "elastic-agent-install")
+	tempDir, err := ioutil.TempDir(filepath.Dir(installDir), "tmp")
 	if err != nil {
 		return err
 	}

--- a/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
+++ b/x-pack/elastic-agent/pkg/artifact/install/atomic/atomic_installer.go
@@ -36,6 +36,9 @@ func NewInstaller(i embeddedInstaller) (*Installer, error) {
 // Install performs installation of program in a specific version.
 func (i *Installer) Install(ctx context.Context, spec program.Spec, version, installDir string) error {
 	// tar installer uses Dir of installDir to determine location of unpack
+	//
+	// installer is ran inside a tmp directory created in the parent installDir, this is so the atomic
+	// rename always occurs on the same mount path that holds the installation directory
 	tempDir, err := ioutil.TempDir(filepath.Dir(installDir), "tmp")
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes #24213

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When running in K8s and the `STATE_PATH` is on a different mount point than the temp directory, it will fail to rename using the atomic installation.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[x] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #24213 
