### PR TITLE
[Heartbeat] Only setuid in elastic-agent image

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -132,7 +132,6 @@ USER {{ .user }}
 {{- if (and (eq .BeatName "heartbeat") (not (contains .from "ubi-minimal")))  }}
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
-ENV BEAT_SETUID_AS={{ .user }}
 ENV SUITES_DIR={{ $beatHome }}/suites
 ENV NODE_VERSION=14.17.5
 ENV PATH="$NODE_PATH/node/bin:$PATH"


### PR DESCRIPTION
Fixes #28572 by only invoking setuid in the elastic-agent container, and no longer in the heartbeat container. See the linked issue for details.

No changelog bump needed as the setuid feature is still unreleased.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~
