### PR TITLE
[Heartbeat] Fix bug where `enabled: false` is ignored.

### DIFF
--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -34,6 +34,9 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
+// ErrMonitorDisabled is returned when the monitor plugin is marked as disabled.
+var ErrMonitorDisabled = errors.New("monitor not loaded, plugin is disabled")
+
 // Monitor represents a configured recurring monitoring configuredJob loaded from a config file. Starting it
 // will cause it to run with the given scheduler until Stop() is called.
 type Monitor struct {
@@ -112,6 +115,10 @@ func newMonitorUnsafe(
 	standardFields, err := stdfields.ConfigToStdMonitorFields(config)
 	if err != nil {
 		return nil, err
+	}
+
+	if !config.Enabled() {
+		return nil, fmt.Errorf("monitor '%s' with id '%s' skipped: %w", standardFields.Name, standardFields.ID, ErrMonitorDisabled)
 	}
 
 	pluginFactory, found := registrar.Get(standardFields.Type)

--- a/heartbeat/monitors/stdfields/stdfields.go
+++ b/heartbeat/monitors/stdfields/stdfields.go
@@ -26,9 +26,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-// ErrPluginDisabled is returned when the monitor plugin is marked as disabled.
-var ErrPluginDisabled = errors.New("monitor not loaded, plugin is disabled")
-
 type ServiceFields struct {
 	Name string `config:"name"`
 }
@@ -58,10 +55,6 @@ func ConfigToStdMonitorFields(config *common.Config) (StdMonitorFields, error) {
 		if mpi.Service.Name == "" {
 			mpi.Service.Name = mpi.LegacyServiceName
 		}
-	}
-
-	if !mpi.Enabled {
-		return mpi, ErrPluginDisabled
 	}
 
 	return mpi, nil

--- a/heartbeat/tests/system/config/heartbeat.yml.j2
+++ b/heartbeat/tests/system/config/heartbeat.yml.j2
@@ -8,6 +8,10 @@ heartbeat.monitors:
   timeout: {{monitor.timeout}}
   {% endif -%}
 
+  {%- if monitor.enabled is defined %}
+  enabled: {{monitor.enabled}}
+  {% endif -%}
+
   {%- if monitor.tags is defined %}
   tags:
     {% for tag in monitor.tags -%}

--- a/heartbeat/tests/system/test_base.py
+++ b/heartbeat/tests/system/test_base.py
@@ -5,6 +5,7 @@ from heartbeat import BaseTest
 from elasticsearch import Elasticsearch
 from beat.beat import INTEGRATION_TESTS
 from beat import common_tests
+from time import sleep
 
 
 class Test(BaseTest, common_tests.TestExportsMixin):
@@ -53,7 +54,7 @@ class Test(BaseTest, common_tests.TestExportsMixin):
         )
 
         heartbeat_proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("heartbeat is running"))
+        self.wait_until(lambda: self.log_contains("skipping disabled monitor"))
         heartbeat_proc.check_kill_and_wait()
 
     def test_fields_under_root(self):


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/27599

This properly handles skipped monitors, and also fixes the broken test for this.

Additionally, this switches to the go1.3+ way of handling error hierarchies in `heartbeat.go` using `errors.Is`. It also cleans up the code by no longer making a disabled config an `error` when parsing stdfields. It's now only an error when detected in `monitor.go` which is cleaner.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## How to test this PR locally

Run the default heartbeat.yml, it should no longer crash. Switching `enabled: true` should cause the monitor to run.
