### PR TITLE
Osquerybeat: Fix timestamp serialization for ECS-mapped date field

### DIFF
--- a/x-pack/osquerybeat/internal/ecs/mapping.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping.go
@@ -20,7 +20,7 @@ type Mapping map[string]MappingInfo
 
 // Map creates the copy of the values from the doc[src] key to the doc[dst] key where the dst can be nested '.' delimited key
 // Source is expected to be a simple key name, the destination could be nested child node
-func (m Mapping) Map(doc Doc) Doc {
+func (m Mapping) Map(doc map[string]interface{}) map[string]interface{} {
 	res := make(Doc)
 	for dst, mi := range m {
 		if mi.Value != nil {
@@ -46,7 +46,7 @@ func (d Doc) Get(key string) (val interface{}, ok bool) {
 		}
 		val, ok = node[keys[i]]
 		if ok {
-			node, ok = val.(Doc)
+			node, ok = val.(map[string]interface{})
 			if ok {
 				continue
 			} else {
@@ -65,7 +65,7 @@ func (d Doc) Get(key string) (val interface{}, ok bool) {
 
 func (d Doc) Set(key string, val interface{}) {
 	keys := getKeys(key)
-	node := d
+	node := map[string]interface{}(d)
 
 	// Create nested keys if needed
 	for i := 0; i < len(keys)-1; i++ {
@@ -75,11 +75,19 @@ func (d Doc) Set(key string, val interface{}) {
 
 		inode, ok := node[keys[i]]
 		if ok {
-			node, ok = inode.(Doc)
+			node, ok = inode.(map[string]interface{})
+			// Should never happen, internal implementation
+			if !ok {
+				return
+			}
 		} else {
-			d := make(Doc)
-			node[keys[i]] = d
-			node = d
+			// Need to use the map[string]interface{} for the tree nodes
+			// otherwise the large numbers are serialized into scientific notation in bulk json
+			// which breaks values like unix timestamp in seconds
+			// Fixes the issue https://github.com/elastic/security-team/issues/1950
+			m := make(map[string]interface{})
+			node[keys[i]] = m
+			node = m
 		}
 	}
 

--- a/x-pack/osquerybeat/internal/ecs/mapping_test.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping_test.go
@@ -35,7 +35,7 @@ func TestMap(t *testing.T) {
 		"a.b.c.d.g":     {Field: "uid_signed"},
 	}
 
-	doc := mapping.Map(testOsqueryResult)
+	doc := Doc(mapping.Map(testOsqueryResult))
 
 	for dst, mi := range mapping {
 		val, ok := doc.Get(dst)
@@ -55,7 +55,7 @@ func TestMapBadKeys(t *testing.T) {
 		"..": {Field: "test"},
 	}
 
-	doc := mapping.Map(testOsqueryResult)
+	doc := Doc(mapping.Map(testOsqueryResult))
 
 	for _, mi := range mapping {
 		_, ok := doc.Get(mi.Field)
@@ -74,7 +74,7 @@ func TestMapValue(t *testing.T) {
 		"value.array":  {Value: []interface{}{"1234", "test", 42}},
 	}
 
-	doc := mapping.Map(testOsqueryResult)
+	doc := Doc(mapping.Map(testOsqueryResult))
 
 	for dst, mi := range mapping {
 		val, ok := doc.Get(dst)


### PR DESCRIPTION
## What does this PR do?

Fix timestamp serialization for ECS-mapped date field.
The issue was with the tree-like data structure generated from ECS mapping was having node values
defined as ```type Doc map[string]interface{}``` which was falling back to the defaulting to serializing large numbers as doubles (scientific notation) which is not supported format for the date field in Elasticsearch since 2018. 
Changing the tree nodes to map[string]interface{} type allows libbeat to handle serialization correctly.

## Why is it important?

Resolves: https://github.com/elastic/security-team/issues/1950

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/security-team/issues/1950

## Screenshots
After the change the query with ECS mapping to the date field executes and returns results 
<img width="1201" alt="Screen Shot 2021-10-26 at 4 38 54 PM" src="https://user-images.githubusercontent.com/872351/138958791-606486e8-11ad-4e59-93fb-9f3c4eeb601f.png">

This demonstrates the correct type and value for the package.installed field:
<img width="1020" alt="Screen Shot 2021-10-26 at 4 39 21 PM" src="https://user-images.githubusercontent.com/872351/138958886-89c0d0be-584c-4538-9a50-5a6034f690f6.png">



