### PR TITLE
Fix example command to avoid showing system module under windows

### DIFF
--- a/filebeat/docs/filebeat-modules-options.asciidoc
+++ b/filebeat/docs/filebeat-modules-options.asciidoc
@@ -1,4 +1,4 @@
-:modulename: system nginx mysql
+:modulename: nginx
 
 [id="configuration-{beatname_lc}-modules"]
 == Configure modules

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -1,4 +1,4 @@
-:modulename: system nginx mysql
+:modulename: nginx
 
 //TODO: Remove release-state override before merging.
 
@@ -19,6 +19,8 @@ You'll learn how to:
 
 [role="screenshot"]
 image::./images/kibana-system.png[{beatname_uc} System dashboard]
+
+//TODO: We should replace this with an nginx dashboard rather than system
 
 [float]
 === Before you begin
@@ -79,14 +81,13 @@ include::{libbeat-dir}/tab-widgets/list-modules-widget.asciidoc[]
 --
 
 . From the installation directory, enable one or more modules. For example, the
-following command enables the `system`, `nginx`, and `mysql` module
-configs:
+following command enables the +{modulename}+ module config:
 +
 --
 include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 --
 
-. In the module configs under `modules.d`, enable the desired datasets and
+. In the module config under `modules.d`, enable the desired datasets and
 change the module settings to match your environment.
 +
 For example, log locations are set based on the OS. If your logs aren't in

--- a/libbeat/docs/tab-widgets/start.asciidoc
+++ b/libbeat/docs/tab-widgets/start.asciidoc
@@ -45,7 +45,7 @@ ifdef::has_modules_command[]
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo chown root {beatname_lc}.yml <1>
-sudo chown root modules.d/system.yml <1>
+sudo chown root modules.d/{modulename}.yml <1>
 sudo ./{beatname_lc} -e
 ----------------------------------------------------------------------
 <1> You'll be running {beatname_uc} as root, so you need to change ownership of the
@@ -94,7 +94,7 @@ ifdef::has_modules_command[]
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo chown root /usr/local/etc/{beatname_lc}/{beatname_lc}.yml <1>
-sudo chown root /usr/local/etc/{beatname_lc}/modules.d/system.yml <1>
+sudo chown root /usr/local/etc/{beatname_lc}/modules.d/{modulename}.yml <1>
 sudo {beatname_lc} -e
 ----------------------------------------------------------------------
 <1> You'll be running {beatname_uc} as root, so you need to change ownership of the
@@ -124,7 +124,7 @@ ifdef::has_modules_command[]
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 sudo chown root {beatname_lc}.yml <1>
-sudo chown root modules.d/system.yml <1>
+sudo chown root modules.d/{modulename}.yml <1>
 sudo ./{beatname_lc} -e
 ----------------------------------------------------------------------
 <1> You'll be running {beatname_uc} as root, so you need to change ownership of the

--- a/metricbeat/docs/getting-started.asciidoc
+++ b/metricbeat/docs/getting-started.asciidoc
@@ -1,4 +1,4 @@
-:modulename: apache mysql
+:modulename: nginx
 
 [id="{beatname_lc}-installation-configuration"]
 == {beatname_uc} quick start: installation and configuration
@@ -82,8 +82,8 @@ include::{libbeat-dir}/tab-widgets/list-modules-widget.asciidoc[]
 default configuration without enabling additional modules, {beatname_uc}
 collects system metrics only.
 +
-The following command enables the `apache` and `mysql` configs in the
-`modules.d` directory:
+The following command enables the +{modulename}+ config in the `modules.d`
+directory:
 +
 --
 include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
@@ -92,7 +92,7 @@ include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 See the <<modules-command>> to learn more about this command. If you are using a
 Docker image, see <<running-on-docker>>.
 
-. In the module configs under `modules.d`, change the module settings to match
+. In the module config under `modules.d`, change the module settings to match
 your environment. See <<module-config-options>> for more about available
 settings.
 


### PR DESCRIPTION
Fixes #29568 

TODO: 
- [x] Update observability docs that include the enable and start widgets https://github.com/elastic/observability-docs/pull/1421
- [ ] Look for other places in the docs where we include the enable and start widgets
