### PR TITLE
Be more lenient when checking for Saved Objects API in Kibana

### DIFF
--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -39,7 +39,9 @@ import (
 )
 
 var (
-	MinimumRequiredVersionSavedObjects = common.MustNewVersion("7.15.0")
+	// We started using Saved Objects API in 7.15. But to help integration
+	// developers migrate their dashboards we are more lenient.
+	MinimumRequiredVersionSavedObjects = common.MustNewVersion("7.14.0")
 )
 
 type Connection struct {

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -121,7 +121,7 @@ class Test(BaseTest, common_tests.TestExportsMixin):
 
     def is_saved_object_api_available(self):
         kibana_semver = semver.VersionInfo.parse(self.get_version())
-        return semver.compare(kibana_semver, "7.14.0") >= 0
+        return semver.VersionInfo.parse("7.14.0")<= kibana_semver
 
     def get_version(self):
         url = self.get_kibana_url() + "/api/status"

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -121,7 +121,7 @@ class Test(BaseTest, common_tests.TestExportsMixin):
 
     def is_saved_object_api_available(self):
         kibana_semver = semver.VersionInfo.parse(self.get_version())
-        return kibana_semver.major == 7 and kibana_semver.minor < 15 or kibana_semver.major >= 8
+        return semver.compare(kibana_semver, "7.14.0") >= 0
 
     def get_version(self):
         url = self.get_kibana_url() + "/api/status"

--- a/metricbeat/tests/system/test_base.py
+++ b/metricbeat/tests/system/test_base.py
@@ -121,7 +121,7 @@ class Test(BaseTest, common_tests.TestExportsMixin):
 
     def is_saved_object_api_available(self):
         kibana_semver = semver.VersionInfo.parse(self.get_version())
-        return semver.VersionInfo.parse("7.14.0")<= kibana_semver
+        return semver.VersionInfo.parse("7.14.0") <= kibana_semver
 
     def get_version(self):
         url = self.get_kibana_url() + "/api/status"

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -20,7 +20,7 @@ services:
       - "script.context.template.cache_max_size=2000"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.12.0
+    image: docker.elastic.co/logstash/logstash:7.14.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -30,7 +30,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.12.0
+    image: docker.elastic.co/kibana/kibana:7.14.0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300


### PR DESCRIPTION
## What does this PR do?

This PR sets the minimum required version for Kibana to 7.14 for using the Saved Objects API. The change lets module developers use the last released version for exporting dashboards.

The PR also updates the testing environment to 7.14, so dashboard exporting and importing can be tested using e2e tests.

## Why is it important?

Support module developers and run e2e tests to catch issues.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

Requires https://github.com/elastic/beats/pull/27424