### PR TITLE
Skip add_kubernetes_metadata processor if kubernetes metadata are aleady there

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -22,6 +22,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add daemonset.name in pods controlled by DaemonSets {pull}26808[26808], {issue}25816[25816]
 - Kubernetes autodiscover fails in node scope if node name cannot be discovered {pull}26947[26947]
 - Loading Kibana assets (dashboards, index templates) rely on Saved Object API. So to provide a reliable service, Beats can only import and export dasbhboards using at least Kibana 7.15. {issue}20672[20672] {pull}27220[27220]
+- Skip add_kubernetes_metadata processor when kubernetes metadata are already present {pull}27689[27689]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -268,6 +268,7 @@ func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 		k.log.Debug("No container match string, not adding kubernetes data")
 		return event, nil
 	}
+
 	k.log.Debugf("Using the following index key %s", index)
 	metadata := k.cache.get(index)
 	if metadata == nil {

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -90,7 +90,7 @@ func isKubernetesAvailableWithRetry(client k8sclient.Interface) bool {
 
 // kubernetesMetadataExist checks whether an event is already enriched with kubernetes metadata
 func kubernetesMetadataExist(event *beat.Event) bool {
-	if _, err := event.GetValue("kubernetes.namespace"); err != nil {
+	if _, err := event.GetValue("kubernetes"); err != nil {
 		return false
 	}
 	return true

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-// Test metadata updates don't replace existing pod metrics
-func TestAnnotatorDeepUpdate(t *testing.T) {
+// Test Annotator is skipped if kubernetes metadata already exist
+func TestAnnotatorSkipped(t *testing.T) {
 	cfg := common.MustNewConfigFrom(map[string]interface{}{
 		"lookup_fields": []string{"kubernetes.pod.name"},
 	})
@@ -53,8 +53,7 @@ func TestAnnotatorDeepUpdate(t *testing.T) {
 			"kubernetes": common.MapStr{
 				"pod": common.MapStr{
 					"labels": common.MapStr{
-						"dont":     "replace",
-						"original": "fields",
+						"added": "should not",
 					},
 				},
 			},
@@ -84,10 +83,6 @@ func TestAnnotatorDeepUpdate(t *testing.T) {
 				"metrics": common.MapStr{
 					"a": 1,
 					"b": 2,
-				},
-				"labels": common.MapStr{
-					"dont":     "replace",
-					"original": "fields",
 				},
 			},
 		},


### PR DESCRIPTION
## What does this PR do?

This PR prevents `add_kubernetes_metadata` processor from running in cases kubernetes metadata are already present in an event.

## Why is it important?

This change prevents metadata being overridden by the processor.
Also In cases where the processor is run by `elastic-agent` (enabled by default) it fails since the matchers are not properly configured (see https://github.com/elastic/beats/issues/27216).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Run filebeat on kubernetes with kubernetes autodiscover provider enabled [(doc)](https://www.elastic.co/guide/en/beats/filebeat/master/configuration-autodiscover.html, the provider adds the metadata) and also `add_kubernetes_metadata`  processor enabled.
Check in the logs that the processor is being skipped.

2. Run filebeat on kubernetes with input of type container [(doc)](https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-input-container.html) and also `add_kubernetes_metadata` enabled.
Check in the logs that the processor starts and adds the metadata.

## Related issues
- Closes https://github.com/elastic/beats/issues/27216 