### PR TITLE
Filebeat: Change compatibility test stage to test against previos minor instead of 7.11

### DIFF
--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -44,9 +44,9 @@ stages:
     pythonIntegTest:
         mage: "mage pythonIntegTest"       ## run the ITs only if the changeset affects a specific module.
         stage: mandatory
-    module-compat-7.11:
-      mage: >-                 ## Run module integration tests under ES 7.11 to ensure ingest pipeline compatibility.
-        STACK_ENVIRONMENT=7.11
+    module-compat-prev-minor:
+      mage: >-                 ## Run module integration tests under previous minor of ES to ensure ingest pipeline compatibility.
+        STACK_ENVIRONMENT=prev-minor
         TESTING_FILEBEAT_SKIP_DIFF=1
         PYTEST_ADDOPTS='-k test_modules'
         mage pythonIntegTest

--- a/testing/environments/prev-minor.yml
+++ b/testing/environments/prev-minor.yml
@@ -1,0 +1,38 @@
+# This is the previous minor for compatibility tests.
+
+version: '2.3'
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
+      retries: 300
+      interval: 1s
+    environment:
+    - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    - "network.host="
+    - "transport.host=127.0.0.1"
+    - "http.host=0.0.0.0"
+    - "xpack.security.enabled=false"
+    - "script.context.template.max_compilations_rate=unlimited"
+    - "script.context.ingest.cache_max_size=2000"
+    - "script.context.processor_conditional.cache_max_size=2000"
+    - "script.context.template.cache_max_size=2000"
+    - "action.destructive_requires_name=false"
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:7.15
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
+      retries: 600
+      interval: 1s
+    volumes:
+      - ./docker/logstash/pipeline:/usr/share/logstash/pipeline:ro
+      - ./docker/logstash/pki:/etc/pki:ro
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.15
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
+      retries: 600
+      interval: 1s


### PR DESCRIPTION
## What does this PR do?

This changes the compatibility test for Filebeat modules to test with the previous released minor.

## Why is it important?

To ensure backwards compatibility with the latest supported version

## Related issues

- Relates #26629
