### PR TITLE
Enable Elasticsearch security for testing

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -13,7 +13,7 @@ services:
     - "network.host="
     - "transport.host=127.0.0.1"
     - "http.host=0.0.0.0"
-    - "xpack.security.enabled=false"
+    - "xpack.security.enabled=true"
     - "script.context.template.max_compilations_rate=unlimited"
     - "script.context.ingest.cache_max_size=2000"
     - "script.context.processor_conditional.cache_max_size=2000"


### PR DESCRIPTION
Elasticsearch security has been disabled for testing to simplify things in the past. In 8.0 Elasticsearch is enabling security by default and we must also run our test suite against the default environment.

I'm opening this as a draft PR to start discussing all the things that need adjusting to make this work with security.