### PR TITLE
Elastic Agent: Migrate state on upgrade

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -83,6 +83,7 @@
 - Disable monitoring during fleet-server bootstrapping. {pull}27222[27222]
 - Change output.elasticsearch.proxy_disabled flag to output.elasticsearch.proxy_disable so fleet uses it. {issue}27670[27670] {pull}27671[27671]
 - Add validation for certificate flags to ensure they are absolute paths. {pull}27779[27779]
+- Migrate state on upgrade {pull}27825[27825]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/application.go
+++ b/x-pack/elastic-agent/pkg/agent/application/application.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/reexec"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/upgrade"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
@@ -30,7 +31,7 @@ type Application interface {
 }
 
 type reexecManager interface {
-	ReExec(argOverrides ...string)
+	ReExec(callback reexec.ShutdownCallbackFn, argOverrides ...string)
 }
 
 type upgraderControl interface {

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_settings.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_settings.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/reexec"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/storage/store"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
@@ -16,7 +17,7 @@ import (
 )
 
 type reexecManager interface {
-	ReExec(argOverrides ...string)
+	ReExec(cb reexec.ShutdownCallbackFn, argOverrides ...string)
 }
 
 // Settings handles settings change coming from fleet and updates log level.
@@ -61,7 +62,7 @@ func (h *Settings) Handle(ctx context.Context, a fleetapi.Action, acker store.Fl
 		h.log.Errorf("failed to commit acker after acknowledging action with id '%s'", action.ActionID)
 	}
 
-	h.reexec.ReExec()
+	h.reexec.ReExec(nil)
 	return nil
 }
 

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/actions/handlers/handler_action_upgrade.go
@@ -38,7 +38,8 @@ func (h *Upgrade) Handle(ctx context.Context, a fleetapi.Action, acker store.Fle
 		return fmt.Errorf("invalid type, expected ActionUpgrade and received %T", a)
 	}
 
-	return h.upgrader.Upgrade(ctx, &upgradeAction{action}, true)
+	_, err := h.upgrader.Upgrade(ctx, &upgradeAction{action}, true)
+	return err
 }
 
 type upgradeAction struct {

--- a/x-pack/elastic-agent/pkg/agent/application/reexec/manager.go
+++ b/x-pack/elastic-agent/pkg/agent/application/reexec/manager.go
@@ -5,6 +5,7 @@
 package reexec
 
 import (
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 )
 
@@ -53,7 +54,7 @@ func (m *manager) ReExec(shutdownCallback ShutdownCallbackFn, argOverrides ...st
 		if shutdownCallback != nil {
 			if err := shutdownCallback(); err != nil {
 				// panic; because there is no going back, everything is shutdown
-				panic(err)
+				panic(errors.New(errors.TypeUnexpected, err, "failure occured during shutdown cleanup"))
 			}
 		}
 

--- a/x-pack/elastic-agent/pkg/agent/application/reexec/manager.go
+++ b/x-pack/elastic-agent/pkg/agent/application/reexec/manager.go
@@ -12,7 +12,7 @@ import (
 type ExecManager interface {
 	// ReExec asynchronously re-executes command in the same PID and memory address
 	// as the currently running application.
-	ReExec(argOverrides ...string)
+	ReExec(callback ShutdownCallbackFn, argOverrides ...string)
 
 	// ShutdownChan returns the shutdown channel the main function should use to
 	// handle shutdown of the current running application.
@@ -31,6 +31,9 @@ type manager struct {
 	complete chan bool
 }
 
+// ShutdownCallbackFn is called once everything is shutdown and allows cleanup during reexec process.
+type ShutdownCallbackFn func() error
+
 // NewManager returns the reexec manager.
 func NewManager(log *logger.Logger, exec string) ExecManager {
 	return &manager{
@@ -42,10 +45,17 @@ func NewManager(log *logger.Logger, exec string) ExecManager {
 	}
 }
 
-func (m *manager) ReExec(argOverrides ...string) {
+func (m *manager) ReExec(shutdownCallback ShutdownCallbackFn, argOverrides ...string) {
 	go func() {
 		close(m.trigger)
 		<-m.shutdown
+
+		if shutdownCallback != nil {
+			if err := shutdownCallback(); err != nil {
+				// panic; because there is no going back, everything is shutdown
+				panic(err)
+			}
+		}
 
 		if err := reexec(m.logger, m.exec, argOverrides...); err != nil {
 			// panic; because there is no going back, everything is shutdown

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -285,6 +285,9 @@ func copyActionStore(newHash string) error {
 	return nil
 }
 
+// shutdownCallback returns a callback function to be executing during shutdown once all processes are closed.
+// this goes through runtime directory of agent and copies all the state files created by processes to new versioned
+// home directory with updated process name to match new version.
 func shutdownCallback(log *logger.Logger, prevVersion, newVersion, newHash string) reexec.ShutdownCallbackFn {
 	if release.Snapshot() {
 		// SNAPSHOT is part of newVersion

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/otiai10/copy"
+
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/reexec"
@@ -23,7 +25,6 @@ import (
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/state"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/fleetapi"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
-	"github.com/otiai10/copy"
 )
 
 const (

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade_test.go
@@ -1,0 +1,55 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShutdownCallback(t *testing.T) {
+	l, _ := logger.New("test", false)
+	tmpDir, err := ioutil.TempDir("", "shutdown-test-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// make homepath agent consistent (in a form of elastic-agent-hash)
+	homePath := filepath.Join(tmpDir, fmt.Sprintf("%s-%s", agentName, release.ShortCommit()))
+
+	filename := "file.test"
+	newCommit := "abc123"
+	sourceVersion := "7.14.0"
+	targetVersion := "7.15.0"
+
+	content := []byte("content")
+	newHome := strings.ReplaceAll(homePath, release.ShortCommit(), newCommit)
+	sourceDir := filepath.Join(homePath, "run", "default", "process-"+sourceVersion)
+	targetDir := filepath.Join(newHome, "run", "default", "process-"+targetVersion)
+
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+
+	cb := shutdownCallback(l, homePath, sourceVersion, targetVersion, newCommit)
+
+	oldFilename := filepath.Join(sourceDir, filename)
+	err = ioutil.WriteFile(oldFilename, content, 0640)
+	require.NoError(t, err, "preparing file failed")
+
+	err = cb()
+	require.NoError(t, err, "callback failed")
+
+	newFilename := filepath.Join(targetDir, filename)
+	newContent, err := ioutil.ReadFile(newFilename)
+	require.NoError(t, err, "reading file failed")
+	require.Equal(t, content, newContent, "contents are not equal")
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/upgrade_test.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/release"
-	"github.com/stretchr/testify/require"
 )
 
 func TestShutdownCallback(t *testing.T) {

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -172,7 +172,7 @@ func run(streams *cli.IOStreams, override cfgOverrider) error {
 		case sig := <-signals:
 			if sig == syscall.SIGHUP {
 				rexLogger.Infof("SIGHUP triggered re-exec")
-				rex.ReExec()
+				rex.ReExec(nil)
 			} else {
 				breakout = true
 			}

--- a/x-pack/elastic-agent/pkg/agent/control/server/server.go
+++ b/x-pack/elastic-agent/pkg/agent/control/server/server.go
@@ -110,7 +110,7 @@ func (s *Server) Status(_ context.Context, _ *proto.Empty) (*proto.StatusRespons
 
 // Restart performs re-exec.
 func (s *Server) Restart(_ context.Context, _ *proto.Empty) (*proto.RestartResponse, error) {
-	s.rex.ReExec()
+	s.rex.ReExec(nil)
 	return &proto.RestartResponse{
 		Status: proto.ActionStatus_SUCCESS,
 	}, nil
@@ -128,7 +128,7 @@ func (s *Server) Upgrade(ctx context.Context, request *proto.UpgradeRequest) (*p
 			Error:  "cannot be upgraded; perform upgrading using Fleet",
 		}, nil
 	}
-	err := u.Upgrade(ctx, &upgradeRequest{request}, false)
+	cb, err := u.Upgrade(ctx, &upgradeRequest{request}, false)
 	if err != nil {
 		return &proto.UpgradeResponse{
 			Status: proto.ActionStatus_FAILURE,
@@ -139,7 +139,7 @@ func (s *Server) Upgrade(ctx context.Context, request *proto.UpgradeRequest) (*p
 	// this ensures that the upgrade response over GRPC is returned
 	go func() {
 		<-time.After(time.Second)
-		s.rex.ReExec()
+		s.rex.ReExec(cb)
 	}()
 	return &proto.UpgradeResponse{
 		Status:  proto.ActionStatus_SUCCESS,

--- a/x-pack/elastic-agent/pkg/release/version.go
+++ b/x-pack/elastic-agent/pkg/release/version.go
@@ -27,6 +27,15 @@ var allowEmptyPgp string
 // with upgrade without requiring Agent to be installed correctly
 var allowUpgrade string
 
+// TrimCommit trims commit up to 6 characters.
+func TrimCommit(commit string) string {
+	hash := commit
+	if len(hash) > hashLen {
+		hash = hash[:hashLen]
+	}
+	return hash
+}
+
 // Commit returns the current build hash or unknown if it was not injected in the build process.
 func Commit() string {
 	return libbeatVersion.Commit()
@@ -34,11 +43,7 @@ func Commit() string {
 
 // ShortCommit returns commit up to 6 characters.
 func ShortCommit() string {
-	hash := Commit()
-	if len(hash) > hashLen {
-		hash = hash[:hashLen]
-	}
-	return hash
+	return TrimCommit(Commit())
 }
 
 // BuildTime returns the build time of the binaries.


### PR DESCRIPTION
## What does this PR do?

This PR adds a shutdown callback called by Reexec manager once everything is shutdown.
This callback is then used to migrate state (located in `paths.home/run/defualt/*`) of running processes from stale version path to new version path. these paths are unique for each version of the process.

e2e needs to be added

## Why is it important?

Without this state of the processes is not migrated which may result in duplicate events.
Fixes: https://github.com/elastic/beats/issues/27773

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
