### PR TITLE
fix(ci): list files in the directory without glob pattern

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -804,10 +804,9 @@ def archiveTestOutput(Map args = [:]) {
             cmd(label: "Archive system tests files", script: 'mage packageSystemTests')
           }
         }
-        def uploadDirName = 'build'
-        def fileName = uploadDirName + "/system-tests-*.tar.gz" // see dev-tools/mage/target/common/package.go#PackageSystemTests method
+        def fileName = 'build/system-tests-*.tar.gz' // see dev-tools/mage/target/common/package.go#PackageSystemTests method
         dir("${BASE_DIR}"){
-          cmd(label: "List files to upload", script: "ls -l ${BASE_DIR}/${uploadDirName}")
+          findFiles(glob: "${fileName}")
           googleStorageUploadExt(
             bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
             credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -806,7 +806,10 @@ def archiveTestOutput(Map args = [:]) {
         }
         def fileName = 'build/system-tests-*.tar.gz' // see dev-tools/mage/target/common/package.go#PackageSystemTests method
         dir("${BASE_DIR}"){
-          findFiles(glob: "${fileName}")
+          def files = findFiles(glob: "${fileName}")
+          files.each { file ->
+            echo "${file.name}"
+          }
           googleStorageUploadExt(
             bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
             credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -804,9 +804,10 @@ def archiveTestOutput(Map args = [:]) {
             cmd(label: "Archive system tests files", script: 'mage packageSystemTests')
           }
         }
-        def fileName = 'build/system-tests-*.tar.gz' // see dev-tools/mage/target/common/package.go#PackageSystemTests method
+        def uploadDirName = 'build'
+        def fileName = uploadDirName + "/system-tests-*.tar.gz" // see dev-tools/mage/target/common/package.go#PackageSystemTests method
         dir("${BASE_DIR}"){
-          cmd(label: "List files to upload", script: "ls -l ${BASE_DIR}/${fileName}")
+          cmd(label: "List files to upload", script: "ls -l ${BASE_DIR}/${uploadDirName}")
           googleStorageUploadExt(
             bucket: "gs://${JOB_GCS_BUCKET}/${env.JOB_NAME}-${env.BUILD_ID}",
             credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Instead of using a glob pattern to list the `system-tests-*.tar.gz` files to upload to the GCP bucket, it limits the `ls` command to the parent dir (`build`).

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
With the previous command, we have noticed errors in the Groovy execution when there are no files matching the glob pattern, causing to fail the upload step.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/pull/22220
- Relates https://github.com/elastic/beats/pull/27069
- Relates https://github.com/elastic/beats/pull/27295


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

From CI build: https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats/detail/PR-28124/2/pipeline/

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<img width="1755" alt="Screenshot 2021-09-27 at 10 51 53" src="https://user-images.githubusercontent.com/951580/134876235-5e3de11c-b63d-4fcc-8748-c9b72f397742.png">


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
>[2021-09-27T01:06:36.137Z] + ls -l src/github.com/elastic/beats/build/system-tests-*.tar.gz
[2021-09-27T01:06:36.137Z] ls: cannot access 'src/github.com/elastic/beats/build/system-tests-*.tar.gz': No such file or directory
script returned exit code 2