### PR TITLE
Cherry-pick #28533 to 7.16: Add proxy_url support to threatintel module's malwarebazaar fileset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -451,6 +451,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Azure signinlogs - Add support for ManagedIdentitySignInLogs, NonInteractiveUserSignInLogs, and ServicePrincipalSignInLogs. {issue}23653[23653]
 - Add `base64Decode` and `base64DecodeNoPad` functions to `httpsjon` templates. {pull}28385[28385]
 - Add latency config option for aws-cloudwatch input. {pull}28509[28509]
+- Added proxy support to threatintel/malwarebazaar. {pull}28533[28533]
 
 
 *Heartbeat*

--- a/filebeat/docs/modules/threatintel.asciidoc
+++ b/filebeat/docs/modules/threatintel.asciidoc
@@ -64,6 +64,10 @@ The URL of the API endpoint to connect with.
 
 How often the API is polled for updated information.
 
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
+
 Abuse.ch URL Threat Intel is mapped to the following ECS fields.
 
 [options="header"]
@@ -104,6 +108,10 @@ The URL of the API endpoint to connect with.
 
 How often the API is polled for updated information.
 
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
+
 Abuse.ch Malware Threat Intel is mapped to the following ECS fields.
 
 [options="header"]
@@ -143,6 +151,10 @@ The URL of the API endpoint to connect with.
 *`var.interval`*::
 
 How often the API is polled for updated information.
+
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
 
 Malware Bazaar Threat Intel is mapped to the following ECS fields.
 
@@ -234,6 +246,10 @@ from the last response as the filter when retrieving new events.
 List of filters to apply when retrieving new events from the MISP server, this
 field is optional and defaults to all events.
 
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
+
 MISP Threat Intel is mapped to the following ECS fields.
 
 [options="header"]
@@ -309,6 +325,10 @@ A comma delimited list of indicator types to include, defaults to all. A list of
 possible types to filter on can be found in the
 https://cybersecurity.att.com/documentation/usm-appliance/otx/about-otx.htm[AlientVault
 OTX documentation].
+
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
 
 
 OTX Threat Intel is mapped to the following ECS fields.
@@ -390,6 +410,10 @@ A comma delimited list of indicator types to include, defaults to all. A list of
 possible types to filter on can be found on the
 https://oasis-open.github.io/cti-documentation/stix/intro.html#stix-21-objects[Stix
 2.1 Object types] page.
+
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
 
 Anomali Threat Intel is mapped to the following ECS fields.
 

--- a/x-pack/filebeat/module/threatintel/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/threatintel/_meta/docs.asciidoc
@@ -59,6 +59,10 @@ The URL of the API endpoint to connect with.
 
 How often the API is polled for updated information.
 
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
+
 Abuse.ch URL Threat Intel is mapped to the following ECS fields.
 
 [options="header"]
@@ -99,6 +103,10 @@ The URL of the API endpoint to connect with.
 
 How often the API is polled for updated information.
 
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
+
 Abuse.ch Malware Threat Intel is mapped to the following ECS fields.
 
 [options="header"]
@@ -138,6 +146,10 @@ The URL of the API endpoint to connect with.
 *`var.interval`*::
 
 How often the API is polled for updated information.
+
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
 
 Malware Bazaar Threat Intel is mapped to the following ECS fields.
 
@@ -229,6 +241,10 @@ from the last response as the filter when retrieving new events.
 List of filters to apply when retrieving new events from the MISP server, this
 field is optional and defaults to all events.
 
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
+
 MISP Threat Intel is mapped to the following ECS fields.
 
 [options="header"]
@@ -304,6 +320,10 @@ A comma delimited list of indicator types to include, defaults to all. A list of
 possible types to filter on can be found in the
 https://cybersecurity.att.com/documentation/usm-appliance/otx/about-otx.htm[AlientVault
 OTX documentation].
+
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
 
 
 OTX Threat Intel is mapped to the following ECS fields.
@@ -385,6 +405,10 @@ A comma delimited list of indicator types to include, defaults to all. A list of
 possible types to filter on can be found on the
 https://oasis-open.github.io/cti-documentation/stix/intro.html#stix-21-objects[Stix
 2.1 Object types] page.
+
+*`var.proxy_url`*::
+
+Optional URL to use as HTTP proxy.
 
 Anomali Threat Intel is mapped to the following ECS fields.
 

--- a/x-pack/filebeat/module/threatintel/malwarebazaar/config/config.yml
+++ b/x-pack/filebeat/module/threatintel/malwarebazaar/config/config.yml
@@ -9,6 +9,9 @@ request.method: POST
 
 request.ssl: {{ .ssl | tojson }}
 {{ end }}
+{{ if .proxy_url }}
+request.proxy_url: {{ .proxy_url }}
+{{ end }}
 request.url: {{ .url }}
 #request.encode_as: application/x-www-form-encoded
 

--- a/x-pack/filebeat/module/threatintel/malwarebazaar/manifest.yml
+++ b/x-pack/filebeat/module/threatintel/malwarebazaar/manifest.yml
@@ -10,6 +10,7 @@ var:
   - name: ssl
   - name: tags
     default: [threatintel-malwarebazaar, forwarded]
+  - name: proxy_url
 
 ingest_pipeline:
   - ingest/pipeline.yml


### PR DESCRIPTION
Cherry-pick of PR elastic/beats#28533 to 7.16 branch. Original message: 

## What does this PR do?

This PR adds proxy support to threatintel module's malwarebazaar fileset.

Also updates the docs to reflect all the existing `proxy_url` options in other filesets.

## Why is it important?

With this change, all the Threat Intel sources support the `proxy_url` configuration option.

The only exception is the `anomali_threatstream` fileset which acts as an HTTP server so it has no use for a proxy option. For this fileset, proxy is configured in the SDK provided by Anomali.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
