### PR TITLE
[automation] update elastic stack version for testing 7.15.3-70c2e21f

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.15.3-1d3806ef-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.15.3-70c2e21f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -17,7 +17,7 @@ services:
     - "indices.id_field_data.enabled=true"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.15.3-1d3806ef-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.15.3-70c2e21f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -27,7 +27,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.15.3-1d3806ef-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.15.3-70c2e21f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.3-1d3806ef-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.3-70c2e21f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -20,7 +20,7 @@ services:
     - "ingest.geoip.downloader.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.15.3-1d3806ef-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.15.3-70c2e21f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -30,7 +30,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.15.3-1d3806ef-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.15.3-70c2e21f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status | grep -q 'Looking good'"]
       retries: 600


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Sun, 5 Dec 2021 17:25:40 GMT, release_branch:7.15, prefix:, end_time:Sun, 5 Dec 2021 23:29:23 GMT, manifest_version:2.0.0, version:7.15.3-SNAPSHOT, branch:7.15, build_id:7.15.3-70c2e21f, build_duration_seconds:21823]