### PR TITLE
Add LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE to system/process

### DIFF
--- a/metricbeat/module/system/process/process.go
+++ b/metricbeat/module/system/process/process.go
@@ -21,6 +21,7 @@ package process
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/pkg/errors"
@@ -90,6 +91,15 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		perCPU:  config.IncludePerCPU,
 		IsAgent: systemModule.IsAgent,
 	}
+
+	// If hostfs is set, we may not want to force the hierarchy override, as the user could be expecting a custom path.
+	if len(paths.Paths.Hostfs) < 2 {
+		override, isset := os.LookupEnv("LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE")
+		if isset {
+			m.stats.CgroupOpts.CgroupsHierarchyOverride = override
+		}
+	}
+
 	err := m.stats.Init()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What does this PR do?

So, a while ago @axw added support for `LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE` in libbeat monitoring. However, it wasn't added to system/process. I'm going to assume it was just overlooked, and there wasn't a reason to exclude it, so this adds it, so we get proper cgroup metrics from a container.

## Why is it important?

This is kind of a bug, as we properly report cgroup metrics within libbeat monitoring, but not within metricbeat.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Pull down and build
- Run metricbeat inside a container, make sure cgroup metrics are correctly reported from within `system/process`
