### PR TITLE
[heartbeat][agent] Remove unnecessary cups dependency

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -191,6 +191,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Log browser `zip_url` download failures as `warn` instead of as `info`. {pull}28440[28440]
 - Properly locate base stream in fleet configs. {pull}28455[28455]
 - Stop logging params values. {pull}28774[28774]
+- Remove accidentally included cups library in docker images. {pull}28853[pull]
 
 *Journalbeat*
 

--- a/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.elastic-agent.tmpl
@@ -57,8 +57,8 @@ RUN case $(arch) in aarch64) YUM_FLAGS="-x bind-license";; esac; \
 
 {{- if (and (contains .image_name "-complete") (not (contains .from "ubi-minimal"))) }}
 RUN for iter in {1..10}; do \
-        yum -y install atk cups gtk gdk xrandr pango libXcomposite libXcursor libXdamage \
-        libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 \
+        yum -y install atk gtk gdk xrandr pango libXcomposite libXcursor libXdamage \
+        libXext libXi libXtst libXScrnSaver libXrandr GConf2 \
         alsa-lib atk gtk3 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
         xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
         yum clean all && \

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -38,8 +38,8 @@ RUN case $(arch) in aarch64) YUM_FLAGS="-x bind-license";; esac; \
     yum -y update $YUM_FLAGS \
   {{- if (eq .BeatName "heartbeat") }}
     && yum -y install epel-release \
-    && yum -y install atk cups gtk gdk xrandr pango libXcomposite libXcursor libXdamage \
-        libXext libXi libXtst cups-libs libXScrnSaver libXrandr GConf2 \
+    && yum -y install atk gtk gdk xrandr pango libXcomposite libXcursor libXdamage \
+        libXext libXi libXtst libXScrnSaver libXrandr GConf2 \
         alsa-lib atk gtk3 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils \
         xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc \
   {{- end }}


### PR DESCRIPTION
We currently install cups mistakenly, it's not needed to support
chromium browsers.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.