### PR TITLE
Fix failing tests on libbeat/common/fmtstr

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -67,6 +67,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove `event.dataset` (ECS) annotion from `libbeat.logp`. {issue}27404[27404]
 - Errors should be thrown as errors. Metricsets inside Metricbeat will now throw errors as the `error` log level. {pull}27804[27804]
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
+- Fix failing tests on `libbeat/common/fmtstr` {pull}28933[28933]
 
 ==== Added
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -67,7 +67,6 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove `event.dataset` (ECS) annotion from `libbeat.logp`. {issue}27404[27404]
 - Errors should be thrown as errors. Metricsets inside Metricbeat will now throw errors as the `error` log level. {pull}27804[27804]
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
-- Fix failing tests on `libbeat/common/fmtstr` {pull}28933[28933]
 
 ==== Added
 

--- a/libbeat/common/fmtstr/formatevents_test.go
+++ b/libbeat/common/fmtstr/formatevents_test.go
@@ -109,7 +109,7 @@ func TestEventFormatString(t *testing.T) {
 			"test timestamp formatter",
 			"%{[key]}: %{+YYYY.MM.dd}",
 			beat.Event{
-				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 				Fields: common.MapStr{
 					"key": "timestamp",
 				},
@@ -121,7 +121,7 @@ func TestEventFormatString(t *testing.T) {
 			"test timestamp formatter",
 			"%{[@timestamp]}: %{+YYYY.MM.dd}",
 			beat.Event{
-				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+				Timestamp: time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 				Fields: common.MapStr{
 					"key": "timestamp",
 				},

--- a/libbeat/common/fmtstr/formattimestamp_test.go
+++ b/libbeat/common/fmtstr/formattimestamp_test.go
@@ -73,14 +73,14 @@ func TestTimestampFormatString(t *testing.T) {
 			"test timestamp formatter",
 			"%{[key]}: %{+YYYY.MM.dd}",
 			common.MapStr{"key": "timestamp"},
-			time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+			time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 			"timestamp: 2015.05.01",
 		},
 		{
 			"test timestamp formatter",
 			"%{[@timestamp]}: %{+YYYY.MM.dd}",
 			common.MapStr{"key": "timestamp"},
-			time.Date(2015, 5, 1, 20, 12, 34, 0, time.Local),
+			time.Date(2015, 5, 1, 20, 12, 34, 0, time.UTC),
 			"2015-05-01T20:12:34.000Z: 2015.05.01",
 		},
 	}


### PR DESCRIPTION
Some timestamp formatting tests were failing because the input time
was set in the local timezone, which affects the final value when
formatting as string.

Now all imput values are set to UTC, so there will be no difference
between the set time and the final string formatting.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It fixes some flaky tests on `libbeat/common/fmtstr`

## Why is it important?

All unit tests pass regardless of the machine's timezone

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

Run the unit tests on `libbeat/common/fmtstr` on a machine whose timezone is offset from UTC, all tests should pass

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
