### PR TITLE
Remove overwriting AWS config with endpoint in aws-cloudwatch input

### DIFF
--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -154,15 +154,13 @@ func (in *awsCloudWatchInput) Run() {
 				in.logger.Infof("aws-cloudwatch input worker for log group: '%v' has started", in.config.LogGroupName)
 				defer in.logger.Infof("aws-cloudwatch input worker for log group '%v' has stopped.", in.config.LogGroupName)
 				defer in.workerWg.Done()
-				in.run()
+				in.run(svc)
 			}()
 		})
 	}
 }
 
-func (in *awsCloudWatchInput) run() {
-	cwConfig := awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, "cloudwatchlogs", in.config.RegionName, in.awsConfig)
-	svc := cloudwatchlogs.New(cwConfig)
+func (in *awsCloudWatchInput) run(svc cloudwatchlogsiface.ClientAPI) {
 	for in.inputCtx.Err() == nil {
 		err := in.getLogEventsFromCloudWatch(svc)
 		if err != nil {


### PR DESCRIPTION
## What does this PR do?

This fix is supposed to be a part of https://github.com/elastic/beats/pull/27007 to fix the hardcoded "cloudwatchlogs" service name for aws-cloudwatch input. 