### PR TITLE
Use v8format=true for Kibana health check

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -36,6 +36,6 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:8.0.0-7e122dd9-SNAPSHOT
     healthcheck:
-      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
+      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600
       interval: 1s


### PR DESCRIPTION
## What does this PR do?

The default format of the /api/status output is changing so update our
check. We'll use v8format=true so that checks against older images will
pass too.

Relates https://github.com/elastic/kibana/pull/110830

## Why is it important?

Allows tests to execute under newer Kibana versions.

## Logs

Old format:
```json

{
  "name": "fd1c727b700f",
  "uuid": "903de1b1-9d8b-4db6-9932-00c8ccd26bbc",
  "version": {
    "number": "8.0.0",
    "build_hash": "b1f38f459f9b5f259e9f99ad9d02f67e90505830",
    "build_number": 45390,
    "build_snapshot": true
  },
  "status": {
    "overall": {
      "since": "2021-09-29T13:46:24.658Z",
      "state": "yellow",
      "title": "Yellow",
      "nickname": "I'll be back",
      "icon": "warning",
      "uiColor": "warning"
    },
```

New format:
```json
{
  "name": "7d1500db67ba",
  "uuid": "d55b6d6c-0b87-4364-915f-cc92af242a67",
  "version": {
    "number": "8.0.0",
    "build_hash": "c647929eeb7881bf3f80dcc1d4dab0027650666e",
    "build_number": 46558,
    "build_snapshot": true
  },
  "status": {
    "overall": {
      "level": "available",
      "summary": "All services are available"
    },
    "core": {
      "elasticsearch": {
        "level": "available",
        "summary": "Elasticsearch is available",
        "meta": {
          "warningNodes": [],
          "incompatibleNodes": []
        }
      },
      "savedObjects": {
        "level": "available",
        "summary": "SavedObjects service has completed migrations and is available",
        "meta": {
          "migratedIndices": {
            "migrated": 0,
            "skipped": 0,
            "patched": 2
          }
        }
      }
    },
```