### PR TITLE
[Agent] Add cmd.Wait() call to process pkg

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -91,6 +91,7 @@
 - Snapshot artifact lookup will use agent.download proxy settings. {issue}27903[27903] {pull}27904[27904]
 - Fix lazy acker to only add new actions to the batch. {pull}27981[27981]
 - Allow HTTP metrics to run in bootstrap mode. Add ability to adjust timeouts for Fleet Server. {pull}28260[28260]
+- Cleanup resources associated with sub-processes. {pull}28593[28593]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -222,7 +222,7 @@ func containerCmd(streams *cli.IOStreams, cmd *cobra.Command) error {
 			logInfo(streams, "Legacy apm-server daemon started.")
 			go func() {
 				if err := func() error {
-					apmProcState, err := apmProc.Process.Wait()
+					apmProcState, err := apmProc.Cmd.Process.Wait()
 					if err != nil {
 						return err
 					}

--- a/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/enroll_cmd.go
@@ -577,7 +577,7 @@ func (c *enrollCmd) startAgent(ctx context.Context) (<-chan *os.ProcessState, er
 	}
 	resChan := make(chan *os.ProcessState)
 	go func() {
-		procState, _ := proc.Process.Wait()
+		procState, _ := proc.Cmd.Process.Wait()
 		resChan <- procState
 	}()
 	c.agentProc = proc

--- a/x-pack/elastic-agent/pkg/core/monitoring/server/processes_test.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/server/processes_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -53,8 +54,10 @@ func TestProcesses(t *testing.T) {
 					"filebeat--8.0.0": {
 						ProcessInfo: &process.Info{
 							PID: 123,
-							Process: &os.Process{
-								Pid: 123,
+							Cmd: &exec.Cmd{
+								Process: &os.Process{
+									Pid: 123,
+								},
 							},
 						},
 						Status: state.Configuring,
@@ -91,8 +94,10 @@ func TestProcesses(t *testing.T) {
 					"filebeat--8.0.0--tag": {
 						ProcessInfo: &process.Info{
 							PID: 123,
-							Process: &os.Process{
-								Pid: 123,
+							Cmd: &exec.Cmd{
+								Process: &os.Process{
+									Pid: 123,
+								},
 							},
 						},
 						Status: state.Configuring,

--- a/x-pack/elastic-agent/pkg/core/plugin/process/app.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/app.go
@@ -189,7 +189,7 @@ func (a *Application) watch(ctx context.Context, p app.Taggable, proc *process.I
 		var procState *os.ProcessState
 
 		select {
-		case ps := <-a.waitProc(proc.Process):
+		case ps := <-a.waitProc(proc.Cmd.Process):
 			procState = ps
 		case <-a.bgContext.Done():
 			return
@@ -275,7 +275,7 @@ func (a *Application) cleanUp() {
 }
 
 func (a *Application) gracefulKill(proc *process.Info) {
-	if proc == nil || proc.Process == nil {
+	if proc == nil || proc.Cmd.Process == nil {
 		return
 	}
 
@@ -288,9 +288,9 @@ func (a *Application) gracefulKill(proc *process.Info) {
 	go func() {
 		wg.Done()
 
-		if _, err := proc.Process.Wait(); err != nil {
+		if _, err := proc.Cmd.Process.Wait(); err != nil {
 			// process is not a child - some OSs requires process to be child
-			a.externalProcess(proc.Process)
+			a.externalProcess(proc.Cmd.Process)
 		}
 		close(doneChan)
 	}()
@@ -304,6 +304,6 @@ func (a *Application) gracefulKill(proc *process.Info) {
 	select {
 	case <-doneChan:
 	case <-t.C:
-		_ = proc.Process.Kill()
+		_ = proc.Cmd.Process.Kill()
 	}
 }

--- a/x-pack/elastic-agent/pkg/core/plugin/process/start.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/start.go
@@ -52,7 +52,7 @@ func (a *Application) start(ctx context.Context, t app.Taggable, cfg map[string]
 		a.stopWatcher(a.state.ProcessInfo)
 
 		// kill the process
-		_ = a.state.ProcessInfo.Process.Kill()
+		_ = a.state.ProcessInfo.Cmd.Process.Kill()
 		a.state.ProcessInfo = nil
 	}
 
@@ -98,7 +98,7 @@ func (a *Application) start(ctx context.Context, t app.Taggable, cfg map[string]
 				a.srvState = nil
 			}
 			if a.state.ProcessInfo != nil {
-				_ = a.state.ProcessInfo.Process.Kill()
+				_ = a.state.ProcessInfo.Cmd.Process.Kill()
 				a.state.ProcessInfo = nil
 			}
 		}

--- a/x-pack/elastic-agent/pkg/core/plugin/process/status.go
+++ b/x-pack/elastic-agent/pkg/core/plugin/process/status.go
@@ -101,8 +101,8 @@ func (a *Application) restart(proc *process.Info) {
 	a.stopWatcher(proc)
 
 	// kill the process
-	if proc != nil && proc.Process != nil {
-		_ = proc.Process.Kill()
+	if proc != nil && proc.Cmd.Process != nil {
+		_ = proc.Cmd.Process.Kill()
 	}
 
 	if proc != a.state.ProcessInfo {

--- a/x-pack/elastic-agent/pkg/core/process/process.go
+++ b/x-pack/elastic-agent/pkg/core/process/process.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/errors"
@@ -22,9 +21,9 @@ var (
 
 // Info groups information about fresh new process
 type Info struct {
-	PID     int
-	Process *os.Process
-	Stdin   io.WriteCloser
+	PID   int
+	Cmd   *exec.Cmd
+	Stdin io.WriteCloser
 }
 
 // Option is an option func to change the underlying command
@@ -60,15 +59,15 @@ func StartContext(ctx context.Context, logger *logger.Logger, path string, confi
 	}
 
 	return &Info{
-		PID:     cmd.Process.Pid,
-		Process: cmd.Process,
-		Stdin:   stdin,
+		PID:   cmd.Process.Pid,
+		Cmd:   cmd,
+		Stdin: stdin,
 	}, err
 }
 
 // Stop stops the process cleanly.
 func (i *Info) Stop() error {
-	return terminateCmd(i.Process)
+	return terminateCmd(i.Cmd.Process)
 }
 
 // StopWait stops the process and waits for it to exit.
@@ -77,6 +76,5 @@ func (i *Info) StopWait() error {
 	if err != nil {
 		return err
 	}
-	_, err = i.Process.Wait()
-	return err
+	return i.Cmd.Wait()
 }


### PR DESCRIPTION
## What does this PR do?

The process runner was missing a call to exec.Command#Wait. It did call Wait on the os.Process,
but there are possibly some handles and goroutines to cleanup in the exec.Command.

## Why is it important?

Without the Wait() call it could leak some resources.

## Checklist

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
