### PR TITLE
Fixup to remove uneeded 8.0 comment from GenerateK8s metadata

### DIFF
--- a/libbeat/common/kubernetes/metadata/pod.go
+++ b/libbeat/common/kubernetes/metadata/pod.go
@@ -106,8 +106,6 @@ func (p *pod) GenerateK8s(obj kubernetes.Resource, opts ...FieldOptions) common.
 	if p.namespace != nil {
 		meta := p.namespace.GenerateFromName(po.GetNamespace())
 		if meta != nil {
-			// Use this in 8.0
-			//out.Put("namespace", meta["namespace"])
 			out.DeepUpdate(meta)
 		}
 	}


### PR DESCRIPTION
This PR removes a not needed comment from libbeat  GenerateK8s method which enriches an event with kubernetes metadata