### PR TITLE
[Filebeat] Add timezone config option to decode_cef and syslog input

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -736,6 +736,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support to `decode_cef` for MAC addresses that do not contain separator characters. {issue}27050[27050] {pull}27109[27109]
 - Add new `hmac` template function for httpjson input {pull}27168[27168]
 - Add `timezone` config option to the `decode_cef` processor. {issue}27232[27232] {pull}27727[27727]
+- Add `timezone` config option to the `syslog` input. {pull}27727[27727]
 - Update `tags` and `threatintel.indicator.provider` fields in `threatintel.anomali` ingest pipeline {issue}24746[24746] {pull}27141[27141]
 - Move AWS module and filesets to GA. {pull}27428[27428]
 - update ecs.version to ECS 1.11.0. {pull}27107[27107]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -735,6 +735,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support to merge registry updates in the filestream input across multiple ACKed batches in case of backpressure in the registry or disk. {pull}25976[25976]
 - Add support to `decode_cef` for MAC addresses that do not contain separator characters. {issue}27050[27050] {pull}27109[27109]
 - Add new `hmac` template function for httpjson input {pull}27168[27168]
+- Add `timezone` config option to the `decode_cef` processor. {issue}27232[27232] {pull}27727[27727]
 - Update `tags` and `threatintel.indicator.provider` fields in `threatintel.anomali` ingest pipeline {issue}24746[24746] {pull}27141[27141]
 - Move AWS module and filesets to GA. {pull}27428[27428]
 - update ecs.version to ECS 1.11.0. {pull}27107[27107]

--- a/filebeat/docs/inputs/input-syslog.asciidoc
+++ b/filebeat/docs/inputs/input-syslog.asciidoc
@@ -7,7 +7,8 @@
 <titleabbrev>Syslog</titleabbrev>
 ++++
 
-The `syslog` input reads Syslog events as specified by RFC 3164 and RFC 5424, over TCP, UDP, or a Unix stream socket.
+The `syslog` input reads Syslog events as specified by RFC 3164 and RFC 5424,
+over TCP, UDP, or a Unix stream socket.
 
 Example configurations:
 
@@ -40,12 +41,21 @@ Example configurations:
 
 ==== Configuration options
 
-The `syslog` input configuration includes format, protocol specific options, and the
-<<{beatname_lc}-input-{type}-common-options>> described later.
+The `syslog` input configuration includes format, protocol specific options, and
+the <<{beatname_lc}-input-{type}-common-options>> described later.
 
 ===== `format`
 
-The syslog variant to use, `rfc3164` or `rfc5424`. To automatically detect the format from the log entries, set this option to `auto`. The default is `rfc3164`.
+The syslog variant to use, `rfc3164` or `rfc5424`. To automatically detect the
+format from the log entries, set this option to `auto`. The default is
+`rfc3164`.
+
+===== `timezone`
+
+IANA time zone name (e.g. `America/New_York`) or fixed time offset (e.g.
+`+0200`) to use when parsing syslog timestamps that do not contain a time zone.
+`Local` may be specified to use the machine's local time zone. Defaults to
+`Local`.
 
 ===== Protocol `udp`:
 

--- a/filebeat/docs/modules/cef.asciidoc
+++ b/filebeat/docs/modules/cef.asciidoc
@@ -46,6 +46,13 @@ A list of tags to include in events. Including `forwarded` indicates that the
 events did not originate on this host and causes `host.name` to not be added to
 events. Defaults to `[cef, forwarded]`.
 
+*`var.timezone`*::
+
+IANA time zone name (e.g. `America/New_York`) or fixed time offset (e.g.
+`+0200`) to use when parsing times from the CEF message that do not contain a
+time zone. `Local` may be specified to use the machine's local time zone.
+Defaults to `UTC`.
+
 [float]
 ==== Forcepoint NGFW Security Management Center
 

--- a/filebeat/input/syslog/config.go
+++ b/filebeat/input/syslog/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/inputsource/udp"
 	"github.com/elastic/beats/v7/filebeat/inputsource/unix"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
@@ -37,6 +38,7 @@ type config struct {
 	harvester.ForwarderConfig `config:",inline"`
 	Format                    syslogFormat           `config:"format"`
 	Protocol                  common.ConfigNamespace `config:"protocol"`
+	Timezone                  *cfgtype.Timezone      `config:"timezone"`
 }
 
 type syslogFormat int
@@ -59,7 +61,8 @@ var defaultConfig = config{
 	ForwarderConfig: harvester.ForwarderConfig{
 		Type: "syslog",
 	},
-	Format: syslogFormatRFC3164,
+	Format:   syslogFormatRFC3164,
+	Timezone: cfgtype.MustNewTimezone("Local"),
 }
 
 type syslogTCP struct {

--- a/filebeat/input/syslog/input.go
+++ b/filebeat/input/syslog/input.go
@@ -179,7 +179,7 @@ func GetCbByConfig(cfg config, forwarder *harvester.Forwarder, log *logp.Logger)
 
 	case syslogFormatRFC5424:
 		return func(data []byte, metadata inputsource.NetworkMetadata) {
-			ev := parseAndCreateEvent5424(data, metadata, time.Local, log)
+			ev := parseAndCreateEvent5424(data, metadata, cfg.Timezone.Location(), log)
 			forwarder.Send(ev)
 		}
 
@@ -187,9 +187,9 @@ func GetCbByConfig(cfg config, forwarder *harvester.Forwarder, log *logp.Logger)
 		return func(data []byte, metadata inputsource.NetworkMetadata) {
 			var ev beat.Event
 			if IsRFC5424Format(data) {
-				ev = parseAndCreateEvent5424(data, metadata, time.Local, log)
+				ev = parseAndCreateEvent5424(data, metadata, cfg.Timezone.Location(), log)
 			} else {
-				ev = parseAndCreateEvent3164(data, metadata, time.Local, log)
+				ev = parseAndCreateEvent3164(data, metadata, cfg.Timezone.Location(), log)
 			}
 			forwarder.Send(ev)
 		}
@@ -198,7 +198,7 @@ func GetCbByConfig(cfg config, forwarder *harvester.Forwarder, log *logp.Logger)
 	}
 
 	return func(data []byte, metadata inputsource.NetworkMetadata) {
-		ev := parseAndCreateEvent3164(data, metadata, time.Local, log)
+		ev := parseAndCreateEvent3164(data, metadata, cfg.Timezone.Location(), log)
 		forwarder.Send(ev)
 	}
 }
@@ -287,7 +287,7 @@ func parseAndCreateEvent3164(data []byte, metadata inputsource.NetworkMetadata, 
 			"message": string(data),
 		})
 	}
-	return createEvent(ev, metadata, time.Local, log)
+	return createEvent(ev, metadata, timezone, log)
 }
 
 func parseAndCreateEvent5424(data []byte, metadata inputsource.NetworkMetadata, timezone *time.Location, log *logp.Logger) beat.Event {
@@ -299,7 +299,7 @@ func parseAndCreateEvent5424(data []byte, metadata inputsource.NetworkMetadata, 
 			"message": string(data),
 		})
 	}
-	return createEvent(ev, metadata, time.Local, log)
+	return createEvent(ev, metadata, timezone, log)
 }
 
 func newBeatEvent(timestamp time.Time, metadata inputsource.NetworkMetadata, fields common.MapStr) beat.Event {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/elastic/beats/v7
 go 1.16
 
 require (
-	4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b
 	cloud.google.com/go v0.51.0
 	cloud.google.com/go/bigquery v1.0.1
 	cloud.google.com/go/pubsub v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-4d63.com/embedfiles v0.0.0-20190311033909-995e0740726f h1:oyYjGRBNq1TxAIG8aHqtxlvqUfzdZf+MbcRb/oweNfY=
-4d63.com/embedfiles v0.0.0-20190311033909-995e0740726f/go.mod h1:HxEsUxoVZyRxsZML/S6e2xAuieFMlGO0756ncWx1aXE=
-4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b h1:+TO4EgK74+Qo/ilRDiF2WpY09Jk9VSJSLe3wEn+dJBw=
-4d63.com/tz v1.1.1-0.20191124060701-6d37baae851b/go.mod h1:SHGqVdL7hd2ZaX2T9uEiOZ/OFAUfCCLURdLPJsd8ZNs=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/libbeat/common/cfgtype/timezone.go
+++ b/libbeat/common/cfgtype/timezone.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cfgtype
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+
+	// Embed the timezone database so this code works across platforms.
+	_ "time/tzdata"
+)
+
+var fixedOffsetFormats = []string{"-07", "-0700", "-07:00"}
+
+// Timezone maps time instants to the zone in use at that time. Typically, the
+// Timezone represents the collection of time offsets in use in a geographical
+// area. For many Locations the time offset varies depending on whether daylight
+// savings time is in use at the time instant.
+type Timezone time.Location
+
+// NewTimezone returns a new timezone.
+func NewTimezone(tz string) (*Timezone, error) {
+	loc, err := loadLocation(tz)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse timezone %q", tz)
+	}
+	return (*Timezone)(loc), nil
+}
+
+// MustNewTimezone returns a new timezone. If tz is invalid it panics.
+func MustNewTimezone(tz string) *Timezone {
+	timestamp, err := NewTimezone(tz)
+	if err != nil {
+		panic(err)
+	}
+	return timestamp
+}
+
+// Location returns a *time.Location. If timezone is nil it returns *time.UTC.
+func (tz *Timezone) Location() *time.Location {
+	if tz == nil {
+		return time.UTC
+	}
+	return (*time.Location)(tz)
+}
+
+// MarshalJSON implements json.Marshaler interface.
+func (tz *Timezone) MarshalJSON() ([]byte, error) {
+	if tz == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(tz.Location().String())
+}
+
+// Unpack converts a time zone name or offset to Timezone. If using a fixed
+// offset then the format must be [+-]HHMM (e.g +0800 or -0530).
+func (tz *Timezone) Unpack(v string) error {
+	timezone, err := NewTimezone(v)
+	if err != nil {
+		return err
+	}
+	*tz = *timezone
+	return nil
+}
+
+func loadLocation(timezone string) (*time.Location, error) {
+	for _, format := range fixedOffsetFormats {
+		t, err := time.Parse(format, timezone)
+		if err == nil {
+			name, offset := t.Zone()
+			return time.FixedZone(name, offset), nil
+		}
+	}
+
+	// Handle IANA time zones.
+	return time.LoadLocation(timezone)
+}

--- a/libbeat/common/cfgtype/timezone_test.go
+++ b/libbeat/common/cfgtype/timezone_test.go
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cfgtype
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimezoneUnpack(t *testing.T) {
+	testCases := []struct {
+		ZoneName string
+	}{
+		{"America/New_York"},
+		{"Local"},
+		{"+0500"},
+		{"-0500"},
+		{"+05:00"},
+		{"-05:00"},
+		{"+05"},
+		{"-05"},
+		{"UTC"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.ZoneName, func(t *testing.T) {
+			tz := &Timezone{}
+			err := tz.Unpack(tc.ZoneName)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestTimezoneUnpackFixedZone(t *testing.T) {
+	tz := &Timezone{}
+	err := tz.Unpack("+0530")
+	require.NoError(t, err)
+
+	now := time.Time{}
+	loc := tz.Location()
+	offset := now.In(loc)
+	offsetHour := offset.Hour()
+	offsetMinute := offset.Minute()
+	require.Equal(t, 5, offsetHour)
+	require.Equal(t, 30, offsetMinute)
+}

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -61,7 +61,7 @@ func ParseTime(timespec string) (Time, error) {
 }
 
 func (t Time) String() string {
-	return time.Time(t).Format(TsLayout)
+	return time.Time(t).UTC().Format(TsLayout)
 }
 
 // MustParseTime is a convenience equivalent of the ParseTime function

--- a/libbeat/processors/timestamp/config.go
+++ b/libbeat/processors/timestamp/config.go
@@ -17,15 +17,17 @@
 
 package timestamp
 
+import "github.com/elastic/beats/v7/libbeat/common/cfgtype"
+
 type config struct {
-	Field          string   `config:"field" validate:"required"`   // Source field containing time time to be parsed.
-	TargetField    string   `config:"target_field"`                // Target field for the parsed time value. The target value is always written as UTC. Defaults to @timestamp.
-	Layouts        []string `config:"layouts" validate:"required"` // Timestamp layouts that define the expected time value format.
-	Timezone       string   `config:"timezone"`                    // Timezone (e.g. America/New_York) to use when parsing a timestamp not containing a timezone.
-	IgnoreMissing  bool     `config:"ignore_missing"`              // Ignore errors when the source field is missing.
-	IgnoreFailure  bool     `config:"ignore_failure"`              // Ignore errors when parsing the timestamp.
-	TestTimestamps []string `config:"test"`                        // A list of timestamps that must parse successfully when loading the processor.
-	ID             string   `config:"id"`                          // An identifier for this processor. Useful for debugging.
+	Field          string            `config:"field" validate:"required"`   // Source field containing time time to be parsed.
+	TargetField    string            `config:"target_field"`                // Target field for the parsed time value. The target value is always written as UTC. Defaults to @timestamp.
+	Layouts        []string          `config:"layouts" validate:"required"` // Timestamp layouts that define the expected time value format.
+	Timezone       *cfgtype.Timezone `config:"timezone"`                    // IANA time zone (e.g. America/New_York) or fixed offset to use when parsing a timestamp not containing a timezone.
+	IgnoreMissing  bool              `config:"ignore_missing"`              // Ignore errors when the source field is missing.
+	IgnoreFailure  bool              `config:"ignore_failure"`              // Ignore errors when parsing the timestamp.
+	TestTimestamps []string          `config:"test"`                        // A list of timestamps that must parse successfully when loading the processor.
+	ID             string            `config:"id"`                          // An identifier for this processor. Useful for debugging.
 }
 
 func defaultConfig() config {

--- a/libbeat/processors/timestamp/docs/timestamp.asciidoc
+++ b/libbeat/processors/timestamp/docs/timestamp.asciidoc
@@ -41,7 +41,7 @@ If a layout does not contain a year then the current year in the specified
 | `field`          | yes      |            | Source field containing the time to be parsed.                                                                        |
 | `target_field`   | no       | @timestamp | Target field for the parsed time value. The target value is always written as UTC.                                    |
 | `layouts`        | yes      |            | Timestamp layouts that define the expected time value format. In addition layouts, `UNIX` and `UNIX_MS` are accepted. |
-| `timezone`       | no       | UTC        | Time zone (e.g. America/New_York) to use when parsing a timestamp not containing a time zone.                           |
+| `timezone`       | no       | UTC        | IANA time zone name (e.g. `America/New_York`) or fixed time offset (e.g. `+0200`) to use when parsing times that do not contain a time zone. `Local` may be specified to use the machine's local time zone.|
 | `ignore_missing` | no       | false      | Ignore errors when the source field is missing.                                                                       |
 | `ignore_failure` | no       | false      | Ignore all errors produced by the processor.                                                                          |
 | `test`           | no       |            | A list of timestamps that must parse successfully when loading the processor.                                         |

--- a/libbeat/processors/timestamp/timestamp.go
+++ b/libbeat/processors/timestamp/timestamp.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"4d63.com/tz"
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -57,16 +56,11 @@ func New(cfg *common.Config) (processors.Processor, error) {
 }
 
 func newFromConfig(c config) (*processor, error) {
-	loc, err := loadLocation(c.Timezone)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to load timezone")
-	}
-
 	p := &processor{
 		config:  c,
 		log:     logp.NewLogger(logName),
 		isDebug: logp.IsDebug(logName),
-		tz:      loc,
+		tz:      c.Timezone.Location(),
 	}
 	if c.ID != "" {
 		p.log = p.log.With("instance_id", c.ID)
@@ -82,21 +76,6 @@ func newFromConfig(c config) (*processor, error) {
 	}
 
 	return p, nil
-}
-
-var timezoneFormats = []string{"-07", "-0700", "-07:00"}
-
-func loadLocation(timezone string) (*time.Location, error) {
-	for _, format := range timezoneFormats {
-		t, err := time.Parse(format, timezone)
-		if err == nil {
-			name, offset := t.Zone()
-			return time.FixedZone(name, offset), nil
-		}
-	}
-
-	// Rest of location formats
-	return tz.LoadLocation(timezone)
 }
 
 func (p *processor) String() string {

--- a/x-pack/filebeat/module/cef/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cef/_meta/docs.asciidoc
@@ -41,6 +41,13 @@ A list of tags to include in events. Including `forwarded` indicates that the
 events did not originate on this host and causes `host.name` to not be added to
 events. Defaults to `[cef, forwarded]`.
 
+*`var.timezone`*::
+
+IANA time zone name (e.g. `America/New_York`) or fixed time offset (e.g.
+`+0200`) to use when parsing times from the CEF message that do not contain a
+time zone. `Local` may be specified to use the machine's local time zone.
+Defaults to `UTC`.
+
 [float]
 ==== Forcepoint NGFW Security Management Center
 

--- a/x-pack/filebeat/module/cef/log/config/input.yml
+++ b/x-pack/filebeat/module/cef/log/config/input.yml
@@ -24,6 +24,9 @@ processors:
         - {from: "message", to: "event.original"}
   - decode_cef:
       field: event.original
+{{ if .timezone }}
+      timezone: '{{ .timezone }}'
+{{ end }}
   - community_id:
   - add_fields:
       target: ''

--- a/x-pack/filebeat/module/cef/log/manifest.yml
+++ b/x-pack/filebeat/module/cef/log/manifest.yml
@@ -14,6 +14,7 @@ var:
     default: syslog
   - name: internal_zones
   - name: external_zones
+  - name: timezone
 
 ingest_pipeline:
   - ingest/pipeline.yml

--- a/x-pack/filebeat/processors/decode_cef/cef/cef.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/cef.go
@@ -134,7 +134,7 @@ func (e *Event) Unpack(data string, opts ...Option) error {
 
 		// Mark the data type and do the actual conversion.
 		field.Type = mapping.Type
-		field.Interface, err = ToType(field.String, mapping.Type)
+		field.Interface, err = toType(field.String, mapping.Type, &settings)
 		if err != nil {
 			// Drop the key because the field value is invalid.
 			delete(e.Extensions, key)

--- a/x-pack/filebeat/processors/decode_cef/cef/cef_test.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/cef_test.go
@@ -411,7 +411,7 @@ func LongField(v int64) *Field {
 }
 func UndocumentedField(v string) *Field { return &Field{String: v} }
 func TimestampField(v string) *Field {
-	ts, err := toTimestamp(v)
+	ts, err := toTimestamp(v, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/x-pack/filebeat/processors/decode_cef/cef/option.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/option.go
@@ -4,6 +4,10 @@
 
 package cef
 
+import (
+	"time"
+)
+
 // Option controls Setting used in unpacking messages.
 type Option interface {
 	Apply(*Settings)
@@ -12,6 +16,8 @@ type Option interface {
 // Settings for unpacking messages.
 type Settings struct {
 	fullExtensionNames bool
+
+	timezone *time.Location
 }
 
 type withFullExtensionNames struct{}
@@ -24,4 +30,18 @@ func (w withFullExtensionNames) Apply(s *Settings) {
 // their full key names (e.g. src -> sourceAddress).
 func WithFullExtensionNames() Option {
 	return withFullExtensionNames{}
+}
+
+type withTimezone struct {
+	timezone *time.Location
+}
+
+func (w withTimezone) Apply(s *Settings) {
+	s.timezone = w.timezone
+}
+
+// WithTimezone causes CEF timestamps that do not contain a timezone to be
+// parsed in the specified timezone.
+func WithTimezone(timezone *time.Location) Option {
+	return withTimezone{timezone}
 }

--- a/x-pack/filebeat/processors/decode_cef/cef/types_test.go
+++ b/x-pack/filebeat/processors/decode_cef/cef/types_test.go
@@ -6,8 +6,10 @@ package cef
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestToTimestamp(t *testing.T) {
@@ -61,9 +63,21 @@ func TestToTimestamp(t *testing.T) {
 	}
 
 	for _, timeValue := range times {
-		_, err := toTimestamp(timeValue)
+		_, err := toTimestamp(timeValue, nil)
 		assert.NoError(t, err, timeValue)
 	}
+}
+
+func TestToTimestampWithTimezone(t *testing.T) {
+	const offsetHour, offsetMin = 2, 15 // +0215
+
+	ct, err := toTimestamp("Jun 23 10:30:03.004", &Settings{timezone: time.FixedZone("", offsetHour*60*60+offsetMin*60)})
+	require.NoError(t, err)
+
+	// 2021-06-23 08:15:03.004 +0000 UTC
+	ts := time.Time(ct).UTC()
+	assert.Equal(t, 10-offsetHour, ts.Hour())
+	assert.Equal(t, 30-offsetMin, ts.Minute())
 }
 
 func TestToMACAddress(t *testing.T) {

--- a/x-pack/filebeat/processors/decode_cef/config.go
+++ b/x-pack/filebeat/processors/decode_cef/config.go
@@ -4,13 +4,16 @@
 
 package decode_cef
 
+import "github.com/elastic/beats/v7/libbeat/common/cfgtype"
+
 type config struct {
-	Field         string `config:"field"`          // Source field containing the CEF message.
-	TargetField   string `config:"target_field"`   // Target field for the CEF object.
-	IgnoreMissing bool   `config:"ignore_missing"` // Ignore missing source field.
-	IgnoreFailure bool   `config:"ignore_failure"` // Ignore failures when the source field does not contain a CEF message. Parse errors do not cause failures, but are added to error.message.
-	ID            string `config:"id"`             // Instance ID for debugging purposes.
-	ECS           bool   `config:"ecs"`            // Generate ECS fields.
+	Field         string            `config:"field"`          // Source field containing the CEF message.
+	TargetField   string            `config:"target_field"`   // Target field for the CEF object.
+	IgnoreMissing bool              `config:"ignore_missing"` // Ignore missing source field.
+	IgnoreFailure bool              `config:"ignore_failure"` // Ignore failures when the source field does not contain a CEF message. Parse errors do not cause failures, but are added to error.message.
+	ID            string            `config:"id"`             // Instance ID for debugging purposes.
+	ECS           bool              `config:"ecs"`            // Generate ECS fields.
+	Timezone      *cfgtype.Timezone `config:"timezone"`       // Timezone used when parsing timestamps that do not contain a time zone or offset.
 }
 
 func defaultConfig() config {

--- a/x-pack/filebeat/processors/decode_cef/decode_cef.go
+++ b/x-pack/filebeat/processors/decode_cef/decode_cef.go
@@ -86,7 +86,7 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 
 	// If the version < 0 after parsing then none of the data is valid so return here.
 	var ce cef.Event
-	if err = ce.Unpack(cefData, cef.WithFullExtensionNames()); ce.Version < 0 && err != nil {
+	if err = ce.Unpack(cefData, cef.WithFullExtensionNames(), cef.WithTimezone(p.Timezone.Location())); ce.Version < 0 && err != nil {
 		if p.IgnoreFailure {
 			return event, nil
 		}

--- a/x-pack/filebeat/processors/decode_cef/docs/decode_cef.asciidoc
+++ b/x-pack/filebeat/processors/decode_cef/docs/decode_cef.asciidoc
@@ -33,6 +33,7 @@ The `decode_cef` processor has the following configuration settings.
 | `target_field`   | no       | cef     | Target field where the parsed CEF object will be written.                    |
 | `ecs`            | no       | true    | Generate Elastic Common Schema (ECS) fields from the CEF data.
                                           Certain CEF header and extension values will be used to populate ECS fields. |
+| `timezone`       | no       | UTC     | IANA time zone name (e.g. `America/New_York`) or fixed time offset (e.g. `+0200`) to use when parsing times that do not contain a time zone. `Local` may be specified to use the machine's local time zone.|
 | `ignore_missing` | no       | false   | Ignore errors when the source field is missing.                              |
 | `ignore_failure` | no       | false   | Ignore failures when the source field does not contain a CEF message.        |
 | `id`             | no       |         | An identifier for this processor instance. Useful for debugging.             |


### PR DESCRIPTION
## What does this PR do?

CEF messages that contain timestamps without a timezone were parsed as UTC. The time zone was not
configurable. This adds a `timezone` option to the decode_cef processor and cef module to allow the
time zone to be specified when a timestamp does not contain an offset or zone.

    CEF:0|Aruba Networks|ClearPass|6.8.7.120583|2002|RADIUS Accounting|1|rt=Aug 04 2021 11:31:15

This also replaces the deprecated `import "4d63.com/tz"` with Go's relatively new built-in
`time/tzdata` package. The `timestamp` processor was updated.

While I was adding the a timezone config type I made the syslog input's timezone configurable too.

Fixes #27232

## Why is it important?

Timestamps were being interpreted incorrectly.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] Do a manual test of the module with netcat.

## Related issues

- Closes #27232

## Logs

`2021-09-03T10:08:32.659-0400    DEBUG   [processors]    processors/processor.go:120     Generated new processors: rename=[{From:message To:event.original}], decode_cef={"Field":"event.original","TargetField":"cef","IgnoreMissing":false,"IgnoreFailure":false,"ID":"","ECS":true,"Timezone":"America/New_York"}, community_id=[target=network.community_id, fields=[source_ip=source.ip, source_port=source.port, destination_ip=destination.ip, destination_port=destination.port, transport_protocol=network.transport, icmp_type=icmp.type, icmp_code=icmp.code], seed=0], add_fields={"ecs":{"version":"1.11.0"}}`

## Manual test

```
filebeat.modules:
  - module: cef
    log:
      enabled: true
      var:
        syslog_host: localhost
        syslog_port: 9003
        timezone: America/New_York

output.console.pretty: true
```

```
{
  "@timestamp": "2021-08-04T15:31:15.000Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.0.0",
    "pipeline": "filebeat-8.0.0-cef-log-pipeline",
    "truncated": false
  },
  "input": {
    "type": "syslog"
  },
  "observer": {
    "vendor": "Aruba Networks",
    "product": "ClearPass",
    "version": "6.8.7.120583"
  },
  "message": "RADIUS Accounting",
  "ecs": {
    "version": "1.11.0"
  },
  "agent": {
    "type": "filebeat",
    "version": "8.0.0",
    "ephemeral_id": "e5b474fd-98af-44d6-9fae-a1cbdbee99f5",
    "id": "7292d176-7008-484e-b7d0-008ce53fe838",
    "name": "mac15"
  },
  "fileset": {
    "name": "log"
  },
  "cef": {
    "extensions": {
      "deviceReceiptTime": "2021-08-04T15:31:15.000Z"
    },
    "version": "0",
    "device": {
      "vendor": "Aruba Networks",
      "product": "ClearPass",
      "version": "6.8.7.120583",
      "event_class_id": "2002"
    },
    "name": "RADIUS Accounting",
    "severity": "1"
  },
  "log": {
    "source": {
      "address": "127.0.0.1:60040"
    }
  },
  "tags": [
    "cef",
    "forwarded"
  ],
  "service": {
    "type": "cef"
  },
  "event": {
    "severity": 1,
    "module": "cef",
    "dataset": "cef.log",
    "original": "CEF:0|Aruba Networks|ClearPass|6.8.7.120583|2002|RADIUS Accounting|1|rt=Aug 04 2021 11:31:15",
    "code": "2002"
  }
}
```