### PR TITLE
processors/actions/add_fields: Do not panic if event.Fields is nil map

### DIFF
--- a/libbeat/processors/actions/add_fields.go
+++ b/libbeat/processors/actions/add_fields.go
@@ -77,7 +77,9 @@ func (af *addFields) Run(event *beat.Event) (*beat.Event, error) {
 		fields = fields.Clone()
 	}
 
-	if af.overwrite {
+	if event.Fields == nil {
+		event.Fields = fields
+	} else if af.overwrite {
 		event.Fields.DeepUpdate(fields)
 	} else {
 		event.Fields.DeepUpdateNoOverwrite(fields)

--- a/libbeat/processors/actions/add_fields_test.go
+++ b/libbeat/processors/actions/add_fields_test.go
@@ -113,5 +113,12 @@ func TestAddFields(t *testing.T) {
 				`{add_fields: {target: "", fields: {a.change: b}}}`,
 			),
 		},
+		"add fields to nil event": {
+			event: nil,
+			want: common.MapStr{
+				"fields": common.MapStr{"field": "test"},
+			},
+			cfg: single(`{add_fields: {fields: {field: test}}}`),
+		},
 	})
 }

--- a/libbeat/processors/actions/common_test.go
+++ b/libbeat/processors/actions/common_test.go
@@ -50,7 +50,10 @@ func testProcessors(t *testing.T, cases map[string]testCase) {
 				}
 			}
 
-			current := &beat.Event{Fields: test.event.Clone()}
+			current := &beat.Event{}
+			if test.event != nil {
+				current.Fields = test.event.Clone()
+			}
 			for i, processor := range ps {
 				var err error
 				current, err = processor.Run(current)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Avoid panicking when the add_fields processor is run on an event whose Fields map is nil. This can be the case when setting normalize to `false` in [`MakeDefaultSupport`](https://github.com/elastic/beats/blob/cca59bad174b56ced2f74bccc6694f233752eecd/libbeat/publisher/processing/default.go#L96).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Disabling event normalization avoids copying every event into a second map (and its memory allocation along with it).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]
