### PR TITLE
Cherry-pick to 7.x: docs: link to new APM book (#28519)

### DIFF
--- a/libbeat/docs/shared-instrumentation.asciidoc
+++ b/libbeat/docs/shared-instrumentation.asciidoc
@@ -7,7 +7,7 @@
 
 Libbeat uses the Elastic APM Go Agent to instrument its publishing pipeline.
 Currently, only the Elasticsearch output is instrumented.
-To gain insight into the performance of {beatname_uc}, you can enable this instrumentation and send trace data to APM Server.
+To gain insight into the performance of {beatname_uc}, you can enable this instrumentation and send trace data to the APM Integration.
 
 Example configuration with instrumentation enabled:
 
@@ -41,19 +41,19 @@ Environments can be filtered in the {kibana-ref}/xpack-apm.html[APM app].
 [float]
 ==== `hosts`
 
-The {apm-server-ref-v}/getting-started-apm-server.html[APM Server] hosts to report instrumentation data to.
+The APM integration {apm-guide-ref}/input-apm.html[host] to report instrumentation data to.
 Defaults to `http://localhost:8200`.
 
 [float]
 ==== `api_key`
 
-{apm-server-ref-v}/api-key.html[API key] used to secure communication with the APM Server(s).
+The {apm-guide-ref}/input-apm.html[API Key] used to secure communication with the APM Integration.
 If `api_key` is set then `secret_token` will be ignored.
 
 [float]
 ==== `secret_token`
 
-{apm-server-ref-v}/secret-token.html[Secret token] used to secure communication with the APM Server(s).
+The {apm-guide-ref}/input-apm.html[Secret token] used to secure communication with the APM Integration.
 
 [float]
 ==== `profiling.cpu.enabled`

--- a/libbeat/docs/shared/obs-apps.asciidoc
+++ b/libbeat/docs/shared/obs-apps.asciidoc
@@ -15,14 +15,14 @@ ifeval::["{beatname_lc}"!="filebeat"]
 |Logs
 endif::[]
 ifeval::["{beatname_lc}"!="winlogbeat"]
-|{winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat}] 
+|{winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat}]
 |Windows event logs
 endif::[]
 ifeval::["{beatname_lc}"!="heartbeat"]
 |{heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat}]
 |Uptime information
 endif::[]
-|{apm-overview-ref-v}/index.html[APM]
+|{apm-guide-ref}/index.html[APM]
 |Application performance metrics
 ifeval::["{beatname_lc}"!="auditbeat"]
 |{auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat}]
@@ -48,7 +48,7 @@ endif::[]
 |Monitor availability issues across your apps and services
 
 |{kibana-ref}/xpack-apm.html[APM app]
-|Monitor application performance 
+|Monitor application performance
 
 |{kibana-ref}/xpack-siem.html[{siem-app}]
 |Analyze security events

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -97,7 +97,7 @@ with a {logstash-ref}/use-ingest-pipelines.html[{ls} pipeline config].
 <4> The current version of {beatname_uc}.
 
 In addition to metadata, {beatname_uc} provides the `processor.event` field, which
-can be used to separate {apm-overview-ref-v}/apm-data-model.html[event types] into different indices.
+can be used to separate {apm-guide-ref}/data-model.html[event types] into different indices.
 endif::[]
 
 ifndef::apm-server[]
@@ -180,7 +180,7 @@ endif::[]
 ifdef::apm-server[]
 ==== {ls} and ILM
 
-When used with {apm-server-ref}/ilm.html[Index lifecycle management], {ls} does not need to create a new index each day.
+When used with Index lifecycle management, {ls} does not need to create a new index each day.
 Here's a sample {ls} configuration file that would accomplish this:
 
 [source,logstash]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: link to new APM book (#28519)