### PR TITLE
Change renaming `@timestamp` to copying values in Ingest pipelines

### DIFF
--- a/filebeat/module/nginx/ingress_controller/ingest/pipeline.yml
+++ b/filebeat/module/nginx/ingress_controller/ingest/pipeline.yml
@@ -208,9 +208,9 @@ processors:
       patterns:
         - ^%{IP:source.ip}$
       ignore_failure: true
-  - rename:
-      field: "@timestamp"
-      target_field: event.created
+  - set:
+      copy_from: "@timestamp"
+      field: event.created
   - date:
       field: nginx.ingress_controller.time
       target_field: "@timestamp"

--- a/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
@@ -43,7 +43,6 @@ processors:
 - set:
     copy_from: "@timestamp"
     field: "event.created"
-    ignore_empty_value: true
 - date:
     field: "syslog5424_ts"
     formats: ["ISO8601", "UNIX"]

--- a/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/checkpoint/firewall/ingest/pipeline.yml
@@ -40,10 +40,10 @@ processors:
     - message
     - host
     ignore_missing: true
-- rename:
-    field: "@timestamp"
-    target_field: "event.created"
-    ignore_missing: true
+- set:
+    copy_from: "@timestamp"
+    field: "event.created"
+    ignore_empty_value: true
 - date:
     field: "syslog5424_ts"
     formats: ["ISO8601", "UNIX"]


### PR DESCRIPTION
## What does this PR do?

This PR changes renaming `@timestamp` fields in Ingest pipelines to copying them. 

## Why is it important?

Filebeat sends events to data streams now. However, data streams require `@timestamp` fields in every event. Some Ingest pipelines either get rid of or on failure `@timestamp` is missing from events. This is a problem and the event cannot be indexed.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
