### PR TITLE
[Heartbeat] Separate http req per task

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,6 +155,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Remove accidentally included cups library in docker images. {pull}28853[pull]
 - Fix broken monitors with newer versions of image relying on dup3. {pull}28938[pull]
+- Fix race condition in http monitors using `mode:all` that can cause crashes. {pull}29697[pull]
 
 *Metricbeat*
 

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -45,6 +45,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 )
 
+type requestFactory func() (*http.Request, error)
+
 func newHTTPMonitorHostJob(
 	addr string,
 	config *Config,
@@ -54,10 +56,7 @@ func newHTTPMonitorHostJob(
 	validator multiValidator,
 ) (jobs.Job, error) {
 
-	request, err := buildRequest(addr, config, enc)
-	if err != nil {
-		return nil, err
-	}
+	var reqFactory requestFactory = func() (*http.Request, error) { return buildRequest(addr, config, enc) }
 
 	return jobs.MakeSimpleJob(func(event *beat.Event) error {
 		var redirects []string
@@ -67,7 +66,13 @@ func newHTTPMonitorHostJob(
 			Transport:     transport,
 			Timeout:       config.Transport.Timeout,
 		}
-		_, _, err := execPing(event, client, request, body, config.Transport.Timeout, validator, config.Response)
+
+		req, err := reqFactory()
+		if err != nil {
+			return fmt.Errorf("could not make http request: %w", err)
+		}
+
+		_, _, err = execPing(event, client, req, body, config.Transport.Timeout, validator, config.Response)
 		if len(redirects) > 0 {
 			event.PutValue("http.response.redirects", redirects)
 		}
@@ -84,17 +89,14 @@ func newHTTPMonitorIPsJob(
 	validator multiValidator,
 ) (jobs.Job, error) {
 
-	req, err := buildRequest(addr, config, enc)
+	var reqFactory requestFactory = func() (*http.Request, error) { return buildRequest(addr, config, enc) }
+
+	hostname, port, err := splitHostnamePort(addr)
 	if err != nil {
 		return nil, err
 	}
 
-	hostname, port, err := splitHostnamePort(req)
-	if err != nil {
-		return nil, err
-	}
-
-	pingFactory := createPingFactory(config, port, tls, req, body, validator)
+	pingFactory := createPingFactory(config, port, tls, reqFactory, body, validator)
 	job, err := monitors.MakeByHostJob(hostname, config.Mode, monitors.NewStdResolver(), pingFactory)
 
 	return job, err
@@ -104,14 +106,19 @@ func createPingFactory(
 	config *Config,
 	port uint16,
 	tls *tlscommon.TLSConfig,
-	request *http.Request,
+	reqFactory requestFactory,
 	body []byte,
 	validator multiValidator,
 ) func(*net.IPAddr) jobs.Job {
 	timeout := config.Transport.Timeout
-	isTLS := request.URL.Scheme == "https"
 
 	return monitors.MakePingIPFactory(func(event *beat.Event, ip *net.IPAddr) error {
+		request, err := reqFactory()
+		if err != nil {
+			return fmt.Errorf("could not create http request: %w", err)
+		}
+		isTLS := request.URL.Scheme == "https"
+
 		addr := net.JoinHostPort(ip.String(), strconv.Itoa(int(port)))
 		d := &dialchain.DialerChain{
 			Net: dialchain.MakeConstAddrDialer(addr, dialchain.TCPDialer(timeout)),
@@ -163,7 +170,12 @@ func createPingFactory(
 			Transport:     httpcommon.HeaderRoundTripper(transport, map[string]string{"User-Agent": userAgent}),
 		}
 
-		_, end, err := execPing(event, client, request, body, timeout, validator, config.Response)
+		req, err := reqFactory()
+		if err != nil {
+			return fmt.Errorf("could not create http request: %w", err)
+		}
+
+		_, end, err := execPing(event, client, req, body, timeout, validator, config.Response)
 		cbMutex.Lock()
 		defer cbMutex.Unlock()
 
@@ -313,11 +325,15 @@ func execRequest(client *http.Client, req *http.Request) (start time.Time, resp 
 	return start, resp, nil
 }
 
-func splitHostnamePort(requ *http.Request) (string, uint16, error) {
-	host := requ.URL.Host
+func splitHostnamePort(addr string) (string, uint16, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return "", 0, err
+	}
+	host := u.Host
 	// Try to add a default port if needed
 	if strings.LastIndex(host, ":") == -1 {
-		switch requ.URL.Scheme {
+		switch u.Scheme {
 		case urlSchemaHTTP:
 			host += ":80"
 		case urlSchemaHTTPS:
@@ -330,7 +346,7 @@ func splitHostnamePort(requ *http.Request) (string, uint16, error) {
 	}
 	p, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
-		return "", 0, fmt.Errorf("'%v' is no valid port number in '%v'", port, requ.URL.Host)
+		return "", 0, fmt.Errorf("'%v' is no valid port number in '%v'", port, u.Host)
 	}
 	return host, uint16(p), nil
 }

--- a/heartbeat/monitors/active/http/task.go
+++ b/heartbeat/monitors/active/http/task.go
@@ -113,11 +113,11 @@ func createPingFactory(
 	timeout := config.Transport.Timeout
 
 	return monitors.MakePingIPFactory(func(event *beat.Event, ip *net.IPAddr) error {
-		request, err := reqFactory()
+		req, err := reqFactory()
 		if err != nil {
 			return fmt.Errorf("could not create http request: %w", err)
 		}
-		isTLS := request.URL.Scheme == "https"
+		isTLS := req.URL.Scheme == "https"
 
 		addr := net.JoinHostPort(ip.String(), strconv.Itoa(int(port)))
 		d := &dialchain.DialerChain{
@@ -168,11 +168,6 @@ func createPingFactory(
 			CheckRedirect: checkRedirect,
 			Timeout:       timeout,
 			Transport:     httpcommon.HeaderRoundTripper(transport, map[string]string{"User-Agent": userAgent}),
-		}
-
-		req, err := reqFactory()
-		if err != nil {
-			return fmt.Errorf("could not create http request: %w", err)
 		}
 
 		_, end, err := execPing(event, client, req, body, timeout, validator, config.Response)

--- a/heartbeat/monitors/active/http/task_test.go
+++ b/heartbeat/monitors/active/http/task_test.go
@@ -106,7 +106,7 @@ func TestSplitHostnamePort(t *testing.T) {
 			request := &http.Request{
 				URL: url,
 			}
-			host, port, err := splitHostnamePort(request)
+			host, port, err := splitHostnamePort(request.URL.String())
 
 			if err != nil {
 				if test.expectedError == nil {

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -96,11 +96,11 @@ setup.kibana:
 # ================================== Outputs ===================================
 
 # Configure what output to use when sending the data collected by the beat.
-
+output.console: ~
 # ---------------------------- Elasticsearch Output ----------------------------
-output.elasticsearch:
+#output.elasticsearch:
   # Array of hosts to connect to.
-  hosts: ["localhost:9200"]
+  #hosts: ["localhost:9200"]
 
   # Protocol - either `http` (default) or `https`.
   #protocol: "https"

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -96,11 +96,11 @@ setup.kibana:
 # ================================== Outputs ===================================
 
 # Configure what output to use when sending the data collected by the beat.
-output.console: ~
+
 # ---------------------------- Elasticsearch Output ----------------------------
-#output.elasticsearch:
+output.elasticsearch:
   # Array of hosts to connect to.
-  #hosts: ["localhost:9200"]
+  hosts: ["localhost:9200"]
 
   # Protocol - either `http` (default) or `https`.
   #protocol: "https"


### PR DESCRIPTION
This is an attempt to fix the race reported in #29580 by instantiating a separate http request per HTTP task. The theory being that the HTTP library modifies the headers and that the req object is not safe to share.

This has passed manual testing using `mode: all` against endpoints with multiple A records. 

Tests are not included here due to the tricky nature of testing here, but we will do so in a follow-up

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
