### PR TITLE
[filebeat] Add write access to 'url.value' from 'request.transforms'.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -756,6 +756,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Improve memory usage of line reader of `log` and `filestream` input. {pull}27782[27782]
 - Add `ignore_empty_value` flag to `httpjson` `split` processor. {pull}27880[27880]
 - Update Cisco ASA/FTD ingest pipeline grok/dissect patterns for multiple message IDs. {issue}26869[26869] {pull}26879[26879]
+- Add write access to `url.value` from `request.transforms` in `httpjson` input. {pull}27937[27937]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -466,7 +466,7 @@ Available transforms for request: [`append`, `delete`, `set`].
 
 Can read state from: [`.last_response.*`, `.last_event.*`, `.cursor.*`, `.header.*`, `.url.*`, `.body.*`].
 
-Can write state to: [`header.*`, `url.params.*`, `body.*`].
+Can write state to: [`body.*`, `header.*`, `url.*`].
 
 ["source","yaml",subs="attributes"]
 ----

--- a/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/pagination.go
@@ -19,7 +19,7 @@ const paginationNamespace = "pagination"
 func registerPaginationTransforms() {
 	registerTransform(paginationNamespace, appendName, newAppendPagination)
 	registerTransform(paginationNamespace, deleteName, newDeletePagination)
-	registerTransform(paginationNamespace, setName, newSetPagination)
+	registerTransform(paginationNamespace, setName, newSetRequestPagination)
 }
 
 type pagination struct {

--- a/x-pack/filebeat/input/httpjson/internal/v2/request.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/request.go
@@ -22,7 +22,7 @@ const requestNamespace = "request"
 func registerRequestTransforms() {
 	registerTransform(requestNamespace, appendName, newAppendRequest)
 	registerTransform(requestNamespace, deleteName, newDeleteRequest)
-	registerTransform(requestNamespace, setName, newSetRequest)
+	registerTransform(requestNamespace, setName, newSetRequestPagination)
 }
 
 type httpClient struct {

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_set.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_set.go
@@ -39,7 +39,7 @@ type set struct {
 
 func (set) transformName() string { return setName }
 
-func newSetRequest(cfg *common.Config, log *logp.Logger) (transform, error) {
+func newSetRequestPagination(cfg *common.Config, log *logp.Logger) (transform, error) {
 	set, err := newSet(cfg, log)
 	if err != nil {
 		return nil, err
@@ -52,6 +52,8 @@ func newSetRequest(cfg *common.Config, log *logp.Logger) (transform, error) {
 		set.runFunc = setHeader
 	case targetURLParams:
 		set.runFunc = setURLParams
+	case targetURLValue:
+		set.runFunc = setURLValue
 	default:
 		return nil, fmt.Errorf("invalid target type: %s", set.targetInfo.Type)
 	}
@@ -68,28 +70,6 @@ func newSetResponse(cfg *common.Config, log *logp.Logger) (transform, error) {
 	switch set.targetInfo.Type {
 	case targetBody:
 		set.runFunc = setBody
-	default:
-		return nil, fmt.Errorf("invalid target type: %s", set.targetInfo.Type)
-	}
-
-	return &set, nil
-}
-
-func newSetPagination(cfg *common.Config, log *logp.Logger) (transform, error) {
-	set, err := newSet(cfg, log)
-	if err != nil {
-		return nil, err
-	}
-
-	switch set.targetInfo.Type {
-	case targetBody:
-		set.runFunc = setBody
-	case targetHeader:
-		set.runFunc = setHeader
-	case targetURLParams:
-		set.runFunc = setURLParams
-	case targetURLValue:
-		set.runFunc = setURLValue
 	default:
 		return nil, fmt.Errorf("invalid target type: %s", set.targetInfo.Type)
 	}

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_set_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_set_test.go
@@ -41,72 +41,40 @@ func TestNewSet(t *testing.T) {
 			expectedErr: "invalid target: cursor.foo",
 		},
 		{
-			name:        "newSetRequest targets body",
-			constructor: newSetRequest,
+			name:        "newSetRequestPagination targets body",
+			constructor: newSetRequestPagination,
 			config: map[string]interface{}{
 				"target": "body.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "body"},
 		},
 		{
-			name:        "newSetRequest targets header",
-			constructor: newSetRequest,
+			name:        "newSetRequestPagination targets header",
+			constructor: newSetRequestPagination,
 			config: map[string]interface{}{
 				"target": "header.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "header"},
 		},
 		{
-			name:        "newSetRequest targets url param",
-			constructor: newSetRequest,
+			name:        "newSetRequestPagination targets url param",
+			constructor: newSetRequestPagination,
 			config: map[string]interface{}{
 				"target": "url.params.foo",
 			},
 			expectedTarget: targetInfo{Name: "foo", Type: "url.params"},
 		},
 		{
-			name:        "newSetRequest targets something else",
-			constructor: newSetRequest,
-			config: map[string]interface{}{
-				"target": "cursor.foo",
-			},
-			expectedErr: "invalid target: cursor.foo",
-		},
-		{
-			name:        "newSetPagination targets body",
-			constructor: newSetPagination,
-			config: map[string]interface{}{
-				"target": "body.foo",
-			},
-			expectedTarget: targetInfo{Name: "foo", Type: "body"},
-		},
-		{
-			name:        "newSetPagination targets header",
-			constructor: newSetPagination,
-			config: map[string]interface{}{
-				"target": "header.foo",
-			},
-			expectedTarget: targetInfo{Name: "foo", Type: "header"},
-		},
-		{
-			name:        "newSetPagination targets url param",
-			constructor: newSetPagination,
-			config: map[string]interface{}{
-				"target": "url.params.foo",
-			},
-			expectedTarget: targetInfo{Name: "foo", Type: "url.params"},
-		},
-		{
-			name:        "newSetPagination targets url value",
-			constructor: newSetPagination,
+			name:        "newSetRequestPagination targets url value",
+			constructor: newSetRequestPagination,
 			config: map[string]interface{}{
 				"target": "url.value",
 			},
 			expectedTarget: targetInfo{Type: "url.value"},
 		},
 		{
-			name:        "newSetPagination targets something else",
-			constructor: newSetPagination,
+			name:        "newSetRequestPagination targets something else",
+			constructor: newSetRequestPagination,
 			config: map[string]interface{}{
 				"target": "cursor.foo",
 			},

--- a/x-pack/filebeat/input/httpjson/internal/v2/transform_test.go
+++ b/x-pack/filebeat/input/httpjson/internal/v2/transform_test.go
@@ -46,7 +46,7 @@ func TestTransformableClone(t *testing.T) {
 }
 
 func TestNewTransformsFromConfig(t *testing.T) {
-	registerTransform("test", setName, newSetRequest)
+	registerTransform("test", setName, newSetRequestPagination)
 	t.Cleanup(func() { registeredTransforms = newRegistry() })
 
 	cases := []struct {
@@ -126,7 +126,7 @@ func TestNewBasicTransformsFromConfig(t *testing.T) {
 		return fakeTransform{}, nil
 	}
 
-	registerTransform("test", setName, newSetRequest)
+	registerTransform("test", setName, newSetRequestPagination)
 	registerTransform("test", "fake", fakeConstr)
 	t.Cleanup(func() { registeredTransforms = newRegistry() })
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds write access to url.value from the request.transforms context.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Some use cases require to set the url for the next request from a previously stored value.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
