### PR TITLE
Re-apply fix for auditd dashboard

### DIFF
--- a/filebeat/module/auditd/_meta/kibana/7/visualization/5ebdbe50-0a0f-11e7-825f-6748cda7d858-ecs.json
+++ b/filebeat/module/auditd/_meta/kibana/7/visualization/5ebdbe50-0a0f-11e7-825f-6748cda7d858-ecs.json
@@ -7,7 +7,7 @@
                 "indexRefName": "kibanaSavedObjectMeta.searchSourceJSON.index",
                 "query": {
                     "language": "kuery",
-                    "query": "event.action:EXECVE"
+                    "query": "event.action:execve"
                 }
             }
         },


### PR DESCRIPTION
Re-applies the fix introduced by #27646, as it's been reverted in #27636. This is caused by merging PRs in a different order than in master.

