### PR TITLE
Fix annotation enrichment

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change Docker base image from CentOS 7 to Ubuntu 20.04 {pull}29681[29681]
 - Fix annotations enrichment
 - Fix annotations enrichment. {pull}29605[29605]
+- Enrich kubernetes metadata with node annotations. {pull}29605[29605]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add job.name in pods controlled by Jobs {pull}28954[28954]
 - Change Docker base image from CentOS 7 to Ubuntu 20.04 {pull}29681[29681]
 - Fix annotations enrichment
+- Fix annotations enrichment. {pull}29605[29605]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - `include_matches` option of `journald` input no longer accepts a list of string. {pull}29294[29294]
 - Add job.name in pods controlled by Jobs {pull}28954[28954]
 - Change Docker base image from CentOS 7 to Ubuntu 20.04 {pull}29681[29681]
+- Fix annotations enrichment
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -30,8 +30,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - `include_matches` option of `journald` input no longer accepts a list of string. {pull}29294[29294]
 - Add job.name in pods controlled by Jobs {pull}28954[28954]
 - Change Docker base image from CentOS 7 to Ubuntu 20.04 {pull}29681[29681]
-- Fix annotations enrichment
-- Fix annotations enrichment. {pull}29605[29605]
 - Enrich kubernetes metadata with node annotations. {pull}29605[29605]
 
 *Auditbeat*

--- a/libbeat/common/kubernetes/metadata/metadata.go
+++ b/libbeat/common/kubernetes/metadata/metadata.go
@@ -72,11 +72,12 @@ func WithFields(key string, value interface{}) FieldOptions {
 	}
 }
 
-// WithLabels FieldOption allows adding labels under sub-resource(kind)
+// WithMetadata FieldOption allows adding labels and annotations under sub-resource(kind)
 // example if kind=namespace namespace.labels key will be added
-func WithLabels(kind string) FieldOptions {
+func WithMetadata(kind string) FieldOptions {
 	return func(meta common.MapStr) {
 		safemapstr.Put(meta, strings.ToLower(kind)+".labels", meta["labels"])
+		safemapstr.Put(meta, strings.ToLower(kind)+".annotations", meta["annotations"])
 	}
 }
 

--- a/libbeat/common/kubernetes/metadata/metadata.go
+++ b/libbeat/common/kubernetes/metadata/metadata.go
@@ -76,8 +76,12 @@ func WithFields(key string, value interface{}) FieldOptions {
 // example if kind=namespace namespace.labels key will be added
 func WithMetadata(kind string) FieldOptions {
 	return func(meta common.MapStr) {
-		safemapstr.Put(meta, strings.ToLower(kind)+".labels", meta["labels"])
-		safemapstr.Put(meta, strings.ToLower(kind)+".annotations", meta["annotations"])
+		if meta["labels"] != nil {
+			safemapstr.Put(meta, strings.ToLower(kind)+".labels", meta["labels"])
+		}
+		if meta["annotations"] != nil {
+			safemapstr.Put(meta, strings.ToLower(kind)+".annotations", meta["annotations"])
+		}
 	}
 }
 

--- a/libbeat/common/kubernetes/metadata/node_test.go
+++ b/libbeat/common/kubernetes/metadata/node_test.go
@@ -52,7 +52,10 @@ func TestNode_Generate(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "bar",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Node",
@@ -71,12 +74,18 @@ func TestNode_Generate(t *testing.T) {
 				"labels": common.MapStr{
 					"foo": "bar",
 				},
+				"annotations": common.MapStr{
+					"key2": "value2",
+				},
 			}},
 		},
 	}
 
-	cfg := common.NewConfig()
-	metagen := NewNodeMetadataGenerator(cfg, nil, client)
+	// cfg := common.NewConfig()
+	nodeConfig, _ := common.NewConfigFrom(map[string]interface{}{
+		"include_annotations": []string{"key1"},
+	})
+	metagen := NewNodeMetadataGenerator(nodeConfig, nil, client)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.Generate(test.input))
@@ -102,7 +111,9 @@ func TestNode_GenerateFromName(t *testing.T) {
 					Labels: map[string]string{
 						"foo": "bar",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						"key": "value",
+					},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Node",
@@ -121,15 +132,21 @@ func TestNode_GenerateFromName(t *testing.T) {
 				"labels": common.MapStr{
 					"foo": "bar",
 				},
+				"annotations": common.MapStr{
+					"key": "value",
+				},
 			},
 		},
 	}
 
 	for _, test := range tests {
-		cfg := common.NewConfig()
+		// cfg := common.NewConfig()
+		nodeConfig, _ := common.NewConfigFrom(map[string]interface{}{
+			"include_annotations": []string{"key"},
+		})
 		nodes := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		nodes.Add(test.input)
-		metagen := NewNodeMetadataGenerator(cfg, nodes, client)
+		metagen := NewNodeMetadataGenerator(nodeConfig, nodes, client)
 
 		accessor, err := meta.Accessor(test.input)
 		require.NoError(t, err)

--- a/libbeat/common/kubernetes/metadata/node_test.go
+++ b/libbeat/common/kubernetes/metadata/node_test.go
@@ -81,11 +81,10 @@ func TestNode_Generate(t *testing.T) {
 		},
 	}
 
-	// cfg := common.NewConfig()
-	nodeConfig, _ := common.NewConfigFrom(map[string]interface{}{
-		"include_annotations": []string{"key1"},
+	cfg, _ := common.NewConfigFrom(Config{
+		IncludeAnnotations: []string{"key2"},
 	})
-	metagen := NewNodeMetadataGenerator(nodeConfig, nil, client)
+	metagen := NewNodeMetadataGenerator(cfg, nil, client)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.Generate(test.input))
@@ -140,13 +139,12 @@ func TestNode_GenerateFromName(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		// cfg := common.NewConfig()
-		nodeConfig, _ := common.NewConfigFrom(map[string]interface{}{
-			"include_annotations": []string{"key"},
+		cfg, _ := common.NewConfigFrom(Config{
+			IncludeAnnotations: []string{"key"},
 		})
 		nodes := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		nodes.Add(test.input)
-		metagen := NewNodeMetadataGenerator(nodeConfig, nodes, client)
+		metagen := NewNodeMetadataGenerator(cfg, nodes, client)
 
 		accessor, err := meta.Accessor(test.input)
 		require.NoError(t, err)

--- a/libbeat/common/kubernetes/metadata/pod.go
+++ b/libbeat/common/kubernetes/metadata/pod.go
@@ -100,7 +100,7 @@ func (p *pod) GenerateK8s(obj kubernetes.Resource, opts ...FieldOptions) common.
 	}
 
 	if p.node != nil {
-		meta := p.node.GenerateFromName(po.Spec.NodeName, WithLabels("node"))
+		meta := p.node.GenerateFromName(po.Spec.NodeName, WithMetadata("node"))
 		if meta != nil {
 			out.Put("node", meta["node"])
 		} else {

--- a/libbeat/common/kubernetes/metadata/pod_test.go
+++ b/libbeat/common/kubernetes/metadata/pod_test.go
@@ -737,7 +737,9 @@ func TestPod_GenerateWithNodeNamespaceWithAddResourceConfig(t *testing.T) {
 						"nodekey":  "nodevalue",
 						"nodekey2": "nodevalue2",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						"node.annotation": "node.value",
+					},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Node",
@@ -755,7 +757,9 @@ func TestPod_GenerateWithNodeNamespaceWithAddResourceConfig(t *testing.T) {
 						"app.kubernetes.io/name": "kube-state-metrics",
 						"nskey2":                 "nsvalue2",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						"ns.annotation": "ns.value",
+					},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Namespace",
@@ -773,6 +777,9 @@ func TestPod_GenerateWithNodeNamespaceWithAddResourceConfig(t *testing.T) {
 				"namespace_labels": common.MapStr{
 					"app_kubernetes_io/name": "kube-state-metrics",
 				},
+				"namespace_annotations": common.MapStr{
+					"ns_annotation": "ns.value",
+				},
 				"node": common.MapStr{
 					"name": "testnode",
 					"uid":  uid,
@@ -780,6 +787,9 @@ func TestPod_GenerateWithNodeNamespaceWithAddResourceConfig(t *testing.T) {
 						"nodekey2": "nodevalue2",
 					},
 					"hostname": "node1",
+					"annotations": common.MapStr{
+						"node_annotation": "node.value",
+					},
 				},
 				"labels": common.MapStr{
 					"app_kubernetes_io/component": "exporter",
@@ -802,10 +812,12 @@ func TestPod_GenerateWithNodeNamespaceWithAddResourceConfig(t *testing.T) {
 		assert.NoError(t, err)
 
 		namespaceConfig, _ := common.NewConfigFrom(map[string]interface{}{
-			"include_labels": []string{"app.kubernetes.io/name"},
+			"include_labels":      []string{"app.kubernetes.io/name"},
+			"include_annotations": []string{"ns.annotation"},
 		})
 		nodeConfig, _ := common.NewConfigFrom(map[string]interface{}{
-			"include_labels": []string{"nodekey2"},
+			"include_labels":      []string{"nodekey2"},
+			"include_annotations": []string{"node.annotation"},
 		})
 		metaConfig := AddResourceMetadataConfig{
 			Namespace:  namespaceConfig,

--- a/libbeat/common/kubernetes/metadata/service_test.go
+++ b/libbeat/common/kubernetes/metadata/service_test.go
@@ -279,7 +279,9 @@ func TestService_GenerateWithNamespace(t *testing.T) {
 					Labels: map[string]string{
 						"nskey": "nsvalue",
 					},
-					Annotations: map[string]string{},
+					Annotations: map[string]string{
+						"ns.annotation": "value",
+					},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Namespace",
@@ -300,21 +302,26 @@ func TestService_GenerateWithNamespace(t *testing.T) {
 					"namespace_labels": common.MapStr{
 						"nskey": "nsvalue",
 					},
+					"namespace_annotations": common.MapStr{
+						"ns_annotation": "value",
+					},
 				},
 			},
 		},
 	}
 
 	for _, test := range tests {
-		cfg := common.NewConfig()
+		nsConfig, _ := common.NewConfigFrom(map[string]interface{}{
+			"include_annotations": []string{"ns.annotation"},
+		})
 		services := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		services.Add(test.input)
 
 		namespaces := cache.NewStore(cache.MetaNamespaceKeyFunc)
 		namespaces.Add(test.namespace)
-		nsMeta := NewNamespaceMetadataGenerator(cfg, namespaces, client)
+		nsMeta := NewNamespaceMetadataGenerator(nsConfig, namespaces, client)
 
-		metagen := NewServiceMetadataGenerator(cfg, services, nsMeta, client)
+		metagen := NewServiceMetadataGenerator(nsConfig, services, nsMeta, client)
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.output, metagen.Generate(test.input))
 		})


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?
node annotations enrichment doesn't work, with the config:
```
add_resource_metadata:
  node:
    include_annotations: ["test.annotation"]
```
events were not enriched with nodes annotation metadata

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
1. Create a kind kubernetes cluster.
2. run metricbeat ([how-to](https://github.com/elastic/beats/blob/master/metricbeat/module/kubernetes/_meta/test/docs/README.md)) with k8s configuration:
```
kubernetes.yml: |-
    - module: kubernetes
      metricsets:
        - node
        - system
        - pod
        - container
        - volume
      add_resource_metadata:
        node:
          include_annotations: ["another.annotation", "example.annotation"]
      period: 10s
      host: ${NODE_NAME}
      hosts: ["https://${NODE_NAME}:10250"]
      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
      ssl.verification_mode: "none"
```
3. edit kind node so that the list of annotations include `another.annotation` and `example.annotation`:
```
$ kubectl describe node kind-control-plane
...
Annotations:        another.annotation: another
                    example.annotation: example
                    kubeadm.alpha.kubernetes.io/cri-socket: unix:///run/containerd/containerd.sock
                    node.alpha.kubernetes.io/ttl: 0
                    volumes.kubernetes.io/controller-managed-attach-detach: true
...
```
## Related issues

- Closes https://github.com/elastic/beats/issues/29597

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots
All node/namespace metadata:
<img width="1107" alt="Screenshot 2022-01-05 at 15 11 50" src="https://user-images.githubusercontent.com/28299531/148231454-1a770293-0243-4069-9981-68b68523d028.png">

note that annotations metadata were only added to pod and container metricsets:
<img width="1929" alt="Screenshot 2022-01-05 at 15 13 22" src="https://user-images.githubusercontent.com/28299531/148232235-5de93cf4-1052-4f1c-8af9-5238a31b85e3.png">


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
