### PR TITLE
Build cloud docker images for elastic-agent

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -335,10 +335,12 @@ def tagAndPush(Map args = [:]) {
   }
   // supported image flavours
   def variants = ["", "-oss", "-ubi8"]
-  // 
+
   if(beatName == 'elastic-agent'){
       variants.add("-complete")
+      variants.add("-cloud")
   }
+
   variants.each { variant ->
     tags.each { tag ->
       // TODO:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -459,9 +459,9 @@ def tagAndPush(Map args = [:]) {
   // supported image flavours
   def variants = ["", "-oss", "-ubi8"]
 
-  // only add complete variant for the elastic-agent
   if(beatName == 'elastic-agent'){
       variants.add("-complete")
+      variants.add("-cloud")
   }
 
   variants.each { variant ->

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -1001,8 +1001,9 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         # This image gets a 'complete' variant for synthetics and other large
-        # packages too big to fit in the main image
-        variants: ["complete"]
+        # packages too big to fit in the main image. In addition, the 'cloud'
+        # variant for the specific cloud requirements.
+        variants: ["complete", "cloud"]
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
@@ -1027,8 +1028,9 @@ specs:
         <<: *elastic_docker_spec
         <<: *elastic_license_for_binaries
         # This image gets a 'complete' variant for synthetics and other large
-        # packages too big to fit in the main image
-        variants: ["complete"]
+        # packages too big to fit in the main image. In addition, the 'cloud'
+        # variant for the specific cloud requirements.
+        variants: ["complete", "cloud"]
         files:
           '{{.BeatName}}{{.BinaryExt}}':
             source: ./build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -23,6 +23,10 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
 {{- range $i, $modulesd := .ModulesDirs }}
     chmod 0775 {{ $beatHome}}/{{ $modulesd }} && \
 {{- end }}
+{{- if (and (eq .Variant "cloud") (not (contains .from "ubi-minimal")))  }}
+    tar -xvf metricbeat-*.tar.gz --strip-components 1 --directory /opt --wildcards "*metricbeat" --directory && \
+    tar -xvf filebeat-*.tar.gz --strip-components 1 --directory /opt --wildcards "*filebeat" --directory && \
+{{- end }}
     true
 
 FROM {{ .from }}
@@ -41,7 +45,7 @@ RUN case $(arch) in aarch64) YUM_FLAGS="-x bind-license";; esac; \
         yum install -y epel-release &&  \
         yum update -y $YUM_FLAGS && \
         yum install -y jq && \
-        
+
         yum clean all && \
         exit_code=0 && break || exit_code=$? && echo "yum error: retry $iter in 10s" && sleep 10; \
     done; \
@@ -133,6 +137,11 @@ RUN chmod 0770 {{ $beatHome }}
 RUN mkdir /licenses
 COPY --from=home {{ $beatHome }}/LICENSE.txt /licenses
 COPY --from=home {{ $beatHome }}/NOTICE.txt /licenses
+
+{{- if (and (eq .Variant "cloud") (not (contains .from "ubi-minimal")))  }}
+COPY --from=home /opt/filebeat /opt/filebeat
+COPY --from=home /opt/metricbeat /opt/metricbeat
+{{- end }}
 
 {{- if ne .user "root" }}
 RUN groupadd --gid 1000 {{ .BeatName }}

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -24,8 +24,8 @@ RUN mkdir -p {{ $beatHome }}/data {{ $beatHome }}/data/elastic-agent-{{ commit_s
     chmod 0775 {{ $beatHome}}/{{ $modulesd }} && \
 {{- end }}
 {{- if (and (eq .Variant "cloud") (not (contains .from "ubi-minimal")))  }}
-    tar -xvf metricbeat-*.tar.gz --strip-components 1 --directory /opt --wildcards "*metricbeat" --directory && \
-    tar -xvf filebeat-*.tar.gz --strip-components 1 --directory /opt --wildcards "*filebeat" --directory && \
+    tar -xvf {{ $beatHome }}/data/elastic-agent-*/downloads/metricbeat-*.tar.gz --strip-components 1 --directory /opt --wildcards "*metricbeat" --directory && \
+    tar -xvf {{ $beatHome }}/data/elastic-agent-*/downloads/filebeat-*.tar.gz --strip-components 1 --directory /opt --wildcards "*filebeat" --directory && \
 {{- end }}
     true
 


### PR DESCRIPTION
## What does this PR do?

Build cloud docker images for elastic-agent that requires the metricbeat and filebeat binaries in the /opt folder

## Why is it important?

As part of the cloud initiative let's provide those docker images as part of the Beats projects.
