### PR TITLE
[metricbeat] Metrics collected without container name for autodiscovered pods

### DIFF
--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -332,7 +332,7 @@ func (p *pod) emit(pod *kubernetes.Pod, flag string) {
 			portsMap.DeepUpdate(ports)
 		}
 	}
-	if len(eventList) != 0 {
+	if len(eventList) != 0  && anyContainerRunning == false { // If there are no containers in pod, do not append
 		event := p.podEvent(flag, pod, portsMap, anyContainerRunning, annotations, namespaceAnnotations)
 		// Ensure that the pod level event is published first to avoid
 		// pod metadata overriding a valid container metadata.

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -332,7 +332,7 @@ func (p *pod) emit(pod *kubernetes.Pod, flag string) {
 			portsMap.DeepUpdate(ports)
 		}
 	}
-	if len(eventList) != 0  && anyContainerRunning == false { // If there are no containers in pod, do not append
+	if len(eventList) != 0 && anyContainerRunning == false { // If there are no containers in pod, do not append
 		event := p.podEvent(flag, pod, portsMap, anyContainerRunning, annotations, namespaceAnnotations)
 		// Ensure that the pod level event is published first to avoid
 		// pod metadata overriding a valid container metadata.


### PR DESCRIPTION
Bug fix for metrics collected on auto-discovered pods on Kubernetes

## What does this PR do?

This PR adds a check for pods are running before adding event meant for Pod level metrics

## Why is it important?
In some cases when container is not in Running state and metrics are collect, they do not have container label. It results in 2 timeseries, one with container label and other without container label.


- [x ] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

