### PR TITLE
CI: disable e2e for elastic-agent on tags/branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -519,6 +519,11 @@ def getBeatsName(baseDir) {
 */
 def e2e(Map args = [:]) {
   if (!args.e2e?.get('enabled', false)) { return }
+  // Skip running the tests on branches or tags if configured.
+  if (!isPR() && args.e2e?.get('when', false)) {
+    if (isBranch() && !args.e2e.when.get('branches', true)) { return }
+    if (isTag() && !args.e2e.when.get('tags', true)) { return }
+  }
   if (args.e2e.get('entrypoint', '')?.trim()) {
     e2e_with_entrypoint(args)
   } else {

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -98,6 +98,9 @@ stages:
             enabled: true
             job: 'e2e-tests/e2e-testing-mbp'
             testMatrixFile: '.ci/.e2e-tests-for-elastic-agent.yaml'
+            when:                  ## Customise when to run this subtask in the packaging stage.
+                branches: false    ## Only on a PR basis for the time being
+                tags: false        ## e2e on branches/tags is already in place with the downstream build.
         stage: packaging
     packaging-arm:
         packaging-arm: "mage package"


### PR DESCRIPTION
## What does this PR do?

Disable e2e for elastic-agent in the main pipeline (ONLY) for the merge commits into branches or tags. In other words, the e2e testing for elastic-agent will be enabled only on a PR basis.

Though, the e2e testing for elastic-agent happens in the e2e specific pipeline, that happens when there is a merge commit.

## Why is it important?

After merging https://github.com/elastic/beats/pull/24112 it seems the e2e for the elastic-agent are failing and might mislead the status in the GitHub checks for the merge commits in the branches.

See 

![image](https://user-images.githubusercontent.com/2871786/137621491-5a28f9ff-71fa-496a-b271-cc355511ced8.png)
