### PR TITLE
Indicate in banner that Journalbeat has been removed in 7.16

### DIFF
--- a/journalbeat/docs/page_header.html
+++ b/journalbeat/docs/page_header.html
@@ -1,4 +1,2 @@
-This functionality is experimental and may be changed or removed completely in a
-future release. Elastic will take a best effort approach to fix any issues, but
-experimental features are not subject to the support SLA of official GA
-features.
+Starting in version 7.16, this experimental functionality has been removed. You
+should use the journald input in Filebeat instead.


### PR DESCRIPTION
Updating banner for 7.15 because it is the last version of Journalbeat that will be published.