### PR TITLE
Add note on docker container as a requirement for browser monitors

### DIFF
--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -8,8 +8,9 @@ beta[] The options described here configure {beatname_uc} to run the synthetic
 monitoring test suites via Synthetic Agent on the Chromium browser.
 Additional shared options are defined in <<monitor-options>>. 
 
-Please note that browser based monitors can only be run in our {beatname_uc} docker image,
-or via the `elastic-agent-complete` docker image. See the {observability-guide}/synthetics-quickstart.html[synthetics quick start guide].
+Browser based monitors can only be run in our {beatname_uc} docker image,
+or via the `elastic-agent-complete` docker image. 
+See the {observability-guide}/synthetics-quickstart.html[synthetics quick start guide].
 for more information.
 
 Example configuration:

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -6,7 +6,12 @@ See the {observability-guide}/synthetics-quickstart.html[quick start guide].
 
 beta[] The options described here configure {beatname_uc} to run the synthetic
 monitoring test suites via Synthetic Agent on the Chromium browser.
-Additional shared options are defined in <<monitor-options>>.
+Additional shared options are defined in <<monitor-options>>. 
+
+Please note that browser based monitors can only be run in our {beatname_uc} docker image,
+or via the `elastic-agent-complete` docker image. See the {observability-guide}/synthetics-quickstart.html[synthetics quick start guide].
+for more information.
+
 Example configuration:
 
 [source,yaml]

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -10,8 +10,7 @@ Additional shared options are defined in <<monitor-options>>.
 
 Browser based monitors can only be run in our {beatname_uc} docker image,
 or via the `elastic-agent-complete` docker image. 
-See the {observability-guide}/synthetics-quickstart.html[synthetics quick start guide].
-for more information.
+For more information, see {observability-guide}/synthetics-quickstart.html[Synthetic monitoring using Docker].
 
 Example configuration:
 


### PR DESCRIPTION
We mention that you need the container in the synthetics guide, but not on this page, this is a bit cleaner.
