### PR TITLE
Revert "Fix issue where --insecure didn't propogate to Fleet Server E…

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -87,7 +87,6 @@
 - Add "_monitoring" suffix to monitoring instance names to remove ambiguity with the status command. {issue}25449[25449]
 - Ignore ErrNotExists when fixing permissions. {issue}27836[27836] {pull}27846[27846]
 - Snapshot artifact lookup will use agent.download proxy settings. {issue}27903[27903] {pull}27904[27904]
-- Fix issue where --insecure didn't propogate to Fleet Server ES connection. {pull}27969[27969]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -299,7 +299,6 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context) (string, error) {
 		c.options.FleetServer.ConnStr, c.options.FleetServer.ServiceToken,
 		c.options.FleetServer.PolicyID,
 		c.options.FleetServer.Host, c.options.FleetServer.Port,
-		c.options.Insecure,
 		c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA,
 		c.options.FleetServer.Headers,
 		c.options.ProxyURL,
@@ -496,7 +495,6 @@ func (c *enrollCmd) enroll(ctx context.Context, persistentConfig map[string]inte
 			c.options.FleetServer.ConnStr, c.options.FleetServer.ServiceToken,
 			c.options.FleetServer.PolicyID,
 			c.options.FleetServer.Host, c.options.FleetServer.Port,
-			c.options.Insecure,
 			c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA,
 			c.options.FleetServer.Headers,
 			c.options.ProxyURL, c.options.ProxyDisabled, c.options.ProxyHeaders)
@@ -802,7 +800,7 @@ func storeAgentInfo(s saver, reader io.Reader) error {
 
 func createFleetServerBootstrapConfig(
 	connStr, serviceToken, policyID, host string,
-	port uint16, insecure bool,
+	port uint16,
 	cert, key, esCA string,
 	headers map[string]string,
 	proxyURL string,
@@ -859,12 +857,6 @@ func createFleetServerBootstrapConfig(
 				Key:         key,
 			},
 		}
-	}
-	if insecure {
-		if cfg.Server.TLS == nil {
-			cfg.Server.TLS = &tlscommon.Config{}
-		}
-		cfg.Server.TLS.VerificationMode = tlscommon.VerifyNone
 	}
 
 	if localFleetServer {


### PR DESCRIPTION
## What does this PR do?

Reverting commit `cbbe8c2a8674630f5bd9ba441c128826bc8269c5` introduced in https://github.com/elastic/beats/pull/27969

The change needs more deeply change and caused failures in our integration pipeline. I'm already working on a change and have a PR soon

## Why is it important?

Causes failures in integations pipeline

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
