### PR TITLE
Improve performance of autodiscover

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -542,6 +542,7 @@ for a few releases. Please use other tools provided by Elastic to fetch data fro
 - Update cloud.google.com/go library. {pull}28229[28229]
 - Add additional metadata to the root HTTP endpoint. {pull}28265[28265]
 - Upgrade k8s.io/client-go library. {pull}28228[28228]
+- Improve performance of autodiscover {pull}28524[28524]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -56,6 +56,9 @@ type Config struct {
 	Templates template.MapperSettings `config:"templates"`
 
 	AddResourceMetadata *metadata.AddResourceMetadataConfig `config:"add_resource_metadata"`
+
+	// Workers is the number of workers to run to process incoming kuberentes watch events
+	Workers int `config:"workers"`
 }
 
 // Public variable, so specific beats (as Filebeat) can set a different cleanup timeout if they need it.
@@ -68,6 +71,7 @@ func defaultConfig() *Config {
 		CleanupTimeout: DefaultCleanupTimeout,
 		Prefix:         "co.elastic",
 		Unique:         false,
+		Workers:        1,
 	}
 }
 

--- a/libbeat/autodiscover/providers/kubernetes/node.go
+++ b/libbeat/autodiscover/providers/kubernetes/node.go
@@ -78,6 +78,7 @@ func NewNodeEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pu
 		Node:         config.Node,
 		IsUpdated:    isUpdated,
 		HonorReSyncs: true,
+		Workers:      config.Workers,
 	}, nil)
 
 	if err != nil {

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -84,6 +84,7 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 		Node:         config.Node,
 		Namespace:    config.Namespace,
 		HonorReSyncs: true,
+		Workers:      config.Workers,
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Pod{}, err)
@@ -92,6 +93,7 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 	options := kubernetes.WatchOptions{
 		SyncTimeout: config.SyncPeriod,
 		Node:        config.Node,
+		Workers:     config.Workers,
 	}
 	if config.Namespace != "" {
 		options.Namespace = config.Namespace
@@ -106,6 +108,7 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 	}
 	namespaceWatcher, err := kubernetes.NewWatcher(client, &kubernetes.Namespace{}, kubernetes.WatchOptions{
 		SyncTimeout: config.SyncPeriod,
+		Workers:     config.Workers,
 	}, nil)
 	if err != nil {
 		logger.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Namespace{}, err)

--- a/libbeat/autodiscover/providers/kubernetes/service.go
+++ b/libbeat/autodiscover/providers/kubernetes/service.go
@@ -57,6 +57,7 @@ func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface,
 		SyncTimeout:  config.SyncPeriod,
 		Namespace:    config.Namespace,
 		HonorReSyncs: true,
+		Workers:      config.Workers,
 	}, nil)
 
 	if err != nil {
@@ -70,6 +71,7 @@ func NewServiceEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface,
 	namespaceWatcher, err = kubernetes.NewWatcher(client, &kubernetes.Namespace{}, kubernetes.WatchOptions{
 		SyncTimeout: config.SyncPeriod,
 		Namespace:   config.Namespace,
+		Workers:     config.Workers,
 	}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Namespace{}, err)

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -20,6 +20,7 @@ package cfgfile
 import (
 	"sync"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/joeshaw/multierror"
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
@@ -160,7 +161,9 @@ func HashConfig(c *common.Config) (uint64, error) {
 	if err := c.Unpack(&config); err != nil {
 		return 0, err
 	}
-	return hashstructure.Hash(config, nil)
+	return hashstructure.Hash(config, &hashstructure.HashOptions{
+		Hasher: xxhash.New(),
+	})
 }
 
 func (r *RunnerList) copyRunnerList() map[uint64]Runner {

--- a/libbeat/common/kubernetes/watcher.go
+++ b/libbeat/common/kubernetes/watcher.go
@@ -215,9 +215,9 @@ func (w *watcher) enqueue(obj interface{}, state string) {
 	}
 	if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		w.logger.Debugf("Enqueued DeletedFinalStateUnknown contained object: %+v", deleted.Obj)
-		w.queue.Add(&item{key, obj, state})
+		w.queue.Add(item{key, obj, state})
 	} else {
-		w.queue.Add(&item{key, nil, state})
+		w.queue.Add(item{key, nil, state})
 	}
 
 }
@@ -230,9 +230,9 @@ func (w *watcher) process(ctx context.Context) bool {
 	}
 	defer w.queue.Done(obj)
 
-	var entry *item
+	var entry item
 	var ok bool
-	if entry, ok = obj.(*item); !ok {
+	if entry, ok = obj.(item); !ok {
 		utilruntime.HandleError(fmt.Errorf("expected *item in workqueue but got %#v", obj))
 		return true
 	}
@@ -245,7 +245,7 @@ func (w *watcher) process(ctx context.Context) bool {
 		return true
 	}
 	if !exists {
-		if entry.state == delete && entry.objectRaw != nil {
+		if entry.state == delete {
 			w.logger.Debugf("Object %+v was not found in the store, deleting anyway!", key)
 			// delete anyway in order to clean states
 			w.handler.OnDelete(entry.objectRaw)

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -241,6 +241,7 @@ endif::[]
   either take `node` or `cluster` as values. `node` scope allows discovery of resources in
   the specified node. `cluster` scope allows cluster wide discovery. Only `pod` and `node` resources
   can be discovered at node scope.
+`workers`:: (Optional) The number of parallel instances that should process Kubernetes watch events. The default is 1.
 `add_resource_metadata`:: (Optional) Specify labels and annotations filters for the extra metadata coming from Node and Namespace.
  `add_resource_metadata` can be done for `node` or `namespace`. By default all labels will be included
   while annotations are not added by default. This settings are useful when labels' and annotations'

--- a/libbeat/processors/add_kubernetes_metadata/config.go
+++ b/libbeat/processors/add_kubernetes_metadata/config.go
@@ -40,6 +40,9 @@ type kubeAnnotatorConfig struct {
 	DefaultIndexers Enabled       `config:"default_indexers"`
 
 	AddResourceMetadata *metadata.AddResourceMetadataConfig `config:"add_resource_metadata"`
+
+	// Workers is the number of workers to run to process incoming kuberentes watch events
+	Workers int `config:"workers"`
 }
 
 type Enabled struct {
@@ -55,6 +58,7 @@ func defaultKubernetesAnnotatorConfig() kubeAnnotatorConfig {
 		DefaultMatchers: Enabled{true},
 		DefaultIndexers: Enabled{true},
 		Scope:           "node",
+		Workers:         1,
 	}
 }
 

--- a/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
+++ b/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
@@ -141,5 +141,6 @@ client. It defaults to `KUBECONFIG` environment variable if present.
 `cleanup_timeout`:: (Optional) Specify the time of inactivity before stopping the
 running configuration for a container. This is `60s` by default.
 `sync_period`:: (Optional) Specify the timeout for listing historical resources.
+`workers`:: (Optional) The number of parallel instances that should process Kubernetes watch events. The default is 1.
 `default_indexers.enabled`:: (Optional) Enable or disable default pod indexers when you want to specify your own.
 `default_matchers.enabled`:: (Optional) Enable or disable default pod matchers when you want to specify your own.

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -184,6 +184,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Confi
 			SyncTimeout: config.SyncPeriod,
 			Node:        config.Host,
 			Namespace:   config.Namespace,
+			Workers:     config.Workers,
 		}, nil)
 		if err != nil {
 			k.log.Errorf("Couldn't create kubernetes watcher for %T", &kubernetes.Pod{})


### PR DESCRIPTION

Enhancement

## What does this PR do?

This PR does the following:

* Add workers to the kubernetes watcher to do parallel processing of pod objects
* Fix the workqueue implementation as it was putting in whole objects. The workqueue is supposed to dedupe same objects that are already in the queue.
* Make autodiscover accumulate updates to the reloader. Each time beats starts up, if there are a large number of monitorable entities, each one of the configs calls reload on all the configs which took 20 minutes to process on some of our large clusters
* Change the cfgfile.Hash to use xxHash which is 9 times faster than the default used by hashstructure. 

## Why is it important?

On startup the creation of metricbeat/filebeat modules can take too long without these changes. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


- [ ]

## How to test this PR locally



## Related issues



## Use cases


## Screenshots


## Logs


