### PR TITLE
Elastic-agent snapshot lookup will use proxy settings

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -86,6 +86,7 @@
 - Migrate state on upgrade {pull}27825[27825]
 - Add "_monitoring" suffix to monitoring instance names to remove ambiguity with the status command. {issue}25449[25449]
 - Ignore ErrNotExists when fixing permissions. {issue}27836[27836] {pull}27846[27846]
+- Snapshot artifact lookup will use agent.download proxy settings. {issue}27903[27903] {pull}27904[27904]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/snapshot/downloader.go
@@ -7,9 +7,9 @@ package snapshot
 import (
 	"encoding/json"
 	"fmt"
-	gohttp "net/http"
 	"strings"
 
+	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download/http"
@@ -27,7 +27,7 @@ func NewDownloader(config *artifact.Config, versionOverride string) (download.Do
 }
 
 func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.Config, error) {
-	snapshotURI, err := snapshotURI(versionOverride)
+	snapshotURI, err := snapshotURI(versionOverride, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect remote snapshot repo, proceeding with configured: %v", err)
 	}
@@ -43,7 +43,7 @@ func snapshotConfig(config *artifact.Config, versionOverride string) (*artifact.
 	}, nil
 }
 
-func snapshotURI(versionOverride string) (string, error) {
+func snapshotURI(versionOverride string, config *artifact.Config) (string, error) {
 	version := release.Version()
 	if versionOverride != "" {
 		if strings.HasSuffix(versionOverride, "-SNAPSHOT") {
@@ -52,8 +52,13 @@ func snapshotURI(versionOverride string) (string, error) {
 		version = versionOverride
 	}
 
+	client, err := config.HTTPTransportSettings.Client(httpcommon.WithAPMHTTPInstrumentation())
+	if err != nil {
+		return "", err
+	}
+
 	artifactsURI := fmt.Sprintf("https://artifacts-api.elastic.co/v1/search/%s-SNAPSHOT/elastic-agent", version)
-	resp, err := gohttp.Get(artifactsURI)
+	resp, err := client.Get(artifactsURI)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What does this PR do?

Change the HTTP client from the standard library client to one built
from the http settings supplied to the artifact downloader
(`agent.download` in fleet.yml) so that proxy settings are used for the
initial request to find the artifact location as well as the subsequent
download.

## Why is it important?

Allows agent to upgrade to snapshot versions when agents are behind an Internet proxy.

## Checklist

- [x] My code follows the style guidelines of this project
- [] ~~I have commented my code, particularly in hard-to-understand areas~~
- [] ~~I have made corresponding changes to the documentation~~
- [] ~~I have made corresponding change to the default configuration files~~
- [] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Deploy agent behind an Internet proxy.
2. Add a `agent.download.proxy_url` setting to `fleet.yml`.
3. Trigger an upgrade to a newer snapshot version through the Fleet UI

## Related issues

- Closes #27903
