### PR TITLE
[Auditbeat] scanner honor include_files

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -213,6 +213,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix dataset using 100% CPU and becoming unresponsive in some scenarios. {pull}19033[19033] {pull}19764[19764]
 - system/socket: Fixed tracking of long-running connections. {pull}19033[19033]
+- file_integrity: honor include_files when doing initial scan. {issue}27273[27273] {pull}27722[27722]
 
 *Filebeat*
 

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -258,7 +258,7 @@ func TestIncludedExcludedFiles(t *testing.T) {
 	}
 
 	config := getConfig(dir)
-	config["include_files"] = []string{`\.ssh\/`}
+	config["include_files"] = []string{`\.ssh`}
 	config["recursive"] = true
 	ms := mbtest.NewPushMetricSetV2(t, config)
 

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -258,7 +258,7 @@ func TestIncludedExcludedFiles(t *testing.T) {
 	}
 
 	config := getConfig(dir)
-	config["include_files"] = []string{`\.ssh/`}
+	config["include_files"] = []string{`\.ssh\/`}
 	config["recursive"] = true
 	ms := mbtest.NewPushMetricSetV2(t, config)
 

--- a/auditbeat/module/file_integrity/scanner.go
+++ b/auditbeat/module/file_integrity/scanner.go
@@ -140,6 +140,11 @@ func (s *scanner) walkDir(dir string, action Action) error {
 			}
 			return nil
 		}
+
+		if !info.IsDir() && !s.config.IsIncludedPath(path) {
+			return nil
+		}
+
 		defer func() { startTime = time.Now() }()
 
 		event := s.newScanEvent(path, info, err, action)


### PR DESCRIPTION
## What does this PR do?

In auditbeat scanner:

- If included_files is set and file name does not match included_files then it is
  skipped
- directories are included even if they don't match included_files
  because the contents might

## Why is it important?

All files were being scanned in first scan unless listed in `exclude_files`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

`mage goUnitTest`

## Related issues

- Closes #27273