### PR TITLE
[Libbeat] Add dashboard string_replacements config:Dashboards 

### DIFF
--- a/libbeat/dashboards/config.go
+++ b/libbeat/dashboards/config.go
@@ -21,17 +21,18 @@ import "time"
 
 // Config represents the config values for dashboards
 type Config struct {
-	Enabled        bool   `config:"enabled"`
-	KibanaIndex    string `config:"kibana_index"`
-	Index          string `config:"index"`
-	Dir            string `config:"directory"`
-	File           string `config:"file"`
-	Beat           string `config:"beat"`
-	URL            string `config:"url"`
-	OnlyDashboards bool   `config:"only_dashboards"`
-	OnlyIndex      bool   `config:"only_index"`
-	AlwaysKibana   bool   `config:"always_kibana"`
-	Retry          *Retry `config:"retry"`
+	Enabled            bool              `config:"enabled"`
+	KibanaIndex        string            `config:"kibana_index"`
+	Index              string            `config:"index"`
+	Dir                string            `config:"directory"`
+	File               string            `config:"file"`
+	Beat               string            `config:"beat"`
+	URL                string            `config:"url"`
+	OnlyDashboards     bool              `config:"only_dashboards"`
+	OnlyIndex          bool              `config:"only_index"`
+	AlwaysKibana       bool              `config:"always_kibana"`
+	Retry              *Retry            `config:"retry"`
+	StringReplacements map[string]string `config:"string_replacements"`
 }
 
 // Retry handles query retries

--- a/libbeat/dashboards/kibana_loader.go
+++ b/libbeat/dashboards/kibana_loader.go
@@ -220,7 +220,16 @@ func (loader KibanaLoader) addReferences(path string, dashboard []byte) (string,
 func (loader KibanaLoader) formatDashboardAssets(content []byte) []byte {
 	content = ReplaceIndexInDashboardObject(loader.config.Index, content)
 	content = EncodeJSONObjects(content)
-	content = ReplaceStringInDashboard("CHANGEME_HOSTNAME", loader.hostname, content)
+
+	replacements := loader.config.StringReplacements
+	if replacements == nil {
+		replacements = make(map[string]string)
+	}
+	replacements["CHANGEME_HOSTNAME"] = loader.hostname
+	for needle, replacement := range replacements {
+		content = ReplaceStringInDashboard(needle, replacement, content)
+	}
+
 	return content
 }
 

--- a/libbeat/docs/dashboardsconfig.asciidoc
+++ b/libbeat/docs/dashboardsconfig.asciidoc
@@ -125,3 +125,8 @@ Duration interval between Kibana connection retries. Defaults to 1 second.
 
 Maximum number of retries before exiting with an error. Set to 0 for unlimited retrying.
 Default is unlimited.
+
+[float]
+==== `setup.dashboards.string_replacements`
+
+The needle and replacements string map, which is used to replace needle string in dashboards and their references contents.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?
This PR add dashboard `string_replacements` config, which can be used to replace content, like title or id, in dashboard and its references configuration.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
With this configuration, we can setup multiple same dashboards not only differ with host name, but also other aspects. Such as different services deploy on a single machine and want same dashboard to display running information.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [ x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
