### PR TITLE
notice: update copyright year

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2021 Elasticsearch BV
+Copyright 2014-2022 Elasticsearch BV
 
 This product includes software developed by The Apache Software 
 Foundation (http://www.apache.org/).


### PR DESCRIPTION
## What does this PR do?

Update copyright year

Otherwise ` make check-default` fails with 

```
[2022-01-05T03:40:50.014Z] diff --git a/NOTICE.txt b/NOTICE.txt
[2022-01-05T03:40:50.014Z] index 070c3c55b..bc566be38 100644
[2022-01-05T03:40:50.014Z] --- a/NOTICE.txt
[2022-01-05T03:40:50.014Z] +++ b/NOTICE.txt
[2022-01-05T03:40:50.014Z] @@ -1,5 +1,5 @@
[2022-01-05T03:40:50.014Z]  Elastic Beats
[2022-01-05T03:40:50.014Z] -Copyright 2014-2021 Elasticsearch BV
[2022-01-05T03:40:50.014Z] +Copyright 2014-2022 Elasticsearch BV
[2022-01-05T03:40:50.014Z]  
[2022-01-05T03:40:50.014Z]  This product includes software developed by The Apache Software 
[2022-01-05T03:40:50.014Z]  Foundation (http://www.apache.org/).
[2022-01-05T03:40:50.953Z] NOTICE.txt: needs update
[2022-01-05T03:40:50.953Z] Makefile:123: recipe for target 'check-no-changes' failed
```