### PR TITLE
[7.x] [DOCS] Update api_key example on elasticsearch output

### DIFF
--- a/libbeat/docs/https.asciidoc
+++ b/libbeat/docs/https.asciidoc
@@ -54,7 +54,7 @@ For example:
 ----------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["https://myEShost:9200"]
-  api_key: "KnR6yE41RrSowb0kQ0HWoA" <1>
+  api_key: "ZCV7VnwBgnX0T19fN8Qe:KnR6yE41RrSowb0kQ0HWoA" <1>
 ----------------------------------------------------------------------
 <1> This API key must have the privileges required to publish events to {es}.
 To create an API key like this, see <<beats-api-keys>>.


### PR DESCRIPTION
## What does this PR do?

The same as [PR 28288](https://github.com/elastic/beats/pull/28288) but for https://www.elastic.co/guide/en/beats/filebeat/current/securing-communication-elasticsearch.html
Update `api_key` example on elasticsearch output to include the `id` and the `api_key`

## Why is it important?

Current example is misleading as the elasticsearch output uses `api_key` to refer to what should be `id:api_key`. A few customers have stumbled on this as they thought they would need only the `api_key` part from the `POST /_security/api_key` response:
```
{
  "id" : "ZCV7VnwBgnX0T19fN8Qe",
  "name" : "my-api-key",
  "expiration" : 1633624888071,
  "api_key" : "sWBxrOMISVCmEyGDlwwcOg"
}
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

-  [ ]  My code follows the style guidelines of this project 
- [ ]  I have commented my code, particularly in hard-to-understand areas 
- [x] I have made corresponding changes to the documentation
- [ ]  I have made corresponding change to the default configuration files 
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
