### PR TITLE
CI: nightly/weekly builds for 7.x targeting 7.16 instead

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -21,8 +21,8 @@ pipeline {
     stage('Nighly beats builds') {
       steps {
         runBuild(quietPeriod: 0, job: 'Beats/beats/master')
-        runBuild(quietPeriod: 2000, job: 'Beats/beats/7.x')
-        runBuild(quietPeriod: 4000, job: 'Beats/beats/7.<minor>')
+        runBuild(quietPeriod: 2000, job: 'Beats/beats/7.16')
+        runBuild(quietPeriod: 4000, job: 'Beats/beats/7.15')
       }
     }
   }
@@ -35,9 +35,5 @@ pipeline {
 
 def runBuild(Map args = [:]) {
   def jobName = args.job
-  if (jobName.contains('7.<minor>')) {
-    def parts = stackVersions.release().split('\\.')
-    jobName = args.job.replaceAll('<minor>', parts[1])
-  }
   build(quietPeriod: args.quietPeriod, job: jobName, parameters: [booleanParam(name: 'macosTest', value: true)], wait: false, propagate: false)
 }

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -18,12 +18,11 @@ pipeline {
     cron('H H(1-2) * * 0')
   }
   stages {
-    stage('Nighly beats builds') {
+    stage('Weekly beats builds') {
       steps {
         runBuild(quietPeriod: 0, job: 'Beats/beats/master')
-        runBuild(quietPeriod: 1000, job: 'Beats/beats/7.x')
-        // <minor> is an alias to be replaced with the latest release branch
-        runBuild(quietPeriod: 2000, job: 'Beats/beats/7.<minor>')
+        runBuild(quietPeriod: 1000, job: 'Beats/beats/7.16')
+        runBuild(quietPeriod: 2000, job: 'Beats/beats/7.15')
       }
     }
   }
@@ -36,9 +35,5 @@ pipeline {
 
 def runBuild(Map args = [:]) {
   def jobName = args.job
-  if (jobName.contains('7.<minor>')) {
-    def parts = stackVersions.release().split('\\.')
-    jobName = args.job.replaceAll('<minor>', parts[1])
-  }
   build(quietPeriod: args.quietPeriod, job: jobName, parameters: [booleanParam(name: 'awsCloudTests', value: true)], wait: false, propagate: false)
 }


### PR DESCRIPTION
## What does this PR do?

Use fixed branch versions

## Why is it important?

`7.x` branch was renamed to `7.16`