### PR TITLE
[Filebeat] Fix logger statement in aws-s3 input

### DIFF
--- a/x-pack/filebeat/input/awss3/sqs_s3_event.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event.go
@@ -173,7 +173,7 @@ func (p *sqsS3EventProcessor) keepalive(ctx context.Context, log *logp.Logger, w
 
 			// Renew visibility.
 			if err := p.sqs.ChangeMessageVisibility(ctx, msg, p.sqsVisibilityTimeout); err != nil {
-				log.Warn("Failed to extend message visibility timeout.", "error", err)
+				log.Warnw("Failed to extend message visibility timeout.", "error", err)
 			}
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

It should have used `Warnw` instead of `Warn` because it included structured data.

## Why is it important?

The makes the formatting of log messages better and easier to read.

