### PR TITLE
Fix default_field generation for multi_fields

### DIFF
--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -26,6 +26,9 @@ import (
 	"github.com/elastic/beats/v7/libbeat/mapping"
 )
 
+// DefaultField controls the default value for the default_field flag.
+const DefaultField = true
+
 var (
 	minVersionAlias                   = common.MustNewVersion("6.4.0")
 	minVersionFieldMeta               = common.MustNewVersion("7.6.0")
@@ -62,7 +65,7 @@ type fieldState struct {
 func (p *Processor) Process(fields mapping.Fields, state *fieldState, output common.MapStr) error {
 	if state == nil {
 		// Set the defaults.
-		state = &fieldState{DefaultField: true}
+		state = &fieldState{DefaultField: DefaultField}
 	}
 
 	for _, field := range fields {
@@ -257,6 +260,23 @@ func (p *Processor) ip(f *mapping.Field) common.MapStr {
 	return property
 }
 
+func stateFromField(f *mapping.Field) *fieldState {
+	if f == nil {
+		return nil
+	}
+	st := &fieldState{
+		DefaultField: DefaultField,
+		Path:         f.Name,
+	}
+	if f.DefaultField != nil {
+		st.DefaultField = *f.DefaultField
+	}
+	if f.Path != "" {
+		st.Path = f.Path + "." + f.Name
+	}
+	return st
+}
+
 func (p *Processor) keyword(f *mapping.Field) common.MapStr {
 	property := p.getDefaultProperties(f)
 
@@ -277,7 +297,7 @@ func (p *Processor) keyword(f *mapping.Field) common.MapStr {
 
 	if len(f.MultiFields) > 0 {
 		fields := common.MapStr{}
-		p.Process(f.MultiFields, nil, fields)
+		p.Process(f.MultiFields, stateFromField(f), fields)
 		property["fields"] = fields
 	}
 
@@ -299,7 +319,7 @@ func (p *Processor) wildcard(f *mapping.Field) common.MapStr {
 
 	if len(f.MultiFields) > 0 {
 		fields := common.MapStr{}
-		p.Process(f.MultiFields, nil, fields)
+		p.Process(f.MultiFields, stateFromField(f), fields)
 		property["fields"] = fields
 	}
 
@@ -335,7 +355,7 @@ func (p *Processor) text(f *mapping.Field) common.MapStr {
 
 	if len(f.MultiFields) > 0 {
 		fields := common.MapStr{}
-		p.Process(f.MultiFields, nil, fields)
+		p.Process(f.MultiFields, stateFromField(f), fields)
 		properties["fields"] = fields
 	}
 

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -18,6 +18,7 @@
 package template
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -691,6 +692,41 @@ func TestProcessDefaultField(t *testing.T) {
 				},
 			},
 		},
+		// Check that multi_fields are correctly stored in defaultFields.
+		mapping.Field{
+			Name: "qux",
+			Type: "keyword",
+			MultiFields: []mapping.Field{
+				{
+					Name: "text",
+					Type: "text",
+				},
+			},
+		},
+		mapping.Field{
+			Name:         "bouba",
+			Type:         "keyword",
+			DefaultField: &disableDefaultField,
+			MultiFields: []mapping.Field{
+				{
+					Name:         "text",
+					Type:         "text",
+					DefaultField: &enableDefaultField,
+				},
+			},
+		},
+		mapping.Field{
+			Name:         "kiki",
+			Type:         "keyword",
+			DefaultField: &enableDefaultField,
+			MultiFields: []mapping.Field{
+				{
+					Name:         "text",
+					Type:         "text",
+					DefaultField: &disableDefaultField,
+				},
+			},
+		},
 	}
 
 	version, err := common.NewVersion("7.0.0")
@@ -704,13 +740,19 @@ func TestProcessDefaultField(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Len(t, defaultFields, 4)
-	assert.Contains(t, defaultFields,
-		"foo",
+	expectedFields := []string{
 		"bar",
-		"nested.foo",
+		"foo",
 		"nested.bar",
-	)
+		"nested.foo",
+		"qux",
+		"qux.text",
+		"bouba.text",
+		"kiki",
+	}
+	sort.Strings(defaultFields)
+	sort.Strings(expectedFields)
+	assert.Equal(t, defaultFields, expectedFields)
 }
 
 func TestProcessWildcardOSS(t *testing.T) {


### PR DESCRIPTION


Fixes #16923

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Corrects the handling of multi-fields for the assembling of the default_fields list.

## Why is it important?

Now multi-fields are correctly added to the default_fields list, instead of a bunch of dangling `text` fields.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Closes #16923
