### PR TITLE
Disable flaky tests in Metricbeat aws module

### DIFF
--- a/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
+++ b/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/25130")
 	config := mtest.GetConfigForTest(t, "billing", "24h")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/24200")
 	config := mtest.GetConfigForTest(t, "cloudwatch", "300s")
 
 	config = addCloudwatchMetricsToConfig(config)

--- a/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/24201")
 	config := mtest.GetConfigForTest(t, "ec2", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)

--- a/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
+++ b/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/24202")
 	config := mtest.GetConfigForTest(t, "rds", "60s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("flaky test: https://github.com/elastic/beats/issues/24205")
 	config := mtest.GetConfigForTest(t, "sqs", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to temporarily disable these flaky tests and wait till https://github.com/elastic/beats/pull/28528 gets merged (blocked by e2e test failure in elastic-agent).