### PR TITLE
Add beta label to browser monitors

### DIFF
--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -4,7 +4,7 @@
 TIP: Want to get started with synthetic monitoring?
 See the {observability-guide}/synthetics-quickstart.html[quick start guide].
 
-The options described here configure {beatname_uc} to run the synthetic
+beta[] The options described here configure {beatname_uc} to run the synthetic
 monitoring test suites via Synthetic Agent on the Chromium browser.
 Additional shared options are defined in <<monitor-options>>.
 Example configuration:


### PR DESCRIPTION
Browser monitors are in beta, but this page doesn't indicate that.