### PR TITLE
Rename Fleet User Guide

### DIFF
--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -73,8 +73,8 @@ https://www.elastic.co/blog/beats-6-7-0-released[Beats 6.7.0 release blog].
 
 NOTE: {beats} central management has been removed starting in version 7.14.0.
 Looking for a replacement? Refer to the
-{fleet-guide}/index.html[Fleet User Guide] to learn how to deploy and centrally
-manage a single {agent} to monitor and secure each host. 
+{fleet-guide}/index.html[Fleet and Elastic Agent Guide] to learn how to deploy
+and centrally manage a single {agent} to monitor and secure each host. 
 
 ==== Upgrade {beats} binaries to 7.0
 


### PR DESCRIPTION
## What does this PR do?

Renames _Fleet User Guide_ to _Fleet and Elastic Agent Guide_

## Why is it important?

Required because the book is being renamed.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Relates https://github.com/elastic/observability-docs/issues/1104
