### PR TITLE
Remove beta warning for SASL/SCRAM on Kafka GA

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -289,6 +289,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update to ECS 8.0 fields. {pull}28620[28620]
 - Add http.pprof.enabled option to libbeat to allow http/pprof endpoints on the socket that libbeat creates for metrics. {issue}21965[21965]
 - Support custom analyzers in fields.yml. {issue}28540[28540] {pull}28926[28926]
+- SASL/SCRAM in the Kafka output is no longer beta. {pull}29126[29126]
 
 *Auditbeat*
 

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -79,8 +79,6 @@ The password for connecting to Kafka.
 
 ===== `sasl.mechanism`
 
-beta[]
-
 The SASL mechanism to use when connecting to Kafka. It can be one of:
 
 * `PLAIN` for SASL/PLAIN.


### PR DESCRIPTION
## What does this PR do?

Remove the beta warning in the documentation for SASL/SCRAM on Kafka now that it's included in the end-to-end tests.
## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
