### PR TITLE
Do not mention removal if version is not specified in `cfgwarn` messages

### DIFF
--- a/libbeat/common/cfgwarn/cfgwarn.go
+++ b/libbeat/common/cfgwarn/cfgwarn.go
@@ -35,7 +35,10 @@ func Beta(format string, v ...interface{}) {
 // Deprecate logs a deprecation message.
 // The version string contains the version when the future will be removed
 func Deprecate(version string, format string, v ...interface{}) {
-	postfix := fmt.Sprintf(" Will be removed in version: %s", version)
+	var postfix string
+	if version != "" {
+		postfix = fmt.Sprintf(" Will be removed in version: %s", version)
+	}
 	logp.NewLogger(selector, zap.AddCallerSkip(1)).Warnf("DEPRECATED: "+format+postfix, v...)
 }
 

--- a/libbeat/common/cfgwarn/cfgwarn.go
+++ b/libbeat/common/cfgwarn/cfgwarn.go
@@ -33,7 +33,8 @@ func Beta(format string, v ...interface{}) {
 }
 
 // Deprecate logs a deprecation message.
-// The version string contains the version when the future will be removed
+// The version string contains the version when the future will be removed.
+// If version is empty, the message  will not mention the removal of the feature.
 func Deprecate(version string, format string, v ...interface{}) {
 	var postfix string
 	if version != "" {


### PR DESCRIPTION
## What does this PR do?

This PR changes the message emitted by `cfgwarn.Deprecate` if the version is not specified. Previously, if version was not specified, still the `"Will be removed:"` message was added. A few deprecated features in Beats are never going to be removed. Thus, the version is empty. However, with the "Will be removed" addition the message can be misleading.

## Why is it important?

Avoid user confusion. Some features are deprecated, but will never be removed. For example, we deprecated the `log` input in favour of filestream. But we do not intend to remove the outdated input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~