### PR TITLE
Skip Flaky Tests 

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -196,6 +196,7 @@ func TestFilestreamCloseEOF(t *testing.T) {
 
 // test_empty_lines from test_harvester.py
 func TestFilestreamEmptyLine(t *testing.T) {
+	t.Skip("Flaky test https://github.com/elastic/beats/issues/27585")
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"
@@ -693,6 +694,7 @@ func TestFilestreamTruncateCheckOffset(t *testing.T) {
 }
 
 func TestFilestreamTruncateBlockedOutput(t *testing.T) {
+	t.Skip("Flaky test https://github.com/elastic/beats/issues/270851")
 	env := newInputTestingEnvironment(t)
 	env.pipeline = &mockPipelineConnector{blocking: true}
 


### PR DESCRIPTION


## What does this PR do?

https://github.com/elastic/beats/issues/27085
https://github.com/elastic/beats/issues/27585

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

```


[2021-08-25T07:29:05.332Z] === Failed

[2021-08-25T07:29:05.332Z] === FAIL: filebeat/input/filestream TestFilestreamEmptyLine (1.01s)

[2021-08-25T07:29:05.332Z]     environment_test.go:188: 

[2021-08-25T07:29:05.332Z]         	Error Trace:	environment_test.go:188

[2021-08-25T07:29:05.332Z]         	            				input_integration_test.go:229

[2021-08-25T07:29:05.332Z]         	Error:      	Not equal: 

[2021-08-25T07:29:05.332Z]         	            	expected: 58

[2021-08-25T07:29:05.332Z]         	            	actual  : 37

[2021-08-25T07:29:05.332Z]         	Test:       	TestFilestreamEmptyLine

[2021-08-25T07:29:05.332Z] 

[2021-08-25T07:29:05.332Z] === FAIL: filebeat/input/filestream TestFilestreamTruncateBlockedOutput (0.01s)

[2021-08-25T07:29:05.332Z]     environment_test.go:185: error when getting expected key 'filestream::.global::native::9819782-108' from store: failed in store/get operation on store 'filebeat': expected object

[2021-08-25T07:29:05.332Z] 

[2021-08-25T07:29:05.332Z] DONE 737 tests, 4 skipped, 2 failures in 31.813s

[2021-08-25T07:29:05.332Z] Error: exit status 1
```


