### PR TITLE
Add request id to HTTP transactions to allow tracking.

### DIFF
--- a/x-pack/elastic-agent/pkg/remote/client.go
+++ b/x-pack/elastic-agent/pkg/remote/client.go
@@ -168,12 +168,12 @@ func (c *Client) Send(
 	body io.Reader,
 ) (*http.Response, error) {
 	// Generate a request ID for tracking
-	var reqId string
+	var reqID string
 	if u, err := id.Generate(); err == nil {
-		reqId = u.String()
+		reqID = u.String()
 	}
 
-	c.log.Debugf("Request method: %s, path: %s, reqId: %s", method, path, reqId)
+	c.log.Debugf("Request method: %s, path: %s, reqID: %s", method, path, reqID)
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	requester := c.nextRequester()
@@ -191,8 +191,8 @@ func (c *Client) Send(
 	req.Header.Set("kbn-xsrf", "1") // Without this Kibana will refuse to answer the request.
 
 	// If available, add the request id as an HTTP header
-	if reqId != "" {
-		req.Header.Add("X-Request-ID", reqId)
+	if reqID != "" {
+		req.Header.Add("X-Request-ID", reqID)
 	}
 
 	// copy headers.


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the "X-Request-ID" header to HTTP transactions with Fleet Server. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This allows tracking of the transaction through the cloud proxy and into Fleet Server.  The request Id can be aligned across log entries.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- [x ] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

