### PR TITLE
[Docs] Update logging.files.permissions documentation to consider umask (#20584)

### DIFF
--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -41,14 +41,14 @@ That means in case there are some states where the TTL expired, these are only r
 The permissions mask to apply on registry data file. The default value is 0600. The permissions option must be a valid Unix-style file permissions mask expressed in octal notation. In Go, numbers in octal notation must start with 0.
 
 The most permissive mask allowed is 0640. If a higher permissions mask is
-specified via this setting, it will be subject to a umask of 0027.
+specified via this setting, it will be subject to an umask of 0027.
 
 This option is not supported on Windows.
 
 Examples:
 
-    0640: give read and write access to the file owner, and read access to members of the group associated with the file.
-    0600: give read and write access to the file owner, and no access to all others.
+* 0640: give read and write access to the file owner, and read access to members of the group associated with the file.
+* 0600: give read and write access to the file owner, and no access to all others.
 
 [source,yaml]
 -------------------------------------------------------------------------------------

--- a/filebeat/docs/howto/override-config-settings.asciidoc
+++ b/filebeat/docs/howto/override-config-settings.asciidoc
@@ -37,7 +37,7 @@ logging.files:
   path: /var/log/filebeat
   name: filebeat
   keepfiles: 7
-  permissions: 0644
+  permissions: 0640
 ----
 
 To override the logging level and send logging output to standard error instead

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -32,7 +32,7 @@ logging.files:
   path: /var/log/{beatname_lc}
   name: {beatname_lc}
   keepfiles: 7
-  permissions: 0644
+  permissions: 0640
 ----
 endif::win_only[]
 
@@ -45,7 +45,7 @@ logging.files:
   path: C:{backslash}ProgramData{backslash}{beatname_lc}{backslash}Logs
   name: {beatname_lc}
   keepfiles: 7
-  permissions: 0644
+  permissions: 0640
 ----
 endif::win_only[]
 
@@ -231,12 +231,15 @@ The permissions mask to apply when rotating log files. The default value is
 expressed in octal notation. In Go, numbers in octal notation must start with
 '0'.
 
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to an umask of 0027.
+
+This option is not supported on Windows.
+
 Examples:
 
-* 0644: give read and write access to the file owner, and read access to all others.
+* 0640: give read and write access to the file owner, and read access to members of the group associated with the file.
 * 0600: give read and write access to the file owner, and no access to all others.
-* 0664: give read and write access to the file owner and members of the group
-associated with the file, as well as read access to all other users.
 
 [float]
 ==== `logging.files.interval`


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Resolves (#20584)

Changes implemented in the (#14119) made all Beats-created files and folders apply an `umask of 0027` (on POSIX systems). 

According to the @ycombinator comment available at the [discuss.elastic: rotated-log-files-have-incorrect-permissions](https://discuss.elastic.co/t/rotated-log-files-have-incorrect-permissions/244623)

> This is a security measure. Any files/folders created by Beats get a umask of 0027. This means any files will have at most 0640 permissions and any folders will have at most 0750 permissions. Essentially, we deliberately don't want any Beats-created files/folders to be world-readable.

This PR updates the following document files to reflect the latest changes (regarding the `umask 0027`):

* `loggingconfig.asciidoc` which is included in the:
  * `auditbeat/docs/configuring-howto.asciidoc`
  * `filebeat/docs/configuring-howto.asciidoc`
  * `heartbeat/docs/configuring-howto.asciidoc`
  * `journalbeat/docs/configuring-howto.asciidoc`
  * `metricbeat/docs/configuring-howto.asciidoc`
  * `packetbeat/docs/configuring-howto.asciidoc`
  * `winlogbeat/docs/configuring-howto.asciidoc`
  * `x-pack/functionbeat/docs/configuring-howto.asciidoc`
* `filebeat-general-options.asciidoc` which is included in the:
  * `filebeat/docs/configuring-howto.asciidoc` 
* `override-config-settings.asciidoc` which is insluded in the:
  * `filebeat/docs/howto/howto.asciidoc` 



## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This PR aims to fix the confusion/uncertainty (_based on the number of issues created regarding `umask 0027`_) introduced with the mismatch between the code changes introduced in the (#14119) and the current documentation available for the 7.x, 7.15 and master.

This PR updates documents available at the (filebeat example, other beats are also updated):
* https://www.elastic.co/guide/en/beats/filebeat/current/configuration-logging.html#_logging_files_permissions
* https://www.elastic.co/guide/en/beats/filebeat/7.x/configuration-general-options.html#_registry_file_permissions


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
I don't know how (or if I have permissions) to add labels to this pull request 😢 
- [x] Team:Docs
- [x] Docs
- [x] backport-v7.x ??

Regarding the `@jenkins-beats-ci CI-approved contributor — It requires manual inspection `, I would say it's because I used github's `<?@users.noreply.github.com>` address instead of my own on (used to sign the ) 🤔 

If needed I can create a new PR where I will use 

## How to test this PR locally

- I've read the https://github.com/elastic/docs/blob/master/README.asciidoc but I'm, still fighting with running the docker image on my os x (m1) locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

Closes #20584

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
