### PR TITLE
x-pack/auditbeat/tracing: fix invalid span in array punning

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix handling of long file names on Windows. {issue}25334[25334] {pull}28517[28517]
 - System/socket dataset: Fix uninstallation of return kprobes. {issue}28608[28608] {pull}28609[28609]
 - Replace usage of deprecated `process.ppid` field with `process.parent.pid`. {pull}28620[28620]
+- Fix auditbeat tracing struct decoding. {pull}28580[28580]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/tracing/decoder.go
+++ b/x-pack/auditbeat/tracing/decoder.go
@@ -320,9 +320,8 @@ func (d *structDecoder) Decode(raw []byte, meta Metadata) (s interface{}, err er
 		}
 		switch dec.typ {
 		case FieldTypeInteger:
-			if err := copyInt(
-				unsafe.Pointer(uintptr(destPtr)+dec.dst),
-				unsafe.Pointer(&raw[dec.src]), uint8(dec.len)); err != nil {
+			err := copyInt(unsafe.Add(destPtr, dec.dst), unsafe.Pointer(&raw[dec.src]), uint8(dec.len))
+			if err != nil {
 				return nil, fmt.Errorf("bad size=%d for integer field=%s", dec.len, dec.name)
 			}
 
@@ -335,13 +334,13 @@ func (d *structDecoder) Decode(raw []byte, meta Metadata) (s interface{}, err er
 			if len > 0 && raw[offset+len-1] == 0 {
 				len--
 			}
-			*((*string)(unsafe.Pointer(uintptr(destPtr) + dec.dst))) = string(raw[offset : offset+len])
+			*(*string)(unsafe.Add(destPtr, dec.dst)) = string(raw[offset : offset+len])
 
 		case FieldTypeMeta:
-			*(*Metadata)(unsafe.Pointer(uintptr(destPtr) + dec.dst)) = meta
+			*(*Metadata)(unsafe.Add(destPtr, dec.dst)) = meta
 
 		case FieldTypeRaw:
-			copy((*(*[maxRawCopySize]byte)(unsafe.Pointer(uintptr(destPtr) + dec.dst)))[:dec.len], raw[dec.src:dec.src+dec.len])
+			copy(unsafe.Slice((*byte)(unsafe.Add(destPtr, dec.dst)), dec.len), raw[dec.src:])
 		}
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Previously the copy for the raw case converted the unsafe pointer to a concrete
array of 2048 bytes due to an unnecessary pointer dereference. This invalidly
spans beyond the end of the struct allocation. This is identified either with a
build using the race detector or with `-gcflags=all=-d=checkptr`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This removes invalid unsafe behaviour.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

N/A

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Standard testing.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #17165

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

N/A

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

N/A

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

N/A