### PR TITLE
[mergify]: forwardport into the master branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
   - name: forward-port patches to master branch
     conditions:
       - merged
-      - label=backport-v8.1.0
+      - label=forwardport-master
     actions:
       backport:
         assignees:


### PR DESCRIPTION
## What does this PR do?

Standardise the backports to be always from the `master`/`main` branch into `7.x`/`8.x` branches. Then use `forwardport-{branch}` to backport from `7.x`/`8.x` branches into the `{branch}` branch

## Why is it important?

This should avoid any misleading with the labels semantic.