### PR TITLE
[libbeat] Allow fingerprint processor to read @timestamp

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -229,6 +229,7 @@ for a few releases. Please use other tools provided by Elastic to fetch data fro
 - Fix handling of float data types within processors. {issue}28279[28279] {pull}28280[28280]
 - Allow `clone3` syscall in seccomp filters. {pull}28117[28117]
 - Remove unnecessary escaping step in dashboard loading, so they can be displayed in Kibana. {pull}28395[28395]
+- Fix `fingerprint` processor to give it access to the `@timestamp` field. {issue}28683[28683]
 
 *Auditbeat*
 

--- a/libbeat/processors/fingerprint/docs/fingerprint.asciidoc
+++ b/libbeat/processors/fingerprint/docs/fingerprint.asciidoc
@@ -8,6 +8,9 @@
 The `fingerprint` processor generates a fingerprint of an event based on a
 specified subset of its fields.
 
+The value that is hashed is constructed as a concatenation of the field name and
+field value separated by `|`. For example `|field1|value1|field2|value2|`.
+
 [source,yaml]
 -----------------------------------------------------
 processors:
@@ -17,7 +20,8 @@ processors:
 
 The following settings are supported:
 
-`fields`:: List of fields to use as the source for the fingerprint.
+`fields`:: List of fields to use as the source for the fingerprint. The list
+will be alphabetically sorted by the processor.
 `ignore_missing`:: (Optional) Whether to ignore missing fields. Default is `false`.
 `target_field`:: (Optional) Field in which the generated fingerprint should be stored. Default is `fingerprint`.
 `method`:: (Optional) Algorithm to use for computing the fingerprint. Must be one of: `md5`, `sha1`, `sha256`, `sha384`, `sha512`, `xxhash`. Default is `sha256`.

--- a/libbeat/processors/fingerprint/errors.go
+++ b/libbeat/processors/fingerprint/errors.go
@@ -54,7 +54,7 @@ func makeErrConfigUnpack(cause error) errConfigUnpack {
 	return errConfigUnpack{cause}
 }
 func (e errConfigUnpack) Error() string {
-	return fmt.Sprintf("failed to unpack %v processor configuration: %v", processorName, e.cause)
+	return fmt.Sprintf("failed to unpack %v processor configuration: %v", procName, e.cause)
 }
 
 func makeErrComputeFingerprint(cause error) errComputeFingerprint {

--- a/libbeat/processors/fingerprint/fingerprint_test.go
+++ b/libbeat/processors/fingerprint/fingerprint_test.go
@@ -54,6 +54,15 @@ func TestWithConfig(t *testing.T) {
 			},
 			want: "14a0364b79acbe4c78dd5e77db2c93ae8c750518b32581927d50b3eef407184e",
 		},
+		"with @timestamp": {
+			config: common.MapStr{
+				"fields": []string{"@timestamp", "message"},
+			},
+			input: common.MapStr{
+				"message": `test message "hello world"`,
+			},
+			want: "081da76e049554943843b83948ac83ab7aa79fd2849331813e02042586021c26",
+		},
 	}
 
 	for name, test := range cases {
@@ -63,7 +72,7 @@ func TestWithConfig(t *testing.T) {
 			require.NoError(t, err)
 
 			testEvent := &beat.Event{
-				Timestamp: time.Now(),
+				Timestamp: time.Unix(1635443183, 0),
 				Fields:    test.input.Clone(),
 			}
 			newEvent, err := p.Run(testEvent)


### PR DESCRIPTION
## What does this PR do?

Use `beat.Event.GetValue` so that @timestamp and @metadata are accessible to
be hashed.

Also clarify the documentation to explain how the value being hashed is constructed.

Fixes #28683

## Why is it important?

Allows for the `@timestamp` value to be incorporated into fingerprints.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues


- Closes #28683
