### PR TITLE
Allow worker or workers for output config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -264,6 +264,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Upgrade k8s.io/client-go library. {pull}28228[28228]
 - Update kubernetes scheduler and controllermanager endpoints in elastic-agent-standalone-kubernetes.yaml with secure ports {pull}28675[28675]
 - Add options to configure k8s client qps/burst. {pull}28151[28151]
+- Allow `workers` or `worker` in output configuration. {pull}28726[28726]
 
 *Auditbeat*
 

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -115,7 +115,7 @@ The default value is `false`.
 
 The number of workers per configured host publishing events to Elasticsearch. This
 is best used with load balancing mode enabled. Example: If you have 2 hosts and
-3 workers, in total 6 workers are started (3 for each host).
+3 workers, in total 6 workers are started (3 for each host). `workers` is an alias.
 
 The default value is `1`.
 

--- a/libbeat/outputs/hosts.go
+++ b/libbeat/outputs/hosts.go
@@ -24,10 +24,12 @@ import "github.com/elastic/beats/v7/libbeat/common"
 // host list by the number of `workers`.
 func ReadHostList(cfg *common.Config) ([]string, error) {
 	config := struct {
-		Hosts  []string `config:"hosts"  validate:"required"`
-		Worker int      `config:"worker" validate:"min=1"`
+		Hosts   []string `config:"hosts"  validate:"required"`
+		Worker  int      `config:"worker" validate:"min=1"`
+		Workers int      `config:"workers" validate:"min=1"`
 	}{
-		Worker: 1,
+		Worker:  1,
+		Workers: 1,
 	}
 
 	err := cfg.Unpack(&config)
@@ -36,6 +38,11 @@ func ReadHostList(cfg *common.Config) ([]string, error) {
 	}
 
 	lst := config.Hosts
+
+	if config.Workers > config.Worker {
+		config.Worker = config.Workers
+	}
+
 	if len(lst) == 0 || config.Worker <= 1 {
 		return lst, nil
 	}

--- a/libbeat/outputs/hosts_test.go
+++ b/libbeat/outputs/hosts_test.go
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package outputs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestReadHostsList(t *testing.T) {
+	tests := map[string]struct {
+		cfg       *common.Config
+		want      []string
+		has_error bool
+	}{
+		"empty config": {
+			cfg:       common.MustNewConfigFrom(common.MapStr{}),
+			want:      nil,
+			has_error: true,
+		},
+		"one host": {
+			cfg: common.MustNewConfigFrom(common.MapStr{
+				"hosts": []string{"10.45.3.2:9220"},
+			}),
+			want:      []string{"10.45.3.2:9220"},
+			has_error: false,
+		},
+		"two hosts": {
+			cfg: common.MustNewConfigFrom(common.MapStr{
+				"hosts": []string{"10.45.3.2:9220", "10.45.3.1:9230"},
+			}),
+			want:      []string{"10.45.3.2:9220", "10.45.3.1:9230"},
+			has_error: false,
+		},
+		"one host 2 worker": {
+			cfg: common.MustNewConfigFrom(common.MapStr{
+				"hosts":  []string{"10.45.3.2:9220"},
+				"worker": 2,
+			}),
+			want:      []string{"10.45.3.2:9220", "10.45.3.2:9220"},
+			has_error: false,
+		},
+		"two host 2 worker": {
+			cfg: common.MustNewConfigFrom(common.MapStr{
+				"hosts":  []string{"10.45.3.2:9220", "10.45.3.1:9230"},
+				"worker": 2,
+			}),
+			want:      []string{"10.45.3.2:9220", "10.45.3.2:9220", "10.45.3.1:9230", "10.45.3.1:9230"},
+			has_error: false,
+		},
+		"two host 2 workers": {
+			cfg: common.MustNewConfigFrom(common.MapStr{
+				"hosts":   []string{"10.45.3.2:9220", "10.45.3.1:9230"},
+				"workers": 2,
+			}),
+			want:      []string{"10.45.3.2:9220", "10.45.3.2:9220", "10.45.3.1:9230", "10.45.3.1:9230"},
+			has_error: false,
+		},
+	}
+
+	for name, tc := range tests {
+		got, err := ReadHostList(tc.cfg)
+		if tc.has_error {
+			assert.NotNil(t, err, name)
+		} else {
+			assert.Nil(t, err, name)
+		}
+		assert.EqualValues(t, tc.want, got, name)
+	}
+}

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -203,7 +203,7 @@ The configurable ClientID used for logging, debugging, and auditing purposes. Th
 
 ===== `worker`
 
-The number of concurrent load-balanced Kafka output workers.
+The number of concurrent load-balanced Kafka output workers. `workers` is an alias.
 
 ===== `codec`
 

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -256,7 +256,7 @@ The default value is `false`.
 
 The number of workers per configured host publishing events to {ls}. This
 is best used with load balancing mode enabled. Example: If you have 2 hosts and
-3 workers, in total 6 workers are started (3 for each host).
+3 workers, in total 6 workers are started (3 for each host). `workers` is an alias.
 
 [[loadbalance]]
 ===== `loadbalance`

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -154,7 +154,7 @@ See <<configuration-output-codec>> for more information.
 ===== `worker`
 
 The number of workers to use for each host configured to publish events to Redis. Use this setting along with the
-`loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host).
+`loadbalance` option. For example, if you have 2 hosts and 3 workers, in total 6 workers are started (3 for each host). `workers` is an alias.
 
 ===== `loadbalance`
 


### PR DESCRIPTION
## What does this PR do?

Allows `workers` or `worker` to be used to set the number of output
workers.  The greater of the two will be used if both are present.

## Why is it important?

We have had multiple performance issues where `workers` was used
instead of `worker`.  `workers` is not an error and is very hard to
see.  The plural is more natural.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

``` bash
cd libbeat\outputs
go test
```