### PR TITLE
[mergify]: keep the house clean for conflicts in automated bumps

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,6 +21,7 @@ pull_request_rules:
       - -merged
       - -closed
       - conflict
+      - -author=apmmachine
     actions:
         comment:
           message: |
@@ -32,6 +33,18 @@ pull_request_rules:
             git merge upstream/{{base}}
             git push upstream {{head}}
             ```
+  - name: close automated pull requests with bump updates if any conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+      - author=apmmachine
+      - label=automation
+    actions:
+      close:
+        message: |
+          This pull request has been automatically closed by Mergify.
+          There are some other up-to-date pull requests.
   - name: automatic approval for automated pull requests with bump updates
     conditions:
       - author=apmmachine


### PR DESCRIPTION
## What does this PR do?

Close obsoleted PRs that are related to the automated bumps when they are in conflict.

For instance: https://github.com/elastic/beats/pull/29385

![image](https://user-images.githubusercontent.com/2871786/146229671-eb23b4ca-366e-47fd-b08c-5b8894574a37.png)


Therefore, it's not needed to be resolved but wait for the more up-to-date PRs to be merged.
