### PR TITLE
Update Index template loading guide to use the correct endpoint

### DIFF
--- a/libbeat/docs/howto/load-index-templates.asciidoc
+++ b/libbeat/docs/howto/load-index-templates.asciidoc
@@ -292,7 +292,7 @@ ifdef::deb_os,rpm_os[]
 
 ["source","sh",subs="attributes"]
 ----
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
 ----
 endif::deb_os,rpm_os[]
 
@@ -301,7 +301,7 @@ ifdef::mac_os[]
 
 ["source","sh",subs="attributes"]
 ----
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
 ----
 endif::mac_os[]
 
@@ -310,7 +310,7 @@ ifdef::linux_os[]
 
 ["source","sh",subs="attributes"]
 ----
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_index_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
 ----
 endif::linux_os[]
 
@@ -321,6 +321,6 @@ endif::win_only[]
 
 ["source","sh",subs="attributes"]
 ----
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_template/{beatname_lc}-{version}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_index_template/{beatname_lc}-{version}
 ----
 endif::win_os[]

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -330,7 +330,7 @@ layer. See <<enable-ecs-compatibility>>.
 +
 ["source","sh",subs="attributes"]
 ----
-DELETE /_template/metricbeat-{version}
+DELETE /_index_template/metricbeat-{version}
 ----
 +
 Because the index template was loaded without the compatibility layer enabled,


### PR DESCRIPTION
## What does this PR do?

This PR updates the documentation for loading index templates manually. The endpoint used in the documentation was outdated. That lead to some confusion.

## Why is it important?

To let our users copy-paste calls and end up with the desired effects.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
