### PR TITLE
Fix environmental var setup under agent

### DIFF
--- a/libbeat/cmd/instance/metrics/metrics.go
+++ b/libbeat/cmd/instance/metrics/metrics.go
@@ -32,7 +32,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/metric/system/numcpu"
 	"github.com/elastic/beats/v7/libbeat/metric/system/process"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
-	"github.com/elastic/beats/v7/libbeat/paths"
 )
 
 var (
@@ -288,7 +287,6 @@ func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
 	}
 
 	cgroups, err := cgroup.NewReaderOptions(cgroup.ReaderOptions{
-		RootfsMountpoint:         paths.Paths.Hostfs,
 		IgnoreRootCgroups:        true,
 		CgroupsHierarchyOverride: os.Getenv(libbeatMonitoringCgroupsHierarchyOverride),
 	})


### PR DESCRIPTION
## What does this PR do?

This fixes yet another issue with how `hostfs` is being set under agent. Agent needs its own logic for setting the environment variables used by upstream libraries for an alternate hostfs--the user needs to be able to change these values arbitrarily, and we need to deal with the fact that this is a case where per-metricset settings are trying to set a global variable, so we need logic to deal with the fact that not every metricset will want to set `hostfs`. I've tested this, and it works, and I'm not sure we can do much better without making breaking changes in various parts of metricbeat.

## Why is it important?

Without this, user-supplied `hostfs` settings will change some metricsets, and not others.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

This is a nightmare to test. Anything that requires agent and docker is just a pain. Here's some steps using `elastic-package`

- pull down the change and everything
- in the `elastic-agent` directory, run `PACKAGES=docker mage dev:package`
- fetch the image name from `docker images`. It should be something like `docker.elastic.co/beats/elastic-agent-complete:7.16.0`
- Substitute that value for the default `elastic-agent` image name in the `elastic-package` docker-compose file, which should be under `~/.elastic-package/profiles/[profile-name]/stack/snapshot.yml` 
- run `elastic-package stack up   --version 7.16.0-SNAPSHOT`
- Tinker around with the `hostfs` setting in fleet, make sure everything works.
