### PR TITLE
Overwrite index name in index template correctly

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -147,6 +147,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Skip configuration checks in autodiscover for configurations that are already running {pull}29048[29048]
 - Fix `decode_json_processor` to always respect `add_error_key` {pull}29107[29107]
 - Fix `add_labels` flattening of array values. {pull}29211[29211]
+- Overwrite index name in index template correctly. {issue}28571[28571] {pull}29299[29299]
 
 *Auditbeat*
 

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -53,9 +53,9 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) (err error)
 		return nil
 	}
 
-	list, ok := content["objects"]
+	list, ok := content["references"]
 	if !ok {
-		return errors.New("empty index pattern")
+		return errors.New("no references")
 	}
 
 	updateObject := func(obj common.MapStr) {

--- a/libbeat/dashboards/modify_json.go
+++ b/libbeat/dashboards/modify_json.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -53,44 +51,14 @@ func ReplaceIndexInIndexPattern(index string, content common.MapStr) (err error)
 		return nil
 	}
 
-	list, ok := content["references"]
-	if !ok {
-		return errors.New("no references")
+	// This uses Put instead of DeepUpdate to avoid modifying types for
+	// inner objects. (DeepUpdate will replace maps with MapStr).
+	content.Put("id", index)
+	// Only overwrite title if it exists.
+	if _, err := content.GetValue("attributes.title"); err == nil {
+		content.Put("attributes.title", index)
 	}
 
-	updateObject := func(obj common.MapStr) {
-		// This uses Put instead of DeepUpdate to avoid modifying types for
-		// inner objects. (DeepUpdate will replace maps with MapStr).
-		obj.Put("id", index)
-		// Only overwrite title if it exists.
-		if _, err := obj.GetValue("attributes.title"); err == nil {
-			obj.Put("attributes.title", index)
-		}
-	}
-
-	switch v := list.(type) {
-	case []interface{}:
-		for _, objIf := range v {
-			switch obj := objIf.(type) {
-			case common.MapStr:
-				updateObject(obj)
-			case map[string]interface{}:
-				updateObject(obj)
-			default:
-				return errors.Errorf("index pattern object has unexpected type %T", v)
-			}
-		}
-	case []map[string]interface{}:
-		for _, obj := range v {
-			updateObject(obj)
-		}
-	case []common.MapStr:
-		for _, obj := range v {
-			updateObject(obj)
-		}
-	default:
-		return errors.Errorf("index pattern objects have unexpected type %T", v)
-	}
 	return nil
 }
 

--- a/libbeat/dashboards/modify_json_test.go
+++ b/libbeat/dashboards/modify_json_test.go
@@ -125,117 +125,67 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 		expected common.MapStr
 	}{
 		{
-			title: "Replace in []interface(map).map",
-			input: common.MapStr{"references": []interface{}{map[string]interface{}{
-				"id":   "phonybeat-*",
-				"type": "index-pattern",
-				"attributes": map[string]interface{}{
-					"title":         "phonybeat-*",
-					"timeFieldName": "@timestamp",
-				}}}},
-			index: "otherindex-*",
-			expected: common.MapStr{"references": []interface{}{map[string]interface{}{
-				"id":   "otherindex-*",
-				"type": "index-pattern",
-				"attributes": map[string]interface{}{
-					"title":         "otherindex-*",
-					"timeFieldName": "@timestamp",
-				}}}},
-		},
-		{
-			title: "Replace in []interface(map).mapstr",
-			input: common.MapStr{"references": []interface{}{map[string]interface{}{
-				"id":   "phonybeat-*",
-				"type": "index-pattern",
-				"attributes": common.MapStr{
-					"title":         "phonybeat-*",
-					"timeFieldName": "@timestamp",
-				}}}},
-			index: "otherindex-*",
-			expected: common.MapStr{"references": []interface{}{map[string]interface{}{
-				"id":   "otherindex-*",
-				"type": "index-pattern",
-				"attributes": common.MapStr{
-					"title":         "otherindex-*",
-					"timeFieldName": "@timestamp",
-				}}}},
-		},
-		{
-			title: "Replace in []map.mapstr",
-			input: common.MapStr{"references": []map[string]interface{}{{
-				"id":   "phonybeat-*",
-				"type": "index-pattern",
-				"attributes": common.MapStr{
-					"title":         "phonybeat-*",
-					"timeFieldName": "@timestamp",
-				}}}},
-			index: "otherindex-*",
-			expected: common.MapStr{"references": []map[string]interface{}{{
-				"id":   "otherindex-*",
-				"type": "index-pattern",
-				"attributes": common.MapStr{
-					"title":         "otherindex-*",
-					"timeFieldName": "@timestamp",
-				}}}},
-		},
-		{
 			title: "Replace in []mapstr.mapstr",
-			input: common.MapStr{"references": []common.MapStr{{
+			input: common.MapStr{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
 					"title":         "phonybeat-*",
 					"timeFieldName": "@timestamp",
-				}}}},
+				}},
 			index: "otherindex-*",
-			expected: common.MapStr{"references": []common.MapStr{{
+			expected: common.MapStr{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
 					"title":         "otherindex-*",
 					"timeFieldName": "@timestamp",
-				}}}},
+				}},
 		},
 		{
 			title: "Replace in []mapstr.interface(mapstr)",
-			input: common.MapStr{"references": []common.MapStr{{
+			input: common.MapStr{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 				"attributes": interface{}(common.MapStr{
 					"title":         "phonybeat-*",
 					"timeFieldName": "@timestamp",
-				})}}},
+				})},
 			index: "otherindex-*",
-			expected: common.MapStr{"references": []common.MapStr{{
+			expected: common.MapStr{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 				"attributes": interface{}(common.MapStr{
 					"title":         "otherindex-*",
 					"timeFieldName": "@timestamp",
-				})}}},
+				})},
 		},
 		{
 			title: "Do not create missing attributes",
-			input: common.MapStr{"references": []common.MapStr{{
-				"id":   "phonybeat-*",
-				"type": "index-pattern",
-			}}},
+			input: common.MapStr{
+				"attributes": common.MapStr{},
+				"id":         "phonybeat-*",
+				"type":       "index-pattern",
+			},
 			index: "otherindex-*",
-			expected: common.MapStr{"references": []common.MapStr{{
-				"id":   "otherindex-*",
-				"type": "index-pattern",
-			}}},
+			expected: common.MapStr{
+				"attributes": common.MapStr{},
+				"id":         "otherindex-*",
+				"type":       "index-pattern",
+			},
 		},
 		{
 			title: "Create missing id",
-			input: common.MapStr{"references": []common.MapStr{{
-				"type": "index-pattern",
-			}}},
+			input: common.MapStr{
+				"attributes": common.MapStr{},
+				"type":       "index-pattern",
+			},
 			index: "otherindex-*",
-			expected: common.MapStr{"references": []common.MapStr{{
-				"id":   "otherindex-*",
-				"type": "index-pattern",
-			}}},
+			expected: common.MapStr{
+				"attributes": common.MapStr{},
+				"id":         "otherindex-*",
+				"type":       "index-pattern",
+			},
 		},
 	}
 

--- a/libbeat/dashboards/modify_json_test.go
+++ b/libbeat/dashboards/modify_json_test.go
@@ -126,7 +126,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 	}{
 		{
 			title: "Replace in []interface(map).map",
-			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
+			input: common.MapStr{"references": []interface{}{map[string]interface{}{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 				"attributes": map[string]interface{}{
@@ -134,7 +134,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 					"timeFieldName": "@timestamp",
 				}}}},
 			index: "otherindex-*",
-			expected: common.MapStr{"objects": []interface{}{map[string]interface{}{
+			expected: common.MapStr{"references": []interface{}{map[string]interface{}{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 				"attributes": map[string]interface{}{
@@ -144,7 +144,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 		},
 		{
 			title: "Replace in []interface(map).mapstr",
-			input: common.MapStr{"objects": []interface{}{map[string]interface{}{
+			input: common.MapStr{"references": []interface{}{map[string]interface{}{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
@@ -152,7 +152,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 					"timeFieldName": "@timestamp",
 				}}}},
 			index: "otherindex-*",
-			expected: common.MapStr{"objects": []interface{}{map[string]interface{}{
+			expected: common.MapStr{"references": []interface{}{map[string]interface{}{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
@@ -162,7 +162,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 		},
 		{
 			title: "Replace in []map.mapstr",
-			input: common.MapStr{"objects": []map[string]interface{}{{
+			input: common.MapStr{"references": []map[string]interface{}{{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
@@ -170,7 +170,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 					"timeFieldName": "@timestamp",
 				}}}},
 			index: "otherindex-*",
-			expected: common.MapStr{"objects": []map[string]interface{}{{
+			expected: common.MapStr{"references": []map[string]interface{}{{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
@@ -180,7 +180,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 		},
 		{
 			title: "Replace in []mapstr.mapstr",
-			input: common.MapStr{"objects": []common.MapStr{{
+			input: common.MapStr{"references": []common.MapStr{{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
@@ -188,7 +188,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 					"timeFieldName": "@timestamp",
 				}}}},
 			index: "otherindex-*",
-			expected: common.MapStr{"objects": []common.MapStr{{
+			expected: common.MapStr{"references": []common.MapStr{{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 				"attributes": common.MapStr{
@@ -198,7 +198,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 		},
 		{
 			title: "Replace in []mapstr.interface(mapstr)",
-			input: common.MapStr{"objects": []common.MapStr{{
+			input: common.MapStr{"references": []common.MapStr{{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 				"attributes": interface{}(common.MapStr{
@@ -206,7 +206,7 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 					"timeFieldName": "@timestamp",
 				})}}},
 			index: "otherindex-*",
-			expected: common.MapStr{"objects": []common.MapStr{{
+			expected: common.MapStr{"references": []common.MapStr{{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 				"attributes": interface{}(common.MapStr{
@@ -216,23 +216,23 @@ func TestReplaceIndexInIndexPattern(t *testing.T) {
 		},
 		{
 			title: "Do not create missing attributes",
-			input: common.MapStr{"objects": []common.MapStr{{
+			input: common.MapStr{"references": []common.MapStr{{
 				"id":   "phonybeat-*",
 				"type": "index-pattern",
 			}}},
 			index: "otherindex-*",
-			expected: common.MapStr{"objects": []common.MapStr{{
+			expected: common.MapStr{"references": []common.MapStr{{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 			}}},
 		},
 		{
 			title: "Create missing id",
-			input: common.MapStr{"objects": []common.MapStr{{
+			input: common.MapStr{"references": []common.MapStr{{
 				"type": "index-pattern",
 			}}},
 			index: "otherindex-*",
-			expected: common.MapStr{"objects": []common.MapStr{{
+			expected: common.MapStr{"references": []common.MapStr{{
 				"id":   "otherindex-*",
 				"type": "index-pattern",
 			}}},


### PR DESCRIPTION
## What does this PR do?

After the changes in the dashboard and index template format, custom names were only updated in dashboards, but not in index templates. This PR adjust index template support.

Type assertions were removed because the index template is always a `common.MapStr`.

## Why is it important?

Without this change, custom index names cannot be supported.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #28571