### PR TITLE
docs: add note about aws creds

### DIFF
--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -17,24 +17,30 @@ Some services, such as IAM, do not support regions. The endpoints for these
 services do not include a region. In `aws` module, `endpoint` config is to set
 the `endpoint-code` part, such as `amazonaws.com`, `amazonaws.com.cn`, `c2s.ic.gov`,
 `sc2s.sgov.gov`.
-* *proxy_url*: URL of the proxy to use to connect to AWS web services. The syntax is http(s)://<IP/Hostname>:<port>
+* *proxy_url*: URL of the proxy to use to connect to AWS web services. The syntax is `http(s)://<IP/Hostname>:<port>`
 
 [float]
 ==== Supported Formats
-* Use `access_key_id`, `secret_access_key` and/or `session_token`
 
-Users can either put the credentials into metricbeat module configuration or use
+NOTE: The examples in this section refer to Metricbeat,
+but the credential options for authentication with AWS are the same no matter which Beat is being used.
+
+* Use `access_key_id`, `secret_access_key`, and/or `session_token`
+
+Users can either put the credentials into the Metricbeat module configuration or use
 environment variable `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and/or
 `AWS_SESSION_TOKEN` instead.
 
 If running on Docker, these environment variables should be added as a part of
 the docker command. For example, with Metricbeat:
 
+[source,terminal]
 ----
 $ docker run -e AWS_ACCESS_KEY_ID=abcd -e AWS_SECRET_ACCESS_KEY=abcd -d --name=metricbeat --user=root --volume="$(pwd)/metricbeat.aws.yml:/usr/share/metricbeat/metricbeat.yml:ro" docker.elastic.co/beats/metricbeat:7.11.1 metricbeat -e -E cloud.auth=elastic:1234 -E cloud.id=test-aws:1234
 ----
 
 Sample `metricbeat.aws.yml` looks like:
+
 [source,yaml]
 ----
 metricbeat.modules:
@@ -49,6 +55,7 @@ metricbeat.modules:
 
 Environment variables can also be added through a file. For example:
 
+[source,terminal]
 ----
 $ cat env.list
 AWS_ACCESS_KEY_ID=abcd
@@ -84,6 +91,7 @@ sure credentials are given under either a credential profile or access keys.
 If running on Docker, the credential file needs to be provided via a volume
 mount. For example, with Metricbeat:
 
+[source,terminal]
 ----
 docker run -d --name=metricbeat --user=root --volume="$(pwd)/metricbeat.aws.yml:/usr/share/metricbeat/metricbeat.yml:ro" --volume="/Users/foo/.aws/credentials:/usr/share/metricbeat/credentials:ro" docker.elastic.co/beats/metricbeat:7.11.1 metricbeat -e -E cloud.auth=elastic:1234 -E cloud.id=test-aws:1234
 ----
@@ -190,6 +198,7 @@ Step 1. Create `example-policy.json` file to include all permissions:
 ----
 
 Step 2. Create IAM policy using the `aws iam create-policy` command:
+[source,terminal]
 ----
 $ aws iam create-policy --policy-name example-policy --policy-document file://example-policy.json
 ----
@@ -208,6 +217,7 @@ Step 3. Create the JSON file `example-role-trust-policy.json` that defines the t
 ----
 
 Step 4. Create the IAM role and attach the policy:
+[source,terminal]
 ----
 $ aws iam create-role --role-name example-role --assume-role-policy-document file://example-role-trust-policy.json
 $ aws iam attach-role-policy --role-name example-role --policy-arn "arn:aws:iam::123456789012:policy/example-policy"
@@ -228,6 +238,7 @@ https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[Tempor
 for more details.
 `sts get-session-token` AWS CLI can be used to generate temporary credentials. For example. with MFA-enabled:
 
+[source,terminal]
 ----
 aws> sts get-session-token --serial-number arn:aws:iam::1234:mfa/your-email@example.com --token-code 456789 --duration-seconds 129600
 ----


### PR DESCRIPTION
### Backstory

@bmorelli25:

> The AWS module documentation shows up in the metricbeat, filebeat, and heartbeat docs, but always refers to metricbeat config. See the filebeat docs for an example: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-aws.html#_supported_formats_2.

@kaiyan-sheng:

> Yes this is by design. Because for all AWS related modules, no matter it's in Metricbeat, Filebeat or Functionbeat, it's all using the same credential options for authentication with AWS. Maybe under the Supported Formats section, we should remove the metricbeat.modules: line so it's less confusing? Thank you!

### Proposed solution

@kaiyan-sheng, how do you feel about this solution? There are a lot of references to Metricbeat, so I'm not sure I want to remove the metricbeat.modules line. This PR adds a note at the top of the instructions that says Metricbeat is used for examples, but that the examples are applicable to any beat.

### Related

For https://github.com/elastic/beats/pull/24767.
