### PR TITLE
[Filebeat] Sophos Module - support for changed field names

### DIFF
--- a/x-pack/filebeat/module/sophos/xg/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/sophos/xg/ingest/pipeline.yml
@@ -178,6 +178,10 @@ processors:
     target_field: observer.serial_number
     ignore_missing: true
 - rename:
+    field: sophos.xg.device_serial_id
+    target_field: observer.serial_number
+    ignore_missing: true
+- rename:
     field: sophos.xg.out_interface
     target_field: observer.egress.interface.name
     ignore_missing: true
@@ -190,7 +194,15 @@ processors:
     target_field: observer.ingress.zone
     ignore_missing: true
 - rename:
+    field: sophos.xg.src_zone_type
+    target_field: observer.ingress.zone
+    ignore_missing: true
+- rename:
     field: sophos.xg.dstzonetype
+    target_field: observer.egress.zone
+    ignore_missing: true
+- rename:
+    field: sophos.xg.dst_zone_type
     target_field: observer.egress.zone
     ignore_missing: true
 


### PR DESCRIPTION
In Version 18.0.1 and 18.5.1 fileld names changed to device_serial_id, src_zone_type and  dst_zone_type.

- Bug
- Enhancement

## What does this PR do?

Some field changed in these versions:
- device_id -> device_serial_id,
- srczonetype -> src_zone_type and
- dstzonetype -> dst_zone_type.

Added rename processors for alls three. All identical to the former ones.

Also srczone and dstzone changed. But I could only find a remove processor and I'm not sure if they are preserved anywhere else. In my opinion they should be and in my use case they need to be so I did not add them to the remove processor.