### PR TITLE
[DOCS] Add processor "when" syntax into "and", "or" condition examples

### DIFF
--- a/libbeat/docs/processors-using.asciidoc
+++ b/libbeat/docs/processors-using.asciidoc
@@ -398,11 +398,14 @@ For example, to configure the condition
 
 [source,yaml]
 ------
-or:
-  - equals:
-      http.response.code: 304
-  - equals:
-      http.response.code: 404
+processors:
+  - <processor_name>:
+      when:
+        or:
+          - equals:
+              http.response.code: 304
+          - equals:
+              http.response.code: 404
 ------
 
 [float]
@@ -426,11 +429,14 @@ For example, to configure the condition
 
 [source,yaml]
 ------
-and:
-  - equals:
-      http.response.code: 200
-  - equals:
-      status: OK
+processors:
+  - <processor_name>:
+      when:
+        and:
+          - equals:
+              http.response.code: 200
+          - equals:
+              status: OK
 ------
 
 To configure a condition like `<condition1> OR <condition2> AND <condition3>`:


### PR DESCRIPTION
Changes:
- This PR is to add following lines into the condition examples of `and`, `or`, to make them more friendly to refer to.
```
processors:
  - <processor_name>:
      when:
```