### PR TITLE
Port IncludeAnnotations setting to Agent and small manifest fix

### DIFF
--- a/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone-kubernetes.yaml
@@ -441,7 +441,7 @@ data:
       #      maxconn: 10
       #      network: tcp
       #      period: 10s
-      #      condition: ${kubernetes.pod.labels.app} == 'redis'
+      #      condition: ${kubernetes.labels.app} == 'redis'
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
+++ b/deploy/kubernetes/elastic-agent-standalone/elastic-agent-standalone-daemonset-configmap.yaml
@@ -441,4 +441,4 @@ data:
       #      maxconn: 10
       #      network: tcp
       #      period: 10s
-      #      condition: ${kubernetes.pod.labels.app} == 'redis'
+      #      condition: ${kubernetes.labels.app} == 'redis'

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	AddResourceMetadata *metadata.AddResourceMetadataConfig `config:"add_resource_metadata"`
 	IncludeLabels       []string                            `config:"include_labels"`
 	ExcludeLabels       []string                            `config:"exclude_labels"`
+	IncludeAnnotations  []string                            `config:"include_annotations"`
 
 	LabelsDedot      bool `config:"labels.dedot"`
 	AnnotationsDedot bool `config:"annotations.dedot"`

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/kubernetes.go
@@ -130,7 +130,7 @@ type Eventer interface {
 	Stop()
 }
 
-// newWatcher initializes the proper watcher according to the given resource (pod, node, service).
+// newEventer initializes the proper eventer according to the given resource (pod, node, service).
 func (p *dynamicProvider) newEventer(
 	resourceType string,
 	comm composable.DynamicProviderComm,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
@@ -36,7 +36,7 @@ type nodeData struct {
 	processors []map[string]interface{}
 }
 
-// NewNodeEventer creates a watcher that can discover and process node objects
+// NewNodeEventer creates an eventer that can discover and process node objects
 func NewNodeEventer(
 	comm composable.DynamicProviderComm,
 	cfg *Config,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/node.go
@@ -27,6 +27,7 @@ type node struct {
 	scope          string
 	config         *Config
 	metagen        metadata.MetaGen
+	watcher        kubernetes.Watcher
 }
 
 type nodeData struct {
@@ -35,13 +36,13 @@ type nodeData struct {
 	processors []map[string]interface{}
 }
 
-// NewNodeWatcher creates a watcher that can discover and process node objects
-func NewNodeWatcher(
+// NewNodeEventer creates a watcher that can discover and process node objects
+func NewNodeEventer(
 	comm composable.DynamicProviderComm,
 	cfg *Config,
 	logger *logp.Logger,
 	client k8s.Interface,
-	scope string) (kubernetes.Watcher, error) {
+	scope string) (Eventer, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Node{}, kubernetes.WatchOptions{
 		SyncTimeout:  cfg.SyncPeriod,
 		Node:         cfg.Node,
@@ -57,15 +58,17 @@ func NewNodeWatcher(
 		return nil, errors.New(err, "failed to unpack configuration")
 	}
 	metaGen := metadata.NewNodeMetadataGenerator(rawConfig, watcher.Store(), client)
-	watcher.AddEventHandler(&node{
+	n := &node{
 		logger,
 		cfg.CleanupTimeout,
 		comm,
 		scope,
 		cfg,
-		metaGen})
+		metaGen,
+		watcher}
+	watcher.AddEventHandler(n)
 
-	return watcher, nil
+	return n, nil
 }
 
 func (n *node) emitRunning(node *kubernetes.Node) {
@@ -81,6 +84,16 @@ func (n *node) emitRunning(node *kubernetes.Node) {
 
 func (n *node) emitStopped(node *kubernetes.Node) {
 	n.comm.Remove(string(node.GetUID()))
+}
+
+// Start starts the eventer
+func (n *node) Start() error {
+	return n.watcher.Start()
+}
+
+// Stop stops the eventer
+func (n *node) Stop() {
+	n.watcher.Stop()
 }
 
 // OnAdd ensures processing of node objects that are newly created

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -67,7 +67,7 @@ type namespacePodUpdater struct {
 	locker  sync.Locker
 }
 
-// NewPodEventer creates a watcher that can discover and process pod objects
+// NewPodEventer creates an eventer that can discover and process pod objects
 func NewPodEventer(
 	comm composable.DynamicProviderComm,
 	cfg *Config,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/pod.go
@@ -28,6 +28,8 @@ type pod struct {
 	scope            string
 	config           *Config
 	metagen          metadata.MetaGen
+	watcher          kubernetes.Watcher
+	nodeWatcher      kubernetes.Watcher
 	namespaceWatcher kubernetes.Watcher
 
 	// Mutex used by configuration updates not triggered by the main watcher,
@@ -65,13 +67,13 @@ type namespacePodUpdater struct {
 	locker  sync.Locker
 }
 
-// NewPodWatcher creates a watcher that can discover and process pod objects
-func NewPodWatcher(
+// NewPodEventer creates a watcher that can discover and process pod objects
+func NewPodEventer(
 	comm composable.DynamicProviderComm,
 	cfg *Config,
 	logger *logp.Logger,
 	client k8s.Interface,
-	scope string) (kubernetes.Watcher, error) {
+	scope string) (Eventer, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 		SyncTimeout:  cfg.SyncPeriod,
 		Node:         cfg.Node,
@@ -107,24 +109,57 @@ func NewPodWatcher(
 	}
 	metaGen := metadata.GetPodMetaGen(rawConfig, watcher, nodeWatcher, namespaceWatcher, metaConf)
 
-	p := pod{
+	p := &pod{
 		logger:           logger,
 		cleanupTimeout:   cfg.CleanupTimeout,
 		comm:             comm,
 		scope:            scope,
 		config:           cfg,
 		metagen:          metaGen,
+		watcher:          watcher,
+		nodeWatcher:      nodeWatcher,
 		namespaceWatcher: namespaceWatcher,
 	}
 
-	watcher.AddEventHandler(&p)
+	watcher.AddEventHandler(p)
 
 	if namespaceWatcher != nil && metaConf.Namespace.Enabled() {
 		updater := newNamespacePodUpdater(p.unlockedUpdate, watcher.Store(), &p.crossUpdate)
 		namespaceWatcher.AddEventHandler(updater)
 	}
 
-	return watcher, nil
+	return p, nil
+}
+
+// Start starts the eventer
+func (p *pod) Start() error {
+	if p.nodeWatcher != nil {
+		err := p.nodeWatcher.Start()
+		if err != nil {
+			return err
+		}
+	}
+
+	if p.namespaceWatcher != nil {
+		if err := p.namespaceWatcher.Start(); err != nil {
+			return err
+		}
+	}
+
+	return p.watcher.Start()
+}
+
+// Stop stops the eventer
+func (p *pod) Stop() {
+	p.watcher.Stop()
+
+	if p.namespaceWatcher != nil {
+		p.namespaceWatcher.Stop()
+	}
+
+	if p.nodeWatcher != nil {
+		p.nodeWatcher.Stop()
+	}
 }
 
 func (p *pod) emitRunning(pod *kubernetes.Pod) {

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -37,7 +37,7 @@ type serviceData struct {
 	processors []map[string]interface{}
 }
 
-// NewServiceEventer creates a watcher that can discover and process service objects
+// NewServiceEventer creates an eventer that can discover and process service objects
 func NewServiceEventer(
 	comm composable.DynamicProviderComm,
 	cfg *Config,

--- a/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/kubernetes/service.go
@@ -27,6 +27,7 @@ type service struct {
 	scope            string
 	config           *Config
 	metagen          metadata.MetaGen
+	watcher          kubernetes.Watcher
 	namespaceWatcher kubernetes.Watcher
 }
 
@@ -36,13 +37,13 @@ type serviceData struct {
 	processors []map[string]interface{}
 }
 
-// NewServiceWatcher creates a watcher that can discover and process service objects
-func NewServiceWatcher(
+// NewServiceEventer creates a watcher that can discover and process service objects
+func NewServiceEventer(
 	comm composable.DynamicProviderComm,
 	cfg *Config,
 	logger *logp.Logger,
 	client k8s.Interface,
-	scope string) (kubernetes.Watcher, error) {
+	scope string) (Eventer, error) {
 	watcher, err := kubernetes.NewWatcher(client, &kubernetes.Service{}, kubernetes.WatchOptions{
 		SyncTimeout:  cfg.SyncPeriod,
 		Node:         cfg.Node,
@@ -68,17 +69,38 @@ func NewServiceWatcher(
 	}
 
 	metaGen := metadata.NewServiceMetadataGenerator(rawConfig, watcher.Store(), namespaceMeta, client)
-	watcher.AddEventHandler(&service{
+	s := &service{
 		logger,
 		cfg.CleanupTimeout,
 		comm,
 		scope,
 		cfg,
 		metaGen,
+		watcher,
 		namespaceWatcher,
-	})
+	}
+	watcher.AddEventHandler(s)
 
-	return watcher, nil
+	return s, nil
+}
+
+// Start starts the eventer
+func (s *service) Start() error {
+	if s.namespaceWatcher != nil {
+		if err := s.namespaceWatcher.Start(); err != nil {
+			return err
+		}
+	}
+	return s.watcher.Start()
+}
+
+// Stop stops the eventer
+func (s *service) Stop() {
+	s.watcher.Stop()
+
+	if s.namespaceWatcher != nil {
+		s.namespaceWatcher.Stop()
+	}
 }
 
 func (s *service) emitRunning(service *kubernetes.Service) {


### PR DESCRIPTION
## What does this PR do?
Small followup fix related to https://github.com/elastic/beats/pull/27691:
- Fix proposed manifest's condition from `kubernetes.pod.labels.app == redis` to ``kubernetes.labels.app == redis`
- Port `IncludeAnnotations`
- Handle start/stop of watchers properly


## How to test this PR manually
Using the following redis Pod:
```
apiVersion: v1
kind: Pod
metadata:
  name: redis
  labels:
    role: main
    app: redis
  annotations:
    level: production
spec:
  hostNetwork: true
  dnsPolicy: ClusterFirstWithHostNet
  containers:
    - name: redis
      image: redis:latest
      ports:
        - name: web
          containerPort: 6379
          protocol: TCP
```

Test the following scenarios:

1.  Check Pod's annotation is added as metadata
```
providers.kubernetes:
  scope: node
  kube_config: /Users/chrismark/.kube/config
  node: "kind-control-plane"
  cleanup_timeout: 360s
  include_annotations: ["level"]
  resources:
    pod:
      enabled: true

inputs:
- name: redis
  type: redis/metrics
  use_output: default
  meta:
    package:
      name: redis
      version: 0.3.6
  data_stream:
    namespace: default
  streams:
    - data_stream:
        dataset: redis.info
        type: metrics
      metricsets:
        - info
      hosts:
        - '${kubernetes.pod.ip}:${kubernetes.container.port}'
      idle_timeout: 20s
      maxconn: 10
      network: tcp
      period: 10s
      condition: ${kubernetes.labels.app} == 'redis' AND ${kubernetes.container.port_name} == 'web'
```

2.  Check condition based on `kubernetes.namespace_annotations.foo == bar`

`kubectl annotate ns default foo=bar`

```
providers.kubernetes:
  scope: node
  kube_config: /Users/chrismark/.kube/config
  node: "kind-control-plane"
  cleanup_timeout: 360s
  include_annotations: ["level"]
  resources:
    pod:
      enabled: true

inputs:
- name: redis
  type: redis/metrics
  use_output: default
  meta:
    package:
      name: redis
      version: 0.3.6
  data_stream:
    namespace: default
  streams:
    - data_stream:
        dataset: redis.info
        type: metrics
      metricsets:
        - info
      hosts:
        - '${kubernetes.pod.ip}:${kubernetes.container.port}'
      idle_timeout: 20s
      maxconn: 10
      network: tcp
      period: 10s
      condition: ${kubernetes.namespace_annotations.foo} == 'bar' AND ${kubernetes.container.port_name} == 'web'
```

3. Check that ns annotations are being added to Pod's metadata.
 ```
providers.kubernetes:
  scope: node
  kube_config: /Users/chrismark/.kube/config
  node: "kind-control-plane"
  cleanup_timeout: 360s
  include_annotations: ["level"]
  add_resource_metadata:
     namespace:
       include_annotations: ["foo"]
  resources:
    pod:
      enabled: true

inputs:
- name: redis
  type: redis/metrics
  use_output: default
  meta:
    package:
      name: redis
      version: 0.3.6
  data_stream:
    namespace: default
  streams:
    - data_stream:
        dataset: redis.info
        type: metrics
      metricsets:
        - info
      hosts:
        - '${kubernetes.pod.ip}:${kubernetes.container.port}'
      idle_timeout: 20s
      maxconn: 10
      network: tcp
      period: 10s
      condition: ${kubernetes.labels.app} == 'redis' AND ${kubernetes.container.port_name} == 'web'
```