### PR TITLE
Fix output.elasticsearch.proxy_disable flag

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -81,7 +81,7 @@
 - Fix issue with atomic extract running in K8s {pull}27396[27396]
 - Fix issue with install directory in state path in K8s {pull}27396[27396]
 - Disable monitoring during fleet-server bootstrapping. {pull}27222[27222]
-- Change output.elasticsearch.proxy_disabled flag to output.elasticsearch.proxy_disable so fleet uses it. {issue}27670[27670]
+- Change output.elasticsearch.proxy_disabled flag to output.elasticsearch.proxy_disable so fleet uses it. {issue}27670[27670] {pull}27671[27671]
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -81,6 +81,7 @@
 - Fix issue with atomic extract running in K8s {pull}27396[27396]
 - Fix issue with install directory in state path in K8s {pull}27396[27396]
 - Disable monitoring during fleet-server bootstrapping. {pull}27222[27222]
+- Change output.elasticsearch.proxy_disabled flag to output.elasticsearch.proxy_disable so fleet uses it. {issue}27670[27670]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -834,7 +834,7 @@ func createFleetServerBootstrapConfig(
 		}
 	}
 	es.ProxyURL = proxyURL
-	es.ProxyDisabled = proxyDisabled
+	es.ProxyDisable = proxyDisabled
 	es.ProxyHeaders = proxyHeaders
 
 	cfg := configuration.DefaultFleetAgentConfig()

--- a/x-pack/elastic-agent/pkg/agent/configuration/fleet_server.go
+++ b/x-pack/elastic-agent/pkg/agent/configuration/fleet_server.go
@@ -33,17 +33,17 @@ type FleetServerOutputConfig struct {
 
 // Elasticsearch is the configuration for elasticsearch.
 type Elasticsearch struct {
-	Protocol      string            `config:"protocol" yaml:"protocol"`
-	Hosts         []string          `config:"hosts" yaml:"hosts"`
-	Path          string            `config:"path" yaml:"path,omitempty"`
-	Username      string            `config:"username" yaml:"username,omitempty"`
-	Password      string            `config:"password" yaml:"password,omitempty"`
-	ServiceToken  string            `config:"service_token" yaml:"service_token,omitempty"`
-	TLS           *tlscommon.Config `config:"ssl" yaml:"ssl,omitempty"`
-	Headers       map[string]string `config:"headers" yaml:"headers,omitempty"`
-	ProxyURL      string            `config:"proxy_url" yaml:"proxy_url,omitempty"`
-	ProxyDisabled bool              `config:"proxy_disabled" yaml:"proxy_disabled"`
-	ProxyHeaders  map[string]string `config:"proxy_headers" yaml:"proxy_headers"`
+	Protocol     string            `config:"protocol" yaml:"protocol"`
+	Hosts        []string          `config:"hosts" yaml:"hosts"`
+	Path         string            `config:"path" yaml:"path,omitempty"`
+	Username     string            `config:"username" yaml:"username,omitempty"`
+	Password     string            `config:"password" yaml:"password,omitempty"`
+	ServiceToken string            `config:"service_token" yaml:"service_token,omitempty"`
+	TLS          *tlscommon.Config `config:"ssl" yaml:"ssl,omitempty"`
+	Headers      map[string]string `config:"headers" yaml:"headers,omitempty"`
+	ProxyURL     string            `config:"proxy_url" yaml:"proxy_url,omitempty"`
+	ProxyDisable bool              `config:"proxy_disable" yaml:"proxy_disable"`
+	ProxyHeaders map[string]string `config:"proxy_headers" yaml:"proxy_headers"`
 }
 
 // ElasticsearchFromConnStr returns an Elasticsearch configuration from the connection string.


### PR DESCRIPTION
## What does this PR do?

Rename the output.elasticsearch.proxy_disabled flag to proxy_disable as
that is what the flag appears as under all other settings including
fleet.

## Why is it important?

fleet-server expects the setting to be named proxy_disable

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [] ~~I have commented my code, particularly in hard-to-understand areas
- [] ~~I have made corresponding changes to the documentation
- [] ~~I have made corresponding change to the default configuration files~~
- [] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #27670 