### PR TITLE
Agent configuration overridden by default fleet config

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -91,6 +91,7 @@
 - Snapshot artifact lookup will use agent.download proxy settings. {issue}27903[27903] {pull}27904[27904]
 - Fix lazy acker to only add new actions to the batch. {pull}27981[27981]
 - Allow HTTP metrics to run in bootstrap mode. Add ability to adjust timeouts for Fleet Server. {pull}28260[28260]
+- Fix agent configuration overwritten by default fleet config. {pull}29297[29297]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/application/application.go
+++ b/x-pack/elastic-agent/pkg/agent/application/application.go
@@ -39,10 +39,11 @@ type upgraderControl interface {
 }
 
 // New creates a new Agent and bootstrap the required subsystem.
-func New(log *logger.Logger, pathConfigFile string, reexec reexecManager, statusCtrl status.Controller, uc upgraderControl, agentInfo *info.AgentInfo) (Application, error) {
+func New(log *logger.Logger, reexec reexecManager, statusCtrl status.Controller, uc upgraderControl, agentInfo *info.AgentInfo) (Application, error) {
 	// Load configuration from disk to understand in which mode of operation
 	// we must start the elastic-agent, the mode of operation cannot be changed without restarting the
 	// elastic-agent.
+	pathConfigFile := paths.ConfigFile()
 	rawConfig, err := config.LoadFile(pathConfigFile)
 	if err != nil {
 		return nil, err
@@ -66,7 +67,6 @@ func createApplication(
 ) (Application, error) {
 	log.Info("Detecting execution mode")
 	ctx := context.Background()
-
 	cfg, err := configuration.NewFromConfig(rawConfig)
 	if err != nil {
 		return nil, err

--- a/x-pack/elastic-agent/pkg/agent/application/application_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/application_test.go
@@ -3,3 +3,34 @@
 // you may not use this file except in compliance with the Elastic License.
 
 package application
+
+import (
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestMergeFleetConfig(t *testing.T) {
+	cfg := map[string]interface{}{
+		"fleet": map[string]interface{}{
+			"enabled":        true,
+			"kibana":         map[string]interface{}{"host": "demo"},
+			"access_api_key": "123",
+		},
+		"agent": map[string]interface{}{
+			"grpc": map[string]interface{}{
+				"port": uint16(6790),
+			},
+		},
+	}
+
+	rawConfig := config.MustNewConfigFrom(cfg)
+	storage, conf, err := mergeFleetConfig(rawConfig)
+	require.NoError(t, err)
+	assert.NotNil(t, storage)
+	assert.NotNil(t, conf)
+	assert.Equal(t, conf.Fleet.Enabled, cfg["fleet"].(map[string]interface{})["enabled"])
+	assert.Equal(t, conf.Fleet.AccessAPIKey, cfg["fleet"].(map[string]interface{})["access_api_key"])
+	assert.Equal(t, conf.Settings.GRPC.Port, cfg["agent"].(map[string]interface{})["grpc"].(map[string]interface{})["port"].(uint16))
+}

--- a/x-pack/elastic-agent/pkg/agent/application/application_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/application_test.go
@@ -5,10 +5,12 @@
 package application
 
 import (
-	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/config"
 )
 
 func TestMergeFleetConfig(t *testing.T) {

--- a/x-pack/elastic-agent/pkg/agent/cmd/run.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/run.go
@@ -142,7 +142,7 @@ func run(streams *cli.IOStreams, override cfgOverrider) error {
 	}
 	defer control.Stop()
 
-	app, err := application.New(logger, pathConfigFile, rex, statusCtrl, control, agentInfo)
+	app, err := application.New(logger, rex, statusCtrl, control, agentInfo)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?

Elastic agent configuration options were overwritten by fleet default configuration options, even in standalone mode.

## Why is it important?

undesired behavior.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/elastic-agent-client/issues/28
