### PR TITLE
Only connect to Elasticsearch instances with the same version or newer

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -138,6 +138,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add FIPS configuration option for all AWS API calls. {pull}28899[28899]
 - Add `default_region` config to AWS common module. {pull}29415[29415]
 - Add support for latest k8s versions v1.23 and v1.22 {pull}29575[29575]
+- Only connect to Elasticsearch instances with the same version or newer. {pull}29683[29683]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -460,6 +460,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # auditbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -460,7 +460,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # auditbeat expects Elasticseach to be the same version or newer than the Beat.
+  # auditbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -48,7 +48,7 @@ stages:
       mage: >-                 ## Run module integration tests under previous minor of ES to ensure ingest pipeline compatibility.
         STACK_ENVIRONMENT=prev-minor
         TESTING_FILEBEAT_SKIP_DIFF=1
-        TESTING_ALLOW_OLDER=1
+        TESTING_FILEBEAT_ALLOW_OLDER=1
         PYTEST_ADDOPTS='-k test_modules'
         mage pythonIntegTest
       withModule: true

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -48,6 +48,7 @@ stages:
       mage: >-                 ## Run module integration tests under previous minor of ES to ensure ingest pipeline compatibility.
         STACK_ENVIRONMENT=prev-minor
         TESTING_FILEBEAT_SKIP_DIFF=1
+        TESTING_ALLOW_OLDER=1
         PYTEST_ADDOPTS='-k test_modules'
         mage pythonIntegTest
       withModule: true

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1404,7 +1404,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # filebeat expects Elasticseach to be the same version or newer than the Beat.
+  # filebeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1404,6 +1404,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # filebeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -125,7 +125,7 @@ class Test(BaseTest):
             "-M", "*.*.input.close_eof=true",
         ]
         # allow connecting older versions of Elasticsearch
-        if os.getenv("TESTING_ALLOW_OLDER"):
+        if os.getenv("TESTING_FILEBEAT_ALLOW_OLDER"):
             cmd.extend(["-E", "output.elasticsearch.allow_older_versions=true"])
 
         # Based on the convention that if a name contains -json the json format is needed. Currently used for LS.

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -124,6 +124,9 @@ class Test(BaseTest):
                 module=module, fileset=fileset, test_file=test_file),
             "-M", "*.*.input.close_eof=true",
         ]
+        # allow connecting older versions of Elasticsearch
+        if os.getenv("TESTING_ALLOW_OLDER"):
+            cmd.extend(["-E", "output.elasticsearch.allow_older_versions=true"])
 
         # Based on the convention that if a name contains -json the json format is needed. Currently used for LS.
         if "-json" in test_file:

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -606,7 +606,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # heartbeat expects Elasticseach to be the same version or newer than the Beat.
+  # heartbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -606,6 +606,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # heartbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
@@ -77,7 +77,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # {{.BeatName}} expects Elasticseach to be the same version or newer than the Beat.
+  # {{.BeatName}} expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
@@ -77,6 +77,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # {{.BeatName}} expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
 {{include "ssl.reference.yml.tmpl" . | indent 2 }}
   # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
   #kerberos.enabled: true

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -872,6 +872,7 @@ func (b *Beat) checkElasticsearchVersion() {
 			return err
 		}
 		if esVersion.LessThan(beatVersion) {
+			logp.Err("Elasticsearch instance is too old. ES=%v Beat=%s", esVersion, b.Info.Version)
 			return elasticsearch.ErrTooOld
 		}
 		return nil

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -872,8 +872,7 @@ func (b *Beat) checkElasticsearchVersion() {
 			return err
 		}
 		if esVersion.LessThan(beatVersion) {
-			logp.Err("Elasticsearch instance is too old. ES=%v Beat=%s", esVersion, b.Info.Version)
-			return elasticsearch.ErrTooOld
+			return fmt.Errorf("%v ES=%s, Beat=%s.", elasticsearch.ErrTooOld, esVersion.String(), b.Info.Version)
 		}
 		return nil
 	})

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -857,7 +857,9 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 	return nil
 }
 
-// checkElasticsearchVersion TODO
+// checkElasticsearchVersion registers a global callback to make sure ES instance we are connecting
+// to is at least on the same version as the Beat.
+// If the check is disabled or the output is not Elasticsearch, nothing happens.
 func (b *Beat) checkElasticsearchVersion() {
 	if b.Config.Output.Name() != "elasticsearch" || b.isConnectionToOlderVersionAllowed() {
 		return

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -41,7 +41,7 @@ import (
 var (
 	errPayloadTooLarge = errors.New("the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped")
 
-	ErrTooOld = errors.New("Elasticsearch is too old. If you would like to connect to older instances enable sdfsf.dsfsd.")
+	ErrTooOld = errors.New("Elasticsearch is too old. If you would like to connect to older instances set output.elasticsearch.allow_older_versions to true.")
 )
 
 // Client is an elasticsearch client.

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -41,7 +41,7 @@ import (
 var (
 	errPayloadTooLarge = errors.New("the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped")
 
-	ErrTooOld = errors.New("Elasticsearch is too old. If you would like to connect to older instances set output.elasticsearch.allow_older_versions to true.")
+	ErrTooOld = errors.New("Elasticsearch is too old. Please upgrade the instance. If you would like to connect to older instances set output.elasticsearch.allow_older_versions to true.")
 )
 
 // Client is an elasticsearch client.

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -38,7 +38,11 @@ import (
 	"github.com/elastic/beats/v7/libbeat/testing"
 )
 
-var errPayloadTooLarge = errors.New("the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped")
+var (
+	errPayloadTooLarge = errors.New("the bulk payload is too large for the server. Consider to adjust `http.max_content_length` parameter in Elasticsearch or `bulk_max_size` in the beat. The batch has been dropped")
+
+	ErrTooOld = errors.New("Elasticsearch is too old. If you would like to connect to older instances enable sdfsf.dsfsd.")
+)
 
 // Client is an elasticsearch client.
 type Client struct {

--- a/libbeat/outputs/elasticsearch/config.go
+++ b/libbeat/outputs/elasticsearch/config.go
@@ -43,6 +43,7 @@ type elasticsearchConfig struct {
 	MaxRetries         int                     `config:"max_retries"`
 	Backoff            Backoff                 `config:"backoff"`
 	NonIndexablePolicy *common.ConfigNamespace `config:"non_indexable_policy"`
+	AllowOlderVersion  bool                    `config:"allow_older_versions"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`
 }

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -60,6 +60,9 @@ This output works with all compatible versions of Elasticsearch. See the
 https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
 Matrix].
 
+For optimal experience, {beatname_uc} only connects to instances that are at least on the
+same version as the Beat. The check can be disabled by setting `output.elasticsearch.allow_older_versions`.
+
 ==== Configuration options
 
 You can specify the following options in the `elasticsearch` section of the +{beatname_lc}.yml+ config file:
@@ -667,6 +670,14 @@ Elasticsearch after a network error. The default is `60s`.
 ===== `timeout`
 
 The http request timeout in seconds for the Elasticsearch request. The default is 90.
+
+==== `allow_older_versions`
+
+By default, {beatname_uc} expects the Elasticsearch instance to be on the same or newer version to provide
+optimal experience. We suggest you connect to the same version to make sure all features {beatname_uc} is using are
+available in your Elasticsearch instance.
+
+You can disable the check for example during updating the Elastic Stack, so data collection can go on.
 
 ===== `ssl`
 

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -42,7 +42,7 @@ output:
     {% for k, v in elasticsearch.items() -%}
     {{ k }}: {{ v }}
     {% endfor -%}
-    # older versions have to be alloed because mockbeat is on v9.9.9
+    # older versions have to be allowed because mockbeat is on v9.9.9
     allow_older_versions: true
   {%- endif %}
 

--- a/libbeat/tests/system/config/mockbeat.yml.j2
+++ b/libbeat/tests/system/config/mockbeat.yml.j2
@@ -42,6 +42,8 @@ output:
     {% for k, v in elasticsearch.items() -%}
     {{ k }}: {{ v }}
     {% endfor -%}
+    # older versions have to be alloed because mockbeat is on v9.9.9
+    allow_older_versions: true
   {%- endif %}
 
   # Redis as output

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1323,6 +1323,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # metricbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1323,7 +1323,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # metricbeat expects Elasticseach to be the same version or newer than the Beat.
+  # metricbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -955,7 +955,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # packetbeat expects Elasticseach to be the same version or newer than the Beat.
+  # packetbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -955,6 +955,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # packetbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -391,6 +391,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # winlogbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -391,7 +391,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # winlogbeat expects Elasticseach to be the same version or newer than the Beat.
+  # winlogbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -516,7 +516,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # auditbeat expects Elasticseach to be the same version or newer than the Beat.
+  # auditbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -516,6 +516,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # auditbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -48,6 +48,7 @@ stages:
       mage: >-                 ## Run module integration tests under previous minor of ES to ensure ingest pipeline compatibility.
         STACK_ENVIRONMENT=prev-minor
         TESTING_FILEBEAT_SKIP_DIFF=1
+        TESTING_ALLOW_OLDER=1
         PYTEST_ADDOPTS='-k test_xpack_modules'
         mage pythonIntegTest
       withModule: true

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -48,7 +48,7 @@ stages:
       mage: >-                 ## Run module integration tests under previous minor of ES to ensure ingest pipeline compatibility.
         STACK_ENVIRONMENT=prev-minor
         TESTING_FILEBEAT_SKIP_DIFF=1
-        TESTING_ALLOW_OLDER=1
+        TESTING_FILEBEAT_ALLOW_OLDER=1
         PYTEST_ADDOPTS='-k test_xpack_modules'
         mage pythonIntegTest
       withModule: true

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3634,7 +3634,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # filebeat expects Elasticseach to be the same version or newer than the Beat.
+  # filebeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3634,6 +3634,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # filebeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -638,7 +638,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # functionbeat expects Elasticseach to be the same version or newer than the Beat.
+  # functionbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -638,6 +638,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # functionbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -606,7 +606,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # heartbeat expects Elasticseach to be the same version or newer than the Beat.
+  # heartbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -606,6 +606,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # heartbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1844,6 +1844,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # metricbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1844,7 +1844,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # metricbeat expects Elasticseach to be the same version or newer than the Beat.
+  # metricbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -357,6 +357,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # osquerybeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -357,7 +357,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # osquerybeat expects Elasticseach to be the same version or newer than the Beat.
+  # osquerybeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -955,7 +955,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # packetbeat expects Elasticseach to be the same version or newer than the Beat.
+  # packetbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -955,6 +955,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # packetbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -434,7 +434,7 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
-  # winlogbeat expects Elasticseach to be the same version or newer than the Beat.
+  # winlogbeat expects Elasticsearch to be the same version or newer than the Beat.
   # Lift the version restriction by setting allow_older_versions to true.
   #allow_older_versions: false
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -434,6 +434,10 @@ output.elasticsearch:
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 
+  # winlogbeat expects Elasticseach to be the same version or newer than the Beat.
+  # Lift the version restriction by setting allow_older_versions to true.
+  #allow_older_versions: false
+
   # Use SSL settings for HTTPS.
   #ssl.enabled: true
 


### PR DESCRIPTION
## What does this PR do?

This PR adds a new callback to all Elasticsearch connections to check if the version is at least the same as the Beat. The check can be disabled by setting the new option `output.elasticsearch.allow_older_versions` to true.

## Why is it important?

By restricting the Elasticsearch versions we can provide optimal experience. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes https://github.com/elastic/beats/issues/29264