### PR TITLE
Mergify.yml merge to queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,8 @@
 queue_rules:
-  - name: default
+  - name: modified ^testing/environments/snapshot*
+    conditions:
+      - check-success=beats-ci/pr-merge
+  - name: modified ^.mergify.yml
     conditions:
       - check-success=beats-ci/pr-merge
 pull_request_rules:
@@ -93,7 +96,7 @@ pull_request_rules:
     actions:
       queue:
         method: squash
-        name: modified ^.mergify.ym
+        name: modified ^.mergify.yml
   - name: delete upstream branch with changes on ^.mergify.yml that has been merged or closed
     conditions:
       - or:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,8 +1,5 @@
 queue_rules:
-  - name: modified ^testing/environments/snapshot*
-    conditions:
-      - check-success=beats-ci/pr-merge
-  - name: modified ^.mergify.yml
+  - name: default
     conditions:
       - check-success=beats-ci/pr-merge
 pull_request_rules:
@@ -53,7 +50,7 @@ pull_request_rules:
     actions:
       queue:
         method: squash
-        name: modified ^testing/environments/snapshot*
+        name: default
   - name: delete upstream branch after merging changes on testing/environments/snapshot* or it's closed
     conditions:
       - or:
@@ -96,7 +93,7 @@ pull_request_rules:
     actions:
       queue:
         method: squash
-        name: modified ^.mergify.yml
+        name: default
   - name: delete upstream branch with changes on ^.mergify.yml that has been merged or closed
     conditions:
       - or:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,7 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=beats-ci/pr-merge
 pull_request_rules:
   - name: forward-port patches to master branch
     conditions:
@@ -40,14 +44,13 @@ pull_request_rules:
         message: Automatically approving mergify
   - name: automatic squash and merge with success checks and the files matching the regex ^testing/environments/snapshot* are modified.
     conditions:
-      - check-success=beats-ci/pr-merge
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$
       - "#approved-reviews-by>=1"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: false
+        name: modified ^testing/environments/snapshot*
   - name: delete upstream branch after merging changes on testing/environments/snapshot* or it's closed
     conditions:
       - or:
@@ -83,15 +86,14 @@ pull_request_rules:
         message: Automatically approving mergify
   - name: automatic squash and merge with success checks and the files matching the regex ^.mergify.yml is modified.
     conditions:
-      - check-success=beats-ci/pr-merge
       - label=automation
       - files~=^\.mergify\.yml$
       - head~=^add-backport-next.*
       - "#approved-reviews-by>=1"
     actions:
-      merge:
+      queue:
         method: squash
-        strict: false
+        name: modified ^.mergify.ym
   - name: delete upstream branch with changes on ^.mergify.yml that has been merged or closed
     conditions:
       - or:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -47,6 +47,7 @@ pull_request_rules:
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$
       - "#approved-reviews-by>=1"
+      - check-success=beats-ci/pr-merge
     actions:
       queue:
         method: squash
@@ -90,6 +91,7 @@ pull_request_rules:
       - files~=^\.mergify\.yml$
       - head~=^add-backport-next.*
       - "#approved-reviews-by>=1"
+      - check-success=beats-ci/pr-merge
     actions:
       queue:
         method: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,10 +44,10 @@ pull_request_rules:
         message: Automatically approving mergify
   - name: automatic squash and merge with success checks and the files matching the regex ^testing/environments/snapshot* are modified.
     conditions:
+      - check-success=beats-ci/pr-merge
       - label=automation
       - files~=^testing/environments/snapshot.*\.yml$
       - "#approved-reviews-by>=1"
-      - check-success=beats-ci/pr-merge
     actions:
       queue:
         method: squash
@@ -87,11 +87,11 @@ pull_request_rules:
         message: Automatically approving mergify
   - name: automatic squash and merge with success checks and the files matching the regex ^.mergify.yml is modified.
     conditions:
+      - check-success=beats-ci/pr-merge
       - label=automation
       - files~=^\.mergify\.yml$
       - head~=^add-backport-next.*
       - "#approved-reviews-by>=1"
-      - check-success=beats-ci/pr-merge
     actions:
       queue:
         method: squash


### PR DESCRIPTION
## What does this PR do?

It changes  merge action to queue in .mergify.yml

## Why is it important?

The configuration uses the deprecated strict mode of the merge action.
A brownout is planned for the whole December 6th, 2021 day.
This option will be removed on January 10th, 2022.
For more information: https://blog.mergify.io/strict-mode-deprecation/

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
