### PR TITLE
Use the generic helper for opening file to read in filestream

### DIFF
--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -29,6 +29,7 @@ import (
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cleanup"
+	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -244,7 +245,7 @@ func (inp *filestream) openFile(log *logp.Logger, path string, offset int64) (*o
 	}
 
 	ok := false
-	f, err := os.OpenFile(path, os.O_RDONLY, os.FileMode(0))
+	f, err := file.ReadOpen(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed opening %s: %s", path, err)
 	}


### PR DESCRIPTION
## What does this PR do?

This PR uses the platform-dependent function to open files for harvesting.

## Why is it important?

This change lets filestream input open files on Windows in a way it can be deleted.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #29113
