### PR TITLE
[libbeat] Remove common.Float

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -55,6 +55,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove `NumCPU` as clients should update the CPU count on the fly in case of config changes in a VM. {pull}23154[23154]
 - Remove Metricbeat EventFetcher and EventsFetcher interface. Use the reporter interface instead. {pull}25093[25093]
 - Update Darwin build image to a debian 10 base that increases the MacOS SDK and minimum supported version used in build to 10.14. {issue}24193[24193]
+- Removed the `common.Float` type. {issue}28279[28279] {pull}28280[28280] {pull}28376[28376]
 
 ==== Bugfixes
 
@@ -123,7 +124,3 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Update Go version to 1.16.5. {issue}26182[26182] {pull}26186[26186]
 - Introduce `libbeat/beat.Beat.OutputConfigReloader` {pull}28048[28048]
 - Update Go version to 1.17.1. {pull}27543[27543]
-
-==== Deprecated
-
-- Deprecated the `common.Float` type. {issue}28279[28279] {pull}28280[28280]

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -31,15 +31,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
-
-// Float is a float64 wrapper that implements the encoding/json Marshaler
-// interface to add a decimal point to all float values.
-//
-// Deprecated: This type should no longer be used and the Marshaler interface
-// is not consulted while marshaling to JSON in libbeat outputs.
-type Float float64
-
 // EventConverter is used to convert MapStr objects for publishing
 type EventConverter interface {
 	Convert(m MapStr) MapStr
@@ -304,11 +295,6 @@ func joinKeys(keys ...string) string {
 		keys = keys[1:]
 	}
 	return strings.Join(keys, ".")
-}
-
-// Defines the marshal of the Float type
-func (f Float) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("%.6f", f)), nil
 }
 
 // DeDot a string by replacing all . with _

--- a/libbeat/common/event_test.go
+++ b/libbeat/common/event_test.go
@@ -396,22 +396,6 @@ func TestMarshalUnmarshalArray(t *testing.T) {
 	}
 }
 
-func TestMarshalFloatValues(t *testing.T) {
-	assert := assert.New(t)
-
-	var f float64
-
-	f = 5
-
-	a := MapStr{
-		"f": Float(f),
-	}
-
-	b, err := json.Marshal(a)
-	assert.Nil(err)
-	assert.Equal(string(b), "{\"f\":5.000000}")
-}
-
 func TestNormalizeTime(t *testing.T) {
 	ny, err := time.LoadLocation("America/New_York")
 	if err != nil {

--- a/libbeat/conditions/range.go
+++ b/libbeat/conditions/range.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
@@ -129,7 +128,7 @@ func (c Range) Check(event ValuesMap) bool {
 				return false
 			}
 
-		case float64, float32, common.Float:
+		case float64, float32:
 			floatValue := reflect.ValueOf(value).Float()
 
 			if !checkValue(floatValue, rangeValue) {


### PR DESCRIPTION
## What does this PR do?

Remove deprecated common.Float from 8.0.

https://github.com/elastic/beats/pull/28280#issuecomment-937795157

## Why is it important?

Removes unused code.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #28279
- Relates #28280
