### PR TITLE
Filebeat module sophos documentation fixes

### DIFF
--- a/filebeat/docs/modules/sophos.asciidoc
+++ b/filebeat/docs/modules/sophos.asciidoc
@@ -16,7 +16,7 @@ logs in syslog format or from a file for the following devices:
 - `xg` fileset: supports Sophos XG SFOS logs.
 - `utm` fileset: supports Sophos UTM logs.
 
-To configure a remote syslog destination, please reference the https://community.sophos.com/kb/en-us/123184[SophosXG/SFOS Documentation].
+To configure a remote syslog destination, please reference the https://docs.sophos.com/nsg/sophos-firewall/18.5/Help/en-us/webhelp/onlinehelp/nsg/tasks/SyslogServerAdd.html[SophosXG/SFOS Documentation].
 
 The syslog format choosen in Sophos configuration should be `Central Reporting Format`.
 
@@ -25,8 +25,8 @@ include::../include/gs-link.asciidoc[]
 [float]
 === Compatibility
 
-This module has been tested against SFOS version 17.5.x and 18.0.x.
-Versions above this are expected to work but have not been tested.
+This module has been tested against SFOS version 17.5.x, 18.0.x, and 18.5.x.
+Versions above this and between 18.0 - 18.5 are expected to work but have not been tested.
 
 include::../include/configuring-intro.asciidoc[]
 

--- a/filebeat/docs/modules/sophos.asciidoc
+++ b/filebeat/docs/modules/sophos.asciidoc
@@ -18,7 +18,7 @@ logs in syslog format or from a file for the following devices:
 
 To configure a remote syslog destination, please reference the https://community.sophos.com/kb/en-us/123184[SophosXG/SFOS Documentation].
 
-The syslog format choosen should be `Default`.
+The syslog format choosen in Sophos configuration should be `Central Reporting Format`.
 
 include::../include/gs-link.asciidoc[]
 

--- a/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
@@ -11,17 +11,17 @@ logs in syslog format or from a file for the following devices:
 - `xg` fileset: supports Sophos XG SFOS logs.
 - `utm` fileset: supports Sophos UTM logs.
 
-To configure a remote syslog destination, please reference the https://community.sophos.com/kb/en-us/123184[SophosXG/SFOS Documentation].
+To configure a remote syslog destination, please reference the https://docs.sophos.com/nsg/sophos-firewall/18.5/Help/en-us/webhelp/onlinehelp/nsg/tasks/SyslogServerAdd.html[SophosXG/SFOS Documentation].
 
-The syslog format choosen should be `Default`.
+The syslog format choosen in Sophos configuration should be `Central Reporting Format`.
 
 include::../include/gs-link.asciidoc[]
 
 [float]
 === Compatibility
 
-This module has been tested against SFOS version 17.5.x and 18.0.x.
-Versions above this are expected to work but have not been tested.
+This module has been tested against SFOS version 17.5.x, 18.0.x, and 18.5.x.
+Versions above this and between 18.0 - 18.5 are expected to work but have not been tested.
 
 include::../include/configuring-intro.asciidoc[]
 


### PR DESCRIPTION
## What does this PR do?

**Syslog options**
Setting the correct syslog output option in Sophos is mandatory for the filebeat module to work.

There are two possible settings inside Sophos:
1. `Device Standard Format`
2. `Central Reporting Format`

When using `Device Standard Format` weird parsing error, timestamp issues and more occur frequently. I suggest to change it to `Central Reporting Format`. With the `Central reporting format` no parsing issues where detected.

**Version update**
I am currently running the module successfully against version 18.5, so I suggest to bump the supported version in the docs.

## Why is it important?

With the wrong syslog format set in sending from Sophos to Filebeat, the module will not work properly. Anyone using this module expects clear guidance on what to configure on both sides.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
