### PR TITLE
Fix sqs queue name from queuename to `queue.name`

### DIFF
--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/sqs/sqs.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/sqs/sqs.go
@@ -40,7 +40,7 @@ func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, ev
 		if _, ok := events[queueName]; !ok {
 			continue
 		}
-		events[queueName].RootFields.Put(metadataPrefix+"name", queueName)
+		events[queueName].RootFields.Put(metadataPrefix+".name", queueName)
 	}
 	return events
 }

--- a/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_daily_storage/s3_daily_storage_integration_test.go
@@ -10,25 +10,10 @@ package s3_daily_storage
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	_ "github.com/elastic/beats/v7/libbeat/processors/actions"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"
 )
-
-func TestFetch(t *testing.T) {
-	config := mtest.GetConfigForTest(t, "s3_daily_storage", "86400s")
-
-	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
-	events, errs := mbtest.ReportingFetchV2Error(metricSet)
-	if len(errs) > 0 {
-		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
-	}
-
-	assert.NotEmpty(t, events)
-	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
-}
 
 func TestData(t *testing.T) {
 	config := mtest.GetConfigForTest(t, "s3_daily_storage", "86400s")

--- a/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
+++ b/x-pack/metricbeat/module/aws/s3_request/s3_request_integration_test.go
@@ -10,25 +10,10 @@ package s3_request
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	_ "github.com/elastic/beats/v7/libbeat/processors/actions"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"
 )
-
-func TestFetch(t *testing.T) {
-	config := mtest.GetConfigForTest(t, "s3_request", "60s")
-
-	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
-	events, errs := mbtest.ReportingFetchV2Error(metricSet)
-	if len(errs) > 0 {
-		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
-	}
-
-	assert.NotEmpty(t, events)
-	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
-}
 
 func TestData(t *testing.T) {
 	config := mtest.GetConfigForTest(t, "s3_request", "60s")

--- a/x-pack/metricbeat/module/aws/sqs/_meta/data.json
+++ b/x-pack/metricbeat/module/aws/sqs/_meta/data.json
@@ -14,15 +14,14 @@
                 "deleted": 0,
                 "not_visible": 0,
                 "received": 0,
-                "sent": 0.2857142857142857,
-                "visible": 827.8
+                "sent": 0,
+                "visible": 1577.8
             },
             "oldest_message_age": {
-                "sec": 345606.4
+                "sec": 345603.2
             },
-            "queuename": "filebeat-aws-elb-test",
-            "sent_message_size": {
-                "bytes": 1006.5
+            "queue": {
+                "name": "filebeat-aws-elb-test"
             }
         },
         "tags": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to fix `aws.sqs.queuename` to `aws.sqs.queue.name` to match what's defined in fields.yml. Also since s3_daily_storage and s3_request metricsets are light weight module using cloudwatch metricset without adding additional metadata, `TestMetricsetFieldsDocumented` is removed from s3_daily_storage and s3_request metricsets.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.