### PR TITLE
[Filebeat] Add info to aws-s3 log messages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,7 +27,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - add_docker_metadata processor: Replace usage of deprecated `process.ppid` field with `process.parent.pid`. {pull}28620[28620]
 - Use data streams instead of indices for storing events from Beats. {pull}28450[28450]
 - Remove option `setup.template.type` and always load composable template with data streams. {pull}28450[28450]
-- Remove several ILM options (`rollover_alias` and `pattern`) as data streams does not require index aliases. {pull}28450[28450] 
+- Remove several ILM options (`rollover_alias` and `pattern`) as data streams does not require index aliases. {pull}28450[28450]
 - Index template's default_fields setting is only populated with ECS fields. {pull}28596[28596] {issue}28215[28215]
 - Remove deprecated `--template` and `--ilm-policy` flags. Use `--index-management` instead. {pull}28870[28870]
 - Remove options `logging.files.suffix` and default to datetime endings. {pull}28927[28927]
@@ -355,6 +355,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support in aws-s3 input for custom script parsing of s3 notifications. {pull}28946[28946]
 - Improve error handling in aws-s3 input for malformed s3 notifications. {issue}28828[28828] {pull}28946[28946]
 - Add support for parsers on journald input {pull}29070[29070]
+- Add elapsed time information to `aws-s3` input errors and log messages. {pull}29328[29328]
 - Add support in httpjson input for oAuth2ProviderDefault of password grant_type. {pull}29087[29087]
 
 *Heartbeat*

--- a/x-pack/filebeat/input/awss3/sqs.go
+++ b/x-pack/filebeat/input/awss3/sqs.go
@@ -88,7 +88,10 @@ func (r *sqsReader) Receive(ctx context.Context) error {
 				}()
 
 				if err := r.msgHandler.ProcessSQS(ctx, &msg); err != nil {
-					r.log.Warnw("Failed processing SQS message.", "error", err, "message_id", *msg.MessageId)
+					r.log.Warnw("Failed processing SQS message.",
+						"error", err,
+						"message_id", *msg.MessageId,
+						"elapsed_time_ns", time.Since(start))
 				}
 			}(msg, time.Now())
 		}

--- a/x-pack/filebeat/input/awss3/sqs_s3_event.go
+++ b/x-pack/filebeat/input/awss3/sqs_s3_event.go
@@ -265,7 +265,7 @@ func (p *sqsS3EventProcessor) processS3Events(ctx context.Context, log *logp.Log
 	defer acker.Wait()
 
 	var errs []error
-	for _, event := range s3Events {
+	for i, event := range s3Events {
 		s3Processor := p.s3ObjectHandler.Create(ctx, log, acker, event)
 		if s3Processor == nil {
 			continue
@@ -274,8 +274,8 @@ func (p *sqsS3EventProcessor) processS3Events(ctx context.Context, log *logp.Log
 		// Process S3 object (download, parse, create events).
 		if err := s3Processor.ProcessS3Object(); err != nil {
 			errs = append(errs, errors.Wrapf(err,
-				"failed processing S3 event for object key %q in bucket %q",
-				event.S3.Object.Key, event.S3.Bucket.Name))
+				"failed processing S3 event for object key %q in bucket %q (object record %d of %d in SQS notification)",
+				event.S3.Object.Key, event.S3.Bucket.Name, i+1, len(s3Events)))
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

This adds elapsed_time_ns into S3 object read errors and SQS processing warning log messages. This gives context about how long it took to fail. Extended times could be an indicator of a blocked output.

It also adds the number of S3 records contained in the SQS notification to error messages. This gives context about how many S3 objects were being processed when a failure occurs.

## Why is it important?

This helps give more context around errors.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs / Errors

`failed to get s3 object (elasped_time_ns=16284): fake connectivity failure`

`failed processing SQS message (it will return to queue after visibility timeout): failed processing S3 event for object key "log.json" in bucket "foo" (object record 1 of 1 in SQS notification): fake connectivity problem`

`{"log.level":"warn","@timestamp":"2021-12-07T15:33:00.129-0500","log.logger":"aws-s3","log.origin":{"file.name":"awss3/sqs.go","file.line":91},"message":"Failed processing SQS message.","error":{"message":"fake connectivity failure"},"message_id":"9c68cbc8-f415-0dfc-c484-0203cd1a0c23","elapsed_time_ns":77483,"ecs.version":"1.6.0"}`
