### PR TITLE
[httpjson] Fix httpjson rate limit processing and documentation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -309,6 +309,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update indentation for azure filebeat configuration. {pull}26604[26604]
 - Auditd: Fix Top Exec Commands dashboard visualization. {pull}27638[27638]
 - Store offset in `log.offset` field of events from the filestream input. {pull}27688[27688]
+- Fix `httpjson` input rate limit processing and documentation. {pull}[]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -103,10 +103,9 @@ The state has the following elements:
 - `last_response.page`: A number indicating the page number of the last response.
 - `first_event`: A map representing the first event sent to the output (result from applying transforms to `last_response.body`).
 - `last_event`: A map representing the last event sent to the output (result from applying transforms to `last_response.body`).
-- `url.value`: The full URL with params and fragments.
-- `url.params`: A map containing the URL params.
-- `header`: A map containing the headers. References request headers when used in <<request-transforms>> or <<request-rate-limit>> configuration sections, and to the last response headers when used in <<response-transforms>>, <<response-split>> or <<response-pagination>> configuration sections.
-- `body`: A map containing the body. References request body when used in <<request-transforms>> configuration section, and to the last response body when used in <<response-transforms>>, <<response-split>> or <<response-pagination>> configuration sections.
+- `url`: The last requested URL as a raw https://pkg.go.dev/net/url#URL[`url.URL`] Go type.
+- `header`: A map containing the headers. References the next request headers when used in <<request-transforms>> or <<response-pagination>> configuration sections, and to the last response headers when used in <<response-transforms>>, <<response-split>>, or <<request-rate-limit>> configuration sections.
+- `body`: A map containing the body. References the next request body when used in <<request-transforms>> or <<response-pagination>> configuration sections, and to the last response body when used in <<response-transforms>> or <<response-split>> configuration sections.
 - `cursor`: A map containing any data the user configured to be stored between restarts (See <<cursor>>).
 
 All of the mentioned objects are only stored at runtime, except `cursor`, which has values that are persisted between restarts.
@@ -463,7 +462,7 @@ List of transforms to apply to the request before each execution.
 
 Available transforms for request: [`append`, `delete`, `set`].
 
-Can read state from: [`.last_response.*`, `.last_event.*`, `.cursor.*`].
+Can read state from: [`.last_response.*`, `.last_event.*`, `.cursor.*`, `.header.*`, `.url.*`, `.body.*`].
 
 Can write state to: [`header.*`, `url.params.*`, `body.*`].
 
@@ -583,7 +582,7 @@ List of transforms that will be applied to the response to every new page reques
 
 Available transforms for pagination: [`append`, `delete`, `set`].
 
-Can read state from: [`.last_response.*`, `.first_event.*`, `.last_event.*`, `.cursor.*`].
+Can read state from: [`.last_response.*`, `.first_event.*`, `.last_event.*`, `.cursor.*`, `.header.*`, `.url.*`, `.body.*`].
 
 Can write state to: [`body.*`, `header.*`, `url.*`].
 

--- a/x-pack/filebeat/input/httpjson/internal/v2/rate_limiter.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/rate_limiter.go
@@ -102,9 +102,10 @@ func (r *rateLimiter) getRateLimit(resp *http.Response) (int64, error) {
 	}
 
 	tr := transformable{}
-	tr.setHeader(resp.Header)
+	ctx := emptyTransformContext()
+	ctx.updateLastResponse(response{header: resp.Header.Clone()})
 
-	remaining, _ := r.remaining.Execute(emptyTransformContext(), tr, nil, r.log)
+	remaining, _ := r.remaining.Execute(ctx, tr, nil, r.log)
 	if remaining == "" {
 		return 0, errors.New("remaining value is empty")
 	}
@@ -122,7 +123,7 @@ func (r *rateLimiter) getRateLimit(resp *http.Response) (int64, error) {
 		return 0, nil
 	}
 
-	reset, _ := r.reset.Execute(emptyTransformContext(), tr, nil, r.log)
+	reset, _ := r.reset.Execute(ctx, tr, nil, r.log)
 	if reset == "" {
 		return 0, errors.New("reset value is empty")
 	}

--- a/x-pack/filebeat/input/httpjson/internal/v2/rate_limiter_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/rate_limiter_test.go
@@ -24,9 +24,9 @@ func TestGetRateLimitReturns0IfRemainingQuota(t *testing.T) {
 	tplLimit := &valueTpl{}
 	tplReset := &valueTpl{}
 	tplRemaining := &valueTpl{}
-	assert.NoError(t, tplLimit.Unpack(`[[.header.Get "X-Rate-Limit-Limit"]]`))
-	assert.NoError(t, tplReset.Unpack(`[[.header.Get "X-Rate-Limit-Reset"]]`))
-	assert.NoError(t, tplRemaining.Unpack(`[[.header.Get "X-Rate-Limit-Remaining"]]`))
+	assert.NoError(t, tplLimit.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Limit"]]`))
+	assert.NoError(t, tplReset.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Reset"]]`))
+	assert.NoError(t, tplRemaining.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Remaining"]]`))
 	rateLimit := &rateLimiter{
 		limit:     tplLimit,
 		reset:     tplReset,
@@ -47,9 +47,9 @@ func TestGetRateLimitReturns0IfEpochInPast(t *testing.T) {
 	tplLimit := &valueTpl{}
 	tplReset := &valueTpl{}
 	tplRemaining := &valueTpl{}
-	assert.NoError(t, tplLimit.Unpack(`[[.header.Get "X-Rate-Limit-Limit"]]`))
-	assert.NoError(t, tplReset.Unpack(`[[.header.Get "X-Rate-Limit-Reset"]]`))
-	assert.NoError(t, tplRemaining.Unpack(`[[.header.Get "X-Rate-Limit-Remaining"]]`))
+	assert.NoError(t, tplLimit.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Limit"]]`))
+	assert.NoError(t, tplReset.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Reset"]]`))
+	assert.NoError(t, tplRemaining.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Remaining"]]`))
 	rateLimit := &rateLimiter{
 		limit:     tplLimit,
 		reset:     tplReset,
@@ -74,9 +74,9 @@ func TestGetRateLimitReturnsResetValue(t *testing.T) {
 	tplLimit := &valueTpl{}
 	tplReset := &valueTpl{}
 	tplRemaining := &valueTpl{}
-	assert.NoError(t, tplLimit.Unpack(`[[.header.Get "X-Rate-Limit-Limit"]]`))
-	assert.NoError(t, tplReset.Unpack(`[[.header.Get "X-Rate-Limit-Reset"]]`))
-	assert.NoError(t, tplRemaining.Unpack(`[[.header.Get "X-Rate-Limit-Remaining"]]`))
+	assert.NoError(t, tplLimit.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Limit"]]`))
+	assert.NoError(t, tplReset.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Reset"]]`))
+	assert.NoError(t, tplRemaining.Unpack(`[[.last_response.header.Get "X-Rate-Limit-Remaining"]]`))
 	rateLimit := &rateLimiter{
 		limit:     tplLimit,
 		reset:     tplReset,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
- Fixes the rate limit processing. Previously it was reading the value from `.headers` but it was expected from the documentation to be accessed through `.last_response.headers`
- Fixes several documentation errors

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Users were not getting rate limit data when they were using the feature as documented.
The documentation was not accurate about data access contexts.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Relates

Closes #23023