### PR TITLE
Osquerybeat: Fix osquery logger plugin severy levels mapping

### DIFF
--- a/x-pack/osquerybeat/beater/logger_plugin.go
+++ b/x-pack/osquerybeat/beater/logger_plugin.go
@@ -35,15 +35,19 @@ const osqueryLogMessageFieldsCount = 6
 
 type osqLogSeverity int
 
+// The severity levels are taken from osquery source
+// https://github.com/osquery/osquery/blob/master/osquery/core/plugins/logger.h#L39
+//  enum StatusLogSeverity {
+// 	  O_INFO = 0,
+// 	  O_WARNING = 1,
+// 	  O_ERROR = 2,
+// 	  O_FATAL = 3,
+//  };
 const (
-	severityEmerg osqLogSeverity = iota
-	severityAlert
-	severityCrit
-	severityErr
-	severityWarn
-	severityNotice
-	severityInfo
-	severityDebug
+	severityInfo osqLogSeverity = iota
+	severityWarning
+	severityError
+	severityFatal
 )
 
 func (m *osqueryLogMessage) Log(typ logger.LogType, log *logp.Logger) {
@@ -65,14 +69,12 @@ func (m *osqueryLogMessage) Log(typ logger.LogType, log *logp.Logger) {
 	args = append(args, m.UnixTime)
 
 	switch osqLogSeverity(m.Severity) {
-	case severityEmerg, severityAlert, severityCrit:
+	case severityError, severityFatal:
 		log.Errorw(m.Message, args...)
-	case severityWarn, severityNotice:
+	case severityWarning:
 		log.Warnw(m.Message, args...)
 	case severityInfo:
 		log.Infow(m.Message, args...)
-	case severityDebug:
-		log.Debugw(m.Message, args...)
 	default:
 		log.Debugw(m.Message, args...)
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes the osquery logger plugin log severity level mapping. For example 0 severity was mapped to error and was logged as "error" in osquerybeat logs instead of "info" level.


## Why is it important?

Log level correctness


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Logs

Osquerybeat log before the change, showing "error" level log:
```
 {"log.level":"error","@timestamp":"2021-09-07T21:36:56.248-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/logger_plugin.go","file.line":69},"message":"Calling configure for logger osq_logger","service.name":    "osquerybeat","ctx":"logger","osquery.log_type":"status","osquery.severity":0,"osquery.filename":"config.cpp","osquery.line":891,"osquery.cal_time":"Wed Sep  8 01:36:53 2021 UTC","osquery.time":1631065013,"ecs.version":"1.6.0"}
```

Osquerybeat log after the change, showing the correct "info" level log:
```
{"log.level":"info","@timestamp":"2021-09-07T22:05:24.843-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/logger_plugin.go","file.line":69},"message":"Event publisher not enabled: openbsm: Publisher disabled via configuration","service.name":"osquerybeat","ctx":"logger","osquery.log_type":"status","osquery.severity":0,"osquery.filename":"eventfactory.cpp","osquery.line":156,"osquery.cal_time":"Wed Sep  8 02:05:24 2021 UTC","osquery.time":1631066724,"ecs.version":"1.6.0"} 
```