### PR TITLE
Add '_monitoring' suffix to monitoring process names

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -84,6 +84,7 @@
 - Change output.elasticsearch.proxy_disabled flag to output.elasticsearch.proxy_disable so fleet uses it. {issue}27670[27670] {pull}27671[27671]
 - Add validation for certificate flags to ensure they are absolute paths. {pull}27779[27779]
 - Migrate state on upgrade {pull}27825[27825]
+- Add "_monitoring" suffix to monitoring instance names to remove ambiguity with the status command. {issue}25449[25449]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/status.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/status.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"text/tabwriter"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -96,14 +97,16 @@ func humanOutput(w io.Writer, status *client.AgentStatus) error {
 		fmt.Fprint(w, "Applications: (none)\n")
 	} else {
 		fmt.Fprint(w, "Applications:\n")
+		tw := tabwriter.NewWriter(w, 4, 1, 2, ' ', 0)
 		for _, app := range status.Applications {
-			fmt.Fprintf(w, "  * %s\t(%s)\n", app.Name, app.Status)
+			fmt.Fprintf(tw, "  * %s\t(%s)\n", app.Name, app.Status)
 			if app.Message == "" {
-				fmt.Fprint(w, "    (no message)\n")
+				fmt.Fprint(tw, "\t(no message)\n")
 			} else {
-				fmt.Fprintf(w, "    %s\n", app.Message)
+				fmt.Fprintf(tw, "\t%s\t\n", app.Message)
 			}
 		}
+		tw.Flush()
 	}
 	return nil
 }

--- a/x-pack/elastic-agent/pkg/agent/cmd/status.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/status.go
@@ -103,7 +103,7 @@ func humanOutput(w io.Writer, status *client.AgentStatus) error {
 			if app.Message == "" {
 				fmt.Fprint(tw, "\t(no message)\n")
 			} else {
-				fmt.Fprintf(tw, "\t%s\t\n", app.Message)
+				fmt.Fprintf(tw, "\t%s\n", app.Message)
 			}
 		}
 		tw.Flush()

--- a/x-pack/elastic-agent/pkg/agent/cmd/status_test.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/status_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package cmd
 
 import (

--- a/x-pack/elastic-agent/pkg/agent/cmd/status_test.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/status_test.go
@@ -41,7 +41,7 @@ var testStatus = &client.AgentStatus{
 	},
 }
 
-func ExampleHumanOutput() {
+func ExamplehumanOutput() {
 	humanOutput(os.Stdout, testStatus)
 	// Output:
 	// Status: HEALTHY
@@ -57,7 +57,7 @@ func ExampleHumanOutput() {
 	//                            Running
 }
 
-func ExampleJSONOutput() {
+func ExamplejsonOutput() {
 	jsonOutput(os.Stdout, testStatus)
 	// Output:
 	// {
@@ -96,7 +96,7 @@ func ExampleJSONOutput() {
 	// }
 }
 
-func ExampleYAMLOutput() {
+func ExampleyamlOutput() {
 	yamlOutput(os.Stdout, testStatus)
 	// Output:
 	// status: 2

--- a/x-pack/elastic-agent/pkg/agent/cmd/status_test.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/status_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/client"
+)
+
+var testStatus = &client.AgentStatus{
+	Status:  client.Healthy,
+	Message: "",
+	Applications: []*client.ApplicationStatus{{
+		ID:      "id_1",
+		Name:    "filebeat",
+		Status:  client.Healthy,
+		Message: "Running",
+		Payload: nil,
+	}, {
+		ID:      "id_2",
+		Name:    "metricbeat",
+		Status:  client.Healthy,
+		Message: "Running",
+		Payload: nil,
+	}, {
+		ID:      "id_3",
+		Name:    "filebeat_monitoring",
+		Status:  client.Healthy,
+		Message: "Running",
+		Payload: nil,
+	}, {
+		ID:      "id_4",
+		Name:    "metricbeat_monitoring",
+		Status:  client.Healthy,
+		Message: "Running",
+		Payload: nil,
+	},
+	},
+}
+
+func ExampleHumanOutput() {
+	humanOutput(os.Stdout, testStatus)
+	// Output:
+	// Status: HEALTHY
+	// Message: (no message)
+	// Applications:
+	//   * filebeat               (HEALTHY)
+	//                            Running
+	//   * metricbeat             (HEALTHY)
+	//                            Running
+	//   * filebeat_monitoring    (HEALTHY)
+	//                            Running
+	//   * metricbeat_monitoring  (HEALTHY)
+	//                            Running
+}
+
+func ExampleJSONOutput() {
+	jsonOutput(os.Stdout, testStatus)
+	// Output:
+	// {
+	//     "Status": 2,
+	//     "Message": "",
+	//     "Applications": [
+	//         {
+	//             "ID": "id_1",
+	//             "Name": "filebeat",
+	//             "Status": 2,
+	//             "Message": "Running",
+	//             "Payload": null
+	//         },
+	//         {
+	//             "ID": "id_2",
+	//             "Name": "metricbeat",
+	//             "Status": 2,
+	//             "Message": "Running",
+	//             "Payload": null
+	//         },
+	//         {
+	//             "ID": "id_3",
+	//             "Name": "filebeat_monitoring",
+	//             "Status": 2,
+	//             "Message": "Running",
+	//             "Payload": null
+	//         },
+	//         {
+	//             "ID": "id_4",
+	//             "Name": "metricbeat_monitoring",
+	//             "Status": 2,
+	//             "Message": "Running",
+	//             "Payload": null
+	//         }
+	//     ]
+	// }
+}
+
+func ExampleYAMLOutput() {
+	yamlOutput(os.Stdout, testStatus)
+	// Output:
+	// status: 2
+	// message: ""
+	// applications:
+	// - id: id_1
+	//   name: filebeat
+	//   status: 2
+	//   message: Running
+	//   payload: {}
+	// - id: id_2
+	//   name: metricbeat
+	//   status: 2
+	//   message: Running
+	//   payload: {}
+	// - id: id_3
+	//   name: filebeat_monitoring
+	//   status: 2
+	//   message: Running
+	//   payload: {}
+	// - id: id_4
+	//   name: metricbeat_monitoring
+	//   status: 2
+	//   message: Running
+	//   payload: {}
+}

--- a/x-pack/elastic-agent/pkg/agent/operation/operator.go
+++ b/x-pack/elastic-agent/pkg/agent/operation/operator.go
@@ -305,9 +305,11 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 	var err error
 
 	monitor := o.monitor
+	appName := p.BinaryName()
 	if app.IsSidecar(p) {
 		// make watchers unmonitorable
 		monitor = noop.NewMonitor()
+		appName += "_monitoring"
 	}
 
 	if p.ServicePort() == 0 {
@@ -315,7 +317,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 		a, err = process.NewApplication(
 			o.bgContext,
 			p.ID(),
-			p.BinaryName(),
+			appName,
 			o.pipelineID,
 			o.config.LoggingConfig.Level.String(),
 			desc,
@@ -331,7 +333,7 @@ func (o *Operator) getApp(p Descriptor) (Application, error) {
 		a, err = service.NewApplication(
 			o.bgContext,
 			p.ID(),
-			p.BinaryName(),
+			appName,
 			o.pipelineID,
 			o.config.LoggingConfig.Level.String(),
 			p.ServicePort(),


### PR DESCRIPTION
## What does this PR do?

Add '_monitoring' suffix to monitoring process names so that they can be
distinguished from other processes. This is relevant for the status
command where the beat instances appear the same in output. Changed the
output format of the human readable option to better align text with the
longer names.

## Why is it important?

Allows users to determine if the monitoring instances, or "regular" beats instances are healthy.

## Checklist

- [x] My code follows the style guidelines of this project
- [] ~~I have commented my code, particularly in hard-to-understand areas~~
- [] ~~I have made corresponding changes to the documentation~~
- [] ~~I have made corresponding change to the default configuration files~~
- [] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

run `elastic-agent status`

## Related issues

- Closes #25449

## Logs

Example of the new output:
```
bash-4.2$ elastic-agent status
Status: HEALTHY
Message: (no message)
Applications:
  * metricbeat_monitoring  (HEALTHY)
                           Running
  * filebeat               (HEALTHY)
                           Running
  * metricbeat             (HEALTHY)
                           Running
  * filebeat_monitoring    (HEALTHY)
                           Running
```