### PR TITLE
ci: uses aliases for the branches

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,7 +22,7 @@ pipeline {
       steps {
         runBuild(quietPeriod: 0, branch: 'master')
         runBuild(quietPeriod: 2000, branch: '8.<minor>')
-        runBuild(quietPeriod: 4000, branch: '7.<minor>')
+        runBuild(quietPeriod: 2000, branch: '7.<next-minor>')
       }
     }
   }
@@ -41,6 +41,9 @@ def runBuild(Map args = [:]) {
   }
   if (branch.contains('7.<minor>')) {
     branch = bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
+  }
+  if (branch.contains('7.<next-minor>')) {
+    branch = bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
   }
   build(quietPeriod: args.quietPeriod, job: "Beats/beats/${branch}", parameters: [booleanParam(name: 'macosTest', value: true)], wait: false, propagate: false)
 }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,7 +22,7 @@ pipeline {
       steps {
         runBuild(quietPeriod: 0, branch: 'master')
         runBuild(quietPeriod: 2000, branch: '8.<minor>')
-        runBuild(quietPeriod: 2000, branch: '7.<next-minor>')
+        runBuild(quietPeriod: 4000, branch: '7.<next-minor>')
       }
     }
   }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -45,7 +45,7 @@ def runBuilds(Map args = [:]) {
   branches.each { branch ->
     build(quietPeriod: quietPeriod, job: "Beats/beats/${branch}", parameters: [booleanParam(name: 'macosTest', value: true)], wait: false, propagate: false)
     // Increate the quiet period for the next iteration
-    quietPeriod += quietPeriodFactor
+    quietPeriod += args.quietPeriodFactor
   }
 }
 

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,13 +20,9 @@ pipeline {
   stages {
     stage('Nighly beats builds') {
       steps {
-        runBuild(quietPeriod: 0, job: 'Beats/beats/master')
-        // This should be `current_8` bump.getCurrentMinorReleaseFor8
-        runBuild(quietPeriod: 2000, job: 'Beats/beats/8.0')
-        // This should be `current_7` bump.getCurrentMinorReleaseFor7 or
-        // `next_minor_7`  bump.getNextMinorReleaseFor7
-        runBuild(quietPeriod: 4000, job: 'Beats/beats/7.17')
-        runBuild(quietPeriod: 6000, job: 'Beats/beats/7.16')
+        runBuild(quietPeriod: 0, branch: 'master')
+        runBuild(quietPeriod: 2000, branch: '8.<minor>')
+        runBuild(quietPeriod: 4000, branch: '7.<minor>')
       }
     }
   }
@@ -38,6 +34,13 @@ pipeline {
 }
 
 def runBuild(Map args = [:]) {
-  def jobName = args.job
-  build(quietPeriod: args.quietPeriod, job: jobName, parameters: [booleanParam(name: 'macosTest', value: true)], wait: false, propagate: false)
+  def branch = args.branch
+  // special macro to look for the latest minor version
+  if (branch.contains('8.<minor>')) {
+    branch = bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
+  }
+  if (branch.contains('7.<minor>')) {
+    branch = bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
+  }
+  build(quietPeriod: args.quietPeriod, job: "Beats/beats/${branch}", parameters: [booleanParam(name: 'macosTest', value: true)], wait: false, propagate: false)
 }

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -45,7 +45,7 @@ def runBuilds(Map args = [:]) {
   branches.each { branch ->
     build(quietPeriod: quietPeriod, job: "Beats/beats/${branch}", parameters: [booleanParam(name: 'awsCloudTests', value: true)], wait: false, propagate: false)
     // Increate the quiet period for the next iteration
-    quietPeriod += quietPeriodFactor
+    quietPeriod += args.quietPeriodFactor
   }
 }
 

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -22,7 +22,7 @@ pipeline {
       steps {
         runBuild(quietPeriod: 0, branch: 'master')
         runBuild(quietPeriod: 1000, branch: '8.<minor>')
-        runBuild(quietPeriod: 2000, branch: '7.<minor>')
+        runBuild(quietPeriod: 2000, branch: '7.<next-minor>')
       }
     }
   }
@@ -41,6 +41,9 @@ def runBuild(Map args = [:]) {
   }
   if (branch.contains('7.<minor>')) {
     branch = bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
+  }
+  if (branch.contains('7.<next-minor>')) {
+    branch = bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
   }
   build(quietPeriod: args.quietPeriod, job: "Beats/beats/${branch}", parameters: [booleanParam(name: 'awsCloudTests', value: true)], wait: false, propagate: false)
 }

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -20,9 +20,7 @@ pipeline {
   stages {
     stage('Weekly beats builds') {
       steps {
-        runBuild(quietPeriod: 0, branch: 'master')
-        runBuild(quietPeriod: 1000, branch: '8.<minor>')
-        runBuild(quietPeriod: 2000, branch: '7.<next-minor>')
+        runBuilds(quietPeriodFactor: 1000, branches: ['master', '8.<minor>', '7.<minor>', '7.<next-minor>'])
       }
     }
   }
@@ -33,17 +31,37 @@ pipeline {
   }
 }
 
-def runBuild(Map args = [:]) {
-  def branch = args.branch
+def runBuilds(Map args = [:]) {
+  def branches = []
+  // Expand macros and filter duplicated matches.
+  args.branches.each { branch ->
+    def branchName = getBranchName(branch)
+    if (!branches.contains(branchName)) {
+      branches << branchName
+    }
+  }
+
+  def quietPeriod = 0
+  branches.each { branch ->
+    build(quietPeriod: quietPeriod, job: "Beats/beats/${branch}", parameters: [booleanParam(name: 'awsCloudTests', value: true)], wait: false, propagate: false)
+    // Increate the quiet period for the next iteration
+    quietPeriod += quietPeriodFactor
+  }
+}
+
+def getBranchName(branch) {
   // special macro to look for the latest minor version
   if (branch.contains('8.<minor>')) {
-    branch = bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
+   return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
+  }
+  if (branch.contains('8.<next-minor>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
   }
   if (branch.contains('7.<minor>')) {
-    branch = bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
+    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
   }
   if (branch.contains('7.<next-minor>')) {
-    branch = bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
+    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
   }
-  build(quietPeriod: args.quietPeriod, job: "Beats/beats/${branch}", parameters: [booleanParam(name: 'awsCloudTests', value: true)], wait: false, propagate: false)
+  return branch
 }


### PR DESCRIPTION
## What does this PR do?

Use aliases and support current minor release branch and next minor release branch for the two major releases.

## Why is it important?

We don't need to worry about maintaining those schedule jobs anymore

## Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1488
Relies on https://github.com/elastic/apm-pipeline-library/blob/main/vars/bumpUtils.txt
