### PR TITLE
[mergify] squash without rebasing

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -45,7 +45,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: smart+fasttrack
+        strict: false
   - name: delete upstream branch after merging changes on testing/environments/snapshot* or it's closed
     conditions:
       - or:
@@ -89,7 +89,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: smart+fasttrack
+        strict: false
   - name: delete upstream branch with changes on ^.mergify.yml that has been merged or closed
     conditions:
       - or:


### PR DESCRIPTION
## What does this PR do?

Squash and merge without rebasing the PR.

## Why is it important?

This extra step added a new build in the CI, and the CI already merge the PR with the target branch anyway

See https://docs.mergify.io/actions/merge/#options

![image](https://user-images.githubusercontent.com/2871786/137697463-24b7b5d4-b0e9-462e-9871-e5984ac3a7b7.png)
