### PR TITLE
Write to rootfields instead of modulefields

### DIFF
--- a/metricbeat/module/kibana/stats/data.go
+++ b/metricbeat/module/kibana/stats/data.go
@@ -123,7 +123,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 		event.Error = elastic.MakeErrorForMissingField("cluster_uuid", elastic.Kibana)
 		return event.Error
 	}
-	event.ModuleFields.Put("elasticsearch.cluster.id", elasticsearchClusterID)
+	event.RootFields.Put("elasticsearch.cluster.id", elasticsearchClusterID)
 
 	// Set service ID
 	uuid, err := dataFields.GetValue("uuid")


### PR DESCRIPTION
### Summary

`elasticsearch.cluster.id` property is currently written to the kibana `ModuleFields` when it should be a top-level field