### PR TITLE
No changelog for 8.0.0-beta1

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -3,6 +3,11 @@
 :issue: https://github.com/elastic/beats/issues/
 :pull: https://github.com/elastic/beats/pull/
 
+[[release-notes-8.0.0-beta1]]
+=== Beats version 8.0.0-beta1
+
+Changes will be described in a later RC / GA.
+
 [[release-notes-8.0.0-alpha2]]
 === Beats version 8.0.0-alpha2
 

--- a/libbeat/docs/release.asciidoc
+++ b/libbeat/docs/release.asciidoc
@@ -8,6 +8,7 @@ This section summarizes the changes in each release. Also read
 <<breaking-changes>> for more detail about changes that affect
 upgrade.
 
+* <<release-notes-8.0.0-beta1>>
 * <<release-notes-8.0.0-alpha2>>
 * <<release-notes-8.0.0-alpha1>>
 * <<release-notes-7.15.1>>


### PR DESCRIPTION
Part 8.0.0-beta1 release. Needs to forward-ported to `master`.
