### PR TITLE
[mergify] automate approval for automated bumps

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,9 +26,9 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
-  - name: automatic approval for mergify pull requests with bump updates
+  - name: automatic approval for automated pull requests with bump updates
     conditions:
-      - author=mergify[bot]
+      - author=apmmachine
       - check-success=beats-ci/pr-merge
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$


### PR DESCRIPTION
## What does this PR do?

Automated bumps are created by the `apmmachine` account rather than the `mergify[bot]` therefore https://github.com/elastic/beats/pull/28425 was not approved automatically and merged afterwards

## Why is it important?

Automate the merge task