### PR TITLE
Update Filebeat module documentation to point to integrations doc

### DIFF
--- a/filebeat/docs/modules/apache.asciidoc
+++ b/filebeat/docs/modules/apache.asciidoc
@@ -8,12 +8,15 @@ This file is generated! See scripts/docs_collector.py
 
 == Apache module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access and error logs created by the
 https://httpd.apache.org/[Apache HTTP] server.
 
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
+
 
 [float]
 === Compatibility

--- a/filebeat/docs/modules/auditd.asciidoc
+++ b/filebeat/docs/modules/auditd.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Auditd module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs from the audit daemon
 (`auditd`).
 

--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == AWS module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for aws logs. It uses filebeat s3 input to get log files from
 AWS S3 buckets with SQS notification or directly polling list of S3 objects in an S3 bucket.
 The use of SQS notification is preferred: polling list of S3 objects is expensive

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Azure module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The azure module retrieves different types of log data from Azure.
 There are several requirements before using the module since the logs will actually be read from azure event hubs.
 
@@ -118,6 +120,7 @@ Users can also use this in case of a Hybrid Cloud model, where one may define th
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
+
 
 [float]
 === Dashboards

--- a/filebeat/docs/modules/barracuda.asciidoc
+++ b/filebeat/docs/modules/barracuda.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Barracuda Web Application Firewall logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/bluecoat.asciidoc
+++ b/filebeat/docs/modules/bluecoat.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Blue Coat Director logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/cef.asciidoc
+++ b/filebeat/docs/modules/cef.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == CEF module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Common Event Format (CEF) data over Syslog. When
 messages are received over the syslog protocol the syslog input will parse the
 header and set the timestamp value. Then the

--- a/filebeat/docs/modules/checkpoint.asciidoc
+++ b/filebeat/docs/modules/checkpoint.asciidoc
@@ -11,6 +11,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Check Point module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Check Point firewall logs. It supports logs from the Log
 Exporter in the Syslog RFC 5424 format. If you need to ingest Check Point logs
 in CEF format then please use the <<filebeat-module-cef, `CEF module`>> (more
@@ -25,7 +27,6 @@ Example Log Exporter config:
 `cp_log_export add name testdestination target-server 192.168.1.1 target-port 9001 protocol udp format syslog`
 
 include::../include/gs-link.asciidoc[]
-
 
 [float]
 === Compatibility

--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Cisco module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Cisco network device's logs and Cisco Umbrella. It includes the following
 filesets for receiving logs over syslog or read from a file:
 

--- a/filebeat/docs/modules/crowdstrike.asciidoc
+++ b/filebeat/docs/modules/crowdstrike.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == CrowdStrike module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the {beatname_uc} module for CrowdStrike Falcon using the Falcon https://www.crowdstrike.com/blog/tech-center/integrate-with-your-siem[SIEM Connector]. This module collects this data, converts it to ECS, and ingests it to view in the SIEM. By default, the Falcon SIEM connector outputs JSON formatted Falcon Streaming API event data.
 
 This module segments events forwarded by the Falcon SIEM connector into two datasets for endpoint data and Falcon platform audit data.

--- a/filebeat/docs/modules/cyberarkpas.asciidoc
+++ b/filebeat/docs/modules/cyberarkpas.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 beta[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving CyberArk Privileged Account Security (PAS) logs over Syslog or a file.
 
 The {plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugin is required to run this module.

--- a/filebeat/docs/modules/cylance.asciidoc
+++ b/filebeat/docs/modules/cylance.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving CylanceProtect logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/f5.asciidoc
+++ b/filebeat/docs/modules/f5.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for F5 network device's logs. It includes the following
 filesets for receiving logs over syslog or read from a file:
 

--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Fortinet module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Fortinet logs sent in the syslog format. It supports the
 following devices:
 

--- a/filebeat/docs/modules/gcp.asciidoc
+++ b/filebeat/docs/modules/gcp.asciidoc
@@ -10,6 +10,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Google Cloud module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for Google Cloud logs. It supports reading audit, VPC flow,
 and firewall logs that have been exported from Stackdriver to a

--- a/filebeat/docs/modules/google_workspace.asciidoc
+++ b/filebeat/docs/modules/google_workspace.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Google Workspace module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting data from the different Google Workspace audit reports APIs.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/haproxy.asciidoc
+++ b/filebeat/docs/modules/haproxy.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == haproxy module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs from a (`haproxy`) process.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == IIS module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access and error logs created by the
 Internet Information Services (IIS) HTTP server.
 

--- a/filebeat/docs/modules/imperva.asciidoc
+++ b/filebeat/docs/modules/imperva.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Imperva SecureSphere logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/infoblox.asciidoc
+++ b/filebeat/docs/modules/infoblox.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Infoblox NIOS logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/iptables.asciidoc
+++ b/filebeat/docs/modules/iptables.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Iptables module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for iptables and ip6tables logs. It parses logs received
 over the network via syslog or from a file. Also, it understands the prefix added
 by some Ubiquiti firewalls, which includes the rule set name, rule number and

--- a/filebeat/docs/modules/juniper.asciidoc
+++ b/filebeat/docs/modules/juniper.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Juniper module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting data from the different Juniper Products. Currently supports these filesets:
 
 - `srx` fileset: Supports Juniper SRX logs

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Kafka module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses the logs created by
 https://kafka.apache.org/[Kafka].
 

--- a/filebeat/docs/modules/microsoft.asciidoc
+++ b/filebeat/docs/modules/microsoft.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Microsoft module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting data from the different Microsoft Products. Currently supports these filesets:
 
 - `defender_atp` fileset: Supports Microsoft Defender for Endpoint (Microsoft Defender ATP)

--- a/filebeat/docs/modules/mongodb.asciidoc
+++ b/filebeat/docs/modules/mongodb.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == MongoDB module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs created by
 https://www.mongodb.com/[MongoDB].
 

--- a/filebeat/docs/modules/mysql.asciidoc
+++ b/filebeat/docs/modules/mysql.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == MySQL module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses the slow logs and error logs
 created by https://www.mysql.com/[MySQL].
 

--- a/filebeat/docs/modules/mysqlenterprise.asciidoc
+++ b/filebeat/docs/modules/mysqlenterprise.asciidoc
@@ -10,7 +10,10 @@ This file is generated! See scripts/docs_collector.py
 
 
 == MySQL Enterprise module
+
 beta[]
+
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for different types of MySQL logs. Currently focusing on data from the MySQL Enterprise Audit Plugin in JSON format.
 

--- a/filebeat/docs/modules/nats.asciidoc
+++ b/filebeat/docs/modules/nats.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == nats module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the nats module.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == NetFlow module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving NetFlow and IPFIX flow records over UDP. This
 input supports NetFlow versions 1, 5, 6, 7, 8 and 9, as well as IPFIX. For
 NetFlow versions older than 9, fields are mapped automatically to NetFlow v9.

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -9,6 +9,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Nginx module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access and error logs created by the
 http://nginx.org/[Nginx] HTTP server.
 

--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 beta[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Office 365 logs received via one of the Office 365 API
 endpoints. It currently supports user, admin, system, and policy actions and
 events from Office 365 and Azure AD activity logs exposed by the Office 365

--- a/filebeat/docs/modules/okta.asciidoc
+++ b/filebeat/docs/modules/okta.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Okta module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The Okta module collects events from the
 https://developer.okta.com/docs/reference/[Okta API]. Specifically this supports
 reading from the https://developer.okta.com/docs/reference/api/system-log/[Okta

--- a/filebeat/docs/modules/osquery.asciidoc
+++ b/filebeat/docs/modules/osquery.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Osquery module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and decodes the result logs written by
 https://osquery.readthedocs.io/en/latest/introduction/using-osqueryd/[osqueryd]
 in the JSON format. To set up osqueryd follow the osquery installation

--- a/filebeat/docs/modules/panw.asciidoc
+++ b/filebeat/docs/modules/panw.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Palo Alto Networks module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == PostgreSQL module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module  collects and parses logs created by
 https://www.postgresql.org/[PostgreSQL].
 

--- a/filebeat/docs/modules/proofpoint.asciidoc
+++ b/filebeat/docs/modules/proofpoint.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Proofpoint Email Security logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/rabbitmq.asciidoc
+++ b/filebeat/docs/modules/rabbitmq.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == RabbitMQ module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the module for parsing https://www.rabbitmq.com/logging.html[RabbitMQ log files]
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/docs/modules/radware.asciidoc
+++ b/filebeat/docs/modules/radware.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Radware DefensePro logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/redis.asciidoc
+++ b/filebeat/docs/modules/redis.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Redis module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses logs and slowlogs created by
 https://redis.io/[Redis].
 

--- a/filebeat/docs/modules/santa.asciidoc
+++ b/filebeat/docs/modules/santa.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Santa module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs from
 https://github.com/google/santa[Google Santa], a security
 tool for macOS that monitors process executions and can blacklist/whitelist

--- a/filebeat/docs/modules/sonicwall.asciidoc
+++ b/filebeat/docs/modules/sonicwall.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Sonicwall-FW logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/sophos.asciidoc
+++ b/filebeat/docs/modules/sophos.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Sophos module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Sophos Products, currently it accepts
 logs in syslog format or from a file for the following devices:
 

--- a/filebeat/docs/modules/squid.asciidoc
+++ b/filebeat/docs/modules/squid.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Squid logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/suricata.asciidoc
+++ b/filebeat/docs/modules/suricata.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Suricata module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module to the Suricata IDS/IPS/NSM log. It parses logs that are in the
 https://suricata.readthedocs.io/en/latest/output/eve/eve-json-format.html[
 Suricata Eve JSON format].

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == System module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs created by the system logging
 service of common Unix/Linux based distributions.
 

--- a/filebeat/docs/modules/tomcat.asciidoc
+++ b/filebeat/docs/modules/tomcat.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Apache Tomcat access logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Traefik module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access logs created by
 https://traefik.io/[Træfik].
 

--- a/filebeat/docs/modules/zeek.asciidoc
+++ b/filebeat/docs/modules/zeek.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Zeek (Bro) Module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for https://zeek.org/[Zeek], which used to be called Bro. It
 parses logs that are in the Zeek JSON format.
 

--- a/filebeat/docs/modules/zookeeper.asciidoc
+++ b/filebeat/docs/modules/zookeeper.asciidoc
@@ -8,6 +8,8 @@ This file is generated! See scripts/docs_collector.py
 
 == ZooKeeper module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses the logs created by https://zookeeper.apache.org/[Apache ZooKeeper]
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/docs/modules/zoom.asciidoc
+++ b/filebeat/docs/modules/zoom.asciidoc
@@ -10,7 +10,10 @@ This file is generated! See scripts/docs_collector.py
 
 
 == Zoom module
+
 beta[]
+
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for Zoom webhook logs. The module creates an HTTP listener that accepts incoming webhooks from Zoom.
 

--- a/filebeat/docs/modules/zscaler.asciidoc
+++ b/filebeat/docs/modules/zscaler.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Zscaler NSS logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/module/apache/_meta/docs.asciidoc
+++ b/filebeat/module/apache/_meta/docs.asciidoc
@@ -3,12 +3,15 @@
 
 == Apache module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access and error logs created by the
 https://httpd.apache.org/[Apache HTTP] server.
 
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
+
 
 [float]
 === Compatibility

--- a/filebeat/module/auditd/_meta/docs.asciidoc
+++ b/filebeat/module/auditd/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Auditd module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs from the audit daemon
 (`auditd`).
 

--- a/filebeat/module/haproxy/_meta/docs.asciidoc
+++ b/filebeat/module/haproxy/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == haproxy module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs from a (`haproxy`) process.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/module/iis/_meta/docs.asciidoc
+++ b/filebeat/module/iis/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == IIS module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access and error logs created by the
 Internet Information Services (IIS) HTTP server.
 

--- a/filebeat/module/kafka/_meta/docs.asciidoc
+++ b/filebeat/module/kafka/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Kafka module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses the logs created by
 https://kafka.apache.org/[Kafka].
 

--- a/filebeat/module/mongodb/_meta/docs.asciidoc
+++ b/filebeat/module/mongodb/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == MongoDB module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs created by
 https://www.mongodb.com/[MongoDB].
 

--- a/filebeat/module/mysql/_meta/docs.asciidoc
+++ b/filebeat/module/mysql/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == MySQL module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses the slow logs and error logs
 created by https://www.mysql.com/[MySQL].
 

--- a/filebeat/module/nats/_meta/docs.asciidoc
+++ b/filebeat/module/nats/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == nats module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the nats module.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/module/nginx/_meta/docs.asciidoc
+++ b/filebeat/module/nginx/_meta/docs.asciidoc
@@ -4,6 +4,8 @@
 
 == Nginx module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access and error logs created by the
 http://nginx.org/[Nginx] HTTP server.
 

--- a/filebeat/module/osquery/_meta/docs.asciidoc
+++ b/filebeat/module/osquery/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Osquery module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and decodes the result logs written by
 https://osquery.readthedocs.io/en/latest/introduction/using-osqueryd/[osqueryd]
 in the JSON format. To set up osqueryd follow the osquery installation

--- a/filebeat/module/postgresql/_meta/docs.asciidoc
+++ b/filebeat/module/postgresql/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == PostgreSQL module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module  collects and parses logs created by
 https://www.postgresql.org/[PostgreSQL].
 

--- a/filebeat/module/redis/_meta/docs.asciidoc
+++ b/filebeat/module/redis/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Redis module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses logs and slowlogs created by
 https://redis.io/[Redis].
 

--- a/filebeat/module/santa/_meta/docs.asciidoc
+++ b/filebeat/module/santa/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Santa module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs from
 https://github.com/google/santa[Google Santa], a security
 tool for macOS that monitors process executions and can blacklist/whitelist

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == System module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses logs created by the system logging
 service of common Unix/Linux based distributions.
 

--- a/filebeat/module/traefik/_meta/docs.asciidoc
+++ b/filebeat/module/traefik/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Traefik module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module parses access logs created by
 https://traefik.io/[Træfik].
 

--- a/libbeat/docs/shared/integration-link.asciidoc
+++ b/libbeat/docs/shared/integration-link.asciidoc
@@ -1,0 +1,17 @@
+.Prefer to use {agent} for this use case?
+****
+Refer to the
+https://docs.elastic.co/en/integrations/{modulename}[Elastic Integrations documentation].
+
+[%collapsible]
+.Learn more
+====
+{agent} is a single, unified agent that you can deploy to hosts or containers to
+collect data and send it to the {stack}. {agent} uses integrations to connect
+your data to the {stack}. Behind the scenes, {agent} runs the {beats} shippers
+required for your configuration. Refer to the documentation for a detailed
+{fleet-guide}/beats-agent-comparison.html[comparison of {beats} and {agent}]. 
+
+====
+
+****

--- a/x-pack/filebeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/aws/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 == AWS module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for aws logs. It uses filebeat s3 input to get log files from
 AWS S3 buckets with SQS notification or directly polling list of S3 objects in an S3 bucket.
 The use of SQS notification is preferred: polling list of S3 objects is expensive

--- a/x-pack/filebeat/module/azure/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/azure/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Azure module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The azure module retrieves different types of log data from Azure.
 There are several requirements before using the module since the logs will actually be read from azure event hubs.
 
@@ -113,6 +115,7 @@ Users can also use this in case of a Hybrid Cloud model, where one may define th
 include::../include/what-happens.asciidoc[]
 
 include::../include/gs-link.asciidoc[]
+
 
 [float]
 === Dashboards

--- a/x-pack/filebeat/module/barracuda/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/barracuda/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Barracuda Web Application Firewall logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/bluecoat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/bluecoat/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Blue Coat Director logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/cef/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cef/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == CEF module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Common Event Format (CEF) data over Syslog. When
 messages are received over the syslog protocol the syslog input will parse the
 header and set the timestamp value. Then the

--- a/x-pack/filebeat/module/checkpoint/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/checkpoint/_meta/docs.asciidoc
@@ -6,6 +6,8 @@
 
 == Check Point module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Check Point firewall logs. It supports logs from the Log
 Exporter in the Syslog RFC 5424 format. If you need to ingest Check Point logs
 in CEF format then please use the <<filebeat-module-cef, `CEF module`>> (more
@@ -20,7 +22,6 @@ Example Log Exporter config:
 `cp_log_export add name testdestination target-server 192.168.1.1 target-port 9001 protocol udp format syslog`
 
 include::../include/gs-link.asciidoc[]
-
 
 [float]
 === Compatibility

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Cisco module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Cisco network device's logs and Cisco Umbrella. It includes the following
 filesets for receiving logs over syslog or read from a file:
 

--- a/x-pack/filebeat/module/crowdstrike/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/crowdstrike/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == CrowdStrike module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the {beatname_uc} module for CrowdStrike Falcon using the Falcon https://www.crowdstrike.com/blog/tech-center/integrate-with-your-siem[SIEM Connector]. This module collects this data, converts it to ECS, and ingests it to view in the SIEM. By default, the Falcon SIEM connector outputs JSON formatted Falcon Streaming API event data.
 
 This module segments events forwarded by the Falcon SIEM connector into two datasets for endpoint data and Falcon platform audit data.

--- a/x-pack/filebeat/module/cyberarkpas/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cyberarkpas/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 beta[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving CyberArk Privileged Account Security (PAS) logs over Syslog or a file.
 
 The {plugins}/ingest-geoip.html[ingest-geoip] Elasticsearch plugin is required to run this module.

--- a/x-pack/filebeat/module/cylance/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cylance/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving CylanceProtect logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/f5/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/f5/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for F5 network device's logs. It includes the following
 filesets for receiving logs over syslog or read from a file:
 

--- a/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Fortinet module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Fortinet logs sent in the syslog format. It supports the
 following devices:
 

--- a/x-pack/filebeat/module/gcp/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/gcp/_meta/docs.asciidoc
@@ -5,6 +5,7 @@
 
 == Google Cloud module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for Google Cloud logs. It supports reading audit, VPC flow,
 and firewall logs that have been exported from Stackdriver to a

--- a/x-pack/filebeat/module/google_workspace/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/google_workspace/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Google Workspace module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting data from the different Google Workspace audit reports APIs.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/imperva/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/imperva/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Imperva SecureSphere logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/infoblox/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/infoblox/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Infoblox NIOS logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/iptables/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Iptables module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for iptables and ip6tables logs. It parses logs received
 over the network via syslog or from a file. Also, it understands the prefix added
 by some Ubiquiti firewalls, which includes the rule set name, rule number and

--- a/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Juniper module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting data from the different Juniper Products. Currently supports these filesets:
 
 - `srx` fileset: Supports Juniper SRX logs

--- a/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Microsoft module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting data from the different Microsoft Products. Currently supports these filesets:
 
 - `defender_atp` fileset: Supports Microsoft Defender for Endpoint (Microsoft Defender ATP)

--- a/x-pack/filebeat/module/mysqlenterprise/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/mysqlenterprise/_meta/docs.asciidoc
@@ -5,7 +5,10 @@
 
 
 == MySQL Enterprise module
+
 beta[]
+
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for different types of MySQL logs. Currently focusing on data from the MySQL Enterprise Audit Plugin in JSON format.
 

--- a/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netflow/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == NetFlow module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving NetFlow and IPFIX flow records over UDP. This
 input supports NetFlow versions 1, 5, 6, 7, 8 and 9, as well as IPFIX. For
 NetFlow versions older than 9, fields are mapped automatically to NetFlow v9.

--- a/x-pack/filebeat/module/o365/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/o365/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 beta[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Office 365 logs received via one of the Office 365 API
 endpoints. It currently supports user, admin, system, and policy actions and
 events from Office 365 and Azure AD activity logs exposed by the Office 365

--- a/x-pack/filebeat/module/okta/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/okta/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Okta module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The Okta module collects events from the
 https://developer.okta.com/docs/reference/[Okta API]. Specifically this supports
 reading from the https://developer.okta.com/docs/reference/api/system-log/[Okta

--- a/x-pack/filebeat/module/panw/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/panw/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Palo Alto Networks module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Palo Alto Networks PAN-OS firewall monitoring logs received
 over Syslog or read from a file. It currently supports messages of Traffic and
 Threat types.

--- a/x-pack/filebeat/module/proofpoint/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/proofpoint/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Proofpoint Email Security logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/rabbitmq/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/rabbitmq/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == RabbitMQ module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the module for parsing https://www.rabbitmq.com/logging.html[RabbitMQ log files]
 
 include::../include/what-happens.asciidoc[]

--- a/x-pack/filebeat/module/radware/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/radware/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Radware DefensePro logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/sonicwall/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sonicwall/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Sonicwall-FW logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Sophos module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for Sophos Products, currently it accepts
 logs in syslog format or from a file for the following devices:
 

--- a/x-pack/filebeat/module/squid/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/squid/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Squid logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/suricata/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Suricata module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module to the Suricata IDS/IPS/NSM log. It parses logs that are in the
 https://suricata.readthedocs.io/en/latest/output/eve/eve-json-format.html[
 Suricata Eve JSON format].

--- a/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Apache Tomcat access logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zeek/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Zeek (Bro) Module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for https://zeek.org/[Zeek], which used to be called Bro. It
 parses logs that are in the Zeek JSON format.
 

--- a/x-pack/filebeat/module/zookeeper/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zookeeper/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == ZooKeeper module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ module collects and parses the logs created by https://zookeeper.apache.org/[Apache ZooKeeper]
 
 include::../include/what-happens.asciidoc[]

--- a/x-pack/filebeat/module/zoom/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zoom/_meta/docs.asciidoc
@@ -5,7 +5,10 @@
 
 
 == Zoom module
+
 beta[]
+
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for Zoom webhook logs. The module creates an HTTP listener that accepts incoming webhooks from Zoom.
 

--- a/x-pack/filebeat/module/zscaler/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zscaler/_meta/docs.asciidoc
@@ -7,6 +7,8 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for receiving Zscaler NSS logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]


### PR DESCRIPTION
## What does this PR do?

Adds links that point to the integrations documentation.

Link to preview: https://beats_28036.docs-preview.app.elstc.co/diff 

## Why is it important?

Raises visibility of integrations and Elastic Agent plus makes it possible for users to determine whether a specific service that's currently supported in Filebeat is also supported in Elastic Agent.

## Questions

- [ ] Should we include this info box in the input documentation, too?
- [x] Have we missed any modules (I'm looking at the published integrations doc, but it's not the latest).
- [x] Is the top of the file the best location for the info box? I originally had it at the end of the intro, but in some cases, that pushed the info too far down the page.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Related to https://github.com/elastic/observability-docs/issues/1006

## Screenshots

Note that the link will send users directly to the docs for the corresponding integration.

The "Learn More" info will be collapsed by default (for users who already know about Elastic Agent).

![image](https://user-images.githubusercontent.com/14206422/134257355-ee1fb9dc-cf01-46f4-b872-c42c5a5c425c.png)

