### PR TITLE
[mergify] auto-merge with a new condition to apply if approved > 0

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -41,6 +41,7 @@ pull_request_rules:
       - check-success=beats-ci/pr-merge
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$
+      - "#approved-reviews-by>=1"
     actions:
       merge:
         method: squash
@@ -84,6 +85,7 @@ pull_request_rules:
       - label=automation
       - files~=^\.mergify\.yml$
       - head~=^add-backport-next.*
+      - "#approved-reviews-by>=1"
     actions:
       merge:
         method: squash


### PR DESCRIPTION
## What does this PR do?

Fix a corner case and add the condition that the mergify rule is only evaluated if the automated PRs have been approved. The approval can happen automatically (mergify provides a rule for such) or manually by someone else.

## Why is it important?

This is only affecting the automated PRs created with the bump of a new ElasticStack snapshot version that happens once a day or when a new ElasticStack release is cut. 

Even though in those cases, this issue will not happen always! Only when the build is green (builds in Beats don't always build correctly, since, flakiness in the tests, flakiness in the infrastructure, or third party system, or a PR got merged and broke something...)

What does it happen?

If the automated PR (only the one changing the ES snapshot version or the new release) passed, then it gets tried to be merged, but since there is not an approval  (it's required to be approved at least for one person) then it gets merged with the target branch and a new build will happen. This is a sequential process and does not happen often and when it does the recurrence will be avoided since https://github.com/elastic/beats/blob/master/Jenkinsfile#L36