### PR TITLE
Add warning about removing Functionbeat

### DIFF
--- a/x-pack/functionbeat/function/beater/functionbeat.go
+++ b/x-pack/functionbeat/function/beater/functionbeat.go
@@ -55,6 +55,7 @@ type Functionbeat struct {
 
 // New creates an instance of functionbeat.
 func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
+
 	c := &config.DefaultConfig
 	if err := cfg.Unpack(c); err != nil {
 		return nil, fmt.Errorf("error reading config file: %+v", err)
@@ -82,6 +83,8 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 // Run starts functionbeat.
 func (bt *Functionbeat) Run(b *beat.Beat) error {
 	defer bt.cancel()
+
+	bt.log.Warn("Functionbeat is going to be removed in 8.1")
 
 	outputName := b.Config.Output.Name()
 	if !isOutputSupported(outputName) {

--- a/x-pack/functionbeat/manager/beater/functionbeat.go
+++ b/x-pack/functionbeat/manager/beater/functionbeat.go
@@ -51,6 +51,8 @@ func (bt *Functionbeat) Run(b *beat.Beat) error {
 	bt.log.Info("Functionbeat is running")
 	defer bt.log.Info("Functionbeat stopped running")
 
+	bt.log.Warn("Functionbeat is going to be removed in 8.1")
+
 	return nil
 }
 

--- a/x-pack/functionbeat/manager/cmd/root.go
+++ b/x-pack/functionbeat/manager/cmd/root.go
@@ -5,6 +5,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -31,6 +32,8 @@ func init() {
 
 	RootCmd.RemoveCommand(RootCmd.RunCmd)
 	RootCmd.Run = func(_ *cobra.Command, _ []string) {
+		fmt.Println("Functionbeat is going to be removed in 8.1")
+
 		RootCmd.Usage()
 		os.Exit(1)
 	}


### PR DESCRIPTION
## What does this PR do?

This PR adds a deprecation warning to Functionbeat.

## Why is it important?

The Beat is going to be removed in the future, in favour of https://github.com/elastic/elastic-serverless-forwarder

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
