### PR TITLE
[packaging][ci] simplify input parameters

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -40,8 +40,6 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'macos', defaultValue: false, description: 'Allow macOS stages.')
-    booleanParam(name: 'linux', defaultValue: true, description: 'Allow linux stages.')
-    booleanParam(name: 'arm', defaultValue: true, description: 'Allow ARM stages.')
   }
   stages {
     stage('Filter build') {
@@ -125,12 +123,6 @@ pipeline {
               stage('Package Linux'){
                 agent { label 'ubuntu-18 && immutable' }
                 options { skipDefaultCheckout() }
-                when {
-                  beforeAgent true
-                  expression {
-                    return params.linux
-                  }
-                }
                 environment {
                   HOME = "${env.WORKSPACE}"
                   PLATFORMS = [
@@ -224,12 +216,6 @@ pipeline {
               stage('Package Docker images for linux/arm64'){
                 agent { label 'arm' }
                 options { skipDefaultCheckout() }
-                when {
-                  beforeAgent true
-                  expression {
-                    return params.arm
-                  }
-                }
                 environment {
                   HOME = "${env.WORKSPACE}"
                   PACKAGES = "docker"
@@ -335,7 +321,7 @@ def tagAndPush(Map args = [:]) {
   }
   // supported image flavours
   def variants = ["", "-oss", "-ubi8"]
-  // 
+  //
   if(beatName == 'elastic-agent'){
       variants.add("-complete")
   }


### PR DESCRIPTION
## What does this PR do?

Remove `linux` and `arm` input parameters.

## Why is it important?

Simplify the logic, since the e2e pipeline uses both architectures.

Rather than adding more logic to the e2e pipeline in case a packaging build was triggered through the UI in Jenkins. Let's enforce the rule to build docker images for both architectures.

Maybe the granularity could be done on a beats level, since the current bottleneck happens with the `x-pack/elastic-agent` module. But that's something that could be anyway solved if we use the `packaging` and `e2e` within the default/main CI pipeline that already provides those particular stages.


