### PR TITLE
Drop event batch when get HTTP status 413 from ES

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -68,6 +68,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove `event.dataset` (ECS) annotion from `libbeat.logp`. {issue}27404[27404]
 - Errors should be thrown as errors. Metricsets inside Metricbeat will now throw errors as the `error` log level. {pull}27804[27804]
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
+- Drop event batch when get HTTP status 413 from Elasticsearch to avoid infinite loop {issue}14350[14350] {pull}29368[29368]
 
 ==== Added
 

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -38,6 +38,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/testing"
 )
 
+var errPayloadTooLarge = errors.New("the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped")
+
 // Client is an elasticsearch client.
 type Client struct {
 	conn eslegclient.Connection
@@ -180,9 +182,13 @@ func (client *Client) Clone() *Client {
 func (client *Client) Publish(ctx context.Context, batch publisher.Batch) error {
 	events := batch.Events()
 	rest, err := client.publishEvents(ctx, events)
-	if len(rest) == 0 {
+
+	switch {
+	case err == errPayloadTooLarge:
+		batch.Drop()
+	case len(rest) == 0:
 		batch.ACK()
-	} else {
+	default:
 		batch.RetryEvents(rest)
 	}
 	return err
@@ -220,7 +226,11 @@ func (client *Client) publishEvents(ctx context.Context, data []publisher.Event)
 	}
 
 	status, result, sendErr := client.conn.Bulk(ctx, "", "", nil, bulkItems)
+
 	if sendErr != nil {
+		if status == http.StatusRequestEntityTooLarge {
+			sendErr = errPayloadTooLarge
+		}
 		err := apm.CaptureError(ctx, fmt.Errorf("failed to perform any bulk index operations: %w", sendErr))
 		err.Send()
 		client.log.Error(err)

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -44,6 +44,103 @@ import (
 	"github.com/elastic/beats/v7/libbeat/version"
 )
 
+type testIndexSelector struct{}
+
+func (testIndexSelector) Select(event *beat.Event) (string, error) {
+	return "test", nil
+}
+
+type batchMock struct {
+	// we embed the interface so we are able to implement the interface partially,
+	// only functions needed for tests are implemented
+	// if you use a function that is not implemented in the mock it will panic
+	publisher.Batch
+	events      []publisher.Event
+	ack         bool
+	drop        bool
+	retryEvents []publisher.Event
+}
+
+func (bm batchMock) Events() []publisher.Event {
+	return bm.events
+}
+func (bm *batchMock) ACK() {
+	bm.ack = true
+}
+func (bm *batchMock) Drop() {
+	bm.drop = true
+}
+func (bm *batchMock) RetryEvents(events []publisher.Event) {
+	bm.retryEvents = events
+}
+
+func TestPublishStatusCode(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	event := publisher.Event{Content: beat.Event{Fields: common.MapStr{"field": 1}}}
+	events := []publisher.Event{event}
+
+	t.Run("returns pre-defined error and drops batch when 413", func(t *testing.T) {
+		esMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			w.Write([]byte("Request failed to get to the server (status code: 413)")) // actual response from ES
+		}))
+		defer esMock.Close()
+
+		client, err := NewClient(
+			ClientSettings{
+				ConnectionSettings: eslegclient.ConnectionSettings{
+					URL: esMock.URL,
+				},
+				Index: testIndexSelector{},
+			},
+			nil,
+		)
+		assert.NoError(t, err)
+
+		event := publisher.Event{Content: beat.Event{Fields: common.MapStr{"field": 1}}}
+		events := []publisher.Event{event}
+		batch := &batchMock{
+			events: events,
+		}
+
+		err = client.Publish(ctx, batch)
+
+		assert.Error(t, err)
+		assert.Equal(t, errPayloadTooLarge, err, "should be a pre-defined error")
+		assert.True(t, batch.drop, "should must be dropped")
+	})
+
+	t.Run("retries the batch if bad HTTP status", func(t *testing.T) {
+		esMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer esMock.Close()
+
+		client, err := NewClient(
+			ClientSettings{
+				ConnectionSettings: eslegclient.ConnectionSettings{
+					URL: esMock.URL,
+				},
+				Index: testIndexSelector{},
+			},
+			nil,
+		)
+		assert.NoError(t, err)
+
+		batch := &batchMock{
+			events: events,
+		}
+
+		err = client.Publish(ctx, batch)
+
+		assert.Error(t, err)
+		assert.False(t, batch.ack, "should not be acknowledged")
+		assert.Len(t, batch.retryEvents, len(events), "all events should be in retry")
+	})
+}
+
 func TestCollectPublishFailsNone(t *testing.T) {
 	client, err := NewClient(
 		ClientSettings{


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

To prevent infinite loops when having `http.max_content_length` set
too low or `bulk_max_size` too high we now handle this status code
separately and drop the whole event batch producing a detailed error
message on the console.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Because without this change beats are forever stuck once they get the first 413 response from Elasticsearch.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~I have made corresponding changes to the documentation~
~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Run Elastisearch locally with its default configuration
2. Prepare a configuration file for filebeat that ingests a log file:

`your_filebeat.yml`
```yaml
filebeat:
  inputs:
    - type: log
      paths:
        - /path/to/your/file.log
output:
  elasticsearch:
    hosts: ["localhost:9200"]
```

**Notice, the filename must be changed to your location**

3. Compile filebeat out of this branch
4. Run `filebeat setup -e -c your_filebeat.yml`
5. Once the setup succeeds stop the filebeat
6. Restart Elasticsearch using this configuration:
```yaml
http:
  max_content_length: 100KB
  compression: false
```
Now it's easier to cause 413 in Elasticsearch because of the lower limit, however, we had to run `filebeat setup` before we set this limit in order to create required indices out of templates, otherwise the templates would be too large.

6. Run the compiled filebeat for ingestion `filebeat -e -c your_filebeat.yml`
7. Prepare this script that generates random strings of the given size or use your own approach:

`ras.sh`
```bash
#!/bin/bash

len=${1-16}
charset=${2-'a-zA-Z_0-9'}

LC_ALL=C tr -dc $charset </dev/urandom | head -c $len ; echo -n
```

8. Now you can run this command with various size parameters to write into your log file from step 2. 

This will write a message with 10 characters to the log file:

```sh
echo "[DEBUG] $(date) $(./ras.sh 10)" >> /path/to/your/file.log
```

This should work just fine but this one should cause an error:

```sh
echo "[DEBUG] $(date) $(./ras.sh 10)" >> /path/to/your/file.log
echo "[DEBUG] $(date) $(./ras.sh 10)" >> /path/to/your/file.log
sleep 11 # the file is scanned every 10 sec by default
echo "[DEBUG] $(date) $(./ras.sh 105000)" >> /path/to/your/file.log
sleep 11
echo "[DEBUG] $(date) $(./ras.sh 10)" >> /path/to/your/file.log
echo "[DEBUG] $(date) $(./ras.sh 10)" >> /path/to/your/file.log
echo "[DEBUG] $(date) $(./ras.sh 10)" >> /path/to/your/file.log
```

Before this PR you would see this error and filebeat would go in an infinite loop:

```json
{
  "log.level": "error",
  "@timestamp": "2021-12-09T15:30:02.523+0100",
  "log.logger": "elasticsearch",
  "log.origin": {
    "file.name": "elasticsearch/client.go",
    "file.line": 226
  },
  "message": "failed to perform any bulk index operations: 413 Request Entity Too Large: ",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
```

After this PR you would see and no infinite loop:

```json
{
  "log.level": "error",
  "@timestamp": "2021-12-09T16:07:33.509+0100",
  "log.logger": "elasticsearch",
  "log.origin": {
    "file.name": "elasticsearch/client.go",
    "file.line": 236
  },
  "message": "failed to perform any bulk index operations: the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
```

You should see 5 more 10 character messages in the index (via Kibana Discover) after the last command and the big message should be dropped. If there are no `sleep` commands in between, the dropped batch might include short messages as well. For test purposes it's better to keep them.

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
Closes #14350 


