### PR TITLE
[Winlogbeat] Add support for custom XML queries

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -27,7 +27,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - add_docker_metadata processor: Replace usage of deprecated `process.ppid` field with `process.parent.pid`. {pull}28620[28620]
 - Use data streams instead of indices for storing events from Beats. {pull}28450[28450]
 - Remove option `setup.template.type` and always load composable template with data streams. {pull}28450[28450]
-- Remove several ILM options (`rollover_alias` and `pattern`) as data streams does not require index aliases. {pull}28450[28450] 
+- Remove several ILM options (`rollover_alias` and `pattern`) as data streams does not require index aliases. {pull}28450[28450]
 - Index template's default_fields setting is only populated with ECS fields. {pull}28596[28596] {issue}28215[28215]
 - Remove deprecated `--template` and `--ilm-policy` flags. Use `--index-management` instead. {pull}28870[28870]
 - Remove options `logging.files.suffix` and default to datetime endings. {pull}28927[28927]
@@ -393,7 +393,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add more DNS error codes to the Sysmon module. {issue}15685[15685]
 - Add support for event language selection from config file {pull}19818[19818]
 - Add configuration option for registry file flush timeout {issue}29001[29001] {pull}29053[29053]
-- Add support for custom XML queries {issue}1054[1054] {pull}XXXX[XXXX]
+- Add support for custom XML queries {issue}1054[1054] {pull}29330[29330]
 
 *Elastic Log Driver*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -393,6 +393,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add more DNS error codes to the Sysmon module. {issue}15685[15685]
 - Add support for event language selection from config file {pull}19818[19818]
 - Add configuration option for registry file flush timeout {issue}29001[29001] {pull}29053[29053]
+- Add support for custom XML queries {issue}1054[1054] {pull}XXXX[XXXX]
 
 *Elastic Log Driver*
 

--- a/winlogbeat/_meta/config/header.yml.tmpl
+++ b/winlogbeat/_meta/config/header.yml.tmpl
@@ -26,7 +26,8 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. Please
+# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
+# must not be used with the ignore_older, level, event_id, or provider keys. Please
 # visit the documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig

--- a/winlogbeat/_meta/config/header.yml.tmpl
+++ b/winlogbeat/_meta/config/header.yml.tmpl
@@ -26,8 +26,9 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
-# must not be used with the ignore_older, level, event_id, or provider keys. Please
-# visit the documentation for the complete details of each option.
+# The supported keys are name, id, xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml.
+# The xml_query key requires an id and must not be used with the name,
+# ignore_older, level, event_id, or provider keys. Please visit the
+# documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -180,7 +180,7 @@ The name key must not be used with custom XML queries.
 A unique identifier for the event log. This key is required when using a custom
 XML query.
 
-In other cases, it can be used to uniquely identify an event log. This is
+It is used to uniquely identify the event log reader in the registry file. This is
 useful if multiple event logs are being set up to watch the same channel or file. If an
 ID is not given, the `event_logs.name` value will be used.
 
@@ -381,7 +381,7 @@ winlogbeat.event_logs:
       </QueryList>
 --------------------------------------------------------------------------------
 
-XML queries may also be created in Event Viewer using custom views. The query
+XML queries may also be created in Windows Event Viewer using custom views. The query
 can be created using a graphical interface and the corresponding XML can be
 retrieved from the XML tab.
 

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -112,9 +112,9 @@ reading additional event log records.
 ==== `event_logs.name`
 
 The name of the event log to monitor. Each dictionary under `event_logs` must
-have a `name` field. You can get a list of available event logs by running
-`Get-EventLog *` in PowerShell.  Here is a sample of the output from the
-command:
+have a `name` field, except for those which use a custom XML query. You can
+get a list of available event logs by running `Get-EventLog *` in PowerShell.
+Here is a sample of the output from the command:
 
 [source,sh]
 --------------------------------------------------------------------------------
@@ -135,8 +135,6 @@ Channel names can also be specified if running on Windows Vista or newer. A
 channel is a named stream of events that transports events from an event source
 to an event log. Most channels are tied to specific event publishers. Here is an
 example showing how to list all channels using PowerShell.
-
-The name key must not be used with custom XML queries.
 
 [source,sh]
 --------------------------------------------------------------------------------
@@ -173,6 +171,8 @@ of how to read from an .evtx file in the <<reading-from-evtx,FAQ>>.
 winlogbeat.event_logs:
   - name: 'C:\backup\sysmon-2019.08.evtx'
 --------------------------------------------------------------------------------
+
+The name key must not be used with custom XML queries.
 
 [float]
 ==== `event_logs.id`

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -137,6 +137,9 @@ channel is a named stream of events that transports events from an event source
 to an event log. Most channels are tied to specific event publishers. Here is an
 example showing how to list all channels using PowerShell.
 
+If a custom XML query is provided, the name will act as an identifier for this
+event log.
+
 [source,sh]
 --------------------------------------------------------------------------------
 PS C:\> Get-WinEvent -ListLog * | Format-List -Property LogName
@@ -334,6 +337,35 @@ VSSAudit
 Microsoft-Windows-Security-Auditing
 Microsoft-Windows-Eventlog
 --------------------------------------------------------------------------------
+
+[float]
+==== `event_logs.xml_query`
+
+Provide a custom XML query. This option is mutually exclusive with the `event_id`,
+`ignore_older`, `level`, and `provider` options. These options should be included in
+the XML query directly. Custom XML queries provide more flexibility and advanced
+options than the simpler query options in {beatname_uc}.
+*{vista_and_newer}*
+
+Here is a configuration which will collect DHCP server events from multiple channels:
+
+[source,yaml]
+--------------------------------------------------------------------------------
+winlogbeat.event_logs:
+  - name: dhcp-server
+    xml_query: >
+      <QueryList>
+        <Query Id="0" Path="DhcpAdminEvents">
+          <Select Path="DhcpAdminEvents">*</Select>
+          <Select Path="Microsoft-Windows-Dhcp-Server/FilterNotifications">*</Select>
+          <Select Path="Microsoft-Windows-Dhcp-Server/Operational">*</Select>
+        </Query>
+      </QueryList>
+--------------------------------------------------------------------------------
+
+XML queries may also be created in Event Viewer using custom views. The query
+can be created using a graphical interface and the corresponding XML can be
+retrieved from the XML tab.
 
 [float]
 ==== `event_logs.include_xml`

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -87,7 +87,6 @@ winlogbeat.shutdown_timeout: 30s
 A list of entries (called 'dictionaries' in YAML) that specify which event logs
 to monitor. Each entry in the list defines an event log to monitor as well as
 any information to be associated with the event log (filter, tags, and so on).
-The `name` field is the only required field for each event log.
 
 [source,yaml]
 --------------------------------------------------------------------------------
@@ -137,8 +136,7 @@ channel is a named stream of events that transports events from an event source
 to an event log. Most channels are tied to specific event publishers. Here is an
 example showing how to list all channels using PowerShell.
 
-If a custom XML query is provided, the name will act as an identifier for this
-event log.
+The name key must not be used with custom XML queries.
 
 [source,sh]
 --------------------------------------------------------------------------------
@@ -174,6 +172,26 @@ of how to read from an .evtx file in the <<reading-from-evtx,FAQ>>.
 --------------------------------------------------------------------------------
 winlogbeat.event_logs:
   - name: 'C:\backup\sysmon-2019.08.evtx'
+--------------------------------------------------------------------------------
+
+[float]
+==== `event_logs.id`
+
+A unique identifier for the event log. This key is required when using a custom
+XML query.
+
+In other cases, it can be used to uniquely identify an event log. This is
+useful if multiple event logs are being set up to watch the same channel or file. If an
+ID is not given, the `event_logs.name` value will be used.
+
+This value must be unique.
+
+[source,yaml]
+--------------------------------------------------------------------------------
+winlogbeat.event_logs:
+  - name: Application
+    id: application-logs
+    ignore_older: 168h
 --------------------------------------------------------------------------------
 
 [float]
@@ -341,10 +359,10 @@ Microsoft-Windows-Eventlog
 [float]
 ==== `event_logs.xml_query`
 
-Provide a custom XML query. This option is mutually exclusive with the `event_id`,
+Provide a custom XML query. This option is mutually exclusive with the `name`, `event_id`,
 `ignore_older`, `level`, and `provider` options. These options should be included in
-the XML query directly. Custom XML queries provide more flexibility and advanced
-options than the simpler query options in {beatname_uc}.
+the XML query directly. Furthermore, an `id` must be provided. Custom XML queries
+provide more flexibility and advanced options than the simpler query options in {beatname_uc}.
 *{vista_and_newer}*
 
 Here is a configuration which will collect DHCP server events from multiple channels:
@@ -352,7 +370,7 @@ Here is a configuration which will collect DHCP server events from multiple chan
 [source,yaml]
 --------------------------------------------------------------------------------
 winlogbeat.event_logs:
-  - name: dhcp-server
+  - id: dhcp-server-logs
     xml_query: >
       <QueryList>
         <Query Id="0" Path="DhcpAdminEvents">

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -31,6 +31,7 @@ import (
 type ConfigCommon struct {
 	API      string `config:"api"`       // Name of the API to use. Optional.
 	Name     string `config:"name"`      // Name of the event log or channel or file.
+	ID       string `config:"id"`        // Identifier for the event log.
 	XMLQuery string `config:"xml_query"` // Custom query XML. Must not be used with the keys from eventlog.query.
 }
 

--- a/winlogbeat/eventlog/factory.go
+++ b/winlogbeat/eventlog/factory.go
@@ -29,8 +29,9 @@ import (
 // EventLog. Each implementation is free to support additional configuration
 // options.
 type ConfigCommon struct {
-	API  string `config:"api"`  // Name of the API to use. Optional.
-	Name string `config:"name"` // Name of the event log or channel or file.
+	API      string `config:"api"`       // Name of the API to use. Optional.
+	Name     string `config:"name"`      // Name of the event log or channel or file.
+	XMLQuery string `config:"xml_query"` // Custom query XML. Must not be used with the keys from eventlog.query.
 }
 
 type validator interface {

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -402,7 +402,6 @@ func newEventLogging(options *common.Config) (EventLog, error) {
 // using the Windows Event Log.
 func newWinEventLog(options *common.Config) (EventLog, error) {
 	var xmlQuery string
-	var channelName string
 	var err error
 
 	c := defaultWinEventLogConfig
@@ -415,7 +414,6 @@ func newWinEventLog(options *common.Config) (EventLog, error) {
 		xmlQuery = c.XMLQuery
 		id = c.ID
 	} else {
-		channelName = c.Name
 		if id == "" {
 			id = c.Name
 		}
@@ -455,7 +453,7 @@ func newWinEventLog(options *common.Config) (EventLog, error) {
 		id:          id,
 		config:      c,
 		query:       xmlQuery,
-		channelName: channelName,
+		channelName: c.Name,
 		file:        filepath.IsAbs(c.Name),
 		maxRead:     c.BatchReadSize,
 		renderBuf:   make([]byte, renderBufferSize),

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -412,7 +412,6 @@ func newWinEventLog(options *common.Config) (EventLog, error) {
 	id := c.ID
 	if c.XMLQuery != "" {
 		xmlQuery = c.XMLQuery
-		id = c.ID
 	} else {
 		if id == "" {
 			id = c.Name

--- a/winlogbeat/eventlog/wineventlog_experimental.go
+++ b/winlogbeat/eventlog/wineventlog_experimental.go
@@ -47,6 +47,7 @@ const (
 type winEventLogExp struct {
 	config      winEventLogConfig
 	query       string
+	id          string                   // Identifier of this event log.
 	channelName string                   // Name of the channel from which to read.
 	file        bool                     // Reading from file rather than channel.
 	maxRead     int                      // Maximum number returned in one Read.
@@ -59,7 +60,7 @@ type winEventLogExp struct {
 
 // Name returns the name of the event log (i.e. Application, Security, etc.).
 func (l *winEventLogExp) Name() string {
-	return l.channelName
+	return l.id
 }
 
 func (l *winEventLogExp) Open(state checkpoint.EventLogState) error {
@@ -205,11 +206,11 @@ func (l *winEventLogExp) processHandle(h win.EvtHandle) (*Record, error) {
 	}
 
 	if l.file {
-		r.File = l.channelName
+		r.File = l.id
 	}
 
 	r.Offset = checkpoint.EventLogState{
-		Name:         l.channelName,
+		Name:         l.id,
 		RecordNumber: r.RecordID,
 		Timestamp:    r.TimeCreated.SystemTime,
 	}
@@ -241,6 +242,11 @@ func (l *winEventLogExp) Close() error {
 // newWinEventLogExp creates and returns a new EventLog for reading event logs
 // using the Windows Event Log.
 func newWinEventLogExp(options *common.Config) (EventLog, error) {
+	var xmlQuery string
+	var err error
+	var isFile bool
+	var log *logp.Logger
+
 	cfgwarn.Experimental("The %s event log reader is experimental.", winEventLogExpAPIName)
 
 	c := winEventLogConfig{BatchReadSize: 512}
@@ -248,29 +254,38 @@ func newWinEventLogExp(options *common.Config) (EventLog, error) {
 		return nil, err
 	}
 
-	queryLog := c.Name
-	isFile := false
-	if info, err := os.Stat(c.Name); err == nil && info.Mode().IsRegular() {
-		path, err := filepath.Abs(c.Name)
+	id := c.ID
+	if c.XMLQuery != "" {
+		xmlQuery = c.XMLQuery
+		log = logp.NewLogger("wineventlog").With("id", id)
+	} else {
+		if id == "" {
+			id = c.Name
+		}
+
+		queryLog := c.Name
+		if info, err := os.Stat(c.Name); err == nil && info.Mode().IsRegular() {
+			path, err := filepath.Abs(c.Name)
+			if err != nil {
+				return nil, err
+			}
+			isFile = true
+			queryLog = "file://" + path
+		}
+
+		xmlQuery, err = win.Query{
+			Log:         queryLog,
+			IgnoreOlder: c.SimpleQuery.IgnoreOlder,
+			Level:       c.SimpleQuery.Level,
+			EventID:     c.SimpleQuery.EventID,
+			Provider:    c.SimpleQuery.Provider,
+		}.Build()
 		if err != nil {
 			return nil, err
 		}
-		isFile = true
-		queryLog = "file://" + path
-	}
 
-	query, err := win.Query{
-		Log:         queryLog,
-		IgnoreOlder: c.SimpleQuery.IgnoreOlder,
-		Level:       c.SimpleQuery.Level,
-		EventID:     c.SimpleQuery.EventID,
-		Provider:    c.SimpleQuery.Provider,
-	}.Build()
-	if err != nil {
-		return nil, err
+		log = logp.NewLogger("wineventlog").With("id", id).With("channel", c.Name)
 	}
-
-	log := logp.NewLogger("wineventlog").With("channel", c.Name)
 
 	renderer, err := win.NewRenderer(win.NilHandle, log)
 	if err != nil {
@@ -279,7 +294,8 @@ func newWinEventLogExp(options *common.Config) (EventLog, error) {
 
 	l := &winEventLogExp{
 		config:      c,
-		query:       query,
+		query:       xmlQuery,
+		id:          id,
 		channelName: c.Name,
 		file:        isFile,
 		maxRead:     c.BatchReadSize,

--- a/winlogbeat/eventlog/wineventlog_experimental.go
+++ b/winlogbeat/eventlog/wineventlog_experimental.go
@@ -255,14 +255,14 @@ func newWinEventLogExp(options *common.Config) (EventLog, error) {
 	}
 
 	id := c.ID
+	if id == "" {
+		id = c.Name
+	}
+
 	if c.XMLQuery != "" {
 		xmlQuery = c.XMLQuery
 		log = logp.NewLogger("wineventlog").With("id", id)
 	} else {
-		if id == "" {
-			id = c.Name
-		}
-
 		queryLog := c.Name
 		if info, err := os.Stat(c.Name); err == nil && info.Mode().IsRegular() {
 			path, err := filepath.Abs(c.Name)

--- a/winlogbeat/eventlog/wineventlog_test.go
+++ b/winlogbeat/eventlog/wineventlog_test.go
@@ -39,8 +39,13 @@ import (
 
 const (
 	// Names that are registered by the test for logging events.
-	providerName = "WinlogbeatTestGo"
-	sourceName   = "Integration Test"
+	providerName   = "WinlogbeatTestGo"
+	sourceName     = "Integration Test"
+	customXMLQuery = `<QueryList>
+    <Query Id="0" Path="WinlogbeatTestGo">
+        <Select Path="WinlogbeatTestGo">*</Select>
+    </Query>
+</QueryList>`
 
 	// Event message files used when logging events.
 
@@ -53,6 +58,116 @@ const (
 	// netevent.dll has messages that require no message parameters.
 	netEventMsgFile = "%SystemRoot%\\System32\\netevent.dll"
 )
+
+func TestWinEventLogConfig_Validate(t *testing.T) {
+	tests := []struct {
+		In      winEventLogConfig
+		WantErr bool
+		Desc    string
+	}{
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					ID:       "test",
+					XMLQuery: customXMLQuery,
+				},
+			},
+			WantErr: false,
+			Desc:    "xml query: all good",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					ID:       "test",
+					XMLQuery: customXMLQuery[:len(customXMLQuery)-4], // Malformed XML by truncation.
+				},
+			},
+			WantErr: true,
+			Desc:    "xml query: malformed XML",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					XMLQuery: customXMLQuery,
+				},
+			},
+			WantErr: true,
+			Desc:    "xml query: missing ID",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					ID:       "test",
+					Name:     "test",
+					XMLQuery: customXMLQuery,
+				},
+			},
+			WantErr: true,
+			Desc:    "xml query: conflicting keys (xml query and name)",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					ID:       "test",
+					XMLQuery: customXMLQuery,
+				},
+				SimpleQuery: query{IgnoreOlder: 1},
+			},
+			WantErr: true,
+			Desc:    "xml query: conflicting keys (xml query and ignore_older)",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					ID:       "test",
+					XMLQuery: customXMLQuery,
+				},
+				SimpleQuery: query{Level: "error"},
+			},
+			WantErr: true,
+			Desc:    "xml query: conflicting keys (xml query and level)",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					ID:       "test",
+					XMLQuery: customXMLQuery,
+				},
+				SimpleQuery: query{EventID: "1000"},
+			},
+			WantErr: true,
+			Desc:    "xml query: conflicting keys (xml query and event_id)",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{
+					ID:       "test",
+					XMLQuery: customXMLQuery,
+				},
+				SimpleQuery: query{Provider: []string{providerName}},
+			},
+			WantErr: true,
+			Desc:    "xml query: conflicting keys (xml query and provider)",
+		},
+		{
+			In: winEventLogConfig{
+				ConfigCommon: ConfigCommon{},
+			},
+			WantErr: true,
+			Desc:    "missing name",
+		},
+	}
+
+	for _, tc := range tests {
+		gotErr := tc.In.Validate()
+
+		if tc.WantErr {
+			assert.NotNil(t, gotErr, tc.Desc)
+		} else {
+			assert.Nil(t, gotErr, "%q got unexpected err: %v", tc.Desc, gotErr)
+		}
+	}
+}
 
 func TestWindowsEventLogAPI(t *testing.T) {
 	testWindowsEventLog(t, winEventLogAPIName)
@@ -78,6 +193,34 @@ func testWindowsEventLog(t *testing.T, api string) {
 	openLog := func(t testing.TB, config map[string]interface{}) EventLog {
 		return openLog(t, api, nil, config)
 	}
+
+	// Test reading from an event log using a custom XML query.
+	t.Run("custom_xml_query", func(t *testing.T) {
+		cfg := map[string]interface{}{
+			"id":        "custom-xml-query",
+			"xml_query": customXMLQuery,
+		}
+
+		log := openLog(t, cfg)
+		defer log.Close()
+
+		var eventCount int
+
+		for eventCount < totalEvents {
+			records, err := log.Read()
+			if err != nil {
+				t.Fatal("read error", err)
+			}
+			if len(records) == 0 {
+				t.Fatal("read returned 0 records")
+			}
+
+			t.Logf("Read() returned %d events.", len(records))
+			eventCount += len(records)
+		}
+
+		assert.Equal(t, totalEvents, eventCount)
+	})
 
 	t.Run("batch_read_size_config", func(t *testing.T) {
 		const batchReadSize = 2

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -24,10 +24,11 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
-# must not be used with the ignore_older, level, event_id, or provider keys. Please
-# visit the documentation for the complete details of each option.
+# The supported keys are name, id, xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml.
+# The xml_query key requires an id and must not be used with the name,
+# ignore_older, level, event_id, or provider keys. Please visit the
+# documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 
 winlogbeat.event_logs:

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -24,8 +24,9 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. Please
+# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
+# must not be used with the ignore_older, level, event_id, or provider keys. Please
 # visit the documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -13,10 +13,11 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
-# must not be used with the ignore_older, level, event_id, or provider keys. Please
-# visit the documentation for the complete details of each option.
+# The supported keys are name, id, xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml.
+# The xml_query key requires an id and must not be used with the name,
+# ignore_older, level, event_id, or provider keys. Please visit the
+# documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 
 winlogbeat.event_logs:

--- a/winlogbeat/winlogbeat.yml
+++ b/winlogbeat/winlogbeat.yml
@@ -13,8 +13,9 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. Please
+# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
+# must not be used with the ignore_older, level, event_id, or provider keys. Please
 # visit the documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -24,10 +24,11 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
-# must not be used with the ignore_older, level, event_id, or provider keys. Please
-# visit the documentation for the complete details of each option.
+# The supported keys are name, id, xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml.
+# The xml_query key requires an id and must not be used with the name,
+# ignore_older, level, event_id, or provider keys. Please visit the
+# documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 
 winlogbeat.event_logs:

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -24,8 +24,9 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. Please
+# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
+# must not be used with the ignore_older, level, event_id, or provider keys. Please
 # visit the documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -13,10 +13,11 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
-# must not be used with the ignore_older, level, event_id, or provider keys. Please
-# visit the documentation for the complete details of each option.
+# The supported keys are name, id, xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml.
+# The xml_query key requires an id and must not be used with the name,
+# ignore_older, level, event_id, or provider keys. Please visit the
+# documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 
 winlogbeat.event_logs:

--- a/x-pack/winlogbeat/winlogbeat.yml
+++ b/x-pack/winlogbeat/winlogbeat.yml
@@ -13,8 +13,9 @@
 # accompanying options. The YAML data type of event_logs is a list of
 # dictionaries.
 #
-# The supported keys are name (required), tags, fields, fields_under_root,
-# forwarded, ignore_older, level, event_id, provider, and include_xml. Please
+# The supported keys are name (required), xml_query, tags, fields, fields_under_root,
+# forwarded, ignore_older, level, event_id, provider, and include_xml. The xml_query
+# must not be used with the ignore_older, level, event_id, or provider keys. Please
 # visit the documentation for the complete details of each option.
 # https://go.es.io/WinlogbeatConfig
 


### PR DESCRIPTION
## What does this PR do?

- Added new configuration field (xml_query) to support custom XML queries
- This new configuration item will conflict with existing simple
query configuration items (ignore_older, event_id, level, provider)
- Validator has been updated to check for key conflicts and XML syntax,
but does not check for correctness of XML schema.

## Why is it important?

The existing filtering options for Winlogbeat don't provide enough control when trying to filter out unwanted events. A user may want to include multiple channels in the same query or filter out certain SIDs. Custom XML queries provide a very powerful mechanism for fine tuning what events should be searched.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- A quick way to generate XML queries is to create a custom view in Event Viewer and export the XML. This can be pasted as-is into a winlogbeat config:
```yaml
winlogbeat.event_logs:
  - name: dhcp-server
    xml_query: >
      <QueryList>
        <Query Id="0" Path="DhcpAdminEvents">
          <Select Path="DhcpAdminEvents">*</Select>
          <Select Path="Microsoft-Windows-Dhcp-Server/FilterNotifications">*</Select>
          <Select Path="Microsoft-Windows-Dhcp-Server/Operational">*</Select>
        </Query>
      </QueryList>
```
- The bookmark should be written to the registry file:
```yaml
- name: microsoft-dhcp
  record_number: 10
  timestamp: 2021-12-06T20:40:54.198229Z
  bookmark: "<BookmarkList>\r\n  <Bookmark Channel='DhcpAdminEvents' RecordId='0'/>\r\n
    \ <Bookmark Channel='Microsoft-Windows-Dhcp-Server/FilterNotifications' RecordId='0'/>\r\n
    \ <Bookmark Channel='Microsoft-Windows-Dhcp-Server/Operational' RecordId='10'
    IsCurrent='true'/>\r\n</BookmarkList>"
```
- There should be one bookmark per channel at minimum. I believe this is being generated by Windows, so in theory it should always do the right thing here, regardless of how complicated the query becomes. The `record_number` at the top-level registry entry is irrelevant here, since winlogbeat will always select the bookmark value(s) first. The record_number is only used in cases where custom queries are NOT given and no bookmark was produced previously (I've never seen this occur, so I'm not sure under what circumstances this will happen).

## Related issues

- Closes #1054
