### PR TITLE
Resolve #27289

### DIFF
--- a/x-pack/functionbeat/manager/aws/template_builder.go
+++ b/x-pack/functionbeat/manager/aws/template_builder.go
@@ -248,6 +248,11 @@ func (d *defaultTemplateBuilder) roleTemplate(function installer, name string) *
 
 	// Create the roles for the lambda.
 	// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+
+	roleName = "functionbeat-lambda-" + name + "-" + cloudformation.Ref("AWS::Region")
+	if (len(roleName) > 64) {
+		roleName = roleName[:len(roleName) - (len(roleName)-64)]
+	}
 	return &iam.Role{
 		AssumeRolePolicyDocument: map[string]interface{}{
 			"Statement": []interface{}{
@@ -264,7 +269,7 @@ func (d *defaultTemplateBuilder) roleTemplate(function installer, name string) *
 			},
 		},
 		Path:     "/",
-		RoleName: "functionbeat-lambda-" + name + "-" + cloudformation.Ref("AWS::Region"),
+		RoleName: roleName,
 		// Allow the lambda to write log to cloudwatch logs.
 		// doc: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
 		Policies: policies,


### PR DESCRIPTION
- Bug

## What does this PR do?

Trims the end of the role name if it's longer than 64 characters so that the cloudformation is valid.

## Why is it important?

Can't deploy if we chose a reasonable name, due to invalid cloud formation. See [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Run tests.

## Related issues

- Closes #27289 

## Use cases

Restricts RoleName to 64 characters.