### PR TITLE
Move `fips_enabled` setting to AWS Common

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -229,6 +229,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Discover changes in Kubernetes nodes metadata as soon as they happen. {pull}23139[23139]
 - Support self signed certificates on outputs {pull}29229[29229]
 - Update k8s library {pull}29394[29394]
+- Add FIPS configuration option for all AWS API calls. {pull}[28899]
 
 *Auditbeat*
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -68,6 +68,24 @@ If endpoint is specified, `regions` config becomes required. For example:
     - ec2
 ----
 
+* *fips_enabled*
+
+Enforces the use of FIPS service endpoints. See <<aws-credentials-config,AWS credentials options>> for more information.
+
+[source,yaml]
+----
+- module: aws
+  period: 5m
+  fips_enabled: true
+  regions:
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+  metricsets:
+    - ec2
+----
+
 The aws module comes with a predefined dashboard. For example:
 
 image::./images/metricbeat-aws-overview.png[]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -182,9 +182,7 @@ file_selectors:
 [float]
 ==== `fips_enabled`
 
-Enabling this option changes the service name from `s3` to `s3-fips` for
-connecting to the correct service endpoint. For example:
-`s3-fips.us-gov-east-1.amazonaws.com`.
+Moved to <<aws-credentials-config,AWS credentials options>>.
 
 [id="input-{type}-include_s3_metadata"]
 [float]

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -160,6 +160,12 @@ filebeat.modules:
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   cloudwatch:
     enabled: false
 
@@ -211,6 +217,12 @@ filebeat.modules:
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
   ec2:
     enabled: false
@@ -264,6 +276,12 @@ filebeat.modules:
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   elb:
     enabled: false
 
@@ -315,6 +333,12 @@ filebeat.modules:
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
   s3access:
     enabled: false
@@ -368,6 +392,12 @@ filebeat.modules:
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   vpcflow:
     enabled: false
 
@@ -419,6 +449,12 @@ filebeat.modules:
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
 #----------------------------- AWS Fargate Module -----------------------------
 - module: awsfargate
@@ -475,6 +511,12 @@ filebeat.modules:
     # Time used to sleep between AWS FilterLogEvents API calls inside the same collection period
     # Default api_sleep is 200 ms
     #var.api_sleep: 200ms
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
 #-------------------------------- Azure Module --------------------------------
 - module: azure

--- a/x-pack/filebeat/input/awscloudwatch/input.go
+++ b/x-pack/filebeat/input/awscloudwatch/input.go
@@ -131,7 +131,8 @@ func NewInput(cfg *common.Config, connector channel.Connector, context input.Con
 // Run runs the input
 func (in *awsCloudWatchInput) Run() {
 	// Please see https://docs.aws.amazon.com/general/latest/gr/cwl_region.html for more info on Amazon CloudWatch Logs endpoints.
-	cwConfig := awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, "logs", in.config.RegionName, in.awsConfig)
+	logsServiceName := awscommon.CreateServiceName("logs", in.config.AwsConfig.FIPSEnabled, in.config.RegionName)
+	cwConfig := awscommon.EnrichAWSConfigWithEndpoint(in.config.AwsConfig.Endpoint, logsServiceName, in.config.RegionName, in.awsConfig)
 	svc := cloudwatchlogs.New(cwConfig)
 
 	var logGroupNames []string

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -25,7 +25,6 @@ type config struct {
 	SQSWaitTime         time.Duration        `config:"sqs.wait_time"`         // The max duration for which the SQS ReceiveMessage call waits for a message to arrive in the queue before returning.
 	SQSMaxReceiveCount  int                  `config:"sqs.max_receive_count"` // The max number of times a message should be received (retried) before deleting it.
 	SQSScript           *scriptConfig        `config:"sqs.notification_parsing_script"`
-	FIPSEnabled         bool                 `config:"fips_enabled"`
 	MaxNumberOfMessages int                  `config:"max_number_of_messages"`
 	QueueURL            string               `config:"queue_url"`
 	BucketARN           string               `config:"bucket_arn"`
@@ -48,7 +47,6 @@ func defaultConfig() config {
 		BucketListPrefix:    "",
 		SQSWaitTime:         20 * time.Second,
 		SQSMaxReceiveCount:  5,
-		FIPSEnabled:         false,
 		MaxNumberOfMessages: 5,
 		PathStyle:           false,
 	}
@@ -99,7 +97,7 @@ func (c *config) Validate() error {
 			c.APITimeout, c.SQSWaitTime)
 	}
 
-	if c.FIPSEnabled && c.NonAWSBucketName != "" {
+	if c.AWSConfig.FIPSEnabled && c.NonAWSBucketName != "" {
 		return errors.New("fips_enabled cannot be used with a non-AWS S3 bucket.")
 	}
 	if c.PathStyle && c.NonAWSBucketName == "" {

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -38,7 +38,6 @@ func TestConfig(t *testing.T) {
 			SQSWaitTime:         20 * time.Second,
 			BucketListInterval:  120 * time.Second,
 			BucketListPrefix:    "",
-			FIPSEnabled:         false,
 			PathStyle:           false,
 			MaxNumberOfMessages: 5,
 			ReaderConfig: readerConfig{

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -155,13 +155,11 @@ func (in *s3Input) Run(inputContext v2.Context, pipeline beat.Pipeline) error {
 }
 
 func (in *s3Input) createSQSReceiver(ctx v2.Context, client beat.Client) (*sqsReader, error) {
-	s3ServiceName := "s3"
-	if in.config.FIPSEnabled {
-		s3ServiceName = "s3-fips"
-	}
+	s3ServiceName := awscommon.CreateServiceName("s3", in.config.AWSConfig.FIPSEnabled, in.awsConfig.Region)
+	sqsServiceName := awscommon.CreateServiceName("sqs", in.config.AWSConfig.FIPSEnabled, in.awsConfig.Region)
 
 	sqsAPI := &awsSQSAPI{
-		client:            sqs.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AWSConfig.Endpoint, "sqs", in.awsConfig.Region, in.awsConfig)),
+		client:            sqs.New(awscommon.EnrichAWSConfigWithEndpoint(in.config.AWSConfig.Endpoint, sqsServiceName, in.awsConfig.Region, in.awsConfig)),
 		queueURL:          in.config.QueueURL,
 		apiTimeout:        in.config.APITimeout,
 		visibilityTimeout: in.config.VisibilityTimeout,
@@ -198,10 +196,7 @@ func (in *s3Input) createSQSReceiver(ctx v2.Context, client beat.Client) (*sqsRe
 }
 
 func (in *s3Input) createS3Lister(ctx v2.Context, cancelCtx context.Context, client beat.Client, persistentStore *statestore.Store, states *states) (*s3Poller, error) {
-	s3ServiceName := "s3"
-	if in.config.FIPSEnabled {
-		s3ServiceName = "s3-fips"
-	}
+	s3ServiceName := awscommon.CreateServiceName("s3", in.config.AWSConfig.FIPSEnabled, in.awsConfig.Region)
 	var bucketName string
 	var bucketID string
 	if in.config.NonAWSBucketName != "" {

--- a/x-pack/filebeat/module/aws/_meta/config.yml
+++ b/x-pack/filebeat/module/aws/_meta/config.yml
@@ -63,6 +63,12 @@
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   cloudwatch:
     enabled: false
 
@@ -114,6 +120,12 @@
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
   ec2:
     enabled: false
@@ -167,6 +179,12 @@
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   elb:
     enabled: false
 
@@ -218,6 +236,12 @@
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
   s3access:
     enabled: false
@@ -271,6 +295,12 @@
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   vpcflow:
     enabled: false
 
@@ -322,3 +352,9 @@
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:

--- a/x-pack/filebeat/module/aws/cloudtrail/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/config/aws-s3.yml
@@ -81,6 +81,10 @@ max_number_of_messages: {{ .max_number_of_messages }}
 proxy_url: {{ .proxy_url }}
 {{ end }}
 
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudtrail/manifest.yml
@@ -28,6 +28,7 @@ var:
   - name: fips_enabled
   - name: proxy_url
   - name: max_number_of_messages
+  - name: ssl
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/cloudwatch/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/config/aws-s3.yml
@@ -66,6 +66,10 @@ max_number_of_messages: {{ .max_number_of_messages }}
 proxy_url: {{ .proxy_url }}
 {{ end }}
 
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
+++ b/x-pack/filebeat/module/aws/cloudwatch/manifest.yml
@@ -22,6 +22,7 @@ var:
   - name: fips_enabled
   - name: proxy_url
   - name: max_number_of_messages
+  - name: ssl
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/ec2/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/ec2/config/aws-s3.yml
@@ -66,6 +66,10 @@ max_number_of_messages: {{ .max_number_of_messages }}
 proxy_url: {{ .proxy_url }}
 {{ end }}
 
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/ec2/manifest.yml
+++ b/x-pack/filebeat/module/aws/ec2/manifest.yml
@@ -22,6 +22,7 @@ var:
   - name: fips_enabled
   - name: proxy_url
   - name: max_number_of_messages
+  - name: ssl
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/elb/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/elb/config/aws-s3.yml
@@ -66,6 +66,10 @@ max_number_of_messages: {{ .max_number_of_messages }}
 proxy_url: {{ .proxy_url }}
 {{ end }}
 
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/elb/manifest.yml
+++ b/x-pack/filebeat/module/aws/elb/manifest.yml
@@ -22,6 +22,7 @@ var:
   - name: fips_enabled
   - name: proxy_url
   - name: max_number_of_messages
+  - name: ssl
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/s3access/config/aws-s3.yml
+++ b/x-pack/filebeat/module/aws/s3access/config/aws-s3.yml
@@ -66,6 +66,10 @@ max_number_of_messages: {{ .max_number_of_messages }}
 proxy_url: {{ .proxy_url }}
 {{ end }}
 
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
 tags: {{.tags | tojson}}
 publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}
 

--- a/x-pack/filebeat/module/aws/s3access/manifest.yml
+++ b/x-pack/filebeat/module/aws/s3access/manifest.yml
@@ -22,6 +22,7 @@ var:
   - name: fips_enabled
   - name: proxy_url
   - name: max_number_of_messages
+  - name: ssl
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/module/aws/vpcflow/config/input.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/config/input.yml
@@ -68,6 +68,10 @@ max_number_of_messages: {{ .max_number_of_messages }}
 proxy_url: {{ .proxy_url }}
 {{ end }}
 
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
 {{ else if eq .input "file" }}
 
 type: log

--- a/x-pack/filebeat/module/aws/vpcflow/manifest.yml
+++ b/x-pack/filebeat/module/aws/vpcflow/manifest.yml
@@ -22,6 +22,7 @@ var:
   - name: fips_enabled
   - name: proxy_url
   - name: max_number_of_messages
+  - name: ssl
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/input.yml

--- a/x-pack/filebeat/module/awsfargate/_meta/config.yml
+++ b/x-pack/filebeat/module/awsfargate/_meta/config.yml
@@ -52,3 +52,9 @@
     # Time used to sleep between AWS FilterLogEvents API calls inside the same collection period
     # Default api_sleep is 200 ms
     #var.api_sleep: 200ms
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:

--- a/x-pack/filebeat/module/awsfargate/log/config/aws-cloudwatch.yml
+++ b/x-pack/filebeat/module/awsfargate/log/config/aws-cloudwatch.yml
@@ -56,6 +56,14 @@ session_token: {{ .session_token }}
 role_arn: {{ .role_arn }}
 {{ end }}
 
+{{ if .proxy_url }}
+proxy_url: {{ .proxy_url }}
+{{ end }}
+
+{{ if .ssl }}
+ssl: {{ .ssl | tojson }}
+{{ end }}
+
 processors:
   - add_fields:
       target: ''

--- a/x-pack/filebeat/module/awsfargate/log/manifest.yml
+++ b/x-pack/filebeat/module/awsfargate/log/manifest.yml
@@ -20,6 +20,8 @@ var:
   - name: scan_frequency
   - name: api_timeout
   - name: api_sleep
+  - name: proxy_url
+  - name: ssl
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/{{.input}}.yml

--- a/x-pack/filebeat/modules.d/aws.yml.disabled
+++ b/x-pack/filebeat/modules.d/aws.yml.disabled
@@ -66,6 +66,12 @@
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   cloudwatch:
     enabled: false
 
@@ -117,6 +123,12 @@
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
   ec2:
     enabled: false
@@ -170,6 +182,12 @@
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   elb:
     enabled: false
 
@@ -221,6 +239,12 @@
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
 
   s3access:
     enabled: false
@@ -274,6 +298,12 @@
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
 
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:
+
   vpcflow:
     enabled: false
 
@@ -325,3 +355,9 @@
 
     # The maximum number of messages to return from SQS. Valid values: 1 to 10.
     #var.max_number_of_messages: 5
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:

--- a/x-pack/filebeat/modules.d/awsfargate.yml.disabled
+++ b/x-pack/filebeat/modules.d/awsfargate.yml.disabled
@@ -55,3 +55,9 @@
     # Time used to sleep between AWS FilterLogEvents API calls inside the same collection period
     # Default api_sleep is 200 ms
     #var.api_sleep: 200ms
+
+    # URL to proxy AWS API calls
+    #var.proxy_url: http://proxy:3128
+
+    # Configures the SSL settings, ie. set trusted CAs, ignore certificate verification....
+    #var.ssl:

--- a/x-pack/libbeat/autodiscover/providers/aws/ec2/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/ec2/provider.go
@@ -64,8 +64,9 @@ func AutodiscoverBuilder(
 	if config.Regions == nil {
 		// set default region to make initial aws api call
 		awsCfg.Region = "us-west-1"
+		ec2ServiceName := awscommon.CreateServiceName("ec2", config.AWSConfig.FIPSEnabled, awsCfg.Region)
 		svcEC2 := ec2.New(awscommon.EnrichAWSConfigWithEndpoint(
-			config.AWSConfig.Endpoint, "ec2", awsCfg.Region, awsCfg))
+			config.AWSConfig.Endpoint, ec2ServiceName, awsCfg.Region, awsCfg))
 
 		completeRegionsList, err := awsauto.GetRegions(svcEC2)
 		if err != nil {
@@ -81,8 +82,9 @@ func AutodiscoverBuilder(
 			logp.Error(errors.Wrap(err, "error loading AWS config for aws_ec2 autodiscover provider"))
 		}
 		awsCfg.Region = region
+		ec2ServiceName := awscommon.CreateServiceName("ec2", config.AWSConfig.FIPSEnabled, region)
 		clients = append(clients, ec2.New(awscommon.EnrichAWSConfigWithEndpoint(
-			config.AWSConfig.Endpoint, "ec2", region, awsCfg)))
+			config.AWSConfig.Endpoint, ec2ServiceName, region, awsCfg)))
 	}
 
 	return internalBuilder(uuid, bus, config, newAPIFetcher(clients), keystore)

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -63,8 +63,9 @@ func AutodiscoverBuilder(
 
 	// Construct MetricSet with a full regions list if there is no region specified.
 	if config.Regions == nil {
+		ec2ServiceName := awscommon.CreateServiceName("ec2", config.AWSConfig.FIPSEnabled, awsCfg.Region)
 		svcEC2 := ec2.New(awscommon.EnrichAWSConfigWithEndpoint(
-			config.AWSConfig.Endpoint, "ec2", awsCfg.Region, awsCfg))
+			config.AWSConfig.Endpoint, ec2ServiceName, awsCfg.Region, awsCfg))
 
 		completeRegionsList, err := awsauto.GetRegions(svcEC2)
 		if err != nil {
@@ -86,8 +87,9 @@ func AutodiscoverBuilder(
 			logp.Err("error loading AWS config for aws_elb autodiscover provider: %s", err)
 		}
 		awsCfg.Region = region
+		elbServiceName := awscommon.CreateServiceName("elasticloadbalancing", config.AWSConfig.FIPSEnabled, region)
 		clients = append(clients, elasticloadbalancingv2.New(awscommon.EnrichAWSConfigWithEndpoint(
-			config.AWSConfig.Endpoint, "elasticloadbalancing", region, awsCfg)))
+			config.AWSConfig.Endpoint, elbServiceName, region, awsCfg)))
 	}
 
 	return internalBuilder(uuid, bus, config, newAPIFetcher(clients), keystore)

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -22,6 +22,12 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
+// OptionalGovCloudFIPS is a list of services on AWS GovCloud that is not FIPS by default.
+// These services follow the standard <service name>-fips.<region>.amazonaws.com format.
+var OptionalGovCloudFIPS = map[string]bool{
+	"s3": true,
+}
+
 // ConfigAWS is a structure defined for AWS credentials
 type ConfigAWS struct {
 	AccessKeyID          string `config:"access_key_id"`
@@ -175,9 +181,6 @@ func EnrichAWSConfigWithEndpoint(endpoint string, serviceName string, regionName
 //Create AWS service name based on Region and FIPS
 func CreateServiceName(serviceName string, fipsEnabled bool, region string) string {
 	if fipsEnabled {
-		OptionalGovCloudFIPS := map[string]bool{
-			"s3": true,
-		}
 		_, found := OptionalGovCloudFIPS[serviceName]
 		if !strings.HasPrefix(region, "us-gov-") || found {
 			return serviceName + "-fips"

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -5,8 +5,10 @@
 package aws
 
 import (
+	"crypto/tls"
 	"net/http"
 	"net/url"
+	"strings"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
@@ -16,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
@@ -29,23 +32,32 @@ type ConfigAWS struct {
 	Endpoint             string `config:"endpoint"`
 	RoleArn              string `config:"role_arn"`
 	ProxyUrl             string `config:"proxy_url"`
+	FIPSEnabled          bool   `config:"fips_enabled"`
+	// TLS provides ssl/tls setup settings
+	TLS *tlscommon.Config `config:"ssl" yaml:"ssl,omitempty" json:"ssl,omitempty"`
 }
 
 // InitializeAWSConfig function creates the awssdk.Config object from the provided config
 func InitializeAWSConfig(config ConfigAWS) (awssdk.Config, error) {
 	AWSConfig, _ := GetAWSCredentials(config)
+	var proxy func(*http.Request) (*url.URL, error)
 	if config.ProxyUrl != "" {
 		proxyUrl, err := httpcommon.NewProxyURIFromString(config.ProxyUrl)
 		if err != nil {
 			return AWSConfig, err
 		}
-
-		httpClient := &http.Client{
-			Transport: &http.Transport{
-				Proxy: http.ProxyURL(proxyUrl.URI()),
-			},
-		}
-		AWSConfig.HTTPClient = httpClient
+		proxy = http.ProxyURL(proxyUrl.URI())
+	}
+	var tlsConfig *tls.Config
+	if config.TLS != nil {
+		TLSConfig, _ := tlscommon.LoadTLSConfig(config.TLS)
+		tlsConfig = TLSConfig.ToConfig()
+	}
+	AWSConfig.HTTPClient = &http.Client{
+		Transport: &http.Transport{
+			Proxy:           proxy,
+			TLSClientConfig: tlsConfig,
+		},
 	}
 	return AWSConfig, nil
 }
@@ -143,17 +155,42 @@ func getRoleArn(config ConfigAWS, awsConfig awssdk.Config) awssdk.Config {
 // EnrichAWSConfigWithEndpoint function enabled endpoint resolver for AWS
 // service clients when endpoint is given in config.
 func EnrichAWSConfigWithEndpoint(endpoint string, serviceName string, regionName string, awsConfig awssdk.Config) awssdk.Config {
+	var eurl string
 	if endpoint != "" {
 		parsedEndpoint, _ := url.Parse(endpoint)
 		if parsedEndpoint.Scheme != "" {
 			awsConfig.EndpointResolver = awssdk.ResolveWithEndpointURL(endpoint)
 		} else {
 			if regionName == "" {
-				awsConfig.EndpointResolver = awssdk.ResolveWithEndpointURL("https://" + serviceName + "." + endpoint)
+				eurl = "https://" + serviceName + "." + endpoint
 			} else {
-				awsConfig.EndpointResolver = awssdk.ResolveWithEndpointURL("https://" + serviceName + "." + regionName + "." + endpoint)
+				eurl = "https://" + serviceName + "." + regionName + "." + endpoint
 			}
+			awsConfig.EndpointResolver = awssdk.ResolveWithEndpointURL(eurl)
 		}
 	}
 	return awsConfig
+}
+
+//Create AWS service name based on Region and FIPS
+func CreateServiceName(serviceName string, fipsEnabled bool, region string) string {
+	if fipsEnabled {
+		OptionalGovCloudFIPS := []string{"s3"}
+		_, found := Find(OptionalGovCloudFIPS, serviceName)
+		if !strings.HasPrefix(region, "us-gov-") || found {
+			return serviceName + "-fips"
+		}
+	}
+	return serviceName
+}
+
+// Find takes a slice and looks for an element in it. If found it will
+// return it's key, otherwise it will return -1 and a bool of false.
+func Find(slice []string, val string) (int, bool) {
+	for i, item := range slice {
+		if item == val {
+			return i, true
+		}
+	}
+	return -1, false
 }

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -175,22 +175,13 @@ func EnrichAWSConfigWithEndpoint(endpoint string, serviceName string, regionName
 //Create AWS service name based on Region and FIPS
 func CreateServiceName(serviceName string, fipsEnabled bool, region string) string {
 	if fipsEnabled {
-		OptionalGovCloudFIPS := []string{"s3"}
-		_, found := Find(OptionalGovCloudFIPS, serviceName)
+		OptionalGovCloudFIPS := map[string]bool{
+			"s3": true,
+		}
+		_, found := OptionalGovCloudFIPS[serviceName]
 		if !strings.HasPrefix(region, "us-gov-") || found {
 			return serviceName + "-fips"
 		}
 	}
 	return serviceName
-}
-
-// Find takes a slice and looks for an element in it. If found it will
-// return it's key, otherwise it will return -1 and a bool of false.
-func Find(slice []string, val string) (int, bool) {
-	for i, item := range slice {
-		if item == val {
-			return i, true
-		}
-	}
-	return -1, false
 }

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -30,17 +30,16 @@ var OptionalGovCloudFIPS = map[string]bool{
 
 // ConfigAWS is a structure defined for AWS credentials
 type ConfigAWS struct {
-	AccessKeyID          string `config:"access_key_id"`
-	SecretAccessKey      string `config:"secret_access_key"`
-	SessionToken         string `config:"session_token"`
-	ProfileName          string `config:"credential_profile_name"`
-	SharedCredentialFile string `config:"shared_credential_file"`
-	Endpoint             string `config:"endpoint"`
-	RoleArn              string `config:"role_arn"`
-	ProxyUrl             string `config:"proxy_url"`
-	FIPSEnabled          bool   `config:"fips_enabled"`
-	// TLS provides ssl/tls setup settings
-	TLS *tlscommon.Config `config:"ssl" yaml:"ssl,omitempty" json:"ssl,omitempty"`
+	AccessKeyID          string            `config:"access_key_id"`
+	SecretAccessKey      string            `config:"secret_access_key"`
+	SessionToken         string            `config:"session_token"`
+	ProfileName          string            `config:"credential_profile_name"`
+	SharedCredentialFile string            `config:"shared_credential_file"`
+	Endpoint             string            `config:"endpoint"`
+	RoleArn              string            `config:"role_arn"`
+	ProxyUrl             string            `config:"proxy_url"`
+	FIPSEnabled          bool              `config:"fips_enabled"`
+	TLS                  *tlscommon.Config `config:"ssl" yaml:"ssl,omitempty" json:"ssl,omitempty"`
 }
 
 // InitializeAWSConfig function creates the awssdk.Config object from the provided config

--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -10,8 +10,9 @@ import (
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
 func TestInitializeAWSConfig(t *testing.T) {

--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -6,11 +6,34 @@ package aws
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestInitializeAWSConfig(t *testing.T) {
+	inputConfig := ConfigAWS{
+		AccessKeyID:     "123",
+		SecretAccessKey: "abc",
+		TLS: &tlscommon.Config{
+			VerificationMode: 1,
+		},
+		ProxyUrl: "http://proxy:3128",
+	}
+	awsConfig, err := InitializeAWSConfig(inputConfig)
+	assert.NoError(t, err)
+
+	retrievedAWSConfig, err := awsConfig.Credentials.Retrieve(context.Background())
+	assert.NoError(t, err)
+
+	assert.Equal(t, inputConfig.AccessKeyID, retrievedAWSConfig.AccessKeyID)
+	assert.Equal(t, inputConfig.SecretAccessKey, retrievedAWSConfig.SecretAccessKey)
+	assert.Equal(t, true, awsConfig.HTTPClient.(*http.Client).Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify)
+	assert.NotNil(t, awsConfig.HTTPClient.(*http.Client).Transport.(*http.Transport).Proxy)
+}
 
 func TestGetAWSCredentials(t *testing.T) {
 	inputConfig := ConfigAWS{
@@ -83,6 +106,58 @@ func TestEnrichAWSConfigWithEndpoint(t *testing.T) {
 		t.Run(c.title, func(t *testing.T) {
 			enrichedAWSConfig := EnrichAWSConfigWithEndpoint(c.endpoint, c.serviceName, c.region, c.awsConfig)
 			assert.Equal(t, c.expectedAWSConfig, enrichedAWSConfig)
+		})
+	}
+}
+
+func TestCreateServiceName(t *testing.T) {
+	cases := []struct {
+		title               string
+		serviceName         string
+		fips_enabled        bool
+		region              string
+		expectedServiceName string
+	}{
+		{
+			"S3 - non-fips - us-east-1",
+			"s3",
+			false,
+			"us-east-1",
+			"s3",
+		},
+		{
+			"S3 - non-fips - us-gov-east-1",
+			"s3",
+			false,
+			"us-gov-east-1",
+			"s3",
+		},
+		{
+			"S3 - fips - us-gov-east-1",
+			"s3",
+			true,
+			"us-gov-east-1",
+			"s3-fips",
+		},
+		{
+			"EC2 - fips - us-gov-east-1",
+			"ec2",
+			true,
+			"us-gov-east-1",
+			"ec2",
+		},
+		{
+			"EC2 - fips - us-east-1",
+			"ec2",
+			true,
+			"us-east-1",
+			"ec2-fips",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			serviceName := CreateServiceName(c.serviceName, c.fips_enabled, c.region)
+			assert.Equal(t, c.expectedServiceName, serviceName)
 		})
 	}
 }

--- a/x-pack/libbeat/docs/aws-credentials-config.asciidoc
+++ b/x-pack/libbeat/docs/aws-credentials-config.asciidoc
@@ -18,6 +18,8 @@ services do not include a region. In `aws` module, `endpoint` config is to set
 the `endpoint-code` part, such as `amazonaws.com`, `amazonaws.com.cn`, `c2s.ic.gov`,
 `sc2s.sgov.gov`.
 * *proxy_url*: URL of the proxy to use to connect to AWS web services. The syntax is `http(s)://<IP/Hostname>:<port>`
+* *fips_enabled*: Enabling this option changes the service names from `s3` to `s3-fips` for connecting to the correct service endpoint. For example: `s3-fips.us-gov-east-1.amazonaws.com`. All services used by Beats are FIPS compatible except for `tagging` but only certain regions are FIPS compatible. See https://aws.amazon.com/compliance/fips/ or the appropriate service page, https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html, for a full list of FIPS endpoints and regions.
+* *ssl*: This specifies SSL/TLS configuration. If the ssl section is missing, the host's CAs are used for HTTPS connections. See <<configuration-ssl>> for more information.
 
 [float]
 ==== Supported Formats

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -58,6 +58,24 @@ If endpoint is specified, `regions` config becomes required. For example:
     - ec2
 ----
 
+* *fips_enabled*
+
+Enforces the use of FIPS service endpoints. See <<aws-credentials-config,AWS credentials options>> for more information.
+
+[source,yaml]
+----
+- module: aws
+  period: 5m
+  fips_enabled: true
+  regions:
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+  metricsets:
+    - ec2
+----
+
 The aws module comes with a predefined dashboard. For example:
 
 image::./images/metricbeat-aws-overview.png[]

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata.go
@@ -21,14 +21,14 @@ const (
 )
 
 // addMetadata adds metadata to the given events map based on namespace
-func addMetadata(namespace string, endpoint string, regionName string, awsConfig awssdk.Config, events map[string]mb.Event) map[string]mb.Event {
+func addMetadata(namespace string, endpoint string, regionName string, awsConfig awssdk.Config, fips_enabled bool, events map[string]mb.Event) map[string]mb.Event {
 	switch namespace {
 	case namespaceEC2:
-		return ec2.AddMetadata(endpoint, regionName, awsConfig, events)
+		return ec2.AddMetadata(endpoint, regionName, awsConfig, fips_enabled, events)
 	case namespaceRDS:
-		return rds.AddMetadata(endpoint, regionName, awsConfig, events)
+		return rds.AddMetadata(endpoint, regionName, awsConfig, fips_enabled, events)
 	case namespaceSQS:
-		return sqs.AddMetadata(endpoint, regionName, awsConfig, events)
+		return sqs.AddMetadata(endpoint, regionName, awsConfig, fips_enabled, events)
 	default:
 		return events
 	}

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/ec2/ec2.go
@@ -22,9 +22,10 @@ import (
 const metadataPrefix = "aws.ec2.instance."
 
 // AddMetadata adds metadata for EC2 instances from a specific region
-func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, events map[string]mb.Event) map[string]mb.Event {
+func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, fips_enabled bool, events map[string]mb.Event) map[string]mb.Event {
+	ec2ServiceName := awscommon.CreateServiceName("ec2", fips_enabled, regionName)
 	svcEC2 := ec2.New(awscommon.EnrichAWSConfigWithEndpoint(
-		endpoint, "ec2", regionName, awsConfig))
+		endpoint, ec2ServiceName, regionName, awsConfig))
 
 	instancesOutputs, err := getInstancesPerRegion(svcEC2)
 	if err != nil {

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
@@ -21,9 +21,10 @@ import (
 const metadataPrefix = "aws.rds.db_instance."
 
 // AddMetadata adds metadata for RDS instances from a specific region
-func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, events map[string]mb.Event) map[string]mb.Event {
+func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, fips_enabled bool, events map[string]mb.Event) map[string]mb.Event {
+	rdsServiceName := awscommon.CreateServiceName("rds", fips_enabled, regionName)
 	svc := rds.New(awscommon.EnrichAWSConfigWithEndpoint(
-		endpoint, "rds", regionName, awsConfig))
+		endpoint, rdsServiceName, regionName, awsConfig))
 
 	// Get DBInstance IDs per region
 	dbDetailsMap, err := getDBInstancesPerRegion(svc)

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/sqs/sqs.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/sqs/sqs.go
@@ -22,9 +22,10 @@ import (
 const metadataPrefix = "aws.sqs.queue"
 
 // AddMetadata adds metadata for SQS queues from a specific region
-func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, events map[string]mb.Event) map[string]mb.Event {
+func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, fips_enabled bool, events map[string]mb.Event) map[string]mb.Event {
+	sqsServiceName := awscommon.CreateServiceName("sqs", fips_enabled, regionName)
 	svc := sqs.New(awscommon.EnrichAWSConfigWithEndpoint(
-		endpoint, "sqs", regionName, awsConfig))
+		endpoint, sqsServiceName, regionName, awsConfig))
 
 	// Get queueUrls for each region
 	queueURLs, err := getQueueUrls(svc)


### PR DESCRIPTION
## What does this PR do?

Moves the `fips_enabled` config option from the aws-s3 input to the AWS Common module to allow for any AWS related module to be able to use FIPS endpoints.  Also updated all FIPS capable services to use the above config to set the endpoint.  The only service that didn't support FIPS was `tagging`. Also adds TLS configuration to the AWS common module.

## Why is it important?

Currently with the aws-s3 input the S3 bucket operations are able to use the FIPS endpoints but there is a single SQS API call that doesn't utilize FIPS if the setting is configured.  Also the Cloudwatch input nor the AWS Metricbeat module are able to use FIPS currently. Reference https://discuss.elastic.co/t/sqs-client-ignores-the-fips-flag-for-the-service-endpoint/288687

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally


## Related issues


## Use cases


## Screenshots



## Logs


