### PR TITLE
[Winlogbeat] Add configuration for registry file flush timeout

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -376,6 +376,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add more DNS error codes to the Sysmon module. {issue}15685[15685]
 - Add support for event language selection from config file {pull}19818[19818]
+- Add configuration option for registry file flush timeout {issue}29001[29001] {pull}XXXX[XXXX]
 
 *Elastic Log Driver*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -376,7 +376,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add more DNS error codes to the Sysmon module. {issue}15685[15685]
 - Add support for event language selection from config file {pull}19818[19818]
-- Add configuration option for registry file flush timeout {issue}29001[29001] {pull}XXXX[XXXX]
+- Add configuration option for registry file flush timeout {issue}29001[29001] {pull}29053[29053]
 
 *Elastic Log Driver*
 

--- a/winlogbeat/_meta/config/header.yml.tmpl
+++ b/winlogbeat/_meta/config/header.yml.tmpl
@@ -15,6 +15,12 @@
 # directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
+# The timeout value that controls when registry entries are written to disk
+# (flushed). When an unwritten update exceeds this value, it triggers a write
+# to disk. When flush is set to 0s, the registry is written to disk after each
+# batch of events has been published successfully. The default value is 5s.
+#winlogbeat.registry_flush: 5s
+
 {{end -}}
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -110,7 +110,7 @@ func (eb *Winlogbeat) setup(b *beat.Beat) error {
 	config := &eb.config
 
 	var err error
-	eb.checkpoint, err = checkpoint.NewCheckpoint(config.RegistryFile, 10, config.RegistryFlush)
+	eb.checkpoint, err = checkpoint.NewCheckpoint(config.RegistryFile, config.RegistryFlush)
 	if err != nil {
 		return err
 	}

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -110,7 +110,7 @@ func (eb *Winlogbeat) setup(b *beat.Beat) error {
 	config := &eb.config
 
 	var err error
-	eb.checkpoint, err = checkpoint.NewCheckpoint(config.RegistryFile, 10, 5*time.Second)
+	eb.checkpoint, err = checkpoint.NewCheckpoint(config.RegistryFile, 10, config.RegistryFlush)
 	if err != nil {
 		return err
 	}

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -42,7 +42,6 @@ type Checkpoint struct {
 	file          string         // File where the state is persisted.
 	fileLock      sync.RWMutex   // Lock that protects concurrent reads/writes to file.
 	numUpdates    int            // Number of updates received since last persisting to disk.
-	maxUpdates    int            // Maximum number of updates to buffer before persisting to disk.
 	flushInterval time.Duration  // Maximum time interval that can pass before persisting to disk.
 	sort          []string       // Slice used for sorting states map (store to save on mallocs).
 
@@ -72,24 +71,16 @@ type EventLogState struct {
 // guarantee any in-memory state information is flushed to disk.
 //
 // file is the name of the file where event log state is persisted as YAML.
-// maxUpdates is the maximum number of updates checkpoint will accept before
-// triggering a flush to disk. interval is maximum amount of time that can
-// pass since the last flush before triggering a flush to disk (minimum value
-// is 1s).
-func NewCheckpoint(file string, maxUpdates int, interval time.Duration) (*Checkpoint, error) {
+// interval is maximum amount of time that can pass since the last flush
+// before triggering a flush to disk (minimum value is 1s).
+func NewCheckpoint(file string, interval time.Duration) (*Checkpoint, error) {
 	c := &Checkpoint{
 		done:          make(chan struct{}),
 		file:          file,
-		maxUpdates:    maxUpdates,
 		flushInterval: interval,
 		sort:          make([]string, 0, 10),
 		states:        make(map[string]EventLogState),
 		save:          make(chan EventLogState, 1),
-	}
-
-	// Minimum batch size.
-	if c.maxUpdates < 1 {
-		c.maxUpdates = 1
 	}
 
 	// Minimum flush interval.
@@ -139,9 +130,6 @@ loop:
 			c.states[s.Name] = s
 			c.lock.Unlock()
 			c.numUpdates++
-			if c.numUpdates < c.maxUpdates {
-				continue
-			}
 		case <-flushTimer.C:
 		}
 

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -35,6 +35,7 @@ const (
 var (
 	DefaultSettings = WinlogbeatConfig{
 		RegistryFile: DefaultRegistryFile,
+		RegistryFlush: 5*time.Second,
 	}
 )
 
@@ -42,6 +43,7 @@ var (
 type WinlogbeatConfig struct {
 	EventLogs       []*common.Config `config:"event_logs"`
 	RegistryFile    string           `config:"registry_file"`
+	RegistryFlush   time.Duration    `config:"registry_flush"`
 	ShutdownTimeout time.Duration    `config:"shutdown_timeout"`
 }
 

--- a/winlogbeat/config/config.go
+++ b/winlogbeat/config/config.go
@@ -34,8 +34,8 @@ const (
 
 var (
 	DefaultSettings = WinlogbeatConfig{
-		RegistryFile: DefaultRegistryFile,
-		RegistryFlush: 5*time.Second,
+		RegistryFile:  DefaultRegistryFile,
+		RegistryFlush: 5 * time.Second,
 	}
 )
 

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -47,6 +47,23 @@ backslashes. Forward slashes are easier to work with in YAML because there is no
 need to escape them.
 
 [float]
+==== `registry_flush`
+
+The timeout value that controls when registry entries are written to disk
+(flushed). When an unwritten update exceeds this value, it triggers a write
+to disk. When flush is set to 0s, the registry is written to disk after each
+batch of events has been published successfully.
+
+The default value is 5s.
+
+Valid time units are `ns`, `us`, `ms`, `s`, `m`, `h`.
+
+[source,yaml]
+--------------------------------------------------------------------------------
+winlogbeat.registry_flush: 5s
+--------------------------------------------------------------------------------
+
+[float]
 ==== `shutdown_timeout`
 
 The amount of time to wait for all events to be published when shutting down.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -14,6 +14,12 @@
 # directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
+# The timeout value that controls when registry entries are written to disk
+# (flushed). When an unwritten update exceeds this value, it triggers a write
+# to disk. When flush is set to 0s, the registry is written to disk after each
+# batch of events has been published successfully. The default value is 5s.
+#winlogbeat.registry_flush: 5s
+
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -14,12 +14,6 @@
 # directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
-# The timeout value that controls when registry entries are written to disk
-# (flushed). When an unwritten update exceeds this value, it triggers a write
-# to disk. When flush is set to 0s, the registry is written to disk after each
-# batch of events has been published successfully. The default value is 5s.
-#winlogbeat.registry_flush: 5s
-
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
@@ -1033,7 +1027,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-
+  
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 # ------------------------------- Console Output -------------------------------

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -14,6 +14,12 @@
 # directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
+# The timeout value that controls when registry entries are written to disk
+# (flushed). When an unwritten update exceeds this value, it triggers a write
+# to disk. When flush is set to 0s, the registry is written to disk after each
+# batch of events has been published successfully. The default value is 5s.
+#winlogbeat.registry_flush: 5s
+
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
@@ -1027,7 +1033,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-  
+
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 # ------------------------------- Console Output -------------------------------

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -14,6 +14,12 @@
 # directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
+# The timeout value that controls when registry entries are written to disk
+# (flushed). When an unwritten update exceeds this value, it triggers a write
+# to disk. When flush is set to 0s, the registry is written to disk after each
+# batch of events has been published successfully. The default value is 5s.
+#winlogbeat.registry_flush: 5s
+
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -14,6 +14,12 @@
 # directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
+# The timeout value that controls when registry entries are written to disk
+# (flushed). When an unwritten update exceeds this value, it triggers a write
+# to disk. When flush is set to 0s, the registry is written to disk after each
+# batch of events has been published successfully. The default value is 5s.
+#winlogbeat.registry_flush: 5s
+
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
@@ -1070,7 +1076,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-  
+
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 # ------------------------------- Console Output -------------------------------

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -14,12 +14,6 @@
 # directory in which it was started.
 #winlogbeat.registry_file: .winlogbeat.yml
 
-# The timeout value that controls when registry entries are written to disk
-# (flushed). When an unwritten update exceeds this value, it triggers a write
-# to disk. When flush is set to 0s, the registry is written to disk after each
-# batch of events has been published successfully. The default value is 5s.
-#winlogbeat.registry_flush: 5s
-
 # event_logs specifies a list of event logs to monitor as well as any
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
@@ -1076,7 +1070,7 @@ output.elasticsearch:
 
   # Permissions to use for file creation. The default is 0600.
   #permissions: 0600
-
+  
   # Configure automatic file rotation on every startup. The default is true.
   #rotate_on_startup: true
 # ------------------------------- Console Output -------------------------------


### PR DESCRIPTION
## What does this PR do?

- Added a new option ("winlogbeat.registry_flush") for configuring the
timeout for writting registry entries to disk. The previously hard-coded
value of 5 seconds is now the default value.

## Why is it important?

The value is currently hard-coded and environments that have lots of event activity will cause unnecessary CPU usage due to excessive flushing/writing. By tuning this value, the flush interval can be adjusted to reduce CPU churn.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Add the option to the configuration file (`winlogbeat.yml`):
```
winlogbeat.registry_flush: 30s
```
Default is `5s`. Value should be a duration value (i.e., `5s`, `1m`)

## Related issues

- Closes #29001 
