### PR TITLE
backport: Add 7.15 branch

### DIFF
--- a/.backportrc.json
+++ b/.backportrc.json
@@ -1,6 +1,6 @@
 {
   "upstream": "elastic/beats",
-  "branches": [ { "name": "7.x", "checked": true }, "7.15", "7.14" ],
+  "branches": [ { "name": "7.x", "checked": true }, "7.15", "7.15", "7.14" ],
   "labels": ["backport"],
   "autoAssign": true,
   "prTitle": "Cherry-pick to {targetBranch}: {commitMessages}"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -151,6 +151,19 @@ pull_request_rules:
   - name: backport patches to 7.15 branch
     conditions:
       - merged
+      - label=backport-v7.16.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.15"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 7.15 branch
+    conditions:
+      - merged
       - label=backport-v7.15.0
     actions:
       backport:


### PR DESCRIPTION
Merge as soon as 7.15 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821