### PR TITLE
[Heartbeat] Decode gzip content when content encoding header is specified

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -83,9 +83,12 @@ func SizedResponseHandler(bytes int) http.HandlerFunc {
 	)
 }
 
-func CustomResponseHandler(body []byte, status int) http.HandlerFunc {
+func CustomResponseHandler(body []byte, status int, extraHeaders map[string]string) http.HandlerFunc {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
+			for key, val := range extraHeaders {
+				w.Header().Add(key, val)
+			}
 			w.WriteHeader(status)
 			w.Write(body)
 		},

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -822,8 +822,9 @@ func gzipBuffer(t *testing.T, toZip string) *bytes.Buffer {
 	return &gzipBuffer
 }
 
-// This test ensures Heartbeat will decode the response body if the server specifies
-// that it is gzip encoded.
+/*
+ * This test ensures Heartbeat will decode the response body if the server specifies
+ * that it is gzip encoded. This is a test of the happy path where client/server behave as expected. */
 func TestDecodesGzip(t *testing.T) {
 	gzBuffer := gzipBuffer(t, "TestEncodingAccept")
 
@@ -839,16 +840,17 @@ func TestDecodesGzip(t *testing.T) {
 
 	content, err := evt.Fields.GetValue("http.response.body.content")
 
-	// decode gzip content if 'Content-Encoding' header is present
 	assert.NoError(t, err)
 	assert.Exactly(t, content, "TestEncodingAccept")
 }
 
-// This test verifies that, in the absence of the response header `Content-Encoding: gzip`, Heartbeat
-// will not decode the response body.
+/*
+ * This test verifies that, in the absence of the response header `Content-Encoding: gzip`, Heartbeat
+ * will not decode the response body. */
 func TestNoGzipDecodeWithoutHeader(t *testing.T) {
 	gzBuffer := gzipBuffer(t, "TestEncodingAccept")
 
+	// here Heartbeat asks the server for a `gzip` body, but the server omits the appropriate response header
 	server := httptest.NewServer(hbtest.CustomResponseHandler(gzBuffer.Bytes(), 200, map[string]string{}))
 	defer server.Close()
 
@@ -863,6 +865,30 @@ func TestNoGzipDecodeWithoutHeader(t *testing.T) {
 
 	// doesn't decode gzip text without content header
 	assert.Exactly(t, content, "\x1f\x8b\b\x00\x00\x00\x00\x00\x00\xff\nI-.q\xcdK\xceO\xc9\xccKwLNN-(\x01\x04\x00\x00\xff\xffW\xbeE\x0e\x12\x00\x00\x00")
+}
+
+/* When Heartbeat doesn't request `gzip`, and the server responds with a `gzip` body/header anyway,
+ * Heartbeat will still decode it gracefully. This is a case where the server behaved inappropriately,
+ * but as long as the header is included Heartbeat tries to do the right thing. */
+func TestGzipDecodeWithoutRequestHeader(t *testing.T) {
+	gzBuffer := gzipBuffer(t, "TestEncodingAccept")
+
+	server := httptest.NewServer(hbtest.CustomResponseHandler(gzBuffer.Bytes(), 200, map[string]string{
+		"Content-Encoding": "gzip",
+	}))
+	defer server.Close()
+
+	evt := sendTLSRequest(t, server.URL, false, map[string]interface{}{
+		// no header here from Heartbeat asking the server for `gzip`
+		"response.include_body": "always",
+	})
+
+	content, err := evt.Fields.GetValue("http.response.body.content")
+
+	assert.NoError(t, err)
+
+	// Heartbeat decoded the `gzip` even without requesting it
+	assert.Exactly(t, content, "TestEncodingAccept")
 }
 
 func TestUserAgentInject(t *testing.T) {

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -825,9 +825,9 @@ func gzipBuffer(t *testing.T, toZip string) *bytes.Buffer {
 // This test ensures Heartbeat will decode the response body if the server specifies
 // that it is gzip encoded.
 func TestDecodesGzip(t *testing.T) {
-	gzip := gzipBuffer(t, "TestEncodingAccept")
+	gzBuffer := gzipBuffer(t, "TestEncodingAccept")
 
-	server := httptest.NewServer(hbtest.CustomResponseHandler(gzip.Bytes(), 200, map[string]string{
+	server := httptest.NewServer(hbtest.CustomResponseHandler(gzBuffer.Bytes(), 200, map[string]string{
 		"Content-Encoding": "gzip",
 	}))
 	defer server.Close()
@@ -847,9 +847,9 @@ func TestDecodesGzip(t *testing.T) {
 // This test verifies that, in the absence of the response header `Content-Encoding: gzip`, Heartbeat
 // will not decode the response body.
 func TestNoGzipDecodeWithoutHeader(t *testing.T) {
-	gzip := gzipBuffer(t, "TestEncodingAccept")
+	gzBuffer := gzipBuffer(t, "TestEncodingAccept")
 
-	server := httptest.NewServer(hbtest.CustomResponseHandler(gzip.Bytes(), 200, map[string]string{}))
+	server := httptest.NewServer(hbtest.CustomResponseHandler(gzBuffer.Bytes(), 200, map[string]string{}))
 	defer server.Close()
 
 	evt := sendTLSRequest(t, server.URL, false, map[string]interface{}{

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -414,7 +414,7 @@ func TestJsonBody(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			server := httptest.NewServer(hbtest.CustomResponseHandler([]byte(tc.responseBody), 200, map[string]string{}))
+			server := httptest.NewServer(hbtest.CustomResponseHandler([]byte(tc.responseBody), 200, nil))
 			defer server.Close()
 
 			jsonCheck := common.MapStr{"description": tc.name}
@@ -822,6 +822,8 @@ func gzipBuffer(t *testing.T, toZip string) *bytes.Buffer {
 	return &gzipBuffer
 }
 
+// This test ensures Heartbeat will decode the response body if the server specifies
+// that it is gzip encoded.
 func TestDecodesGzip(t *testing.T) {
 	gzip := gzipBuffer(t, "TestEncodingAccept")
 
@@ -842,6 +844,8 @@ func TestDecodesGzip(t *testing.T) {
 	assert.Exactly(t, content, "TestEncodingAccept")
 }
 
+// This test verifies that, in the absence of the response header `Content-Encoding: gzip`, Heartbeat
+// will not decode the response body.
 func TestNoGzipDecodeWithoutHeader(t *testing.T) {
 	gzip := gzipBuffer(t, "TestEncodingAccept")
 

--- a/heartbeat/monitors/active/http/simple_transp.go
+++ b/heartbeat/monitors/active/http/simple_transp.go
@@ -179,10 +179,6 @@ func (t *SimpleTransport) readResponse(
 	t.sigStartRead()
 
 	if resp.Header.Get("Content-Encoding") == gzipEncoding {
-		resp.Header.Del("Content-Encoding")
-		resp.Header.Del("Content-Length")
-		resp.ContentLength = -1
-
 		unzipper, err := gzip.NewReader(resp.Body)
 		if err != nil {
 			resp.Body.Close()

--- a/heartbeat/monitors/active/http/simple_transp.go
+++ b/heartbeat/monitors/active/http/simple_transp.go
@@ -39,8 +39,7 @@ const (
 
 // SimpleTransport contains the dialer and read/write callbacks
 type SimpleTransport struct {
-	Dialer             transport.Dialer
-	DisableCompression bool
+	Dialer transport.Dialer
 
 	OnStartWrite func()
 	OnEndWrite   func()
@@ -86,17 +85,6 @@ func (t *SimpleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	requestedGzip := false
-	if t.DisableCompression &&
-		req.Header.Get("Accept-Encoding") == "" &&
-		req.Header.Get("Range") == "" &&
-		req.Method != "HEAD" {
-
-		requestedGzip = true
-		req.Header.Add("Accept-Encoding", gzipEncoding)
-		defer req.Header.Del("Accept-Encoding")
-	}
-
 	done := req.Context().Done()
 	readerDone := make(chan readReturn, 1)
 	writerDone := make(chan error, 1)
@@ -108,7 +96,7 @@ func (t *SimpleTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// read response
 	go func() {
-		resp, err := t.readResponse(conn, req, requestedGzip)
+		resp, err := t.readResponse(conn, req)
 		readerDone <- readReturn{resp, err}
 	}()
 
@@ -180,7 +168,6 @@ func (c comboConnReadCloser) Close() error {
 func (t *SimpleTransport) readResponse(
 	conn net.Conn,
 	req *http.Request,
-	requestedGzip bool,
 ) (*http.Response, error) {
 	reader := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(reader, req)
@@ -191,7 +178,7 @@ func (t *SimpleTransport) readResponse(
 
 	t.sigStartRead()
 
-	if requestedGzip && resp.Header.Get("Content-Encoding") == gzipEncoding {
+	if resp.Header.Get("Content-Encoding") == gzipEncoding {
 		resp.Header.Del("Content-Encoding")
 		resp.Header.Del("Content-Length")
 		resp.ContentLength = -1


### PR DESCRIPTION
## What does this PR do?

Resolves https://github.com/elastic/beats/issues/28303

This patch will cause Heartbeat to decode `gzip`-encoded content when the `Content-Encoding` header specifies `gzip` as its value.

On the linked issue there is discussion about always detecting if content is `gzip` and decoding it automatically. This change does not yet account for that.

## Why is it important?

There have been confusing results for customers where the content indexed into Elasticsearch does not correlate to what they expect to see. Almost never should Heartbeat be shipping `gzip`-encoded content for search/storage.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] When a server specifies that content is `gzip`-encoded, Heartbeat should decode it and index the decoded body

## How to test this PR locally

- [ ] Create a monitor that asks for `gzip` content. You can test the response from the server before configuring the monitor by running a `curl` request such as: `curl -X GET https://www.google.com -v --http1.1 -H "Accept-Encoding: gzip" -o test.gzip`

## Use cases

If users want to index the response body, they'll need this feature to decode it if it's compressed. Today, there's no way to decode compressed bodies because of this bug.

## Screenshots

The linked issue has an associated SDH that includes screens of how this content looks when it's indexed (i.e. not human-readable).
