### PR TITLE
Fix go mod in apm beats update CI job

### DIFF
--- a/.ci/apm-beats-update.groovy
+++ b/.ci/apm-beats-update.groovy
@@ -126,7 +126,9 @@ def beatsUpdate() {
         git config --global --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
 
         go mod edit -replace github.com/elastic/beats/v7=\${GOPATH}/src/github.com/elastic/beats-local
+        go mod tidy
         echo '{"name": "${GOPATH}/src/github.com/elastic/beats-local", "licenceType": "Elastic"}' >> \${GOPATH}/src/github.com/elastic/beats-local/dev-tools/notice/overrides.json
+
         make update
         git commit -a -m beats-update
 


### PR DESCRIPTION
`go mod tidy` should be executed after custom modifications of `go.mod`
to avoid problems due to missing entries in `go.sum`.

This should solve failures like this one:
```
[2021-08-15T13:03:19.235Z] go: github.com/elastic/beats/v7@v7.0.0-alpha2.0.20210812232037-f144f63593df requires
[2021-08-15T13:03:19.235Z] 	github.com/eclipse/paho.mqtt.golang@v1.3.5: missing go.sum entry; to add it:
[2021-08-15T13:03:19.235Z] 	go mod download github.com/eclipse/paho.mqtt.golang
[2021-08-15T13:03:19.235Z] /var/lib/jenkins/workspace/Beats_apm-beats-update_master/.gvm/versions/go1.16.6.linux.amd64/bin/go build -o build/linux/bin/mage github.com/magefile/mage
[2021-08-15T13:03:19.235Z] go: github.com/elastic/beats/v7@v7.0.0-alpha2.0.20210812232037-f144f63593df requires
[2021-08-15T13:03:19.235Z] 	github.com/eclipse/paho.mqtt.golang@v1.3.5: missing go.sum entry; to add it:
[2021-08-15T13:03:19.235Z] 	go mod download github.com/eclipse/paho.mqtt.golang
```

Seen in https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fapm-beats-update/detail/master/1329/pipeline