### PR TITLE
[elastic-agent] Use -complete in docker image name, not tag

### DIFF
--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -195,17 +195,18 @@ func (b *dockerBuilder) expandDockerfile(templatesDir string, data map[string]in
 }
 
 func (b *dockerBuilder) dockerBuild(variant string) (string, error) {
-	tag := fmt.Sprintf("%s:%s", b.imageName, b.Version)
+	imageName := b.imageName
 	if variant != "" {
-		tag = fmt.Sprintf("%s-%s", tag, variant)
+		imageName = fmt.Sprintf("%s-%s", imageName, variant)
 	}
+	taggedImageName := fmt.Sprintf("%s:%s", imageName, b.Version)
 	if b.Snapshot {
-		tag = tag + "-SNAPSHOT"
+		taggedImageName = taggedImageName + "-SNAPSHOT"
 	}
 	if repository, _ := b.ExtraVars["repository"]; repository != "" {
-		tag = fmt.Sprintf("%s/%s", repository, tag)
+		taggedImageName = fmt.Sprintf("%s/%s", repository, taggedImageName)
 	}
-	return tag, sh.Run("docker", "build", "-t", tag, b.buildDir)
+	return taggedImageName, sh.Run("docker", "build", "-t", taggedImageName, b.buildDir)
 }
 
 func (b *dockerBuilder) dockerSave(tag string) error {


### PR DESCRIPTION
Backport of #27399 to 7.x

Previously `complete` images were named `elastic-agent:8.0.0-complete`, this changes them to `elastic-agent-complete:8.0.0` to be compatible with our release process.
