### PR TITLE
[agent] fix the inject_headers transpiler rule

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_output_true-filebeat.yml
@@ -39,5 +39,7 @@ output:
     hosts:
       - 127.0.0.1:9200
       - 127.0.0.1:9300
+    headers:
+      h1: test-header
     username: elastic
     password: changeme

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/enabled_true-filebeat.yml
@@ -39,5 +39,7 @@ output:
     hosts:
       - 127.0.0.1:9200
       - 127.0.0.1:9300
+    headers:
+      h1: test-header
     username: elastic
     password: changeme

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/fleet_server-fleet-server.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/fleet_server-fleet-server.yml
@@ -8,6 +8,8 @@ fleet:
 output:
   elasticsearch:
     hosts: [ 127.0.0.1:9200, 127.0.0.1:9300 ]
+    headers:
+      h1: test-header
     username: fleet
     password: fleetpassword
 

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-filebeat.yml
@@ -68,6 +68,9 @@ output:
     hosts:
       - 127.0.0.1:9200
       - 127.0.0.1:9300
+    headers:
+      h1: test-header
+
     namespace: test_namespace
     username: elastic
     password: changeme

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-fleet-server.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-fleet-server.yml
@@ -8,6 +8,8 @@ fleet:
 output:
   elasticsearch:
     hosts: [ 127.0.0.1:9200, 127.0.0.1:9300 ]
+    headers:
+      h1: test-header
     username: fleet
     password: fleetpassword
 

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-metricbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/namespace-metricbeat.yml
@@ -88,6 +88,9 @@ metricbeat:
 output:
   elasticsearch:
     hosts: [127.0.0.1:9200, 127.0.0.1:9300]
+    headers:
+      h1: test-header
+                    
     namespace: test_namespace
     username: elastic
     password: changeme

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-filebeat.yml
@@ -68,6 +68,8 @@ output:
     hosts:
       - 127.0.0.1:9200
       - 127.0.0.1:9300
+    headers:
+      h1: test-header
     username: elastic
     password: changeme
     bulk_max_size: 23

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-fleet-server.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-fleet-server.yml
@@ -8,6 +8,8 @@ fleet:
 output:
   elasticsearch:
     hosts: [ 127.0.0.1:9200, 127.0.0.1:9300 ]
+    headers:
+      h1: test-header
     username: fleet
     password: fleetpassword
 

--- a/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
+++ b/x-pack/elastic-agent/pkg/agent/program/testdata/single_config-metricbeat.yml
@@ -88,6 +88,8 @@ metricbeat:
 output:
   elasticsearch:
     hosts: [127.0.0.1:9200, 127.0.0.1:9300]
+    headers:
+      h1: test-header
     username: elastic
     password: changeme
     bulk_max_size: 23

--- a/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/rules.go
@@ -1638,12 +1638,12 @@ func (r *InjectHeadersRule) Apply(agentInfo AgentInfo, ast *AST) (err error) {
 		return nil
 	}
 
-	outputsNode, found := Lookup(ast, "outputs")
+	outputNode, found := Lookup(ast, "output")
 	if !found {
 		return nil
 	}
 
-	elasticsearchNode, found := outputsNode.Find("elasticsearch")
+	elasticsearchNode, found := outputNode.Find("elasticsearch")
 	if found {
 		headersNode, found := elasticsearchNode.Find("headers")
 		if found {

--- a/x-pack/elastic-agent/pkg/agent/transpiler/rules_test.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/rules_test.go
@@ -725,7 +725,7 @@ rest: of
 
 		"inject auth headers: no headers": {
 			givenYAML: `
-outputs:
+output:
   elasticsearch:
     hosts:
       - "127.0.0.1:9201"
@@ -734,7 +734,7 @@ outputs:
     port: 5
 `,
 			expectedYAML: `
-outputs:
+output:
   elasticsearch:
     headers:
       h1: test-header
@@ -753,7 +753,7 @@ outputs:
 
 		"inject auth headers: existing headers": {
 			givenYAML: `
-outputs:
+output:
   elasticsearch:
     headers:
       sample-header: existing
@@ -764,7 +764,7 @@ outputs:
     port: 5
 `,
 			expectedYAML: `
-outputs:
+output:
   elasticsearch:
     headers:
       sample-header: existing


### PR DESCRIPTION
## What does this PR do?

Fix the `inject_headers` transpiler rule that adds fleet enrollment metadata into the http headers of resulting beats clients. The rule attempted (and silently failed) to inject the headers into the configuration under the `outputs` node, but at the rule application stage configurations are normalized to use an `output` node instead.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

