### PR TITLE
Remove deprecated/undocumented IncludeCreaterMetadata setting

### DIFF
--- a/libbeat/common/kubernetes/metadata/config.go
+++ b/libbeat/common/kubernetes/metadata/config.go
@@ -28,9 +28,6 @@ type Config struct {
 
 	LabelsDedot      bool `config:"labels.dedot"`
 	AnnotationsDedot bool `config:"annotations.dedot"`
-
-	// Undocumented settings, to be deprecated in favor of `drop_fields` processor:
-	IncludeCreatorMetadata bool `config:"include_creator_metadata"`
 }
 
 // AddResourceMetadataConfig allows adding config for enriching additional resources
@@ -41,7 +38,6 @@ type AddResourceMetadataConfig struct {
 
 // InitDefaults initializes the defaults for the config.
 func (c *Config) InitDefaults() {
-	c.IncludeCreatorMetadata = true
 	c.LabelsDedot = true
 	c.AnnotationsDedot = true
 }

--- a/libbeat/common/kubernetes/metadata/resource.go
+++ b/libbeat/common/kubernetes/metadata/resource.go
@@ -112,17 +112,15 @@ func (r *Resource) GenerateK8s(kind string, obj kubernetes.Resource, options ...
 	}
 
 	// Add controller metadata if present
-	if r.config.IncludeCreatorMetadata {
-		for _, ref := range accessor.GetOwnerReferences() {
-			if ref.Controller != nil && *ref.Controller {
-				switch ref.Kind {
-				// TODO grow this list as we keep adding more `state_*` metricsets
-				case "Deployment",
-					"ReplicaSet",
-					"StatefulSet",
-					"DaemonSet":
-					safemapstr.Put(meta, strings.ToLower(ref.Kind)+".name", ref.Name)
-				}
+	for _, ref := range accessor.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			switch ref.Kind {
+			// TODO grow this list as we keep adding more `state_*` metricsets
+			case "Deployment",
+				"ReplicaSet",
+				"StatefulSet",
+				"DaemonSet":
+				safemapstr.Put(meta, strings.ToLower(ref.Kind)+".name", ref.Name)
 			}
 		}
 	}

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -33,9 +33,6 @@ type Config struct {
 
 	LabelsDedot      bool `config:"labels.dedot"`
 	AnnotationsDedot bool `config:"annotations.dedot"`
-
-	// Undocumented settings, to be deprecated in favor of `drop_fields` processor:
-	IncludeCreatorMetadata bool `config:"include_creator_metadata"`
 }
 
 // Resources config section for resources' config blocks
@@ -55,7 +52,6 @@ func (c *Config) InitDefaults() {
 	c.CleanupTimeout = 60 * time.Second
 	c.SyncPeriod = 10 * time.Minute
 	c.Scope = "node"
-	c.IncludeCreatorMetadata = true
 	c.LabelsDedot = true
 	c.AnnotationsDedot = true
 }


### PR DESCRIPTION
## What does this PR do?

This PR removes `IncludeCreaterMetadata` setting from kubernetes metadata configuration, since it was undocumented and marked for deprecation.

## Why is it important?
This is an undocumented/deprecated setting. Removing this so as to clean up the configuration options.


This change is targeting v8.0.0