### PR TITLE
Fix rds metadata in cloudwatch metricset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -236,6 +236,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix list_docker.go {pull}28374[28374]
 - Use xpack.enabled on SM modules to write into .monitoring indices when using Metricbeat standalone {pull}28365[28365]
 - Fix in rename processor to ingest metrics for `write.iops` to proper field instead of `write_iops` in rds metricset. {pull}28960[28960]
+- Fix rds metadata in cloudwatch metricset. {pull}29106[29106]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
@@ -42,7 +42,6 @@ func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, ev
 	}
 
 	for identifier, output := range dbDetailsMap {
-		fmt.Println("----- identifier = ", identifier)
 		if _, ok := events[identifier]; !ok {
 			continue
 		}
@@ -55,7 +54,6 @@ func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, ev
 			events[identifier].RootFields.Put(metadataPrefix+"status", *output.DBInstanceStatus)
 		}
 
-		fmt.Println("----- output.DBInstanceIdentifier = ", *output.DBInstanceIdentifier)
 		if output.DBInstanceIdentifier != nil {
 			events[identifier].RootFields.Put(metadataPrefix+"identifier", *output.DBInstanceIdentifier)
 		}

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
@@ -42,6 +42,7 @@ func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, ev
 	}
 
 	for identifier, output := range dbDetailsMap {
+		fmt.Println("----- identifier = ", identifier)
 		if _, ok := events[identifier]; !ok {
 			continue
 		}
@@ -54,6 +55,7 @@ func AddMetadata(endpoint string, regionName string, awsConfig awssdk.Config, ev
 			events[identifier].RootFields.Put(metadataPrefix+"status", *output.DBInstanceStatus)
 		}
 
+		fmt.Println("----- output.DBInstanceIdentifier = ", *output.DBInstanceIdentifier)
 		if output.DBInstanceIdentifier != nil {
 			events[identifier].RootFields.Put(metadataPrefix+"identifier", *output.DBInstanceIdentifier)
 		}
@@ -87,7 +89,8 @@ func getDBInstancesPerRegion(svc rdsiface.ClientAPI) (map[string]*rds.DBInstance
 
 	instancesOutputs := map[string]*rds.DBInstance{}
 	for _, dbInstance := range output.DBInstances {
-		instancesOutputs[*dbInstance.DBInstanceIdentifier] = &dbInstance
+		instance := dbInstance
+		instancesOutputs[*instance.DBInstanceIdentifier] = &instance
 	}
 	return instancesOutputs, nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to fix rds identifier overwriting each other in cloudwatch metricset. 

After fixing the bug:
<img width="1375" alt="Screen Shot 2021-11-23 at 10 10 58 AM" src="https://user-images.githubusercontent.com/14081635/143071824-7e94d246-9c79-4c54-bde9-fed0f9087183.png">

Before fixing the bug:
<img width="1446" alt="Screen Shot 2021-11-23 at 10 11 04 AM" src="https://user-images.githubusercontent.com/14081635/143071794-afb98457-7d75-4037-b514-bcd64d4da5ac.png">

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
