### PR TITLE
[Winlogbeat] Tolerate faults when Windows Event Log session is interrupted

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -302,6 +302,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update indentation for azure filebeat configuration. {pull}26604[26604]
 - Update Sophos xg module pipeline to deal with missing `date` and `time` fields. {pull}27834[27834]
 - sophos/xg fileset: Add missing pipeline for System Health logs. {pull}27827[27827] {issue}27826[27826]
+- Tolerate faults when Windows Event Log session is interrupted {issue}27947[27947] {pull}XXXXX[XXXXX]
 
 *Heartbeat*
 
@@ -418,6 +419,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add source.ip validation for event ID 4778 in the Security module. {issue}19627[19627]
 - Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
 - Protect against accessing an undefined variable in Security module. {pull}22937[22937]
+- Tolerate faults when Windows Event Log session is interrupted {issue}27947[27947] {pull}XXXXX[XXXXX]
 
 *Functionbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -302,7 +302,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update indentation for azure filebeat configuration. {pull}26604[26604]
 - Update Sophos xg module pipeline to deal with missing `date` and `time` fields. {pull}27834[27834]
 - sophos/xg fileset: Add missing pipeline for System Health logs. {pull}27827[27827] {issue}27826[27826]
-- Tolerate faults when Windows Event Log session is interrupted {issue}27947[27947] {pull}XXXXX[XXXXX]
+- Tolerate faults when Windows Event Log session is interrupted {issue}27947[27947] {pull}28191[28191]
 
 *Heartbeat*
 
@@ -419,7 +419,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add source.ip validation for event ID 4778 in the Security module. {issue}19627[19627]
 - Protect against accessing undefined variables in Sysmon module. {issue}22219[22219] {pull}22236[22236]
 - Protect against accessing an undefined variable in Security module. {pull}22937[22937]
-- Tolerate faults when Windows Event Log session is interrupted {issue}27947[27947] {pull}XXXXX[XXXXX]
+- Tolerate faults when Windows Event Log session is interrupted {issue}27947[27947] {pull}28191[28191]
 
 *Functionbeat*
 

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -106,7 +106,7 @@ runLoop:
 		openErr := api.Open(evtCheckpoint)
 		if eventlog.IsRecoverable(openErr) {
 			log.Errorf("Encountered recoverable error when opening Windows Event Log: %v", openErr)
-			timed.Wait(cancelCtx, 5 * time.Second)
+			timed.Wait(cancelCtx, 5*time.Second)
 			continue
 		} else if openErr != nil {
 			return fmt.Errorf("failed to open windows event log: %v", openErr)

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -106,7 +106,7 @@ runLoop:
 		openErr := api.Open(evtCheckpoint)
 		if eventlog.IsRecoverable(openErr) {
 			log.Errorf("Encountered recoverable error when opening Windows Event Log: %v", openErr)
-			time.Sleep(time.Second * 5)
+			timed.Wait(cancelCtx, 5 * time.Second)
 			continue
 		} else if openErr != nil {
 			return fmt.Errorf("failed to open windows event log: %v", openErr)

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -106,7 +106,7 @@ runLoop:
 		openErr := api.Open(evtCheckpoint)
 		if eventlog.IsRecoverable(openErr) {
 			log.Errorf("Encountered recoverable error when opening Windows Event Log: %v", openErr)
-			time.Sleep(time.Second*5)
+			time.Sleep(time.Second * 5)
 			continue
 		} else if openErr != nil {
 			return fmt.Errorf("failed to open windows event log: %v", openErr)

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -85,16 +85,7 @@ func (eventlogRunner) Run(
 	publisher cursor.Publisher,
 ) error {
 	log := ctx.Logger.With("eventlog", source.Name())
-	checkpoint := initCheckpoint(log, cursor)
-
 	api := source.(eventlog.EventLog)
-
-	err := api.Open(checkpoint)
-	if err != nil {
-		return fmt.Errorf("failed to open windows event log: %v", err)
-	}
-
-	log.Debugf("Windows Event Log '%s' opened successfully", source.Name())
 
 	// setup closing the API if either the run function is signaled asynchronously
 	// to shut down or when returning after io.EOF
@@ -105,41 +96,64 @@ func (eventlogRunner) Run(
 	})
 	defer cancelFn()
 
-	// read loop
-	for cancelCtx.Err() == nil {
-		records, err := api.Read()
-		switch err {
-		case nil:
-			break
-		case io.EOF:
-			log.Debugf("End of Winlog event stream reached: %v", err)
+runLoop:
+	for {
+		if cancelCtx.Err() != nil {
 			return nil
-		default:
-			// only log error if we are not shutting down
-			if cancelCtx.Err() != nil {
+		}
+
+		evtCheckpoint := initCheckpoint(log, cursor)
+		openErr := api.Open(evtCheckpoint)
+		if eventlog.IsRecoverable(openErr) {
+			log.Errorf("Encountered recoverable error when opening Windows Event Log: %v", openErr)
+			time.Sleep(time.Second*5)
+			continue
+		} else if openErr != nil {
+			return fmt.Errorf("failed to open windows event log: %v", openErr)
+		}
+		log.Debugf("Windows Event Log '%s' opened successfully", source.Name())
+
+		// read loop
+		for cancelCtx.Err() == nil {
+			records, err := api.Read()
+			if eventlog.IsRecoverable(err) {
+				log.Errorf("Encountered recoverable error when reading from Windows Event Log: %v", err)
+				if closeErr := api.Close(); closeErr != nil {
+					log.Errorf("Error closing Windows Event Log handle: %v", closeErr)
+				}
+				continue runLoop
+			}
+			switch err {
+			case nil:
+				break
+			case io.EOF:
+				log.Debugf("End of Winlog event stream reached: %v", err)
 				return nil
+			default:
+				// only log error if we are not shutting down
+				if cancelCtx.Err() != nil {
+					return nil
+				}
+
+				log.Errorf("Error occured while reading from Windows Event Log '%v': %v", source.Name(), err)
+				return err
 			}
 
-			log.Errorf("Error occured while reading from Windows Event Log '%v': %v", source.Name(), err)
-			return err
-		}
+			if len(records) == 0 {
+				timed.Wait(cancelCtx, time.Second)
+				continue
+			}
 
-		if len(records) == 0 {
-			timed.Wait(cancelCtx, time.Second)
-			continue
-		}
-
-		for _, record := range records {
-			event := record.ToEvent()
-			if err := publisher.Publish(event, record.Offset); err != nil {
-				// Publisher indicates disconnect when returning an error.
-				// stop trying to publish records and quit
-				return err
+			for _, record := range records {
+				event := record.ToEvent()
+				if err := publisher.Publish(event, record.Offset); err != nil {
+					// Publisher indicates disconnect when returning an error.
+					// stop trying to publish records and quit
+					return err
+				}
 			}
 		}
 	}
-
-	return nil
 }
 
 func initCheckpoint(log *logp.Logger, cursor cursor.Cursor) checkpoint.EventLogState {

--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -134,7 +134,7 @@ runLoop:
 		err = api.Open(state)
 		if eventlog.IsRecoverable(err) {
 			e.log.Warnw("Open() encountered recoverable error. Trying again...", "error", err)
-			time.Sleep(time.Second*5)
+			time.Sleep(time.Second * 5)
 			continue
 		} else if err != nil {
 			e.log.Warnw("Open() error. No events will be read from this source.", "error", err)

--- a/winlogbeat/eventlog/errors_unix.go
+++ b/winlogbeat/eventlog/errors_unix.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build !windows
+
+package eventlog
+
+// IsRecoverable returns a boolean indicating whether the error represents
+// a condition where the Windows Event Log session can be recovered through a
+// reopening of the handle (Close, Open).
+func IsRecoverable(err error) bool {
+	return false
+}

--- a/winlogbeat/eventlog/errors_windows.go
+++ b/winlogbeat/eventlog/errors_windows.go
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package eventlog
+
+import (
+	win "github.com/elastic/beats/v7/winlogbeat/sys/wineventlog"
+)
+
+// IsRecoverable returns a boolean indicating whether the error represents
+// a condition where the Windows Event Log session can be recovered through a
+// reopening of the handle (Close, Open).
+func IsRecoverable(err error) bool {
+	return err == win.ERROR_INVALID_HANDLE || err == win.RPC_S_SERVER_UNAVAILABLE || err == win.RPC_S_CALL_CANCELLED
+}

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -28,6 +28,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/winlogbeat/checkpoint"
 	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
+	win "github.com/elastic/beats/v7/winlogbeat/sys/wineventlog"
 )
 
 // Debug selectors used in this package.
@@ -50,6 +51,13 @@ var (
 	// readErrors contains counters for the read error types that occur.
 	readErrors = expvar.NewMap("read_errors")
 )
+
+// IsRecoverable returns a boolean indicating whether the error represents
+// a condition where the Windows Event Log session can be recovered through a
+// reopening of the handle (Close, Open).
+func IsRecoverable(err error) bool {
+	return err == win.ERROR_INVALID_HANDLE || err == win.RPC_S_SERVER_UNAVAILABLE || err == win.RPC_S_CALL_CANCELLED
+}
 
 // EventLog is an interface to a Windows Event Log.
 type EventLog interface {

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -28,7 +28,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/winlogbeat/checkpoint"
 	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
-	win "github.com/elastic/beats/v7/winlogbeat/sys/wineventlog"
 )
 
 // Debug selectors used in this package.
@@ -51,13 +50,6 @@ var (
 	// readErrors contains counters for the read error types that occur.
 	readErrors = expvar.NewMap("read_errors")
 )
-
-// IsRecoverable returns a boolean indicating whether the error represents
-// a condition where the Windows Event Log session can be recovered through a
-// reopening of the handle (Close, Open).
-func IsRecoverable(err error) bool {
-	return err == win.ERROR_INVALID_HANDLE || err == win.RPC_S_SERVER_UNAVAILABLE || err == win.RPC_S_CALL_CANCELLED
-}
 
 // EventLog is an interface to a Windows Event Log.
 type EventLog interface {

--- a/winlogbeat/sys/wineventlog/syscall_windows.go
+++ b/winlogbeat/sys/wineventlog/syscall_windows.go
@@ -41,9 +41,12 @@ const NilHandle EvtHandle = 0
 // Event log error codes.
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
 const (
+	ERROR_INVALID_HANDLE      syscall.Errno = 6
 	ERROR_INSUFFICIENT_BUFFER syscall.Errno = 122
 	ERROR_NO_MORE_ITEMS       syscall.Errno = 259
+	RPC_S_SERVER_UNAVAILABLE  syscall.Errno = 1722
 	RPC_S_INVALID_BOUND       syscall.Errno = 1734
+	RPC_S_CALL_CANCELLED      syscall.Errno = 1818
 	ERROR_INVALID_OPERATION   syscall.Errno = 4317
 )
 


### PR DESCRIPTION
## What does this PR do?

- Added a retry mechanism to winlog/input and winlogbeat to reopen a
session to Windows Event Log when certain error conditions are encountered.
- This applies when opening a session to Windows Event Log and
also when reading from Windows Event Log.

## Why is it important?

- Filebeat/winlogbeat should be able to tolerate disruptions with the Windows Event Log service without having to be manually restarted by the user.

## Checklist

- [x] My code follows the style guidelines of this project
    - [x] I have commented my code, particularly in hard-to-understand areas
    - ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

### Reproducing the issue

- Run filebeat (with winlog input) or winlogbeat on Windows system. The channel subscription doesn't
matter, it can be `Security` or other channels. Make sure debug logging and logging to STDERR is enabled.

```powershell
.\winlogbeat -e -d "*"
```
```powershell
.\filebeat -e -d "*"
```

- You should eventually see messages every second indicating no logs to read. This is normal.
- Stop the `Windows Event Log` service.
- The filebeat/winlogbeat log should report errors (usually RPC cancelled). The messages logged every second no longer appear.
- Restarting the `Windows Event Log` service has no effect. New event logs are not picked up by filebeat/winlogbeat.
- The only way to get filebeat/winlogbeat watching logs again is to restart it.

### Testing the fix

- Deploy fixed binary to system
- Run filebeat/winlogbeat as before
- Stop the `Windows Event Log` service.
- Watch the logs for "Recoverable error". The handle to Windows Event Log should be reopened within a matter of seconds.
- Start the `Windows Event Log` service.
- New events should flow in as they are generated.

## Logs

The following logs are from filebeat. Winlogbeat produces similar logs.

Logs showing normal activity (when no event logs are being generated):
```
2021-09-29T07:09:39.778-0700    DEBUG   [eventlog_detail]       eventlog/wineventlog.go:298     WinEventLog[Security] No more events
2021-09-29T07:09:40.788-0700    DEBUG   [eventlog_detail]       eventlog/wineventlog.go:298     WinEventLog[Security] No more events
2021-09-29T07:09:41.794-0700    DEBUG   [eventlog_detail]       eventlog/wineventlog.go:298     WinEventLog[Security] No more events
2021-09-29T07:09:42.799-0700    DEBUG   [eventlog_detail]       eventlog/wineventlog.go:298     WinEventLog[Security] No more events
...
```

Logs indicating original problem (error may vary):
```
2021-09-29T07:09:51.939-0700    WARN    eventlog/wineventlog.go:314     WinEventLog[Security] EventHandles returned error The remote procedure call was cancelled.
2021-09-29T07:09:51.939-0700    ERROR   [input.winlog]  winlog/input.go:123     Error occured while reading from Windows Event Log 'Security': The remote procedure call was cancelled.       {"id": "DF05023D528B0A9F", "input_source": "Security", "eventlog": "Security"}

...

2021-09-29T07:09:51.939-0700    DEBUG   [eventlog]      eventlog/wineventlog.go:284     WinEventLog[Security] Closing handle
2021-09-29T07:09:51.939-0700    ERROR   [input.winlog]  compat/compat.go:122    Input 'winlog' failed with: input.go:130: input DF05023D528B0A9F failed (id=DF05023D528B0A9F)
        The remote procedure call was cancelled.        {"id": "DF05023D528B0A9F"}
```

Logs showing issue resolved by fix (error may vary):
```
2021-09-29T07:00:28.159-0700    ERROR   [input.winlog]  winlog/input.go:110     Encountered recoverable error when opening Windows Event Log: The RPC server is unavailable.  {"id": "DF05023D528B0A9F", "input_source": "Security", "eventlog": "Security"}

...

2021-09-29T07:00:33.165-0700    DEBUG   [input.winlog]  winlog/input.go:116     Windows Event Log 'Security' opened successfully     {"id": "DF05023D528B0A9F", "input_source": "Security", "eventlog": "Security"}
```

## Related issues

- Closes #27947
