### PR TITLE
[Winlogbeat] Fix AccessList & AccessMask processing in security data_stream

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -241,6 +241,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Tolerate faults when Windows Event Log session is interrupted {issue}27947[27947] {pull}28191[28191]
 - Add ECS 1.9 new users fields {pull}26509[26509]
 - Don't split hyphenated tokens {pull}28483[28483]
+- Correctly handle AccessMask if it is an integer or list of masks. {pull}29016[29016]
 
 *Functionbeat*
 


### PR DESCRIPTION
## What does this PR do?

  - According to MS documentation examples AccessList contains a space
    separated list of access masks and AccessMask contains an integer.
  - Retain old behavior if AccessMask contains a space separated
    list of access masks
  - Add new code to parse AccessList as space separated list of
    access masks
  - Add new code to parse AccessMask if an integer

## Why is it important?

Sometimes AccessList and AccessMask were parsed incorrectly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

``` bash
cd x-pack\winlogbeat\module\security\test
go test -v
```

## Related issues

- Relates elastic/integrations#2156