### PR TITLE
Heartbeat: handle panic when job spanws multiple tasks

### DIFF
--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -299,7 +299,7 @@ func (s *Scheduler) runRecursiveTask(jobCtx context.Context, task TaskFunc, wg *
 			// irrelevant
 			go s.runRecursiveTask(jobCtx, cont, wg, jobSem)
 		}
-		if jobSem != nil && len(continuations) == 0 {
+		if jobSem != nil && len(continuations) == 0 && s.stats.activeTasks.Get() == 0 {
 			jobSem.Release(1)
 		}
 	}


### PR DESCRIPTION
+ When mode is set to `all`, multiple active taks exists which results in panic error as we are acquiring the lock only single time per monitor and trying to release it more than once. 

```
panic: semaphore: released more than held

go/pkg/mod/golang.org/x/sync@v0.0.0-20200317015054-43a5402ce75a/semaphore/semaphore.go:103 +0xed
github.com/elastic/beats/v7/heartbeat/scheduler.(*Scheduler).runRecursiveTask(0xc000720000, 0x1101964a0, 0xc00073c440, 0xc00000ec20, 0xc000058a20, 0xc00011c0f0, 0xc04114cb9b52d7b0, 0x346f4dc, 0x1110a1b60)
	dev/beats/heartbeat/scheduler/scheduler.go:303 +0x2e5
created by github.com/elastic/beats/v7/heartbeat/scheduler.(*Scheduler).runRecursiveTask
	dev/beats/heartbeat/scheduler/scheduler.go:300 +0x246
```