### PR TITLE
Default to legacy format if JSON template is loaded

### DIFF
--- a/libbeat/docs/template-config.asciidoc
+++ b/libbeat/docs/template-config.asciidoc
@@ -28,7 +28,8 @@ you must <<load-template-manually,load the template manually>>.
 
 ifndef::apm-server[]
 *`setup.template.type`*:: Deprecated in 7.16. The type of template to use. The default value is `index`,
-that loads {ref}/index-templates.html[index templates].
+that loads {ref}/index-templates.html[index templates]. If JSON templates are used, it defaults to `legacy`.
+
 Further options: `legacy`, {ref}/indices-templates-v1.html[legacy index templates] before Elasticsearch v7.8.
 Use this to avoid breaking existing deployments.
 And `component`, selecting it loads a component template which can be included in index templates.
@@ -132,6 +133,11 @@ setup.template.append_fields:
 *`setup.template.json.enabled`*:: Set to `true` to load a
 JSON-based template file. Specify the path to your {es} index template file and
 set the name of the template.
+
+When loading JSON templates, `setup.template.type` defaults to legacy, so you
+do not have to migrate your existing JSON template. However, in 8.0 the support
+for the format is dropped.
+
 +
 ["source","yaml",subs="attributes"]
 ----------------------------------------------------------------------

--- a/libbeat/idxmgmt/std.go
+++ b/libbeat/idxmgmt/std.go
@@ -371,11 +371,7 @@ func getEventCustomIndex(evt *beat.Event, beatInfo beat.Info) string {
 }
 
 func unpackTemplateConfig(cfg *common.Config) (config template.TemplateConfig, err error) {
-	config = template.DefaultConfig()
-	if cfg != nil {
-		err = cfg.Unpack(&config)
-	}
-	return config, err
+	return template.Unpack(cfg)
 }
 
 func applyILMSettings(

--- a/libbeat/template/config.go
+++ b/libbeat/template/config.go
@@ -20,6 +20,7 @@ package template
 import (
 	"fmt"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/mapping"
 )
@@ -74,6 +75,21 @@ func DefaultConfig() TemplateConfig {
 		Order:    1,
 		Priority: 150,
 	}
+}
+
+func Unpack(c *common.Config) (TemplateConfig, error) {
+	jsonEnabled, _ := c.Bool("json.enabled", -1)
+	config := DefaultConfig()
+	if jsonEnabled {
+		cfgwarn.Deprecate("8.0.0", "Please migrate your JSON templates from legacy template format to composable index template.")
+		config.Type = IndexTemplateLegacy
+	}
+	var err error
+	if c != nil {
+		err = c.Unpack(&config)
+	}
+	return config, err
+
 }
 
 func (t *IndexTemplateType) Unpack(v string) error {

--- a/libbeat/template/config.go
+++ b/libbeat/template/config.go
@@ -78,6 +78,10 @@ func DefaultConfig() TemplateConfig {
 }
 
 func Unpack(c *common.Config) (TemplateConfig, error) {
+	if c == nil {
+		return DefaultConfig(), nil
+	}
+
 	jsonEnabled, _ := c.Bool("json.enabled", -1)
 	config := DefaultConfig()
 	if jsonEnabled {

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -77,6 +77,7 @@ setup.template:
   name: {{ es_template_name }}
   pattern: {{ es_template_pattern }}
   overwrite: {{ template_overwrite|default("false") }}
+  type: {{ template_type|default("index") }}
   json:
     enabled: {{ template_json_enabled|default("false") }}
     path: {{ template_json_path }}

--- a/libbeat/tests/system/test_template.py
+++ b/libbeat/tests/system/test_template.py
@@ -94,7 +94,6 @@ class Test(BaseTest):
         es = self.es_client()
         self.copy_files(["template.json"])
         path = os.path.join(self.working_dir, "template.json")
-        print(path)
 
         self.render_config_template(
             elasticsearch={"hosts": self.get_host()},
@@ -102,6 +101,7 @@ class Test(BaseTest):
             template_json_enabled="true",
             template_json_path=path,
             template_json_name=template_name,
+            template_type="index",
         )
 
         proc = self.start_beat()


### PR DESCRIPTION
## What does this PR do?

If JSON template is configured for loading, Filebeat should still default to legacy index template formats to avoid breaking existing template configurations. It also adds a warning to let users know that they have to migrate from legacy format.

## Why is it important?

Minimizes the breaking changes of moving from legacy templates to composable templates.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
