### PR TITLE
[automation] update elastic stack version for testing 8.0.0-fd4587f2

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-37ccb579-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-fd4587f2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -21,7 +21,7 @@ services:
     - "script.context.template.cache_max_size=2000"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:8.0.0-37ccb579-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:8.0.0-fd4587f2-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -31,7 +31,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-37ccb579-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-fd4587f2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-37ccb579-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-fd4587f2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -37,7 +37,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-37ccb579-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-fd4587f2-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 6 Jan 2022 00:15:44 GMT, release_branch:8.0, prefix:, end_time:Thu, 6 Jan 2022 07:21:30 GMT, manifest_version:2.0.0, version:8.0.0-SNAPSHOT, branch:8.0, build_id:8.0.0-fd4587f2, build_duration_seconds:25546]