### PR TITLE
Disable TestParsersMultilineMaxBytes and TestFilestreamTruncateBlockedOutput

### DIFF
--- a/filebeat/input/filestream/input_integration_test.go
+++ b/filebeat/input/filestream/input_integration_test.go
@@ -693,6 +693,7 @@ func TestFilestreamTruncateCheckOffset(t *testing.T) {
 }
 
 func TestFilestreamTruncateBlockedOutput(t *testing.T) {
+	t.Skip("Flaky test https://github.com/elastic/beats/issues/27085")
 	env := newInputTestingEnvironment(t)
 	env.pipeline = &mockPipelineConnector{blocking: true}
 

--- a/filebeat/input/filestream/parsers_integration_test.go
+++ b/filebeat/input/filestream/parsers_integration_test.go
@@ -397,6 +397,7 @@ func TestParsersMultilineTimeout(t *testing.T) {
 
 // test_max_bytes from test_multiline.py
 func TestParsersMultilineMaxBytes(t *testing.T) {
+	t.Skip("Flaky test https://github.com/elastic/beats/issues/28088")
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"


### PR DESCRIPTION
## What does this PR do?

Disabling flaky test
Issue reported: 
- https://github.com/elastic/beats/issues/28088
- https://github.com/elastic/beats/issues/27085

## Why is it important?


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

cc @kvch I assigned reported issue to you