### PR TITLE
[mergify]: notify conflicts in PRs that are still open

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,6 +14,8 @@ pull_request_rules:
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: ask to resolve conflict
     conditions:
+      - -merged
+      - -closed
       - conflict
     actions:
         comment:


### PR DESCRIPTION
## What does this PR do?

Notify only if the PR is still open

## Why is it important?

Avoid notifications when PRs are closed or merged. Sometimes the reevaluation of the mergify rules can happen, no idea how, and then notifications are sent.