### PR TITLE
[Metricbeat] Pass through cgroup errors

### DIFF
--- a/libbeat/metric/system/cgroup/reader.go
+++ b/libbeat/metric/system/cgroup/reader.go
@@ -113,8 +113,9 @@ func NewReaderOptions(opts ReaderOptions) (*Reader, error) {
 
 	// Determine what subsystems are supported by the kernel.
 	subsystems, err := SupportedSubsystems(opts.RootfsMountpoint)
+	// We can return a not-quite-an-error ErrCgroupsMissing here, so return the bare error.
 	if err != nil {
-		return nil, errors.Wrap(err, "error finding subsystems")
+		return nil, err
 	}
 
 	// Locate the mountpoints of those subsystems.


### PR DESCRIPTION
## What does this PR do?
This is a one-line fix that passes through a typed error. This was causing downstream code to fail when it looked for a `ErrCgroupsMissing` error.

## Why is it important?

This was leading to errors getting reported that shouldn't be. `ErrCgroupsMissing` is technically more a soft error, depending on system configuration. 

## Checklist


- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

