### PR TITLE
Fix istio docs regarding default metricsets

### DIFF
--- a/metricbeat/docs/modules/istio.asciidoc
+++ b/metricbeat/docs/modules/istio.asciidoc
@@ -20,8 +20,6 @@ For versions after `1.5`, `istiod` and `proxy` metricsets can be used.
 
 `istiod` collects metrics directly from Istio Daemon while `proxy` collects from each of the proxy sidecars.
 
-The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
-
 [float]
 === Compatibility
 

--- a/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/istio/_meta/docs.asciidoc
@@ -8,8 +8,6 @@ For versions after `1.5`, `istiod` and `proxy` metricsets can be used.
 
 `istiod` collects metrics directly from Istio Daemon while `proxy` collects from each of the proxy sidecars.
 
-The default metricsets are `mesh`, `mixer`, `pilot`, `galley`, `citadel`.
-
 [float]
 === Compatibility
 


### PR DESCRIPTION
## What does this PR do?
Small correction about default metricsets. There are no default metricsets in `istio` module.

Wait until https://github.com/elastic/beats/pull/29873 is merged.