### PR TITLE
Allow elastic agent in containers to use basic auth to get service token

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -93,6 +93,7 @@
 - Fix lazy acker to only add new actions to the batch. {pull}27981[27981]
 - Allow HTTP metrics to run in bootstrap mode. Add ability to adjust timeouts for Fleet Server. {pull}28260[28260]
 - Fix agent configuration overwritten by default fleet config. {pull}29297[29297]
+- Allow agent containers to use basic auth to create a service token. {pull}29651[29651]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/container.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/container.go
@@ -328,16 +328,21 @@ func runContainerCmd(streams *cli.IOStreams, cmd *cobra.Command, cfg setupConfig
 	return run(streams, logToStderr)
 }
 
+// TokenResp is used to decode a response for generating a service token
 type TokenResp struct {
 	Created bool    `json:"created"`
 	Token   TokenKV `json:"token"`
 }
 
+// TokenKV contains the name and value of a service token
 type TokenKV struct {
 	Name  string `json:"name"`
 	Value string `json:"value"`
 }
 
+// ensureServiceToken will ensure that the cfg specified has the service_token attributes filled.
+//
+// If no token is specified it will use the elasticsearch username/password to request a new token from elasticsearch.
 func ensureServiceToken(streams *cli.IOStreams, cfg *setupConfig) error {
 	// There's already a service token
 	if cfg.Kibana.Fleet.ServiceToken != "" || cfg.FleetServer.Elasticsearch.ServiceToken != "" {

--- a/x-pack/elastic-agent/pkg/agent/cmd/setup_config.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/setup_config.go
@@ -43,8 +43,6 @@ type elasticsearchConfig struct {
 	CA                   string `config:"ca"`
 	CATrustedFingerprint string `config:"ca_trusted_fingerprint"`
 	Host                 string `config:"host"`
-	Username             string `config:"username"`
-	Password             string `config:"password"`
 	ServiceToken         string `config:"service_token"`
 	Insecure             bool   `config:"insecure"`
 }
@@ -60,6 +58,8 @@ type kibanaFleetConfig struct {
 	CA           string `config:"ca"`
 	Host         string `config:"host"`
 	Setup        bool   `config:"setup"`
+	Username     string `config:"username"`
+	Password     string `config:"password"`
 	ServiceToken string `config:"service_token"`
 }
 
@@ -91,8 +91,6 @@ func defaultAccessConfig() (setupConfig, error) {
 			CertKey: envWithDefault("", "FLEET_SERVER_CERT_KEY"),
 			Elasticsearch: elasticsearchConfig{
 				Host:                 envWithDefault("http://elasticsearch:9200", "FLEET_SERVER_ELASTICSEARCH_HOST", "ELASTICSEARCH_HOST"),
-				Username:             envWithDefault("elastic", "FLEET_SERVER_ELASTICSEARCH_USERNAME", "ELASTICSEARCH_USERNAME"),
-				Password:             envWithDefault("changeme", "FLEET_SERVER_ELASTICSEARCH_PASSWORD", "ELASTICSEARCH_PASSWORD"),
 				ServiceToken:         envWithDefault("", "FLEET_SERVER_SERVICE_TOKEN"),
 				CA:                   envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA", "ELASTICSEARCH_CA"),
 				CATrustedFingerprint: envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA_TRUSTED_FINGERPRINT"),
@@ -110,6 +108,8 @@ func defaultAccessConfig() (setupConfig, error) {
 			Fleet: kibanaFleetConfig{
 				Setup:        envBool("KIBANA_FLEET_SETUP"),
 				Host:         envWithDefault("http://kibana:5601", "KIBANA_FLEET_HOST", "KIBANA_HOST"),
+				Username:     envWithDefault("elastic", "KIBANA_FLEET_USERNAME", "ELASTICSEARCH_USERNAME"),
+				Password:     envWithDefault("changeme", "KIBANA_FLEET_PASSWORD", "ELASTICSEARCH_PASSWORD"),
 				ServiceToken: envWithDefault("", "KIBANA_FLEET_SERVICE_TOKEN", "FLEET_SERVER_SERVICE_TOKEN"),
 				CA:           envWithDefault("", "KIBANA_FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA"),
 			},

--- a/x-pack/elastic-agent/pkg/agent/cmd/setup_config.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/setup_config.go
@@ -43,6 +43,8 @@ type elasticsearchConfig struct {
 	CA                   string `config:"ca"`
 	CATrustedFingerprint string `config:"ca_trusted_fingerprint"`
 	Host                 string `config:"host"`
+	Username             string `config:"username"`
+	Password             string `config:"password"`
 	ServiceToken         string `config:"service_token"`
 	Insecure             bool   `config:"insecure"`
 }
@@ -89,6 +91,8 @@ func defaultAccessConfig() (setupConfig, error) {
 			CertKey: envWithDefault("", "FLEET_SERVER_CERT_KEY"),
 			Elasticsearch: elasticsearchConfig{
 				Host:                 envWithDefault("http://elasticsearch:9200", "FLEET_SERVER_ELASTICSEARCH_HOST", "ELASTICSEARCH_HOST"),
+				Username:             envWithDefault("elastic", "FLEET_SERVER_ELASTICSEARCH_USERNAME", "ELASTICSEARCH_USERNAME"),
+				Password:             envWithDefault("changeme", "FLEET_SERVER_ELASTICSEARCH_PASSWORD", "ELASTICSEARCH_PASSWORD"),
 				ServiceToken:         envWithDefault("", "FLEET_SERVER_SERVICE_TOKEN"),
 				CA:                   envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA", "ELASTICSEARCH_CA"),
 				CATrustedFingerprint: envWithDefault("", "FLEET_SERVER_ELASTICSEARCH_CA_TRUSTED_FINGERPRINT"),
@@ -104,10 +108,7 @@ func defaultAccessConfig() (setupConfig, error) {
 		},
 		Kibana: kibanaConfig{
 			Fleet: kibanaFleetConfig{
-				// Remove FLEET_SETUP in 8.x
-				// The FLEET_SETUP environment variable boolean is a fallback to the old name. The name was updated to
-				// reflect that its setting up Fleet in Kibana versus setting up Fleet Server.
-				Setup:        envBool("KIBANA_FLEET_SETUP", "FLEET_SETUP"),
+				Setup:        envBool("KIBANA_FLEET_SETUP"),
 				Host:         envWithDefault("http://kibana:5601", "KIBANA_FLEET_HOST", "KIBANA_HOST"),
 				ServiceToken: envWithDefault("", "KIBANA_FLEET_SERVICE_TOKEN", "FLEET_SERVER_SERVICE_TOKEN"),
 				CA:           envWithDefault("", "KIBANA_FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA"),


### PR DESCRIPTION
## What does this PR do?

Allow the agent to use basic auth defined by env vars to retrieve a
service token from Elasticsearch and inject it into the config used for
the agent and fleet.

## Why is it important?

Allow the agent started in a container to use basic auth to contact Elasticsearch and generate a `service_token`.
This should fix the tests which rely on docker-compose.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

- Closes #29603

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->