### PR TITLE
Do not overwrite content type if it is multipart in Kibana loader

### DIFF
--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -214,7 +214,7 @@ func (conn *Connection) SendWithContext(ctx context.Context, method, extraPath s
 	addHeaders(req.Header, headers)
 
 	contentType := req.Header.Get("Content-Type")
-	if contentType != "multipart/form-data" && contentType != "application/ndjson" {
+	if !strings.HasPrefix(contentType, "multipart/form-data") && contentType != "application/ndjson" {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")

--- a/x-pack/filebeat/module/netflow/dashboards.yml
+++ b/x-pack/filebeat/module/netflow/dashboards.yml
@@ -2,25 +2,25 @@
 
 dashboards:
   - id: 77326664-23be-4bf1-a126-6d7e60cfc024
-    file: filebeat-netflow-geo-location.json
+    file: filebeat-netflow-geo-location.ndjson
 
   - id: 38012abe-c611-4124-8497-381fcd85acc8
-    file: filebeat-netflow-traffic-analysis.json
+    file: filebeat-netflow-traffic-analysis.ndjson
 
   - id: c64665f9-d222-421e-90b0-c7310d944b8a
-    file: filebeat-netflow-autonomous-systems.json
+    file: filebeat-netflow-autonomous-systems.ndjson
 
   - id: acd7a630-0c71-4840-bc9e-4a3801374a32
-    file: filebeat-netflow-conversation-partners.json
+    file: filebeat-netflow-conversation-partners.ndjson
 
   - id: 34e26884-161a-4448-9556-43b5bf2f62a2
-    file: filebeat-netflow-overview.json
+    file: filebeat-netflow-overview.ndjson
 
   - id: feebb4e6-b13e-4e4e-b9fc-d3a178276425
-    file: filebeat-netflow-flow-exporters.json
+    file: filebeat-netflow-flow-exporters.ndjson
 
   - id: 94972700-de4a-4272-9143-2fa8d4981365
-    file: filebeat-netflow-flow-records.json
+    file: filebeat-netflow-flow-records.ndjson
 
   - id: 14387a13-53bc-43a4-b9cd-63977aa8d87c
-    file: filebeat-netflow-top-n.json
+    file: filebeat-netflow-top-n.ndjson


### PR DESCRIPTION
## What does this PR do?

This PR fixes dashboard loading. Kibana loader overwrites every content type to application/json. However, for multipart file transfer it has to be set to multipart/formdata and application/ndjson. Otherwise, loading the assets fails.

Also, a module file has not been updated with new dashboard names.

## Why is it important?

Index template loading was not working.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~