### PR TITLE
Osquerybeat: Change osquerybeat packaging for windows, replace .MSI file with extracted osqueryd.exe during build process

### DIFF
--- a/x-pack/osquerybeat/beater/install.go
+++ b/x-pack/osquerybeat/beater/install.go
@@ -34,9 +34,7 @@ func installOsqueryWithDir(ctx context.Context, dir string) error {
 	fn := distro.OsquerydDistroFilename()
 	var installFunc func(context.Context, string, string, bool) error
 
-	if runtime.GOOS == "windows" {
-		installFunc = install.InstallFromMSI
-	} else if runtime.GOOS == "darwin" {
+	if runtime.GOOS == "darwin" {
 		installFunc = install.InstallFromPkg
 	}
 

--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -57,19 +57,27 @@ func GetDataInstallDir(osarch OSArch) string {
 	return filepath.Join(DataInstallDir, osarch.OS, osarch.Arch)
 }
 
-func OsquerydFilename() string {
-	if runtime.GOOS == "windows" {
+func OsquerydFilenameForOS(os string) string {
+	if os == "windows" {
 		return osqueryDName + ".exe"
 	}
 	return osqueryDName
+}
+
+func OsquerydFilename() string {
+	return OsquerydFilenameForOS(runtime.GOOS)
 }
 
 func OsquerydDarwinApp() string {
 	return osqueryDarwinApp
 }
 
+func OsquerydPathForOS(os, dir string) string {
+	return filepath.Join(dir, OsquerydFilenameForOS(os))
+}
+
 func OsquerydPath(dir string) string {
-	return filepath.Join(dir, OsquerydFilename())
+	return OsquerydPathForOS(runtime.GOOS, dir)
 }
 
 func OsquerydDarwinDistroPath() string {
@@ -87,7 +95,7 @@ func OsquerydDistroFilename() string {
 func OsquerydDistroPlatformFilename(platform string) string {
 	switch platform {
 	case "windows":
-		return osqueryName + "-" + osqueryVersion + osqueryMSIExt
+		return OsquerydFilenameForOS(platform)
 	case "darwin":
 		return osqueryName + "-" + osqueryVersion + osqueryPkgExt
 	}

--- a/x-pack/osquerybeat/magefile.go
+++ b/x-pack/osquerybeat/magefile.go
@@ -8,15 +8,20 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/magefile/mage/mg"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/command"
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/distro"
 	osquerybeat "github.com/elastic/beats/v7/x-pack/osquerybeat/scripts/mage"
 
 	// mage:import
@@ -77,10 +82,103 @@ func Clean() error {
 	return devtools.Clean(paths)
 }
 
+func extractFromMSI() error {
+	if os.Getenv("GOOS") != "windows" {
+		return nil
+	}
+
+	ctx := context.Background()
+
+	execCommand := func(name string, args ...string) error {
+		ps := strings.Join(append([]string{name}, args...), " ")
+		fmt.Println(ps)
+		output, err := command.Execute(ctx, name, args...)
+		if err != nil {
+			fmt.Println(ps, ", failed: ", err)
+			return err
+		}
+		fmt.Print(output)
+		return err
+	}
+
+	// Install msitools
+	err := execCommand("apt", "update")
+	if err != nil {
+		return err
+	}
+
+	err = execCommand("apt", "install", "-y", "msitools")
+	if err != nil {
+		return err
+	}
+
+	osArchs := osquerybeat.OSArchs(devtools.Platforms)
+
+	for _, osarch := range osArchs {
+		if osarch.OS != "windows" {
+			continue
+		}
+		spec, err := distro.GetSpec(osarch)
+		if err != nil {
+			if errors.Is(err, distro.ErrUnsupportedOS) {
+				continue
+			} else {
+				return err
+			}
+		}
+		dip := distro.GetDataInstallDir(osarch)
+		msiFile := spec.DistroFilepath(dip)
+
+		// MSI extract
+		err = execCommand("msiextract", "--directory", dip, msiFile)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("copy osqueryd.exe from MSI")
+		dp := distro.OsquerydPathForOS(osarch.OS, dip)
+		err = devtools.Copy(filepath.Join(dip, "osquery", "osqueryd", "osqueryd.exe"), dp)
+		if err != nil {
+			fmt.Println("copy osqueryd.exe from MSI failed: ", err)
+			return err
+		}
+		// Chmod set to the same as other executables in the final package
+		if err = os.Chmod(dp, 0755); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // GolangCrossBuild build the Beat binary inside of the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
-	return devtools.GolangCrossBuild(devtools.DefaultGolangCrossBuildArgs())
+	// This is to fix a defect in the field where msiexec fails to extract the osqueryd.exe
+	// from bundled osquery.msi, with error code 1603
+	// https://docs.microsoft.com/en-us/troubleshoot/windows-server/application-management/msi-installation-error-1603
+	// SDH: https://github.com/elastic/sdh-beats/issues/1575
+	// Currently we can't reproduce this is issue, but here we can eliminate the need for calling msiexec
+	// if extract the osqueryd.exe binary during the build.
+	//
+	// The builder docker images are Debian so we need to install msitools for
+	// linux in order to extract the osqueryd.exe from MSI during build process.	// Install MSI tools in order to extract file from MSI
+	// Ideally we would want these to be a part of the build docker image,
+	// but doing this here for now due to limited time before 7.16.2
+	//
+	// The cross build is currently called for two binaries osquerybeat and osqquery-extension
+	// Only install msitools and extract osqueryd.exe during osquerybeat build on windows
+	args := devtools.DefaultGolangCrossBuildArgs()
+
+	// Install msitools only
+	if !strings.HasPrefix(args.Name, "osquery-extension-") {
+		// Install msitools in the container and extract osqueryd.exe from MSI
+		if err := extractFromMSI(); err != nil {
+			return err
+		}
+	}
+
+	return devtools.GolangCrossBuild(args)
 }
 
 // BuildGoDaemon builds the go-daemon binary (use crossBuildGoDaemon).

--- a/x-pack/osquerybeat/scripts/mage/distro.go
+++ b/x-pack/osquerybeat/scripts/mage/distro.go
@@ -24,20 +24,20 @@ import (
 
 // FetchOsqueryDistros fetches Osquery official distros as a part of the build
 func FetchOsqueryDistros() error {
-	osArchs := osArchs(devtools.Platforms)
+	osArchs := OSArchs(devtools.Platforms)
 	log.Printf("Fetch Osquery distros for %v", osArchs)
 
 	for _, osarch := range osArchs {
 		spec, err := distro.GetSpec(osarch)
 		if err != nil {
 			if errors.Is(err, distro.ErrUnsupportedOS) {
-				log.Printf("The build spec %v is not supported, continue", spec)
+				log.Printf("The build spec %v is not supported, continue\n", spec)
 				continue
 			} else {
 				return err
 			}
 		}
-		log.Print("Found spec:", spec)
+		log.Println("Found spec:", spec)
 
 		fetched, err := checkCacheAndFetch(osarch, spec)
 		if err != nil {
@@ -66,7 +66,7 @@ func FetchOsqueryDistros() error {
 	return nil
 }
 
-func osArchs(platforms devtools.BuildPlatformList) []distro.OSArch {
+func OSArchs(platforms devtools.BuildPlatformList) []distro.OSArch {
 	mp := make(map[distro.OSArch]struct{})
 
 	for _, platform := range platforms {

--- a/x-pack/osquerybeat/scripts/mage/package.go
+++ b/x-pack/osquerybeat/scripts/mage/package.go
@@ -23,7 +23,7 @@ func CustomizePackaging() {
 		// TODO: this could be moved to dev-tools/packaging/packages.yml for the next release
 		var mode os.FileMode = 0644
 		// If distFile is osqueryd binary then it should be executable
-		if distFile == distro.OsquerydFilename() {
+		if distFile == distro.OsquerydFilenameForOS(args.OS) {
 			mode = 0750
 		}
 		arch := defaultArch


### PR DESCRIPTION
## What does this PR do?

Addresses the issue reported by one of the customers where attempt to extract osquery.exe from included osqueryd.exe bundle with ```msiexec``` returns error 1603.
It seems there's an MSI installation occurring that's failing and producing that windows installer error code:
https://docs.microsoft.com/en-us/troubleshoot/windows-server/application-management/msi-installation-error-1603

Related SDH #:
https://github.com/elastic/sdh-beats/issues/1575

There could be multiple causes for this error and at the moment we could not reproduce or find the reason why this is happening in the customer's environment.

The solution here relies on ```msitools``` package available for linux. 
The packaging for windows has changed eliminating the need to use ```msiexec``` during osquerybeat install. 
Now, the following additions are made during the build/packaging for windows (only!):
1. Install ```msitools``` in the builder (debian) container.
2. Use ```msiextract``` in order to extract files from official osquery .msi distro.
3. Include ```osqueryd.exe``` in the ```osquerybeat``` bundle instead of osquery msi distro.

This is not ideal because it installs ```msitools```  for every windows packaging call, but probably is the fastest way to get this change into 7.16.3 release. Ideally it would be better to have ```msitools``` baked into the beats builders docker images.
Would love to have some feedback if there are better options available with beats @ruflin @blakerouse @lykkin.

## Why is it important?

Addresses SDH #:
https://github.com/elastic/sdh-beats/issues/1575

## Checklist

- [x ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Relates https://github.com/elastic/sdh-beats/issues/1575

## Screenshots
Tested osquerybeat running with windows, ubuntu and macos agents:

<img width="1066" alt="Screen Shot 2022-01-11 at 3 31 10 PM" src="https://user-images.githubusercontent.com/872351/149022099-0ce90176-b6d9-493e-86a7-39fb53c5c66b.png">

<img width="1095" alt="Screen Shot 2022-01-11 at 3 49 48 PM" src="https://user-images.githubusercontent.com/872351/149022265-b008bf30-ab20-40c9-af24-498ebf7ef61f.png">

<img width="1077" alt="Screen Shot 2022-01-11 at 3 52 51 PM" src="https://user-images.githubusercontent.com/872351/149022280-f8e92475-7937-4885-845b-0609803db0d2.png">


