### PR TITLE
Do not try to load ILM if check_exists if false

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -200,6 +200,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Preserve annotations in a kubernetes namespace metadata {pull}27045[27045]
 - Allow conditional processing in `decode_xml` and `decode_xml_wineventlog`. {pull}27159[27159]
 - Fix build constraint that caused issues with doc builds. {pull}27381[27381]
+- Do not try to load ILM policy if `check_exists` is `false`. {pull}27508[27508] {issue}26322[26322]
 
 *Auditbeat*
 

--- a/libbeat/docs/shared-ilm.asciidoc
+++ b/libbeat/docs/shared-ilm.asciidoc
@@ -110,8 +110,8 @@ When set to `false`, disables the check for an existing lifecycle policy. The
 default is `true`. You need to disable this check if the {beatname_uc}
 user connecting to a secured cluster doesn't have the `read_ilm` privilege.
 
-If you set this option to `false`, set `setup.ilm.overwrite: true` so the
-lifecycle policy can be installed.
+If you set this option to `false`, lifecycle policy will not be installed, even if
+`setup.ilm.overwrite` is set to `true`.
 
 [float]
 [[setup-ilm-overwrite-option]]

--- a/libbeat/idxmgmt/ilm/ilm_test.go
+++ b/libbeat/idxmgmt/ilm/ilm_test.go
@@ -243,21 +243,21 @@ func TestDefaultSupport_Manager_EnsureAlias(t *testing.T) {
 				onCreateAlias(alias).Return(nil),
 			},
 			fail: nil,
-			cfg:  map[string]interface{}{"check_exists": false, "overwrite": true},
+			cfg:  map[string]interface{}{"check_exists": true, "overwrite": true},
 		},
 		"try overwrite existing": {
 			calls: []onCall{
 				onCreateAlias(alias).Return(errOf(ErrAliasAlreadyExists)),
 			},
 			fail: nil, // we detect that that the alias exists, and call it a day.
-			cfg:  map[string]interface{}{"check_exists": false, "overwrite": true},
+			cfg:  map[string]interface{}{"check_exists": true, "overwrite": true},
 		},
 		"fail to overwrite": {
 			calls: []onCall{
 				onCreateAlias(alias).Return(errOf(ErrAliasCreateFailed)),
 			},
 			fail: ErrAliasCreateFailed,
-			cfg:  map[string]interface{}{"check_exists": false, "overwrite": true},
+			cfg:  map[string]interface{}{"check_exists": true, "overwrite": true},
 		},
 	}
 

--- a/libbeat/idxmgmt/ilm/std.go
+++ b/libbeat/idxmgmt/ilm/std.go
@@ -104,11 +104,16 @@ func (m *stdManager) CheckEnabled() (bool, error) {
 
 func (m *stdManager) EnsureAlias() error {
 	log := m.log
+	if !m.checkExists {
+		log.Infof("Index alias is not checked as setup.ilm.check_exists is disabled")
+		return nil
+	}
+
 	overwrite := m.Overwrite()
 	name := m.alias.Name
 
 	var exists bool
-	if m.checkExists && !overwrite {
+	if !overwrite {
 		var err error
 		exists, err = m.client.HasAlias(name)
 		if err != nil {
@@ -143,11 +148,16 @@ func (m *stdManager) EnsureAlias() error {
 
 func (m *stdManager) EnsurePolicy(overwrite bool) (bool, error) {
 	log := m.log
+	if !m.checkExists {
+		log.Infof("ILM policy is not checked as setup.ilm.check_exists is disabled")
+		return false, nil
+	}
+
 	overwrite = overwrite || m.Overwrite()
 	name := m.policy.Name
 
 	var exists bool
-	if m.checkExists && !overwrite {
+	if !overwrite {
 		var err error
 		exists, err = m.client.HasILMPolicy(name)
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

Previously, if both `setup.ilm.check_exists` and `setup.ilm.overwrite` was disabled, Beats would still believe that the alias and/or the ILM policy has to be loaded.

This might be a breaking change, but from now on if `check_exists` is disabled, `overwrite` is ignored. But I think it is acceptable because people would only disable `check_exists` if the user connecting to ES does not have the required permissions. Thus, if the user does not have read permission for ILM components, it means that it does not have enough permission to load ILM components. Thus, trying to overwrite anything when `check_exists` is disabled makes no sense. If this is not good enough reasoning, the solution can be changed to still not load anything with the weird settings.

## Why is it important?

Without this change Beats will try to load ILM components if `check_exists` is set to false regardless of the `overwrite` settings.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #26322