### PR TITLE
Do not add date to index if `@meta.index` is set

### DIFF
--- a/libbeat/beat/events/util.go
+++ b/libbeat/beat/events/util.go
@@ -27,9 +27,8 @@ const (
 	// precedence over values defined using FieldMetaIndex or FieldMetaRawIndex.
 	FieldMetaAlias = "alias"
 
-	// FieldMetaIndex defines the base index name to use for the event. The value is suffixed
-	// with a Y-m-d value based on the event's timestamp. If set, it takes precedence over the
-	// value defined using FieldMetaRawIndex.
+	// FieldMetaIndex defines the data stream name to use for the event.
+	// If set, it takes precedence over the value defined using FieldMetaRawIndex.
 	FieldMetaIndex = "index"
 
 	// FieldMetaRawIndex defines the raw index name to use for the event. It is used as-is, without

--- a/libbeat/idxmgmt/std.go
+++ b/libbeat/idxmgmt/std.go
@@ -61,12 +61,6 @@ type indexSelector struct {
 	beatInfo beat.Info
 }
 
-type ilmIndexSelector struct {
-	index    outil.Selector
-	st       *indexState
-	beatInfo beat.Info
-}
-
 type componentType uint8
 
 //go:generate stringer -linecomment -type componentType
@@ -292,15 +286,6 @@ func (m *indexManager) setupWithILM() (bool, error) {
 	return withILM, nil
 }
 
-func (s *ilmIndexSelector) Select(evt *beat.Event) (string, error) {
-	if idx := getEventCustomIndex(evt, s.beatInfo); idx != "" {
-		return idx, nil
-	}
-
-	idx, err := s.index.Select(evt)
-	return idx, err
-}
-
 func (s indexSelector) Select(evt *beat.Event) (string, error) {
 	if idx := getEventCustomIndex(evt, s.beatInfo); idx != "" {
 		return idx, nil
@@ -314,9 +299,7 @@ func getEventCustomIndex(evt *beat.Event, beatInfo beat.Info) string {
 	}
 
 	if idx, err := events.GetMetaStringValue(*evt, events.FieldMetaIndex); err == nil {
-		ts := evt.Timestamp.UTC()
-		return fmt.Sprintf("%s-%d.%02d.%02d",
-			strings.ToLower(idx), ts.Year(), ts.Month(), ts.Day())
+		return strings.ToLower(idx)
 	}
 
 	// This is functionally identical to Meta["alias"], returning the overriding

--- a/libbeat/idxmgmt/std_test.go
+++ b/libbeat/idxmgmt/std_test.go
@@ -18,7 +18,6 @@
 package idxmgmt
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -108,13 +107,6 @@ func TestDefaultSupport_BuildSelector(t *testing.T) {
 	stable := func(s string) nameFunc {
 		return func(_ time.Time) string { return s }
 	}
-	dateIdx := func(base string) nameFunc {
-		return func(ts time.Time) string {
-			ts = ts.UTC()
-			ext := fmt.Sprintf("%d.%02d.%02d", ts.Year(), ts.Month(), ts.Day())
-			return fmt.Sprintf("%v-%v", base, ext)
-		}
-	}
 
 	cases := map[string]struct {
 		ilmCalls []onCall
@@ -136,7 +128,7 @@ func TestDefaultSupport_BuildSelector(t *testing.T) {
 		"event index without ilm": {
 			ilmCalls: noILM,
 			cfg:      map[string]interface{}{"index": "test-%{[agent.version]}"},
-			want:     dateIdx("test"),
+			want:     stable("test"),
 			meta: common.MapStr{
 				"index": "test",
 			},
@@ -144,7 +136,7 @@ func TestDefaultSupport_BuildSelector(t *testing.T) {
 		"event index without ilm must be lowercase": {
 			ilmCalls: noILM,
 			cfg:      map[string]interface{}{"index": "test-%{[agent.version]}"},
-			want:     dateIdx("test"),
+			want:     stable("test"),
 			meta: common.MapStr{
 				"index": "Test",
 			},
@@ -162,7 +154,7 @@ func TestDefaultSupport_BuildSelector(t *testing.T) {
 		"event index with ilm": {
 			ilmCalls: ilmTemplateSettings("test-9.9.9"),
 			cfg:      map[string]interface{}{"index": "test-%{[agent.version]}"},
-			want:     dateIdx("event-index"),
+			want:     stable("event-index"),
 			meta: common.MapStr{
 				"index": "event-index",
 			},


### PR DESCRIPTION
## What does this PR do?

When `@meta.index` is set, Beats no longer concatenates datetime to the end of the index name. Adding the extra suffix is not needed because data streams take care of index naming and maintenance for us.

## Why is it important?

This change was missing from the original PR. This will probably fix the issue in Stack Monitoring.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

Closes #29657