### PR TITLE
[CI]: exclude packaging meta-stage on branches and tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,11 +141,9 @@ pipeline {
     stage('Packaging') {
       options { skipDefaultCheckout() }
       when {
-        // Always when running builds on branches/tags
         // On a PR basis, skip if changes are only related to docs.
         // Always when forcing the input parameter
         anyOf {
-          not { changeRequest() }                           // If no PR
           allOf {                                           // If PR and no docs changes
             expression { return env.ONLY_DOCS == "false" }
             changeRequest()


### PR DESCRIPTION
## What does this PR do?

Follow up from https://github.com/elastic/beats/pull/28589

Explicitly disable the packaging on tags/branches

## Why is it important?

Leftover since the change could be done in the Pipeline itself or the `Jenkinsfile.yml`, https://github.com/elastic/beats/pull/28589 only applied the changes in the `Jenkinsfile.yml`, this PR ensures the same change applies in both cases.

