### PR TITLE
Mark logging.ecs and json as deprecated

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1444,11 +1444,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2355,11 +2355,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1636,11 +1636,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1386,11 +1386,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/libbeat/_meta/config/logging.reference.yml.tmpl
+++ b/libbeat/_meta/config/logging.reference.yml.tmpl
@@ -74,9 +74,11 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -269,11 +269,15 @@ true.
 
 When true, logs messages in JSON format. The default is false.
 
+deprecated::[7.16.0]
+
 [float]
 ==== `logging.ecs`
 
 When true, logs messages with minimal required Elastic Common Schema (ECS)
 information.
+
+deprecated::[7.16.0]
 
 ifndef::serverless[]
 [float]

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2255,11 +2255,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1938,11 +1938,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1366,11 +1366,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1500,11 +1500,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -4597,11 +4597,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1239,11 +1239,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1636,11 +1636,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2786,11 +2786,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -958,11 +958,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -1938,11 +1938,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1409,11 +1409,13 @@ logging.files:
   #suffix: count
 
 # Set to true to log messages in JSON format.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.json: false
 
 # Set to true, to log messages with minimal required Elastic Common Schema (ECS)
 # information. Recommended to use in combination with `logging.json=true`
 # Defaults to false.
+# Deprecated: As of 7.16.0 this setting is deprecated and will be removed in an upcoming release.
 #logging.ecs: false
 
 # ============================= X-Pack Monitoring ==============================


### PR DESCRIPTION
## What does this PR do?

Mark `logging.ecs` and `logging.json` as deprecated for the `v7.16.0` release.
These attributes will no longer be used in 8.0.

## Why is it important?

These settings will be removed for 8.0 as part of the work to get all components producing ECS logs by default.
The PR is https://github.com/elastic/beats/pull/28573

## Checklist

- [] ~~My code follows the style guidelines of this project~~
- [] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [] ~~I have added tests that prove my fix is effective or that my feature works~~
- [] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Relates #15544 