### PR TITLE
Add summary to journeys which don't emit journey:end (early node subprocess exits)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Heartbeat*
 - Only add monitor.status to browser events when summary. {pull}29460[29460]
+- Also add summary to journeys for which the synthetics runner crashes. {pull}29606[29606]
 
 *Metricbeat*
 

--- a/libbeat/README.md
+++ b/libbeat/README.md
@@ -8,7 +8,7 @@ If you want to create a new project that reads some sort of operational data
 and ships it to Elasticsearch, we suggest you make use of this library. Please
 start by reading our [CONTRIBUTING](../CONTRIBUTING.md) file. We also have a
 [developer
-guide](https://www.elastic.co/guide/en/beats/libbeat/current/new-beat.html) to
+guide](https://www.elastic.co/guide/en/beats/devguide/master/index.html) to
 help you with the creation of new Beats.
 
 Please also open a topic on the [forums](https://discuss.elastic.co/c/beats/libbeat) and

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -122,6 +122,24 @@ func TestEnrichSynthEvent(t *testing.T) {
 		check   func(t *testing.T, e *beat.Event, je *journeyEnricher)
 	}{
 		{
+			"cmd/status",
+			&journeyEnricher{},
+			&SynthEvent{
+				Type:  "cmd/status",
+				Error: &SynthError{Name: "cmdexit", Message: "cmd err msg"},
+			},
+			true,
+			func(t *testing.T, e *beat.Event, je *journeyEnricher) {
+				v := lookslike.MustCompile(map[string]interface{}{
+					"summary": map[string]int{
+						"up":   0,
+						"down": 1,
+					},
+				})
+				testslike.Test(t, v, e.Fields)
+			},
+		},
+		{
 			"journey/end",
 			&journeyEnricher{},
 			&SynthEvent{Type: "journey/end"},

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -21,6 +21,18 @@ import (
 	"github.com/elastic/go-lookslike/testslike"
 )
 
+func makeStepEvent(typ string, ts float64, name string, index int, status string, urlstr string, err *SynthError) *SynthEvent {
+	return &SynthEvent{
+		Type:                 typ,
+		TimestampEpochMicros: 1000 + ts,
+		PackageVersion:       "1.0.0",
+		Step:                 &Step{Name: name, Index: index, Status: status},
+		Error:                err,
+		Payload:              common.MapStr{},
+		URL:                  urlstr,
+	}
+}
+
 func TestJourneyEnricher(t *testing.T) {
 	journey := &Journey{
 		Name: "A Journey Name",
@@ -49,17 +61,6 @@ func TestJourneyEnricher(t *testing.T) {
 		PackageVersion:       "1.0.0",
 		Journey:              journey,
 		Payload:              common.MapStr{},
-	}
-	makeStepEvent := func(typ string, ts float64, name string, index int, status string, urlstr string, err *SynthError) *SynthEvent {
-		return &SynthEvent{
-			Type:                 typ,
-			TimestampEpochMicros: 1000 + ts,
-			PackageVersion:       "1.0.0",
-			Step:                 &Step{Name: name, Index: index, Status: status},
-			Error:                err,
-			Payload:              common.MapStr{},
-			URL:                  urlstr,
-		}
 	}
 	url1 := "http://example.net/url1"
 	url2 := "http://example.net/url2"
@@ -210,6 +211,78 @@ func TestEnrichSynthEvent(t *testing.T) {
 				t.Errorf("journeyEnricher.enrichSynthEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			tt.check(t, e, tt.je)
+		})
+	}
+}
+
+func TestNoSummaryOnAfterHook(t *testing.T) {
+	journey := &Journey{
+		Name: "A journey that fails after completing",
+		Id:   "my-bad-after-all-hook",
+	}
+	journeyStart := &SynthEvent{
+		Type:                 "journey/start",
+		TimestampEpochMicros: 1000,
+		PackageVersion:       "1.0.0",
+		Journey:              journey,
+		Payload:              common.MapStr{},
+	}
+	syntherr := &SynthError{
+		Message: "my-errmsg",
+		Name:    "my-errname",
+		Stack:   "my\nerr\nstack",
+	}
+	journeyEnd := &SynthEvent{
+		Type:                 "journey/end",
+		TimestampEpochMicros: 2000,
+		PackageVersion:       "1.0.0",
+		Journey:              journey,
+		Payload:              common.MapStr{},
+	}
+	cmdStatus := &SynthEvent{
+		Type:                 "cmd/status",
+		Error:                &SynthError{Name: "cmdexit", Message: "cmd err msg"},
+		TimestampEpochMicros: 3000,
+	}
+
+	badStepUrl := "https://example.com/bad-step"
+	synthEvents := []*SynthEvent{
+		journeyStart,
+		makeStepEvent("step/start", 10, "Step1", 1, "", "", nil),
+		makeStepEvent("step/end", 20, "Step1", 1, "failed", badStepUrl, syntherr),
+		journeyEnd,
+		cmdStatus,
+	}
+
+	je := &journeyEnricher{}
+
+	for idx, se := range synthEvents {
+		e := &beat.Event{}
+		t.Run(fmt.Sprintf("event %d", idx), func(t *testing.T) {
+			enrichErr := je.enrich(e, se)
+
+			if se != nil && se.Type == "cmd/status" {
+				t.Run("no summary in cmd/status", func(t *testing.T) {
+					require.NotContains(t, e.Fields, "summary")
+				})
+			}
+
+			// Only the journey/end event should get a summary when
+			// it's emitted before the cmd/status (when an afterX hook fails).
+			if se != nil && se.Type == "journey/end" {
+				require.Equal(t, stepError(syntherr), enrichErr)
+
+				u, _ := url.Parse(badStepUrl)
+				t.Run("summary in journey/end", func(t *testing.T) {
+					v := lookslike.MustCompile(common.MapStr{
+						"synthetics.type":     "heartbeat/summary",
+						"url":                 wrappers.URLFields(u),
+						"monitor.duration.us": int64(journeyEnd.Timestamp().Sub(journeyStart.Timestamp()) / time.Microsecond),
+					})
+
+					testslike.Test(t, v, e.Fields)
+				})
+			}
 		})
 	}
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer.go
@@ -29,7 +29,7 @@ func (e ExecMultiplexer) writeSynthEvent(se *SynthEvent) {
 		e.eventCounter.Store(-1)
 	}
 	hasCurrentJourney := e.currentJourney.Load()
-	if se.Type == "journey/end" {
+	if se.Type == "journey/end" || se.Type == "cmd/status" {
 		e.currentJourney.Store(false)
 	}
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer_test.go
@@ -18,7 +18,7 @@ func TestExecMultiplexer(t *testing.T) {
 	var testJourneys []*Journey
 	var testEvents []*SynthEvent
 	time := float64(0)
-	for jIdx := 0; jIdx < 3; jIdx++ {
+	for jIdx := 0; jIdx < 4; jIdx++ {
 		time++ // fake time to make events seem spaced out
 		journey := &Journey{
 			Name: fmt.Sprintf("J%d", jIdx),
@@ -45,11 +45,20 @@ func TestExecMultiplexer(t *testing.T) {
 			})
 		}
 
-		testEvents = append(testEvents, &SynthEvent{
-			Journey:              journey,
-			Type:                 "journey/end",
-			TimestampEpochMicros: time,
-		})
+		// We want one of the test journeys to end with a cmd/status indicating it failed
+		if jIdx != 4 {
+			testEvents = append(testEvents, &SynthEvent{
+				Journey:              journey,
+				Type:                 "journey/end",
+				TimestampEpochMicros: time,
+			})
+		} else {
+			testEvents = append(testEvents, &SynthEvent{
+				Journey:              journey,
+				Type:                 "cmd/status",
+				TimestampEpochMicros: time,
+			})
+		}
 	}
 
 	// Write the test events in another go routine since writes block
@@ -77,7 +86,7 @@ Loop:
 	i := 0 // counter for index, resets on journey change
 	for _, se := range results {
 		require.Equal(t, i, se.index)
-		if se.Type == "journey/end" {
+		if se.Type == "journey/end" || se.Type == "cmd/status" {
 			i = 0
 		} else {
 			i++

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -196,8 +196,9 @@ func runCmd(
 		if err != nil {
 			str := fmt.Sprintf("command exited with status %d: %s", cmd.ProcessState.ExitCode(), err)
 			mpx.writeSynthEvent(&SynthEvent{
-				Type:  "cmd/status",
-				Error: &SynthError{Name: "cmdexit", Message: str},
+				Type:                 "cmd/status",
+				Error:                &SynthError{Name: "cmdexit", Message: str},
+				TimestampEpochMicros: float64(time.Now().UnixMicro()),
 			})
 			logp.Warn("Error executing command '%s' (%d): %s", loggableCmd.String(), cmd.ProcessState.ExitCode(), err)
 		}
@@ -243,7 +244,7 @@ func lineToSynthEventFactory(typ string) func(bytes []byte, text string) (res *S
 		logp.Info("%s: %s", typ, text)
 		return &SynthEvent{
 			Type:                 typ,
-			TimestampEpochMicros: float64(time.Now().UnixNano() / int64(time.Millisecond)),
+			TimestampEpochMicros: float64(time.Now().UnixMicro()),
 			Payload: map[string]interface{}{
 				"message": text,
 			},


### PR DESCRIPTION
## What does this PR do?

Fixes #28770.

This PR ensures that Heartbeat will add a summary to journeys in which the `node` subprocess for [the `synthetics` runner](https://github.com/elastic/synthetics) crashes before emitting a `journey:end` event.

This change will ensure that _all_ journeys will contain a summary, even the ones which cause the runner itself to exit earlier.

To better understand how Heartbeat interfaces with the `synthetics` runner, and thus understand this fix, see the section below.

## Understanding this fix: how Heartbeat works with `elastic-synthetics`

Before I explain how to test this PR, it's worth explaining how Heartbeat and the Synthetics runner work together.

Currently, `heartbeat` will use the `elastic-synthetics` executable, which comes from [the `synthetics` runner project](https://github.com/elastic/synthetics), to run `inline` journeys (like the ones you define within a `heartbeat.yml` file). This executable will (or at least should) be available in the `PATH`.

https://github.com/elastic/beats/blob/bea8e454ea289e28ea260a8c88e7997364da2a75/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go#L69

See the executable name defined here:

https://github.com/elastic/synthetics/blob/ea6eb357953e5a4c5ec3cd5a1ab031a03a6c918a/package.json#L22

When running the `inline` journey using the `elastic-synthetics` executable, it will pass it the `--rich-events` flag, which causes the runner itself to emit rich JSON events.

https://github.com/elastic/beats/blob/bea8e454ea289e28ea260a8c88e7997364da2a75/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go#L123

Heartbeat can then easily use these JSON events to create `SynthEvents`, which it will then try to "enrich".

https://github.com/elastic/beats/blob/bea8e454ea289e28ea260a8c88e7997364da2a75/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go#L240-L252

To see the runner emitting these events, try creating a simple journey, like the one below:

```
step('google', () => {
  page.goto('https://www.google.com');
});

step('BBC', () => {
  page.goto('https://www.bbc.co.uk');
});
```

And then, run it using `cat ~/Repositories/synthetics/test/test.js | npx @elastic/synthetics --inline --rich-events`. You will see that for each part of the journey execution, it will emit a different type of event, as defined in the code excerpt below, which comes from the recorder:

https://github.com/elastic/synthetics/blob/30c536e53d93495fa8824e31ffd99c01a95c0376/src/core/runner.ts#L117-L141

> ⭐  **Tip**: to make these events more human-readable, try installing [`jq`](https://stedolan.github.io/jq/) and pipe your journey run into it (as in `cat ~/Repositories/synthetics/test/test.js | npx @elastic/synthetics --inline --rich-events | jq`)

For each of these events, Heartbeat would try to "enrich" them with more data:

https://github.com/elastic/beats/blob/bea8e454ea289e28ea260a8c88e7997364da2a75/x-pack/heartbeat/monitors/browser/synthexec/enrich.go#L104-L146

Especially for `journey:end`, Heartbeat would try to add a `summary` to the emitted document, so that we know data about the whole run.

https://github.com/elastic/beats/blob/bea8e454ea289e28ea260a8c88e7997364da2a75/x-pack/heartbeat/monitors/browser/synthexec/enrich.go#L148-L179

Now, the problem we've had _before_ this PR is that journeys which cause the `elastic-synthetics` executable (ran in a `node` subprocess) to crash, would _not_ emit a `journey:end` event. Consequently, we wouldn't have a `summary` for those journeys.

You can see that no `journey:end` event is emitted by the synthetics runner when you run the following journey, for example:

```js
step('google', () => {
  page.goto('https://www.google.com');
});

step('BBC', () => {
  page.goto('https://www.bbc.co.uk');
  process.exit(1);
});
```

After this change, we'll use the `cmd/status` `SynthEvent` also as a type of event which can be enriched with a `summary`.

https://github.com/elastic/beats/blob/1386a04099c81f791b334616437d71c56109e0e9/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go#L196-L202

Now, a critical part of this change was that **we need a timestamp for the summary events _when journeys fail and we emit a `cmd/status`_**. We need this timestamp so that we can set the `end` of the journey.

https://github.com/elastic/beats/blob/1386a04099c81f791b334616437d71c56109e0e9/x-pack/heartbeat/monitors/browser/synthexec/enrich.go#L70-L84

The problem with the `cmd/status` `SynthEvent` was that it did not have a `TimestampEpochMicros` field. It did not have this field because we're _not_ parsing `@timestamp` fields emitted by the `synthetics-runner`. Instead, we're just constructing a `SynthEvent` ourselves.

https://github.com/elastic/beats/blob/1386a04099c81f791b334616437d71c56109e0e9/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go#L198-L201

I then tried to use the same method we use to generate timestamps for when capturing line events, shown below:

https://github.com/elastic/beats/blob/1386a04099c81f791b334616437d71c56109e0e9/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go#L246

That procedure however, didn't yield correct results, causing timestamps generated in the method below to date back to 1970.

https://github.com/elastic/beats/blob/1386a04099c81f791b334616437d71c56109e0e9/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go#L89-L95

That problem took me a lot of debugging time, until I noticed summaries were just published a long time in the past.

After figuring that out, I simply used the new `UnixMicro` method (as in `time.Now().UnixMicro()`) to generate timestamps for `cmd/status` events, and it all worked out fine 😄 


## Why is it important?

This change is important because, in Kibana, we perform queries which look at a journey's summary to determine what to display.

Previously, the lack of a `summary` for our journeys has caused a monitor/check-group not to be displayed in Kibana, as pointed out in https://github.com/elastic/kibana/issues/116850#issuecomment-958125573. That problem happened because we were looking for documents with a `summary` as a way of indicating whether a monitor/check-group had finished running. However, monitors which caused the `node` subprocess to exit early would never be shown because Heartbeat would never add a `summary` document them.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

I'd appreciate if reviewers could:

- [ ] Double check whether my understanding of the problem and desired acceptance-criteria are correct.
- [ ] Double check whether my manual testing is sufficient to prove the acceptance-criteria is met
- [ ] Confirm you agree with what I've written in the _"Further Changes"_ section
- [ ] Verify whether my backport labels are correct (it's my first time contributing to this repo)

## How to test this PR locally

1. Create a journey which will cause the node subprocess to exit, like the one below:
    ```js
    step('google', () => {
      page.goto('https://www.google.com');
    });

    step('BBC', () => {
      page.goto('https://www.bbc.co.uk');
      process.exit(1);
    });
    ```
2. Confirm that the journey above _does not_ emit a `journey:end` event by running it with the synthetics runner (you must have built it before running the command below).
    ```
    $ cat ~/Repositories/synthetics/test/test.js | node ~/Repositories/synthetics/dist/cli.js --inline --rich-events
    ```
3. Create a `heartbeat.yml` pointing to your desired Elastic Stack for testing, and paste that journey into an inline monitor:
    ```yaml
    output.elasticsearch:
      hosts: ["http://localhost:9200"]
      username: "elastic"
      password: "changeme"

    heartbeat.monitors:
    - type: browser
      id: it-exits
      name: Journey that exits
      schedule: '@every 1m'
      source:
        inline:
          script: |-
            step('google', () => {
              page.goto('https://www.google.com');
            });

            step('BBC', () => {
              page.goto('https://www.bbc.co.uk');
              process.exit(1);
            });
    ```
4. Checkout this branch, and build Heartbeat (`mage build` within `x-pack/heartbeat`).
5. Run Heartbeat using the `heartbeat.yml` file from step 3
    ```
    ELASTIC_SYNTHETICS_CAPABLE=true ./heartbeat -c /tmp/heartbeat.yml -e -d "*"
    ```
6. In Kibana, look for documents which match your new monitor's ID. You should now see summaries for all command failure events too.
    ```
    GET /heartbeat-*/_search
    {
      "sort": [
        {
          "@timestamp": {
            "order": "desc"
          }
        }
      ], 
      "query": {
        "bool": {
          "must": [
            {
              "match": {
                "monitor.id": "it-exits-inline"
              }
            },
            {
              "match": {
                "synthetics.type": "heartbeat/summary"
              }
            }
          ]
        }
      }
    }
    ```

### Other recommended checks

1. Verify that the journey which does not complete appears in the `Uptime > Monitors` page
2. Change the monitor's name and ID and rollback this change to confirm no summaries appear without this change

## Related issues

- Relates to https://github.com/elastic/kibana/issues/117228
- Relates to https://github.com/elastic/kibana/issues/116850
- Fixes #28770 

## Use cases

This PR allows users to see their monitors in the `Uptime > Monitors` page even when those monitors crash before being finished, which means it's easier to debug what happened to them.

## Further Changes

As you test this PR, you will notice that the `Uptime > Monitors` page in Kibana will only display the step which did not crash. This behaviour occurs because we don't have a `step/end` event for the step which crashed.

Additionally, you will notice that journeys with syntax errors do not even start and therefore do not have summary. That's a different case from an early exit, instead, it's not even a start. Similar problems may occur when a journey can't even start for any other reason.

Therefore, I suggest that we create the two following issues:
* Emit `journey/start` events (or, alternatively, `journey/prepare`) even when there are syntax errors or other conditions which prevent journeys from even starting
* Update the UI so that the we display the step which causes the synthetics runner to crash

I considered the two issues above to be out of scope for this PR. Please let me know if you agree and if you're happy with the current behaviour.