### PR TITLE
[libbeat] Fix add_labels flattening of arrays values

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -142,6 +142,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix the wrong beat name on monitoring and state endpoint {issue}27755[27755]
 - Skip configuration checks in autodiscover for configurations that are already running {pull}29048[29048]
 - Fix `decode_json_processor` to always respect `add_error_key` {pull}29107[29107]
+- Fix `add_labels` flattening of array values. {pull}29211[29211]
 
 *Auditbeat*
 
@@ -188,7 +189,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Revert usageDetails api version to 2019-01-01. {pull}28995[28995]
 - Fix in `aws-s3` input regarding provider discovery through endpoint {pull}28963[28963]
 - Fix `threatintel.misp` filters configuration. {issue}27970[27970]
-- Fix opening files on Windows in filestream so open files can be deleted. {issue}29113[29113] {pull}29180[29180] 
+- Fix opening files on Windows in filestream so open files can be deleted. {issue}29113[29113] {pull}29180[29180]
 
 *Heartbeat*
 

--- a/libbeat/common/config.go
+++ b/libbeat/common/config.go
@@ -259,6 +259,11 @@ func (c *Config) IsArray() bool {
 	return c.access().IsArray()
 }
 
+// FlattenedKeys return a sorted flattened views of the set keys in the configuration.
+func (c *Config) FlattenedKeys() []string {
+	return c.access().FlattenedKeys(configOpts...)
+}
+
 func (c *Config) PrintDebugf(msg string, params ...interface{}) {
 	selector := selectorConfigWithPassword
 	filtered := false

--- a/libbeat/processors/actions/add_labels.go
+++ b/libbeat/processors/actions/add_labels.go
@@ -20,8 +20,6 @@ package actions
 import (
 	"fmt"
 
-	"github.com/elastic/go-ucfg"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/checks"
@@ -77,8 +75,7 @@ func flattenLabels(labels common.MapStr) (common.MapStr, error) {
 		return nil, err
 	}
 
-	flatKeys := (*ucfg.Config)(labelConfig).FlattenedKeys()
-
+	flatKeys := labelConfig.FlattenedKeys()
 	flatMap := make(common.MapStr, len(flatKeys))
 	for _, k := range flatKeys {
 		v, err := labelConfig.String(k, -1)

--- a/libbeat/processors/actions/add_labels_test.go
+++ b/libbeat/processors/actions/add_labels_test.go
@@ -59,5 +59,16 @@ func TestAddLabels(t *testing.T) {
 				`{add_labels.labels: {l2: b, lc: b}}`,
 			),
 		},
+		"add array": {
+			event: common.MapStr{},
+			want: common.MapStr{
+				"labels": common.MapStr{
+					"array.0":       "foo",
+					"array.1":       "bar",
+					"array.2.hello": "world",
+				},
+			},
+			cfg: single(`{add_labels: {labels: {array: ["foo", "bar", {"hello": "world"}]}}}`),
+		},
 	})
 }


### PR DESCRIPTION
## What does this PR do?

The processor was not working as described in the [docs](https://www.elastic.co/guide/en/beats/winlogbeat/current/add-labels.html). For example:

```yaml
# Input config
processors:
  - add_labels:
      labels:
        number: 1
        with.dots: test
        nested:
          with.dots: nested
        array:
          - do
          - re
          - with.field: mi
```

```json
# Observed
{
  "labels": {
    "array": [
      "do",
      "re",
      {
        "with": {
          "field": "mi"
        }
      }
    ],
    "nested.with.dots": "nested",
    "number": 1,
    "with.dots": "test"
  }
```

```json
# Expected
{
  "labels": {
    "number": 1,
    "with.dots": "test",
    "nested.with.dots": "nested",
    "array.0": "do",
    "array.1": "re",
    "array.2.with.field": "mi"
  }
}
```


## Why is it important?

The generated values to not align with the docs or how `labels` is described in ECS.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

