### PR TITLE
Pass logging.level from elastic agent to processes.

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -149,3 +149,4 @@
 - Add diagnostics command to gather beat metadata. {pull}28265[28265]
 - Add diagnostics collect command to gather beat metadata, config, policy, and logs and bundle it into an archive. {pull}28461[28461]
 - Add `KIBANA_FLEET_SERVICE_TOKEN` to Elastic Agent container. {pull}28096[28096]
+- Pass the `logging.level` setting to all configs that the Elastic Agent renders for its processes. {issue}28392[28392]

--- a/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/controller.go
+++ b/x-pack/elastic-agent/pkg/agent/application/pipeline/emitter/controller.go
@@ -70,6 +70,11 @@ func (e *Controller) Update(c *config.Config) error {
 		return err
 	}
 
+	// Merge agent logging level
+	if err := c.Merge(map[string]interface{}{"logging": map[string]interface{}{"level": e.agentInfo.LogLevel()}}); err != nil {
+		return err // TODO fail here or just log that the level is present?
+	}
+
 	// perform and verify ast translation
 	m, err := c.ToMapStr()
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Insert the logging.level config setting into the configuration passed to
sub processes when emitting a config from a policy.

## Why is it important?

Allows operators to view debug logs for the beats/processes which are started by the agent by altering the log level.
The agent's log level value will be passed to all processes it creates.
This can already be done today by altering it in Kibana

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1) install/enroll elastic agent to fleet
2) change log level of agent in fleet
3) view agent logs and metricbeat/filebeat logs

## Related issues

- Closes #28392 