### PR TITLE
Add comment in metricbeat configmap to avoid leader election in large  k8s clusters

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -19,6 +19,9 @@ data:
         - type: kubernetes
           scope: cluster
           node: ${NODE_NAME}
+          # In large Kubernetes clusters consider setting unique to false
+          # to avoid using the leader election strategy and
+          # instead run a dedicated Metricbeat instance using a Deployment in addition to the DaemonSet
           unique: true
           templates:
             - config:

--- a/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-daemonset-configmap.yaml
@@ -19,6 +19,9 @@ data:
         - type: kubernetes
           scope: cluster
           node: ${NODE_NAME}
+          # In large Kubernetes clusters consider setting unique to false
+          # to avoid using the leader election strategy and
+          # instead run a dedicated Metricbeat instance using a Deployment in addition to the DaemonSet
           unique: true
           templates:
             - config:


### PR DESCRIPTION
## What does this PR do?

Add a comment in metricbeat daemonset configmap to avoid setting `unique:true` in case of large kubernetes clusters. 

## Why is it important?

Enabling leader election on Kubernetes means that only the one daemonset instance holding a lease will request cluster wide metrics from `kube-state-metrics`. In very large clusters this can cause performance issues. 
In [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-kubernetes.html#_deploying_metricbeat_to_collect_cluster_level_metrics_in_large_clusters) there is a suggestion for working around this kind of problems. 
It would be nice to add that also in the proposed configmap so that users can notice it more easily.