### PR TITLE
doc: update filebeat dissect processor field tokenization example

### DIFF
--- a/libbeat/processors/dissect/docs/dissect.asciidoc
+++ b/libbeat/processors/dissect/docs/dissect.asciidoc
@@ -74,14 +74,14 @@ For this example, imagine that an application generates the following messages:
 "789 - App02 - Database is refreshing tables"
 ----
 
-Use the `dissect` processor to split each message into two fields, for example,
+Use the `dissect` processor to split each message into three fields, for example, `service.pid`,
 `service.name` and `service.status`:
 
 [source,yaml]
 ----
 processors:
   - dissect:
-      tokenizer: '"%{pid|integer} - %{service.name} - %{service.status}"'
+      tokenizer: '"%{service.pid|integer} - %{service.name} - %{service.status}"'
       field: "message"
       target_prefix: ""
 ----
@@ -98,7 +98,7 @@ This configuration produces fields like:
 ----
 
 `service.name` is an ECS {ref}/keyword.html[keyword field], which means that you
-can use it in {es} for filtering, sorting, and aggregations. 
+can use it in {es} for filtering, sorting, and aggregations.
 
 When possible, use ECS-compatible field names. For more information, see the
 {ecs-ref}/index.html[Elastic Common Schema] documentation.


### PR DESCRIPTION
## What does this PR do?

Improves documentation for the filebeat `dissect` processor.

## Why is it important?

The `dissect` processor has only 1 example of configuration with (possibly) an error in the suggested syntax.
I came across it while trying to setup a filebeat instance.

https://www.elastic.co/guide/en/beats/filebeat/current/dissect.html#dissect-example

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Deos the changelog need to be updated for doc-only changes?

## Author's Checklist

- [ ] Validate the information changed in the doc actually reflects reality, the suggested content is my guess after a quick look at the code, but I didn't write a test for it
