### PR TITLE
Update Filebeat aws module doc

### DIFF
--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -158,7 +158,10 @@ Default to be 300 seconds.
 
 *`var.api_timeout`*::
 
-Maximum duration before AWS API request will be interrupted. Default to be 120 seconds.
+The maximum duration of the AWS API call. If it exceeds the timeout, the AWS API
+call will be interrupted. The default AWS API timeout is `120s`.
+
+The API timeout must be longer than the `sqs.wait_time` value.
 
 *`var.bucket_arn`*::
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -232,7 +232,7 @@ applications and services.
 
 [float]
 [[aws-api-requests]]
-== AWS API requests count per metricset
+== AWS API requests count
 This session is to document what are the AWS API called made by each metricset
 in `aws` module. This will be useful for users to estimate costs for using `aws`
 module.
@@ -245,7 +245,6 @@ ListMetrics max page size: 500, based on https://docs.aws.amazon.com/AmazonCloud
 GetMetricData max page size: 100, based on https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html[AWS API GetMetricData]
 
 [float]
-=== `cloudwatch`
 |===
 | AWS API Name | AWS API Count | Frequency
 | IAM ListAccountAliases | 1 | Once on startup
@@ -255,52 +254,6 @@ GetMetricData max page size: 100, based on https://docs.aws.amazon.com/AmazonClo
 | CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per namespace per collection period
 |===
 `billing`, `ebs`, `elb`, `sns`, `usage` and `lambda` are the same as `cloudwatch` metricset.
-
-[float]
-=== `ec2`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| EC2 DescribeInstances | 1 | Per region per collection period
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
-
-[float]
-=== `rds`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| RDS DescribeDBInstances | 1 | Per region per collection period
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
-
-[float]
-=== `sqs`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
-
-[float]
-=== `s3_daily_storage` and `s3_request`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
 
 [id="aws-credentials-config"]
 include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -153,7 +153,10 @@ Default to be 300 seconds.
 
 *`var.api_timeout`*::
 
-Maximum duration before AWS API request will be interrupted. Default to be 120 seconds.
+The maximum duration of the AWS API call. If it exceeds the timeout, the AWS API
+call will be interrupted. The default AWS API timeout is `120s`.
+
+The API timeout must be longer than the `sqs.wait_time` value.
 
 *`var.bucket_arn`*::
 

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -224,7 +224,7 @@ applications and services.
 
 [float]
 [[aws-api-requests]]
-== AWS API requests count per metricset
+== AWS API requests count
 This session is to document what are the AWS API called made by each metricset
 in `aws` module. This will be useful for users to estimate costs for using `aws`
 module.
@@ -237,7 +237,6 @@ ListMetrics max page size: 500, based on https://docs.aws.amazon.com/AmazonCloud
 GetMetricData max page size: 100, based on https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_GetMetricData.html[AWS API GetMetricData]
 
 [float]
-=== `cloudwatch`
 |===
 | AWS API Name | AWS API Count | Frequency
 | IAM ListAccountAliases | 1 | Once on startup
@@ -247,52 +246,6 @@ GetMetricData max page size: 100, based on https://docs.aws.amazon.com/AmazonClo
 | CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per namespace per collection period
 |===
 `billing`, `ebs`, `elb`, `sns`, `usage` and `lambda` are the same as `cloudwatch` metricset.
-
-[float]
-=== `ec2`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| EC2 DescribeInstances | 1 | Per region per collection period
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
-
-[float]
-=== `rds`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| RDS DescribeDBInstances | 1 | Per region per collection period
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
-
-[float]
-=== `sqs`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
-
-[float]
-=== `s3_daily_storage` and `s3_request`
-|===
-| AWS API Name | AWS API Count | Frequency
-| IAM ListAccountAliases | 1 | Once on startup
-| STS GetCallerIdentity | 1 | Once on startup
-| EC2 DescribeRegions| 1 | Once on startup
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
-| CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per collection period
-|===
 
 [id="aws-credentials-config"]
 include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This is a small fix in Filebeat doc to sync the definition of api_timeout config between aws-s3 input and the aws module.