### PR TITLE
[Beats] Build darwin/arm64 and universal binary

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -211,6 +211,8 @@ def linuxPlatforms() {
             'windows/amd64',
             'windows/386',
             'darwin/amd64'
+            // TODO(AndersonQ): comment in after the tests pass
+            // 'darwin/arm64'
           ].join(' ')
 }
 

--- a/auditbeat/magefile.go
+++ b/auditbeat/magefile.go
@@ -28,6 +28,7 @@ import (
 
 	auditbeat "github.com/elastic/beats/v7/auditbeat/scripts/mage"
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
@@ -72,6 +73,13 @@ func CrossBuild() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.

--- a/dev-tools/mage/common.go
+++ b/dev-tools/mage/common.go
@@ -235,6 +235,25 @@ func HaveKubectl() error {
 	return nil
 }
 
+// IsDarwinUniversal indicates whether ot not the darwin/universal should be
+// assembled. If both platforms darwin/adm64 and darwin/arm64 are listed, then
+// IsDarwinUniversal returns true.
+// Note: Platforms might be edited at different moments, therefore it's necessary
+// to perform this check on the fly.
+func IsDarwinUniversal() bool {
+	var darwinAMD64, darwinARM64 bool
+	for _, p := range Platforms {
+		if p.Name == "darwin/arm64" {
+			darwinARM64 = true
+		}
+		if p.Name == "darwin/amd64" {
+			darwinAMD64 = true
+		}
+	}
+
+	return darwinAMD64 && darwinARM64
+}
+
 // FindReplace reads a file, performs a find/replace operation, then writes the
 // output to the same file path.
 func FindReplace(file string, re *regexp.Regexp, repl string) error {
@@ -586,7 +605,7 @@ func ParallelCtx(ctx context.Context, fns ...interface{}) {
 // Parallel runs the given functions in parallel with an upper limit set based
 // on GOMAXPROCS.
 func Parallel(fns ...interface{}) {
-	ParallelCtx(context.Background(), fns...)
+	ParallelCtx(context.TODO(), fns...)
 }
 
 // funcTypeWrap wraps a valid FuncType to FuncContextError

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -172,7 +172,7 @@ func CrossBuild(options ...CrossBuildOption) error {
 		mg.Deps(func() error { return gotool.Mod.Download() })
 	}
 
-	// Build the magefile for Linux so we can run it inside the container.
+	// Build the magefile for Linux, so we can run it inside the container.
 	mg.Deps(buildMage)
 
 	log.Println("crossBuild: Platform list =", params.Platforms)
@@ -194,6 +194,33 @@ func CrossBuild(options ...CrossBuildOption) error {
 
 	// Each build runs in parallel.
 	Parallel(deps...)
+
+	// It needs to run after all the builds, as it needs the darwin binaries.
+	if err := assembleDarwinUniversal(params); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// assembleDarwinUniversal checks if darwin/amd64 and darwin/arm64 were build,
+// if so, it generates a darwin/universal binary that is the merge fo them two.
+func assembleDarwinUniversal(params crossBuildParams) error {
+	if IsDarwinUniversal() {
+		builder := GolangCrossBuilder{
+			// the docker image for darwin/arm64 is the one capable of merging the binaries.
+			Platform:      "darwin/arm64",
+			Target:        "assembleDarwinUniversal",
+			InDir:         params.InDir,
+			ImageSelector: params.ImageSelector}
+		if err := builder.Build(); err != nil {
+			return errors.Wrapf(err,
+				"failed merging darwin/amd64 and darwin/arm64 into darwin/universal target=%v for platform=%v",
+				builder.Target,
+				builder.Platform)
+		}
+	}
+
 	return nil
 }
 
@@ -222,6 +249,8 @@ func CrossBuildImage(platform string) (string, error) {
 	case platform == "darwin/amd64":
 		tagSuffix = "darwin-debian10"
 	case platform == "darwin/arm64":
+		tagSuffix = "darwin-arm64-debian10"
+	case platform == "darwin/universal":
 		tagSuffix = "darwin-arm64-debian10"
 	case platform == "linux/arm64":
 		tagSuffix = "arm"

--- a/dev-tools/mage/pkg.go
+++ b/dev-tools/mage/pkg.go
@@ -43,8 +43,10 @@ func Package() error {
 			"UseCommunityBeatPackaging, UseElasticBeatPackaging or USeElasticBeatWithoutXPackPackaging first.")
 	}
 
+	platforms := updateWithDarwinUniversal(Platforms)
+
 	var tasks []interface{}
-	for _, target := range Platforms {
+	for _, target := range platforms {
 		for _, pkg := range Packages {
 			if pkg.OS != target.GOOS() || pkg.Arch != "" && pkg.Arch != target.Arch() {
 				continue
@@ -110,6 +112,20 @@ func Package() error {
 
 	Parallel(tasks...)
 	return nil
+}
+
+// updateWithDarwinUniversal checks if darwin/amd64 and darwin/arm64, are listed
+// if so, the universal binary was built, then we need to package it as well.
+func updateWithDarwinUniversal(platforms BuildPlatformList) BuildPlatformList {
+	if IsDarwinUniversal() {
+		platforms = append(platforms,
+			BuildPlatform{
+				Name:  "darwin/universal",
+				Flags: CGOSupported | CrossBuildSupported | Default,
+			})
+	}
+
+	return platforms
 }
 
 // isPackageTypeSelected returns true if SelectedPackageTypes is empty or if

--- a/dev-tools/mage/pkgtypes.go
+++ b/dev-tools/mage/pkgtypes.go
@@ -121,8 +121,10 @@ var OSArchNames = map[string]map[PackageType]map[string]string{
 	},
 	"darwin": map[PackageType]map[string]string{
 		TarGz: map[string]string{
-			"386":   "x86",
-			"amd64": "x86_64",
+			"386":       "x86",
+			"amd64":     "x86_64",
+			"arm64":     "aarch64",
+			"universal": "universal",
 		},
 	},
 	"linux": map[PackageType]map[string]string{
@@ -423,12 +425,12 @@ func (s PackageSpec) Evaluate(args ...map[string]interface{}) PackageSpec {
 			}
 
 			f.Source = filepath.Join(s.packageDir, filepath.Base(f.Target))
-			if err = ioutil.WriteFile(createDir(f.Source), []byte(content), 0644); err != nil {
+			if err = ioutil.WriteFile(CreateDir(f.Source), []byte(content), 0644); err != nil {
 				panic(errors.Wrapf(err, "failed to write file containing content for target=%v", target))
 			}
 		case f.Template != "":
 			f.Source = filepath.Join(s.packageDir, filepath.Base(f.Template))
-			if err := s.ExpandFile(f.Template, createDir(f.Source)); err != nil {
+			if err := s.ExpandFile(f.Template, CreateDir(f.Source)); err != nil {
 				panic(errors.Wrapf(err, "failed to expand template file for target=%v", target))
 			}
 		default:
@@ -566,7 +568,7 @@ func PackageZip(spec PackageSpec) error {
 	spec.OutputFile = Zip.AddFileExtension(spec.OutputFile)
 
 	// Write the zip file.
-	if err := ioutil.WriteFile(createDir(spec.OutputFile), buf.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(CreateDir(spec.OutputFile), buf.Bytes(), 0644); err != nil {
 		return errors.Wrap(err, "failed to write zip file")
 	}
 
@@ -587,6 +589,27 @@ func PackageTarGz(spec PackageSpec) error {
 	// Create a new tar archive.
 	w := tar.NewWriter(buf)
 	baseDir := spec.rootDir()
+
+	// Replace the darwin-universal by darwin-x86_64 and darwin-arm64. Also
+	// keep the other files.
+	if spec.Name == "elastic-agent" && spec.OS == "darwin" && spec.Arch == "universal" {
+		newFiles := map[string]PackageFile{}
+		for filename, pkgFile := range spec.Files {
+			if strings.Contains(pkgFile.Target, "darwin-universal") &&
+				strings.Contains(pkgFile.Target, "downloads") {
+
+				amdFilename, amdpkgFile := replaceFileArch(filename, pkgFile, "x86_64")
+				armFilename, armpkgFile := replaceFileArch(filename, pkgFile, "aarch64")
+
+				newFiles[amdFilename] = amdpkgFile
+				newFiles[armFilename] = armpkgFile
+			} else {
+				newFiles[filename] = pkgFile
+			}
+		}
+
+		spec.Files = newFiles
+	}
 
 	// Add files to tar.
 	for _, pkgFile := range spec.Files {
@@ -632,7 +655,7 @@ func PackageTarGz(spec PackageSpec) error {
 
 	// Open the output file.
 	log.Println("Creating output file at", spec.OutputFile)
-	outFile, err := os.Create(createDir(spec.OutputFile))
+	outFile, err := os.Create(CreateDir(spec.OutputFile))
 	if err != nil {
 		return err
 	}
@@ -656,6 +679,14 @@ func PackageTarGz(spec PackageSpec) error {
 	}
 
 	return errors.Wrap(CreateSHA512File(spec.OutputFile), "failed to create .sha512 file")
+}
+
+func replaceFileArch(filename string, pkgFile PackageFile, arch string) (string, PackageFile) {
+	filename = strings.ReplaceAll(filename, "universal", arch)
+	pkgFile.Source = strings.ReplaceAll(pkgFile.Source, "universal", arch)
+	pkgFile.Target = strings.ReplaceAll(pkgFile.Target, "universal", arch)
+
+	return filename, pkgFile
 }
 
 // PackageDeb packages a deb file. This requires Docker to execute FPM.

--- a/dev-tools/mage/platforms.go
+++ b/dev-tools/mage/platforms.go
@@ -35,7 +35,7 @@ var BuildPlatforms = BuildPlatformList{
 	{"darwin/386", CGOSupported | CrossBuildSupported},
 	{"darwin/amd64", CGOSupported | CrossBuildSupported | Default},
 	{"darwin/arm", CGOSupported},
-	{"darwin/arm64", CGOSupported},
+	{"darwin/arm64", CGOSupported | CrossBuildSupported | Default},
 	{"dragonfly/amd64", CGOSupported},
 	{"freebsd/386", CGOSupported},
 	{"freebsd/amd64", CGOSupported},
@@ -326,13 +326,13 @@ func newPlatformExpression(expr string) (*platformExpression, error) {
 
 // NewPlatformList returns a new BuildPlatformList based on given expression.
 //
-// By default the initial set include only the platforms designated as defaults.
+// By default, the initial set include only the platforms designated as defaults.
 // To add additional platforms to list use an addition term that is designated
 // with a plug sign (e.g. "+netbsd" or "+linux/armv7"). Or you may use "+all"
 // to change the initial set to include all possible platforms then filter
 // from there (e.g. "+all linux windows").
 //
-// The expression can consists of selections (e.g. "linux") and/or
+// The expression can consist of selections (e.g. "linux") and/or
 // removals (e.g."!windows"). Each term can be valid GOOS or a valid GOOS/Arch
 // pair.
 //

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -63,8 +63,8 @@ var (
 	PLATFORMS    = EnvOr("PLATFORMS", "")
 	PACKAGES     = EnvOr("PACKAGES", "")
 
-	// CrossBuildMountModcache, if true, mounts $GOPATH/pkg/mod into
-	// the crossbuild images at /go/pkg/mod, read-only.
+	// CrossBuildMountModcache mounts $GOPATH/pkg/mod into
+	// the crossbuild images at /go/pkg/mod, read-only,  when set to true.
 	CrossBuildMountModcache = true
 
 	BeatName        = EnvOr("BEAT_NAME", filepath.Base(CWD()))

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -28,6 +28,7 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	filebeat "github.com/elastic/beats/v7/filebeat/scripts/mage"
 
 	// mage:import
@@ -71,6 +72,13 @@ func CrossBuild() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.

--- a/libbeat/magefile.go
+++ b/libbeat/magefile.go
@@ -22,6 +22,7 @@ package main
 
 import (
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/common"
@@ -52,4 +53,11 @@ func Fields() error {
 // Config generates example and reference configuration for libbeat.
 func Config() error {
 	return devtools.Config(devtools.ShortConfigType|devtools.ReferenceConfigType, devtools.DefaultConfigFileParams(), ".")
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }

--- a/packetbeat/magefile.go
+++ b/packetbeat/magefile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	packetbeat "github.com/elastic/beats/v7/packetbeat/scripts/mage"
 
 	// mage:import
@@ -70,6 +71,13 @@ func CrossBuild() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.

--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -15,6 +15,7 @@ import (
 
 	auditbeat "github.com/elastic/beats/v7/auditbeat/scripts/mage"
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 
 	// mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
@@ -59,6 +60,13 @@ func BuildGoDaemon() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.

--- a/x-pack/dockerlogbeat/magefile.go
+++ b/x-pack/dockerlogbeat/magefile.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
-
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/common"
 	// mage:import
@@ -118,7 +117,7 @@ func createContainer(ctx context.Context, cli *client.Client, arch string) error
 		Tags:       []string{rootImageName},
 		Dockerfile: dockerfile,
 	}
-	//build, wait for output
+	// build, wait for output
 	buildResp, err := cli.ImageBuild(ctx, buildContext, buildOpts)
 	if err != nil {
 		return errors.Wrap(err, "error building final container image")
@@ -201,7 +200,7 @@ func BuildContainer(ctx context.Context) error {
 			return errors.Wrap(err, "error writing exported container")
 		}
 
-		//misc prepare operations
+		// misc prepare operations
 
 		err = devtools.Copy("config.json", filepath.Join(buildDir, "config.json"))
 		if err != nil {
@@ -240,7 +239,7 @@ func Uninstall(ctx context.Context) error {
 		return errors.Wrap(err, "error creating docker client")
 	}
 
-	//check to see if we have a plugin we need to remove
+	// check to see if we have a plugin we need to remove
 	plugins, err := cli.PluginList(ctx, filters.Args{})
 	if err != nil {
 		return errors.Wrap(err, "error getting list of plugins")
@@ -359,7 +358,7 @@ func Build() {
 	mg.SerialDeps(CrossBuild, BuildContainer)
 }
 
-// GolangCrossBuild build the Beat binary inside of the golang-builder.
+// GolangCrossBuild build the Beat binary inside the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
 	buildArgs := devtools.DefaultBuildArgs()

--- a/x-pack/filebeat/magefile.go
+++ b/x-pack/filebeat/magefile.go
@@ -16,6 +16,7 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	filebeat "github.com/elastic/beats/v7/filebeat/scripts/mage"
 
 	// mage:import
@@ -62,6 +63,13 @@ func BuildGoDaemon() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.

--- a/x-pack/functionbeat/magefile.go
+++ b/x-pack/functionbeat/magefile.go
@@ -17,6 +17,7 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	functionbeat "github.com/elastic/beats/v7/x-pack/functionbeat/scripts/mage"
 
 	// mage:import
@@ -139,6 +140,13 @@ func Fields() { mg.Deps(functionbeat.Update.Fields) }
 // Config is an alias for update:config. This is a workaround for
 // https://github.com/magefile/mage/issues/217.
 func Config() { mg.Deps(functionbeat.Update.Config) }
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
+}
 
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.

--- a/x-pack/libbeat/magefile.go
+++ b/x-pack/libbeat/magefile.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 
 	// mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/common"
@@ -32,4 +33,11 @@ func Build() error {
 // Fields generates a fields.yml for the Beat.
 func Fields() error {
 	return devtools.GenerateFieldsYAML()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }

--- a/x-pack/metricbeat/magefile.go
+++ b/x-pack/metricbeat/magefile.go
@@ -20,6 +20,7 @@ import (
 	"github.com/magefile/mage/sh"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	metricbeat "github.com/elastic/beats/v7/metricbeat/scripts/mage"
 
 	// mage:import
@@ -132,6 +133,13 @@ func BuildSystemTestBinary() error {
 		log.Printf("BuildSystemTestGoBinary (go %v) took %v.", strings.Join(args, " "), time.Since(start))
 	}()
 	return sh.RunV("go", args...)
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.

--- a/x-pack/osquerybeat/dev-tools/packaging/packages.yml
+++ b/x-pack/osquerybeat/dev-tools/packaging/packages.yml
@@ -91,6 +91,14 @@ specs:
             source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
+      arch: amd64
+      types: [tgz]
+      spec:
+        <<: *unix_binary_spec
+        <<: *elastic_license_for_binaries
+
+    - os: darwin
+      arch: arm64
       types: [tgz]
       spec:
         <<: *unix_binary_spec

--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -138,6 +138,7 @@ var specs = map[OSArch]Spec{
 	{"linux", "amd64"}:   {"_1.linux_x86_64.tar.gz", osqueryDistroLinuxSHA256, true},
 	{"linux", "arm64"}:   {"_1.linux_aarch64.tar.gz", osqueryDistroLinuxARMSHA256, true},
 	{"darwin", "amd64"}:  {osqueryPkgExt, osqueryDistroDarwinSHA256, false},
+	{"darwin", "arm64"}:  {osqueryPkgExt, osqueryDistroDarwinSHA256, false},
 	{"windows", "amd64"}: {osqueryMSIExt, osqueryDistroWindowsSHA256, false},
 }
 

--- a/x-pack/osquerybeat/magefile.go
+++ b/x-pack/osquerybeat/magefile.go
@@ -20,6 +20,7 @@ import (
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/command"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/distro"
 	osquerybeat "github.com/elastic/beats/v7/x-pack/osquerybeat/scripts/mage"
@@ -187,6 +188,13 @@ func CrossBuild() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.

--- a/x-pack/packetbeat/magefile.go
+++ b/x-pack/packetbeat/magefile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/magefile/mage/sh"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/dev-tools/mage/target/build"
 	packetbeat "github.com/elastic/beats/v7/packetbeat/scripts/mage"
 
 	//mage:import
@@ -114,6 +115,13 @@ func BuildGoDaemon() error {
 // CrossBuildGoDaemon cross-builds the go-daemon binary using Docker.
 func CrossBuildGoDaemon() error {
 	return devtools.CrossBuildGoDaemon()
+}
+
+// AssembleDarwinUniversal merges the darwin/amd64 and darwin/arm64 into a single
+// universal binary using `lipo`. It assumes the darwin/amd64 and darwin/arm64
+// were built and only performs the merge.
+func AssembleDarwinUniversal() error {
+	return build.AssembleDarwinUniversal()
 }
 
 // Package packages the Beat for distribution.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It enables the Elastic-Agent and Beats to be built for `darwin/arm64` and generates a universal binary (`darwin/universal`).

The [universal binary](https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary) is the merge of the `darwin/arm64` with `darwin/amd64`. Therefore it requires to first build the  `darwin/arm64` and `darwin/amd64` and them _"merge"_ them together into the `darwin/universal`. Also `darwin/universal` isn't a valid platform or OS/ARCH pair, therefore it isn't recognised by the Go compiler. Given that, the choice was to add `darwin/arm64` as a new platform for the Elastic-Agent and when ever both platforms (`darwin/arm64` and `darwin/amd64`) are built, also generate and package the universal binary.
Even though  it's ~quite~ an implicit behaviour, the alternative would also require a lot of changes and exceptions to have our build process recognising `darwin/universal`, but compiling `darwin/arm64` and `darwin/amd64` and merging them. Also the current process makes available all three of them, allowing the user to choose which fits better their needs. The drawback of the universal binary is its size, the double of the single binaries.

A new target, `BuildDarwinUniversal`  was added on the `x-pack`s `magefile`s required by the Elastic-Agent.

Also fixes some small typos, redundant information on the help command and remove the use of some deprecated functions.

## Why is it important?

We need to support Mac with M1 chips

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] build darwin/arm64 binary
- [x] build universal 2 binary
- [x] use mage to automatically build the universal binary

## How to test this PR locally
1. Build the elastic-agent for the new platforms:
   - **darwin/arm64**: `PLATFORMS="darwin/arm64" PACKAGES="tar.gz" mage package`
   - **darwin/universal**: `PLATFORMS="darwin/arm64,darwin/amd64" PACKAGES="tar.gz" mage package`

2. Run the elastic-agent

####**Watch out:**
The elastic-agent tries to download any binary it might need to comply with the assigned policy. However none of the new binaries from this PR are present on the artifact API and other applications (e.g. fleet-server and elastic-endpoint) also aren't publishing `darwin/arm64` versions. Therefore if the elastic-agent tries to download them, it'll fail. This is the expected behavior and this PR does not address it, see *Out of Scope*.

## Out of scope:
 - Handle downloading binaries that does not publish `darwin-universal` artifacts on the artifact API
 - Handle upgrading a `darwin/amd64` agent running under Rosetta2 on a Mac with M1 chip. This will be addressed on another PR.

## Related issues

- Relates elastic/elastic-agent#151
- Closes elastic/beats#29582