### PR TITLE
Fix path in vagrant windows script

### DIFF
--- a/dev-tools/vagrant_scripts/winProvision.ps1
+++ b/dev-tools/vagrant_scripts/winProvision.ps1
@@ -7,7 +7,7 @@ if (-Not (Test-Path $gopath_beats)) {
     echo 'Creating github.com\\elastic in the GOPATH'
     New-Item -itemtype directory -path "C:\\Gopath\\src\\github.com\\elastic" -force
     echo "Symlinking C:\\Vagrant to C:\\Gopath\\src\\github.com\\elastic"
-    cmd /c mklink /d $gopath_beats \\\\vboxsvr\\vagrant
+    cmd /c mklink /d $gopath_beats \\vboxsvr\vagrant
 }
 
 if (-Not (Get-Command "gvm" -ErrorAction SilentlyContinue)) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fixes the volume path in vagrant windows script.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The symlink was pointing to an unexisting folder due to the wrong path.
