### PR TITLE
[CI]: use the downstream packaging pipeline for branches/tags

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -102,6 +102,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^auditbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -112,3 +115,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^auditbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -105,6 +105,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^filebeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -115,3 +118,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^filebeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -107,6 +107,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^heartbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -117,3 +120,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^heartbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss

--- a/journalbeat/Jenkinsfile.yml
+++ b/journalbeat/Jenkinsfile.yml
@@ -44,6 +44,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^journalbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -54,3 +57,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^journalbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -96,6 +96,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^metricbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -106,3 +109,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^metricbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -100,6 +100,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^packetbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -110,3 +113,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^packetbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -72,3 +72,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^winlogbeat/.*"
+              - "@oss"               ## special token regarding the changeset for the oss

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -100,6 +100,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/auditbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -110,3 +113,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/auditbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/dockerlogbeat/Jenkinsfile.yml
+++ b/x-pack/dockerlogbeat/Jenkinsfile.yml
@@ -34,6 +34,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/dockerlogbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -44,3 +47,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/dockerlogbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -101,6 +101,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/elastic-agent/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -111,3 +114,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/elastic-agent/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -126,6 +126,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/filebeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -136,3 +139,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/filebeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -97,3 +97,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/functionbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -91,6 +91,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/heartbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -101,3 +104,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/heartbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -108,6 +108,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/metricbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -118,3 +121,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/metricbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -81,3 +81,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/osquerybeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -101,6 +101,9 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/packetbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack
     packaging-arm:
         packaging-arm: "mage package"
         e2e:
@@ -111,3 +114,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/packetbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -74,3 +74,6 @@ stages:
         when:
             branches: false    ## Only on a PR basis for the time being
             tags: false        ## packaging on branches/tags is already in place with the downstream build.
+            changeset:         ## when PR contains any of those entries in the changeset
+              - "^x-pack/winlogbeat/.*"
+              - "@xpack"             ## special token regarding the changeset for the xpack


### PR DESCRIPTION
## Context

To clarify the existing CI pipelines please see the below details:

1) `Main pipeline` is the one that validates every single commit in this repository. It's implemented in the `Jenkinsfile` and specifically in each `<beat>/Jenkinsfile.yml`
2) `Packaging pipeline` is the one that validates the packages are generated as expected for each beat:
  a) On merge to any branches it gets triggered if the `Main pipeline` build finished correctly.
  b) On a PR basis if someone comment with `/package` or use the Jenkins UI.
3) `E2e pipeline` is the one that runs the tests defined in https://github.com/elastic/e2e-testing. It gets triggered immediately after the `Packaging pipeline` finished correctly.
4) `Beats-tester` is the one that runs the tests defined in https://github.com/elastic/beats-tester. It gets triggered immediately after the `Main pipeline` build finished correctly. Or if someone adds the GitHub comment `/beats-tester`

## What does this PR do?

Remove packaging/e2e in the `Main pipeline` for merge-commits in branches or tags.

## Why is it important?

Avoid duplicated tasks since the `Packaging` pipeline is already doing it.

Eventually, we will tweak the `Packaging` pipeline to let running individual beats, and then we will be able to remove all the packaging implementation details and e2e defined in the `Main` pipeline. As we will eventually use the downstream jobs. TBD

But this proposal should reduce the build load in `Beats-CI` quite a bit!