### PR TITLE
[mergify] report open backported PRs once a week

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -101,6 +101,17 @@ pull_request_rules:
         - files~=^\.mergify\.yml$
     actions:
       delete_head_branch:
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - "#check-success>0"
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
   - name: notify the backport policy
     conditions:
       - -label~=^backport

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -108,6 +108,7 @@ pull_request_rules:
       - author=mergify[bot]
       - "#check-success>0"
       - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
+      - "#assignee>=1"
     actions:
       comment:
         message: |


### PR DESCRIPTION
## What does this PR do?

Notify to the `assignees` when an **automated** backport Pull Request has not been merged yet.

When?:
- Once a week (modays)
- PR was created by `mergify`
- It has at least one GitHub check. (We want to notify regardless of the GitHub check status)
- It has at least one assignee.

## Why is it important?

Avoid missing backports.

## UI

See https://github.com/elastic/apm-pipeline-library/pull/1380#issuecomment-968886593

![image](https://user-images.githubusercontent.com/2871786/141786749-501d5d7e-d06e-454c-be59-b424eadad495.png)
