### PR TITLE
Fix/certs insecure

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/fleet_server_bootstrap.go
+++ b/x-pack/elastic-agent/pkg/agent/application/fleet_server_bootstrap.go
@@ -108,7 +108,7 @@ func newFleetServerBootstrap(
 		agentInfo,
 		router,
 		&pipeline.ConfigModifiers{
-			Filters: []pipeline.FilterFunc{filters.StreamChecker, modifiers.InjectFleet(rawConfig, sysInfo.Info(), agentInfo)},
+			Filters: []pipeline.FilterFunc{filters.StreamChecker, modifiers.InjectInsecureOutput(cfg.Fleet), modifiers.InjectFleet(rawConfig, sysInfo.Info(), agentInfo)},
 		},
 	)
 	if err != nil {

--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -123,7 +123,7 @@ func newLocal(
 		router,
 		&pipeline.ConfigModifiers{
 			Decorators: []pipeline.DecoratorFunc{modifiers.InjectMonitoring},
-			Filters:    []pipeline.FilterFunc{filters.StreamChecker},
+			Filters:    []pipeline.FilterFunc{filters.StreamChecker, modifiers.InjectInsecureOutput(cfg.Fleet)},
 		},
 		caps,
 		monitor,

--- a/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/managed_mode.go
@@ -147,7 +147,7 @@ func newManaged(
 		router,
 		&pipeline.ConfigModifiers{
 			Decorators: []pipeline.DecoratorFunc{modifiers.InjectMonitoring},
-			Filters:    []pipeline.FilterFunc{filters.StreamChecker, modifiers.InjectFleet(rawConfig, sysInfo.Info(), agentInfo)},
+			Filters:    []pipeline.FilterFunc{filters.StreamChecker, modifiers.InjectInsecureOutput(cfg.Fleet), modifiers.InjectFleet(rawConfig, sysInfo.Info(), agentInfo)},
 		},
 		caps,
 		monitor,

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/modifiers/insecure_output_decorator.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/modifiers/insecure_output_decorator.go
@@ -1,0 +1,84 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package modifiers
+
+import (
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/transpiler"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/core/logger"
+)
+
+const (
+	sslKey              = "ssl"
+	verificationModeKey = "verification_mode"
+	sslVerificationKey  = "ssl.verification_mode"
+)
+
+// InjectInsecureOutput injects a verification none into output configuration.
+func InjectInsecureOutput(fleetConfig *configuration.FleetAgentConfig) func(*logger.Logger, *transpiler.AST) error {
+	return func(_ *logger.Logger, rootAst *transpiler.AST) error {
+		// if verification mode is not set abort
+		if fleetConfig == nil ||
+			fleetConfig.Server == nil ||
+			fleetConfig.Server.TLS == nil ||
+			fleetConfig.Server.TLS.VerificationMode == tlscommon.VerifyFull {
+			// no change
+			return nil
+		}
+
+		// look for outputs
+		// inject verification mode to each output
+		outputsNode, ok := transpiler.Lookup(rootAst, outputsKey)
+		if !ok {
+			// no outputs from configuration; skip
+			return nil
+		}
+
+		outputsList, ok := outputsNode.Value().(*transpiler.Dict)
+		if !ok {
+			return nil
+		}
+
+		outputsNodeCollection, ok := outputsList.Value().([]transpiler.Node)
+		if !ok {
+			return nil
+		}
+
+		modeString := fleetConfig.Server.TLS.VerificationMode.String()
+
+		for _, outputNode := range outputsNodeCollection {
+			outputKV, ok := outputNode.(*transpiler.Key)
+			if !ok {
+				continue
+			}
+
+			output, ok := outputKV.Value().(*transpiler.Dict)
+			if !ok {
+				continue
+			}
+
+			// do not overwrite already specified config
+			_, found := output.Find(sslVerificationKey)
+			if found {
+				continue
+			}
+
+			// it may be broken down
+			if sslNode, found := output.Find(sslKey); found {
+				if _, found := sslNode.Find(verificationModeKey); found {
+					continue
+				}
+			}
+
+			output.Insert(
+				transpiler.NewKey(sslVerificationKey, transpiler.NewStrVal(modeString)),
+			)
+
+		}
+
+		return nil
+	}
+}

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/modifiers/insecure_output_decorator_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/modifiers/insecure_output_decorator_test.go
@@ -1,0 +1,96 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package modifiers
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/transpiler"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectInsecure(t *testing.T) {
+	cases := []struct {
+		Name             string
+		Config           map[string]interface{}
+		Expected         map[string]interface{}
+		VerificationMode tlscommon.TLSVerificationMode
+	}{
+		{
+			Name: "no change on default",
+			Config: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"elasticsearch": map[string]interface{}{
+						"key": "value",
+					},
+				},
+			},
+			Expected: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"elasticsearch": map[string]interface{}{
+						"key": "value",
+					},
+				},
+			},
+			VerificationMode: tlscommon.VerifyFull, // default
+		},
+		{
+			Name: "inject none",
+			Config: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"elasticsearch": map[string]interface{}{
+						"key": "value",
+					},
+				},
+			},
+			Expected: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"elasticsearch": map[string]interface{}{
+						"key":                   "value",
+						"ssl.verification_mode": "none",
+					},
+				},
+			},
+			VerificationMode: tlscommon.VerifyNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			fn := InjectInsecureOutput(&configuration.FleetAgentConfig{
+				Server: &configuration.FleetServerConfig{
+					TLS: &tlscommon.Config{
+						VerificationMode: tc.VerificationMode,
+					},
+				},
+			})
+
+			ast, err := transpiler.NewAST(tc.Config)
+			require.NoError(t, err)
+			expectedAST, err := transpiler.NewAST(tc.Expected)
+			require.NoError(t, err)
+
+			require.NoError(t, fn(nil, ast))
+
+			visitor := &transpiler.MapVisitor{}
+			expectedVisitor := &transpiler.MapVisitor{}
+
+			ast.Accept(visitor)
+			expectedAST.Accept(expectedVisitor)
+
+			if !assert.True(t, cmp.Equal(expectedVisitor.Content, visitor.Content)) {
+				diff := cmp.Diff(expectedVisitor.Content, visitor.Content)
+				if diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+
+}

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -304,6 +304,7 @@ func (c *enrollCmd) fleetServerBootstrap(ctx context.Context) (string, error) {
 		c.options.ProxyURL,
 		c.options.ProxyDisabled,
 		c.options.ProxyHeaders,
+		c.options.Insecure,
 	)
 	if err != nil {
 		return "", err
@@ -497,7 +498,9 @@ func (c *enrollCmd) enroll(ctx context.Context, persistentConfig map[string]inte
 			c.options.FleetServer.Host, c.options.FleetServer.Port,
 			c.options.FleetServer.Cert, c.options.FleetServer.CertKey, c.options.FleetServer.ElasticsearchCA,
 			c.options.FleetServer.Headers,
-			c.options.ProxyURL, c.options.ProxyDisabled, c.options.ProxyHeaders)
+			c.options.ProxyURL, c.options.ProxyDisabled, c.options.ProxyHeaders,
+			c.options.Insecure,
+		)
 		if err != nil {
 			return err
 		}
@@ -806,16 +809,21 @@ func createFleetServerBootstrapConfig(
 	proxyURL string,
 	proxyDisabled bool,
 	proxyHeaders map[string]string,
+	insecure bool,
 ) (*configuration.FleetAgentConfig, error) {
 	localFleetServer := connStr != ""
 
-	es, err := configuration.ElasticsearchFromConnStr(connStr, serviceToken)
+	es, err := configuration.ElasticsearchFromConnStr(connStr, serviceToken, insecure)
 	if err != nil {
 		return nil, err
 	}
 	if esCA != "" {
-		es.TLS = &tlscommon.Config{
-			CAs: []string{esCA},
+		if es.TLS == nil {
+			es.TLS = &tlscommon.Config{
+				CAs: []string{esCA},
+			}
+		} else {
+			es.TLS.CAs = []string{esCA}
 		}
 	}
 	if host == "" {
@@ -856,6 +864,9 @@ func createFleetServerBootstrapConfig(
 				Certificate: cert,
 				Key:         key,
 			},
+		}
+		if insecure {
+			cfg.Server.TLS.VerificationMode = tlscommon.VerifyNone
 		}
 	}
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/inspect.go
@@ -259,10 +259,16 @@ func getProgramsFromConfig(log *logger.Logger, agentInfo *info.AgentInfo, cfg *c
 	if err != nil {
 		return nil, err
 	}
+
+	configuration, err := configuration.NewFromConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	composableWaiter := newWaitForCompose(composableCtrl)
 	configModifiers := &pipeline.ConfigModifiers{
 		Decorators: []pipeline.DecoratorFunc{modifiers.InjectMonitoring},
-		Filters:    []pipeline.FilterFunc{filters.StreamChecker},
+		Filters:    []pipeline.FilterFunc{filters.StreamChecker, modifiers.InjectInsecureOutput(configuration.Fleet)},
 	}
 
 	if !isStandalone {

--- a/x-pack/elastic-agent/pkg/agent/configuration/fleet_server.go
+++ b/x-pack/elastic-agent/pkg/agent/configuration/fleet_server.go
@@ -47,7 +47,7 @@ type Elasticsearch struct {
 }
 
 // ElasticsearchFromConnStr returns an Elasticsearch configuration from the connection string.
-func ElasticsearchFromConnStr(conn string, serviceToken string) (Elasticsearch, error) {
+func ElasticsearchFromConnStr(conn string, serviceToken string, insecure bool) (Elasticsearch, error) {
 	u, err := url.Parse(conn)
 	if err != nil {
 		return Elasticsearch{}, err
@@ -63,6 +63,11 @@ func ElasticsearchFromConnStr(conn string, serviceToken string) (Elasticsearch, 
 		Hosts:    []string{u.Host},
 		Path:     u.Path,
 		TLS:      nil,
+	}
+	if insecure {
+		cfg.TLS = &tlscommon.Config{
+			VerificationMode: tlscommon.VerifyNone,
+		}
 	}
 	if serviceToken != "" {
 		cfg.ServiceToken = serviceToken

--- a/x-pack/elastic-agent/pkg/agent/transpiler/ast.go
+++ b/x-pack/elastic-agent/pkg/agent/transpiler/ast.go
@@ -104,6 +104,11 @@ func (d *Dict) Find(key string) (Node, bool) {
 	return nil, false
 }
 
+// Insert inserts a value into a collection.
+func (d *Dict) Insert(node Node) {
+	d.value = append(d.value, node)
+}
+
 func (d *Dict) String() string {
 	var sb strings.Builder
 	for i := 0; i < len(d.value); i++ {


### PR DESCRIPTION
## What does this PR do?

At the moment when we enter `--insecure` during install/enroll it applies only for communication between agent and fleet server.
This is a source of confusion as users often times expect all communication to be insecure.

This PR propagates insecure also to fleet-server to ES communication and after it is enrolled it also updates output definition passed to processes.

## Why is it important?

in case fleet-server to ES communication is not `insecure` we often see x509 errors when self signed certs are used. Especially when ES is running on other machine than the one running fleet-server. In this case self signed cert is not validated as it's generated usually for localhost/`127.0.0.1` and validation fails when dialing IP of ES machine. 

Passing this to processes is important in case we have not only `fleet-server` running on edge but also monitoring or other integration. If we did not pass this, no events would be sent to ES (same failures as the one during enroll in fleet server scenario)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test
1. Create elastic stack instance with ES and Kibana  enable TLS using self signed cert.
2. On another machine try to enroll with ` --fleet-server-es` pointing to ES from step 1 and ` --fleet-server-es-ca` shared with the ES from step 1
3. enroll should be successful 
4. logs are visible in logs tab/metrics dashboards are populated