### PR TITLE
Change "filebeat.config.modules.enabled" to "true"

### DIFF
--- a/filebeat/_meta/config/filebeat.global.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.global.reference.yml.tmpl
@@ -40,7 +40,7 @@
     #reload.enabled: true
     #reload.period: 10s
   #modules:
-    #enabled: false
+    #enabled: true
     #path: modules.d/*.yml
     #reload.enabled: true
     #reload.period: 10s

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1024,7 +1024,7 @@ filebeat.inputs:
     #reload.enabled: true
     #reload.period: 10s
   #modules:
-    #enabled: false
+    #enabled: true
     #path: modules.d/*.yml
     #reload.enabled: true
     #reload.period: 10s

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3177,7 +3177,7 @@ filebeat.inputs:
     #reload.enabled: true
     #reload.period: 10s
   #modules:
-    #enabled: false
+    #enabled: true
     #path: modules.d/*.yml
     #reload.enabled: true
     #reload.period: 10s


### PR DESCRIPTION
As per https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-configuration-reloading.html#load-module-config, the default value of `filebeat.config.modules.enabled` is `true`. 

Having it as `false` in `filebeat.reference.yml` is confusing.
