### PR TITLE
[Metricbeat] support credentials_json in gcp module

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -129,7 +129,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Introduce `libbeat/beat.Beat.OutputConfigReloader` {pull}28048[28048]
 - Update Go version to 1.17.1. {pull}27543[27543]
 - Whitelist `GCP_*` environment variables in dev tools {pull}28364[28364]
-- Add support for `credentials_json` in `gcp` module, `billing` metricset {pull}29584[29584]
+- Add support for `credentials_json` in `gcp` module, all metricsets {pull}29584[29584]
 
 ==== Deprecated
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -129,6 +129,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Introduce `libbeat/beat.Beat.OutputConfigReloader` {pull}28048[28048]
 - Update Go version to 1.17.1. {pull}27543[27543]
 - Whitelist `GCP_*` environment variables in dev tools {pull}28364[28364]
+- Add support for `credentials_json` in `gcp` module, `billing` metricset {pull}29584[29584]
 
 ==== Deprecated
 

--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -302,7 +302,7 @@ func getCurrentDate() string {
 }
 
 func generateEventID(currentDate string, rowItems []bigquery.Value) string {
-	// create eventID using hash of current_date + invoice_month + project_id + cost_type
+	// create eventID using hash of current_date + invoice.month + project.id + project.name
 	// This will prevent more than one billing metric getting collected in the same day.
 	eventID := currentDate + rowItems[0].(string) + rowItems[1].(string) + rowItems[2].(string)
 	h := sha256.New()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Adds support for `credentials_json` metricset configuration parameter to `gcp.billing` and `gcp.metrics` metricset.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
This change is required to support at metricset level this parameter that is already supported in Kibana Integration UI.

Filebeat `gcp` inputs support this parameter and due to the [limitations in Kibana](https://github.com/elastic/kibana/issues/112272) is not possible to use input level variables but globals are required. This PR fixes this in order to prevent having a configuration parameter in the UI that is not used by inputs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build `x-pack/metricbeat`
2. Configure `gcp` module with:
```
  - module: gcp
    metricsets:
      - billing
    zone: "eu-"
    project_id: "..."
    credentials_json: '' # add your GCP SA JSON key content here
    exclude_labels: false
    dataset_id: "integration_testing_detached"
    table_pattern: "billing_export_test_data_detached"
    period: 24h

```
3. Add your credentials in `credentials_json`
4. Setup a BigQuery table with dummy data
5. Run metricbeat and see collected data, it should work

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://github.com/elastic/integrations/pull/2312

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
