### PR TITLE
Osquerybeat: Fix restart flags after previously bad config

### DIFF
--- a/x-pack/osquerybeat/beater/osquery_runner.go
+++ b/x-pack/osquerybeat/beater/osquery_runner.go
@@ -68,10 +68,10 @@ func (r *osqueryRunner) Run(parentCtx context.Context, runfn osqueryRunFunc) err
 
 			// Wait until osquery runner exists
 			wg.Wait()
-
-			// Set the flags to use
-			flags = newFlags
 		}
+
+		// Set the flags to use
+		flags = newFlags
 
 		// Start osqueryd if not running
 		if cn == nil {


### PR DESCRIPTION
## What does this PR do?

Fixes the oquery flags update defect.

The issue is reproducible with the following steps:
1. Apply bad config flag
```
{
  "options": {
    "disable_events": false,
    "enable_file_events": true
    "enable_ntfs_publisher": true
  }
 }
```
2. Osquery stops with error
```
[elastic_agent.osquerybeat][error] process exited with error: ERROR: unknown command line flag 'enable_ntfs_publisher': exit status 1
```

3. Remove ```enable_ntfs_publisher``` option.
4. The osquery uses old flags to (visible in debug log) and fails.

Expected result, the new flags are used and osquery becomes usable (can issue ad-hoc queries for example)

This is a minimal change to fix this for 7.16 next RC is on 11/10.

If I get time before 11/10, will revisit the osquery runner one more time.
If not will leave it for 8.0 to improve.

## Why is it important?

Fixes the osquery configuration options update defect in 7.16

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

