### PR TITLE
Auditbeat: Fix processes misattribution in system/socket dataset

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -149,6 +149,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system module: Fix panic during initialisation when /proc/stat can't be read. {pull}17569[17569]
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - Fix handling of root and relative paths {issue}24430[24430] {pull}28354[28354]
+- system/socket: Fix bugs leading to wrong process being attributed to flows. {pull}29166[29166] {issue}17165[17165]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/socket/events.go
+++ b/x-pack/auditbeat/module/system/socket/events.go
@@ -189,6 +189,7 @@ type tcpAcceptResult struct {
 }
 
 func (e *tcpAcceptResult) asFlow() flow {
+	evTime := kernelTime(e.Meta.Timestamp)
 	f := flow{
 		sock:     e.Sock,
 		pid:      e.Meta.PID,
@@ -196,7 +197,8 @@ func (e *tcpAcceptResult) asFlow() flow {
 		proto:    protoTCP,
 		dir:      directionIngress,
 		complete: true,
-		lastSeen: kernelTime(e.Meta.Timestamp),
+		lastSeen: evTime,
+		created:  evTime,
 	}
 	if e.Af == unix.AF_INET {
 		f.local = newEndpointIPv4(e.LAddr, e.LPort, 0, 0)
@@ -217,7 +219,7 @@ func (e *tcpAcceptResult) String() string {
 // Update the state with the contents of this event.
 func (e *tcpAcceptResult) Update(s *state) error {
 	if e.Sock != 0 {
-		return s.UpdateFlow(e.asFlow())
+		return s.CreateSocket(e.asFlow())
 	}
 	return nil
 }
@@ -233,6 +235,7 @@ type tcpAcceptResult4 struct {
 }
 
 func (e *tcpAcceptResult4) asFlow() flow {
+	evTime := kernelTime(e.Meta.Timestamp)
 	f := flow{
 		sock:     e.Sock,
 		pid:      e.Meta.PID,
@@ -240,7 +243,8 @@ func (e *tcpAcceptResult4) asFlow() flow {
 		proto:    protoTCP,
 		dir:      directionIngress,
 		complete: true,
-		lastSeen: kernelTime(e.Meta.Timestamp),
+		lastSeen: evTime,
+		created:  evTime,
 	}
 	f.local = newEndpointIPv4(e.LAddr, e.LPort, 0, 0)
 	f.remote = newEndpointIPv4(e.RAddr, e.RPort, 0, 0)
@@ -256,7 +260,7 @@ func (e *tcpAcceptResult4) String() string {
 // Update the state with the contents of this event.
 func (e *tcpAcceptResult4) Update(s *state) error {
 	if e.Sock != 0 {
-		return s.UpdateFlow(e.asFlow())
+		return s.CreateSocket(e.asFlow())
 	}
 	return nil
 }

--- a/x-pack/auditbeat/module/system/socket/events.go
+++ b/x-pack/auditbeat/module/system/socket/events.go
@@ -948,6 +948,24 @@ func (e *execveRet) Update(s *state) error {
 	return nil
 }
 
+type forkRet struct {
+	Meta   tracing.Metadata `kprobe:"metadata"`
+	Retval int              `kprobe:"retval"`
+}
+
+// String returns a representation of the event.
+func (e *forkRet) String() string {
+	return fmt.Sprintf("%s <- fork %d", header(e.Meta), e.Retval)
+}
+
+// Update the state with the contents of this event.
+func (e *forkRet) Update(s *state) error {
+	if e.Retval <= 0 {
+		return nil
+	}
+	return s.ForkProcess(e.Meta.PID, uint32(e.Retval), kernelTime(e.Meta.Timestamp))
+}
+
 type doExit struct {
 	Meta tracing.Metadata `kprobe:"metadata"`
 }

--- a/x-pack/auditbeat/module/system/socket/kprobes.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes.go
@@ -186,6 +186,15 @@ var sharedKProbes = []helper.ProbeDef{
 		Decoder: helper.NewStructDecoder(func() interface{} { return new(commitCreds) }),
 	},
 
+	{
+		Probe: tracing.Probe{
+			Type:      tracing.TypeKRetProbe,
+			Name:      "clone3_ret",
+			Address:   "{{.DO_FORK}}",
+			Fetchargs: "retval={{.RET}}",
+		},
+		Decoder: helper.NewStructDecoder(func() interface{} { return new(forkRet) }),
+	},
 	/***************************************************************************
 	 * IPv4
 	 **************************************************************************/

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -945,8 +945,16 @@ func (f *flow) toEvent(final bool) (ev mb.Event, err error) {
 	}
 
 	src, dst := local, remote
-	if f.dir == directionIngress {
+	switch f.dir {
+	case directionIngress:
 		src, dst = dst, src
+	case directionUnknown:
+		// For some flows we can miss information to determine the source (dir=unknown).
+		// As a last resort, assume that the client side uses a higher port number
+		// than the server.
+		if localAddr.Port < remoteAddr.Port {
+			src, dst = dst, src
+		}
 	}
 
 	inetType := f.inetType

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -577,7 +577,7 @@ func (s *state) ForkProcess(parentPID, childPID uint32, ts kernelTime) error {
 			pid:         childPID,
 			name:        parent.name,
 			path:        parent.path,
-			args:        parent.args, // TODO: shallow copy
+			args:        parent.args,
 			created:     ts,
 			uid:         parent.uid,
 			gid:         parent.gid,

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -29,19 +29,19 @@ import (
 type logWrapper testing.T
 
 func (l *logWrapper) Errorf(format string, args ...interface{}) {
-	l.Logf("error: "+format, args)
+	l.Logf("error: "+format, args...)
 }
 
 func (l *logWrapper) Warnf(format string, args ...interface{}) {
-	l.Logf("warning: "+format, args)
+	l.Logf("warning: "+format, args...)
 }
 
 func (l *logWrapper) Infof(format string, args ...interface{}) {
-	l.Logf("info: "+format, args)
+	l.Logf("info: "+format, args...)
 }
 
 func (l *logWrapper) Debugf(format string, args ...interface{}) {
-	l.Logf("debug: "+format, args)
+	l.Logf("debug: "+format, args...)
 }
 
 func TestTCPConnWithProcess(t *testing.T) {

--- a/x-pack/auditbeat/module/system/socket/template.go
+++ b/x-pack/auditbeat/module/system/socket/template.go
@@ -41,6 +41,7 @@ var functionAlternatives = map[string][]string{
 	"SYS_EXECVE":        syscallAlternatives("execve"),
 	"SYS_GETTIMEOFDAY":  syscallAlternatives("gettimeofday"),
 	"SYS_UNAME":         syscallAlternatives("newuname"),
+	"DO_FORK":           {"_do_fork", "do_fork"},
 }
 
 func syscallAlternatives(syscall string) []string {

--- a/x-pack/auditbeat/tracing/perfevent.go
+++ b/x-pack/auditbeat/tracing/perfevent.go
@@ -99,7 +99,8 @@ func NewPerfChannel(cfg ...PerfChannelConf) (channel *PerfChannel, err error) {
 		streams:     make(map[uint64]stream),
 		pid:         perf.AllThreads,
 		attr: perf.Attr{
-			Type: perf.TracepointEvent,
+			Type:    perf.TracepointEvent,
+			ClockID: unix.CLOCK_MONOTONIC,
 			SampleFormat: perf.SampleFormat{
 				Raw:      true,
 				StreamID: true,


### PR DESCRIPTION
## What does this PR do?

This PR adds some fixes to Auditbeat's system/socket dataset in order to improve the process/flow correlation. During  testing, the following issues have been identified.

- Process forks were not tracked. This was an oversight that would trigger async process information fetch
- Receiving a new socket via `accept` was not handled properly. This was a major cause of process misattribution as the new flow could be associated to the previous process using the socket.
-  Fixes wrong client/server identification in some scenarios.

## Why is it important?

It had been reported that the dataset could provide incorrect process information, associating flows with the wrong process, and could also mismatch the origin of a connection, assigning the server side as the client.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Fixes #17165
