### PR TITLE
Deprecate generating custom Beats

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -129,3 +129,4 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 ==== Deprecated
 
 - Deprecated the `common.Float` type. {issue}28279[28279] {pull}28280[28280]
+- Deprecate Beat generators. {pull}28814[28814]

--- a/docs/devguide/creating-beat-from-metricbeat.asciidoc
+++ b/docs/devguide/creating-beat-from-metricbeat.asciidoc
@@ -1,6 +1,8 @@
 [[creating-beat-from-metricbeat]]
 === Creating a Beat based on Metricbeat
 
+deprecated:[7.16.0]
+
 The metricset Beat generator enables you to create a Beat that uses Metricbeat as a library and has your
 own metricsets.
 

--- a/docs/devguide/newbeat.asciidoc
+++ b/docs/devguide/newbeat.asciidoc
@@ -1,6 +1,8 @@
 [[new-beat]]
 == Creating a New Beat
 
+deprecated:[7.16.0]
+
 This guide walks you through the steps for creating a new Elastic Beat.  The
 Beats are a collection of lightweight daemons that collect operational data from
 your servers and ship it to Elasticsearch or Logstash.  The common parts for

--- a/generator/common/beatgen/beatgen.go
+++ b/generator/common/beatgen/beatgen.go
@@ -92,6 +92,8 @@ var configList = []ConfigItem{
 
 // Generate generates a new custom beat
 func Generate() error {
+	fmt.Println("Generating custom Beats are going to be removed in 8.0.0.")
+
 	cfg, err := getConfig()
 	if err != nil {
 		return errors.Wrap(err, "error getting config")

--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -6,6 +6,8 @@
 [[community-beats]]
 == Community Beats
 
+Please note that generating new Beats is deprecated since 7.16.
+
 The open source community has been hard at work developing new Beats. You can check
 out some of them here.
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a warning to users who are generating their own Beats. From 8.0.0, it is not going to be supported.

## Why is it important?

To manage users' expectations.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
