### PR TITLE
Fix YAML indentation in `parsers` examples

### DIFF
--- a/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
@@ -164,11 +164,11 @@ The multiline message is stored under the key `msg`.
   ...
   parsers:
     - ndjson:
-      keys_under_root: true
-      message_key: msg
+        keys_under_root: true
+        message_key: msg
     - multiline:
-      type: counter
-      lines_count: 3
+        type: counter
+        lines_count: 3
 ----
 
 See the available parser settings in detail below.
@@ -197,9 +197,9 @@ Example configuration:
 [source,yaml]
 ----
 - ndjson:
-  keys_under_root: true
-  add_error_key: true
-  message_key: log
+    keys_under_root: true
+    add_error_key: true
+    message_key: log
 ----
 
 *`keys_under_root`*:: By default, the decoded JSON is placed under a "json" key
@@ -256,5 +256,5 @@ all containers under the default Kubernetes logs path:
     - "/var/log/containers/*.log"
   parsers:
     - container:
-      stream: stdout
+        stream: stdout
 ----


### PR DESCRIPTION
Type of change: Docs

## What does this PR do?
The indentation is incorrect in the `filestream` `parsers` example snippets — filebeat expects each `parsers` array item to be an object with a single key containing an object of parameters, but the examples show each `parsers` array item as an object with multiple keys.  The existing syntax causes filebeat to fail to start.  This MR fixes the documentation to produce the YAML structure that filebeat expects, so that the snippets can be successfully used in filebeat.

## Why is it important?
The existing documentation is inaccurate, causing confusion about what YAML structure filebeat actually expects.

## Checklist
- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

## How to test this PR locally
- Install filebeat 7.16.2
- Use the existing YAML snippets in the documentation to try to add a parser to the default config — filebeat fails to launch
- Use the updated YAML snippets in this MR — filebeat successfully launches

## Related issues
- https://discuss.elastic.co/t/filebeat-filestream-input-parsers-multiline-fails/290543

## Use cases

## Screenshots

## Logs
The message filebeat outputs when using the existing YAML snippets in the documentation:
```
Exiting: Failed to start crawler: creating input reloader failed: error while parsing multiline parser config: unknown matcher type: accessing '0.parsers.0.multiline' accessing '0'
```