### PR TITLE
chore(ci): use same branching schema for e2e

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -417,7 +417,7 @@ def runE2ETests(){
 def triggerE2ETests(String suite) {
   echo("Triggering E2E tests for PR-${env.CHANGE_ID}. Test suites: ${suite}.")
 
-  def branchName = isPR() ? "${env.CHANGE_TARGET}" : "${env.JOB_BASE_NAME}.x"
+  def branchName = isPR() ? "${env.CHANGE_TARGET}" : "${env.JOB_BASE_NAME}"
   def e2eTestsPipeline = "e2e-tests/e2e-testing-mbp/${branchName}"
   def beatVersion = "${env.BEAT_VERSION}-SNAPSHOT"
 


### PR DESCRIPTION
## What does this PR do?
When triggering the e2e tests for Beats branches, we want to follow the same branch name schema than in Beats.

For that reason we are renaming e2e's maintenance branches from 7.15.x to 7.15

## Why is it important?
Consistency across related projects, aligining with stack versions