### PR TITLE
Sysmon EventID 3 - Add source.address

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -175,6 +175,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Winlogbeat*
 
 - Add support for custom XML queries {issue}1054[1054] {pull}29330[29330]
+- Add source.address to Sysmon EventID 3 {pull}29703[29703]
 
 *Elastic Log Driver*
 

--- a/x-pack/winlogbeat/module/sysmon/ingest/sysmon.yml
+++ b/x-pack/winlogbeat/module/sysmon/ingest/sysmon.yml
@@ -626,6 +626,12 @@ processors:
       ignore_failure: true
       ignore_missing: true
       if: ctx?.winlog?.event_data?.SourceIp != null && ctx?.winlog?.event_data?.SourceIp != ""
+  - set:
+      field: source.address
+      copy_from: winlog.event_data.SourceIp
+      ignore_empty_value: true
+      ignore_failure: true
+      if: ctx?.winlog?.event_data?.SourceIp != null && ctx?.winlog?.event_data?.SourceIp != "" && ctx.event.code == "3"
   - rename:
       field: winlog.event_data.SourceHostname
       target_field: source.domain


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Enhancement
-->

## What does this PR do?

Add the source.adress field to EVENT ID 3
https://www.elastic.co/guide/en/ecs/current/ecs-source.html#field-source-address

## Why is it important?

During the revision of some windows detection rules I've found that Sysmon's event ID 3 does not populate the source.address field, so those rules cannot be used
The affected rules are

- Remote Scheduled Task Creation
- Incoming Execution via PowerShell Remoting
- Remotely Started Services via RPC
- Potential SharpRDP Behavior
- WMI Incoming Lateral Movement
- Incoming Execution via WinRM Remote Shell

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

