### PR TITLE
[Heartbeat] Stop logging sensitive params

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -189,6 +189,7 @@ for a few releases. Please use other tools provided by Elastic to fetch data fro
 - Fix broken seccomp filtering and improve security via `setcap` and `setuid` when running as root on linux in containers. {pull}27878[27878]
 - Log browser `zip_url` download failures as `warn` instead of as `info`. {pull}28440[28440]
 - Properly locate base stream in fleet configs. {pull}28455[28455]
+- Stop logging params values. {pull}28774[28774]
 
 *Journalbeat*
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -122,17 +122,20 @@ func runCmd(
 	cmd.Env = append(os.Environ(), "NODE_ENV=production")
 	cmd.Args = append(cmd.Args, "--rich-events")
 
-	if len(params) > 0 {
-		paramsBytes, _ := json.Marshal(params)
-		cmd.Args = append(cmd.Args, "--params", string(paramsBytes))
-	}
-
 	if len(filterJourneys.Tags) > 0 {
 		cmd.Args = append(cmd.Args, "--tags", strings.Join(filterJourneys.Tags, " "))
 	}
 
 	if filterJourneys.Match != "" {
 		cmd.Args = append(cmd.Args, "--match", filterJourneys.Match)
+	}
+
+	// Variant of the command with no params, which could contain sensitive stuff
+	loggableCmd := exec.Command(cmd.Path, cmd.Args...)
+	if len(params) > 0 {
+		paramsBytes, _ := json.Marshal(params)
+		cmd.Args = append(cmd.Args, "--params", string(paramsBytes))
+		loggableCmd.Args = append(loggableCmd.Args, "--params", fmt.Sprintf("\"{%d hidden params}\"", len(params)))
 	}
 
 	// We need to pass both files in here otherwise we get a broken pipe, even
@@ -142,7 +145,7 @@ func runCmd(
 	// see the docs for ExtraFiles in https://golang.org/pkg/os/exec/#Cmd
 	cmd.Args = append(cmd.Args, "--outfd", "3")
 
-	logp.Info("Running command: %s in directory: '%s'", cmd.String(), cmd.Dir)
+	logp.Info("Running command: %s in directory: '%s'", loggableCmd.String(), cmd.Dir)
 
 	if stdinStr != nil {
 		logp.Debug(debugSelector, "Using stdin str %s", *stdinStr)
@@ -189,14 +192,14 @@ func runCmd(
 		err := cmd.Wait()
 		jsonWriter.Close()
 		jsonReader.Close()
-		logp.Info("Command has completed(%d): %s", cmd.ProcessState.ExitCode(), cmd.String())
+		logp.Info("Command has completed(%d): %s", cmd.ProcessState.ExitCode(), loggableCmd.String())
 		if err != nil {
 			str := fmt.Sprintf("command exited with status %d: %s", cmd.ProcessState.ExitCode(), err)
 			mpx.writeSynthEvent(&SynthEvent{
 				Type:  "cmd/status",
 				Error: &SynthError{Name: "cmdexit", Message: str},
 			})
-			logp.Warn("Error executing command '%s' (%d): %s", cmd.String(), cmd.ProcessState.ExitCode(), err)
+			logp.Warn("Error executing command '%s' (%d): %s", loggableCmd.String(), cmd.ProcessState.ExitCode(), err)
 		}
 		wg.Wait()
 		mpx.Close()


### PR DESCRIPTION
This change causes heartbeat to no longer log parameter values, instead
interpolating an opaque string.

Fixes #28771

We now create logs like:
```
2021-11-02T17:25:27.804-0500    INFO    synthexec/synthexec.go:148      Running command: /tmp/elastic-synthetics-unzip-714880603/node_modules/.bin/elastic-synthetics /tmp/elastic-synthetics-unzip-714880603/node_modules/.bin/elastic-synthetics /tmp/elastic-synthetics-unzip-714880603 --screenshots on --rich-events --params "{1 hidden params}" in directory: '/tmp/elastic-synthetics-unzip-714880603'
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Tested with https://github.com/elastic/synthetics-demo/blob/main/heartbeat/monitors.d/todos-zipurl.yml
