### PR TITLE
#28472 fix flaky tests in libbeat fmtstr to use time.UTC instead of time.Local

### DIFF
--- a/libbeat/common/fmtstr/formatevents_test.go
+++ b/libbeat/common/fmtstr/formatevents_test.go
@@ -109,7 +109,7 @@ func TestEventFormatString(t *testing.T) {
 			"test timestamp formatter",
 			"%{[key]}: %{+YYYY.MM.dd}",
 			beat.Event{
-				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 				Fields: common.MapStr{
 					"key": "timestamp",
 				},
@@ -121,7 +121,7 @@ func TestEventFormatString(t *testing.T) {
 			"test timestamp formatter",
 			"%{[@timestamp]}: %{+YYYY.MM.dd}",
 			beat.Event{
-				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 				Fields: common.MapStr{
 					"key": "timestamp",
 				},

--- a/libbeat/common/fmtstr/formattimestamp_test.go
+++ b/libbeat/common/fmtstr/formattimestamp_test.go
@@ -73,14 +73,14 @@ func TestTimestampFormatString(t *testing.T) {
 			"test timestamp formatter",
 			"%{[key]}: %{+YYYY.MM.dd}",
 			common.MapStr{"key": "timestamp"},
-			time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+			time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 			"timestamp: 2015.05.01",
 		},
 		{
 			"test timestamp formatter",
 			"%{[@timestamp]}: %{+YYYY.MM.dd}",
 			common.MapStr{"key": "timestamp"},
-			time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+			time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 			"2015-05-01T20:12:34.000Z: 2015.05.01",
 		},
 	}


### PR DESCRIPTION
- Cleanup #28472

## What does this PR do?

There are four unit tests that seem to be about re-formatting a timestamp in UTC. However, the unit tests generate the expected time using `time.Local`, which produces inconsistent results based on the local timezone used by e.g. the developer.  If my understanding of the purpose of the test cases is correct, then using `time.UTC` should resolve any potential inconsistencies.

## Why is it important?

Tests should work everywhere.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

- is the PR author correct in their understanding of the purpose of the Tests being modified

## How to test this PR locally

Ci/CD tests should pass as normal. You should be able to run the same tests locally on a box that does not use UTC, and have them pass.

## Related issues

- Closes #28472

## Use cases

- N/A

## Screenshots

- N/A

## Logs

See ticket #28472
