### PR TITLE
Metricbeat enterprise search module: add xpack.enabled support

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -175,6 +175,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add k8s metadata in state_cronjob metricset. {pull}29572[29572]
 - Add `elasticsearch.cluster.id` field to Beat and Kibana modules. {pull}29577[29577]
 - Add `elasticsearch.cluster.id` field to Logstash module. {pull}29625[29625]
+- Add `xpack.enabled` support for Enterprise Search module. {pull}29871[29871]
 
 *Packetbeat*
 
@@ -211,9 +212,3 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 ==== Known Issue
 
 *Journalbeat*
-
-
-
-
-
-

--- a/metricbeat/docs/modules/enterprisesearch.asciidoc
+++ b/metricbeat/docs/modules/enterprisesearch.asciidoc
@@ -20,6 +20,17 @@ The module has been tested with Enterprise Search versions 7.16.0 and higher. Ve
 === Usage
 The Enterprise Search module requires a set of credentials (a username and a password) for an Elasticserch user for a user that has a `monitor` https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html#privileges-list-cluster[cluster privilege].
 
+[float]
+=== Usage for {stack} Monitoring
+
+The Enterprise Search module can be used to collect metrics shown in our {stack-monitor-app}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` in configuration.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].
+
 
 [float]
 === Example configuration
@@ -35,8 +46,8 @@ metricbeat.modules:
   enabled: true
   period: 10s
   hosts: ["http://localhost:3002"]
-  username: elastic
-  password: changeme
+  #username: "user"
+  #password: "secret"
 ----
 
 This module supports TLS connections when using `ssl` config field, as described in <<configuration-ssl>>.

--- a/metricbeat/helper/elastic/elastic.go
+++ b/metricbeat/helper/elastic/elastic.go
@@ -44,6 +44,9 @@ const (
 
 	// Beats product
 	Beats
+
+	// Enterprise Search product
+	EnterpriseSearch
 )
 
 func (p Product) xPackMonitoringIndexString() string {
@@ -52,6 +55,7 @@ func (p Product) xPackMonitoringIndexString() string {
 		"kibana",
 		"logstash",
 		"beats",
+		"ent-search",
 	}
 
 	if int(p) < 0 || int(p) > len(indexProductNames) {
@@ -67,6 +71,7 @@ func (p Product) String() string {
 		"kibana",
 		"logstash",
 		"beats",
+		"enterprisesearch",
 	}
 
 	if int(p) < 0 || int(p) > len(productNames) {

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -510,8 +510,8 @@ metricbeat.modules:
   enabled: true
   period: 10s
   hosts: ["http://localhost:3002"]
-  username: elastic
-  password: changeme
+  #username: "user"
+  #password: "secret"
 
 #------------------------------ Envoyproxy Module ------------------------------
 - module: envoyproxy

--- a/x-pack/metricbeat/module/enterprisesearch/_meta/config-xpack.yml
+++ b/x-pack/metricbeat/module/enterprisesearch/_meta/config-xpack.yml
@@ -1,4 +1,5 @@
 - module: enterprisesearch
+  xpack.enabled: true
   metricsets: ["health", "stats"]
   enabled: true
   period: 10s

--- a/x-pack/metricbeat/module/enterprisesearch/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/enterprisesearch/_meta/docs.asciidoc
@@ -7,3 +7,14 @@ The module has been tested with Enterprise Search versions 7.16.0 and higher. Ve
 [float]
 === Usage
 The Enterprise Search module requires a set of credentials (a username and a password) for an Elasticserch user for a user that has a `monitor` https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html#privileges-list-cluster[cluster privilege].
+
+[float]
+=== Usage for {stack} Monitoring
+
+The Enterprise Search module can be used to collect metrics shown in our {stack-monitor-app}
+UI in {kib}. To enable this usage, set `xpack.enabled: true` in configuration.
+
+NOTE: When this module is used for {stack} Monitoring, it sends metrics to the
+monitoring index instead of the default index typically used by {metricbeat}.
+For more details about the monitoring index, see
+{ref}/config-monitoring-indices.html[Configuring indices for monitoring].

--- a/x-pack/metricbeat/module/enterprisesearch/docker-compose.yml
+++ b/x-pack/metricbeat/module/enterprisesearch/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - 3002:3002
 
   elasticsearch:
-    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-7.15.0}-1
+    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-8.0.0-SNAPSHOT}-1
     build:
       args:
         ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-7.15.0}

--- a/x-pack/metricbeat/module/enterprisesearch/stats/stats.go
+++ b/x-pack/metricbeat/module/enterprisesearch/stats/stats.go
@@ -38,7 +38,8 @@ func init() {
 
 type MetricSet struct {
 	mb.BaseMetricSet
-	http *helper.HTTP
+	http         *helper.HTTP
+	XPackEnabled bool
 }
 
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
@@ -48,9 +49,19 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	config := struct {
+		XPackEnabled bool `config:"xpack.enabled"`
+	}{
+		XPackEnabled: false,
+	}
+	if err := base.Module().UnpackConfig(&config); err != nil {
+		return nil, err
+	}
 	return &MetricSet{
 		base,
 		http,
+		config.XPackEnabled,
 	}, nil
 }
 
@@ -63,7 +74,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 		return errors.Wrap(err, "error in fetch")
 	}
 
-	err = eventMapping(report, content)
+	err = eventMapping(report, content, m.XPackEnabled)
 	if err != nil {
 		return errors.Wrap(err, "error converting event")
 	}

--- a/x-pack/metricbeat/module/enterprisesearch/test_enterprisesearch.py
+++ b/x-pack/metricbeat/module/enterprisesearch/test_enterprisesearch.py
@@ -11,19 +11,11 @@ class Test(XPackTest):
 
     # -------------------------------------------------------------------------
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
-    def test_health_xpack_disabled(self, xpackEnabled):
-        """Tests the Health API and the associated metricset with XPack disabled"""
-        self.health_check(xpackEnabled=False)
-
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
-    def test_health_xpack_enabled(self, xpackEnabled):
-        """Tests the Health API and the associated metricset with XPack enabled"""
-        self.health_check(xpackEnabled=True)
-
-    def health_check(self, xpackEnabled):
+    def test_health(self):
+        """Tests the Health API and the associated metricset"""
 
         # Setup the environment
-        self.setup_environment(metricset="health", xpackEnabled=xpackEnabled)
+        self.setup_environment(metricset="health")
 
         # Get a single event for testing
         evt = self.get_event()
@@ -33,23 +25,14 @@ class Test(XPackTest):
 
         health = evt["enterprisesearch"]["health"]
         self.assertIn("jvm", health)
-        self.assertEqual(evt["index"].startsWith(".monitoring-"), xpackEnabled)
 
     # -------------------------------------------------------------------------
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
-    def test_stats_xpack_disabled(self):
-        """Tests the Stats API and the associated metricset with XPack disabled"""
-        self.stats_check(xpackEnabled=False)
-
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
-    def test_stats_xpack_enabled(self):
-        """Tests the Stats API and the associated metricset with XPack enabled"""
-        self.stats_check(xpackEnabled=True)
-
-    def stats_check(self, xpackEnabled):
+    def test_stats(self):
+        """Tests the Stats API and the associated metricset"""
 
         # Setup the environment
-        self.setup_environment(metricset="stats", xpackEnabled=xpackEnabled)
+        self.setup_environment(metricset="stats")
 
         # Get a single event for testing
         evt = self.get_event()
@@ -59,10 +42,9 @@ class Test(XPackTest):
 
         stats = evt["enterprisesearch"]["stats"]
         self.assertIn("http", stats)
-        self.assertEqual(evt["index"].startsWith(".monitoring-"), xpackEnabled)
 
     # -------------------------------------------------------------------------
-    def setup_environment(self, metricset, xpackEnabled):
+    def setup_environment(self, metricset):
         """Sets up the testing environment and starts all components needed"""
 
         self.render_config_template(modules=[{
@@ -71,8 +53,7 @@ class Test(XPackTest):
             "hosts": [self.compose_host(service="enterprise_search")],
             "username": self.get_username(),
             "password": self.get_password(),
-            "period": "5s",
-            "xpack.enabled": xpackEnabled
+            "period": "5s"
         }])
 
         proc = self.start_beat(home=self.beat_path)

--- a/x-pack/metricbeat/module/enterprisesearch/test_enterprisesearch.py
+++ b/x-pack/metricbeat/module/enterprisesearch/test_enterprisesearch.py
@@ -13,14 +13,14 @@ class Test(XPackTest):
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_health_xpack_disabled(self, xpackEnabled):
         """Tests the Health API and the associated metricset with XPack disabled"""
-        self.test_health(xpackEnabled=False)
+        self.health_check(xpackEnabled=False)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_health_xpack_enabled(self, xpackEnabled):
         """Tests the Health API and the associated metricset with XPack enabled"""
-        self.test_health(xpackEnabled=True)
+        self.health_check(xpackEnabled=True)
 
-    def test_health(self, xpackEnabled):
+    def health_check(self, xpackEnabled):
 
         # Setup the environment
         self.setup_environment(metricset="health", xpackEnabled=xpackEnabled)
@@ -39,14 +39,14 @@ class Test(XPackTest):
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_stats_xpack_disabled(self):
         """Tests the Stats API and the associated metricset with XPack disabled"""
-        self.test_stats(xpackEnabled=False)
+        self.stats_check(xpackEnabled=False)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_stats_xpack_enabled(self):
         """Tests the Stats API and the associated metricset with XPack enabled"""
-        self.test_stats(xpackEnabled=True)
+        self.stats_check(xpackEnabled=True)
 
-    def test_stats(self, xpackEnabled):
+    def stats_check(self, xpackEnabled):
 
         # Setup the environment
         self.setup_environment(metricset="stats", xpackEnabled=xpackEnabled)

--- a/x-pack/metricbeat/module/enterprisesearch/test_enterprisesearch.py
+++ b/x-pack/metricbeat/module/enterprisesearch/test_enterprisesearch.py
@@ -13,12 +13,12 @@ class Test(XPackTest):
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_health_xpack_disabled(self, xpackEnabled):
         """Tests the Health API and the associated metricset with XPack disabled"""
-        test_health(xpackEnabled=False)
+        self.test_health(xpackEnabled=False)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_health_xpack_enabled(self, xpackEnabled):
         """Tests the Health API and the associated metricset with XPack enabled"""
-        test_health(xpackEnabled=True)
+        self.test_health(xpackEnabled=True)
 
     def test_health(self, xpackEnabled):
 
@@ -39,12 +39,12 @@ class Test(XPackTest):
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_stats_xpack_disabled(self):
         """Tests the Stats API and the associated metricset with XPack disabled"""
-        test_stats(xpackEnabled=False)
+        self.test_stats(xpackEnabled=False)
 
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, 'integration test')
     def test_stats_xpack_enabled(self):
         """Tests the Stats API and the associated metricset with XPack enabled"""
-        test_stats(xpackEnabled=True)
+        self.test_stats(xpackEnabled=True)
 
     def test_stats(self, xpackEnabled):
 

--- a/x-pack/metricbeat/modules.d/enterprisesearch-xpack.yml.disabled
+++ b/x-pack/metricbeat/modules.d/enterprisesearch-xpack.yml.disabled
@@ -1,0 +1,11 @@
+# Module: enterprisesearch
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-enterprisesearch.html
+
+- module: enterprisesearch
+  xpack.enabled: true
+  metricsets: ["health", "stats"]
+  enabled: true
+  period: 10s
+  hosts: ["http://localhost:3002"]
+  #username: "user"
+  #password: "secret"

--- a/x-pack/metricbeat/modules.d/enterprisesearch.yml.disabled
+++ b/x-pack/metricbeat/modules.d/enterprisesearch.yml.disabled
@@ -6,5 +6,5 @@
   enabled: true
   period: 10s
   hosts: ["http://localhost:3002"]
-  username: elastic
-  password: changeme
+  #username: "user"
+  #password: "secret"


### PR DESCRIPTION
## What does this PR do?

Add `xpack.enabled` support for Enterprise Search Metricbeat module.

This allows metrics retrieved to be available in Stack Monitoring Kibana plugin, as this plugin changes the indices retrieved from `.metricbeat-*` to `.monitoring-*`. `xpack.enabled: true` allows changing the index to be used to .monitoring-*, as already implemented for Elasticsearch, Kibana and Logstash modules.

## Why is it important?

This change is needed to allow Enterprise Search Metricbeat module to produce metrics that can be consumed by Stack Monitoring Kibana plugin. Stack Monitoring won't display Enterprise Search metrics otherwise.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/kibana/issues/121975
- Relates https://github.com/elastic/enterprise-search-team/issues/987