### PR TITLE
[automation] update elastic stack version for testing 6.8.19-f17b075f

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.19-fac6e556-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.19-f17b075f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       retries: 300
@@ -15,7 +15,7 @@ services:
     - "http.host=0.0.0.0"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:6.8.19-fac6e556-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:6.8.19-f17b075f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -25,7 +25,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:6.8.19-fac6e556-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:6.8.19-f17b075f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.19-fac6e556-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.19-f17b075f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       retries: 300
@@ -16,7 +16,7 @@ services:
     - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:6.8.19-fac6e556-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:6.8.19-f17b075f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:6.8.19-fac6e556-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:6.8.19-f17b075f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", 'python -c ''import urllib, json; response = urllib.urlopen("http://localhost:5601/api/status"); data = json.loads(response.read()); exit(1) if data["status"]["overall"]["state"] != "green" else exit(0);''']
       retries: 600


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 13 Sep 2021 17:14:01 GMT, release_branch:6.8, prefix:, end_time:Mon, 13 Sep 2021 21:51:41 GMT, manifest_version:2.0.0, version:6.8.19-SNAPSHOT, branch:6.8, build_id:6.8.19-f17b075f, build_duration_seconds:16660]