### PR TITLE
Filebeat: Error on startup for unconfigured module

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -111,22 +111,6 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *common.Config) (b
 	if err != nil {
 		return nil, err
 	}
-	if !moduleRegistry.Empty() {
-		logp.Info("Enabled modules/filesets: %s", moduleRegistry.InfoString())
-		for _, mod := range moduleRegistry.ModuleNames() {
-			if mod == "" {
-				continue
-			}
-			filesets, err := moduleRegistry.ModuleConfiguredFilesets(mod)
-			if err != nil {
-				logp.Err("Failed listing filesets for module %s", mod)
-				continue
-			}
-			if len(filesets) == 0 {
-				logp.Warn("Module %s is enabled but has no enabled filesets", mod)
-			}
-		}
-	}
 
 	moduleInputs, err := moduleRegistry.GetInputConfigs()
 	if err != nil {

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -100,6 +100,20 @@ func newModuleRegistry(modulesPath string,
 		}
 	}
 
+	logp.Info("Enabled modules/filesets: %s", reg.InfoString())
+	for _, mod := range reg.ModuleNames() {
+		if mod == "" {
+			continue
+		}
+		filesets, err := reg.ModuleConfiguredFilesets(mod)
+		if err != nil {
+			logp.Err("Failed listing filesets for module %s", mod)
+			continue
+		}
+		if len(filesets) == 0 {
+			return nil, errors.Errorf("module %s is configured but has no enabled filesets", mod)
+		}
+	}
 	return &reg, nil
 }
 


### PR DESCRIPTION
## What does this PR do?

Since #27526 and #27762, Filebeat will have all filesets disabled by default. To prevent user confusion, a warning message to alert the user of a configured module without any enabled filesets was added. However, due to Filebeat internals, this message will only appear for modules configured from the command-line (--modules flag).

This updates the code to ensure it works also for modules configured via modules.d directory and turns the warning into an error that prevents startup.

## Why is it important?

Helps users figure out configuration problems earlier.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
