### PR TITLE
[docs] index-patterns.html#reload-fields => index-patterns.html

### DIFF
--- a/libbeat/docs/faq-refresh-index.asciidoc
+++ b/libbeat/docs/faq-refresh-index.asciidoc
@@ -11,7 +11,7 @@ http.response.headers = {
 }
 ----------------------------------------------------------------------
 
-To fix this you need to {kibana-ref}/index-patterns.html#reload-fields[reload the index pattern] in {kib} under the Management->Index Patterns, and the index pattern will be
+To fix this you need to {kibana-ref}/index-patterns.html[reload the index pattern] in {kib} under the Management->Index Patterns, and the index pattern will be
 updated with a field for each key available in the dictionary:
 
 [source,shell]


### PR DESCRIPTION
I'm working on updating the kibana docs to account for the rename of kibana index patterns to data views. I've created a redirect but this is insufficient for named anchor tags. The easiest way forward is to remove the anchor tag for now and replace it once the data view docs have been committed, otherwise the new docs will never pass CI. 