### PR TITLE
Transform json.Number values from http_endpoint

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -297,6 +297,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix gcp/vpcflow module error where input type was defaulting to file. {pull}24719[24719]
 - Fix s3 input when there is a blank line in the log file. {pull}25357[25357]
 - Fixes the Snyk module to work with the new API changes. {pull}27358[27358]
+- Fixes a bug in `http_endpoint` that caused numbers encoded as strings. {issue}27382[27382] {pull}27480[27480]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -16,6 +16,7 @@ import (
 	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/jsontransform"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
@@ -134,6 +135,9 @@ func decodeJSON(body io.Reader) (objs []common.MapStr, rawMessages []json.RawMes
 		default:
 			return nil, nil, errUnsupportedType
 		}
+	}
+	for i := range objs {
+		jsontransform.TransformNumbers(objs[i])
 	}
 	return objs, rawMessages, nil
 }

--- a/x-pack/filebeat/input/http_endpoint/handler_test.go
+++ b/x-pack/filebeat/input/http_endpoint/handler_test.go
@@ -26,8 +26,8 @@ func Test_httpReadJSON(t *testing.T) {
 	}{
 		{
 			name:       "single object",
-			body:       `{"a": "42", "b": "c"}`,
-			wantObjs:   []common.MapStr{{"a": "42", "b": "c"}},
+			body:       `{"a": 42, "b": "c"}`,
+			wantObjs:   []common.MapStr{{"a": int64(42), "b": "c"}},
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -52,8 +52,8 @@ func Test_httpReadJSON(t *testing.T) {
 		},
 		{
 			name:       "sequence of objects accepted (CRLF)",
-			body:       `{"a":"1"}` + "\r" + `{"a":"2"}`,
-			wantObjs:   []common.MapStr{{"a": "1"}, {"a": "2"}},
+			body:       `{"a":1}` + "\r" + `{"a":2}`,
+			wantObjs:   []common.MapStr{{"a": int64(1)}, {"a": int64(2)}},
 			wantStatus: http.StatusOK,
 		},
 		{
@@ -97,6 +97,23 @@ func Test_httpReadJSON(t *testing.T) {
 				[]byte(`{"a":"4"}`),
 			},
 			wantObjs:   []common.MapStr{{"a": "1"}, {"a": "2"}, {"a": "3"}, {"a": "4"}},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "numbers",
+			body: `{"a":1} [{"a":false},{"a":3.14}] {"a":-4}`,
+			wantRawMessage: []json.RawMessage{
+				[]byte(`{"a":1}`),
+				[]byte(`{"a":false}`),
+				[]byte(`{"a":3.14}`),
+				[]byte(`{"a":-4}`),
+			},
+			wantObjs: []common.MapStr{
+				{"a": int64(1)},
+				{"a": false},
+				{"a": 3.14},
+				{"a": int64(-4)},
+			},
 			wantStatus: http.StatusOK,
 		},
 	}


### PR DESCRIPTION
## What does this PR do?

This adds a necessary transform to the output of http_endpoint so that numeric values are encoded as such instead of as a string.

## Why is it important?

After a refactor of the input, numeric values in the original input were being encoded as a string in the output event.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Fixes #27382