### PR TITLE
Fix gcp metrics metricset apply aligner to all metric_types (#29513)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -96,6 +96,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Use xpack.enabled on SM modules to write into .monitoring indices when using Metricbeat standalone {pull}28365[28365]
 - Fix in rename processor to ingest metrics for `write.iops` to proper field instead of `write_iops` in rds metricset. {pull}28960[28960]
 - Enhance filter check in kubernetes event metricset. {pull}29470[29470]
+- Fix gcp metrics metricset apply aligner to all metric_types {pull}29514[29513]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metrics_requester.go
@@ -69,22 +69,21 @@ func (r *metricsRequester) Metric(ctx context.Context, serviceName, metricType s
 	return
 }
 
-func (r *metricsRequester) Metrics(ctx context.Context, sdc metricsConfig, metricsMeta map[string]metricMeta) ([]timeSeriesWithAligner, error) {
+func (r *metricsRequester) Metrics(ctx context.Context, serviceName string, aligner string, metricsToCollect map[string]metricMeta) ([]timeSeriesWithAligner, error) {
 	var lock sync.Mutex
 	var wg sync.WaitGroup
 	results := make([]timeSeriesWithAligner, 0)
 
-	aligner := sdc.Aligner
-	for mt, meta := range metricsMeta {
+	for mt, meta := range metricsToCollect {
 		wg.Add(1)
 
 		metricMeta := meta
 		go func(mt string) {
 			defer wg.Done()
 
-			r.logger.Debugf("For metricType %s, metricMeta = %d", mt, metricMeta)
+			r.logger.Debugf("For metricType %s, metricMeta = %d,  aligner = %s", mt, metricMeta, aligner)
 			interval, aligner := getTimeIntervalAligner(metricMeta.ingestDelay, metricMeta.samplePeriod, r.config.period, aligner)
-			ts := r.Metric(ctx, sdc.ServiceName, mt, interval, aligner)
+			ts := r.Metric(ctx, serviceName, mt, interval, aligner)
 			lock.Lock()
 			defer lock.Unlock()
 			results = append(results, ts)

--- a/x-pack/metricbeat/module/gcp/metrics/metricset.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset.go
@@ -165,7 +165,11 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err error) {
 	for _, sdc := range m.MetricsConfig {
 		m.Logger().Debugf("metrics config: %v", sdc)
-		responses, err := m.requester.Metrics(ctx, sdc, m.metricsMeta)
+		metricsToCollect := map[string]metricMeta{}
+		for _, v := range sdc.MetricTypes {
+			metricsToCollect[sdc.AddPrefixTo(v)] = m.metricsMeta[sdc.AddPrefixTo(v)]
+		}
+		responses, err := m.requester.Metrics(ctx, sdc.ServiceName, sdc.Aligner, metricsToCollect)
 		if err != nil {
 			err = errors.Wrapf(err, "error trying to get metrics for project '%s' and zone '%s' or region '%s'", m.config.ProjectID, m.config.Zone, m.config.Region)
 			m.Logger().Error(err)

--- a/x-pack/metricbeat/module/gcp/metrics/metricset.go
+++ b/x-pack/metricbeat/module/gcp/metrics/metricset.go
@@ -165,6 +165,10 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err error) {
 	for _, sdc := range m.MetricsConfig {
 		m.Logger().Debugf("metrics config: %v", sdc)
+		// m.metricsMeta contains all metrics to be collected, not just the one in the current MetricsConfig.
+		// this loop filters the metrics in metricsMeta so requester.Metrics can collect only the appropriate
+		// ones.
+		// See https://github.com/elastic/beats/pull/29514
 		metricsToCollect := map[string]metricMeta{}
 		for _, v := range sdc.MetricTypes {
 			metricsToCollect[sdc.AddPrefixTo(v)] = m.metricsMeta[sdc.AddPrefixTo(v)]


### PR DESCRIPTION
Type of change
- Bug



## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

* Each aligner is applied to all metric types, that will incur more Google monitoring API calls and more costs.

* There are many unnecessary metrics with wrong aligner in MetricBeat events.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

see issue #29513

## Related issues

- Closes #29513  

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

It works as expected. There are only two metrics in events.

![image](https://user-images.githubusercontent.com/12824991/146663939-966e1eed-154d-4d18-8ac9-fdedc17604a0.png)

