### PR TITLE
add/use blocking wait for test data in statsd

### DIFF
--- a/metricbeat/mb/testing/modules.go
+++ b/metricbeat/mb/testing/modules.go
@@ -344,20 +344,20 @@ func NewPushMetricSetV2WithContext(t testing.TB, config interface{}) mb.PushMetr
 	return pushMetricSet
 }
 
-// capturingPushReporterV2 stores all the events and errors from a metricset's
+// CapturingPushReporterV2 stores all the events and errors from a metricset's
 // Run method.
-type capturingPushReporterV2 struct {
+type CapturingPushReporterV2 struct {
 	context.Context
 	eventsC chan mb.Event
 }
 
-func newCapturingPushReporterV2(ctx context.Context) *capturingPushReporterV2 {
-	return &capturingPushReporterV2{Context: ctx, eventsC: make(chan mb.Event)}
+func newCapturingPushReporterV2(ctx context.Context) *CapturingPushReporterV2 {
+	return &CapturingPushReporterV2{Context: ctx, eventsC: make(chan mb.Event)}
 }
 
 // report writes an event to the output channel and returns true. If the output
 // is closed it returns false.
-func (r *capturingPushReporterV2) report(event mb.Event) bool {
+func (r *CapturingPushReporterV2) report(event mb.Event) bool {
 	select {
 	case <-r.Done():
 		// Publisher is stopped.
@@ -368,16 +368,16 @@ func (r *capturingPushReporterV2) report(event mb.Event) bool {
 }
 
 // Event stores the passed-in event into the events array
-func (r *capturingPushReporterV2) Event(event mb.Event) bool {
+func (r *CapturingPushReporterV2) Event(event mb.Event) bool {
 	return r.report(event)
 }
 
 // Error stores the given error into the errors array.
-func (r *capturingPushReporterV2) Error(err error) bool {
+func (r *CapturingPushReporterV2) Error(err error) bool {
 	return r.report(mb.Event{Error: err})
 }
 
-func (r *capturingPushReporterV2) capture(waitEvents int) []mb.Event {
+func (r *CapturingPushReporterV2) capture(waitEvents int) []mb.Event {
 	var events []mb.Event
 	for {
 		select {
@@ -393,7 +393,8 @@ func (r *capturingPushReporterV2) capture(waitEvents int) []mb.Event {
 	}
 }
 
-func (r *capturingPushReporterV2) blockingCapture(waitEvents int) []mb.Event {
+// BlockingCapture blocks until waitEvents n of events are captured
+func (r *CapturingPushReporterV2) BlockingCapture(waitEvents int) []mb.Event {
 	var events []mb.Event
 	for {
 		select {
@@ -418,13 +419,9 @@ func RunPushMetricSetV2(timeout time.Duration, waitEvents int, metricSet mb.Push
 	return r.capture(waitEvents)
 }
 
-// RunPushMetricSetV2BlockingWait runs the given push metricset
-// and block wait for the number of waitEvents
-func RunPushMetricSetV2BlockingWait(waitEvents int, metricSet mb.PushMetricSetV2) []mb.Event {
-	r := newCapturingPushReporterV2(context.Background())
-
-	go metricSet.Run(r)
-	return r.blockingCapture(waitEvents)
+// GetCapturingPushReporterV2 is a factory for a capturing push metricset
+func GetCapturingPushReporterV2() mb.PushReporterV2 {
+	return newCapturingPushReporterV2(context.Background())
 }
 
 // RunPushMetricSetV2WithContext run the given push metricset for the specific amount of

--- a/x-pack/metricbeat/module/airflow/statsd/data_test.go
+++ b/x-pack/metricbeat/module/airflow/statsd/data_test.go
@@ -8,7 +8,10 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"sync"
 	"testing"
+
+	"github.com/elastic/beats/v7/x-pack/metricbeat/module/statsd/server"
 
 	"github.com/stretchr/testify/require"
 
@@ -57,12 +60,22 @@ func TestData(t *testing.T) {
 
 	ms := mbtest.NewPushMetricSetV2(t, getConfig())
 	var events []mb.Event
+	var reporter mb.PushReporterV2
 	done := make(chan interface{})
-	go func() {
-		events = mbtest.RunPushMetricSetV2BlockingWait(1, ms)
-		close(done)
-	}()
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		reporter = mbtest.GetCapturingPushReporterV2()
+		ms.(*server.MetricSet).ServerStart()
+		wg.Done()
 
+		go ms.Run(reporter)
+		events = reporter.(*mbtest.CapturingPushReporterV2).BlockingCapture(1)
+
+		close(done)
+	}(wg)
+
+	wg.Wait()
 	createEvent(t)
 	<-done
 

--- a/x-pack/metricbeat/module/airflow/statsd/data_test.go
+++ b/x-pack/metricbeat/module/airflow/statsd/data_test.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -36,7 +35,7 @@ func getConfig() map[string]interface{} {
 		"host":       STATSD_HOST,
 		"port":       STATSD_PORT,
 		"period":     "100ms",
-		"ttl":        "0s",
+		"ttl":        "1ms",
 	}
 }
 
@@ -60,7 +59,7 @@ func TestData(t *testing.T) {
 	var events []mb.Event
 	done := make(chan interface{})
 	go func() {
-		events = mbtest.RunPushMetricSetV2(30*time.Second, 1, ms)
+		events = mbtest.RunPushMetricSetV2BlockingWait(1, ms)
 		close(done)
 	}()
 

--- a/x-pack/metricbeat/module/statsd/server/server.go
+++ b/x-pack/metricbeat/module/statsd/server/server.go
@@ -71,9 +71,10 @@ func defaultConfig() Config {
 // multiple fetch calls.
 type MetricSet struct {
 	mb.BaseMetricSet
-	server    serverhelper.Server
-	processor *metricProcessor
-	mappings  map[string]StatsdMapping
+	server        serverhelper.Server
+	serverStarted bool
+	processor     *metricProcessor
+	mappings      map[string]StatsdMapping
 }
 
 // New create a new instance of the MetricSet
@@ -191,13 +192,30 @@ func (m *MetricSet) getEvents() []*mb.Event {
 	return events
 }
 
+// ServerStart starts the underlying m.server
+func (m *MetricSet) ServerStart() {
+	if m.serverStarted {
+		return
+	}
+	m.server.Start()
+}
+
+// ServerStop stops the underlying m.server
+func (m *MetricSet) ServerStop() {
+	if !m.serverStarted {
+		return
+	}
+
+	m.server.Stop()
+}
+
 // Run method provides the module with a reporter with which events can be reported.
 func (m *MetricSet) Run(reporter mb.PushReporterV2) {
 	period := m.Module().Config().Period
 
 	// Start event watcher
-	m.server.Start()
-	defer m.server.Stop()
+	m.ServerStart()
+	defer m.ServerStop()
 
 	reportPeriod := time.NewTicker(period)
 	for {

--- a/x-pack/metricbeat/module/statsd/server/server.go
+++ b/x-pack/metricbeat/module/statsd/server/server.go
@@ -198,6 +198,7 @@ func (m *MetricSet) ServerStart() {
 		return
 	}
 	m.server.Start()
+	m.serverStarted = true
 }
 
 // ServerStop stops the underlying m.server
@@ -207,6 +208,7 @@ func (m *MetricSet) ServerStop() {
 	}
 
 	m.server.Stop()
+	m.serverStarted = false
 }
 
 // Run method provides the module with a reporter with which events can be reported.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

Enhancement
## What does this PR do?
Add a blocking wait on airflow.statsd TestData in order to stabilise flaky test due to timeout
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
We have some random failure on the test because of resource constraints that let the timeout expire.
Enforcing a blocking wait remove the timeout
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
