### PR TITLE
[filebeat] fix crowdstrike ingest pipeline

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,7 +82,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - threatintel module: Changed the type of `threatintel.indicator.first_seen` from `keyword` to `date`. {pull}26765[26765]
 - Remove all alias fields pointing to ECS fields from modules. This affects the Suricata and Traefik modules. {issue}10535[10535] {pull}26627[26627]
 - Add option for S3 input to work without SQS notification {issue}18205[18205] {pull}27332[27332]
-- Fix crowdstrike ingest pipeline that was creating flattened `process` fields. {issue}27623[27623]
+- Fix crowdstrike ingest pipeline that was creating flattened `process` fields. {issue}27622[27622] {pull}27623[27623]
 
 *Heartbeat*
 - Remove long deprecated `watch_poll` functionality. {pull}27166[27166]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,6 +82,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - threatintel module: Changed the type of `threatintel.indicator.first_seen` from `keyword` to `date`. {pull}26765[26765]
 - Remove all alias fields pointing to ECS fields from modules. This affects the Suricata and Traefik modules. {issue}10535[10535] {pull}26627[26627]
 - Add option for S3 input to work without SQS notification {issue}18205[18205] {pull}27332[27332]
+- Fix crowdstrike ingest pipeline that was creating flattened `process` fields. {issue}27623[27623]
 
 *Heartbeat*
 - Remove long deprecated `watch_poll` functionality. {pull}27166[27166]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,7 +82,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - threatintel module: Changed the type of `threatintel.indicator.first_seen` from `keyword` to `date`. {pull}26765[26765]
 - Remove all alias fields pointing to ECS fields from modules. This affects the Suricata and Traefik modules. {issue}10535[10535] {pull}26627[26627]
 - Add option for S3 input to work without SQS notification {issue}18205[18205] {pull}27332[27332]
-- Fix crowdstrike ingest pipeline that was creating flattened `process` fields. {issue}27622[27622] {pull}27623[27623]
+- Fix Crowdstrike ingest pipeline that was creating flattened `process` fields. {issue}27622[27622] {pull}27623[27623]
 
 *Heartbeat*
 - Remove long deprecated `watch_poll` functionality. {pull}27166[27166]

--- a/x-pack/filebeat/module/crowdstrike/falcon/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/crowdstrike/falcon/ingest/pipeline.yml
@@ -284,9 +284,10 @@ processors:
             def args = Arrays.asList(/ /.split(commandLine));
             args.removeIf(arg -> arg == "");
 
-            ctx["process.command_line"] = commandLine;
-            ctx["process.args"] = args;
-            ctx["process.executable"] = args.get(0);
+            ctx['process'] = new HashMap();
+            ctx.process.command_line = commandLine;
+            ctx.process.args = args;
+            ctx.process.executable = args.get(0);
           }
         }
   - pipeline:


### PR DESCRIPTION
fix process fields that were being created as flattened fields

## What does this PR do?

This fix the process fields that were being created as flatenned fields instead of nested.

## Why is it important?

Mixing flattened fields and nested fields with similar name is confusing and could lead to errors when running queries or automated processes that expects the nested fields.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

## How to test this PR locally

## Related issues


- Closes #27622

## Use cases


## Screenshots

## Logs
