### PR TITLE
[elastic-agent] proxy requests to subprocesses to their metrics endpoints

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -13,6 +13,7 @@
 - Remove the `--kibana-url` from `install` and `enroll` command. {pull}25529[25529]
 - Default to port 80 and 443 for Kibana and Fleet Server connections. {pull}25723[25723]
 - Remove deprecated/undocumented IncludeCreatorMetadata setting from kubernetes metadata config options {pull}28006[28006]
+- The `/processes/<subprocess>` endpoint proxies to the subprocess's monitoring endpoint, instead of querying its `/stats` endpoint {pull}28165[28165]
 
 ==== Bugfixes
 - Fix rename *ConfigChange to *PolicyChange to align on changes in the UI. {pull}20779[20779]

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process.go
@@ -67,8 +67,9 @@ func processHandler(statsHandler func(http.ResponseWriter, *http.Request) error)
 			// proxy stats for elastic agent process
 			return statsHandler(w, r)
 		}
+		beatsEndpoint := vars["beatsEndpoint"]
 
-		metricsBytes, statusCode, metricsErr := processMetrics(r.Context(), id)
+		metricsBytes, statusCode, metricsErr := processMetrics(r.Context(), id, beatsEndpoint)
 		if metricsErr != nil {
 			return metricsErr
 		}
@@ -82,7 +83,7 @@ func processHandler(statsHandler func(http.ResponseWriter, *http.Request) error)
 	}
 }
 
-func processMetrics(ctx context.Context, id string) ([]byte, int, error) {
+func processMetrics(ctx context.Context, id, path string) ([]byte, int, error) {
 	detail, err := parseID(id)
 	if err != nil {
 		return nil, 0, err
@@ -98,7 +99,7 @@ func processMetrics(ctx context.Context, id string) ([]byte, int, error) {
 		endpoint += "_monitor"
 	}
 
-	hostData, err := parse.ParseURL(endpoint, "http", "", "", "stats", "")
+	hostData, err := parse.ParseURL(endpoint, "http", "", "", path, "")
 	if err != nil {
 		return nil, 0, errorWithStatus(http.StatusInternalServerError, err)
 	}

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process.go
@@ -37,6 +37,7 @@ const (
 var (
 	// ErrProgramNotSupported returned when requesting metrics for not supported program.
 	ErrProgramNotSupported = errors.New("specified program is not supported")
+	errPathNotFound        = errors.New("endpoint not found")
 	invalidChars           = map[rune]struct{}{
 		'"':  {},
 		'<':  {},
@@ -67,14 +68,13 @@ func processHandler(statsHandler func(http.ResponseWriter, *http.Request) error)
 			// proxy stats for elastic agent process
 			return statsHandler(w, r)
 		}
-		// TODO: allowlist of accepted endpoints to proxy to?
-		beatsEndpoint := vars["beatsEndpoint"]
+		beatsPath := vars["beatsPath"]
 
 		endpoint, err := generateEndpoint(id)
 		if err != nil {
 			return err
 		}
-		metricsBytes, statusCode, metricsErr := processMetrics(r.Context(), endpoint, beatsEndpoint)
+		metricsBytes, statusCode, metricsErr := processMetrics(r.Context(), endpoint, beatsPath)
 		if metricsErr != nil {
 			return metricsErr
 		}
@@ -88,7 +88,17 @@ func processHandler(statsHandler func(http.ResponseWriter, *http.Request) error)
 	}
 }
 
+var beatsPathAllowlist = map[string]struct{}{
+	"":      struct{}{},
+	"stats": struct{}{},
+	"state": struct{}{},
+}
+
 func processMetrics(ctx context.Context, endpoint, path string) ([]byte, int, error) {
+	if _, ok := beatsPathAllowlist[path]; !ok {
+		return nil, http.StatusNotFound, errPathNotFound
+	}
+
 	hostData, err := parse.ParseURL(endpoint, "http", "", "", path, "")
 	if err != nil {
 		return nil, 0, errorWithStatus(http.StatusInternalServerError, err)

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process_linux_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process_linux_test.go
@@ -2,7 +2,8 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//go:build !windows
+//go:build linux
+// +build linux
 
 package server
 

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process_linux_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process_linux_test.go
@@ -37,10 +37,10 @@ func TestProcessProxyRequest(t *testing.T) {
 	server.Start()
 	defer server.Close()
 
-	for _, path := range []string{"/stats", "/", "/state"} {
+	for _, path := range []string{"stats", "", "state"} {
 		respBytes, _, err := processMetrics(context.Background(), endpoint, path)
 		require.NoError(t, err)
 		// Verify that the server saw the path we tried to request
-		assert.Equal(t, path, string(respBytes))
+		assert.Equal(t, "/"+path, string(respBytes))
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process_linux_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process_linux_test.go
@@ -1,0 +1,45 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !windows
+
+package server
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessProxyRequest(t *testing.T) {
+	sock := "/tmp/elastic-agent-test.sock"
+	defer os.Remove(sock)
+
+	endpoint := "http+unix://" + sock
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Write the path to the client so they can verify the request
+		// was correct
+		w.Write([]byte(r.URL.Path))
+	}))
+
+	// Mimic subprocesses and listen on a unix socket
+	l, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	server.Listener = l
+	server.Start()
+	defer server.Close()
+
+	for _, path := range []string{"/stats", "/", "/state"} {
+		respBytes, _, err := processMetrics(context.Background(), endpoint, path)
+		require.NoError(t, err)
+		// Verify that the server saw the path we tried to request
+		assert.Equal(t, path, string(respBytes))
+	}
+}

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
@@ -4,14 +4,11 @@
 package server
 
 import (
-	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 )
 
 func TestParseID(t *testing.T) {
@@ -88,33 +85,5 @@ func TestStatusErr(t *testing.T) {
 
 			require.Equal(t, tc.ExpectedStatusCode, tw.statusCode)
 		})
-	}
-}
-
-func TestBeatsPathAllowlist(t *testing.T) {
-	ctx := context.Background()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("OK"))
-	}))
-	defer server.Close()
-	endpoint := server.URL
-
-	tcs := []struct {
-		path       string
-		statusCode int
-	}{
-		{"", http.StatusOK},
-		{"stats", http.StatusOK},
-		{"state", http.StatusOK},
-		{"not-allowed", http.StatusNotFound},
-		{"nested/path", http.StatusNotFound},
-	}
-
-	for _, tc := range tcs {
-		_, respCode, err := processMetrics(ctx, endpoint, tc.path)
-		assert.Equal(t, respCode, tc.statusCode)
-		if tc.statusCode > 299 {
-			assert.Error(t, err, errPathNotFound.Error())
-		}
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
@@ -4,15 +4,10 @@
 package server
 
 import (
-	"context"
 	"errors"
-	"net"
 	"net/http"
-	"net/http/httptest"
-	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,31 +85,5 @@ func TestStatusErr(t *testing.T) {
 
 			require.Equal(t, tc.ExpectedStatusCode, tw.statusCode)
 		})
-	}
-}
-
-func TestProcessProxyRequest(t *testing.T) {
-	sock := "/tmp/elastic-agent-test.sock"
-	defer os.Remove(sock)
-
-	endpoint := "http+unix://" + sock
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Write the path to the client so they can verify the request
-		// was correct
-		w.Write([]byte(r.URL.Path))
-	}))
-
-	// Mimic subprocesses and listen on a unix socket
-	l, err := net.Listen("unix", sock)
-	require.NoError(t, err)
-	server.Listener = l
-	server.Start()
-	defer server.Close()
-
-	for _, path := range []string{"/stats", "/", "/state"} {
-		respBytes, _, err := processMetrics(context.Background(), endpoint, path)
-		require.NoError(t, err)
-		// Verify that the server saw the path we tried to request
-		assert.Equal(t, path, string(respBytes))
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
@@ -4,10 +4,15 @@
 package server
 
 import (
+	"context"
 	"errors"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -85,5 +90,31 @@ func TestStatusErr(t *testing.T) {
 
 			require.Equal(t, tc.ExpectedStatusCode, tw.statusCode)
 		})
+	}
+}
+
+func TestProcessProxyRequest(t *testing.T) {
+	sock := "/tmp/elastic-agent-test.sock"
+	defer os.Remove(sock)
+
+	endpoint := "http+unix://" + sock
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Write the path to the client so they can verify the request
+		// was correct
+		w.Write([]byte(r.URL.Path))
+	}))
+
+	// Mimic subprocesses and listen on a unix socket
+	l, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+	server.Listener = l
+	server.Start()
+	defer server.Close()
+
+	for _, path := range []string{"/stats", "/", "/state"} {
+		respBytes, _, err := processMetrics(context.Background(), endpoint, path)
+		require.NoError(t, err)
+		// Verify that the server saw the path we tried to request
+		assert.Equal(t, path, string(respBytes))
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/process_test.go
@@ -4,11 +4,14 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 )
 
 func TestParseID(t *testing.T) {
@@ -85,5 +88,33 @@ func TestStatusErr(t *testing.T) {
 
 			require.Equal(t, tc.ExpectedStatusCode, tw.statusCode)
 		})
+	}
+}
+
+func TestBeatsPathAllowlist(t *testing.T) {
+	ctx := context.Background()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	}))
+	defer server.Close()
+	endpoint := server.URL
+
+	tcs := []struct {
+		path       string
+		statusCode int
+	}{
+		{"", http.StatusOK},
+		{"stats", http.StatusOK},
+		{"state", http.StatusOK},
+		{"not-allowed", http.StatusNotFound},
+		{"nested/path", http.StatusNotFound},
+	}
+
+	for _, tc := range tcs {
+		_, respCode, err := processMetrics(ctx, endpoint, tc.path)
+		assert.Equal(t, respCode, tc.statusCode)
+		if tc.statusCode > 299 {
+			assert.Error(t, err, errPathNotFound.Error())
+		}
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/server.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/server.go
@@ -50,6 +50,8 @@ func exposeMetricsEndpoint(log *logger.Logger, config *common.Config, ns func(st
 	if enableProcessStats {
 		r.HandleFunc("/processes", processesHandler(routesFetchFn))
 		r.Handle("/processes/{processID}", createHandler(processHandler(statsHandler)))
+		r.Handle("/processes/{processID}/", createHandler(processHandler(statsHandler)))
+		r.Handle("/processes/{processID}/{beatsEndpoint}", createHandler(processHandler(statsHandler)))
 	}
 
 	mux := http.NewServeMux()

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/server.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/server.go
@@ -51,7 +51,7 @@ func exposeMetricsEndpoint(log *logger.Logger, config *common.Config, ns func(st
 		r.HandleFunc("/processes", processesHandler(routesFetchFn))
 		r.Handle("/processes/{processID}", createHandler(processHandler(statsHandler)))
 		r.Handle("/processes/{processID}/", createHandler(processHandler(statsHandler)))
-		r.Handle("/processes/{processID}/{beatsEndpoint}", createHandler(processHandler(statsHandler)))
+		r.Handle("/processes/{processID}/{beatsPath}", createHandler(processHandler(statsHandler)))
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

proxy requests to the exposed subprocess for gathering metrics.

## Why is it important?

in order for libbeat services, such as apm-server, to be easily scraped and displayed in the stack monitoring ui, both the `/stats` and `/state` endpoints are necessary. exposing both of these makes it easy to use the `beat` module in metricbeat, as well.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- start the elastic-agent
- verify that requests to a subprocess are proxied to its metrics endpoints:
    
```
# curl -s http://localhost:6791/processes/metricbeat-default | jq '.|keys'
[
  "beat",
  "hostname",
  "name",
  "uuid",
  "version"
]

# curl -s http://localhost:6791/processes/metricbeat-default/state | jq '.|keys'
[
  "beat",
  "host",
  "management",
  "module",
  "output",
  "outputs",
  "queue",
  "service"
]

# curl -s http://localhost:6791/processes/metricbeat-default/stats | jq '.|keys'
[
  "beat",
  "libbeat",
  "metricbeat",
  "system"
]
```

