### PR TITLE
Cherry-pick to 7.x: [Heartbeat] use --params flag for synthetics (#26674)

### DIFF
--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -124,7 +124,7 @@ func runCmd(
 
 	if len(params) > 0 {
 		paramsBytes, _ := json.Marshal(params)
-		cmd.Args = append(cmd.Args, "--suite-params", string(paramsBytes))
+		cmd.Args = append(cmd.Args, "--params", string(paramsBytes))
 	}
 
 	if len(filterJourneys.Tags) > 0 {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Heartbeat] use --params flag for synthetics (#26674)