### PR TITLE
Add 7.15 breaking changes

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.15.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.15.asciidoc
@@ -1,0 +1,21 @@
+[[breaking-changes-7.15]]
+
+=== Breaking changes in 7.15
+++++
+<titleabbrev>7.15</titleabbrev>
+++++
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+
+//[discrete]
+//==== Change title
+
+//Change description
+
+// end::notable-breaking-changes[]
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.


### PR DESCRIPTION
## What does this PR do?

Adds placeholder file for breaking changes in 7.15. The upgrade guide includes this content, so we need to have a placeholder file. This topic should highlight any breaking changes that are likely to have a big impact on users.
