### PR TITLE
[automation] update elastic stack version for testing 7.14.1-c6219279

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.14.1-3af02427-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.14.1-c6219279-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -17,7 +17,7 @@ services:
     - "indices.id_field_data.enabled=true"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.14.1-3af02427-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.14.1-c6219279-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -27,7 +27,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.14.1-3af02427-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.14.1-c6219279-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.1-3af02427-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.1-c6219279-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ingest.geoip.downloader.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.14.1-3af02427-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.14.1-c6219279-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -30,7 +30,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.14.1-3af02427-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.14.1-c6219279-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Fri, 13 Aug 2021 12:14:55 GMT, release_branch:7.14, prefix:, end_time:Fri, 13 Aug 2021 17:40:22 GMT, manifest_version:2.0.0, version:7.14.1-SNAPSHOT, branch:7.14, build_id:7.14.1-c6219279, build_duration_seconds:19527]