### PR TITLE
Warn users when connecting to older Elasticsearch instances

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -136,6 +136,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Support self signed certificates on outputs {pull}29229[29229]
 - Add FIPS configuration option for all AWS API calls. {pull}[28899]
 - Add `default_region` config to AWS common module. {pull}29415[29415]
+- Warn users when connecting to older versions of Elasticsearch instances. {pull}29723[29723]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -862,9 +862,8 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 	return nil
 }
 
-// checkElasticsearchVersion registers a global callback to make sure ES instance we are connecting
-// to is at least on the same version as the Beat.
-// If the check is disabled or the output is not Elasticsearch, nothing happens.
+// warnAboutElasticsearchVersion registers a global callback to warn users once
+// if they try to connect to an older Elasticsearch version than the Beat version.
 func (b *Beat) warnAboutElasticsearchVersion() {
 	if b.Config.Output.Name() != "elasticsearch" {
 		return

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -879,7 +879,7 @@ func (b *Beat) warnAboutElasticsearchVersion() {
 			}
 
 			if esVersion.LessThan(beatVersion) {
-				logp.Warn("Connecting to older version of Elasticsearch. From 8.1, it is going to be disabled by default.")
+				logp.Warn("Connecting to older version of Elasticsearch. From 8.1, connecting to older versions will be disabled by default.")
 			}
 		})
 		return nil


### PR DESCRIPTION
## What does this PR do?

This PR adds a warning message when users connect to older versions of Elasticsearch. From 8.1, connecting to older versions than the Beat version will be disabled by default.

## Why is it important?

Manage users' expectations.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Related #29264
