### PR TITLE
heartbeat: remove w2008 in the CI

### DIFF
--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -79,11 +79,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

remove w2008 in the CI for heartbeat

## Why is it important?

- Win2k8 was already old when heartbeat was created
- It's quite unusual to put heartbeat on a 'legacy' machine
- We've never heard of anyone using heartbeat+win2k8
- The win2k8 tests are flaky
