### PR TITLE
Remove overriding of index pattern on the Kubernetes overview dashboard

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -54,7 +54,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove deprecated config option perfmon.counters from windows/perfmon metricset. {pull}28282[28282]
 - Remove deprecated fields in Redis module. {issue}11835[11835] {pull}28246[28246]
 - system/process metricset: Replace usage of deprecated `process.ppid` field with `process.parent.pid`. {pull}28620[28620]
-- Remove overriding of index pattern on the Kubernetes overview dashboard.
+- Remove overriding of index pattern on the Kubernetes overview dashboard. {pull}29676[29676]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -54,6 +54,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Remove deprecated config option perfmon.counters from windows/perfmon metricset. {pull}28282[28282]
 - Remove deprecated fields in Redis module. {issue}11835[11835] {pull}28246[28246]
 - system/process metricset: Replace usage of deprecated `process.ppid` field with `process.parent.pid`. {pull}28620[28620]
+- Remove overriding of index pattern on the Kubernetes overview dashboard.
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/174a6ad0-30e0-11e7-8df8-6d3604a72912-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/174a6ad0-30e0-11e7-8df8-6d3604a72912-ecs.json
@@ -57,7 +57,6 @@
                                 "type": "sum"
                             }
                         ],
-                        "override_index_pattern": 1,
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3-ecs.json
@@ -57,12 +57,9 @@
                                 "type": "sum"
                             }
                         ],
-                        "override_index_pattern": 1,
                         "point_size": 1,
                         "seperate_axis": 0,
-                        "series_index_pattern": "*",
                         "series_interval": "10s",
-                        "series_time_field": "@timestamp",
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
                         "stacked": "none"

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/e1018b90-2bfb-11e7-859b-f78b612cde28-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/e1018b90-2bfb-11e7-859b-f78b612cde28-ecs.json
@@ -57,11 +57,9 @@
                                 "type": "sum"
                             }
                         ],
-                        "override_index_pattern": 1,
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",
-                        "series_time_field": "@timestamp",
                         "split_color_mode": "gradient",
                         "split_mode": "everything",
                         "stacked": "none"


### PR DESCRIPTION
align visualisations with changes in https://github.com/elastic/integrations/pull/2151

Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

## What does this PR do?

align metricbeat kibana visualisation with changes made in https://github.com/elastic/integrations/pull/2151

## Why is it important?

As described here https://github.com/elastic/kibana/issues/121684 since 7.15 there was a problem due to a misplaced migration causing some visualizations to switch off the "drop last bucket" setting without intention (the default switched from true to false). This can cause visualizations to not show any data even though there is data available. in the case of the usage of the "override index pattern" it is not possible to migrate the "drop series last bucket" setting of the series with overridden index pattern without potentially breaking other user-defined TSVB visualizations. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related https://github.com/elastic/kibana/issues/121684
- Related https://github.com/elastic/beats/issues/28792

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
