### PR TITLE
bump index name version

### DIFF
--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -79,7 +79,7 @@ func (p Product) String() string {
 // MakeXPackMonitoringIndexName method returns the name of the monitoring index for
 // a given product { elasticsearch, kibana, logstash, beats }
 func MakeXPackMonitoringIndexName(product Product) string {
-	const version = "7"
+	const version = "8"
 
 	return fmt.Sprintf(".monitoring-%v-%v-mb", product.xPackMonitoringIndexString(), version)
 }

--- a/metricbeat/helper/elastic/elastic_test.go
+++ b/metricbeat/helper/elastic/elastic_test.go
@@ -38,22 +38,22 @@ func TestMakeXPackMonitoringIndexName(t *testing.T) {
 		{
 			"Elasticsearch monitoring index",
 			Elasticsearch,
-			".monitoring-es-7-mb",
+			".monitoring-es-8-mb",
 		},
 		{
 			"Kibana monitoring index",
 			Kibana,
-			".monitoring-kibana-7-mb",
+			".monitoring-kibana-8-mb",
 		},
 		{
 			"Logstash monitoring index",
 			Logstash,
-			".monitoring-logstash-7-mb",
+			".monitoring-logstash-8-mb",
 		},
 		{
 			"Beats monitoring index",
 			Beats,
-			".monitoring-beats-7-mb",
+			".monitoring-beats-8-mb",
 		},
 	}
 


### PR DESCRIPTION
### Summary
Before 8.x, metricbeat's monitoring packages used to index events with a legacy schema when `xpack.enabled: true` setting was activated. This logic is gone in 8.x and only serves to [target a specific index format](https://github.com/elastic/beats/blob/master/metricbeat/module/elasticsearch/shard/data.go#L136-L139). Since we now index events with a different schema we also need new mappings for the Stack monitoring UI to be compatible.

[These new mappings](https://github.com/elastic/elasticsearch/pull/81744) can't conflict with the current one so they target a version 8 of the `.monitoring-{product}-{version}` pattern. This change bumps the version to target those.

Additional context https://github.com/elastic/kibana/issues/121251