### PR TITLE
[Elastic Agent] Await execution finish on windows

### DIFF
--- a/libbeat/service/service_unix.go
+++ b/libbeat/service/service_unix.go
@@ -25,3 +25,6 @@ func ProcessWindowsControlEvents(stopCallback func()) {
 
 func notifyWindowsServiceStopped() {
 }
+
+// WaitExecutionDone is not used on non-windows platforms.
+func WaitExecutionDone() {}

--- a/libbeat/service/service_windows.go
+++ b/libbeat/service/service_windows.go
@@ -29,13 +29,15 @@ import (
 )
 
 type beatService struct {
-	stopCallback func()
-	done         chan struct{}
+	stopCallback    func()
+	done            chan struct{}
+	executeFinished chan struct{}
 }
 
 var serviceInstance = &beatService{
-	stopCallback: nil,
-	done:         make(chan struct{}, 0),
+	stopCallback:    nil,
+	done:            make(chan struct{}, 0),
+	executeFinished: make(chan struct{}, 0),
 }
 
 // Execute runs the beat service with the arguments and manages changes that
@@ -85,6 +87,8 @@ const couldNotConnect syscall.Errno = 1063
 // stopCallback function is called when the Stop/Shutdown
 // request is received.
 func ProcessWindowsControlEvents(stopCallback func()) {
+	defer close(serviceInstance.executeFinished)
+
 	isInteractive, err := svc.IsAnInteractiveSession()
 	if err != nil {
 		logp.Err("IsAnInteractiveSession: %v", err)
@@ -124,4 +128,13 @@ func ProcessWindowsControlEvents(stopCallback func()) {
 	}
 
 	logp.Err("Windows service setup failed: %+v", err)
+}
+
+// WaitExecutionDone returns only after stop was reported to service manager.
+// If response is not retrieved within 500 millisecond wait is aborted.
+func WaitExecutionDone() {
+	select {
+	case <-serviceInstance.executeFinished:
+	case <-time.After(500 * time.Millisecond):
+	}
 }

--- a/libbeat/service/service_windows.go
+++ b/libbeat/service/service_windows.go
@@ -133,6 +133,11 @@ func ProcessWindowsControlEvents(stopCallback func()) {
 // WaitExecutionDone returns only after stop was reported to service manager.
 // If response is not retrieved within 500 millisecond wait is aborted.
 func WaitExecutionDone() {
+	if isWinService, err := svc.IsWindowsService(); err != nil || !isWinService {
+		// not a service, don't wait
+		return
+	}
+
 	select {
 	case <-serviceInstance.executeFinished:
 	case <-time.After(500 * time.Millisecond):

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -59,10 +59,14 @@ func newRunCommandWithArgs(_ []string, streams *cli.IOStreams) *cobra.Command {
 	}
 }
 
-func run(streams *cli.IOStreams, override cfgOverrider) error { // Windows: Mark service as stopped.
+func run(streams *cli.IOStreams, override cfgOverrider) error {
+	// Windows: Mark service as stopped.
 	// After this is run, the service is considered by the OS to be stopped.
 	// This must be the first deferred cleanup task (last to execute).
-	defer service.NotifyTermination()
+	defer func() {
+		service.NotifyTermination()
+		service.WaitExecutionDone()
+	}()
 
 	locker := filelock.NewAppLocker(paths.Data(), paths.AgentLockFileName)
 	if err := locker.TryLock(); err != nil {


### PR DESCRIPTION
## What does this PR do?

The problem is described in issue: https://github.com/elastic/beats/issues/27527
When user wants to stop the service using service manager, error is returned about unexpected termination and agent is restarted.

Reason for this is that agent won't send `stopped` state to service manager before termination. 
In our codebase we use `NotifyTermination` provided by libbeat on exit. This closes channel and exits the state loop running in a separate goroutine which then should send the `stopped` state to service manager.
The problem is when we exit right after this call and too quickly. In this case goroutine wont reach the point where `stopped` is sent and service manager gets the impression we crashed. 

To fix this we just need to make sure that `svc.Run` in `libbeat/service/service_windows.go` is finished before exiting. Usually it just takes few milliseconds to finish the process but 500 millisecond limit is there to prevent process getting stuck in case something goes wrong.

## Why is it important?

Fixes: https://github.com/elastic/beats/issues/27527

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
