### PR TITLE
Added Github actions workflow to build on MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: build
+
+env:
+  GOPATH: /home/runner/work/gotest/gotest
+  GO111MODULE: off
+  REPO_PATH: src/gotest
+  MACOS_GOPATH: /Users/runner/work/gotest/gotest
+  GITHUB_TOKEN: ${{ github.token }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      id:
+        description: 'Run ID'
+        required: true
+      runner:
+        description: 'Github actions runner'
+        required: true
+        default: 'ubuntu-latest'
+      path:
+        description: 'Directory where to run command'
+        required: false
+        default: ''
+      pr:
+        description: 'Pull request id'
+        required: false
+        default: ''
+      go_version:
+        description: 'Go version'
+        required: false
+        default: '1.17'
+      command:
+        description: 'Command to run'
+        required: true
+        default: ''
+jobs:
+  build:
+    runs-on: ${{ github.event.inputs.runner }}
+    steps:
+    - name: ${{ format('Run ID {0}', github.event.inputs.id) }}
+      run: echo Run ID ${{github.event.inputs.id}}
+    - name: Set environment for macos
+      if: ${{ contains(github.event.inputs.runner, 'macos') }}
+      run: |
+        echo Changed GOPATH to ${{ env.MACOS_GOPATH }}
+        echo "GOPATH="${{ env.MACOS_GOPATH }} >> $GITHUB_ENV
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ github.event.inputs.go_version }}
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ env.GITHUB_REF }}
+        path: ${{ env.REPO_PATH }}
+    - name: Checkout and merge PR
+      if: ${{ github.event.inputs.pr }}
+      run: |
+        set -x
+        cd ${{ env.GOPATH }}/${{ env.REPO_PATH }}
+        git config --global user.email "user@example.com"
+        git config --global user.name "user"
+        git fetch origin pull/${{ github.event.inputs.pr }}/head:${{ github.event.inputs.id }}
+        git checkout ${{ github.event.inputs.id }}
+        git checkout $GITHUB_REF_NAME
+        git merge --no-ff ${{ github.event.inputs.id }}
+    - name: Run command
+      run: |
+        set -x
+        cd ${{ env.GOPATH }}/${{ env.REPO_PATH }}/${{ github.event.inputs.path }}
+        ${{ github.event.inputs.command }}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR adds  Github actions workflow to build on MacOS.

GitHub already provides MacOS support:
- https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
- https://github.blog/changelog/2021-08-16-github-actions-macos-11-big-sur-is-generally-available-on-github-hosted-runners/

## Why is it important?

Delegate the environmental issues to the SaaS.
Ensure the OS coverage happens on a PR basis to avoid merging any PRs that could cause any regression.
Avoid being blocked from the system owner.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

