### PR TITLE
[Filebeat] Accept syslog dates with leading 0

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -740,6 +740,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update `tags` and `threatintel.indicator.provider` fields in `threatintel.anomali` ingest pipeline {issue}24746[24746] {pull}27141[27141]
 - Move AWS module and filesets to GA. {pull}27428[27428]
 - update ecs.version to ECS 1.11.0. {pull}27107[27107]
+- Added support for parsing syslog dates containing a leading 0 (e.g. `Sep 01`) rather than a space. {pull}27775[27775]
 - Add base64 Encode functionality to httpjson input. {pull}27681[27681]
 - Add `join` and `sprintf` functions to `httpjson` input. {pull}27735[27735]
 

--- a/filebeat/input/syslog/parser/syslog_rfc3164.rl
+++ b/filebeat/input/syslog/parser/syslog_rfc3164.rl
@@ -17,7 +17,7 @@
   month = ( "Jan" ("uary")? | "Feb" "ruary"? | "Mar" "ch"? | "Apr" "il"? | "Ma" "y"? | "Jun" "e"? | "Jul" "y"? | "Aug" "ust"? | "Sep" ("tember")? | "Oct" "ober"? | "Nov" "ember"? | "Dec" "ember"?) >tok %month;
 
   # Match: " 5" and "10" as the day
-  multiple_digits_day = (([12][0-9]) | ("3"[01]))>tok %day;
+  multiple_digits_day = (([012][0-9]) | ("3"[01]))>tok %day;
   single_digit_day = [1-9]>tok %day;
   day = (space? single_digit_day | multiple_digits_day);
 

--- a/filebeat/input/syslog/rfc3164_parser.go
+++ b/filebeat/input/syslog/rfc3164_parser.go
@@ -291,10 +291,12 @@ func ParserRFC3164(data []byte, event *event) {
 			goto st_case_119
 		case 120:
 			goto st_case_120
-		case 1:
-			goto st_case_1
 		case 121:
 			goto st_case_121
+		case 1:
+			goto st_case_1
+		case 122:
+			goto st_case_122
 		}
 		goto st_out
 	st_case_0:
@@ -334,7 +336,7 @@ func ParserRFC3164(data []byte, event *event) {
 		tok = p
 
 		goto st2
-	tr133:
+	tr134:
 //line parser/common.rl:107
 
 		event.SetSequence(data[tok:p])
@@ -349,7 +351,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof2
 		}
 	st_case_2:
-//line rfc3164_parser.go:340
+//line rfc3164_parser.go:342
 		goto st2
 	tr1:
 //line parser/common.rl:3
@@ -357,7 +359,7 @@ func ParserRFC3164(data []byte, event *event) {
 		tok = p
 
 		goto st3
-	tr134:
+	tr135:
 //line parser/common.rl:107
 
 		event.SetSequence(data[tok:p])
@@ -372,7 +374,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof3
 		}
 	st_case_3:
-//line rfc3164_parser.go:363
+//line rfc3164_parser.go:365
 		switch data[(p)] {
 		case 65:
 			goto tr4
@@ -401,7 +403,7 @@ func ParserRFC3164(data []byte, event *event) {
 		tok = p
 
 		goto st4
-	tr135:
+	tr136:
 //line parser/common.rl:107
 
 		event.SetSequence(data[tok:p])
@@ -416,7 +418,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof4
 		}
 	st_case_4:
-//line rfc3164_parser.go:407
+//line rfc3164_parser.go:409
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st5
 		}
@@ -459,7 +461,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof8
 		}
 	st_case_8:
-//line rfc3164_parser.go:450
+//line rfc3164_parser.go:452
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto tr19
 		}
@@ -475,7 +477,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof9
 		}
 	st_case_9:
-//line rfc3164_parser.go:466
+//line rfc3164_parser.go:468
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st10
 		}
@@ -500,7 +502,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof11
 		}
 	st_case_11:
-//line rfc3164_parser.go:491
+//line rfc3164_parser.go:493
 		if 48 <= data[(p)] && data[(p)] <= 51 {
 			goto tr22
 		}
@@ -516,7 +518,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof12
 		}
 	st_case_12:
-//line rfc3164_parser.go:507
+//line rfc3164_parser.go:509
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st13
 		}
@@ -549,7 +551,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof14
 		}
 	st_case_14:
-//line rfc3164_parser.go:540
+//line rfc3164_parser.go:542
 		if data[(p)] == 50 {
 			goto tr26
 		}
@@ -568,7 +570,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof15
 		}
 	st_case_15:
-//line rfc3164_parser.go:559
+//line rfc3164_parser.go:561
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st16
 		}
@@ -593,7 +595,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof17
 		}
 	st_case_17:
-//line rfc3164_parser.go:584
+//line rfc3164_parser.go:586
 		if 48 <= data[(p)] && data[(p)] <= 53 {
 			goto tr29
 		}
@@ -609,7 +611,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof18
 		}
 	st_case_18:
-//line rfc3164_parser.go:600
+//line rfc3164_parser.go:602
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st19
 		}
@@ -634,7 +636,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof20
 		}
 	st_case_20:
-//line rfc3164_parser.go:625
+//line rfc3164_parser.go:627
 		if 48 <= data[(p)] && data[(p)] <= 53 {
 			goto tr32
 		}
@@ -650,7 +652,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof21
 		}
 	st_case_21:
-//line rfc3164_parser.go:641
+//line rfc3164_parser.go:643
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st22
 		}
@@ -703,7 +705,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof23
 		}
 	st_case_23:
-//line rfc3164_parser.go:694
+//line rfc3164_parser.go:696
 		switch data[(p)] {
 		case 58:
 			goto tr41
@@ -767,7 +769,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof24
 		}
 	st_case_24:
-//line rfc3164_parser.go:754
+//line rfc3164_parser.go:756
 		switch data[(p)] {
 		case 58:
 			goto tr44
@@ -831,7 +833,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof25
 		}
 	st_case_25:
-//line rfc3164_parser.go:814
+//line rfc3164_parser.go:816
 		switch data[(p)] {
 		case 32:
 			goto tr45
@@ -874,7 +876,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof26
 		}
 	st_case_26:
-//line rfc3164_parser.go:857
+//line rfc3164_parser.go:859
 		switch data[(p)] {
 		case 32:
 			goto tr0
@@ -898,7 +900,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof27
 		}
 	st_case_27:
-//line rfc3164_parser.go:881
+//line rfc3164_parser.go:883
 		switch data[(p)] {
 		case 32:
 			goto st2
@@ -924,7 +926,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof28
 		}
 	st_case_28:
-//line rfc3164_parser.go:907
+//line rfc3164_parser.go:909
 		switch data[(p)] {
 		case 32:
 			goto st29
@@ -956,7 +958,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof30
 		}
 	st_case_30:
-//line rfc3164_parser.go:939
+//line rfc3164_parser.go:941
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto tr52
 		}
@@ -972,7 +974,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof31
 		}
 	st_case_31:
-//line rfc3164_parser.go:955
+//line rfc3164_parser.go:957
 		if data[(p)] == 93 {
 			goto tr54
 		}
@@ -991,7 +993,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof32
 		}
 	st_case_32:
-//line rfc3164_parser.go:974
+//line rfc3164_parser.go:976
 		if data[(p)] == 58 {
 			goto st33
 		}
@@ -1032,7 +1034,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof34
 		}
 	st_case_34:
-//line rfc3164_parser.go:1013
+//line rfc3164_parser.go:1015
 		switch data[(p)] {
 		case 32:
 			goto st26
@@ -1103,7 +1105,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof35
 		}
 	st_case_35:
-//line rfc3164_parser.go:1080
+//line rfc3164_parser.go:1082
 		switch data[(p)] {
 		case 32:
 			goto tr45
@@ -1174,7 +1176,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof36
 		}
 	st_case_36:
-//line rfc3164_parser.go:1147
+//line rfc3164_parser.go:1149
 		switch data[(p)] {
 		case 58:
 			goto tr57
@@ -1224,7 +1226,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof37
 		}
 	st_case_37:
-//line rfc3164_parser.go:1197
+//line rfc3164_parser.go:1199
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st38
 		}
@@ -1305,7 +1307,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof42
 		}
 	st_case_42:
-//line rfc3164_parser.go:1278
+//line rfc3164_parser.go:1280
 		if data[(p)] == 32 {
 			goto st23
 		}
@@ -1324,7 +1326,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof43
 		}
 	st_case_43:
-//line rfc3164_parser.go:1297
+//line rfc3164_parser.go:1299
 		if data[(p)] == 32 {
 			goto st23
 		}
@@ -1348,7 +1350,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof44
 		}
 	st_case_44:
-//line rfc3164_parser.go:1321
+//line rfc3164_parser.go:1323
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto tr67
 		}
@@ -1364,7 +1366,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof45
 		}
 	st_case_45:
-//line rfc3164_parser.go:1337
+//line rfc3164_parser.go:1339
 		switch data[(p)] {
 		case 32:
 			goto tr68
@@ -1413,7 +1415,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof46
 		}
 	st_case_46:
-//line rfc3164_parser.go:1386
+//line rfc3164_parser.go:1388
 		switch data[(p)] {
 		case 32:
 			goto tr61
@@ -1439,7 +1441,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof47
 		}
 	st_case_47:
-//line rfc3164_parser.go:1412
+//line rfc3164_parser.go:1414
 		if 48 <= data[(p)] && data[(p)] <= 51 {
 			goto st16
 		}
@@ -1450,7 +1452,7 @@ func ParserRFC3164(data []byte, event *event) {
 		tok = p
 
 		goto st48
-	tr136:
+	tr137:
 //line parser/common.rl:107
 
 		event.SetSequence(data[tok:p])
@@ -1465,12 +1467,12 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof48
 		}
 	st_case_48:
-//line rfc3164_parser.go:1438
+//line rfc3164_parser.go:1440
 		switch data[(p)] {
 		case 112:
 			goto st49
 		case 117:
-			goto st70
+			goto st71
 		}
 		goto st2
 	st49:
@@ -1491,7 +1493,7 @@ func ParserRFC3164(data []byte, event *event) {
 		case 32:
 			goto tr77
 		case 105:
-			goto st68
+			goto st69
 		}
 		if 9 <= data[(p)] && data[(p)] <= 13 {
 			goto tr77
@@ -1508,12 +1510,14 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof51
 		}
 	st_case_51:
-//line rfc3164_parser.go:1481
+//line rfc3164_parser.go:1483
 		switch data[(p)] {
 		case 32:
 			goto st52
+		case 48:
+			goto tr80
 		case 51:
-			goto tr81
+			goto tr82
 		}
 		switch {
 		case data[(p)] < 49:
@@ -1522,10 +1526,10 @@ func ParserRFC3164(data []byte, event *event) {
 			}
 		case data[(p)] > 50:
 			if 52 <= data[(p)] && data[(p)] <= 57 {
-				goto tr82
+				goto tr83
 			}
 		default:
-			goto tr80
+			goto tr81
 		}
 		goto st2
 	st52:
@@ -1534,10 +1538,10 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_52:
 		if 49 <= data[(p)] && data[(p)] <= 57 {
-			goto tr82
+			goto tr83
 		}
 		goto st2
-	tr82:
+	tr83:
 //line parser/common.rl:3
 
 		tok = p
@@ -1548,15 +1552,15 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof53
 		}
 	st_case_53:
-//line rfc3164_parser.go:1521
+//line rfc3164_parser.go:1525
 		if data[(p)] == 32 {
-			goto tr83
+			goto tr84
 		}
 		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr83
+			goto tr84
 		}
 		goto st2
-	tr83:
+	tr84:
 //line parser/common.rl:27
 
 		event.SetDay(data[tok:p])
@@ -1567,15 +1571,15 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof54
 		}
 	st_case_54:
-//line rfc3164_parser.go:1540
+//line rfc3164_parser.go:1544
 		if data[(p)] == 50 {
-			goto tr85
+			goto tr86
 		}
 		if 48 <= data[(p)] && data[(p)] <= 49 {
-			goto tr84
+			goto tr85
 		}
 		goto st2
-	tr84:
+	tr85:
 //line parser/common.rl:3
 
 		tok = p
@@ -1586,7 +1590,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof55
 		}
 	st_case_55:
-//line rfc3164_parser.go:1559
+//line rfc3164_parser.go:1563
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st56
 		}
@@ -1597,10 +1601,10 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_56:
 		if data[(p)] == 58 {
-			goto tr87
+			goto tr88
 		}
 		goto st2
-	tr87:
+	tr88:
 //line parser/common.rl:31
 
 		event.SetHour(data[tok:p])
@@ -1611,12 +1615,12 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof57
 		}
 	st_case_57:
-//line rfc3164_parser.go:1584
+//line rfc3164_parser.go:1588
 		if 48 <= data[(p)] && data[(p)] <= 53 {
-			goto tr88
+			goto tr89
 		}
 		goto st2
-	tr88:
+	tr89:
 //line parser/common.rl:3
 
 		tok = p
@@ -1627,7 +1631,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof58
 		}
 	st_case_58:
-//line rfc3164_parser.go:1600
+//line rfc3164_parser.go:1604
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st59
 		}
@@ -1638,10 +1642,10 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_59:
 		if data[(p)] == 58 {
-			goto tr90
+			goto tr91
 		}
 		goto st2
-	tr90:
+	tr91:
 //line parser/common.rl:35
 
 		event.SetMinute(data[tok:p])
@@ -1652,12 +1656,12 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof60
 		}
 	st_case_60:
-//line rfc3164_parser.go:1625
+//line rfc3164_parser.go:1629
 		if 48 <= data[(p)] && data[(p)] <= 53 {
-			goto tr91
+			goto tr92
 		}
 		goto st2
-	tr91:
+	tr92:
 //line parser/common.rl:3
 
 		tok = p
@@ -1668,7 +1672,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof61
 		}
 	st_case_61:
-//line rfc3164_parser.go:1641
+//line rfc3164_parser.go:1645
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st62
 		}
@@ -1682,7 +1686,7 @@ func ParserRFC3164(data []byte, event *event) {
 		case 32:
 			goto tr34
 		case 46:
-			goto tr93
+			goto tr94
 		case 58:
 			goto tr37
 		}
@@ -1690,7 +1694,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto tr34
 		}
 		goto st2
-	tr93:
+	tr94:
 //line parser/common.rl:39
 
 		event.SetSecond(data[tok:p])
@@ -1701,12 +1705,12 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof63
 		}
 	st_case_63:
-//line rfc3164_parser.go:1674
+//line rfc3164_parser.go:1678
 		if 48 <= data[(p)] && data[(p)] <= 57 {
-			goto tr94
+			goto tr95
 		}
 		goto st2
-	tr94:
+	tr95:
 //line parser/common.rl:3
 
 		tok = p
@@ -1717,7 +1721,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof64
 		}
 	st_case_64:
-//line rfc3164_parser.go:1690
+//line rfc3164_parser.go:1694
 		switch data[(p)] {
 		case 32:
 			goto tr68
@@ -1733,7 +1737,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto tr68
 		}
 		goto st2
-	tr85:
+	tr86:
 //line parser/common.rl:3
 
 		tok = p
@@ -1744,7 +1748,7 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof65
 		}
 	st_case_65:
-//line rfc3164_parser.go:1717
+//line rfc3164_parser.go:1721
 		if 48 <= data[(p)] && data[(p)] <= 51 {
 			goto st56
 		}
@@ -1760,17 +1764,9 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof66
 		}
 	st_case_66:
-//line rfc3164_parser.go:1733
-		if data[(p)] == 32 {
-			goto tr83
-		}
-		switch {
-		case data[(p)] > 13:
-			if 48 <= data[(p)] && data[(p)] <= 57 {
-				goto st53
-			}
-		case data[(p)] >= 9:
-			goto tr83
+//line rfc3164_parser.go:1737
+		if 48 <= data[(p)] && data[(p)] <= 57 {
+			goto st53
 		}
 		goto st2
 	tr81:
@@ -1784,9 +1780,33 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof67
 		}
 	st_case_67:
-//line rfc3164_parser.go:1757
+//line rfc3164_parser.go:1753
 		if data[(p)] == 32 {
-			goto tr83
+			goto tr84
+		}
+		switch {
+		case data[(p)] > 13:
+			if 48 <= data[(p)] && data[(p)] <= 57 {
+				goto st53
+			}
+		case data[(p)] >= 9:
+			goto tr84
+		}
+		goto st2
+	tr82:
+//line parser/common.rl:3
+
+		tok = p
+
+		goto st68
+	st68:
+		if (p)++; (p) == (pe) {
+			goto _test_eof68
+		}
+	st_case_68:
+//line rfc3164_parser.go:1777
+		if data[(p)] == 32 {
+			goto tr84
 		}
 		switch {
 		case data[(p)] > 13:
@@ -1794,16 +1814,7 @@ func ParserRFC3164(data []byte, event *event) {
 				goto st53
 			}
 		case data[(p)] >= 9:
-			goto tr83
-		}
-		goto st2
-	st68:
-		if (p)++; (p) == (pe) {
-			goto _test_eof68
-		}
-	st_case_68:
-		if data[(p)] == 108 {
-			goto st69
+			goto tr84
 		}
 		goto st2
 	st69:
@@ -1811,11 +1822,8 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof69
 		}
 	st_case_69:
-		if data[(p)] == 32 {
-			goto tr77
-		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr77
+		if data[(p)] == 108 {
+			goto st70
 		}
 		goto st2
 	st70:
@@ -1823,8 +1831,11 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof70
 		}
 	st_case_70:
-		if data[(p)] == 103 {
-			goto st71
+		if data[(p)] == 32 {
+			goto tr77
+		}
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr77
 		}
 		goto st2
 	st71:
@@ -1832,14 +1843,8 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof71
 		}
 	st_case_71:
-		switch data[(p)] {
-		case 32:
-			goto tr77
-		case 117:
+		if data[(p)] == 103 {
 			goto st72
-		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr77
 		}
 		goto st2
 	st72:
@@ -1847,8 +1852,14 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof72
 		}
 	st_case_72:
-		if data[(p)] == 115 {
+		switch data[(p)] {
+		case 32:
+			goto tr77
+		case 117:
 			goto st73
+		}
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr77
 		}
 		goto st2
 	st73:
@@ -1856,8 +1867,17 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof73
 		}
 	st_case_73:
+		if data[(p)] == 115 {
+			goto st74
+		}
+		goto st2
+	st74:
+		if (p)++; (p) == (pe) {
+			goto _test_eof74
+		}
+	st_case_74:
 		if data[(p)] == 116 {
-			goto st69
+			goto st70
 		}
 		goto st2
 	tr5:
@@ -1865,93 +1885,7 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st74
-	tr137:
-//line parser/common.rl:107
-
-		event.SetSequence(data[tok:p])
-
-//line parser/common.rl:3
-
-		tok = p
-
-		goto st74
-	st74:
-		if (p)++; (p) == (pe) {
-			goto _test_eof74
-		}
-	st_case_74:
-//line rfc3164_parser.go:1854
-		if data[(p)] == 101 {
-			goto st75
-		}
-		goto st2
-	st75:
-		if (p)++; (p) == (pe) {
-			goto _test_eof75
-		}
-	st_case_75:
-		if data[(p)] == 99 {
-			goto st76
-		}
-		goto st2
-	st76:
-		if (p)++; (p) == (pe) {
-			goto _test_eof76
-		}
-	st_case_76:
-		switch data[(p)] {
-		case 32:
-			goto tr77
-		case 101:
-			goto st77
-		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr77
-		}
-		goto st2
-	st77:
-		if (p)++; (p) == (pe) {
-			goto _test_eof77
-		}
-	st_case_77:
-		if data[(p)] == 109 {
-			goto st78
-		}
-		goto st2
-	st78:
-		if (p)++; (p) == (pe) {
-			goto _test_eof78
-		}
-	st_case_78:
-		if data[(p)] == 98 {
-			goto st79
-		}
-		goto st2
-	st79:
-		if (p)++; (p) == (pe) {
-			goto _test_eof79
-		}
-	st_case_79:
-		if data[(p)] == 101 {
-			goto st80
-		}
-		goto st2
-	st80:
-		if (p)++; (p) == (pe) {
-			goto _test_eof80
-		}
-	st_case_80:
-		if data[(p)] == 114 {
-			goto st69
-		}
-		goto st2
-	tr6:
-//line parser/common.rl:3
-
-		tok = p
-
-		goto st81
+		goto st75
 	tr138:
 //line parser/common.rl:107
 
@@ -1961,83 +1895,83 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st81
-	st81:
+		goto st75
+	st75:
 		if (p)++; (p) == (pe) {
-			goto _test_eof81
+			goto _test_eof75
 		}
-	st_case_81:
-//line rfc3164_parser.go:1940
+	st_case_75:
+//line rfc3164_parser.go:1874
 		if data[(p)] == 101 {
-			goto st82
+			goto st76
 		}
 		goto st2
-	st82:
+	st76:
 		if (p)++; (p) == (pe) {
-			goto _test_eof82
+			goto _test_eof76
 		}
-	st_case_82:
-		if data[(p)] == 98 {
-			goto st83
+	st_case_76:
+		if data[(p)] == 99 {
+			goto st77
 		}
 		goto st2
-	st83:
+	st77:
 		if (p)++; (p) == (pe) {
-			goto _test_eof83
+			goto _test_eof77
 		}
-	st_case_83:
+	st_case_77:
 		switch data[(p)] {
 		case 32:
 			goto tr77
-		case 114:
-			goto st84
+		case 101:
+			goto st78
 		}
 		if 9 <= data[(p)] && data[(p)] <= 13 {
 			goto tr77
 		}
 		goto st2
-	st84:
+	st78:
 		if (p)++; (p) == (pe) {
-			goto _test_eof84
+			goto _test_eof78
 		}
-	st_case_84:
-		if data[(p)] == 117 {
-			goto st85
+	st_case_78:
+		if data[(p)] == 109 {
+			goto st79
 		}
 		goto st2
-	st85:
+	st79:
 		if (p)++; (p) == (pe) {
-			goto _test_eof85
+			goto _test_eof79
 		}
-	st_case_85:
-		if data[(p)] == 97 {
-			goto st86
+	st_case_79:
+		if data[(p)] == 98 {
+			goto st80
 		}
 		goto st2
-	st86:
+	st80:
 		if (p)++; (p) == (pe) {
-			goto _test_eof86
+			goto _test_eof80
 		}
-	st_case_86:
+	st_case_80:
+		if data[(p)] == 101 {
+			goto st81
+		}
+		goto st2
+	st81:
+		if (p)++; (p) == (pe) {
+			goto _test_eof81
+		}
+	st_case_81:
 		if data[(p)] == 114 {
-			goto st87
+			goto st70
 		}
 		goto st2
-	st87:
-		if (p)++; (p) == (pe) {
-			goto _test_eof87
-		}
-	st_case_87:
-		if data[(p)] == 121 {
-			goto st69
-		}
-		goto st2
-	tr7:
+	tr6:
 //line parser/common.rl:3
 
 		tok = p
 
-		goto st88
+		goto st82
 	tr139:
 //line parser/common.rl:107
 
@@ -2047,27 +1981,104 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st88
+		goto st82
+	st82:
+		if (p)++; (p) == (pe) {
+			goto _test_eof82
+		}
+	st_case_82:
+//line rfc3164_parser.go:1960
+		if data[(p)] == 101 {
+			goto st83
+		}
+		goto st2
+	st83:
+		if (p)++; (p) == (pe) {
+			goto _test_eof83
+		}
+	st_case_83:
+		if data[(p)] == 98 {
+			goto st84
+		}
+		goto st2
+	st84:
+		if (p)++; (p) == (pe) {
+			goto _test_eof84
+		}
+	st_case_84:
+		switch data[(p)] {
+		case 32:
+			goto tr77
+		case 114:
+			goto st85
+		}
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr77
+		}
+		goto st2
+	st85:
+		if (p)++; (p) == (pe) {
+			goto _test_eof85
+		}
+	st_case_85:
+		if data[(p)] == 117 {
+			goto st86
+		}
+		goto st2
+	st86:
+		if (p)++; (p) == (pe) {
+			goto _test_eof86
+		}
+	st_case_86:
+		if data[(p)] == 97 {
+			goto st87
+		}
+		goto st2
+	st87:
+		if (p)++; (p) == (pe) {
+			goto _test_eof87
+		}
+	st_case_87:
+		if data[(p)] == 114 {
+			goto st88
+		}
+		goto st2
 	st88:
 		if (p)++; (p) == (pe) {
 			goto _test_eof88
 		}
 	st_case_88:
-//line rfc3164_parser.go:2026
-		switch data[(p)] {
-		case 97:
-			goto st89
-		case 117:
-			goto st91
+		if data[(p)] == 121 {
+			goto st70
 		}
 		goto st2
+	tr7:
+//line parser/common.rl:3
+
+		tok = p
+
+		goto st89
+	tr140:
+//line parser/common.rl:107
+
+		event.SetSequence(data[tok:p])
+
+//line parser/common.rl:3
+
+		tok = p
+
+		goto st89
 	st89:
 		if (p)++; (p) == (pe) {
 			goto _test_eof89
 		}
 	st_case_89:
-		if data[(p)] == 110 {
+//line rfc3164_parser.go:2046
+		switch data[(p)] {
+		case 97:
 			goto st90
+		case 117:
+			goto st92
 		}
 		goto st2
 	st90:
@@ -2075,14 +2086,8 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof90
 		}
 	st_case_90:
-		switch data[(p)] {
-		case 32:
-			goto tr77
-		case 117:
-			goto st85
-		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr77
+		if data[(p)] == 110 {
+			goto st91
 		}
 		goto st2
 	st91:
@@ -2091,10 +2096,13 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_91:
 		switch data[(p)] {
-		case 108:
-			goto st92
-		case 110:
-			goto st93
+		case 32:
+			goto tr77
+		case 117:
+			goto st86
+		}
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr77
 		}
 		goto st2
 	st92:
@@ -2103,13 +2111,10 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_92:
 		switch data[(p)] {
-		case 32:
-			goto tr77
-		case 121:
-			goto st69
-		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr77
+		case 108:
+			goto st93
+		case 110:
+			goto st94
 		}
 		goto st2
 	st93:
@@ -2120,8 +2125,23 @@ func ParserRFC3164(data []byte, event *event) {
 		switch data[(p)] {
 		case 32:
 			goto tr77
+		case 121:
+			goto st70
+		}
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr77
+		}
+		goto st2
+	st94:
+		if (p)++; (p) == (pe) {
+			goto _test_eof94
+		}
+	st_case_94:
+		switch data[(p)] {
+		case 32:
+			goto tr77
 		case 101:
-			goto st69
+			goto st70
 		}
 		if 9 <= data[(p)] && data[(p)] <= 13 {
 			goto tr77
@@ -2132,8 +2152,8 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st94
-	tr140:
+		goto st95
+	tr141:
 //line parser/common.rl:107
 
 		event.SetSequence(data[tok:p])
@@ -2142,32 +2162,15 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st94
-	st94:
-		if (p)++; (p) == (pe) {
-			goto _test_eof94
-		}
-	st_case_94:
-//line rfc3164_parser.go:2121
-		if data[(p)] == 97 {
-			goto st95
-		}
-		goto st2
+		goto st95
 	st95:
 		if (p)++; (p) == (pe) {
 			goto _test_eof95
 		}
 	st_case_95:
-		switch data[(p)] {
-		case 32:
-			goto tr77
-		case 114:
+//line rfc3164_parser.go:2141
+		if data[(p)] == 97 {
 			goto st96
-		case 121:
-			goto st69
-		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr77
 		}
 		goto st2
 	st96:
@@ -2178,8 +2181,10 @@ func ParserRFC3164(data []byte, event *event) {
 		switch data[(p)] {
 		case 32:
 			goto tr77
-		case 99:
+		case 114:
 			goto st97
+		case 121:
+			goto st70
 		}
 		if 9 <= data[(p)] && data[(p)] <= 13 {
 			goto tr77
@@ -2190,8 +2195,23 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof97
 		}
 	st_case_97:
+		switch data[(p)] {
+		case 32:
+			goto tr77
+		case 99:
+			goto st98
+		}
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr77
+		}
+		goto st2
+	st98:
+		if (p)++; (p) == (pe) {
+			goto _test_eof98
+		}
+	st_case_98:
 		if data[(p)] == 104 {
-			goto st69
+			goto st70
 		}
 		goto st2
 	tr9:
@@ -2199,42 +2219,7 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st98
-	tr141:
-//line parser/common.rl:107
-
-		event.SetSequence(data[tok:p])
-
-//line parser/common.rl:3
-
-		tok = p
-
-		goto st98
-	st98:
-		if (p)++; (p) == (pe) {
-			goto _test_eof98
-		}
-	st_case_98:
-//line rfc3164_parser.go:2188
-		if data[(p)] == 111 {
-			goto st99
-		}
-		goto st2
-	st99:
-		if (p)++; (p) == (pe) {
-			goto _test_eof99
-		}
-	st_case_99:
-		if data[(p)] == 118 {
-			goto st76
-		}
-		goto st2
-	tr10:
-//line parser/common.rl:3
-
-		tok = p
-
-		goto st100
+		goto st99
 	tr142:
 //line parser/common.rl:107
 
@@ -2244,23 +2229,49 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st100
+		goto st99
+	st99:
+		if (p)++; (p) == (pe) {
+			goto _test_eof99
+		}
+	st_case_99:
+//line rfc3164_parser.go:2208
+		if data[(p)] == 111 {
+			goto st100
+		}
+		goto st2
 	st100:
 		if (p)++; (p) == (pe) {
 			goto _test_eof100
 		}
 	st_case_100:
-//line rfc3164_parser.go:2223
-		if data[(p)] == 99 {
-			goto st101
+		if data[(p)] == 118 {
+			goto st77
 		}
 		goto st2
+	tr10:
+//line parser/common.rl:3
+
+		tok = p
+
+		goto st101
+	tr143:
+//line parser/common.rl:107
+
+		event.SetSequence(data[tok:p])
+
+//line parser/common.rl:3
+
+		tok = p
+
+		goto st101
 	st101:
 		if (p)++; (p) == (pe) {
 			goto _test_eof101
 		}
 	st_case_101:
-		if data[(p)] == 116 {
+//line rfc3164_parser.go:2243
+		if data[(p)] == 99 {
 			goto st102
 		}
 		goto st2
@@ -2269,11 +2280,20 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof102
 		}
 	st_case_102:
+		if data[(p)] == 116 {
+			goto st103
+		}
+		goto st2
+	st103:
+		if (p)++; (p) == (pe) {
+			goto _test_eof103
+		}
+	st_case_103:
 		switch data[(p)] {
 		case 32:
 			goto tr77
 		case 111:
-			goto st78
+			goto st79
 		}
 		if 9 <= data[(p)] && data[(p)] <= 13 {
 			goto tr77
@@ -2284,8 +2304,8 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st103
-	tr143:
+		goto st104
+	tr144:
 //line parser/common.rl:107
 
 		event.SetSequence(data[tok:p])
@@ -2294,23 +2314,14 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st103
-	st103:
-		if (p)++; (p) == (pe) {
-			goto _test_eof103
-		}
-	st_case_103:
-//line rfc3164_parser.go:2273
-		if data[(p)] == 101 {
-			goto st104
-		}
-		goto st2
+		goto st104
 	st104:
 		if (p)++; (p) == (pe) {
 			goto _test_eof104
 		}
 	st_case_104:
-		if data[(p)] == 112 {
+//line rfc3164_parser.go:2293
+		if data[(p)] == 101 {
 			goto st105
 		}
 		goto st2
@@ -2319,14 +2330,8 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof105
 		}
 	st_case_105:
-		switch data[(p)] {
-		case 32:
-			goto tr77
-		case 116:
+		if data[(p)] == 112 {
 			goto st106
-		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr77
 		}
 		goto st2
 	st106:
@@ -2334,8 +2339,23 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof106
 		}
 	st_case_106:
+		switch data[(p)] {
+		case 32:
+			goto tr77
+		case 116:
+			goto st107
+		}
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr77
+		}
+		goto st2
+	st107:
+		if (p)++; (p) == (pe) {
+			goto _test_eof107
+		}
+	st_case_107:
 		if data[(p)] == 101 {
-			goto st77
+			goto st78
 		}
 		goto st2
 	tr2:
@@ -2343,27 +2363,15 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st107
-	st107:
-		if (p)++; (p) == (pe) {
-			goto _test_eof107
-		}
-	st_case_107:
-//line rfc3164_parser.go:2322
-		if data[(p)] == 58 {
-			goto st112
-		}
-		if 48 <= data[(p)] && data[(p)] <= 57 {
-			goto st108
-		}
-		goto st2
+		goto st108
 	st108:
 		if (p)++; (p) == (pe) {
 			goto _test_eof108
 		}
 	st_case_108:
+//line rfc3164_parser.go:2342
 		if data[(p)] == 58 {
-			goto st112
+			goto st113
 		}
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st109
@@ -2375,7 +2383,7 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_109:
 		if data[(p)] == 58 {
-			goto st112
+			goto st113
 		}
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st110
@@ -2386,11 +2394,8 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof110
 		}
 	st_case_110:
-		switch data[(p)] {
-		case 45:
-			goto tr18
-		case 58:
-			goto st112
+		if data[(p)] == 58 {
+			goto st113
 		}
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st111
@@ -2401,11 +2406,14 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof111
 		}
 	st_case_111:
-		if data[(p)] == 58 {
-			goto st112
+		switch data[(p)] {
+		case 45:
+			goto tr18
+		case 58:
+			goto st113
 		}
 		if 48 <= data[(p)] && data[(p)] <= 57 {
-			goto st111
+			goto st112
 		}
 		goto st2
 	st112:
@@ -2413,54 +2421,26 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof112
 		}
 	st_case_112:
-		if data[(p)] == 32 {
-			goto tr132
+		if data[(p)] == 58 {
+			goto st113
 		}
-		if 9 <= data[(p)] && data[(p)] <= 13 {
-			goto tr132
+		if 48 <= data[(p)] && data[(p)] <= 57 {
+			goto st112
 		}
 		goto st2
-	tr132:
-//line parser/common.rl:3
-
-		tok = p
-
-		goto st113
 	st113:
 		if (p)++; (p) == (pe) {
 			goto _test_eof113
 		}
 	st_case_113:
-//line rfc3164_parser.go:2404
-		switch data[(p)] {
-		case 32:
-			goto tr134
-		case 42:
-			goto tr134
-		case 46:
-			goto tr134
-		case 65:
-			goto tr136
-		case 68:
-			goto tr137
-		case 70:
-			goto tr138
-		case 74:
-			goto tr139
-		case 77:
-			goto tr140
-		case 78:
-			goto tr141
-		case 79:
-			goto tr142
-		case 83:
-			goto tr143
+		if data[(p)] == 32 {
+			goto tr133
 		}
-		if 48 <= data[(p)] && data[(p)] <= 57 {
-			goto tr135
+		if 9 <= data[(p)] && data[(p)] <= 13 {
+			goto tr133
 		}
-		goto tr133
-	tr3:
+		goto st2
+	tr133:
 //line parser/common.rl:3
 
 		tok = p
@@ -2471,12 +2451,36 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof114
 		}
 	st_case_114:
-//line rfc3164_parser.go:2444
-		if 48 <= data[(p)] && data[(p)] <= 57 {
+//line rfc3164_parser.go:2424
+		switch data[(p)] {
+		case 32:
+			goto tr135
+		case 42:
+			goto tr135
+		case 46:
+			goto tr135
+		case 65:
+			goto tr137
+		case 68:
+			goto tr138
+		case 70:
+			goto tr139
+		case 74:
+			goto tr140
+		case 77:
+			goto tr141
+		case 78:
+			goto tr142
+		case 79:
+			goto tr143
+		case 83:
 			goto tr144
 		}
-		goto st2
-	tr144:
+		if 48 <= data[(p)] && data[(p)] <= 57 {
+			goto tr136
+		}
+		goto tr134
+	tr3:
 //line parser/common.rl:3
 
 		tok = p
@@ -2487,21 +2491,25 @@ func ParserRFC3164(data []byte, event *event) {
 			goto _test_eof115
 		}
 	st_case_115:
-//line rfc3164_parser.go:2460
-		if data[(p)] == 62 {
-			goto tr146
-		}
+//line rfc3164_parser.go:2464
 		if 48 <= data[(p)] && data[(p)] <= 57 {
-			goto st116
+			goto tr145
 		}
 		goto st2
+	tr145:
+//line parser/common.rl:3
+
+		tok = p
+
+		goto st116
 	st116:
 		if (p)++; (p) == (pe) {
 			goto _test_eof116
 		}
 	st_case_116:
+//line rfc3164_parser.go:2480
 		if data[(p)] == 62 {
-			goto tr146
+			goto tr147
 		}
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st117
@@ -2513,7 +2521,7 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_117:
 		if data[(p)] == 62 {
-			goto tr146
+			goto tr147
 		}
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st118
@@ -2525,7 +2533,7 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_118:
 		if data[(p)] == 62 {
-			goto tr146
+			goto tr147
 		}
 		if 48 <= data[(p)] && data[(p)] <= 57 {
 			goto st119
@@ -2537,21 +2545,33 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 	st_case_119:
 		if data[(p)] == 62 {
-			goto tr146
+			goto tr147
+		}
+		if 48 <= data[(p)] && data[(p)] <= 57 {
+			goto st120
 		}
 		goto st2
-	tr146:
-//line parser/common.rl:7
-
-		event.SetPriority(data[tok:p])
-
-		goto st120
 	st120:
 		if (p)++; (p) == (pe) {
 			goto _test_eof120
 		}
 	st_case_120:
-//line rfc3164_parser.go:2524
+		if data[(p)] == 62 {
+			goto tr147
+		}
+		goto st2
+	tr147:
+//line parser/common.rl:7
+
+		event.SetPriority(data[tok:p])
+
+		goto st121
+	st121:
+		if (p)++; (p) == (pe) {
+			goto _test_eof121
+		}
+	st_case_121:
+//line rfc3164_parser.go:2544
 		switch data[(p)] {
 		case 32:
 			goto tr1
@@ -2591,14 +2611,14 @@ func ParserRFC3164(data []byte, event *event) {
 
 		tok = p
 
-		goto st121
-	st121:
+		goto st122
+	st122:
 		if (p)++; (p) == (pe) {
-			goto _test_eof121
+			goto _test_eof122
 		}
-	st_case_121:
-//line rfc3164_parser.go:2570
-		goto st121
+	st_case_122:
+//line rfc3164_parser.go:2590
+		goto st122
 	st_out:
 	_test_eof2:
 		cs = 2
@@ -2957,11 +2977,14 @@ func ParserRFC3164(data []byte, event *event) {
 	_test_eof120:
 		cs = 120
 		goto _test_eof
+	_test_eof121:
+		cs = 121
+		goto _test_eof
 	_test_eof1:
 		cs = 1
 		goto _test_eof
-	_test_eof121:
-		cs = 121
+	_test_eof122:
+		cs = 122
 		goto _test_eof
 
 	_test_eof:
@@ -2969,12 +2992,12 @@ func ParserRFC3164(data []byte, event *event) {
 		}
 		if (p) == eof {
 			switch cs {
-			case 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121:
+			case 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122:
 //line parser/common.rl:11
 
 				event.SetMessage(data[tok:p])
 
-//line rfc3164_parser.go:2703
+//line rfc3164_parser.go:2724
 			}
 		}
 

--- a/filebeat/input/syslog/rfc3164_test.go
+++ b/filebeat/input/syslog/rfc3164_test.go
@@ -663,6 +663,22 @@ func TestParserRFC3164Syslog(t *testing.T) {
 				second:   25,
 			},
 		},
+		{
+			title: "non-compliant rfc3164 date with leading 0",
+			log:   []byte("<123>Sep 01 02:03:04 hostname: message"),
+			syslog: event{
+				priority: 123,
+				message:  "message",
+				hostname: "hostname",
+				program:  "",
+				pid:      -1,
+				month:    9,
+				day:      1,
+				hour:     2,
+				minute:   3,
+				second:   4,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## What does this PR do?

This makes the RFC3164 parser accept dates with a leading 0. This makes the parser a little more liberal than the spec.

From RFC3164 https://datatracker.ietf.org/doc/html/rfc3164#section-4.1.2

> If the day of the month is less than 10, then it MUST be represented as a space and then the number. For example, the 7th day of August would be represented as "Aug 7", with two spaces between the "g" and the "7".

So now it will accept both `Sep 01` and `Sep  1`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

