### PR TITLE
Rename log.path field to log.file.path to be ECS complicant

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -314,6 +314,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Store offset in `log.offset` field of events from the filestream input. {pull}27688[27688]
 - Fix `httpjson` input rate limit processing and documentation. {pull}[]
 - Update Filebeat compatibility function to remove processor description field on ES < 7.9.0 {pull}27774[27774]
+- Make filestream events ECS compliant. {issue}27776[27776]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -84,6 +84,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove all alias fields pointing to ECS fields from modules. This affects the Suricata and Traefik modules. {issue}10535[10535] {pull}26627[26627]
 - Add option for S3 input to work without SQS notification {issue}18205[18205] {pull}27332[27332]
 - Fix Crowdstrike ingest pipeline that was creating flattened `process` fields. {issue}27622[27622] {pull}27623[27623]
+- Rename `log.path` to `log.file.path` in filestream to be consistent with `log` input and ECS. {pull}27761[27761]
 
 *Heartbeat*
 - Remove long deprecated `watch_poll` functionality. {pull}27166[27166]

--- a/libbeat/reader/readfile/metafields.go
+++ b/libbeat/reader/readfile/metafields.go
@@ -51,7 +51,9 @@ func (r *FileMetaReader) Next() (reader.Message, error) {
 	message.Fields.DeepUpdate(common.MapStr{
 		"log": common.MapStr{
 			"offset": r.offset,
-			"path":   r.path,
+			"file": common.MapStr{
+				"path": r.path,
+			},
 		},
 	})
 	return message, err

--- a/libbeat/reader/readfile/metafields_test.go
+++ b/libbeat/reader/readfile/metafields_test.go
@@ -60,7 +60,9 @@ func TestMetaFieldsOffset(t *testing.T) {
 		if len(msg.Content) != 0 {
 			expectedFields = common.MapStr{
 				"log": common.MapStr{
-					"path":   path,
+					"file": common.MapStr{
+						"path": path,
+					},
 					"offset": offset,
 				},
 			}


### PR DESCRIPTION
## What does this PR do?

The PR renames `log.path` to `log.file.path` in filestream input events.

## Why is it important?

The old `log.path` is not ECS compliant and inconsistent with the old log input.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Closes #27776