### PR TITLE
[Filebeat] adding base64encode func to value template

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -772,6 +772,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update `tags` and `threatintel.indicator.provider` fields in `threatintel.anomali` ingest pipeline {issue}24746[24746] {pull}27141[27141]
 - Move AWS module and filesets to GA. {pull}27428[27428]
 - update ecs.version to ECS 1.11.0. {pull}27107[27107]
+- Add base64 Encode functionality to httpjson input. {pull}27681[27681]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -205,6 +205,7 @@ Some built-in helper functions are provided to work with the input state inside 
 - `div`: does the integer division of two integer values.
 - `hmac`: calculates the hmac signature of a list of strings concatenated together. Supports sha1 or sha256. Example `[[hmac "sha256" "secret" "string1" "string2" (formatDate (now) "RFC1123")]]`
 - `base64Encode`: Joins and base64 encodes all supplied strings. Example `[[base64Encode "string1" "string2"]]`
+- `base64EncodeNoPad`: Joins and base64 encodes all supplied strings without padding. Example `[[base64EncodeNoPad "string1" "string2"]]`
 
 In addition to the provided functions, any of the native functions for https://golang.org/pkg/time/#Time[`time.Time`], https://golang.org/pkg/net/http/#Header[`http.Header`], and https://golang.org/pkg/net/url/#Values[`url.Values`] types can be used on the corresponding objects. Examples: `[[(now).Day]]`, `[[.last_response.header.Get "key"]]`
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -204,6 +204,7 @@ Some built-in helper functions are provided to work with the input state inside 
 - `mul`: multiplies two integers.
 - `div`: does the integer division of two integer values.
 - `hmac`: calculates the hmac signature of a list of strings concatenated together. Supports sha1 or sha256. Example `[[hmac "sha256" "secret" "string1" "string2" (formatDate (now) "RFC1123")]]`
+- `base64Encode`: Joins and base64 encodes all supplied strings. Example `[[base64Encode "string1" "string2"]]`
 
 In addition to the provided functions, any of the native functions for https://golang.org/pkg/time/#Time[`time.Time`], https://golang.org/pkg/net/http/#Header[`http.Header`], and https://golang.org/pkg/net/url/#Values[`url.Values`] types can be used on the corresponding objects. Examples: `[[(now).Day]]`, `[[.last_response.header.Get "key"]]`
 

--- a/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
@@ -56,6 +56,7 @@ func (t *valueTpl) Unpack(in string) error {
 			"div":                 div,
 			"hmac":                hmacString,
 			"base64Encode":        base64Encode,
+			"base64EncodeNoPad":   base64EncodeNoPad,
 		}).
 		Delims(leftDelim, rightDelim).
 		Parse(in)
@@ -252,6 +253,15 @@ func base64Encode(values ...string) string {
 	}
 
 	return base64.StdEncoding.EncodeToString([]byte(data))
+}
+
+func base64EncodeNoPad(values ...string) string {
+	data := strings.Join(values, "")
+	if data == "" {
+		return ""
+	}
+
+	return base64.RawStdEncoding.EncodeToString([]byte(data))
 }
 
 func hmacString(hmacType string, hmacKey string, values ...string) string {

--- a/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
@@ -246,7 +246,7 @@ func div(a, b int64) int64 {
 }
 
 func base64Encode(values ...string) string {
-	data := strings.Join(values[:], "")
+	data := strings.Join(values, "")
 	if data == "" {
 		return ""
 	}

--- a/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/value_tpl.go
@@ -9,6 +9,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"hash"
@@ -54,6 +55,7 @@ func (t *valueTpl) Unpack(in string) error {
 			"mul":                 mul,
 			"div":                 div,
 			"hmac":                hmacString,
+			"base64Encode":        base64Encode,
 		}).
 		Delims(leftDelim, rightDelim).
 		Parse(in)
@@ -241,6 +243,15 @@ func mul(a, b int64) int64 {
 
 func div(a, b int64) int64 {
 	return a / b
+}
+
+func base64Encode(values ...string) string {
+	data := strings.Join(values[:], "")
+	if data == "" {
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString([]byte(data))
 }
 
 func hmacString(hmacType string, hmacKey string, values ...string) string {

--- a/x-pack/filebeat/input/httpjson/internal/v2/value_tpl_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/value_tpl_test.go
@@ -276,6 +276,21 @@ func TestValueTpl(t *testing.T) {
 			expectedVal:   "",
 			expectedError: errEmptyTemplateResult.Error(),
 		},
+		{
+			name:        "func base64Encode 2 strings",
+			value:       `[[base64Encode "string1" "string2"]]`,
+			paramCtx:    emptyTransformContext(),
+			paramTr:     transformable{},
+			expectedVal: "c3RyaW5nMXN0cmluZzI=",
+		},
+		{
+			name:          "func base64Encode no value",
+			value:         `[[base64Encode ""]]`,
+			paramCtx:      emptyTransformContext(),
+			paramTr:       transformable{},
+			expectedVal:   "",
+			expectedError: errEmptyTemplateResult.Error(),
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## What does this PR do?

This adds base64encode functionality for value templates in httpjson input.

## Why is it important?

Adds new functionality to httpjson input.
Adding possibility for `.request` and `.header` comes in a separate PR.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #27610 

