### PR TITLE
Remove reference to Beat generators from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,6 @@ create your own Beat.
 
 Please start by reading our [CONTRIBUTING](CONTRIBUTING.md) file.
 
-If you are creating a new Beat, you don't need to submit the code to this
-repository. You can simply start working in a new repository and make use of the
-libbeat packages, by following our [developer
-guide](https://www.elastic.co/guide/en/beats/libbeat/current/new-beat.html).
-After you have a working prototype, open a pull request to add your Beat to the
-list of [community
-Beats](https://github.com/elastic/beats/blob/master/libbeat/docs/communitybeats.asciidoc).
-
 ## Building Beats from the Source
 
 See our [CONTRIBUTING](CONTRIBUTING.md) file for information about setting up


### PR DESCRIPTION
## What does this PR do?

The PR removes broken reference to building your own Beat from the Contributing section of the README.md. It was missing from my previous PR that removed Beat generator code and reference. If anyone wants see the docs now, they have to set the version to 7.16.

## Why is it important?

Clean up.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~