### PR TITLE
Check that `info.NCPU` is not zero

### DIFF
--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -528,7 +528,7 @@ func numParallel() int {
 	maxParallel := runtime.NumCPU()
 
 	info, err := GetDockerInfo()
-	if err == nil && info.NCPU < maxParallel {
+	if err == nil && info.NCPU != 0 && info.NCPU < maxParallel {
 		maxParallel = info.NCPU
 	}
 

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -528,6 +528,8 @@ func numParallel() int {
 	maxParallel := runtime.NumCPU()
 
 	info, err := GetDockerInfo()
+	// Check that info.NCPU != 0 since docker info doesn't return with an
+	// error status if communcation with the daemon failed.
 	if err == nil && info.NCPU != 0 && info.NCPU < maxParallel {
 		maxParallel = info.NCPU
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This adds a check for 0 when determining the concurrency limit used by mage during a build.

## Why is it important?

`docker info -f '{{ json .}}'` exits with 0 even if there was an error, so the check for `err == nil` doesn't catch errors, and the default int value of 0 is used when trying to read `info.NCPU`. This leads to the confusing behaviour where the build stops and hangs forever with no errors and no indication that anything has gone wrong unless you build with --verbose.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Stop the docker daemon `systemctl stop docker` and ensure you don't have it set to automatically start up, either by disabling the socket or masking the service.
Ensure you haven't exported `MAX_PARALLEL` in your shell.
Test to make sure the daemon isn't running by executing `docker info -f '{{ json .}}'` and validating that the output looks like
```
{"ServerErrors":["Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"]...
```
Attempt to build the elastic agent. `DEV=true SNAPSHOT=true PLATFORMS=linux/amd64 TYPES=docker mage package`

On main it will silently hang forever.

On this branch, print the error `docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock` when it is unable to run the build.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
