### PR TITLE
Filebeat auditd: Fix Top Exec Commands dashboard visualization

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -303,6 +303,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixes the Snyk module to work with the new API changes. {pull}27358[27358]
 - Fixes a bug in `http_endpoint` that caused numbers encoded as strings. {issue}27382[27382] {pull}27480[27480]
 - Update indentation for azure filebeat configuration. {pull}26604[26604]
+- Auditd: Fix Top Exec Commands dashboard visualization. {pull}NNN[NNN]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -303,7 +303,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fixes the Snyk module to work with the new API changes. {pull}27358[27358]
 - Fixes a bug in `http_endpoint` that caused numbers encoded as strings. {issue}27382[27382] {pull}27480[27480]
 - Update indentation for azure filebeat configuration. {pull}26604[26604]
-- Auditd: Fix Top Exec Commands dashboard visualization. {pull}NNN[NNN]
+- Auditd: Fix Top Exec Commands dashboard visualization. {pull}27638[27638]
 
 *Heartbeat*
 

--- a/filebeat/module/auditd/_meta/kibana/7/visualization/5ebdbe50-0a0f-11e7-825f-6748cda7d858-ecs.json
+++ b/filebeat/module/auditd/_meta/kibana/7/visualization/5ebdbe50-0a0f-11e7-825f-6748cda7d858-ecs.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "event.action:EXECVE"
+                    "query": "event.action:execve"
                 }
             }
         },


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Updates a Kibana visualization provided by Filebeat's auditd module so that it filters on the lowercase value `execve` instead of uppercase.

## Why is it important?

For a long time the module has been lowercasing the value of the ECS event.action field, but the dashboard wasn't updated.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
