### PR TITLE
[Fortinet] update fortinet module docs

### DIFF
--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -280,8 +280,8 @@ This is a list of FortiOS fields that are mapped to ECS.
 | qclass                     | dns.question.class             |
 | qname                      | dns.question.name              |
 | qtype                      | dns.question.type              |
-| rcvdbyte                   | source.bytes                   |
-| rcvdpkt                    | source.packets                 |
+| rcvdbyte                   | destination.bytes              |
+| rcvdpkt                    | destination.packets            |
 | recipient                  | destination.user.email         |
 | ref                        | event.reference                |
 | remip                      | destination.ip                 |

--- a/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
@@ -275,8 +275,8 @@ This is a list of FortiOS fields that are mapped to ECS.
 | qclass                     | dns.question.class             |
 | qname                      | dns.question.name              |
 | qtype                      | dns.question.type              |
-| rcvdbyte                   | source.bytes                   |
-| rcvdpkt                    | source.packets                 |
+| rcvdbyte                   | destination.bytes              |
+| rcvdpkt                    | destination.packets            |
 | recipient                  | destination.user.email         |
 | ref                        | event.reference                |
 | remip                      | destination.ip                 |


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the documentation for Fortinet ECS mappings

## Why is it important?

Fixes a typo in the documentation for Fortinet ECS mappings

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


