### PR TITLE
Remove TestFetch from kinesis metricset

### DIFF
--- a/x-pack/metricbeat/module/aws/kinesis/kinesis_integration_test.go
+++ b/x-pack/metricbeat/module/aws/kinesis/kinesis_integration_test.go
@@ -10,25 +10,10 @@ package kinesis
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	_ "github.com/elastic/beats/v7/libbeat/processors/actions"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/aws/mtest"
 )
-
-func TestFetch(t *testing.T) {
-	config := mtest.GetConfigForTest(t, "kinesis", "60s")
-
-	metricSet := mbtest.NewReportingMetricSetV2Error(t, config)
-	events, errs := mbtest.ReportingFetchV2Error(metricSet)
-	if len(errs) > 0 {
-		t.Fatalf("Expected 0 error, had %d. %v\n", len(errs), errs)
-	}
-
-	assert.NotEmpty(t, events)
-	mbtest.TestMetricsetFieldsDocumented(t, metricSet, events)
-}
 
 func TestData(t *testing.T) {
 	config := mtest.GetConfigForTest(t, "kinesis", "60s")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to remove TestFetch from `kinesis` metricset because this metricset is directly using `cloudwatch` as an input and is already been tested in `cloudwatch` metricset.