### PR TITLE
[Winlogbeat] Add provider name to Security routing pipeline check

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -118,6 +118,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Winlogbeat*
 
+- Add provider names to Security pipeline conditional check in routing pipeline. {issue}27288[27288] {pull}29781[29781]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/routing/ingest/routing.yml
+++ b/x-pack/winlogbeat/module/routing/ingest/routing.yml
@@ -3,7 +3,7 @@ description: Winlogbeat Routing Pipeline
 processors:
   - pipeline:
       name: '{< IngestPipeline "security" >}'
-      if: ctx?.winlog?.channel == 'Security'
+      if: ctx?.winlog?.channel == 'Security' && ['Microsoft-Windows-Eventlog', 'Microsoft-Windows-Security-Auditing'].contains(ctx?.winlog?.provider_name)
   - pipeline:
       name: '{< IngestPipeline "sysmon" >}'
       if: ctx?.winlog?.channel == 'Microsoft-Windows-Sysmon/Operational'


### PR DESCRIPTION
## What does this PR do?

- Added the two provider names currently supported by the Security pipeline
to the conditional check in the routing pipeline. These two providers are
`Microsoft-Windows-Eventlog` and `Microsoft-Windows-Security-Auditing`.
- This will prevent unsupported providers such as "AD FS" from being
enriched with incorrect information.

## Why is it important?

- Different log providers may use the same event ID. When a pipeline handles an event and blindly acts on the event ID without considering the provider, the event may be enriched with the wrong metadata.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Best way to test this would be to install winlogbeat and point it to the Security channel. I did install AD FS on my system, but I wasn't sure how to generate the necessary events to have them show up in the Security channel.

## Related issues

- Closes #27288

## Use cases

- This in particular affects environments were AD FS is running, as it can log to the security channel, and it can log events that collide with the two existing providers.

