### PR TITLE
ibmmq: Fix timestamp parsing

### DIFF
--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -25,7 +25,6 @@ remove_timestamp = {
     "f5.bigipafm",
     "fortinet.clientendpoint",
     "haproxy.log",
-    "ibmmq.errorlog",
     "icinga.startup",
     "imperva.securesphere",
     "infoblox.nios",

--- a/x-pack/filebeat/module/ibmmq/errorlog/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/ibmmq/errorlog/ingest/pipeline.yml
@@ -30,7 +30,7 @@ processors:
     patterns:
     - 'Process\(%{DATA:process.pid}\) User\(%{WORD:user.name}\) Program\(%{DATA:process.title}\)
       Host\(%{DATA:host.hostname}\) Installation\(%{WORD:ibmmq.errorlog.installation}\)
-      VRMF\(%{DATA:service.version}\)( QMgr\(%{DATA:ibmmq.errorlog.qmgr}\))?( Time\(%{TIMESTAMP_ISO8601:@timestamp}\))?(
+      VRMF\(%{DATA:service.version}\)( QMgr\(%{DATA:ibmmq.errorlog.qmgr}\))?( Time\(%{TIMESTAMP_ISO8601:log_timestamp}\))?(
       RemoteHost\(%{DATA:destination.address}\))?( ArithInsert1\(%{DATA:ibmmq.errorlog.arithinsert1}\))?(
       ArithInsert2\(%{DATA:ibmmq.errorlog.arithinsert2}\))?( CommentInsert1\(%{DATA:ibmmq.errorlog.commentinsert1}\))?(
       CommentInsert2\(%{DATA:ibmmq.errorlog.commentinsert2}\))?( CommentInsert3\(%{DATA:ibmmq.errorlog.commentinsert3}\))?
@@ -41,8 +41,10 @@ processors:
     field: log_timestamp
     target_field: '@timestamp'
     formats:
-    - MM/dd/yyyy hh:mm:ss aa
+    - ISO8601
+    - MM/dd/yyyy hh:mm:ss a
     - dd/MM/yyyy HH:mm:ss
+    - dd.MM.yyyy HH:mm:ss
     ignore_failure: true
 - append:
     field: ibmmq.errorlog.commentinsert

--- a/x-pack/filebeat/module/ibmmq/errorlog/test/AMQERR01.log-expected.json
+++ b/x-pack/filebeat/module/ibmmq/errorlog/test/AMQERR01.log-expected.json
@@ -66,7 +66,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2018-10-11T10:46:25.000Z",
+        "@timestamp": "2018-10-11T08:46:25.924Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -99,7 +99,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-11T10:46:26.000Z",
+        "@timestamp": "2018-10-11T08:46:26.343Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -132,7 +132,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-11T10:46:26.000Z",
+        "@timestamp": "2018-10-11T08:46:26.346Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -264,7 +264,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2018-10-28T15:12:07.000Z",
+        "@timestamp": "2018-10-28T14:12:07.685Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -297,7 +297,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-28T15:12:07.000Z",
+        "@timestamp": "2018-10-28T14:12:07.789Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -330,7 +330,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-28T15:12:08.000Z",
+        "@timestamp": "2018-10-28T14:12:08.663Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -363,7 +363,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-28T15:12:08.000Z",
+        "@timestamp": "2018-10-28T14:12:08.665Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -396,7 +396,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:48:52.000Z",
+        "@timestamp": "2018-10-29T15:48:52.594Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -429,7 +429,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:48:52.000Z",
+        "@timestamp": "2018-10-29T15:48:52.663Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -462,7 +462,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:48:53.000Z",
+        "@timestamp": "2018-10-29T15:48:53.368Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -495,7 +495,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:48:53.000Z",
+        "@timestamp": "2018-10-29T15:48:53.369Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -528,7 +528,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:49:35.000Z",
+        "@timestamp": "2018-10-29T15:49:35.477Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -561,7 +561,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:49:35.000Z",
+        "@timestamp": "2018-10-29T15:49:35.553Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -594,7 +594,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:49:36.000Z",
+        "@timestamp": "2018-10-29T15:49:36.447Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -627,7 +627,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-29T16:49:36.000Z",
+        "@timestamp": "2018-10-29T15:49:36.448Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",

--- a/x-pack/filebeat/module/ibmmq/errorlog/test/AMQERR01_QM1.log-expected.json
+++ b/x-pack/filebeat/module/ibmmq/errorlog/test/AMQERR01_QM1.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2022-01-10T10:25:59.012Z",
+        "@timestamp": "2018-07-13T07:06:00.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -33,7 +33,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.012Z",
+        "@timestamp": "2018-07-13T07:06:00.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -66,7 +66,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.012Z",
+        "@timestamp": "2018-07-13T07:06:00.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -99,7 +99,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.012Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -132,7 +132,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.012Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -165,7 +165,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.012Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -198,7 +198,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.012Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -231,7 +231,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -264,7 +264,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -297,7 +297,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -330,7 +330,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -363,7 +363,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -396,7 +396,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -429,7 +429,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -462,7 +462,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:01.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -495,7 +495,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:02.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -528,7 +528,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:03.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -561,7 +561,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.013Z",
+        "@timestamp": "2018-07-13T07:06:03.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -594,7 +594,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.014Z",
+        "@timestamp": "2018-07-13T07:06:03.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -627,7 +627,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.014Z",
+        "@timestamp": "2018-07-13T07:06:03.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -660,7 +660,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.014Z",
+        "@timestamp": "2018-07-13T07:06:03.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -693,7 +693,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.014Z",
+        "@timestamp": "2018-07-13T07:06:03.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -726,7 +726,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2022-01-10T10:25:59.014Z",
+        "@timestamp": "2018-07-13T07:06:03.000Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",

--- a/x-pack/filebeat/module/ibmmq/errorlog/test/AMQERR01_QM2.log-expected.json
+++ b/x-pack/filebeat/module/ibmmq/errorlog/test/AMQERR01_QM2.log-expected.json
@@ -782,7 +782,7 @@
         "user.name": "felix"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.779Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -816,7 +816,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.803Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -850,7 +850,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.806Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -884,7 +884,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.815Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -918,7 +918,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.818Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -952,7 +952,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.828Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -986,7 +986,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.834Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1020,7 +1020,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.907Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1054,7 +1054,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.907Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1088,7 +1088,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.907Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1122,7 +1122,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.907Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1156,7 +1156,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:18.000Z",
+        "@timestamp": "2018-10-17T11:50:18.908Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1190,7 +1190,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.011Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1224,7 +1224,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.012Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1258,7 +1258,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.108Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1292,7 +1292,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.108Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1326,7 +1326,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.109Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1360,7 +1360,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.109Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1394,7 +1394,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.109Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1428,7 +1428,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.109Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1462,7 +1462,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.110Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1496,7 +1496,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.123Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1530,7 +1530,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.124Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1564,7 +1564,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.124Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1598,7 +1598,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.124Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1632,7 +1632,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.125Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1666,7 +1666,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.124Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1700,7 +1700,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.125Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1734,7 +1734,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.124Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1768,7 +1768,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.125Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1802,7 +1802,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.125Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1836,7 +1836,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.126Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1870,7 +1870,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.131Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1904,7 +1904,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.131Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1938,7 +1938,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.132Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -1972,7 +1972,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.238Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2006,7 +2006,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.269Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2040,7 +2040,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.349Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2074,7 +2074,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.401Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2108,7 +2108,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-17T13:50:19.000Z",
+        "@timestamp": "2018-10-17T11:50:19.638Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2142,7 +2142,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T15:18:48.000Z",
+        "@timestamp": "2018-10-18T13:18:48.524Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2176,7 +2176,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T15:19:11.000Z",
+        "@timestamp": "2018-10-18T13:19:11.833Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2210,7 +2210,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:10:06.000Z",
+        "@timestamp": "2018-10-18T14:10:06.407Z",
         "destination.address": "127.0.0.1",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
@@ -2245,7 +2245,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:10:06.000Z",
+        "@timestamp": "2018-10-18T14:10:06.407Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2279,7 +2279,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:10:12.000Z",
+        "@timestamp": "2018-10-18T14:10:12.046Z",
         "destination.address": "127.0.0.1",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
@@ -2314,7 +2314,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:10:12.000Z",
+        "@timestamp": "2018-10-18T14:10:12.046Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2348,7 +2348,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:10:28.000Z",
+        "@timestamp": "2018-10-18T14:10:28.071Z",
         "destination.address": "127.0.0.1",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
@@ -2383,7 +2383,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:10:28.000Z",
+        "@timestamp": "2018-10-18T14:10:28.071Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2417,7 +2417,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:20.000Z",
+        "@timestamp": "2018-10-18T14:13:20.545Z",
         "destination.address": "127.0.0.1",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
@@ -2452,7 +2452,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:20.000Z",
+        "@timestamp": "2018-10-18T14:13:20.546Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2486,7 +2486,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.803Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2520,7 +2520,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.821Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2554,7 +2554,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.821Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2588,7 +2588,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.822Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2622,7 +2622,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2656,7 +2656,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2690,7 +2690,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2724,7 +2724,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2758,7 +2758,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2792,7 +2792,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2826,7 +2826,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2860,7 +2860,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2894,7 +2894,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.824Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2928,7 +2928,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.823Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2962,7 +2962,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -2996,7 +2996,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3030,7 +3030,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3064,7 +3064,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3098,7 +3098,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3132,7 +3132,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3166,7 +3166,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3200,7 +3200,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3234,7 +3234,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.825Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3268,7 +3268,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.827Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3301,7 +3301,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.828Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3334,7 +3334,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.829Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",
@@ -3367,7 +3367,7 @@
         "user.name": "MUSR_MQADMIN"
     },
     {
-        "@timestamp": "2018-10-18T16:13:46.000Z",
+        "@timestamp": "2018-10-18T14:13:46.830Z",
         "event.dataset": "ibmmq.errorlog",
         "event.kind": "event",
         "event.module": "ibmmq",


### PR DESCRIPTION
## What does this PR do?

Fixes the `@timestamp` parsing in Filebeat's ibmmq module. It had a the following problems:
- Date processor format definition was broken (extra `a` character), which caused the processor to always fail.
- The header date format in some logs was unsupported (`dd.MM.yyyy`).
- The Time() field, with correct TZ and higher precision, was ignored.

Now it will correctly parse the header timestamp for all logs, and use the better Time() field if available.

## Why is it important?

For proper parsing of dates.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
