### PR TITLE
[Filebeat] Update compatibility function to remove processor description on ES < 7.9.0

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -310,6 +310,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Auditd: Fix Top Exec Commands dashboard visualization. {pull}27638[27638]
 - Store offset in `log.offset` field of events from the filestream input. {pull}27688[27688]
 - Fix `httpjson` input rate limit processing and documentation. {pull}[]
+- Update Filebeat compatibility function to remove processor description field on ES < 7.9.0 {pull}27774[27774]
 
 *Heartbeat*
 

--- a/filebeat/fileset/compatibility.go
+++ b/filebeat/fileset/compatibility.go
@@ -416,7 +416,7 @@ func replaceConvertIP(processor Processor, log *logp.Logger) (Processor, error) 
 	return processor, nil
 }
 
-// removeDescription removes the descriptnio config option so ES less than 7.12 will work.
+// removeDescription removes the description config option so ES less than 7.9 will work.
 func removeDescription(processor Processor, log *logp.Logger) (Processor, error) {
 	_, ok := processor.GetString("description")
 	if !ok {

--- a/filebeat/fileset/compatibility.go
+++ b/filebeat/fileset/compatibility.go
@@ -106,6 +106,13 @@ var processorCompatibilityChecks = []processorCompatibility{
 		},
 		adaptConfig: deleteProcessor,
 	},
+	{
+		procType: "*",
+		checkVersion: func(esVersion *common.Version) bool {
+			return esVersion.LessThan(common.MustNewVersion("7.9.0"))
+		},
+		adaptConfig: removeDescription,
+	},
 }
 
 // Processor represents and Ingest Node processor definition.
@@ -273,7 +280,7 @@ nextProcessor:
 
 		// Run compatibility checks on the processor.
 		for _, proc := range processorCompatibilityChecks {
-			if processor.Name() != proc.procType {
+			if processor.Name() != proc.procType && proc.procType != "*" {
 				continue
 			}
 
@@ -281,9 +288,9 @@ nextProcessor:
 				continue
 			}
 
-			processor, err = proc.adaptConfig(processor, log.With("processor_type", proc.procType, "processor_index", i))
+			processor, err = proc.adaptConfig(processor, log.With("processor_type", processor.Name(), "processor_index", i))
 			if err != nil {
-				return fmt.Errorf("failed to adapt %q processor at index %d: %w", proc.procType, i, err)
+				return fmt.Errorf("failed to adapt %q processor at index %d: %w", processor.Name(), i, err)
 			}
 			if processor.IsNil() {
 				continue nextProcessor
@@ -406,5 +413,18 @@ func replaceConvertIP(processor Processor, log *logp.Logger) (Processor, error) 
 	})
 	processor.name = "grok"
 	log.Debug("processor output=", processor.String())
+	return processor, nil
+}
+
+// removeDescription removes the descriptnio config option so ES less than 7.12 will work.
+func removeDescription(processor Processor, log *logp.Logger) (Processor, error) {
+	_, ok := processor.GetString("description")
+	if !ok {
+		return processor, nil
+	}
+
+	log.Debug("Removing unsupported 'description' from processor.")
+	processor.Delete("description")
+
 	return processor, nil
 }


### PR DESCRIPTION
## What does this PR do?

Update Filebeat compatibility function to remove processor description field on ES < 7.9.0

## Why is it important?

Users with new versions of Filebeat and ES versions < 7.9.0 will run into errors when loading module ingest pipelines.  See https://discuss.elastic.co/t/filebeat-v7-14-0-error-in-loading-pipeline/283407

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally



## Related issues


## Use cases



## Screenshots



## Logs


