### PR TITLE
Import the references of dashboard assets using the Saved Objects API

### DIFF
--- a/dev-tools/mage/kibana.go
+++ b/dev-tools/mage/kibana.go
@@ -69,7 +69,7 @@ func KibanaDashboards(moduleDirs ...string) error {
 	// Convert 7.x dashboards to strings.
 	err = sh.Run(pythonExe,
 		filepath.Join(esBeatsDir, "libbeat/scripts/unpack_dashboards.py"),
-		"--glob="+filepath.Join(kibanaBuildDir, "7/*/*.json"))
+		"--glob="+filepath.Join(kibanaBuildDir, "7/dashboards/*.json"))
 	if err != nil {
 		return err
 	}

--- a/libbeat/dashboards/importer.go
+++ b/libbeat/dashboards/importer.go
@@ -116,7 +116,7 @@ func (imp Importer) ImportDir(dirType string, dir string) error {
 
 	var errors []string
 
-	files, err := filepath.Glob(path.Join(dir, "*", "*.json"))
+	files, err := filepath.Glob(path.Join(dir, dirType, "*.json"))
 	if err != nil {
 		return fmt.Errorf("Failed to read directory %s. Error: %s", dir, err)
 	}

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -154,6 +154,11 @@ func (loader KibanaLoader) ImportDashboard(file string) error {
 
 	content = ReplaceStringInDashboard("CHANGEME_HOSTNAME", loader.hostname, content)
 
+	err = loader.importReferences(file, content)
+	if err != nil {
+		return fmt.Errorf("error loading references of dashboard: %+v", err)
+	}
+
 	var obj common.MapStr
 	err = json.Unmarshal(content, &obj)
 	if err != nil {
@@ -162,6 +167,35 @@ func (loader KibanaLoader) ImportDashboard(file string) error {
 
 	if err := loader.client.ImportMultiPartFormFile(importAPI, params, correctExtension(file), obj.String()); err != nil {
 		return fmt.Errorf("error dashboard asset: %+v", err)
+	}
+	return nil
+}
+
+type dashboardObj struct {
+	References []dashboardReference `json:"references"`
+}
+type dashboardReference struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}
+
+func (loader KibanaLoader) importReferences(path string, dashboard []byte) error {
+	var d dashboardObj
+	err := json.Unmarshal(dashboard, &d)
+	if err != nil {
+		return fmt.Errorf("failed to parse dashboard references: %+v", err)
+	}
+
+	base := filepath.Dir(path)
+	for _, ref := range d.References {
+		if ref.Type == "index-pattern" {
+			continue
+		}
+		referencePath := filepath.Join(base, "..", ref.Type, ref.ID+".json")
+		err := loader.ImportDashboard(referencePath)
+		if err != nil {
+			return fmt.Errorf("error loading reference of %s: %s %s: %+v", path, ref.Type, ref.ID, err)
+		}
 	}
 	return nil
 }

--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -92,6 +92,36 @@ func extractError(result []byte) error {
 	return nil
 }
 
+func extractMessage(result []byte) error {
+	var kibanaResult struct {
+		Success bool
+		Errors  []struct {
+			Id    string
+			Type  string
+			Error struct {
+				Type       string
+				References []struct {
+					Type string
+					Id   string
+				}
+			}
+		}
+	}
+	if err := json.Unmarshal(result, &kibanaResult); err != nil {
+		return nil
+	}
+
+	if !kibanaResult.Success {
+		var errs multierror.Errors
+		for _, err := range kibanaResult.Errors {
+			errs = append(errs, fmt.Errorf("error: %s, asset ID=%s; asset type=%s; references=%+v", err.Error.Type, err.Id, err.Type, err.Error.References))
+		}
+		return errs.Err()
+	}
+
+	return nil
+}
+
 // NewKibanaClient builds and returns a new Kibana client
 func NewKibanaClient(cfg *common.Config) (*Client, error) {
 	config := DefaultClientConfig()
@@ -187,8 +217,12 @@ func (conn *Connection) Request(method, extraPath string,
 		return 0, nil, fmt.Errorf("fail to read response %s", err)
 	}
 
+	fmt.Println(resp.StatusCode)
 	if resp.StatusCode >= 300 {
 		retError = extractError(result)
+	} else {
+		fmt.Println("msg")
+		retError = extractMessage(result)
 	}
 	return resp.StatusCode, result, retError
 }

--- a/libbeat/kibana/client.go
+++ b/libbeat/kibana/client.go
@@ -217,11 +217,9 @@ func (conn *Connection) Request(method, extraPath string,
 		return 0, nil, fmt.Errorf("fail to read response %s", err)
 	}
 
-	fmt.Println(resp.StatusCode)
 	if resp.StatusCode >= 300 {
 		retError = extractError(result)
 	} else {
-		fmt.Println("msg")
 		retError = extractMessage(result)
 	}
 	return resp.StatusCode, result, retError

--- a/libbeat/kibana/client_test.go
+++ b/libbeat/kibana/client_test.go
@@ -63,6 +63,21 @@ func TestErrorBadJson(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestErrorJsonWithHTTPOK(t *testing.T) {
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"successCount":0,"success":false,"warnings":[],"errors":[{"id":"abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs","type":"dashboard","title":"[Filebeat MongoDB] Overview ECS","meta":{"title":"[Filebeat MongoDB] Overview ECS","icon":"dashboardApp"},"error":{"type":"missing_references","references":[{"type":"search","id":"e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs"},{"type":"search","id":"bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs"}]}}]}`))
+	}))
+	defer kibanaTs.Close()
+
+	conn := Connection{
+		URL:  kibanaTs.URL,
+		HTTP: http.DefaultClient,
+	}
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Error(t, err)
+}
+
 func TestSuccess(t *testing.T) {
 	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"objects":[{"id":"test-*","type":"index-pattern","updated_at":"2018-01-24T19:04:13.371Z","version":1}]}`))


### PR DESCRIPTION
## What does this PR do?

This PR changes the dashboard loading by first loading its references and then loading the dashboards.

## Why is it important?

If the assets are not loaded in the proper order, the import can fail with unknown references.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
