### PR TITLE
Change elastic-agent pprof default to false

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -149,4 +149,4 @@
 - Add diagnostics command to gather beat metadata. {pull}28265[28265]
 - Add diagnostics collect command to gather beat metadata, config, policy, and logs and bundle it into an archive. {pull}28461[28461]
 - Add `KIBANA_FLEET_SERVICE_TOKEN` to Elastic Agent container. {pull}28096[28096]
-- Enable pprof endpoints for beats processes. Allow pprof endpoints for elastic-agent if enabled. {pull}28983[28983]
+- Allow pprof endpoints for elastic-agent or beats if enabled. {pull}28983[28983] {pull}29155[29155]

--- a/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.p2.yml.tmpl
@@ -35,7 +35,7 @@ inputs:
 #   metrics: true
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
-#   pprof: true
+#   pprof: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/common.reference.p2.yml.tmpl
@@ -109,7 +109,7 @@ inputs:
 #   metrics: false
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
-#   pprof: true
+#   pprof: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
+++ b/x-pack/elastic-agent/_meta/config/elastic-agent.docker.yml.tmpl
@@ -109,7 +109,7 @@ inputs:
 #   metrics: false
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
-#   pprof: true
+#   pprof: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/x-pack/elastic-agent/elastic-agent.docker.yml
+++ b/x-pack/elastic-agent/elastic-agent.docker.yml
@@ -109,7 +109,7 @@ inputs:
 #   metrics: false
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
-#   pprof: true
+#   pprof: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/x-pack/elastic-agent/elastic-agent.reference.yml
+++ b/x-pack/elastic-agent/elastic-agent.reference.yml
@@ -115,7 +115,7 @@ inputs:
 #   metrics: false
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
-#   pprof: true
+#   pprof: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/x-pack/elastic-agent/elastic-agent.yml
+++ b/x-pack/elastic-agent/elastic-agent.yml
@@ -41,7 +41,7 @@ inputs:
 #   metrics: true
 #   # exposes /debug/pprof/ endpoints
 #   # recommended that these endpoints are only enabled if the monitoring endpoint is set to localhost
-#   pprof: true
+#   pprof: false
 #   # exposes agent metrics using http, by default sockets and named pipes are used
 #   http:
 #       # enables http endpoint

--- a/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/beats/beats_monitor.go
@@ -122,8 +122,12 @@ func (b *Monitor) EnrichArgs(spec program.Spec, pipelineID string, args []string
 		appendix = append(appendix,
 			"-E", "http.enabled=true",
 			"-E", "http.host="+endpoint,
-			"-E", "http.pprof.enabled=true",
 		)
+		if b.config.Pprof {
+			appendix = append(appendix,
+				"-E", "http.pprof.enabled=true",
+			)
+		}
 	}
 
 	loggingPath := b.generateLoggingPath(spec, pipelineID)

--- a/x-pack/elastic-agent/pkg/core/monitoring/config/config.go
+++ b/x-pack/elastic-agent/pkg/core/monitoring/config/config.go
@@ -39,6 +39,6 @@ func DefaultConfig() *MonitoringConfig {
 			Port:    defaultPort,
 		},
 		Namespace: defaultNamespace,
-		Pprof:     true,
+		Pprof:     false,
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Change agent.monitoring.pprof to false, allow it to toggle beat
behaviour as well as the agent's.

## Checklist

- [x] My code follows the style guidelines of this project
- [] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation [PR here](https://github.com/elastic/observability-docs/pull/1289)
- [x] I have made corresponding change to the default configuration files
- [] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #29108 
- Relates #21965 