### PR TITLE
Breaking change for 8.0, namespace_annotations replaced by namespace.annotations

### DIFF
--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -217,8 +217,7 @@ func generatePodData(
 	k8sMapping := map[string]interface{}(kubemetaMap.(common.MapStr).Clone())
 
 	if len(namespaceAnnotations) != 0 {
-		// TODO: convert it to namespace.annotations for 8.0
-		k8sMapping["namespace_annotations"] = namespaceAnnotations
+		k8sMapping["namespace"].(common.MapStr).Put("annotations", namespaceAnnotations)
 	}
 
 	// Pass annotations to all events so that it can be used in templating and by annotation builders.
@@ -285,8 +284,7 @@ func generateContainerData(
 		k8sMapping := map[string]interface{}(kubemetaMap.(common.MapStr).Clone())
 
 		if len(namespaceAnnotations) != 0 {
-			// TODO: convert it to namespace.annotations for 8.0
-			k8sMapping["namespace_annotations"] = namespaceAnnotations
+			k8sMapping["namespace"].(common.MapStr).Put("annotations", namespaceAnnotations)
 		}
 
 		// add annotations to be discoverable by templates

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod_test.go
@@ -50,14 +50,16 @@ func TestGeneratePodData(t *testing.T) {
 	data := generatePodData(pod, &Config{}, &podMeta{}, namespaceAnnotations)
 
 	mapping := map[string]interface{}{
-		"namespace": pod.GetNamespace(),
+		"namespace": common.MapStr{
+			"name": pod.GetNamespace(),
+			"annotations": common.MapStr{
+				"nsa": "nsb",
+			},
+		},
 		"pod": common.MapStr{
 			"uid":  string(pod.GetUID()),
 			"name": pod.GetName(),
 			"ip":   pod.Status.PodIP,
-		},
-		"namespace_annotations": common.MapStr{
-			"nsa": "nsb",
 		},
 		"labels": common.MapStr{
 			"foo": "bar",
@@ -73,7 +75,9 @@ func TestGeneratePodData(t *testing.T) {
 				"name": "devcluster",
 				"url":  "8.8.8.8:9090"},
 		}, "kubernetes": common.MapStr{
-			"namespace": "testns",
+			"namespace": common.MapStr{
+				"name": "testns",
+			},
 			"labels": common.MapStr{
 				"foo": "bar",
 			},
@@ -157,7 +161,12 @@ func TestGenerateContainerPodData(t *testing.T) {
 		})
 
 	mapping := map[string]interface{}{
-		"namespace": pod.GetNamespace(),
+		"namespace": common.MapStr{
+			"name": pod.GetNamespace(),
+			"annotations": common.MapStr{
+				"nsa": "nsb",
+			},
+		},
 		"pod": common.MapStr{
 			"uid":  string(pod.GetUID()),
 			"name": pod.GetName(),
@@ -170,9 +179,6 @@ func TestGenerateContainerPodData(t *testing.T) {
 			"runtime":   "crio",
 			"port":      "80",
 			"port_name": "http",
-		},
-		"namespace_annotations": common.MapStr{
-			"nsa": "nsb",
 		},
 		"annotations": common.MapStr{
 			"app": "production",
@@ -192,7 +198,9 @@ func TestGenerateContainerPodData(t *testing.T) {
 				"name": "devcluster",
 				"url":  "8.8.8.8:9090"},
 		}, "kubernetes": common.MapStr{
-			"namespace":   "testns",
+			"namespace": common.MapStr{
+				"name": "testns",
+			},
 			"annotations": common.MapStr{"app": "production"},
 			"labels":      common.MapStr{"foo": "bar"},
 			"pod": common.MapStr{
@@ -272,7 +280,12 @@ func TestEphemeralContainers(t *testing.T) {
 		})
 
 	mapping := map[string]interface{}{
-		"namespace": pod.GetNamespace(),
+		"namespace": common.MapStr{
+			"name": pod.GetNamespace(),
+			"annotations": common.MapStr{
+				"nsa": "nsb",
+			},
+		},
 		"pod": common.MapStr{
 			"uid":  string(pod.GetUID()),
 			"name": pod.GetName(),
@@ -286,9 +299,6 @@ func TestEphemeralContainers(t *testing.T) {
 			"name":    "nginx",
 			"image":   "nginx:1.120",
 			"runtime": "crio",
-		},
-		"namespace_annotations": common.MapStr{
-			"nsa": "nsb",
 		},
 		"annotations": common.MapStr{
 			"app": "production",
@@ -305,7 +315,9 @@ func TestEphemeralContainers(t *testing.T) {
 				"name": "devcluster",
 				"url":  "8.8.8.8:9090"},
 		}, "kubernetes": common.MapStr{
-			"namespace":   "testns",
+			"namespace": common.MapStr{
+				"name": "testns",
+			},
 			"labels":      common.MapStr{"foo": "bar"},
 			"annotations": common.MapStr{"app": "production"},
 			"pod": common.MapStr{
@@ -381,7 +393,9 @@ func (p *podMeta) GenerateECS(obj kubernetes.Resource) common.MapStr {
 func (p *podMeta) GenerateK8s(obj kubernetes.Resource, opts ...metadata.FieldOptions) common.MapStr {
 	k8sPod := obj.(*kubernetes.Pod)
 	return common.MapStr{
-		"namespace": k8sPod.GetNamespace(),
+		"namespace": common.MapStr{
+			"name": k8sPod.GetNamespace(),
+		},
 		"pod": common.MapStr{
 			"uid":  string(k8sPod.GetUID()),
 			"name": k8sPod.GetName(),

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -169,8 +169,7 @@ func generateServiceData(
 	k8sMapping := map[string]interface{}(kubemetaMap.(common.MapStr).Clone())
 
 	if len(namespaceAnnotations) != 0 {
-		// TODO: convert it to namespace.annotations for 8.0
-		k8sMapping["namespace_annotations"] = namespaceAnnotations
+		k8sMapping["namespace"].(common.MapStr).Put("annotations", namespaceAnnotations)
 	}
 
 	// Pass annotations to all events so that it can be used in templating and by annotation builders.

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service_test.go
@@ -61,8 +61,11 @@ func TestGenerateServiceData(t *testing.T) {
 			"name": service.GetName(),
 			"ip":   service.Spec.ClusterIP,
 		},
-		"namespace_annotations": common.MapStr{
-			"nsa": "nsb",
+		"namespace": common.MapStr{
+			"annotations": common.MapStr{
+				"nsa": "nsb",
+			},
+			"name": "testns",
 		},
 		"annotations": common.MapStr{
 			"baz": "ban",
@@ -82,6 +85,9 @@ func TestGenerateServiceData(t *testing.T) {
 				"uid":  string(service.GetUID()),
 				"name": service.GetName(),
 				"ip":   "1.2.3.4",
+			},
+			"namespace": common.MapStr{
+				"name": "testns",
 			},
 			"labels": common.MapStr{
 				"foo": "bar",
@@ -147,6 +153,9 @@ func (s *svcMeta) GenerateK8s(obj kubernetes.Resource, opts ...metadata.FieldOpt
 		},
 		"annotations": common.MapStr{
 			"baz": "ban",
+		},
+		"namespace": common.MapStr{
+			"name": k8sNode.GetNamespace(),
 		},
 	}
 }


### PR DESCRIPTION


## What does this PR do?

As part of https://github.com/elastic/beats/issues/16483  and after merging of https://github.com/elastic/beats/pull/27917 which 

- Updates `kubernetes.namespace` from keyword to group field. 
-  Moves `kubernetes.namespace` which was the name of the namespace to `kubernetes.namespace.name` field.
- Renames `namespace_labels` and `namespace_annotations` metadata  to `namespace.labels` and `namespace.annotations`

Agent's k8s provider needs to be handled accordingly.
In this PR 

- The mappings created by pod and service watcher are updated to add the namespace annotations correctly as `namespace.annotations` instead of `namespace_annotations`.

## Why is it important?

The fields `namespace_annotations` will not be published anymore in 8.0 release. The namespace annotations will be part of `namespace` field which is updated from string to group. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
