### PR TITLE
ci: elastic-agent goIntegTest is not available

### DIFF
--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -36,9 +36,6 @@ stages:
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
-    goIntegTest:
-        mage: "mage goIntegTest"
-        stage: mandatory
     macos:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.


### PR DESCRIPTION
## What does this PR do?

Remove `goIntegTest` for the `x-pack/elastic-agent`

## Why is it important?

It returns https://github.com/elastic/beats/blob/76bf18b0c2be4c8adf1f2a0f9168aadcd04e8593/dev-tools/mage/target/integtest/notests/integtest.go#L27-L30

![image](https://user-images.githubusercontent.com/2871786/146985457-799c0481-5417-40b6-9c22-44941f958e1f.png)

https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fbeats/detail/8.0/186/pipeline/7115#step-14750-log-2