### PR TITLE
override host on statsd metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -371,6 +371,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Preliminary AIX support {pull}27954[27954]
 - Register additional name for `storage` metricset in the azure module. {pull}28447[28447]
 - Update reference to gosigar pacakge for filesystem windows fix. {pull}28909[28909]
+- Override `Host()` on statsd MetricSet {pull}29103[29103]
 
 *Packetbeat*
 

--- a/metricbeat/helper/server/udp/udp.go
+++ b/metricbeat/helper/server/udp/udp.go
@@ -71,6 +71,10 @@ func NewUdpServer(base mb.BaseMetricSet) (server.Server, error) {
 	}, nil
 }
 
+func (g *UdpServer) GetHost() string {
+	return g.udpaddr.String()
+}
+
 func (g *UdpServer) Start() error {
 	listener, err := net.ListenUDP("udp", g.udpaddr)
 	if err != nil {

--- a/x-pack/metricbeat/module/statsd/server/server.go
+++ b/x-pack/metricbeat/module/statsd/server/server.go
@@ -104,6 +104,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}, nil
 }
 
+// Host returns the hostname or other module specific value that identifies a
+// specific host or service instance from which to collect metrics.
+func (b *MetricSet) Host() string {
+	return b.server.(*udp.UdpServer).GetHost()
+}
+
 func buildMappings(config []StatsdMapping) (map[string]StatsdMapping, error) {
 	mappings := make(map[string]StatsdMapping, len(config))
 	replacer := strings.NewReplacer(".", `\.`, "<", "(?P<", ">", ">[^.]+)")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

Enhancement
## What does this PR do?
It adds `Host()` implementation for statsd metricset
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
`Host()` returns the hostname or other module specific value that identifies a specific host or service instance from which to collect metrics.
In the `BaseMetricSet` implementation it uses the `hosts` field from config of the metricset.
`statsd` rather use `host` and `port`,  so a different implementation is needed to report relevant information
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs
```
{"log.level":"debug","@timestamp":"2021-11-23T18:44:13.426+0100","log.logger":"module","log.origin":{"file.name":"module/wrapper.go","file.line":189},"message":"Starting metricSetWrapper[module=statsd, name=server, host=127.0.0.1:8125]","service.name":"metricbeat","ecs.version":"1.6.0"}
```
```
{"log.level":"debug","@timestamp":"2021-11-23T18:45:37.777+0100","log.logger":"module","log.origin":{"file.name":"module/wrapper.go","file.line":189},"message":"Starting metricSetWrapper[module=airflow, name=statsd, host=127.0.0.1:8126]","service.name":"metricbeat","ecs.version":"1.6.0"}
```
<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
