### PR TITLE
Osquerybeat: Fix host_processes missing cmdline arguments

### DIFF
--- a/x-pack/osquerybeat/ext/osquery-extension/internal/proc/cmdline.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/internal/proc/cmdline.go
@@ -5,6 +5,7 @@
 package proc
 
 import (
+	"bytes"
 	"io/ioutil"
 	"strings"
 )
@@ -16,6 +17,8 @@ func ReadCmdLine(root string, pid string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	b = bytes.ReplaceAll(b, []byte{0}, []byte{' '})
 
 	return strings.TrimSpace(string(b)), nil
 }


### PR DESCRIPTION
## What does this PR do?

Fix host_processes missing cmdline arguments.
The arguments in cmdline content are '\0' separated, the parsing code needed to be corrected.

Addresses: https://github.com/elastic/security-team/issues/1812#issuecomment-950393104

## Why is it important?

Addresses: https://github.com/elastic/security-team/issues/1812#issuecomment-950393104

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Screenshots

<img width="940" alt="Screen Shot 2021-10-25 at 10 09 35 AM" src="https://user-images.githubusercontent.com/872351/138712449-f81fb064-e9c8-43ce-bc49-1417ab7c3a34.png">

