### PR TITLE
add support for kinesis record deaggregation in functionbeat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -878,6 +878,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for parallelization factor for kinesis. {pull}20727[20727]
 - Provide more ways to set AWS credentials. {issue}12464[12464] {pull}23344[23344]
 - Add support for multiple regions {pull}21065[21065]
+- Add support for AWS Kinesis record deaggregation {pull}TODO[TODO]
 
 *Winlogbeat*
 

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,10 @@ require (
 	github.com/apoydence/eachers v0.0.0-20181020210610-23942921fe77 // indirect
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/aws/aws-lambda-go v1.6.0
+	github.com/aws/aws-sdk-go v1.19.48
 	github.com/aws/aws-sdk-go-v2 v0.24.0
 	github.com/awslabs/goformation/v4 v4.1.0
+	github.com/awslabs/kinesis-aggregation/go v0.0.0-20200810181507-d352038274c0
 	github.com/blakesmith/ar v0.0.0-20150311145944-8bd4349a67f2
 	github.com/bsm/sarama-cluster v2.1.14-0.20180625083203-7e67d87a6b3f+incompatible
 	github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,11 +128,15 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-lambda-go v1.6.0 h1:T+u/g79zPKw1oJM7xYhvpq7i4Sjc0iVsXZUaqRVVSOg=
 github.com/aws/aws-lambda-go v1.6.0/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
+github.com/aws/aws-sdk-go v1.19.48 h1:YhKzuc9xggUt8jNDc5CmIBeB8GmGtazzq0aCXO4sj6w=
+github.com/aws/aws-sdk-go v1.19.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.24.0 h1:R0lL0krk9EyTI1vmO1ycoeceGZotSzCKO51LbPGq3rU=
 github.com/aws/aws-sdk-go-v2 v0.24.0/go.mod h1:2LhT7UgHOXK3UXONKI5OMgIyoQL6zTAw/jwIeX6yqzw=
 github.com/awslabs/goformation/v3 v3.1.0/go.mod h1:hQ5RXo3GNm2laHWKizDzU5DsDy+yNcenSca2UxN0850=
 github.com/awslabs/goformation/v4 v4.1.0 h1:JRxIW0IjhYpYDrIZOTJGMu2azXKI+OK5dP56ubpywGU=
 github.com/awslabs/goformation/v4 v4.1.0/go.mod h1:MBDN7u1lMNDoehbFuO4uPvgwPeolTMA2TzX1yO6KlxI=
+github.com/awslabs/kinesis-aggregation/go v0.0.0-20200810181507-d352038274c0 h1:D97PNkeea5i2Sbq844BdbULqI5pv7yQw4thPwqEX504=
+github.com/awslabs/kinesis-aggregation/go v0.0.0-20200810181507-d352038274c0/go.mod h1:SghidfnxvX7ribW6nHI7T+IBbc9puZ9kk5Tx/88h8P4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/x-pack/functionbeat/provider/aws/aws/kinesis.go
+++ b/x-pack/functionbeat/provider/aws/aws/kinesis.go
@@ -146,9 +146,12 @@ func (k *Kinesis) createHandler(client core.Client) func(request events.KinesisE
 	return func(request events.KinesisEvent) error {
 		k.log.Debugf("The handler receives %d events", len(request.Records))
 
-		events := transformer.KinesisEvent(request)
+		events, err := transformer.KinesisEvent(request)
+		if err != nil {
+			return err
+		}
 
-		if err := client.PublishAll(events); err != nil {
+		if err = client.PublishAll(events); err != nil {
 			k.log.Errorf("Could not publish events to the pipeline, error: %+v", err)
 			return err
 		}

--- a/x-pack/functionbeat/provider/aws/aws/kinesis_test.go
+++ b/x-pack/functionbeat/provider/aws/aws/kinesis_test.go
@@ -5,11 +5,16 @@
 package aws
 
 import (
+	"crypto/md5"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/awslabs/kinesis-aggregation/go/deaggregator"
+	aggRecProto "github.com/awslabs/kinesis-aggregation/go/records"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -39,6 +44,19 @@ func TestKinesis(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("when publish with agg is successful", func(t *testing.T) {
+		client := &arrayBackedClient{}
+		k, err := NewKinesis(&provider.DefaultProvider{}, cfg)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		c, _ := k.(*Kinesis)
+		handler := c.createHandler(client)
+		err = handler(generateAggregatedKinesisEvent(true))
+		assert.NoError(t, err)
+	})
+
 	t.Run("when publish is not successful", func(t *testing.T) {
 		e := errors.New("something bad")
 		client := &arrayBackedClient{err: e}
@@ -52,6 +70,19 @@ func TestKinesis(t *testing.T) {
 		handler := c.createHandler(client)
 		err = handler(generateKinesisEvent())
 		assert.Equal(t, e, err)
+	})
+
+	t.Run("when publish with agg is not successful", func(t *testing.T) {
+		client := &arrayBackedClient{}
+		k, err := NewKinesis(&provider.DefaultProvider{}, cfg)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		c, _ := k.(*Kinesis)
+		handler := c.createHandler(client)
+		err = handler(generateAggregatedKinesisEvent(false))
+		assert.Error(t, err)
 	})
 
 	t.Run("test config validation", testKinesisConfig)
@@ -69,6 +100,54 @@ func generateKinesisEvent() events.KinesisEvent {
 				EventSourceArn: "arn:aws:iam::00000000:role/functionbeat",
 				Kinesis: events.KinesisRecord{
 					Data:                 []byte("hello world"),
+					PartitionKey:         "abc123",
+					SequenceNumber:       "12345",
+					KinesisSchemaVersion: "v1",
+				},
+			},
+		},
+	}
+}
+
+func generateAggregatedKinesisEvent(validRec bool) events.KinesisEvent {
+	// Heavily based on https://github.com/awslabs/kinesis-aggregation/blob/master/go/deaggregator/deaggregator_test.go
+	aggRec := &aggRecProto.AggregatedRecord{}
+	unquotedHeader, err := strconv.Unquote(deaggregator.KplMagicHeader)
+	if err != nil {
+		panic(err)
+	}
+	aggRecBytes := []byte(unquotedHeader)
+	partKeyTable := make([]string, 0)
+	partKey := uint64(0)
+	hashKey := uint64(0)
+	r := &aggRecProto.Record{
+		ExplicitHashKeyIndex: &hashKey,
+		Data:                 []byte("hello world"),
+		Tags:                 make([]*aggRecProto.Tag, 0),
+	}
+	// This seems to be the only way to trigger the deaggregation module to return an error when needed
+	if validRec {
+		r.PartitionKeyIndex = &partKey
+	}
+	aggRec.Records = append(aggRec.Records, r)
+	partKeyTable = append(partKeyTable, "0")
+
+	aggRec.PartitionKeyTable = partKeyTable
+	data, _ := proto.Marshal(aggRec)
+	md5Hash := md5.Sum(data)
+	aggRecBytes = append(aggRecBytes, data...)
+	aggRecBytes = append(aggRecBytes, md5Hash[:]...)
+
+	return events.KinesisEvent{
+		Records: []events.KinesisEventRecord{
+			events.KinesisEventRecord{
+				AwsRegion:      "east-1",
+				EventID:        "1234",
+				EventName:      "connect",
+				EventSource:    "web",
+				EventSourceArn: "arn:aws:iam::00000000:role/functionbeat",
+				Kinesis: events.KinesisRecord{
+					Data:                 aggRecBytes,
 					PartitionKey:         "abc123",
 					SequenceNumber:       "12345",
 					KinesisSchemaVersion: "v1",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR adds support for properly deaggregating Kinesis records which are in the [aggregated record format](https://github.com/awslabs/amazon-kinesis-producer/blob/master/aggregation-format.md).

## Why is it important?
This change allows FunctionBeat to properly consume records being sent to Kinesis using the aggregated record format. Users often do this for throughput and cost optimization purposes. The current implementation will instead show single records that have the embedded Protobuf serialized format.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
Notes:
- Had to add AWS SDK v1 due to current `kinesis-aggregation` support. There is an [open PR](https://github.com/awslabs/kinesis-aggregation/pull/143) that adds v2 support. Whenever it is reviewed and merged, there can be a followup change to remove the v1 dependency.
- Performed end to end test to verify functionality using a local functionbeat build and test AWS account. Thanks to @ravinaik1312 for his help on testing this!


## How to test this PR locally

- Build local version of functionbeat
- Deploy to AWS Lambda function
- Send aggregated records to Kinesis stream (e.g. using KPL, fluentd, fluent-bit, etc. with the aggregated records option enabled)
- Verify records are properly deaggregated in Elastic

## Related issues

- Closes #28240 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
