### PR TITLE
Save docker-compose logs from integration tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -702,6 +702,7 @@ def withBeatsEnv(Map args = [:], Closure body) {
           error("Error '${err.toString()}'")
         } finally {
           if (archive) {
+            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/system-tests/docker-logs/TEST-docker-compose-*.log')
             archiveTestOutput(directory: directory, testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)
           }
           tearDown()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -702,7 +702,7 @@ def withBeatsEnv(Map args = [:], Closure body) {
           error("Error '${err.toString()}'")
         } finally {
           if (archive) {
-            archiveArtifacts(allowEmptyArchive: true, artifacts: 'build/system-tests/docker-logs/TEST-docker-compose-*.log')
+            archiveArtifacts(allowEmptyArchive: true, artifacts: "${directory}/build/system-tests/docker-logs/TEST-docker-compose-*.log")
             archiveTestOutput(directory: directory, testResults: testResults, artifacts: artifacts, id: args.id, upload: upload)
           }
           tearDown()

--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -139,9 +139,9 @@ func (d *DockerIntegrationTester) Test(dir string, mageTarget string, env map[st
 		args...,
 	)
 
-	err = dumpDockerComposeLogs(dir, mageTarget, composeEnv)
+	err = saveDockerComposeLogs(dir, mageTarget, composeEnv)
 	if err != nil && testErr == nil {
-		// dumping docker-compose logs failed but the test didn't.
+		// saving docker-compose logs failed but the test didn't.
 		return err
 	}
 
@@ -166,7 +166,7 @@ func (d *DockerIntegrationTester) Test(dir string, mageTarget string, env map[st
 	return testErr
 }
 
-func dumpDockerComposeLogs(rootDir string, mageTarget string, composeEnv map[string]string) error {
+func saveDockerComposeLogs(rootDir string, mageTarget string, composeEnv map[string]string) error {
 	var (
 		composeLogDir      = filepath.Join(rootDir, "build", "system-tests", "docker-logs")
 		composeLogFileName = filepath.Join(composeLogDir, "TEST-docker-compose-"+mageTarget+".log")

--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -81,7 +81,7 @@ func (d *DockerIntegrationTester) StepRequirements() IntegrationTestSteps {
 }
 
 // Test performs the tests with docker-compose.
-func (d *DockerIntegrationTester) Test(_ string, mageTarget string, env map[string]string) error {
+func (d *DockerIntegrationTester) Test(dir string, mageTarget string, env map[string]string) error {
 	var err error
 	d.buildImagesOnce.Do(func() { err = dockerComposeBuildImages() })
 	if err != nil {
@@ -139,6 +139,12 @@ func (d *DockerIntegrationTester) Test(_ string, mageTarget string, env map[stri
 		args...,
 	)
 
+	err = dumpDockerComposeLogs(dir, mageTarget, composeEnv)
+	if err != nil && testErr == nil {
+		// dumping docker-compose logs failed but the test didn't.
+		return err
+	}
+
 	// Docker-compose rm is noisy. So only pass through stderr when in verbose.
 	out := ioutil.Discard
 	if mg.Verbose() {
@@ -158,6 +164,38 @@ func (d *DockerIntegrationTester) Test(_ string, mageTarget string, env map[stri
 		return err
 	}
 	return testErr
+}
+
+func dumpDockerComposeLogs(rootDir string, mageTarget string, composeEnv map[string]string) error {
+	var (
+		composeLogDir      = filepath.Join(rootDir, "build", "system-tests", "docker-logs")
+		composeLogFileName = filepath.Join(composeLogDir, "TEST-docker-compose-"+mageTarget+".log")
+	)
+
+	if err := os.MkdirAll(composeLogDir, os.ModeDir|os.ModePerm); err != nil {
+		return fmt.Errorf("creating docker log dir: %w", err)
+	}
+
+	composeLogFile, err := os.Create(composeLogFileName)
+	if err != nil {
+		return fmt.Errorf("creating docker log file: %w", err)
+	}
+	defer composeLogFile.Close()
+
+	_, err = sh.Exec(
+		composeEnv,
+		composeLogFile,
+		composeLogFile,
+		"docker-compose",
+		"-p", dockerComposeProjectName(),
+		"logs",
+		"--no-color",
+	)
+	if err != nil {
+		return fmt.Errorf("executing docker-compose logs: %w", err)
+	}
+
+	return nil
 }
 
 // InsideTest performs the tests inside of environment.

--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -184,8 +184,8 @@ func saveDockerComposeLogs(rootDir string, mageTarget string, composeEnv map[str
 
 	_, err = sh.Exec(
 		composeEnv,
-		composeLogFile,
-		composeLogFile,
+		composeLogFile, // stdout
+		composeLogFile, // stderr
 		"docker-compose",
 		"-p", dockerComposeProjectName(),
 		"logs",

--- a/dev-tools/mage/target/common/package.go
+++ b/dev-tools/mage/target/common/package.go
@@ -30,8 +30,10 @@ import (
 func PackageSystemTests() error {
 	excludeds := []string{".ci", ".git", ".github", "vendor", "dev-tools"}
 
-	// include run as it's the directory we want to compress
-	systemTestsDir := filepath.Join("build", "system-tests", "run")
+	// include run and docker-logs as they are the directories we want to compress
+	systemTestsDir := filepath.Join("build", "system-tests")
+	systemTestsRunDir := filepath.Join(systemTestsDir, "run")
+	systemTestsLogDir := filepath.Join(systemTestsDir, "docker-logs")
 	files, err := devtools.FindFilesRecursive(func(path string, _ os.FileInfo) bool {
 		base := filepath.Base(path)
 		for _, excluded := range excludeds {
@@ -40,7 +42,7 @@ func PackageSystemTests() error {
 			}
 		}
 
-		return strings.HasPrefix(path, systemTestsDir)
+		return strings.HasPrefix(path, systemTestsRunDir) || strings.HasPrefix(path, systemTestsLogDir)
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## What does this PR do?

Captures and preserves the docker-compose logs after running integration or system tests. Allows auditing service logs for issues, in particular it enables auditing the Elasticsearch logs for deprecation warnings after test runs.

## Why is it important?

We need to ensure we aren't using any soon to be deprecated Elasticsearch APIs.

## Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

After running `mage goIntegTest` (or `mage pythonIntegTest`) within a beat, the compose logs should be available under `build/system-tests/docker-logs/TEST-docker-compose-goIntegTest.log`. 

Jenkins will automatically upload the docker-compose service logs to Google Cloud Storage when a test fails. You can manually force Jenkins to upload logs for every test suite by editing appropriate archiving step in the top level Jenkins file.

## Related issues

- Relates [#1821](https://github.com/elastic/observability-dev/issues/1821)
- Relates [#29348](https://github.com/elastic/beats/issues/29348)

## Logs

The libbeat tests produce a single deprecation log (below). I have not found any other logs of interest.

```json
{
  "@timestamp": "2021-12-19T18:13:23.917Z",
  "log.level": "WARN",
  "data_stream.dataset": "deprecation.elasticsearch",
  "data_stream.namespace": "default",
  "data_stream.type": "logs",
  "elasticsearch.event.category": "api",
  "event.code": "deprecated_route_PUT_/_template/{name}",
  "message": "Legacy index templates are deprecated in favor of composable templates.",
  "ecs.version": "1.2.0",
  "service.name": "ES_ECS",
  "event.dataset": "deprecation.elasticsearch",
  "process.thread.name": "elasticsearch[5ca57392301f][transport_worker][T#1]",
  "log.logger": "org.elasticsearch.deprecation.rest.RestController",
  "elasticsearch.cluster.uuid": "mdrgEfcUQWqd2Om68ZQNrQ",
  "elasticsearch.node.id": "gUl4JkToTa-VAL00mPqYSQ",
  "elasticsearch.node.name": "5ca57392301f",
  "elasticsearch.cluster.name": "docker-cluster"
}
```
