### PR TITLE
System/socket: Support kernel_clone() replacement for _do_fork()

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -91,7 +91,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix bugs leading to wrong process being attributed to flows. {pull}29166[29166] {issue}17165[17165]
 - system/socket: Fix process name and arg truncation for long names, paths and args lists. {issue}24667[24667] {pull}29410[29410]
-- system/socket: Fix startup errors on newer 5.x kernels that dropped _do_fork in favor of kernel_clone. {issue}29607[29607] {pull}29743[29743]
+- system/socket: Fix startup errors on newer 5.x kernels due to missing _do_fork function. {issue}29607[29607] {pull}29744[29744]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -91,6 +91,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/package: Fix an error that can occur while trying to persist package metadata. {issue}18536[18536] {pull}18887[18887]
 - system/socket: Fix bugs leading to wrong process being attributed to flows. {pull}29166[29166] {issue}17165[17165]
 - system/socket: Fix process name and arg truncation for long names, paths and args lists. {issue}24667[24667] {pull}29410[29410]
+- system/socket: Fix startup errors on newer 5.x kernels that dropped _do_fork in favor of kernel_clone. {issue}29607[29607] {pull}29743[29743]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/socket/template.go
+++ b/x-pack/auditbeat/module/system/socket/template.go
@@ -41,7 +41,7 @@ var functionAlternatives = map[string][]string{
 	"SYS_EXECVE":        syscallAlternatives("execve"),
 	"SYS_GETTIMEOFDAY":  syscallAlternatives("gettimeofday"),
 	"SYS_UNAME":         syscallAlternatives("newuname"),
-	"DO_FORK":           {"_do_fork", "do_fork"},
+	"DO_FORK":           {"_do_fork", "do_fork", "kernel_clone"},
 }
 
 func syscallAlternatives(syscall string) []string {


### PR DESCRIPTION
## What does this PR do?

Updates the `system/socket` dataset to support kernels 5.10+ where the `do_fork` kernel method is replaced by `kernel_clone`.

## Why is it important?

Lack of support for this method is preventing startup in newer kernels.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Closes #29607