### PR TITLE
Add note that there is no warranty or support for generator code

### DIFF
--- a/docs/devguide/create-metricset.asciidoc
+++ b/docs/devguide/create-metricset.asciidoc
@@ -1,6 +1,8 @@
 [[creating-metricsets]]
 === Creating a Metricset
 
+include::generator-support-note.asciidoc[tag=metricset-generator]
+
 A metricset is the part of a Metricbeat module that fetches and structures the
 data from the remote service. Each module can have multiple metricsets. In this guide, you learn how to create your own metricset.
 

--- a/docs/devguide/generator-support-note.asciidoc
+++ b/docs/devguide/generator-support-note.asciidoc
@@ -1,10 +1,3 @@
-// tag::beat-generator[]
-IMPORTANT: Elastic provides no warranty or support for the code used to generate
-a Beat. The Beat generator is mainly offered as guidance for developers who want
-to create their own data shippers.
-
-// end::beat-generator[]
-
 // tag::metricset-generator[]
 IMPORTANT: Elastic provides no warranty or support for the code used to generate
 metricsets. The generator is mainly offered as guidance for developers who want

--- a/docs/devguide/generator-support-note.asciidoc
+++ b/docs/devguide/generator-support-note.asciidoc
@@ -1,0 +1,20 @@
+// tag::beat-generator[]
+IMPORTANT: Elastic provides no warranty or support for the code used to generate
+a Beat. The Beat generator is mainly offered as guidance for developers who want
+to create their own data shippers.
+
+// end::beat-generator[]
+
+// tag::metricset-generator[]
+IMPORTANT: Elastic provides no warranty or support for the code used to generate
+metricsets. The generator is mainly offered as guidance for developers who want
+to create their own data shippers.
+
+// end::metricset-generator[]
+
+// tag::filebeat-generator[]
+IMPORTANT: Elastic provides no warranty or support for the code used to generate
+modules and filesets. The generator is mainly offered as guidance for developers
+who want to create their own data shippers.
+
+// end::filebeat-generator[]

--- a/docs/devguide/modules-dev-guide.asciidoc
+++ b/docs/devguide/modules-dev-guide.asciidoc
@@ -1,6 +1,8 @@
 [[filebeat-modules-devguide]]
 == Creating a New Filebeat Module
 
+include::generator-support-note.asciidoc[tag=filebeat-generator]
+
 This guide will walk you through creating a new Filebeat module.
 
 All Filebeat modules currently live in the main


### PR DESCRIPTION
## What does this PR do?

Adds note to Beats Developer Guide in places where we talk about code for generating Beats, metricsets, modules, or filesets.

Questions:

- [x] Do we really want this note in all the topics that talk about the generator code, or does it apply to only some of the code? If so, please tell which which parts. I've tried to include the statement where I thought it applies.
- [ ] What do we want to do about the protocol generator docs? The dev team has never had time to update those docs, and they aren't really very useful. If we do keep the docs there, I'm assuming the same restriction applies to the protocol generator, but let me know.

## Why is it important?

The beats generator is old and will be deprecated in 8.0

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes #28426 


