### PR TITLE
Ensure that match_only_text and wildcard fields can be added to default_field list

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -78,6 +78,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Fields of type `match_only_text` (i.e. `message` field) were missing from the template's default_field list. {issue}29633[29633] {pull}29634[29634]
+
 *Auditbeat*
 
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -78,7 +78,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
-- Fields of type `match_only_text` (i.e. `message` field) were missing from the template's default_field list. {issue}29633[29633] {pull}29634[29634]
+- Fields of type `match_only_text` (i.e. `message`) and `wildcard` were missing from the template's default_field list. {issue}29633[29633] {pull}29634[29634]
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -136,7 +136,7 @@ func (p *Processor) Process(fields mapping.Fields, state *fieldState, output, an
 
 		if *field.DefaultField {
 			switch field.Type {
-			case "", "keyword", "text":
+			case "", "keyword", "text", "match_only_text":
 				addToDefaultFields(&field)
 			}
 		}

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -136,7 +136,7 @@ func (p *Processor) Process(fields mapping.Fields, state *fieldState, output, an
 
 		if *field.DefaultField {
 			switch field.Type {
-			case "", "keyword", "text", "match_only_text":
+			case "", "keyword", "text", "match_only_text", "wildcard":
 				addToDefaultFields(&field)
 			}
 		}

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -719,11 +719,16 @@ func TestProcessDefaultField(t *testing.T) {
 				},
 			},
 		},
-		// Ensure that text_only_keyword fields
-		// can be added to default_field
+		// Ensure that text_only_keyword fields can be added to default_field
 		mapping.Field{
 			Name:         "a_match_only_text_field",
 			Type:         "match_only_text",
+			DefaultField: &enableDefaultField,
+		},
+		// Ensure that wildcard fields can be added to default_field
+		mapping.Field{
+			Name:         "a_wildcard_field",
+			Type:         "wildcard",
 			DefaultField: &enableDefaultField,
 		},
 	}
@@ -742,6 +747,7 @@ func TestProcessDefaultField(t *testing.T) {
 
 	expectedFields := []string{
 		"a_match_only_text_field",
+		"a_wildcard_field",
 		"bar",
 		"nested.bar",
 		"nested.foo",

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -719,6 +719,13 @@ func TestProcessDefaultField(t *testing.T) {
 				},
 			},
 		},
+		// Ensure that text_only_keyword fields
+		// can be added to default_field
+		mapping.Field{
+			Name:         "a_match_only_text_field",
+			Type:         "match_only_text",
+			DefaultField: &enableDefaultField,
+		},
 	}
 
 	version, err := common.NewVersion("7.0.0")
@@ -734,6 +741,7 @@ func TestProcessDefaultField(t *testing.T) {
 	}
 
 	expectedFields := []string{
+		"a_match_only_text_field",
 		"bar",
 		"nested.bar",
 		"nested.foo",


### PR DESCRIPTION
## What does this PR do?

Fixes the construction of the index template's `default_field` list so that fields of type _match_only_text_ and _wildcard_ can be added to it.

## Why is it important?

Since support for _match_only_text_ type was introduced in Beats, important fields where missing from the `default_field` index template setting. This affected the `message` field among others.

Note: this PR only completely fixes the issue for the 7.16 branch,  as another (unrelated) feature in 8.0/master also broke `default_field`. See #29633.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #29633