### PR TITLE
print publisher related debug logs for the specific targets

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -379,7 +379,7 @@ github.com/gomodule/redigo v1.8.3 h1:HR0kYDX2RJZvAup8CsiJwxB4dTCSC0AaUq6S4SiLwUc
 github.com/gomodule/redigo v1.8.3/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/flatbuffers v1.12.0 h1:/PtAHvnBY4Kqnx/xCQ3OIV9uYcSFGScBsWI3Oogeh6w=
+github.com/google/flatbuffers v1.12.0 h1:N8EguYFm2wwdpoNcpchQY0tPs85vOJkboFb2dPxmixo=
 github.com/google/flatbuffers v1.12.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/libbeat/publisher/processing/default.go
+++ b/libbeat/publisher/processing/default.go
@@ -349,8 +349,11 @@ func (b *builder) Create(cfg beat.ProcessingConfig, drop bool) (beat.Processor, 
 	}
 
 	// setup 10: debug print final event (P)
-	if b.log.IsDebug() {
-		processors.add(debugPrintProcessor(b.info, b.log))
+	debug := false
+	debugSwitch, _ := cfg.EventMetadata.Fields.Flatten().GetValue("metadata.debugOn")
+	debug, _ = debugSwitch.(bool)
+	if b.log.IsDebug() || debug {
+		processors.add(debugPrintProcessor(b.info, b.log, debug))
 	}
 
 	// setup 11: drop all events if outputs are disabled (P)

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -182,7 +182,7 @@ func makeAddDynMetaProcessor(
 	})
 }
 
-func debugPrintProcessor(info beat.Info, log *logp.Logger) *processorFn {
+func debugPrintProcessor(info beat.Info, log *logp.Logger, debug bool) *processorFn {
 	// ensure only one go-routine is using the encoder (in case
 	// beat.Client is shared between multiple go-routines by accident)
 	var mux sync.Mutex
@@ -200,6 +200,9 @@ func debugPrintProcessor(info beat.Info, log *logp.Logger) *processorFn {
 			return event, nil
 		}
 
+		if debug {
+			log.Infof("Publish event: %s", b)
+		}
 		log.Debugf("Publish event: %s", b)
 		return event, nil
 	})


### PR DESCRIPTION
## Enhancement

## What does this PR do?
Add a new feature to print logs in a specific step(currently, we only focus on `publisher` step) of dealing with a target having the new option.

## Why is it important?

Given this example, if there're more than 30k targets need to be monitored on a single heartbeat instance, in some case, we just want to know the debug log related to publisher processor for some specific targets. That means we're going to make sure if the check for some targets are really executed and the metrics have been sent out.

The current ways we have:
1. starting heartbeat with -d "*", this prints all debug logs, that’s noisy and hard to find the log we cared, also uses too many disk. By the way, this also needs a heartbeat restart, this could be tough if it’s in use for production.

2. starting heartbeat with -d "publisher" , this also prints too much useless logs from undesired targets and also needs a heartbeat restart.

Wondering if we could support a new option like `debugOn` here for a specific target, if it's `true`, heartbeat prints all `publisher` related logs out.

```
- type: http
  schedule: 36 * * * * * *
  hosts:
   - http://127.0.0.1/readiness_api
  check.request:
    method: GET
  check.response:
    status:
    - 200
    - 201
  fields:
    metadata:
      debugOn: true
```

This needn’t restart heartbeat and can be specified to the desired targets as you wish.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues
A coversation for this feature is here:
https://discuss.elastic.co/t/heartbeat-add-feature-to-enable-publisher-processor-or-other-processors-debug-log-for-just-specific-targets/281374

## Use cases

Please refer to the `Why is it important?` part.

## Screenshots:
Will get the logs like the following for the example in `Why is it important`:
```
2021-08-20T09:01:22.013Z	INFO	[processors]	processing/processors.go:204	Publish event: {
  "@timestamp": "2021-08-20T09:01:22.000Z",
  "@metadata": {
    "beat": "heartbeat",
    "type": "_doc",
    "version": "8.0.0",
    "ingress": [
      {
        "namespace": "uptime",
        "name": "up",
        "dimensions": [
          {
...skip...
          {
            "name": "scheme",
            "value": "http"
          },
          {
            "name": "url",
            "value": "http://127.0.0.1/readiness_api"
          }
        ],
        "timestamp": "2021-08-20T09:01:22.000Z",
        "data": 1
      },
...skip...
```
