### PR TITLE
feat: allow for tcp instead of udp for panos

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -289,6 +289,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Filebeat*
 
+- Support TCP for panos/panw filebeat plugin {issue}13533[13533]
 - `container` and `docker` inputs now support reading of labels and env vars written by docker JSON file logging driver. {issue}8358[8358]
 - Add `index` option to all inputs to directly set a per-input index value. {pull}14010[14010]
 - move create-[module,fileset,fields] to mage and enable in x-pack/filebeat {pull}15836[15836]

--- a/x-pack/filebeat/module/panw/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/panw/_meta/docs.asciidoc
@@ -65,6 +65,22 @@ The UDP port to listen for syslog traffic. Defaults to `9001`
 
 NOTE: Ports below 1024 require {beatname_uc} to run as root.
 
+*`var.syslog_protocol`*::
+
+The protocol to receive syslog traffic on. Acceptable values: udp|tcp Defaults to `udp`
+
+*`var.syslog_tcp_ssl.enabled`*::
+
+Enable SSL/TLS for TCP traffic. Defaults to `false`
+
+*`var.syslog_tcp_ssl.certificate`*::
+
+Path to certificate for ssl/tls for TCP traffic
+
+*`var.syslog_tcp_ssl.key`*::
+
+Path to key for ssl/tls for TCP traffic
+
 include::../include/timezone-support.asciidoc[]
 
 [float]

--- a/x-pack/filebeat/module/panw/panos/config/input.yml
+++ b/x-pack/filebeat/module/panw/panos/config/input.yml
@@ -1,8 +1,18 @@
 {{ if eq .input "syslog" }}
 
 type: syslog
+
+{{ if eq .syslog_protocol "tcp"}}
+protocol.tcp:
+  host: "{{.syslog_host}}:{{.syslog_port}}"
+  {{ if .syslog_tcp_ssl.enabled }}
+  ssl.certificate: "{{.syslog_tcp_ssl.certificate}}"
+  ssl.key: "{{.syslog_tcp_ssl.key}}"
+  {{ end }}
+{{ else }}
 protocol.udp:
   host: "{{.syslog_host}}:{{.syslog_port}}"
+{{ end }}
 
 {{ else if eq .input "file" }}
 


### PR DESCRIPTION
Signed-off-by: Hans Knecht <Hans.Knecht@missionlane.com>

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:

-->
- Enhancement
- 
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

In order to support cortex datalake from palo alto (which has the same format) as panos TCP is required instead of UDP.
See #13533 for more information
Closes #13533

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Supporting all of palo alto log sources is vital, especially as cortex datalake is part of their cloud offering

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Create a filebeat.yml with the following:

```
filebeat.modules:
- module: panw
  panos:
    enabled: true
    var.syslog_host: 0.0.0.0
    var.syslog_port: 6514
    var.syslog_protocol: tcp
    var.syslog_tcp_ssl:
      enabled: true
      certificate: /cool/path.cert
      key: /cool/path.key
```

and desired output. Tested that tcp is a drop in replacement

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
