### PR TITLE
warn log entry and no validation failure when both queue_url and buck…

### DIFF
--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -198,6 +198,29 @@ Required when using temporary security credentials.
 AWS IAM Role to assume.
 
 [float]
+=== config behaviour
+Beware that in case both `var.queue_url` and `var.bucket_arn` are not set
+instead of failing to start Filebeat with a config validation error, only the
+specific fileset input will be stopped and a warning printed:
+```
+2021-08-26T14:33:03.661-0600 WARN [aws-s3] awss3/config.go:54 neither queue_url nor bucket_arn were provided, input aws-s3 will stop
+2021-08-26T14:33:10.668-0600 INFO [input.aws-s3] compat/compat.go:111 Input aws-s3 starting {"id": "29F3565F5B2A7070"}
+2021-08-26T14:33:10.668-0600 INFO [input.aws-s3] compat/compat.go:124 Input 'aws-s3' stopped {"id": "29F3565F5B2A7070"}
+```
+
+This behaviour is required in order to reduce destruction of existing Filebeat setup
+where not all AWS module's filesets are defined and will change in next major release.
+
+Setting `enabled: false` in the unused fileset will silence the warning and it is
+the suggested setup. For example (assuming `cloudtrail` as unused fileset):
+```
+- module: aws
+  cloudtrail:
+    enabled: false
+
+```
+
+[float]
 === cloudtrail fileset
 
 CloudTrail monitors events for the account. If user creates a trail, it

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
 	"github.com/elastic/beats/v7/libbeat/common/match"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/reader/parser"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile/encoding"
@@ -50,7 +51,8 @@ func defaultConfig() config {
 
 func (c *config) Validate() error {
 	if c.QueueURL == "" && c.BucketARN == "" {
-		return fmt.Errorf("queue_url or bucket_arn must provided")
+		logp.NewLogger(inputName).Warnf("neither queue_url nor bucket_arn were provided, input %s will stop", inputName)
+		return nil
 	}
 
 	if c.QueueURL != "" && c.BucketARN != "" {

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -92,7 +92,7 @@ func TestConfig(t *testing.T) {
 				},
 			},
 			"",
-			func(queueURL, s3Bucketr string) config {
+			func(queueURL, s3Bucket string) config {
 				c := makeConfig(queueURL, "")
 				regex := match.MustCompile("/CloudTrail/")
 				c.FileSelectors = []fileSelectorConfig{
@@ -112,8 +112,10 @@ func TestConfig(t *testing.T) {
 				"queue_url":  "",
 				"bucket_arn": "",
 			},
-			"queue_url or bucket_arn must provided",
-			nil,
+			"",
+			func(queueURL, s3Bucket string) config {
+				return makeConfig("", "")
+			},
 		},
 		{
 			"error on both queueURL and s3Bucket",

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -193,6 +193,29 @@ Required when using temporary security credentials.
 AWS IAM Role to assume.
 
 [float]
+=== config behaviour
+Beware that in case both `var.queue_url` and `var.bucket_arn` are not set
+instead of failing to start Filebeat with a config validation error, only the
+specific fileset input will be stopped and a warning printed:
+```
+2021-08-26T14:33:03.661-0600 WARN [aws-s3] awss3/config.go:54 neither queue_url nor bucket_arn were provided, input aws-s3 will stop
+2021-08-26T14:33:10.668-0600 INFO [input.aws-s3] compat/compat.go:111 Input aws-s3 starting {"id": "29F3565F5B2A7070"}
+2021-08-26T14:33:10.668-0600 INFO [input.aws-s3] compat/compat.go:124 Input 'aws-s3' stopped {"id": "29F3565F5B2A7070"}
+```
+
+This behaviour is required in order to reduce destruction of existing Filebeat setup
+where not all AWS module's filesets are defined and will change in next major release.
+
+Setting `enabled: false` in the unused fileset will silence the warning and it is
+the suggested setup. For example (assuming `cloudtrail` as unused fileset):
+```
+- module: aws
+  cloudtrail:
+    enabled: false
+
+```
+
+[float]
 === cloudtrail fileset
 
 CloudTrail monitors events for the account. If user creates a trail, it


### PR DESCRIPTION
…et_arn are not provided

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

Bug

## What does this PR do?
see https://github.com/elastic/beats/issues/23226#issuecomment-905255038

we log a warn message if neither `queue_url` nor `bucket_arn` is setup for an AWS module fileset inestead of failing validation

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
if fileset for AWS module is not defined, instead of being explicitly disabled, its config validation won't be skipped: since neither `queue_url` nor `bucket_arn` are defined validation will fail and filebeat exits

without this fix any filebeat setup with custom config where any aws module fileset is not define will prevent to start after update to 7.15

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally
test filebeat with AWS module enabled (similar config like https://github.com/elastic/beats/issues/23226#issuecomment-905255038) without all the filesets explicitly configured as `enabled: false`

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

```
2021-08-26T16:29:12.960+0200    WARN    [aws-s3]        awss3/config.go:55      neither queue_url or bucket_arn were provided, input aws-s3 will stop
```

will replace

```
2021-08-25T12:03:34.312+0200    ERROR   [input.aws-s3]  awss3/input.go:93       getRegionFromQueueURL failed: QueueURL is not in format: https://sqs.{REGION_ENDPOINT}.{ENDPOINT}/{ACCOUNT_NUMBER}/{QUEUE_NAME} {"queue_url": "<no value>"}
```
