### PR TITLE
Osquerybeat: Fix extenstion unable to start on windows

### DIFF
--- a/x-pack/osquerybeat/internal/osqd/args.go
+++ b/x-pack/osquerybeat/internal/osqd/args.go
@@ -82,6 +82,14 @@ var protectedFlags = Flags{
 	"config_refresh": 10,
 }
 
+func init() {
+	// Append platform specific flags
+	plArgs := platformArgs()
+	for k, v := range plArgs {
+		protectedFlags[k] = v
+	}
+}
+
 func convertToArgs(flags Flags) Args {
 	if flags == nil {
 		return nil

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
@@ -45,7 +45,7 @@ func SocketPath(dir string) string {
 	return filepath.Join(dir, "osquery.sock")
 }
 
-func platformArgs() []string {
+func platformArgs() map[string]interface{} {
 	return nil
 }
 

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_windows.go
@@ -28,9 +28,9 @@ func SocketPath(dir string) string {
 	return `\\.\pipe\elastic\osquery\` + uuid.Must(uuid.NewV4()).String()
 }
 
-func platformArgs() []string {
-	return []string{
-		"--allow_unsafe",
+func platformArgs() map[string]interface{} {
+	return map[string]interface{}{
+		"allow_unsafe": true,
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the error on Windows unable to start osquery. 

The corresponding log looked something like this:
```
Failed to run osqueryd: W1021 12:08:45.920866   648 extensions.cpp:426] Will not autoload extension with unsafe directory permissions
```

The issue was missing platform specific flag for Windows in particular from 7.15 that was lost when making changes for reloadable osquery configuration

## Why is it important?

Fixes the error on Windows unable to start osquery. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## Screenshots

Confirmed the osquery runs on windows and returns results: 
<img width="1261" alt="Screen Shot 2021-10-21 at 6 53 10 PM" src="https://user-images.githubusercontent.com/872351/138368208-63ddeb1e-262e-4b13-ba41-a3ff41a9f6bf.png">


