### PR TITLE
Add 7.16 breaking changes

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-7.16.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.16.asciidoc
@@ -14,12 +14,12 @@ including changes to beta or experimental functionality.
 // tag::notable-breaking-changes[]
 
 [discrete]
-==== {journalbeat} is deprecated in 7.16
+==== {journalbeat} is removed in 7.16
 
 {journalbeat}, a lightweight shipper for collecting logs written by the Journald
-system service, is deprecated in 7.16. This functionality is instead provided as
-a {filebeat} input. If you're currently using {journalbeat}, you should begin
-using the `journald` input in {filebeat} instead. For more information, refer to
+system service, is removed in 7.16. This functionality is instead provided as
+a {filebeat} input. If you're currently using {journalbeat}, you should
+use the `journald` input in {filebeat} instead. For more information, refer to
 the
 {filebeat-ref}/filebeat-input-journald.html[Journald input] documentation.
 

--- a/libbeat/docs/release-notes/breaking/breaking-7.16.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.16.asciidoc
@@ -1,0 +1,35 @@
+[[breaking-changes-7.16]]
+
+=== Breaking changes in 7.16
+++++
+<titleabbrev>7.16</titleabbrev>
+++++
+
+See the <<release-notes,release notes>> for a complete list of changes,
+including changes to beta or experimental functionality.
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+// tag::notable-breaking-changes[]
+
+[discrete]
+==== {journalbeat} is deprecated in 7.16
+
+{journalbeat}, a lightweight shipper for collecting logs written by the Journald
+system service, is deprecated in 7.16. This functionality is instead provided as
+a {filebeat} input. If you're currently using {journalbeat}, you should begin
+using the `journald` input in {filebeat} instead. For more information, refer to
+the
+{filebeat-ref}/filebeat-input-journald.html[Journald input] documentation.
+
+If you're using {agent} instead of {beats}, you can collect Journald logs by
+adding the *Custom Journald logs* integration to your agent policy. For more
+information, refer to
+{fleet-guide}/add-integration-to-policy.html[Add an {agent} integration to a policy]. 
+
+//TODO: Add pointer to the integrations docs for custom journald logs when
+//available.
+
+// end::notable-breaking-changes[]
+

--- a/libbeat/docs/release-notes/breaking/breaking-7.16.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-7.16.asciidoc
@@ -31,5 +31,12 @@ information, refer to
 //TODO: Add pointer to the integrations docs for custom journald logs when
 //available.
 
+[discrete]
+==== Custom {beats} generator is deprecated in 7.16
+
+The generator code for creating custom {beats} is deprecated in 7.16.0 and will
+be removed in 8.0.0. You can continue to build custom {beats} using the
+generators available in 7.16, or refer to existing {beats} as working examples.
+
 // end::notable-breaking-changes[]
 

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,8 @@ changes, but there are breaking changes between major versions (e.g. 6.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-7.16>>
+
 * <<breaking-changes-7.15>>
 
 * <<breaking-changes-7.14>>
@@ -42,6 +44,8 @@ See the following topics for a description of breaking changes:
 * <<breaking-changes-7.1>>
 
 * <<breaking-changes-7.0>>
+
+include::breaking-7.16.asciidoc[]
 
 include::breaking-7.15.asciidoc[]
 


### PR DESCRIPTION
## What does this PR do?

Adds breaking changes that we want to highlight in 7.16. Remember that these are the highlights that get pulled into the stack upgrade docs.

Preview link: https://beats_29300.docs-preview.app.elstc.co/guide/en/beats/libbeat/master/breaking-changes-7.16.html

## Why is it important?

Users need to be aware of these changes.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes https://github.com/elastic/observability-docs/issues/1291
