### PR TITLE
Fix structure of filestream input documentation

### DIFF
--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -483,6 +483,8 @@ Set the location of the marker file the following way:
 file_identity.inode_marker.path: /logs/.filebeat-marker
 ----
 
+[[filestream-log-rotation-support]]
+[float]
 === Log rotation
 
 As log files are constantly written, they must be rotated and purged to prevent


### PR DESCRIPTION
## What does this PR do?

This PR fixes the structure of the filestream input documentation.

## Why is it important?

Log rotation showed up under the list of inputs. That is clearly not an input. :) Also, documentation for `parsers`, `prospector` and other options were hard to find due to this structural problem.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~