### PR TITLE
Check IMDSv2 token response is empty

### DIFF
--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go
@@ -80,7 +80,7 @@ func getIMDSv2Token(c *common.Config) string {
 		logger.Warnf("read token request for getting IMDSv2 token returns empty: %s. No token in the metadata request will be used.", err)
 		return ""
 	}
-	
+
 	defer func(body io.ReadCloser) {
 		if body != nil {
 			body.Close()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to fix Metricbeat in xpack from error:
```
kaiyansheng@KaiyanMacBookPro:~/go/src/github.com/elastic/beats/x-pack/metricbeat (fix_rds)$ ./metricbeat modules enable aws
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x10d5c539b]

goroutine 1 [running]:
github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata.getIMDSv2Token(0x10f9d9026)
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go:83 +0x55b
github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata.glob..func2({0x1106b6760, 0xc00138f268}, 0x10f9b86a9)
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/processors/add_cloud_metadata/provider_aws_ec2.go:128 +0x34
github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata.setupFetchers(0xc000029980, 0x110644660)
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/processors/add_cloud_metadata/providers.go:114 +0x216
github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata.New(0x10cc4e567)
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go:74 +0xde
github.com/elastic/beats/v7/libbeat/processors.NewConditional.func1(0xc0002fc240)
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/processors/conditionals.go:36 +0x22
github.com/elastic/beats/v7/libbeat/processors.New({0xc000157040, 0x4, 0xc000a86410})
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/processors/processor.go:111 +0x2bf
github.com/elastic/beats/v7/libbeat/publisher/processing.MakeDefaultSupport.func1({{0x10f9c1ade, 0xa}, {0x10f9c1ade, 0xa}, {0x10f9b367b, 0x5}, 0x0, {0xc0006ac840, 0x10}, {0xc0006ac840, ...}, ...}, ...)
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/publisher/processing/default.go:110 +0xca
github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).configure(0xc000914700, {{0x10f9c1ade, 0xa}, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, {{0x0, ...}, ...}, ...})
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:701 +0x9dc
github.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).InitWithSettings(0xc000bf3be0, {{0x10f9c1ade, 0xa}, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, {{0x0, ...}, ...}, ...})
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:266 +0x85
github.com/elastic/beats/v7/libbeat/cmd/instance.NewInitializedBeat({{0x10f9c1ade, 0xa}, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, {{0x0, 0x0}, ...}, ...})
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:206 +0xa5
github.com/elastic/beats/v7/libbeat/cmd.getModules({{0x10f9c1ade, 0xa}, {0x0, 0x0}, {0x0, 0x0}, 0x0, 0x0, {{0x0, 0x0}, ...}, ...}, ...)
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/cmd/modules.go:63 +0x5f
github.com/elastic/beats/v7/libbeat/cmd.genEnableModulesCmd.func1(0xc0005cca00, {0xc00049d040, 0x1, 0x1})
        /Users/kaiyansheng/go/src/github.com/elastic/beats/libbeat/cmd/modules.go:103 +0x78
github.com/spf13/cobra.(*Command).execute(0xc0005cca00, {0xc00049cff0, 0x1, 0x1})
        /Users/kaiyansheng/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc000164dc0)
        /Users/kaiyansheng/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fc
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/kaiyansheng/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /Users/kaiyansheng/go/src/github.com/elastic/beats/x-pack/metricbeat/main.go:21 +0x25
```

