### PR TITLE
Avoid copying message text to string for filestream input isDroppedLine check

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -63,6 +63,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Fix export dashboard command when running against Elastic Cloud hosted Kibana. {pull}22746[22746]
 - Remove `event.dataset` (ECS) annotion from `libbeat.logp`. {issue}27404[27404]
 - Errors should be thrown as errors. Metricsets inside Metricbeat will now throw errors as the `error` log level. {pull}27804[27804]
+- Avoid copying message text to string for filestream input's `isDroppedLine` check {pull}TODO[TODO]
 
 ==== Added
 

--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -325,7 +325,7 @@ func (inp *filestream) readFromSource(
 
 		s.Offset += int64(message.Bytes)
 
-		if message.IsEmpty() || inp.isDroppedLine(log, string(message.Content)) {
+		if message.IsEmpty() || inp.isDroppedLine(log, message.Content) {
 			continue
 		}
 
@@ -338,7 +338,7 @@ func (inp *filestream) readFromSource(
 
 // isDroppedLine decides if the line is exported or not based on
 // the include_lines and exclude_lines options.
-func (inp *filestream) isDroppedLine(log *logp.Logger, line string) bool {
+func (inp *filestream) isDroppedLine(log *logp.Logger, line []byte) bool {
 	if len(inp.readerConfig.IncludeLines) > 0 {
 		if !matchAny(inp.readerConfig.IncludeLines, line) {
 			log.Debug("Drop line as it does not match any of the include patterns %s", line)
@@ -355,9 +355,9 @@ func (inp *filestream) isDroppedLine(log *logp.Logger, line string) bool {
 	return false
 }
 
-func matchAny(matchers []match.Matcher, text string) bool {
+func matchAny(matchers []match.Matcher, text []byte) bool {
 	for _, m := range matchers {
-		if m.MatchString(text) {
+		if m.Match(text) {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

In go, converting the byte slice `content.Message` to a string causes a new memory allocation to create the immutable copy. This is not necessary to match against the stored regular expressions, as `Match` can operate against a byte slice. This change removes the unneeded string conversion.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
