### PR TITLE
Add config option to attach pprof endpoints to http socket

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -271,6 +271,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update kubernetes scheduler and controllermanager endpoints in elastic-agent-standalone-kubernetes.yaml with secure ports {pull}28675[28675]
 - Add options to configure k8s client qps/burst. {pull}28151[28151]
 - Update to ECS 8.0 fields. {pull}28620[28620]
+- Add http.pprof.enabled option to libbeat to allow http/pprof endpoints on the socket that libbeat creates for metrics. {issue}21965[21965]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1633,6 +1633,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -1632,6 +1632,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2544,6 +2544,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -2545,6 +2545,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1779,6 +1779,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -1778,6 +1778,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1576,6 +1576,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/journalbeat/journalbeat.reference.yml
+++ b/journalbeat/journalbeat.reference.yml
@@ -1575,6 +1575,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/libbeat/_meta/config/http.reference.yml.tmpl
+++ b/libbeat/_meta/config/http.reference.yml.tmpl
@@ -22,3 +22,6 @@
 # Descriptor Definition Language (SDDL) to define the permission. This option cannot be used with
 # `http.user`.
 #http.named_pipe.security_descriptor:
+
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false

--- a/libbeat/_meta/config/http.reference.yml.tmpl
+++ b/libbeat/_meta/config/http.reference.yml.tmpl
@@ -24,4 +24,5 @@
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false

--- a/libbeat/api/routes.go
+++ b/libbeat/api/routes.go
@@ -20,6 +20,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	_ "net/http/pprof"
 	"net/url"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -45,6 +46,14 @@ func NewWithDefaultRoutes(log *logp.Logger, config *common.Config, ns lookupFunc
 		mux.HandleFunc(api, h)
 	}
 	return New(log, mux, config)
+}
+
+func (s *Server) AttachPprof() {
+	s.log.Info("Attaching pprof endpoints")
+	s.mux.HandleFunc("/debug/pprof/", func(w http.ResponseWriter, r *http.Request) {
+		http.DefaultServeMux.ServeHTTP(w, r)
+	})
+
 }
 
 func makeRootAPIHandler(handler handlerFunc) handlerFunc {

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -105,6 +105,7 @@ type beatConfig struct {
 
 	// beat internal components configurations
 	HTTP            *common.Config         `config:"http"`
+	HTTPPprof       *common.Config         `config:"http.pprof"`
 	Path            paths.Path             `config:"path"`
 	Logging         *common.Config         `config:"logging"`
 	MetricLogging   *common.Config         `config:"logging.metrics"`
@@ -455,6 +456,9 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		}
 		s.Start()
 		defer s.Stop()
+		if b.Config.HTTPPprof.Enabled() {
+			s.AttachPprof()
+		}
 	}
 
 	if err = seccomp.LoadFilter(b.Config.Seccomp); err != nil {

--- a/libbeat/docs/http-endpoint.asciidoc
+++ b/libbeat/docs/http-endpoint.asciidoc
@@ -32,7 +32,7 @@ It is recommended to use only localhost. Default is `localhost`
 current user.
 `http.named_pipe.security_descriptor`:: (Optional) Windows Security descriptor string defined in the SDDL format. Default to
 read and write permission for the current user.
-`http.pprof.enabled`:: (Optional) Enable the `/debug/pprof/` endpoints when serving HTTP. Default is `false`.
+`http.pprof.enabled`:: (Optional) Enable the `/debug/pprof/` endpoints when serving HTTP. It is recommended that this is only enabled on localhost as these endpoints may leak data. Default is `false`.
 
 This is the list of paths you can access. For pretty JSON output append `?pretty` to the URL.
 

--- a/libbeat/docs/http-endpoint.asciidoc
+++ b/libbeat/docs/http-endpoint.asciidoc
@@ -32,6 +32,7 @@ It is recommended to use only localhost. Default is `localhost`
 current user.
 `http.named_pipe.security_descriptor`:: (Optional) Windows Security descriptor string defined in the SDDL format. Default to
 read and write permission for the current user.
+`http.pprof.enabled`:: (Optional) Enable the `/debug/pprof/` endpoints when serving HTTP. Default is `false`.
 
 This is the list of paths you can access. For pretty JSON output append `?pretty` to the URL.
 

--- a/libbeat/tests/system/test_http.py
+++ b/libbeat/tests/system/test_http.py
@@ -47,3 +47,10 @@ class Test(BaseTest):
         """
         r = requests.get("http://localhost:5066/not-exist")
         assert r.status_code == 404
+
+    def test_pprof_disabled(self):
+        """
+        Test /debug/pprof/ http endpoint
+        """
+        r = requests.get("http://localhost:5066/debug/pprof/")
+        assert r.status_code == 404

--- a/libbeat/tests/system/test_http_pprof.py
+++ b/libbeat/tests/system/test_http_pprof.py
@@ -37,4 +37,3 @@ class Test(BaseTest):
         """
         r = requests.get("http://localhost:5066/debug/pprof/not-exist")
         assert r.status_code == 404
-

--- a/libbeat/tests/system/test_http_pprof.py
+++ b/libbeat/tests/system/test_http_pprof.py
@@ -1,0 +1,40 @@
+from base import BaseTest
+
+import requests
+import json
+
+
+class Test(BaseTest):
+    def setUp(self):
+        super(BaseTest, self).setUp()
+        self.render_config_template()
+        self.proc = self.start_beat(extra_args=["-E", "http.enabled=true", "-E", "http.pprof.enabled=true"])
+        self.wait_until(lambda: self.log_contains("Starting stats endpoint"))
+
+    def tearDown(self):
+        super(BaseTest, self).tearDown()
+        # Wait till the beat is completely started so it can handle SIGTERM
+        self.wait_until(lambda: self.log_contains("mockbeat start running."))
+        self.proc.check_kill_and_wait()
+
+    def test_pprof(self):
+        """
+        Test /debug/pprof/ http endpoint
+        """
+        r = requests.get("http://localhost:5066/debug/pprof/")
+        assert r.status_code == 200
+
+    def test_pprof_cmdline(self):
+        """
+        Test /debug/pprof/cmdline http endpoint
+        """
+        r = requests.get("http://localhost:5066/debug/pprof/cmdline")
+        assert r.status_code == 200
+
+    def test_pprof_error(self):
+        """
+        Test not existing http endpoint
+        """
+        r = requests.get("http://localhost:5066/debug/pprof/not-exist")
+        assert r.status_code == 404
+

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2456,6 +2456,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -2455,6 +2455,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2128,6 +2128,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -2127,6 +2127,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1555,6 +1555,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -1556,6 +1556,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1688,6 +1688,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -1689,6 +1689,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -4697,6 +4697,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -4698,6 +4698,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1427,6 +1427,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -1426,6 +1426,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1779,6 +1779,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -1778,6 +1778,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2976,6 +2976,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2977,6 +2977,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -1145,6 +1145,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -1146,6 +1146,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2128,6 +2128,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -2127,6 +2127,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1598,6 +1598,9 @@ logging.files:
 # `http.user`.
 #http.named_pipe.security_descriptor:
 
+# Defines if the HTTP pprof endpoints are enabled.
+#http.pprof.enabled: false
+
 # ============================== Process Security ==============================
 
 # Enable or disable seccomp system call filtering on Linux. Default is enabled.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -1599,6 +1599,7 @@ logging.files:
 #http.named_pipe.security_descriptor:
 
 # Defines if the HTTP pprof endpoints are enabled.
+# It is recommended that this is only enabled on localhost as these endpoints may leak data.
 #http.pprof.enabled: false
 
 # ============================== Process Security ==============================


### PR DESCRIPTION
## What does this PR do?

Add a config option to attach `/debug/pprof/` endpoints to the stats handler enabled via `http.enabled`.

## Why is it important?

Currently pprof endpoints are only enabled when the `-httpprof` flag is used; these endpoints are bound to a **different socket** then the stats endpoint. We would like to serve these endpoints on the same socket in order to unify calls from external processes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Enable http and pprof when running a beat via `-E http.enabled=true -E http.pprof.enabled=true`.
Check the `/debug/pprof/` endpoint via curl

## Related issues

- Relates #21965