### PR TITLE
Allow Accept and Content-Type headers to be set

### DIFF
--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -421,7 +421,11 @@ func (conn *Connection) execHTTPRequest(req *http.Request) (int, []byte, error) 
 	}
 
 	for name, value := range conn.Headers {
-		req.Header.Add(name, value)
+		if name == "Content-Type" || name == "Accept" {
+			req.Header.Set(name, value)
+		} else {
+			req.Header.Add(name, value)
+		}
 	}
 
 	// The stlib will override the value in the header based on the configured `Host`

--- a/libbeat/esleg/eslegclient/connection_test.go
+++ b/libbeat/esleg/eslegclient/connection_test.go
@@ -64,3 +64,39 @@ func (c *mockClient) CloseIdleConnections() {}
 func newMockClient() *mockClient {
 	return &mockClient{}
 }
+
+func TestHeaders(t *testing.T) {
+	for _, td := range []struct {
+		input    map[string]string
+		expected map[string][]string
+	}{
+		{input: map[string]string{
+			"Accept":       "application/vnd.elasticsearch+json;compatible-with=7",
+			"Content-Type": "application/vnd.elasticsearch+json;compatible-with=7",
+			"X-My-Header":  "true"},
+			expected: map[string][]string{
+				"Accept":       {"application/vnd.elasticsearch+json;compatible-with=7"},
+				"Content-Type": {"application/vnd.elasticsearch+json;compatible-with=7"},
+				"X-My-Header":  {"true"}}},
+		{input: map[string]string{
+			"X-My-Header": "true"},
+			expected: map[string][]string{
+				"Accept":      {"application/json"},
+				"X-My-Header": {"true"}}},
+	} {
+		conn, err := NewConnection(ConnectionSettings{
+			Headers: td.input,
+		})
+		require.NoError(t, err)
+
+		httpClient := newMockClient()
+		conn.HTTP = httpClient
+
+		req, err := http.NewRequest("GET", "http://fakehost/some/path", nil)
+		require.NoError(t, err)
+		_, _, err = conn.execHTTPRequest(req)
+		require.NoError(t, err)
+
+		require.Equal(t, req.Header, http.Header(td.expected))
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Currently libbeat output always sets an `Accept` header and a `Content-Type` header when sending a body. When users configure http headers for the ES output, this leads to invalid requests as multiple `Accept` header or `Content-Type` information is set. 
With this PR the headers are only set if not configured by the user. 

## Why is it important?

This is important so that users can configure ES `7.x` compatibility headers throughout the `8.x` lifecycle when still running a `7.x` beat. 
While the change is important for `7.16`, it still makes sense to merge into `master` branch to minimize differences and keep backports easy, and because the changes are not specific to these compatibility headers. 

## Current Behavior/Reproduce
* Start ES and Kibana 8.0.0-SNAPSHOT
* Configure compatibility headers for ES output
```
output.elasticsearch:
    headers:
      Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
      Accept: "application/vnd.elasticsearch+json;compatible-with=7"
```
* Start Beat/APM Server 7.16.0-SNAPSHOT
* Observe following error
```
{"log.level":"error","@timestamp":"2021-11-29T11:15:24.530+0100","log.logger":"publisher_pipeline_output","log.origin":{"file.name":"pipeline/output.go","file.line":154},"message":"Failed to connect to backoff(elasticsearch(https://localhost:9200)): 400 Bad Request: {\"error\":{\"root_cause\":[{\"type\":\"media_type_header_exception\",\"reason\":\"Invalid media-type value on header [Accept]\"}],\"type\":\"media_type_header_exception\",\"reason\":\"Invalid media-type value on header [Accept]\",\"caused_by\":{\"type\":\"illegal_argument_exception\",\"reason\":\"Incorrect header [Accept]. Only one value should be provided\"}},\"status\":400}","service.name":"apm-server","ecs.version":"1.6.0"}
```


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
related to https://github.com/elastic/apm-server/issues/6426
