### PR TITLE
Move labels and annotations under kubernetes.namespace.

### DIFF
--- a/libbeat/common/kubernetes/metadata/namespace.go
+++ b/libbeat/common/kubernetes/metadata/namespace.go
@@ -70,8 +70,7 @@ func (n *namespace) GenerateK8s(obj kubernetes.Resource, opts ...FieldOptions) c
 	}
 
 	meta := n.resource.GenerateK8s(resource, obj, opts...)
-	// TODO: remove this call when moving to 8.0
-	meta = flattenMetadata(meta)
+	meta = unifyResourceMetadata(meta)
 
 	// TODO: Add extra fields in here if need be
 	return meta
@@ -95,25 +94,39 @@ func (n *namespace) GenerateFromName(name string, opts ...FieldOptions) common.M
 	return nil
 }
 
-func flattenMetadata(in common.MapStr) common.MapStr {
-	out := common.MapStr{}
-	rawFields, err := in.GetValue(resource)
-	if err != nil {
-		return nil
-	}
-
-	fields, ok := rawFields.(common.MapStr)
+// unifyResourceMetadata moves all the resource's metadata (labels, annotations)
+// under the resource field
+// example input:
+// 				"kubernetes": common.MapStr{
+//					"labels": common.MapStr{
+//						"foo": "bar",
+//					},
+//					"annotations": common.MapStr{
+//						"spam": "baz",
+//					},
+//					"namespace": common.MapStr{
+//						"name": name,
+//						"uid":  uid,
+//					},
+//				},
+// example output:
+// 				"kubernetes": common.MapStr{
+//					"namespace": common.MapStr{
+//						"name": name,
+//						"uid":  uid,
+//						"labels": common.MapStr{
+//							"foo": "bar",
+//						},
+//						"annotations": common.MapStr{
+//							"spam": "baz",
+//						},
+//					},
+//				},
+func unifyResourceMetadata(in common.MapStr) common.MapStr {
+	resourceValues, ok := in[resource].(common.MapStr)
 	if !ok {
-		return nil
+		return in
 	}
-	for k, v := range fields {
-		if k == "name" {
-			out[resource] = v
-		} else {
-			out[resource+"_"+k] = v
-		}
-	}
-
 	populateFromKeys := []string{"labels", "annotations"}
 	for _, key := range populateFromKeys {
 		rawValues, err := in.GetValue(key)
@@ -122,9 +135,10 @@ func flattenMetadata(in common.MapStr) common.MapStr {
 		}
 		values, ok := rawValues.(common.MapStr)
 		if ok {
-			out[resource+"_"+key] = values
+			resourceValues[key] = values
+			in.Delete(key)
 		}
 	}
 
-	return out
+	return in
 }

--- a/libbeat/common/kubernetes/metadata/namespace_test.go
+++ b/libbeat/common/kubernetes/metadata/namespace_test.go
@@ -61,29 +61,20 @@ func TestNamespace_Generate(t *testing.T) {
 					APIVersion: "v1",
 				},
 			},
-			// Use this for 8.0
-			/*
-				output: common.MapStr{
-					"kubernetes": common.MapStr{
-						"namespace": common.MapStr{
-							"name": name,
-							"uid":  uid,
-							"labels": common.MapStr{
-								"foo": "bar",
-							},
+			output: common.MapStr{
+				"kubernetes": common.MapStr{
+					"namespace": common.MapStr{
+						"name": name,
+						"uid":  uid,
+						"labels": common.MapStr{
+							"foo": "bar",
+						},
+						"annotations": common.MapStr{
+							"spam": "baz",
 						},
 					},
-				},*/
-			output: common.MapStr{"kubernetes": common.MapStr{
-				"namespace":     name,
-				"namespace_uid": uid,
-				"namespace_labels": common.MapStr{
-					"foo": "bar",
 				},
-				"namespace_annotations": common.MapStr{
-					"spam": "baz",
-				},
-			}},
+			},
 		},
 	}
 
@@ -129,25 +120,16 @@ func TestNamespace_GenerateFromName(t *testing.T) {
 					APIVersion: "v1",
 				},
 			},
-			// Use this for 8.0
-			/*
-				output: common.MapStr{
-					"namespace": common.MapStr{
-						"name": name,
-						"uid":  uid,
-						"labels": common.MapStr{
-							"foo": "bar",
-						},
-					},
-				},*/
 			output: common.MapStr{
-				"namespace":     name,
-				"namespace_uid": uid,
-				"namespace_labels": common.MapStr{
-					"foo": "bar",
-				},
-				"namespace_annotations": common.MapStr{
-					"spam": "baz",
+				"namespace": common.MapStr{
+					"name": name,
+					"uid":  uid,
+					"labels": common.MapStr{
+						"foo": "bar",
+					},
+					"annotations": common.MapStr{
+						"spam": "baz",
+					},
 				},
 			},
 		},

--- a/libbeat/common/kubernetes/metadata/pod_test.go
+++ b/libbeat/common/kubernetes/metadata/pod_test.go
@@ -579,10 +579,12 @@ func TestPod_GenerateWithNodeNamespace(t *testing.T) {
 					"uid":  uid,
 					"ip":   "127.0.0.5",
 				},
-				"namespace":     "default",
-				"namespace_uid": uid,
-				"namespace_labels": common.MapStr{
-					"nskey": "nsvalue",
+				"namespace": common.MapStr{
+					"name": "default",
+					"uid":  uid,
+					"labels": common.MapStr{
+						"nskey": "nsvalue",
+					},
 				},
 				"node": common.MapStr{
 					"name": "testnode",

--- a/libbeat/common/kubernetes/metadata/service_test.go
+++ b/libbeat/common/kubernetes/metadata/service_test.go
@@ -295,19 +295,12 @@ func TestService_GenerateWithNamespace(t *testing.T) {
 					"labels": common.MapStr{
 						"foo": "bar",
 					},
-					// Use this for 8.0
-					/*
-						"namespace": common.MapStr{
-							"name": "default",
-							"uid":  uid,
-							"labels": common.MapStr{
-								"nskey": "nsvalue",
-							},
-					},*/
-					"namespace":     "default",
-					"namespace_uid": uid,
-					"namespace_labels": common.MapStr{
-						"nskey": "nsvalue",
+					"namespace": common.MapStr{
+						"name": "default",
+						"uid":  uid,
+						"labels": common.MapStr{
+							"nskey": "nsvalue",
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## What does this PR do?

As part of #13911 , after discussions in https://github.com/elastic/beats/issues/16558#issuecomment-598293151
this PR renames `namespace_labels` and `namespace_annotations` to `namespace.labels` and `namespace.annotations`


## Why is it important?


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally


## Related issues

- Relates https://github.com/elastic/beats/issues/16558


