### PR TITLE
Do not use cat API when checking for templates

### DIFF
--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -146,19 +146,12 @@ func (l *ESLoader) loadTemplate(templateName string, templateType IndexTemplateT
 func (l *ESLoader) templateExists(templateName string, templateType IndexTemplateType) (bool, error) {
 	path := templateLoaderPath[templateType] + templateName
 	status, _, err := l.client.Request("HEAD", path, "", nil, nil)
-	if err != nil {
-		return false, err
-	}
-
 	switch status {
 	case http.StatusNotFound:
 		return false, nil
 	case http.StatusOK:
 		return true, nil
 	default:
-		if err == nil {
-			err = &StatusError{status: status}
-		}
 		return false, err
 	}
 }

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -144,8 +144,11 @@ func (l *ESLoader) loadTemplate(templateName string, templateType IndexTemplateT
 
 // templateExists checks if a template exists
 func (l *ESLoader) templateExists(templateName string, templateType IndexTemplateType) (bool, error) {
-	path := templateLoaderPath[templateType] + templateName
-	status, _, err := l.client.Request("HEAD", path, "", nil, nil)
+	path, ok := templateLoaderPath[templateType]
+	if !ok {
+		return false, fmt.Errorf("invalid template type: %+v", templateType)
+	}
+	status, _, err := l.client.Request("HEAD", path+templateName, "", nil, nil)
 	switch status {
 	case http.StatusNotFound:
 		return false, nil

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -145,7 +145,7 @@ func (l *ESLoader) loadTemplate(templateName string, templateType IndexTemplateT
 // templateExists checks if a template exists
 func (l *ESLoader) templateExists(templateName string, templateType IndexTemplateType) (bool, error) {
 	path := templateLoaderPath[templateType] + templateName
-	status, body, err := l.client.Request("HEAD", path, "", nil, nil)
+	status, _, err := l.client.Request("HEAD", path, "", nil, nil)
 	if err != nil {
 		return false, err
 	}

--- a/libbeat/template/load.go
+++ b/libbeat/template/load.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -143,40 +142,13 @@ func (l *ESLoader) loadTemplate(templateName string, templateType IndexTemplateT
 	return nil
 }
 
+// templateExists checks if a template exists
 func (l *ESLoader) templateExists(templateName string, templateType IndexTemplateType) (bool, error) {
-	if templateType == IndexTemplateComponent {
-		return l.checkExistsComponentTemplate(templateName)
-	}
-	return l.checkExistsTemplate(templateName)
-}
-
-// existsTemplate checks if a given template already exist, using the
-// `_cat/templates/<name>` API.
-//
-// An error is returned if the loader failed to execute the request, or a
-// status code indicating some problems is encountered.
-func (l *ESLoader) checkExistsTemplate(name string) (bool, error) {
-	status, body, err := l.client.Request("GET", "/_cat/templates/"+name, "", nil, nil)
+	path := templateLoaderPath[templateType] + templateName
+	status, body, err := l.client.Request("HEAD", path, "", nil, nil)
 	if err != nil {
 		return false, err
 	}
-
-	// Elasticsearch API returns 200, even if the template does not exists. We
-	// need to validate the body to be sure the template is actually known. Any
-	// status code other than 200 will be treated as error.
-	if status != http.StatusOK {
-		return false, &StatusError{status: status}
-	}
-	return strings.Contains(string(body), name), nil
-}
-
-// existsComponentTemplate checks if a component template exists by querying
-// the `_component_template/<name>` API.
-//
-// The resource is assumed as present if a 200 OK status is returned and missing if a 404 is returned.
-// Other status codes or IO errors during the request are reported as error.
-func (l *ESLoader) checkExistsComponentTemplate(name string) (bool, error) {
-	status, _, err := l.client.Request("GET", "/_component_template/"+name, "", nil, nil)
 
 	switch status {
 	case http.StatusNotFound:


### PR DESCRIPTION
## What does this PR do?

This PR removes the usage of the cat API.

## Why is it important?

The cat API is not intended to be used in production. Hence, it has to be removed from Beats prod code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

