### PR TITLE
Cherry-pick to 7.x: Fix formatting of Filebeat name (#27328)

### DIFF
--- a/libbeat/docs/shared-kerberos-config.asciidoc
+++ b/libbeat/docs/shared-kerberos-config.asciidoc
@@ -57,7 +57,7 @@ the keys of the selected principal. Otherwise, authentication will fail.
 [float]
 ==== `config_path`
 
-You need to set the path to the `krb5.conf`, so +{beatname_lc} can find the Kerberos KDC to
+You need to set the path to the `krb5.conf`, so {beatname_uc} can find the Kerberos KDC to
 retrieve a ticket.
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix formatting of Filebeat name (#27328)