### PR TITLE
Skip k8s processor for events coming from Agent

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -83,6 +83,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Skip k8s processor for events coming from Agent. {pull}29809[29809]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -83,7 +83,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
-- Skip k8s processor for events coming from Agent. {pull}29809[29809]
+- Skip k8s processor for events coming produced by processes run by Elastic Agent. {pull}29809[29809]
 
 *Auditbeat*
 

--- a/filebeat/_meta/config/processors.yml.tmpl
+++ b/filebeat/_meta/config/processors.yml.tmpl
@@ -4,4 +4,5 @@ processors:
       when.not.contains.tags: forwarded
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
-  - add_kubernetes_metadata: ~
+  - add_kubernetes_metadata:
+      when.not.has_fields: ['elastic_agent']

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -162,7 +162,8 @@ processors:
       when.not.contains.tags: forwarded
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
-  - add_kubernetes_metadata: ~
+  - add_kubernetes_metadata:
+      when.not.has_fields: ['elastic_agent']
 
 # ================================== Logging ===================================
 

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -101,7 +101,8 @@ processors:
   - add_docker_metadata: ~{{ end }}
 
 {{- if .UseKubernetesMetadataProcessor }}
-  - add_kubernetes_metadata: ~
+  - add_kubernetes_metadata:
+        when.not.has_fields: ['elastic_agent']
 {{- else -}}
 {{ end }}
 {{else}}

--- a/libbeat/_meta/config/processors.yml.tmpl
+++ b/libbeat/_meta/config/processors.yml.tmpl
@@ -7,9 +7,9 @@ processors:
   - add_cloud_metadata: ~
 {{- if .UseDockerMetadataProcessor }}
   - add_docker_metadata: ~{{ end }}
-
 {{- if .UseKubernetesMetadataProcessor }}
-  - add_kubernetes_metadata: ~
+  - add_kubernetes_metadata:
+        when.not.has_fields: ['elastic_agent']
 {{- else -}}
 {{ end }}
 {{else}}

--- a/metricbeat/metricbeat.yml
+++ b/metricbeat/metricbeat.yml
@@ -124,7 +124,8 @@ processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
-  - add_kubernetes_metadata: ~
+  - add_kubernetes_metadata:
+        when.not.has_fields: ['elastic_agent']
 
 
 # ================================== Logging ===================================

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -162,7 +162,8 @@ processors:
       when.not.contains.tags: forwarded
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
-  - add_kubernetes_metadata: ~
+  - add_kubernetes_metadata:
+      when.not.has_fields: ['elastic_agent']
 
 # ================================== Logging ===================================
 

--- a/x-pack/metricbeat/metricbeat.yml
+++ b/x-pack/metricbeat/metricbeat.yml
@@ -124,7 +124,8 @@ processors:
   - add_host_metadata: ~
   - add_cloud_metadata: ~
   - add_docker_metadata: ~
-  - add_kubernetes_metadata: ~
+  - add_kubernetes_metadata:
+        when.not.has_fields: ['elastic_agent']
 
 
 # ================================== Logging ===================================


### PR DESCRIPTION
## What does this PR do?
This PR adds a condition to the `add_kubernetes_metadata` processor so as to be skipped in case the event is produced by an Agent setup.

## Why is it important?
So as to avoid having the `add_kubernetes_metadata` processor being enabled by default when Filebeat/Metricbeat is deployed via Elastic Agent.

Closes https://github.com/elastic/beats/issues/29767