### PR TITLE
docs: simplify permissions for Dockerfile COPY

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -294,10 +294,7 @@ ifeval::["{beatname_lc}"!="auditbeat"]
 ["source", "dockerfile", subs="attributes"]
 --------------------------------------------
 FROM {dockerimage}
-COPY {beatname_lc}.yml /usr/share/{beatname_lc}/{beatname_lc}.yml
-USER root
-RUN chown root:{beatname_lc} /usr/share/{beatname_lc}/{beatname_lc}.yml
-USER {beatname_lc}
+COPY --chown=root:{beatname_lc} {beatname_lc}.yml /usr/share/{beatname_lc}/{beatname_lc}.yml
 --------------------------------------------
 
 endif::[]


### PR DESCRIPTION

- Docs

## What does this PR do?
Simplify the file permission change in referenced Dockerfile by using `COPY --chown` argument.
See the Dockerfile documentation: https://docs.docker.com/engine/reference/builder/#copy

## Why is it important?

The one-step file copy with the right permissions allows to reduce the number of layers in resulting docker image and simplifies the code. See also the article explaining how the multi-step COPY + chown doubles the image size: https://blog.mornati.net/docker-images-and-files-chown

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

