### PR TITLE
Re-enable tests in aws module

### DIFF
--- a/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
+++ b/x-pack/metricbeat/module/aws/billing/billing_integration_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/25130")
 	config := mtest.GetConfigForTest(t, "billing", "24h")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_integration_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/24200")
 	config := mtest.GetConfigForTest(t, "cloudwatch", "300s")
 
 	config = addCloudwatchMetricsToConfig(config)

--- a/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
+++ b/x-pack/metricbeat/module/aws/ec2/ec2_integration_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/24201")
 	config := mtest.GetConfigForTest(t, "ec2", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)

--- a/x-pack/metricbeat/module/aws/kinesis/kinesis_integration_test.go
+++ b/x-pack/metricbeat/module/aws/kinesis/kinesis_integration_test.go
@@ -10,25 +10,10 @@ package kinesis
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	_ "github.com/elastic/beats/v7/libbeat/processors/actions"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"
 )
-
-func TestFetch(t *testing.T) {
-	config := mtest.GetConfigForTest(t, "kinesis", "60s")
-
-	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
-	events, errs := mbtest.ReportingFetchV2Error(metricSet)
-	if len(errs) > 0 {
-		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
-	}
-
-	assert.NotEmpty(t, events)
-	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
-}
 
 func TestData(t *testing.T) {
 	config := mtest.GetConfigForTest(t, "kinesis", "60s")

--- a/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
+++ b/x-pack/metricbeat/module/aws/rds/rds_integration_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/24202")
 	config := mtest.GetConfigForTest(t, "rds", "60s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)

--- a/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
+++ b/x-pack/metricbeat/module/aws/sqs/sqs_integration_test.go
@@ -18,7 +18,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("flaky test: https://github.com/elastic/beats/issues/24205")
 	config := mtest.GetConfigForTest(t, "sqs", "300s")
 
 	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to re-enable the tests in AWS after https://github.com/elastic/beats/pull/28528 got merged.