### PR TITLE
Fix `decode_json_fields` processor to always add error key

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -145,6 +145,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix `fingerprint` processor to give it access to the `@timestamp` field. {issue}28683[28683]
 - Fix the wrong beat name on monitoring and state endpoint {issue}27755[27755]
 - Skip configuration checks in autodiscover for configurations that are already running {pull}29048[29048]
+- Fix `decode_json_processor` to always respect `add_error_key` {pull}29107[29107]
 
 *Auditbeat*
 

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -124,7 +124,8 @@ func (f *decodeJSONFields) Run(event *beat.Event) (*beat.Event, error) {
 			errs = append(errs, err.Error())
 			event.SetErrorWithOption(common.MapStr{
 				"message": "parsing input as JSON: " + err.Error(),
-				"input":   text,
+				"data":    text,
+				"field":   field,
 			}, f.addErrorKey)
 			continue
 		}

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -122,6 +122,10 @@ func (f *decodeJSONFields) Run(event *beat.Event) (*beat.Event, error) {
 		if err != nil {
 			f.logger.Debugf("Error trying to unmarshal %s", text)
 			errs = append(errs, err.Error())
+			event.SetErrorWithOption(common.MapStr{
+				"message": "parsing input as JSON: " + err.Error(),
+				"input":   text,
+			}, f.addErrorKey)
 			continue
 		}
 

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -491,6 +491,27 @@ func TestOverwriteMetadata(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestAddErrorToEventOnUnmarshalError(t *testing.T) {
+	testConfig := common.MustNewConfigFrom(map[string]interface{}{
+		"fields":        "message",
+		"add_error_key": true,
+	})
+
+	input := common.MapStr{
+		"message": "Broken JSON [[",
+	}
+
+	actual := getActualValue(t, testConfig, input)
+
+	errObj, ok := actual["error"].(common.MapStr)
+	require.True(t, ok, "'error' field not present or of invalid type")
+	require.NotNil(t, actual["error"])
+
+	assert.Equal(t, "message", errObj["field"])
+	assert.NotNil(t, errObj["data"])
+	assert.NotNil(t, errObj["message"])
+}
+
 func getActualValue(t *testing.T, config *common.Config, input common.MapStr) common.MapStr {
 	log := logp.NewLogger("decode_json_fields_test")
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When the `decode_json_fields` processor encountered an error while
decoding the JSON it was not always respecting the `add_error_key`
configuration.

This commit fixes it.

## Why is it important?

Errors from `decode_json_fields` processor are now clearly reported

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Add the following to you filebeat configuration:
```yaml
processors:
  - decode_json_fields:
      fields: ["my_json_key"]
      process_array: false
      max_depth: 1
      target: "json_object"
      add_error_key: true
```

Make sure the `my_json_key` field of the event is an invalid JSON.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
