### PR TITLE
Missing setup.ilm.enabled: false in docs.

### DIFF
--- a/libbeat/docs/howto/change-index-name.asciidoc
+++ b/libbeat/docs/howto/change-index-name.asciidoc
@@ -24,7 +24,7 @@ setup.template.pattern: "customname-*"
 -----
 
 ifndef::no_ilm[]
-WARNING: If <<ilm,index lifecycle management>> is enabled (which is typically the default), `setup.template.name` and `setup.template.pattern` are ignored. Thus you need to set `setup.ilm.enabled: false` for it to work.
+WARNING: If <<ilm,index lifecycle management>> is enabled (which is typically the default), `setup.template.name` and `setup.template.pattern` are ignored. Thus you must also set setup.ilm.enabled: false to disable index lifecycle management.
 endif::no_ilm[]
 
 ifndef::no_dashboards[]

--- a/libbeat/docs/howto/change-index-name.asciidoc
+++ b/libbeat/docs/howto/change-index-name.asciidoc
@@ -24,7 +24,7 @@ setup.template.pattern: "customname-*"
 -----
 
 ifndef::no_ilm[]
-WARNING: If <<ilm,index lifecycle management>> is enabled (which is typically the default), `setup.template.name` and `setup.template.pattern` are ignored.
+WARNING: If <<ilm,index lifecycle management>> is enabled (which is typically the default), `setup.template.name` and `setup.template.pattern` are ignored. Thus you need to set `setup.ilm.enabled: false` for it to work.
 endif::no_ilm[]
 
 ifndef::no_dashboards[]


### PR DESCRIPTION
<!-- Type of change
- Docs
-->

## What does this PR do?

Added a line to the docs that represents the `setup.ilm.enabled: false` setting to be needed when sending to alternate indexes.

## Why is it important?

If you follow the guide now, you would edit the setup.template.name and setup.template.pattern and output.elasticsearch.index but not edit the `setup.ilm.enabled` and thus it will not work.


