### PR TITLE
[libbeat] Fix decode_xml array handling when lowercasing keys

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -209,6 +209,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Do not try to load ILM policy if `check_exists` is `false`. {pull}27508[27508] {issue}26322[26322]
 - Fix bug with cgroups hierarchy override path in cgroups {pull}27620[27620]
 - Beat `setup kibana` command may use the elasticsearch API key defined in `output.elasticsearch.api_key`. {issue}24015[24015] {pull}27540[27540]
+- Fix `decode_xml` handling of array merging when using `to_lower: true`. {pull}27922[27922]
 - Seperate namespaces for V1 and V2 controller paths {pull}27676[27676]
 
 *Auditbeat*

--- a/libbeat/common/encoding/xml/decode.go
+++ b/libbeat/common/encoding/xml/decode.go
@@ -80,7 +80,7 @@ func (d *Decoder) decode(attrs []xml.Attr) (string, map[string]interface{}, erro
 			// Add the data to the current object while taking into account
 			// if the current key already exists (in the case of lists).
 			key := d.key(elem.Name.Local)
-			value := elements[elem.Name.Local]
+			value := elements[key]
 			switch v := value.(type) {
 			case nil:
 				elements[key] = add

--- a/libbeat/common/encoding/xml/decode_test.go
+++ b/libbeat/common/encoding/xml/decode_test.go
@@ -366,10 +366,16 @@ func ExampleDecoder_Decode() {
 	//   "event": {
 	//     "eventdata": {
 	//       "binary": "770069006E006C006F00670062006500610074002F0034000000",
-	//       "data": {
-	//         "#text": "running",
-	//         "name": "param2"
-	//       }
+	//       "data": [
+	//         {
+	//           "#text": "winlogbeat",
+	//           "name": "param1"
+	//         },
+	//         {
+	//           "#text": "running",
+	//           "name": "param2"
+	//         }
+	//       ]
 	//     },
 	//     "processingerrordata": {
 	//       "dataitemname": "shellId",

--- a/libbeat/processors/decode_xml/decode_xml_test.go
+++ b/libbeat/processors/decode_xml/decode_xml_test.go
@@ -177,6 +177,41 @@ func TestDecodeXML(t *testing.T) {
 			},
 		},
 		{
+			description: "Decoding with an array and mixed-case keys",
+			config: decodeXMLConfig{
+				Field:   "message",
+				ToLower: true,
+			},
+			Input: common.MapStr{
+				"message": `<AuditBase>
+				  <ContextComponents>
+					<Component>
+					  <RelyingParty>N/A</RelyingParty>
+					</Component>
+					<Component>
+					  <PrimaryAuth>N/A</PrimaryAuth>
+					</Component>
+				  </ContextComponents>
+				</AuditBase>`,
+			},
+			Output: common.MapStr{
+				"message": common.MapStr{
+					"auditbase": map[string]interface{}{
+						"contextcomponents": map[string]interface{}{
+							"component": []interface{}{
+								map[string]interface{}{
+									"relyingparty": "N/A",
+								},
+								map[string]interface{}{
+									"primaryauth": "N/A",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			description: "Decoding with multiple xml objects",
 			config: decodeXMLConfig{
 				Field: "message",


### PR DESCRIPTION
## What does this PR do?

Arrays were not being merged properly when the element name was mixed-case and `to_lower: true` was set in the config (the default).

## Why is it important?

For lists of elements, if the XML element name was mixed-cased then it would drop elements rather than appending them to the array.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

