### PR TITLE
x-pack/filebeat/input/httpjson/internal/v2: allow split chains to continue past empty targets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -749,6 +749,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add base64 Encode functionality to httpjson input. {pull}27681[27681]
 - Add `join` and `sprintf` functions to `httpjson` input. {pull}27735[27735]
 - Improve memory usage of line reader of `log` and `filestream` input. {pull}27782[27782]
+- Add `ignore_error` flag to `httpjson` `split` processor. {pull}27880[27880]
 
 
 *Heartbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -749,7 +749,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add base64 Encode functionality to httpjson input. {pull}27681[27681]
 - Add `join` and `sprintf` functions to `httpjson` input. {pull}27735[27735]
 - Improve memory usage of line reader of `log` and `filestream` input. {pull}27782[27782]
-- Add `ignore_error` flag to `httpjson` `split` processor. {pull}27880[27880]
+- Add `ignore_empty_value` flag to `httpjson` `split` processor. {pull}27880[27880]
 
 
 *Heartbeat*

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -567,6 +567,11 @@ Required if using split type of `string`.  This is the sub string used to split 
 Valid when used with `type: map`. When not empty, defines a new field where the original key value will be stored.
 
 [float]
+==== `response.split[].ignore_error`
+
+If set to true, failure to find a non-empty target will pass operation on to the next nested split operation instead of failing with an error. Default: `false`.
+
+[float]
 ==== `response.split[].split`
 
 Nested split operation. Split operations can be nested at will. An event won't be created until the deepest split operation is applied.

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -567,9 +567,9 @@ Required if using split type of `string`.  This is the sub string used to split 
 Valid when used with `type: map`. When not empty, defines a new field where the original key value will be stored.
 
 [float]
-==== `response.split[].ignore_error`
+==== `response.split[].ignore_empty_value`
 
-If set to true, failure to find a non-empty target will pass operation on to the next nested split operation instead of failing with an error. Default: `false`.
+If set to true, empty or missing value will be ignored and processing will pass on to the next nested split operation instead of failing with an error. Default: `false`.
 
 [float]
 ==== `response.split[].split`

--- a/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
@@ -31,6 +31,7 @@ type splitConfig struct {
 	KeepParent      bool             `config:"keep_parent"`
 	KeyField        string           `config:"key_field"`
 	DelimiterString string           `config:"delimiter"`
+	IgnoreError     bool             `config:"ignore_error"`
 }
 
 func (c *responseConfig) Validate() error {

--- a/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/config_response.go
@@ -24,14 +24,14 @@ type responseConfig struct {
 }
 
 type splitConfig struct {
-	Target          string           `config:"target" validation:"required"`
-	Type            string           `config:"type"`
-	Transforms      transformsConfig `config:"transforms"`
-	Split           *splitConfig     `config:"split"`
-	KeepParent      bool             `config:"keep_parent"`
-	KeyField        string           `config:"key_field"`
-	DelimiterString string           `config:"delimiter"`
-	IgnoreError     bool             `config:"ignore_error"`
+	Target           string           `config:"target" validation:"required"`
+	Type             string           `config:"type"`
+	Transforms       transformsConfig `config:"transforms"`
+	Split            *splitConfig     `config:"split"`
+	KeepParent       bool             `config:"keep_parent"`
+	KeyField         string           `config:"key_field"`
+	DelimiterString  string           `config:"delimiter"`
+	IgnoreEmptyValue bool             `config:"ignore_empty_value"`
 }
 
 func (c *responseConfig) Validate() error {

--- a/x-pack/filebeat/input/httpjson/internal/v2/split.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/split.go
@@ -25,19 +25,19 @@ var (
 // by applying elements of the chain's linked list to an input until completed
 // or an error state is encountered.
 type split struct {
-	log                   *logp.Logger
-	targetInfo            targetInfo
-	kind                  string
-	transforms            []basicTransform
-	child                 *split
-	keepParent            bool
-	ignoreEmptyFieldError bool
-	keyField              string
-	isRoot                bool
-	delimiter             string
+	log              *logp.Logger
+	targetInfo       targetInfo
+	kind             string
+	transforms       []basicTransform
+	child            *split
+	keepParent       bool
+	ignoreEmptyValue bool
+	keyField         string
+	isRoot           bool
+	delimiter        string
 }
 
-// newSplitSplit returns a new split based on the provided config and
+// newSplitResponse returns a new split based on the provided config and
 // logging to the provided logger, tagging the split as the root of the chain.
 func newSplitResponse(cfg *splitConfig, log *logp.Logger) (*split, error) {
 	if cfg == nil {
@@ -79,15 +79,15 @@ func newSplit(c *splitConfig, log *logp.Logger) (*split, error) {
 	}
 
 	return &split{
-		log:                   log,
-		targetInfo:            ti,
-		kind:                  c.Type,
-		keepParent:            c.KeepParent,
-		ignoreEmptyFieldError: c.IgnoreError,
-		keyField:              c.KeyField,
-		delimiter:             c.DelimiterString,
-		transforms:            ts,
-		child:                 s,
+		log:              log,
+		targetInfo:       ti,
+		kind:             c.Type,
+		keepParent:       c.KeepParent,
+		ignoreEmptyValue: c.IgnoreEmptyValue,
+		keyField:         c.KeyField,
+		delimiter:        c.DelimiterString,
+		transforms:       ts,
+		child:            s,
 	}, nil
 }
 
@@ -107,7 +107,7 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 	}
 
 	if v == nil {
-		if s.ignoreEmptyFieldError {
+		if s.ignoreEmptyValue {
 			if s.child != nil {
 				return s.child.split(ctx, root, ch)
 			}
@@ -128,7 +128,7 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 		}
 
 		if len(varr) == 0 {
-			if s.ignoreEmptyFieldError {
+			if s.ignoreEmptyValue {
 				if s.child != nil {
 					return s.child.split(ctx, root, ch)
 				}
@@ -155,7 +155,7 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 		}
 
 		if len(vmap) == 0 {
-			if s.ignoreEmptyFieldError {
+			if s.ignoreEmptyValue {
 				if s.child != nil {
 					return s.child.split(ctx, root, ch)
 				}
@@ -182,7 +182,7 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 		}
 
 		if len(vstr) == 0 {
-			if s.ignoreEmptyFieldError {
+			if s.ignoreEmptyValue {
 				if s.child != nil {
 					return s.child.split(ctx, root, ch)
 				}

--- a/x-pack/filebeat/input/httpjson/internal/v2/split.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/split.go
@@ -21,18 +21,24 @@ var (
 	errExpectedSplitString = errors.New("split was expecting field to be a string")
 )
 
+// split is a split processor chain element. Split processing is executed
+// by applying elements of the chain's linked list to an input until completed
+// or an error state is encountered.
 type split struct {
-	log        *logp.Logger
-	targetInfo targetInfo
-	kind       string
-	transforms []basicTransform
-	child      *split
-	keepParent bool
-	keyField   string
-	isRoot     bool
-	delimiter  string
+	log                   *logp.Logger
+	targetInfo            targetInfo
+	kind                  string
+	transforms            []basicTransform
+	child                 *split
+	keepParent            bool
+	ignoreEmptyFieldError bool
+	keyField              string
+	isRoot                bool
+	delimiter             string
 }
 
+// newSplitSplit returns a new split based on the provided config and
+// logging to the provided logger, tagging the split as the root of the chain.
 func newSplitResponse(cfg *splitConfig, log *logp.Logger) (*split, error) {
 	if cfg == nil {
 		return nil, nil
@@ -42,11 +48,13 @@ func newSplitResponse(cfg *splitConfig, log *logp.Logger) (*split, error) {
 	if err != nil {
 		return nil, err
 	}
-	// we want to be able to identify which split is the root of the chain
+	// We want to be able to identify which split is the root of the chain.
 	split.isRoot = true
 	return split, nil
 }
 
+// newSplit returns a new split based on the provided config and
+// logging to the provided logger.
 func newSplit(c *splitConfig, log *logp.Logger) (*split, error) {
 	ti, err := getTargetInfo(c.Target)
 	if err != nil {
@@ -71,22 +79,27 @@ func newSplit(c *splitConfig, log *logp.Logger) (*split, error) {
 	}
 
 	return &split{
-		log:        log,
-		targetInfo: ti,
-		kind:       c.Type,
-		keepParent: c.KeepParent,
-		keyField:   c.KeyField,
-		delimiter:  c.DelimiterString,
-		transforms: ts,
-		child:      s,
+		log:                   log,
+		targetInfo:            ti,
+		kind:                  c.Type,
+		keepParent:            c.KeepParent,
+		ignoreEmptyFieldError: c.IgnoreError,
+		keyField:              c.KeyField,
+		delimiter:             c.DelimiterString,
+		transforms:            ts,
+		child:                 s,
 	}, nil
 }
 
+// run runs the split operation on the contents of resp, sending successive
+// split results on ch. ctx is passed to transforms that are called during
+// the split.
 func (s *split) run(ctx *transformContext, resp transformable, ch chan<- maybeMsg) error {
 	root := resp.body()
 	return s.split(ctx, root, ch)
 }
 
+// split recursively executes the split processor chain.
 func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybeMsg) error {
 	v, err := root.GetValue(s.targetInfo.Name)
 	if err != nil && err != common.ErrKeyNotFound {
@@ -94,6 +107,12 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 	}
 
 	if v == nil {
+		if s.ignoreEmptyFieldError {
+			if s.child != nil {
+				return s.child.split(ctx, root, ch)
+			}
+			return nil
+		}
 		if s.isRoot {
 			return errEmptyRootField
 		}
@@ -109,6 +128,12 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 		}
 
 		if len(varr) == 0 {
+			if s.ignoreEmptyFieldError {
+				if s.child != nil {
+					return s.child.split(ctx, root, ch)
+				}
+				return nil
+			}
 			if s.isRoot {
 				return errEmptyRootField
 			}
@@ -130,6 +155,12 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 		}
 
 		if len(vmap) == 0 {
+			if s.ignoreEmptyFieldError {
+				if s.child != nil {
+					return s.child.split(ctx, root, ch)
+				}
+				return nil
+			}
 			if s.isRoot {
 				return errEmptyRootField
 			}
@@ -151,6 +182,12 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 		}
 
 		if len(vstr) == 0 {
+			if s.ignoreEmptyFieldError {
+				if s.child != nil {
+					return s.child.split(ctx, root, ch)
+				}
+				return nil
+			}
 			if s.isRoot {
 				return errEmptyRootField
 			}
@@ -169,6 +206,8 @@ func (s *split) split(ctx *transformContext, root common.MapStr, ch chan<- maybe
 	return errors.New("unknown split type")
 }
 
+// sendMessage sends an array or map split result value, v, on ch after performing
+// any necessary transformations. If key is "", the value is an element of an array.
 func (s *split) sendMessage(ctx *transformContext, root common.MapStr, key string, v interface{}, ch chan<- maybeMsg) error {
 	obj, ok := toMapStr(v)
 	if !ok {
@@ -220,6 +259,8 @@ func toMapStr(v interface{}) (common.MapStr, bool) {
 	return common.MapStr{}, false
 }
 
+// sendMessage sends a string split result value, v, on ch after performing any
+// necessary transformations. If key is "", the value is an element of an array.
 func (s *split) sendMessageSplitString(ctx *transformContext, root common.MapStr, v string, ch chan<- maybeMsg) error {
 	clone := root.Clone()
 	_, _ = clone.Put(s.targetInfo.Name, v)

--- a/x-pack/filebeat/input/httpjson/internal/v2/split_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/split_test.go
@@ -354,6 +354,141 @@ func TestSplit(t *testing.T) {
 				{"@timestamp": "1234567890", "items": "Line 3"},
 			},
 		},
+		{
+			name: "A missing array in an object",
+			config: &splitConfig{
+				Target: "body.response",
+				Type:   "array",
+				Split: &splitConfig{
+					Target:      "body.Event.Attributes",
+					IgnoreError: true,
+					KeepParent:  true,
+					Split: &splitConfig{
+						Target:     "body.Event.OtherAttributes",
+						KeepParent: true,
+					},
+				},
+			},
+			ctx: emptyTransformContext(),
+			resp: transformable{
+				"body": common.MapStr{
+					"response": []interface{}{
+						map[string]interface{}{
+							"Event": map[string]interface{}{
+								"timestamp":  "1606324417",
+								"Attributes": []interface{}{},
+								"OtherAttributes": []interface{}{
+									map[string]interface{}{
+										"key": "value",
+									},
+									map[string]interface{}{
+										"key2": "value2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMessages: []common.MapStr{
+				{
+					"Event": common.MapStr{
+						"timestamp":  "1606324417",
+						"Attributes": []interface{}{},
+						"OtherAttributes": common.MapStr{
+							"key": "value",
+						},
+					},
+				},
+				{
+					"Event": common.MapStr{
+						"timestamp":  "1606324417",
+						"Attributes": []interface{}{},
+						"OtherAttributes": common.MapStr{
+							"key2": "value2",
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "A missing map in an object",
+			config: &splitConfig{
+				Target: "body.response",
+				Type:   "array",
+				Split: &splitConfig{
+					Target:      "body.Event.Attributes",
+					Type:        "map",
+					IgnoreError: true,
+					KeepParent:  true,
+					Split: &splitConfig{
+						Type:       "map",
+						Target:     "body.Event.OtherAttributes",
+						KeepParent: true,
+					},
+				},
+			},
+			ctx: emptyTransformContext(),
+			resp: transformable{
+				"body": common.MapStr{
+					"response": []interface{}{
+						map[string]interface{}{
+							"Event": map[string]interface{}{
+								"timestamp":  "1606324417",
+								"Attributes": map[string]interface{}{},
+								"OtherAttributes": map[string]interface{}{
+									// Only include a single item here to avoid
+									// map iteration order flakes.
+									"1": map[string]interface{}{
+										"key": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedMessages: []common.MapStr{
+				{
+					"Event": common.MapStr{
+						"timestamp":  "1606324417",
+						"Attributes": common.MapStr{},
+						"OtherAttributes": common.MapStr{
+							"key": "value",
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "A missing string",
+			config: &splitConfig{
+				Target:          "body.items",
+				Type:            "string",
+				DelimiterString: "\n",
+				IgnoreError:     true,
+				Split: &splitConfig{
+					Target:          "body.other_items",
+					Type:            "string",
+					DelimiterString: "\n",
+				},
+			},
+			ctx: emptyTransformContext(),
+			resp: transformable{
+				"body": common.MapStr{
+					"@timestamp":  "1234567890",
+					"items":       "",
+					"other_items": "Line 1\nLine 2\nLine 3",
+				},
+			},
+			expectedMessages: []common.MapStr{
+				{"@timestamp": "1234567890", "items": "", "other_items": "Line 1"},
+				{"@timestamp": "1234567890", "items": "", "other_items": "Line 2"},
+				{"@timestamp": "1234567890", "items": "", "other_items": "Line 3"},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds a configuration option "ignore_error" that allows a split processor chain to continue if a target field is present but empty.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This is required to address #26008 by allowing multiple splits on an input (see https://github.com/elastic/beats/issues/26008#issuecomment-915875217).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~ Defaults to existing behaviour.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm that the new expected split processor results are correct in `split_test.go`

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Standard testing.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #26008

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

See related issue.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A