### PR TITLE
Ignore context cancell in status reporting

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/operation/operation.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operation.go
@@ -72,7 +72,11 @@ type ApplicationStatusHandler struct{}
 //
 // It updates the status of the application and handles restarting the application is needed.
 func (*ApplicationStatusHandler) OnStatusChange(s *server.ApplicationState, status proto.StateObserved_Status, msg string, payload map[string]interface{}) {
+	if state.IsStateFiltered(msg, payload) {
+		return
+	}
 	app, ok := s.App().(Application)
+
 	if !ok {
 		panic(errors.New("only Application can be registered when using the ApplicationStatusHandler", errors.TypeUnexpected))
 	}

--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -151,8 +151,13 @@ func (o *Operator) HandleConfig(cfg configrequest.Request) (err error) {
 
 	_, stateID, steps, ack, err := o.stateResolver.Resolve(cfg)
 	if err != nil {
-		o.statusReporter.Update(state.Failed, err.Error(), nil)
-		return errors.New(err, errors.TypeConfig, fmt.Sprintf("operator: failed to resolve configuration %s, error: %v", cfg, err))
+		if err == filterContextCancelled(err) {
+			// error is not filtered and should be reported
+			o.statusReporter.Update(state.Failed, err.Error(), nil)
+			err = errors.New(err, errors.TypeConfig, fmt.Sprintf("operator: failed to resolve configuration %s, error: %v", cfg, err))
+		}
+
+		return err
 	}
 	o.statusController.UpdateStateID(stateID)
 

--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -256,6 +256,10 @@ func (a *Application) waitProc(proc *os.Process) <-chan *os.ProcessState {
 
 func (a *Application) setState(s state.Status, msg string, payload map[string]interface{}) {
 	if a.state.Status != s || a.state.Message != msg || !reflect.DeepEqual(a.state.Payload, payload) {
+		if state.IsStateFiltered(msg, payload) {
+			return
+		}
+
 		a.state.Status = s
 		a.state.Message = msg
 		a.state.Payload = payload

--- a/x-pack/elastic-agent/pkg/core/plugin/service/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/service/app.go
@@ -308,6 +308,10 @@ func (a *Application) OnStatusChange(s *server.ApplicationState, status proto.St
 
 func (a *Application) setState(s state.Status, msg string, payload map[string]interface{}) {
 	if a.state.Status != s || a.state.Message != msg || !reflect.DeepEqual(a.state.Payload, payload) {
+		if state.IsStateFiltered(msg, payload) {
+			return
+		}
+
 		a.state.Status = s
 		a.state.Message = msg
 		a.state.Payload = payload

--- a/x-pack/elastic-agent/pkg/core/state/state.go
+++ b/x-pack/elastic-agent/pkg/core/state/state.go
@@ -5,6 +5,9 @@
 package state
 
 import (
+	"context"
+	"strings"
+
 	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/process"
@@ -36,6 +39,10 @@ const (
 	// Stopping is status describing application is stopping.
 	Stopping = Status(proto.StateObserved_STOPPING)
 )
+
+var filteredErrors = []string{
+	context.Canceled.Error(),
+}
 
 // IsInternal returns true if the status is an internal status and not something that should be reported
 // over the protocol as an actual status.
@@ -78,4 +85,15 @@ type State struct {
 type Reporter interface {
 	// OnStateChange is called when state changes.
 	OnStateChange(id string, name string, state State)
+}
+
+// IsStateFiltered returns true if state message contains error out of predefined
+// collection of ignored errors.
+func IsStateFiltered(msg string, payload map[string]interface{}) bool {
+	for _, e := range filteredErrors {
+		if strings.Contains(msg, e) {
+			return true
+		}
+	}
+	return false
 }

--- a/x-pack/elastic-agent/pkg/core/status/reporter.go
+++ b/x-pack/elastic-agent/pkg/core/status/reporter.go
@@ -267,6 +267,10 @@ func (r *reporter) Update(s state.Status, message string, payload map[string]int
 	if !r.isRegistered {
 		return
 	}
+	if state.IsStateFiltered(message, payload) {
+		return
+	}
+
 	if r.status != s || r.message != message || !reflect.DeepEqual(r.payload, payload) {
 		r.status = s
 		r.message = message


### PR DESCRIPTION
## What does this PR do?

Followup to https://github.com/elastic/beats/pull/27210
This PR reduces context cancelled from status reporting including cases when process itself reports failure due to context cancelled. 

Result is that two messages described in a comment linked below will disappear.
These does not alter behaviour and occur just at the time of restarting. But it may look like there's something wrong with process, operator or agent itself as failures propagate up.

## Why is it important?

Fixes: https://github.com/elastic/beats/issues/27062#issuecomment-908108760

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
