### PR TITLE
[mergify] remove backport-skip if added a backport label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -115,6 +115,13 @@ pull_request_rules:
       label:
         add:
           - backport-skip
+  - name: remove-backport label
+    conditions:
+      - label~=backport-v
+    actions:
+      label:
+        remove:
+          - backport-skip
   - name: backport patches to 7.x branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

Remove `backport-skip` label when the backport labels have been added.

## Why is it important?

Keep tidy the GItHub labels

## Test

![image](https://user-images.githubusercontent.com/2871786/136009191-20909c29-d1e3-441c-8bf0-106a29993890.png)

https://github.com/v1v/poc-bump-automation/pull/13
