### PR TITLE
[elastic-agent] Fix docker tar.gz generation for complete image

### DIFF
--- a/dev-tools/mage/dockerbuilder.go
+++ b/dev-tools/mage/dockerbuilder.go
@@ -86,7 +86,7 @@ func (b *dockerBuilder) Build() error {
 			return errors.Wrap(err, "failed to build docker")
 		}
 
-		if err := b.dockerSave(tag); err != nil {
+		if err := b.dockerSave(tag, variant); err != nil {
 			return errors.Wrap(err, "failed to save docker as artifact")
 		}
 	}
@@ -209,7 +209,7 @@ func (b *dockerBuilder) dockerBuild(variant string) (string, error) {
 	return taggedImageName, sh.Run("docker", "build", "-t", taggedImageName, b.buildDir)
 }
 
-func (b *dockerBuilder) dockerSave(tag string) error {
+func (b *dockerBuilder) dockerSave(tag string, variant string) error {
 	if _, err := os.Stat(distributionsDir); os.IsNotExist(err) {
 		err := os.MkdirAll(distributionsDir, 0750)
 		if err != nil {
@@ -220,7 +220,8 @@ func (b *dockerBuilder) dockerSave(tag string) error {
 	outputFile := b.OutputFile
 	if outputFile == "" {
 		outputTar, err := b.Expand(defaultBinaryName+".docker.tar.gz", map[string]interface{}{
-			"Name": b.imageName,
+			"Name":    b.imageName,
+			"Variant": variant,
 		})
 		if err != nil {
 			return err

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -48,7 +48,7 @@ const (
 	packageStagingDir = "build/package"
 
 	// defaultBinaryName specifies the output file for zip and tar.gz.
-	defaultBinaryName = "{{.Name}}-{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
+	defaultBinaryName = "{{.Name}}-{{if .Variant}}{{.Variant}}-{{end}}{{.Version}}{{if .Snapshot}}-SNAPSHOT{{end}}{{if .OS}}-{{.OS}}{{end}}{{if .Arch}}-{{.Arch}}{{end}}"
 )
 
 // PackageType defines the file format of the package (e.g. zip, rpm, etc).
@@ -329,8 +329,10 @@ func (s *PackageSpec) ExtraVar(key, value string) {
 
 // Expand expands a templated string using data from the spec.
 func (s PackageSpec) Expand(in string, args ...map[string]interface{}) (string, error) {
+	// Assign a default value for variant since it's not always passed in
 	return expandTemplate("inline", in, FuncMap,
-		EnvMap(append([]map[string]interface{}{s.evalContext, s.toMap()}, args...)...))
+
+		EnvMap(append([]map[string]interface{}{s.evalContext, {"Variant": ""}, s.toMap()}, args...)...))
 }
 
 // MustExpand expands a templated string using data from the spec. It panics if


### PR DESCRIPTION
This interpolates the `variant` into the format string for .tar.gz docker artifacts. In also correctly handles the case where the format string is used in contexts without variant present, such as darwin. We still need an empty value for the templating language not to error.

Fixes https://github.com/elastic/beats/issues/27608
