### PR TITLE
[mergify] notify the backport policy for open PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -105,6 +105,8 @@ pull_request_rules:
     conditions:
       - -label~=^backport
       - base=master
+      - -merged
+      - -closed
     actions:
       comment:
         message: |
@@ -120,6 +122,8 @@ pull_request_rules:
   - name: remove-backport label
     conditions:
       - label~=backport-v
+      - -merged
+      - -closed
     actions:
       label:
         remove:


### PR DESCRIPTION
## What does this PR do?

Filter those PRs that are still open

## Why is it important?

Sometimes mergify evaluates some rules and apply the notification. Let's avoid this

## Fixes

![image](https://user-images.githubusercontent.com/2871786/141984240-3184c18d-c025-47cf-af46-261909119e79.png)
