### PR TITLE
Add default evenhub settings for each log type

### DIFF
--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -83,7 +83,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
 `eventhub` ::
   _string_
 Is the fully managed, real-time data ingestion service.
-Default value `insights-operational-logs`.
+Default value `insights-operational-logs` for activitylogs, `insights-logs-auditlogs` for auditlogs and `insights-logs-signinlogs` for signinlogs. It is recommended to use separate eventhub for each log type as the field mappings of each log type are different.
 
 `consumer_group` ::
 _string_

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -127,12 +127,6 @@ The azure module comes with several predefined dashboards for general cloud over
 image::./images/filebeat-azure-overview.png[]
 
 
-
-
-
-
-
-
 [float]
 === Fields
 

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -83,7 +83,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
 `eventhub` ::
   _string_
 Is the fully managed, real-time data ingestion service.
-Default value `insights-operational-logs` for activitylogs, `insights-logs-auditlogs` for auditlogs and `insights-logs-signinlogs` for signinlogs. It is recommended to use separate eventhub for each log type as the field mappings of each log type are different.
+Default value of `insights-operational-logs` for activitylogs, `insights-logs-auditlogs` for auditlogs, and `insights-logs-signinlogs` for signinlogs. It is recommended to use a separate eventhub for each log type as the field mappings of each log type are different.
 
 `consumer_group` ::
 _string_

--- a/x-pack/filebeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/azure/_meta/docs.asciidoc
@@ -78,7 +78,7 @@ Will retrieve azure Active Directory audit logs. The audit logs provide traceabi
 `eventhub` ::
   _string_
 Is the fully managed, real-time data ingestion service.
-Default value `insights-operational-logs`.
+Default value of `insights-operational-logs` for activitylogs, `insights-logs-auditlogs` for auditlogs, and `insights-logs-signinlogs` for signinlogs. It is recommended to use a separate eventhub for each log type as the field mappings of each log type are different.
 
 `consumer_group` ::
 _string_
@@ -120,9 +120,3 @@ include::../include/gs-link.asciidoc[]
 The azure module comes with several predefined dashboards for general cloud overview, user activity and alerts. For example:
 
 image::./images/filebeat-azure-overview.png[]
-
-
-
-
-
-


### PR DESCRIPTION
## What does this PR do?

When we only put one default eventhub settings in this reference, the user might be confused they can use a single eventhub for all event types even the field mappings and parsing logic are different. Let's add all default settings with the notes that the user needs to understand each log type has different fields, expicitly.

## Why is it important?

The user could use one single eventhub and having trouble when the logs are parsed from Elasticsearch side.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
