### PR TITLE
elasticsearch module - xpack enabled parity

### DIFF
--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -42,17 +42,15 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	config := struct {
 		ActiveOnly bool `config:"index_recovery.active_only"`
-		XPack      bool `config:"xpack.enabled"`
 	}{
-		ActiveOnly: true,
-		XPack:      false,
+		ActiveOnly: false,
 	}
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
 	localRecoveryPath := recoveryPath
-	if !config.XPack && config.ActiveOnly {
+	if config.ActiveOnly {
 		localRecoveryPath = localRecoveryPath + "?active_only=true"
 	}
 

--- a/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
+++ b/metricbeat/module/elasticsearch/index_recovery/index_recovery.go
@@ -42,15 +42,17 @@ type MetricSet struct {
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	config := struct {
 		ActiveOnly bool `config:"index_recovery.active_only"`
+		XPack      bool `config:"xpack.enabled"`
 	}{
 		ActiveOnly: true,
+		XPack:      false,
 	}
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
 
 	localRecoveryPath := recoveryPath
-	if config.ActiveOnly {
+	if !config.XPack && config.ActiveOnly {
 		localRecoveryPath = localRecoveryPath + "?active_only=true"
 	}
 

--- a/metricbeat/module/elasticsearch/ml_job/_meta/data.json
+++ b/metricbeat/module/elasticsearch/ml_job/_meta/data.json
@@ -22,7 +22,8 @@
             }
         },
         "node": {
-            "id": "27fb1c2fd783"
+            "id": "27fb1c2fd783",
+            "name": "node-1"
         }
     },
     "event": {

--- a/metricbeat/module/elasticsearch/ml_job/data.go
+++ b/metricbeat/module/elasticsearch/ml_job/data.go
@@ -82,6 +82,12 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		event.ModuleFields.Put("cluster.name", info.ClusterName)
 		event.ModuleFields.Put("cluster.id", info.ClusterID)
 
+                if node, exists := job["node"]; exists {
+                    nodeHash := node.(map[string]interface{})
+                    event.ModuleFields.Put("node.id", nodeHash["id"])
+                    event.ModuleFields.Put("node.name", nodeHash["name"])
+                }
+
 		event.MetricSetFields, _ = schema.Apply(job)
 
 		// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`

--- a/metricbeat/module/elasticsearch/ml_job/data.go
+++ b/metricbeat/module/elasticsearch/ml_job/data.go
@@ -81,7 +81,6 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		event.ModuleFields = common.MapStr{}
 		event.ModuleFields.Put("cluster.name", info.ClusterName)
 		event.ModuleFields.Put("cluster.id", info.ClusterID)
-		event.ModuleFields.Put("node.id", info.Name)
 
 		event.MetricSetFields, _ = schema.Apply(job)
 

--- a/metricbeat/module/elasticsearch/ml_job/data.go
+++ b/metricbeat/module/elasticsearch/ml_job/data.go
@@ -82,11 +82,11 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		event.ModuleFields.Put("cluster.name", info.ClusterName)
 		event.ModuleFields.Put("cluster.id", info.ClusterID)
 
-                if node, exists := job["node"]; exists {
-                    nodeHash := node.(map[string]interface{})
-                    event.ModuleFields.Put("node.id", nodeHash["id"])
-                    event.ModuleFields.Put("node.name", nodeHash["name"])
-                }
+		if node, exists := job["node"]; exists {
+			nodeHash := node.(map[string]interface{})
+			event.ModuleFields.Put("node.id", nodeHash["id"])
+			event.ModuleFields.Put("node.name", nodeHash["name"])
+		}
 
 		event.MetricSetFields, _ = schema.Apply(job)
 

--- a/metricbeat/module/elasticsearch/shard/_meta/data.json
+++ b/metricbeat/module/elasticsearch/shard/_meta/data.json
@@ -4,6 +4,9 @@
         "cluster": {
             "id": "WocBBA0QRma0sGpdQ7vLfQ",
             "name": "docker-cluster",
+            "state": {
+                "id": "XNIdeSZxQwyItvGfR5fHSw"
+            },
             "stats": {
                 "state": {
                     "state_uuid": "XNIdeSZxQwyItvGfR5fHSw"

--- a/metricbeat/module/elasticsearch/shard/_meta/data.json
+++ b/metricbeat/module/elasticsearch/shard/_meta/data.json
@@ -4,8 +4,10 @@
         "cluster": {
             "id": "WocBBA0QRma0sGpdQ7vLfQ",
             "name": "docker-cluster",
-            "state": {
-                "id": "XNIdeSZxQwyItvGfR5fHSw"
+            "stats": {
+                "state": {
+                    "state_uuid": "XNIdeSZxQwyItvGfR5fHSw"
+                }
             }
         },
         "index": {

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -72,6 +72,7 @@ func eventsMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 					ModuleFields: common.MapStr{},
 				}
 
+				event.ModuleFields.Put("cluster.state.id", stateData.StateID)
 				event.ModuleFields.Put("cluster.stats.state.state_uuid", stateData.StateID)
 				event.ModuleFields.Put("cluster.id", stateData.ClusterID)
 				event.ModuleFields.Put("cluster.name", stateData.ClusterName)

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -72,7 +72,7 @@ func eventsMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 					ModuleFields: common.MapStr{},
 				}
 
-				event.ModuleFields.Put("cluster.state.id", stateData.StateID)
+				event.ModuleFields.Put("cluster.stats.state.state_uuid", stateData.StateID)
 				event.ModuleFields.Put("cluster.id", stateData.ClusterID)
 				event.ModuleFields.Put("cluster.name", stateData.ClusterName)
 

--- a/metricbeat/module/elasticsearch/shard/data.go
+++ b/metricbeat/module/elasticsearch/shard/data.go
@@ -117,6 +117,7 @@ func eventsMapping(r mb.ReporterV2, content []byte, isXpack bool) error {
 						errs = append(errs, errors.Wrap(err, "failure getting source node information"))
 						continue
 					}
+					event.ModuleFields.Put("node.name", sourceNode["name"])
 					event.MetricSetFields.Put("source_node", sourceNode)
 				}
 


### PR DESCRIPTION
### Summary
- Fix drifts from 7.16 in elasticsearch module's documents when `xpack.enabled` is set.
- Fix incomplete `node` property for `ml_job` and `shard` metricsets
- Fix shard's cluster state property path to be consistent with [cluster_stats](https://github.com/elastic/beats/blob/master/metricbeat/module/elasticsearch/cluster_stats/_meta/data.json#L102)