### PR TITLE
Generalize creating a beat.Event from a reader.Message

### DIFF
--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -27,7 +27,6 @@ import (
 
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
-	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cleanup"
 	"github.com/elastic/beats/v7/libbeat/common/match"
@@ -330,8 +329,7 @@ func (inp *filestream) readFromSource(
 			continue
 		}
 
-		event := inp.eventFromMessage(message, path)
-		if err := p.Publish(event, s); err != nil {
+		if err := p.Publish(message.ToEvent(), s); err != nil {
 			return err
 		}
 	}
@@ -364,22 +362,4 @@ func matchAny(matchers []match.Matcher, text string) bool {
 		}
 	}
 	return false
-}
-
-func (inp *filestream) eventFromMessage(m reader.Message, path string) beat.Event {
-	if m.Fields == nil {
-		m.Fields = common.MapStr{}
-	}
-
-	if len(m.Content) > 0 {
-		if _, ok := m.Fields["message"]; !ok {
-			m.Fields["message"] = string(m.Content)
-		}
-	}
-
-	return beat.Event{
-		Timestamp: m.Ts,
-		Meta:      m.Meta,
-		Fields:    m.Fields,
-	}
 }

--- a/libbeat/reader/message.go
+++ b/libbeat/reader/message.go
@@ -77,6 +77,8 @@ func (m *Message) AddFlagsWithKey(key string, flags ...string) error {
 	return common.AddTagsWithKey(m.Fields, key, flags)
 }
 
+// ToEvent converts a Message to an Event that can be published
+// to the output.
 func (m *Message) ToEvent() beat.Event {
 	if m.Fields == nil {
 		m.Fields = common.MapStr{}

--- a/libbeat/reader/message.go
+++ b/libbeat/reader/message.go
@@ -80,14 +80,12 @@ func (m *Message) AddFlagsWithKey(key string, flags ...string) error {
 // ToEvent converts a Message to an Event that can be published
 // to the output.
 func (m *Message) ToEvent() beat.Event {
-	if m.Fields == nil {
-		m.Fields = common.MapStr{}
-	}
 
 	if len(m.Content) > 0 {
-		if _, ok := m.Fields["message"]; !ok {
-			m.Fields["message"] = string(m.Content)
+		if m.Fields == nil {
+			m.Fields = common.MapStr{}
 		}
+		m.Fields["message"] = string(m.Content)
 	}
 
 	return beat.Event{

--- a/libbeat/reader/message.go
+++ b/libbeat/reader/message.go
@@ -20,6 +20,7 @@ package reader
 import (
 	"time"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
@@ -74,4 +75,22 @@ func (m *Message) AddFlagsWithKey(key string, flags ...string) error {
 	}
 
 	return common.AddTagsWithKey(m.Fields, key, flags)
+}
+
+func (m *Message) ToEvent() beat.Event {
+	if m.Fields == nil {
+		m.Fields = common.MapStr{}
+	}
+
+	if len(m.Content) > 0 {
+		if _, ok := m.Fields["message"]; !ok {
+			m.Fields["message"] = string(m.Content)
+		}
+	}
+
+	return beat.Event{
+		Timestamp: m.Ts,
+		Meta:      m.Meta,
+		Fields:    m.Fields,
+	}
 }

--- a/libbeat/reader/message_test.go
+++ b/libbeat/reader/message_test.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package reader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestToEvent(t *testing.T) {
+	testCases := map[string]struct {
+		msg      Message
+		expected beat.Event
+	}{
+		"empty message; emtpy event": {
+			Message{},
+			beat.Event{},
+		},
+		"empty content, one field": {
+			Message{Fields: common.MapStr{"my_field": "my_value"}},
+			beat.Event{Fields: common.MapStr{"my_field": "my_value"}},
+		},
+		"content, no field": {
+			Message{Content: []byte("my message")},
+			beat.Event{Fields: common.MapStr{"message": "my message"}},
+		},
+		"content, one field": {
+			Message{Content: []byte("my message"), Fields: common.MapStr{"my_field": "my_value"}},
+			beat.Event{Fields: common.MapStr{"message": "my message", "my_field": "my_value"}},
+		},
+		"content, message field": {
+			Message{Content: []byte("my message"), Fields: common.MapStr{"message": "my_message_value"}},
+			beat.Event{Fields: common.MapStr{"message": "my message"}},
+		},
+		"content, meta, message field": {
+			Message{Content: []byte("my message"), Fields: common.MapStr{"my_field": "my_value"}, Meta: common.MapStr{"meta": "id"}},
+			beat.Event{Fields: common.MapStr{"message": "my message", "my_field": "my_value"}, Meta: common.MapStr{"meta": "id"}},
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.expected, test.msg.ToEvent())
+		})
+	}
+
+}


### PR DESCRIPTION
## What does this PR do?

This PR moves the function that creates an event from the Filestream input to libbeat, so becomes reusable.

## Why is it important?

With this change, we can avoid duplicating conversion functions in the codebase.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
