### PR TITLE
Osquerybeat: Improve osquery client connect code. Update config_refresh to 60 seconds.

### DIFF
--- a/x-pack/osquerybeat/internal/osqd/args.go
+++ b/x-pack/osquerybeat/internal/osqd/args.go
@@ -79,7 +79,12 @@ var protectedFlags = Flags{
 
 	// The delimiter for a full query name that is concatenated as "pack_" + {{pack name}} + "_" + {{query name}} by default
 	"pack_delimiter": "_",
-	"config_refresh": 10,
+
+	// Refresh config every 60 seconds
+	// The previous setting was 10 seconds which is unnecessary frequent.
+	// Osquery does not expect that frequent policy/configuration changes
+	// and can tolerate non real-time configuration change application.
+	"config_refresh": 60,
 }
 
 func init() {

--- a/x-pack/osquerybeat/internal/osqdcli/retry.go
+++ b/x-pack/osquerybeat/internal/osqdcli/retry.go
@@ -1,0 +1,62 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package osqdcli
+
+import (
+	"context"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+type retry struct {
+	maxRetry  int
+	retryWait time.Duration
+	log       *logp.Logger
+}
+
+type tryFunc func(ctx context.Context) error
+
+func (r *retry) Run(ctx context.Context, fn tryFunc) (err error) {
+	maxAttempts := r.maxRetry + 1
+	for i := 0; i < maxAttempts; i++ {
+		attempt := i + 1
+		r.log.Debugf("attempt %v out of %v", attempt, maxAttempts)
+
+		err = fn(ctx)
+
+		if err != nil {
+			r.log.Debugf("attempt %v out of %v failed, err: %v", attempt, maxAttempts, err)
+			if i != maxAttempts {
+				if r.retryWait > 0 {
+					r.log.Debugf("wait for %v before next retry", r.retryWait)
+					err = waitWithContext(ctx, retryWait)
+					if err != nil {
+						r.log.Debugf("wait returned err: %v", err)
+						return err
+					}
+				}
+			} else {
+				r.log.Debugf("no more attempts, return err: %v", err)
+				return err
+			}
+		} else {
+			r.log.Debugf("attempt %v out of %v succeeded", attempt, maxAttempts)
+			return nil
+		}
+	}
+	return err
+}
+
+func waitWithContext(ctx context.Context, to time.Duration) error {
+	t := time.NewTimer(to)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+	}
+	return nil
+}

--- a/x-pack/osquerybeat/internal/osqdcli/retry_test.go
+++ b/x-pack/osquerybeat/internal/osqdcli/retry_test.go
@@ -1,0 +1,139 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package osqdcli
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestRetryRun(t *testing.T) {
+	logp.Configure(logp.Config{
+		Level:     logp.DebugLevel,
+		ToStderr:  true,
+		Selectors: []string{"*"},
+	})
+
+	log := logp.NewLogger("retry_test").With("context", "osquery client connect")
+	ctx := context.Background()
+
+	type fields struct {
+		maxRetry  int
+		retryWait time.Duration
+		log       *logp.Logger
+	}
+
+	type args struct {
+		ctx context.Context
+		fn  tryFunc
+	}
+
+	argsWithFunc := func(fn tryFunc) args {
+		return args{
+			ctx: ctx,
+			fn:  fn,
+		}
+	}
+
+	funcSucceedsOnNAttempt := func(attempt int) func(context.Context) error {
+		curAttempt := 1
+		return func(ctx context.Context) error {
+			if curAttempt == attempt {
+				return nil
+			}
+			curAttempt++
+			return ErrAlreadyConnected
+		}
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr error
+	}{
+		{
+			name: "no retries, no wait, success",
+			fields: fields{
+				log: log,
+			},
+			args: argsWithFunc(func(ctx context.Context) error {
+				return nil
+			}),
+		},
+		{
+			name: "no retries, no wait, error",
+			fields: fields{
+				log: log,
+			},
+			args: argsWithFunc(func(ctx context.Context) error {
+				return ErrAlreadyConnected
+			}),
+			wantErr: ErrAlreadyConnected,
+		},
+		{
+			name: "retries, no wait, no more retries fails",
+			fields: fields{
+				maxRetry: 3,
+				log:      log,
+			},
+			args:    argsWithFunc(funcSucceedsOnNAttempt(8)),
+			wantErr: ErrAlreadyConnected,
+		},
+		{
+			name: "retries, no wait, success",
+			fields: fields{
+				maxRetry: 3,
+				log:      log,
+			},
+			args: argsWithFunc(funcSucceedsOnNAttempt(4)),
+		},
+		{
+			name: "retries, with wait, success",
+			fields: fields{
+				maxRetry:  3,
+				retryWait: 1 * time.Millisecond,
+				log:       log,
+			},
+			args: argsWithFunc(funcSucceedsOnNAttempt(4)),
+		},
+		{
+			name: "retries, with wait, success sooner",
+			fields: fields{
+				maxRetry:  3,
+				retryWait: 1 * time.Millisecond,
+				log:       log,
+			},
+			args: argsWithFunc(funcSucceedsOnNAttempt(2)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &retry{
+				maxRetry:  tt.fields.maxRetry,
+				retryWait: tt.fields.retryWait,
+				log:       tt.fields.log,
+			}
+			err := r.Run(tt.args.ctx, tt.args.fn)
+			if err != nil {
+				if tt.wantErr != nil {
+					diff := cmp.Diff(tt.wantErr, err, cmpopts.EquateErrors())
+					if diff != "" {
+						t.Error(diff)
+					}
+				} else {
+					t.Errorf("got err: %v, wantErr: nil", err)
+				}
+			} else if tt.wantErr != nil {
+				t.Errorf("got err: nil, wantErr: %v", tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes code logic in osquery connect with retries.
The error not correctly propagated from this line: 
https://github.com/elastic/beats/blame/20d637e1afc7104e7a1f24532cd491e59ad6b245/x-pack/osquerybeat/internal/osqdcli/client.go#L138
when the context was cancelled while waiting next retry.

This doesn't cause an issue, but is not the correct behavior and could be potentially be misleading when logging 
```
osquery client is connected
```
when the connection attempt was cancelled via context.

This PR also updates the config refresh interval from 10 seconds to 60 seconds. 
This is the interval how often ```osqueryd``` polls our configuration plugin (implemented in osquerybeat) over local RPC (osquery domain socket or pipe). The reasoning for that is explained in the added comment:
```
// Osquery does not expect that frequent policy/configuration changes
// and can tolerate non real-time configuration change application.
```
This follows the similar change in the kolide/launcher:
https://github.com/kolide/launcher/commit/5d318697397977a5e752649f6f702cc2b449b863#diff-4fb691d7c9dc698ab635973bdc357a76d02d94583bc6e0c3e8f5483b2f55996aR150


#### Summary of changes:
* Refactored/extracted ```retry``` logic for osquery reconnect, made it better testable
* Added unit tests covering retry.go
* Updated ```config_refresh``` from 10 to 60 seconds


## Why is it important?

Improves osquery client connect code quality, and unit test coverage, fixes a minor defect there.
Updates for less frequent RPC calls to configuration plugin.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Screenshots
Debug log changes
<img width="1389" alt="Screen Shot 2021-11-05 at 10 36 28 AM" src="https://user-images.githubusercontent.com/872351/140531949-9a051984-b159-4dee-b7b4-4f8f5bbe171b.png">

