### PR TITLE
Osquerybeat: Allow event.category to be set with ECS mapping to value

### DIFF
--- a/x-pack/osquerybeat/internal/pub/publisher.go
+++ b/x-pack/osquerybeat/internal/pub/publisher.go
@@ -117,9 +117,17 @@ func hitToEvent(index, eventType, actionID, responseID string, hit map[string]in
 	}
 
 	// Add event.module for ECS
-	fields["event"] = map[string]string{
-		"module": eventModule,
+	// There could be already "event" properties set, preserve them and set the "event.module"
+	var evf map[string]interface{}
+	ievf, ok := fields["event"]
+	if ok {
+		evf, ok = ievf.(map[string]interface{})
 	}
+	if !ok {
+		evf = make(map[string]interface{})
+	}
+	evf["module"] = eventModule
+	fields["event"] = evf
 
 	fields["type"] = eventType
 	fields["action_id"] = actionID


### PR DESCRIPTION
## What does this PR do?

Allow event.category to be set with ECS mapping to value.
This allows to set the event.category for certain queries with ECS mapping to static value, which makes the results documents compatible with EQL queries/rules.
Before the change the category.module fields was set the way that it was preventing any other event properties that user could have provided.

The static value ECS mapping is currently not supported on UI, so this one was test with manually creating the .fleet-actions document.

Probably can hold off on backporting to 7.16, but it can go into 7.16.1.
@james-elastic @melissaburpo @patrykkopycinski  let me know.

## Why is it important?

One step close to utilizing existing EQL rules.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Screenshots

Example of the processes query with ECS mapping ```event.category``` to ```processes```:

<img width="681" alt="Screen Shot 2021-10-26 at 9 55 09 PM" src="https://user-images.githubusercontent.com/872351/138988078-e0a3ba57-2a2b-4a37-875a-64220dd4c984.png">


Result with ```event.category``` set to processes:

<img width="1296" alt="Screen Shot 2021-10-26 at 9 55 52 PM" src="https://user-images.githubusercontent.com/872351/138988197-b5e53029-550c-46bb-ae49-0d3cf04cb529.png">

