### PR TITLE
Remove event.dataset from logp ecs attributes

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -61,6 +61,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Stop using `mage:import` in community beats. This was ignoring the vendorized beats directory for some mage targets, using the code available in GOPATH, this causes inconsistencies and compilation problems if the version of the code in the GOPATH is different to the vendored one. Use of `mage:import` will continue to be unsupported in custom beats till beats is migrated to go modules, or mage supports vendored dependencies. {issue}13998[13998] {pull}14162[14162]
 - Metricbeat module builders call host parser only once when instantiating light modules. {pull}20149[20149]
 - Fix export dashboard command when running against Elastic Cloud hosted Kibana. {pull}22746[22746]
+- Remove `event.dataset` (ECS) annotion from `libbeat.logp`. {issue}27404[27404]
 
 ==== Added
 

--- a/libbeat/logp/core.go
+++ b/libbeat/logp/core.go
@@ -199,7 +199,6 @@ func makeOptions(cfg Config) []zap.Option {
 	if cfg.ECSEnabled {
 		fields := []zap.Field{
 			zap.String("service.name", cfg.Beat),
-			zap.String("event.dataset", cfg.LogFilename()),
 		}
 		options = append(options, zap.Fields(fields...))
 	}

--- a/libbeat/logp/core_test.go
+++ b/libbeat/logp/core_test.go
@@ -165,11 +165,9 @@ func TestLoggingECSFields(t *testing.T) {
 	logger.Debug("debug")
 	logs := ObserverLogs().TakeAll()
 	if assert.Len(t, logs, 1) {
-		if assert.Len(t, logs[0].Context, 2) {
+		if assert.Len(t, logs[0].Context, 1) {
 			assert.Equal(t, "service.name", logs[0].Context[0].Key)
 			assert.Equal(t, "beat1", logs[0].Context[0].String)
-			assert.Equal(t, "event.dataset", logs[0].Context[1].Key)
-			assert.Equal(t, "beat1.log", logs[0].Context[1].String)
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Remove the `event.dataset` ECS attribute from `libbeat.logp`.

## Why is it important?

`event.dataset` key is appearing twice in documents sent by filebeat running under the elastic-agent. Once is the correct `elastic_agent.X` value, the other is an array that contains the log name.

## Checklist

- [x] My code follows the style guidelines of this project
- [] ~~I have commented my code, particularly in hard-to-understand areas~~
- [] ~~I have made corresponding changes to the documentation~~
- [] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Build + run agent and ensure that log entries only have a single `event.dataset` key set to `elastic_agent.X`

## Related issues

- Closes #27404 