### PR TITLE
Osquerybeat: Add missing osquery top-level configuration properties for auto_table_construction, yara, prometheus_targets

### DIFF
--- a/x-pack/osquerybeat/internal/config/osquery.go
+++ b/x-pack/osquerybeat/internal/config/osquery.go
@@ -59,12 +59,15 @@ type Events struct {
 }
 
 type OsqueryConfig struct {
-	Options   map[string]interface{} `config:"options" json:"options,omitempty"`
-	Schedule  map[string]Query       `config:"schedule" json:"schedule,omitempty"`
-	Packs     map[string]Pack        `config:"packs" json:"packs,omitempty"`
-	Filepaths map[string][]string    `config:"file_paths" json:"file_paths,omitempty"`
-	Views     map[string]string      `config:"views" json:"views,omitempty"`
-	Events    *Events                `config:"events" json:"events,omitempty"`
+	Options               map[string]interface{} `config:"options" json:"options,omitempty"`
+	Schedule              map[string]Query       `config:"schedule" json:"schedule,omitempty"`
+	Packs                 map[string]Pack        `config:"packs" json:"packs,omitempty"`
+	Filepaths             map[string][]string    `config:"file_paths" json:"file_paths,omitempty"`
+	Views                 map[string]string      `config:"views" json:"views,omitempty"`
+	Events                *Events                `config:"events" json:"events,omitempty"`
+	Yara                  map[string]interface{} `config:"yara" json:"yara,omitempty"`
+	PrometheusTargets     map[string]interface{} `config:"prometheus_targets" json:"prometheus_targets,omitempty"`
+	AutoTableConstruction map[string]interface{} `config:"auto_table_construction" json:"auto_table_construction,omitempty"`
 }
 
 func (c OsqueryConfig) Render() ([]byte, error) {


### PR DESCRIPTION
## What does this PR do?

Adds missing osquery top-level configuration properties for auto_table_construction, yara, prometheus_targets.

Immediate defect was reported when people were trying to use ```auto_table_construction``` and the configuration was not applied properly. There were two more top-level configuration properties that were ignored as well.

Here is an example configuration for auto_table_construction:

```
{
  "auto_table_construction": {
    "chrome_history": {
      "path": "\\Users\\%\\AppData\\Local\\Google\\Chrome\\User\\ Data\\Default\\History",
      "columns": [
        "last_visited",
        "url",
        "title",
        "visit_count"
      ],
      "query": "SELECT datetime(last_visit_time/1000000-11644473600, \"unixepoch\") as last_visited, url, title, visit_count FROM urls"
    }
  }
}
```

Before this change the ```auto_table_construction``` was ignored and any query against ```chrome_history``` table was returning an error: ```chrome_history``` table is not found.

With this PR users should be able to query ```chrome_history``` table after applying the configuration above.

<img width="1207" alt="Screen Shot 2021-12-03 at 7 34 27 PM" src="https://user-images.githubusercontent.com/872351/144689834-b9984ebc-ef34-45e4-b9fc-99ead5a3c521.png">


## Why is it important?

Support missing osquery top-level configuration for  ```auto_table_construction```,  ```yara```, ```prometheus_targets```.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

