### PR TITLE
[heartbeat] Only add monitor.status to browser summary events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -46,6 +46,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add support for GMT timezone offsets in `decode_cef`. {pull}20993[20993]
 
 *Heartbeat*
+- Only add monitor.status to browser events when summary. {pull}29460[29460]
 
 *Metricbeat*
 

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -150,7 +150,7 @@ func addMonitorStatus(monitorType string, summaryOnly bool) jobs.JobWrapper {
 			if summaryOnly {
 				hasSummary, _ := event.Fields.HasKey("summary.up")
 				if !hasSummary {
-					return nil, nil
+					return cont, nil
 				}
 			}
 

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -51,7 +51,7 @@ func WrapLightweight(js []jobs.Job, stdMonFields stdfields.StdMonitorFields) []j
 		jobs.WrapAll(
 			js,
 			addMonitorMeta(stdMonFields, len(js) > 1),
-			addMonitorStatus(stdMonFields.Type),
+			addMonitorStatus(stdMonFields.Type, false),
 			addMonitorDuration,
 		),
 		func() jobs.JobWrapper {
@@ -66,7 +66,7 @@ func WrapBrowser(js []jobs.Job, stdMonFields stdfields.StdMonitorFields) []jobs.
 	return jobs.WrapAll(
 		js,
 		addMonitorMeta(stdMonFields, len(js) > 1),
-		addMonitorStatus(stdMonFields.Type),
+		addMonitorStatus(stdMonFields.Type, true),
 	)
 }
 
@@ -142,11 +142,17 @@ func timespan(started time.Time, sched *schedule.Schedule, timeout time.Duration
 // by the original Job will be set as a field. The original error will not be
 // passed through as a return value. Errors may still be present but only if there
 // is an actual error wrapping the error.
-
-func addMonitorStatus(monitorType string) jobs.JobWrapper {
+func addMonitorStatus(monitorType string, summaryOnly bool) jobs.JobWrapper {
 	return func(origJob jobs.Job) jobs.Job {
 		return func(event *beat.Event) ([]jobs.Job, error) {
 			cont, err := origJob(event)
+
+			if summaryOnly {
+				hasSummary, _ := event.Fields.HasKey("summary.up")
+				if !hasSummary {
+					return nil, nil
+				}
+			}
 
 			fields := common.MapStr{
 				"monitor": common.MapStr{

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -428,7 +428,6 @@ func TestInlineBrowserJob(t *testing.T) {
 							"id":          testMonFields.ID,
 							"name":        testMonFields.Name,
 							"type":        fields.Type,
-							"status":      "up",
 							"check_group": "inline-check-group",
 						},
 					}),
@@ -450,7 +449,7 @@ var suiteBrowserJobValues = struct {
 	checkGroup: "journey-1-check-group",
 }
 
-func makeSuiteBrowserJob(t *testing.T, u string) jobs.Job {
+func makeSuiteBrowserJob(t *testing.T, u string, summary bool, suiteErr error) jobs.Job {
 	parsed, err := url.Parse(u)
 	require.NoError(t, err)
 	return func(event *beat.Event) (i []jobs.Job, e error) {
@@ -462,7 +461,18 @@ func makeSuiteBrowserJob(t *testing.T, u string) jobs.Job {
 				"check_group": suiteBrowserJobValues.checkGroup,
 			},
 		})
-		return nil, nil
+		if summary {
+			sumFields := common.MapStr{"up": 0, "down": 0}
+			if suiteErr == nil {
+				sumFields["up"] = 1
+			} else {
+				sumFields["down"] = 1
+			}
+			eventext.MergeEventFields(event, common.MapStr{
+				"summary": sumFields,
+			})
+		}
+		return nil, suiteErr
 	}
 }
 
@@ -470,30 +480,65 @@ func TestSuiteBrowserJob(t *testing.T) {
 	fields := testBrowserMonFields
 	urlStr := "http://foo.com"
 	urlU, _ := url.Parse(urlStr)
+	expectedMonFields := lookslike.MustCompile(map[string]interface{}{
+		"monitor": map[string]interface{}{
+			"id":          fmt.Sprintf("%s-%s", testMonFields.ID, suiteBrowserJobValues.id),
+			"name":        fmt.Sprintf("%s - %s", testMonFields.Name, suiteBrowserJobValues.name),
+			"type":        fields.Type,
+			"check_group": suiteBrowserJobValues.checkGroup,
+			"timespan": common.MapStr{
+				"gte": hbtestllext.IsTime,
+				"lt":  hbtestllext.IsTime,
+			},
+		},
+		"url": URLFields(urlU),
+	})
 	testCommonWrap(t, testDef{
-		"simple",
+		"simple", // has no summary fields!
 		fields,
-		[]jobs.Job{makeSuiteBrowserJob(t, urlStr)},
+		[]jobs.Job{makeSuiteBrowserJob(t, urlStr, false, nil)},
 		[]validator.Validator{
-			lookslike.Compose(
-				urlValidator(t, urlStr),
-				lookslike.Strict(
+			lookslike.Strict(
+				lookslike.Compose(
+					urlValidator(t, urlStr),
+					expectedMonFields,
+				))},
+		nil,
+	})
+	testCommonWrap(t, testDef{
+		"with up summary",
+		fields,
+		[]jobs.Job{makeSuiteBrowserJob(t, urlStr, true, nil)},
+		[]validator.Validator{
+			lookslike.Strict(
+				lookslike.Compose(
+					urlValidator(t, urlStr),
+					expectedMonFields,
 					lookslike.MustCompile(map[string]interface{}{
-						"monitor": map[string]interface{}{
-							"id":          fmt.Sprintf("%s-%s", testMonFields.ID, suiteBrowserJobValues.id),
-							"name":        fmt.Sprintf("%s - %s", testMonFields.Name, suiteBrowserJobValues.name),
-							"type":        fields.Type,
-							"check_group": suiteBrowserJobValues.checkGroup,
-							"status":      "up",
-							"timespan": common.MapStr{
-								"gte": hbtestllext.IsTime,
-								"lt":  hbtestllext.IsTime,
-							},
-						},
-						"url": URLFields(urlU),
+						"monitor": map[string]interface{}{"status": "up"},
+						"summary": map[string]interface{}{"up": 1, "down": 0},
 					}),
-				),
-			)},
+				))},
+		nil,
+	})
+	testCommonWrap(t, testDef{
+		"with down summary",
+		fields,
+		[]jobs.Job{makeSuiteBrowserJob(t, urlStr, true, fmt.Errorf("testerr"))},
+		[]validator.Validator{
+			lookslike.Strict(
+				lookslike.Compose(
+					urlValidator(t, urlStr),
+					expectedMonFields,
+					lookslike.MustCompile(map[string]interface{}{
+						"monitor": map[string]interface{}{"status": "down"},
+						"summary": map[string]interface{}{"up": 0, "down": 1},
+						"error": map[string]interface{}{
+							"type":    isdef.IsString,
+							"message": "testerr",
+						},
+					}),
+				))},
 		nil,
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/26325

we now only add monitor status to summary events for browsers. Additionally, this renames the poorly renamed `wrappers/monitor*` to `wrappers/wrappers*`

## Why is it important?

`monitor.status` should really only be set on unique components of events that constitute a full check. For lightweight checks that means checking an individual IP etc. A step represents progress toward a check, not the check itself. Hence this change.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

We'll want to check that this doesn't break any features in the synthetics UI as well. I'd index to kibana and check that nothing breaks.
