### PR TITLE
auditbeat/module/file_integrity: clean paths obtained from fsnotify before sending

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@ https://github.com/elastic/beats/compare/v7.14.2...v7.15.0[View commits]
 *Auditbeat*
 
 - File Integrity Module: Honor `include_files` when doing initial scan. {issue}27273[27273] {pull}27722[27722]
+- Fix handling of root and relative paths {issue}24430[24430] {pull}28354[28354]
 
 *Filebeat*
 

--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -74,6 +74,8 @@ described later.
 
 *`paths`*:: A list of paths (directories or files) to watch. Globs are
 not supported. The specified paths should exist when the metricset is started.
+Paths should be absolute, although the file integrity module will attempt to
+resolve relative path events to their absolute file path.
 
 *`exclude_files`*:: A list of regular expressions used to filter out events
 for unwanted files. The expressions are matched against the full path of every

--- a/auditbeat/module/file_integrity/_meta/docs.asciidoc
+++ b/auditbeat/module/file_integrity/_meta/docs.asciidoc
@@ -67,6 +67,8 @@ described later.
 
 *`paths`*:: A list of paths (directories or files) to watch. Globs are
 not supported. The specified paths should exist when the metricset is started.
+Paths should be absolute, although the file integrity module will attempt to
+resolve relative path events to their absolute file path.
 
 *`exclude_files`*:: A list of regular expressions used to filter out events
 for unwanted files. The expressions are matched against the full path of every

--- a/auditbeat/module/file_integrity/eventreader_fsevents.go
+++ b/auditbeat/module/file_integrity/eventreader_fsevents.go
@@ -156,6 +156,17 @@ func (r *fsreader) consumeEvents(done <-chan struct{}) {
 					"event_id", event.ID,
 					"event_flags", flagsToString(event.Flags))
 
+				abs, err := filepath.Abs(event.Path)
+				if err != nil {
+					r.log.Errorw("Failed to obtain absolute path",
+						"file_path", event.Path,
+						"error", err,
+					)
+					event.Path = filepath.Clean(event.Path)
+				} else {
+					event.Path = abs
+				}
+
 				start := time.Now()
 				e := NewEvent(event.Path, flagsToAction(event.Flags), SourceFSNotify,
 					r.config.MaxFileSizeBytes, r.config.HashTypes)

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -21,6 +21,7 @@
 package file_integrity
 
 import (
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -139,6 +140,17 @@ func (r *reader) nextEvent(done <-chan struct{}) *Event {
 			r.log.Debugw("Received fsnotify event",
 				"file_path", event.Name,
 				"event_flags", event.Op)
+
+			abs, err := filepath.Abs(event.Name)
+			if err != nil {
+				r.log.Errorw("Failed to obtain absolute path",
+					"file_path", event.Name,
+					"error", err,
+				)
+				event.Name = filepath.Clean(event.Name)
+			} else {
+				event.Name = abs
+			}
 
 			start := time.Now()
 			e := NewEvent(event.Name, opToAction(event.Op), SourceFSNotify,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This cleans incorrectly constructed, but valid, paths obtained from fsnotify and makes relative paths useful.

Note that the code is duplicated across the fsnotify and fsevent functions due to separation by build tags and differences in the types that are being handled. They could be factored into a single `func absolutePathFor(path string, logger *logp.Logger) string`, but there was no obvious place to put that.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently paths of files identified in root by the file integrity module have path with either a `//` prefix or with a `./` if a relative or empty path configuration is provided. This change resolves relative paths to absolute event paths and cleans paths with extraneous path separators and dots.

Testing the root path behaviour in automated testing does not seem feasible.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Run auditbeat with the following configuration

````
- module: file_integrity
  paths:
  - /bin
  - /usr/bin
  - /sbin
  - /usr/sbin
  - /etc
  -
````
or
```
- module: file_integrity
  paths:
  - /bin
  - /usr/bin
  - /sbin
  - /usr/sbin
  - /etc
  - /
```

and then create a file in `/` or in the current working directory for auditbeat.
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #24430.

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

N/A

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A