### PR TITLE
Fix issue where --insecure didn't propogate to Fleet Server ES connection

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -87,6 +87,7 @@
 - Add "_monitoring" suffix to monitoring instance names to remove ambiguity with the status command. {issue}25449[25449]
 - Ignore ErrNotExists when fixing permissions. {issue}27836[27836] {pull}27846[27846]
 - Snapshot artifact lookup will use agent.download proxy settings. {issue}27903[27903] {pull}27904[27904]
+- Fix issue where --insecure didn't propogate to Fleet Server ES connection. {pull}27969[27969]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -299,6 +299,7 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context) (string, error) {
 		c.options.FleetServer.ConnStr, c.options.FleetServer.ServiceToken,
 		c.options.FleetServer.PolicyID,
 		c.options.FleetServer.Host, c.options.FleetServer.Port,
+		c.options.Insecure,
 		c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA,
 		c.options.FleetServer.Headers,
 		c.options.ProxyURL,
@@ -495,6 +496,7 @@ func (c *enrollCmd) enroll(ctx context.Context, persistentConfig map[string]inte
 			c.options.FleetServer.ConnStr, c.options.FleetServer.ServiceToken,
 			c.options.FleetServer.PolicyID,
 			c.options.FleetServer.Host, c.options.FleetServer.Port,
+			c.options.Insecure,
 			c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA,
 			c.options.FleetServer.Headers,
 			c.options.ProxyURL, c.options.ProxyDisabled, c.options.ProxyHeaders)
@@ -800,7 +802,7 @@ func storeAgentInfo(s saver, reader io.Reader) error {
 
 func createFleetServerBootstrapConfig(
 	connStr, serviceToken, policyID, host string,
-	port uint16,
+	port uint16, insecure bool,
 	cert, key, esCA string,
 	headers map[string]string,
 	proxyURL string,
@@ -857,6 +859,12 @@ func createFleetServerBootstrapConfig(
 				Key:         key,
 			},
 		}
+	}
+	if insecure {
+		if cfg.Server.TLS == nil {
+			cfg.Server.TLS = &tlscommon.Config{}
+		}
+		cfg.Server.TLS.VerificationMode = tlscommon.VerifyNone
 	}
 
 	if localFleetServer {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Propogates the `--insecure` flag to the Fleet Server process, so it can communicate with elasticsearch insecurely.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Previously it was not possible to instruct Fleet Server to communicate insecurely with elasticsearch. Now if you are bootstrapping a Fleet Server and using `--insecure` it will also make communication with elasticsearch insecure.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #27956
