### PR TITLE
Multiple kafka outputs for different clientId

### DIFF
--- a/libbeat/outputs/kafka/config_test.go
+++ b/libbeat/outputs/kafka/config_test.go
@@ -71,7 +71,7 @@ func TestConfigAcceptValid(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Can not create test configuration: %v", err)
 			}
-			if _, err := newSaramaConfig(logp.L(), cfg); err != nil {
+			if _, err := newSaramaConfig(logp.L(), cfg, ""); err != nil {
 				t.Fatalf("Failure creating sarama config: %v", err)
 			}
 		})

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -201,6 +201,26 @@ NOTE: Publishing to a subset of available partitions potentially increases resou
 
 The configurable ClientID used for logging, debugging, and auditing purposes. The default is "beats".
 
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.kafka:
+  client_id: 'beats'
+------------------------------------------------------------------------------
+
+beta[]
+
+You can set the clientID dynamically by using a format string to access any event field. For example, this configuration uses a custom field, `kubernetes.pod.annotations.tenant_name`, to set the topic for each event:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.kafka:
+  client_id: '%{[kubernetes.pod.annotations.tenant_name]}_logs'
+------------------------------------------------------------------------------
+
+In this case, a new Kafka client will be created for each calculated `client_id` value.
+
+NOTE: Unused connections will be closed after 15 minutes of inactivity.
+
 ===== `worker`
 
 The number of concurrent load-balanced Kafka output workers.

--- a/libbeat/outputs/kafka/multi_client.go
+++ b/libbeat/outputs/kafka/multi_client.go
@@ -1,0 +1,298 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/outputs/codec"
+	"github.com/elastic/beats/v7/libbeat/outputs/outest"
+	"github.com/elastic/beats/v7/libbeat/outputs/outil"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+)
+
+type (
+	multiClientBuilder func(clientId string) (outputs.Client, error)
+
+	clientInfo struct {
+		Client     outputs.Client
+		LastUsedAt time.Time
+	}
+
+	MultiClient struct {
+		builder          multiClientBuilder
+		log              *logp.Logger
+		clientIdSelector outil.Selector
+
+		clients   map[string]*clientInfo
+		clientsMu sync.RWMutex
+
+		clientsGCStopper chan struct{}
+	}
+)
+
+var (
+	_ outputs.NetworkClient = &MultiClient{}
+)
+
+const (
+	clientsGCPeriod = 15 * time.Minute
+)
+
+func NewKafkaMultiClient(
+	beat beat.Info,
+	observer outputs.Observer,
+	hosts []string,
+	topic outil.Selector,
+	config *kafkaConfig,
+	log *logp.Logger,
+	clientIdSelector outil.Selector,
+) (*MultiClient, error) {
+
+	k := &MultiClient{
+		log:              log,
+		clientIdSelector: clientIdSelector,
+		clients:          make(map[string]*clientInfo),
+	}
+
+	k.builder = func(clientId string) (outputs.Client, error) {
+		goMetricsName := defaultGoMetricsName + "." + clientId // we must use separate metricsNames to avoid data races
+		cfg, err := newSaramaConfig(log, config, goMetricsName)
+		if err != nil {
+			return nil, err
+		}
+		if clientId != "" {
+			cfg.ClientID = clientId
+		}
+
+		writer, err := codec.CreateEncoder(beat, config.Codec)
+		if err != nil {
+			return nil, err
+		}
+
+		client, err := newKafkaClient(observer, hosts, beat.IndexPrefix, config.Key, topic, writer, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Debugf("Connect to kafka hosts %v with clientId: %q", hosts, cfg.ClientID)
+		err = client.Connect()
+		if err != nil {
+			return nil, err
+		}
+
+		return client, err
+	}
+
+	return k, nil
+}
+
+func (k *MultiClient) Connect() error {
+	k.clientsMu.Lock()
+	defer k.clientsMu.Unlock()
+
+	// Checking a builder
+	client, err := k.builder("")
+	if err != nil {
+		return fmt.Errorf(`could not create default client: %w`, err)
+	}
+	_ = client.Close()
+
+	k.clientsGCStopper = make(chan struct{})
+	go k.clientsGC()
+
+	return nil
+}
+
+func (k *MultiClient) Close() error {
+	k.clientsMu.Lock()
+	defer k.clientsMu.Unlock()
+
+	close(k.clientsGCStopper)
+
+	var lastErr error
+
+	for clientId, client := range k.clients {
+		err := client.Client.Close()
+		if err != nil {
+			lastErr = err
+		}
+
+		delete(k.clients, clientId)
+	}
+
+	return lastErr
+}
+
+func (k *MultiClient) Publish(ctx context.Context, batch publisher.Batch) error {
+	eventsByClientId := map[string][]beat.Event{}
+
+	// Separate events by kafka clientId
+	for _, event := range batch.Events() {
+		kafkaClientId, _ := k.clientIdSelector.Select(&event.Content)
+
+		eventsByClientId[kafkaClientId] = append(eventsByClientId[kafkaClientId], event.Content)
+	}
+
+	var (
+		forRetry   []publisher.Event
+		forRetryMu sync.Mutex
+		wg         sync.WaitGroup
+	)
+
+	retryBeatEvents := func(events []beat.Event) {
+		forRetryMu.Lock()
+		for _, event := range events {
+			forRetry = append(forRetry, publisher.Event{Content: event})
+		}
+		forRetryMu.Unlock()
+	}
+
+	for clientId := range eventsByClientId {
+		clientId := clientId
+
+		wg.Add(1)
+		go func() {
+			events := eventsByClientId[clientId]
+
+			client, err := k.getClient(clientId)
+			if err != nil {
+				k.log.Warnf("getClient failed: %s", err)
+				retryBeatEvents(events)
+				wg.Done()
+				return
+			}
+			if client == nil {
+				k.log.Error("there is no client connection")
+				retryBeatEvents(events)
+				wg.Done()
+				return
+			}
+
+			monoBatch := outest.NewBatch(events...)
+			monoBatch.OnSignal = func(sig outest.BatchSignal) {
+				defer wg.Done()
+
+				switch sig.Tag {
+				case outest.BatchRetryEvents:
+					forRetryMu.Lock()
+					forRetry = append(forRetry, sig.Events...)
+					forRetryMu.Unlock()
+
+				case outest.BatchACK:
+					// all ok
+
+				default:
+					k.log.Warnf("unsupported signal tag %d", sig.Tag)
+				}
+			}
+
+			err = client.Publish(ctx, monoBatch)
+			if err != nil {
+				k.log.Warnf("publish error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if len(forRetry) > 0 {
+		batch.RetryEvents(forRetry)
+	} else {
+		batch.ACK()
+	}
+
+	return nil
+}
+
+func (k *MultiClient) String() string {
+	return "kafkaMultiClient"
+}
+
+func (k *MultiClient) getClient(kafkaClientId string) (outputs.Client, error) {
+	var (
+		ci *clientInfo
+		ok bool
+	)
+
+	defer func() {
+		if ci != nil {
+			ci.LastUsedAt = time.Now()
+		}
+	}()
+
+	k.clientsMu.RLock()
+	ci, ok = k.clients[kafkaClientId]
+	k.clientsMu.RUnlock()
+
+	if ok {
+		return ci.Client, nil
+	}
+
+	k.clientsMu.Lock()
+	defer k.clientsMu.Unlock()
+
+	ci, ok = k.clients[kafkaClientId]
+	if ok {
+		return ci.Client, nil
+	}
+
+	client, err := k.builder(kafkaClientId)
+	if err != nil {
+		return nil, fmt.Errorf(`could not create kafka client for clientId %q: %w`, kafkaClientId, err)
+	}
+
+	k.clients[kafkaClientId] = &clientInfo{
+		Client:     client,
+		LastUsedAt: time.Now(),
+	}
+
+	return client, nil
+}
+
+func (k *MultiClient) clientsGC() {
+	ticker := time.NewTicker(clientsGCPeriod)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// pass
+		case <-k.clientsGCStopper:
+			return
+		}
+
+		dropOlderThan := time.Now().Add(-clientsGCPeriod) // Should add some random?
+		k.clientsMu.Lock()
+		for clientId, ci := range k.clients {
+			if ci.LastUsedAt.Before(dropOlderThan) {
+				err := ci.Client.Close()
+				delete(k.clients, clientId)
+
+				k.log.Debugf("Drop useless kafka connection with clientId %q (close error: %v)", clientId, err)
+			}
+		}
+		k.clientsMu.Unlock()
+	}
+}


### PR DESCRIPTION
This PR is WiP now. I'm interested to hear your opinion.

## What does this PR do?
This feature allows setting the clientID dynamically by using a format string to access any event field. It works the same as a topic selector.
A new Kafka client will be created for each calculated `client_id` value.

## Why is it important?
When we use filebeat in multi-tenant k8s nodes we need to separate different pods by specified clientID for each of them.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
Use configuration file with dynamic `client_id` value.
