### PR TITLE
fix: adapt kubernetes event

### DIFF
--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -116,3 +116,17 @@ func ContainerIDWithRuntime(s PodContainerStatus) (string, string) {
 	}
 	return "", ""
 }
+
+func EventLastTimestamp(eve *Event) metav1.Time {
+	lastTimestamp := eve.LastTimestamp
+	if lastTimestamp.IsZero() {
+		if eve.Series != nil && !eve.Series.LastObservedTime.IsZero() {
+			lastTimestamp = metav1.Time(eve.Series.LastObservedTime)
+		} else if !eve.EventTime.IsZero() {
+			lastTimestamp = metav1.Time(eve.EventTime)
+		} else {
+			lastTimestamp = eve.CreationTimestamp
+		}
+	}
+	return lastTimestamp
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
adapt kubernetes event which lastTimestamp is empty or count is empty
```yaml
apiVersion: v1
items:
- action: Scheduling
  apiVersion: v1
  eventTime: "2021-12-22T11:39:51.388829Z"
  firstTimestamp: null
  involvedObject:
    apiVersion: v1
    kind: Pod
    name: insufficent-697c868bd6-xvjxp
    namespace: sjh-ns
    resourceVersion: "390502"
    uid: 11f3fe9f-f918-482d-9302-09f7dc69f450
  kind: Event
  lastTimestamp: null
  message: '0/3 nodes are available: 3 Insufficient cpu.'
  metadata:
    creationTimestamp: "2021-12-22T11:39:51Z"
    name: insufficent-697c868bd6-xvjxp.16c310d3dada4017
    namespace: sjh-ns
    resourceVersion: "5095"
    uid: 956af82e-fb37-44a3-b23e-ab3e158d2e90
  reason: FailedScheduling
  reportingComponent: default-scheduler
  reportingInstance: default-scheduler-mc70ksqfqtofq1s4t4njg
  source: {}
  type: Warning
- action: Scheduling
  apiVersion: v1
  eventTime: "2021-12-22T11:39:51.434179Z"
  firstTimestamp: null
  involvedObject:
    apiVersion: v1
    kind: Pod
    name: insufficent-697c868bd6-xvjxp
    namespace: sjh-ns
    resourceVersion: "390503"
    uid: 11f3fe9f-f918-482d-9302-09f7dc69f450
  kind: Event
  lastTimestamp: null
  message: '0/3 nodes are available: 3 Insufficient cpu.'
  metadata:
    creationTimestamp: "2021-12-22T11:39:51Z"
    name: insufficent-697c868bd6-xvjxp.16c310d3dd8dc308
    namespace: sjh-ns
    resourceVersion: "5202"
    uid: 796cd76b-fc90-427f-a899-2587c181c180
  reason: FailedScheduling
  reportingComponent: default-scheduler
  reportingInstance: default-scheduler-mc70ksqfqtofq1s4t4njg
  series:
    count: 18
    lastObservedTime: "2021-12-22T12:06:01.048247Z"
  source: {}
  type: Warning
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
