### PR TITLE
[Elastic Agent] Add validation to ensure certificate paths are absolute.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -82,6 +82,7 @@
 - Fix issue with install directory in state path in K8s {pull}27396[27396]
 - Disable monitoring during fleet-server bootstrapping. {pull}27222[27222]
 - Change output.elasticsearch.proxy_disabled flag to output.elasticsearch.proxy_disable so fleet uses it. {issue}27670[27670] {pull}27671[27671]
+- Add validation for certificate flags to ensure they are absolute paths. {pull}27779[27779]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -69,6 +70,26 @@ func addEnrollFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("proxy-disabled", "", false, "Disable proxy support including environment variables")
 	cmd.Flags().StringSliceP("proxy-header", "", []string{}, "Proxy headers used with CONNECT request")
 	cmd.Flags().BoolP("delay-enroll", "", false, "Delays enrollment to occur on first start of the Elastic Agent service")
+}
+
+func validateEnrollFlags(cmd *cobra.Command) error {
+	ca, _ := cmd.Flags().GetString("certificate-authorities")
+	if ca != "" && !filepath.IsAbs(ca) {
+		return errors.New("--certificate-authorities must be provided as an absolute path", errors.M("path", ca), errors.TypeConfig)
+	}
+	esCa, _ := cmd.Flags().GetString("fleet-server-es-ca")
+	if esCa != "" && !filepath.IsAbs(esCa) {
+		return errors.New("--fleet-server-es-ca must be provided as an absolute path", errors.M("path", esCa), errors.TypeConfig)
+	}
+	fCert, _ := cmd.Flags().GetString("fleet-server-cert")
+	if fCert != "" && !filepath.IsAbs(fCert) {
+		return errors.New("--fleet-server-cert must be provided as an absolute path", errors.M("path", fCert), errors.TypeConfig)
+	}
+	fCertKey, _ := cmd.Flags().GetString("fleet-server-cert-key")
+	if fCertKey != "" && !filepath.IsAbs(fCertKey) {
+		return errors.New("--fleet-server-cert-key must be provided as an absolute path", errors.M("path", fCertKey), errors.TypeConfig)
+	}
+	return nil
 }
 
 func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string {
@@ -184,6 +205,11 @@ func buildEnrollmentFlags(cmd *cobra.Command, url string, token string) []string
 }
 
 func enroll(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
+	err := validateEnrollFlags(cmd)
+	if err != nil {
+		return err
+	}
+
 	fromInstall, _ := cmd.Flags().GetBool("from-install")
 
 	pathConfigFile := paths.ConfigFile()

--- a/x-pack/elastic-agent/pkg/agent/cmd/install.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/install.go
@@ -42,6 +42,11 @@ would like the Agent to operate.
 }
 
 func installCmd(streams *cli.IOStreams, cmd *cobra.Command, args []string) error {
+	err := validateEnrollFlags(cmd)
+	if err != nil {
+		return err
+	}
+
 	isAdmin, err := install.HasRoot()
 	if err != nil {
 		return fmt.Errorf("unable to perform install command while checking for administrator rights, %v", err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds validation to the `install` and `enroll` command to ensure that certificate paths are absolute paths.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

If absolute paths are not used then that can affect the ability for the Elastic Agent to pass paths to Fleet Server.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #27677
