### PR TITLE
Make the Kafka container healthcheck less noisy

### DIFF
--- a/testing/environments/docker/kafka/Dockerfile
+++ b/testing/environments/docker/kafka/Dockerfile
@@ -22,7 +22,11 @@ ADD healthcheck.sh /healthcheck.sh
 EXPOSE 9092
 EXPOSE 2181
 
-# Healthcheck creates an empty topic foo. As soon as a topic is created, it assumes broke is available
-HEALTHCHECK --interval=1s --retries=600 CMD /healthcheck.sh
+# healthcheck.sh tries to create and delete an empty kafka topic (the topic
+# string is  based on the timestamp), and reports healthy if topic creation
+# was successful.
+# With these parameters, Docker will consider the container unhealthy if the
+# Kafka server is unresponsive for 3 minutes.
+HEALTHCHECK --start-period=10s --interval=5s --timeout=5s --retries=36 CMD /healthcheck.sh
 
 ENTRYPOINT ["/run.sh"]

--- a/testing/environments/docker/kafka/healthcheck.sh
+++ b/testing/environments/docker/kafka/healthcheck.sh
@@ -8,5 +8,5 @@ if [[ $rc != 0 ]]; then
 	exit $rc
 fi
 
-${KAFKA_HOME}/bin/kafka-topic.sh --zookeeper=127.0.0.1:2181 --delete --topic "${TOPIC}"
+${KAFKA_HOME}/bin/kafka-topics.sh --zookeeper=127.0.0.1:2181 --delete --topic "${TOPIC}"
 exit 0


### PR DESCRIPTION
The Kafka Docker container's healthcheck script had a typo that caused it to create an infinite number of garbage topics, which added noise when testing configurations with this container. This PR fixes the script, and adjusts its timeout settings to be a little lower frequency and a little less patient with consistent errors.