### PR TITLE
[DOC] Clarify time units in ttl

### DIFF
--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -282,7 +282,7 @@ are sticky, operating behind load balancers can lead to uneven load distribution
 Specifying a TTL on the connection allows to achieve equal connection distribution between the
 instances.  Specifying a TTL of 0 will disable this feature.
 
-The default value is 0 and it is a https://www.elastic.co/guide/en/beats/libbeat/current/config-file-format-type.html#_duration[Duration].
+The default value is 0. This setting accepts {beats-ref}/config-file-format-type.html#_duration[duration] data type values.
 
 NOTE: The "ttl" option is not yet supported on an async {ls} client (one with the "pipelining" option set).
 

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -282,7 +282,7 @@ are sticky, operating behind load balancers can lead to uneven load distribution
 Specifying a TTL on the connection allows to achieve equal connection distribution between the
 instances.  Specifying a TTL of 0 will disable this feature.
 
-The default value is 0.
+The default value is 0 and it is a https://www.elastic.co/guide/en/beats/libbeat/current/config-file-format-type.html#_duration[Duration].
 
 NOTE: The "ttl" option is not yet supported on an async {ls} client (one with the "pipelining" option set).
 


### PR DESCRIPTION
## What does this PR do?

Clarifies time units for `ttl` setting in Beats, as asked on https://discuss.elastic.co/t/filebeat-ttl-value-is-it-seconds-milliseconds/138646

## Why is it important?

Makes the setting easier to use.

## Checklist

- [ ] Please backport this if possible.
