### PR TITLE
cluster_stats: use correct license value

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -110,6 +110,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Enhance filter check in kubernetes event metricset. {pull}29470[29470]
 - Fix gcp metrics metricset apply aligner to all metric_types {pull}29514[29513]
 - Extract correct index property in kibana.stats metricset {pull}29622[29622]
+- Fixed bug with `elasticsearch/cluster_stats` metricset not recording license expiration date correctly. {pull}29711[29711]
 
 *Packetbeat*
 

--- a/metricbeat/module/elasticsearch/cluster_stats/data.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data.go
@@ -303,22 +303,7 @@ func eventMapping(r mb.ReporterV2, httpClient *helper.HTTP, info elasticsearch.I
 	metricSetFields, _ := schema.Apply(data)
 
 	metricSetFields.Put("stack", stackData)
-	metricSetFields.Put("license", struct {
-		Status       string `json:"status"`
-		Type         string `json:"type"`
-		ExpiryDateMs int    `json:"expiry_date_in_millis"`
-	}{
-		Status:       license.Status,
-		Type:         license.Type,
-		ExpiryDateMs: license.ExpiryDateInMillis,
-	})
-
-	if license.ExpiryDateInMillis != 0 {
-		// We don't want to record a 0 expiry date as this means the license has expired
-		// in the Stack Monitoring UI
-		metricSetFields.Put("expiry_date_in_millis", license.ExpiryDateInMillis)
-	}
-
+	metricSetFields.Put("license", l)
 	metricSetFields.Put("state", clusterStateReduced)
 
 	if err = elasticsearch.PassThruField("version", clusterState, event.ModuleFields); err != nil {

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -145,7 +145,7 @@ class Test(metricbeat.BaseTest):
             t = doc["metricset"]["name"]
             if t != "cluster_stats":
                 continue
-            license = doc["elasticsearch"]["stats"]["license"]
+            license = doc["elasticsearch"]["cluster"]["stats"]["license"]
             issue_date = license["issue_date_in_millis"]
             self.assertIsNot(type(issue_date), float)
 

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -140,6 +140,17 @@ class Test(metricbeat.BaseTest):
         proc.check_kill_and_wait()
         self.assert_no_logged_warnings()
 
+        docs = self.read_output_json()
+        for doc in docs:
+            t = doc["metricset"]["name"]
+            if t != "cluster_stats":
+                continue
+            license = doc["license"]
+            issue_date = license["issue_date_in_millis"]
+            self.assertIsNot(type(issue_date), float)
+
+            self.assertNotIn("expiry_date_in_millis", license)
+
     def create_ml_job(self):
         # Check if an ml job already exists
         response = self.ml_es.get_jobs()

--- a/metricbeat/module/elasticsearch/test_elasticsearch.py
+++ b/metricbeat/module/elasticsearch/test_elasticsearch.py
@@ -145,7 +145,7 @@ class Test(metricbeat.BaseTest):
             t = doc["metricset"]["name"]
             if t != "cluster_stats":
                 continue
-            license = doc["license"]
+            license = doc["elasticsearch"]["stats"]["license"]
             issue_date = license["issue_date_in_millis"]
             self.assertIsNot(type(issue_date), float)
 


### PR DESCRIPTION
### Summary
Fixes `elasticsearch/cluster_stats` metricset not recording license expiration date correctly. This was initially implemented in https://github.com/elastic/beats/pull/14591 but was removed when getting rid of the xpack logic path.

### Testing
- added back the integration test covering this logic
- without this fix the Stack monitoring UI won't load with a `basic` license. Verified it now loads and displays correct data