### PR TITLE
Add support for latest k8s versions

### DIFF
--- a/.ci/scripts/kind-setup.sh
+++ b/.ci/scripts/kind-setup.sh
@@ -1,23 +1,5 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
-kind create cluster --image kindest/node:${K8S_VERSION} --config - <<EOF
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane
-  kubeadmConfigPatches:
-  - |
-    kind: ClusterConfiguration
-    scheduler:
-      extraArgs:
-        bind-address: "0.0.0.0"
-        port: "10251"
-        secure-port: "10259"
-    controllerManager:
-      extraArgs:
-        bind-address: "0.0.0.0"
-        port: "10252"
-        secure-port: "10257"
-EOF
+kind create cluster --image kindest/node:${K8S_VERSION}
 kubectl cluster-info

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -124,6 +124,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Update k8s library {pull}29394[29394]
 - Add FIPS configuration option for all AWS API calls. {pull}28899[28899]
 - Add `default_region` config to AWS common module. {pull}29415[29415]
+- Add support for latest k8s versions v1.23 and v1.22 {pull}29575[29575]
 
 *Auditbeat*
 

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: lint
     k8sTest:
-        k8sTest: "v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
+        k8sTest: "v1.23.1,v1.22.5,v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
         stage: mandatory

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: lint
     k8sTest:
-        k8sTest: "v1.23.0,v1.22.0,v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
+        k8sTest: "v1.23.0,v1.22.0,v1.21.1,v1.20.7,v1.19.11,v1.18.19"
         stage: mandatory

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: lint
     k8sTest:
-        k8sTest: "v1.23.1,v1.22.5,v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
+        k8sTest: "v1.23.0,v1.22.5,v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
         stage: mandatory

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: lint
     k8sTest:
-        k8sTest: "v1.23.0,v1.22.5,v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
+        k8sTest: "v1.23.0,v1.22.0,v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
         stage: mandatory

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -155,7 +155,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.14.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x
+1.14.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
 
 [float]
 === Dashboard

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -155,7 +155,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.14.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
+1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -146,7 +146,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.14.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
+1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -146,7 +146,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.14.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x
+1.14.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/test/integration.go
+++ b/metricbeat/module/kubernetes/test/integration.go
@@ -79,10 +79,12 @@ func GetKubeProxyConfig(t *testing.T, metricSetName string) map[string]interface
 func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface{} {
 	t.Helper()
 	return map[string]interface{}{
-		"module":     "kubernetes",
-		"metricsets": []string{metricSetName},
-		"host":       "${NODE_NAME}",
-		"hosts":      []string{"localhost:10251"},
+		"module":                "kubernetes",
+		"metricsets":            []string{metricSetName},
+		"host":                  "${NODE_NAME}",
+		"hosts":                 []string{"https://0.0.0.0:10259"},
+		"bearer_token_file":     "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		"ssl.verification_mode": "none",
 	}
 }
 
@@ -90,9 +92,11 @@ func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface
 func GetControllerManagerConfig(t *testing.T, metricSetName string) map[string]interface{} {
 	t.Helper()
 	return map[string]interface{}{
-		"module":     "kubernetes",
-		"metricsets": []string{metricSetName},
-		"host":       "${NODE_NAME}",
-		"hosts":      []string{"localhost:10252"},
+		"module":                "kubernetes",
+		"metricsets":            []string{metricSetName},
+		"host":                  "${NODE_NAME}",
+		"hosts":                 []string{"https://0.0.0.0:10257"},
+		"bearer_token_file":     "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		"ssl.verification_mode": "none",
 	}
 }


### PR DESCRIPTION
## What does this PR do?
This PR adds support for latest k8s versions, v1.22 and v1.23.

We also need to consider dropping support for older versions that k8s does not support based on https://endoflife.date/kubernetes and https://kubernetes.io/releases/.

@MichaelKatsoulis @tetianakravchenko @jsoriano  I would love your thoughts on this one. I can create follow up issues for this to discuss it there instead of blocking this one.

This came up after dealing with failures at https://github.com/elastic/beats/pull/29572 since the `Cronjob` API move to `batch/v1` at 1.21 and hence tests are failing for k8s version pior to 1.20.


elastic-package: https://github.com/elastic/elastic-package/pull/634
integrations: https://github.com/elastic/integrations/pull/2372