### PR TITLE
Enable require_alias for Bulk requests for all actions when target is a write alias

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,6 +36,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Enable `require_alias` for Bulk requests for all actions when target is a write alias. {issue}27874[27874] {pull}29879[29879]
+
 
 *Auditbeat*
 

--- a/libbeat/esleg/eslegclient/bulkapi.go
+++ b/libbeat/esleg/eslegclient/bulkapi.go
@@ -55,7 +55,7 @@ type BulkMeta struct {
 	DocType      string `json:"_type,omitempty" struct:"_type,omitempty"`
 	Pipeline     string `json:"pipeline,omitempty" struct:"pipeline,omitempty"`
 	ID           string `json:"_id,omitempty" struct:"_id,omitempty"`
-	RequireAlias bool   `json:"require_alias,omitempty" struct:"require_alias"`
+	RequireAlias bool   `json:"require_alias,omitempty" struct:"require_alias,omitempty"`
 }
 
 type bulkRequest struct {

--- a/libbeat/esleg/eslegclient/bulkapi.go
+++ b/libbeat/esleg/eslegclient/bulkapi.go
@@ -55,7 +55,7 @@ type BulkMeta struct {
 	DocType      string `json:"_type,omitempty" struct:"_type,omitempty"`
 	Pipeline     string `json:"pipeline,omitempty" struct:"pipeline,omitempty"`
 	ID           string `json:"_id,omitempty" struct:"_id,omitempty"`
-	RequireAlias bool   `json:"require_alias" struct:"require_alias"`
+	RequireAlias bool   `json:"require_alias,omitempty" struct:"require_alias"`
 }
 
 type bulkRequest struct {

--- a/libbeat/esleg/eslegclient/bulkapi.go
+++ b/libbeat/esleg/eslegclient/bulkapi.go
@@ -51,10 +51,11 @@ type BulkDeleteAction struct {
 }
 
 type BulkMeta struct {
-	Index    string `json:"_index" struct:"_index"`
-	DocType  string `json:"_type,omitempty" struct:"_type,omitempty"`
-	Pipeline string `json:"pipeline,omitempty" struct:"pipeline,omitempty"`
-	ID       string `json:"_id,omitempty" struct:"_id,omitempty"`
+	Index        string `json:"_index" struct:"_index"`
+	DocType      string `json:"_type,omitempty" struct:"_type,omitempty"`
+	Pipeline     string `json:"pipeline,omitempty" struct:"pipeline,omitempty"`
+	ID           string `json:"_id,omitempty" struct:"_id,omitempty"`
+	RequireAlias bool   `json:"require_alias" struct:"require_alias"`
 }
 
 type bulkRequest struct {

--- a/libbeat/idxmgmt/std.go
+++ b/libbeat/idxmgmt/std.go
@@ -337,12 +337,16 @@ func (s *ilmIndexSelector) Select(evt *beat.Event) (string, error) {
 	return idx, err
 }
 
+func (s ilmIndexSelector) IsAlias() bool { return true }
+
 func (s indexSelector) Select(evt *beat.Event) (string, error) {
 	if idx := getEventCustomIndex(evt, s.beatInfo); idx != "" {
 		return idx, nil
 	}
 	return s.sel.Select(evt)
 }
+
+func (s indexSelector) IsAlias() bool { return false }
 
 func getEventCustomIndex(evt *beat.Event, beatInfo beat.Info) string {
 	if len(evt.Meta) == 0 {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -311,10 +311,11 @@ func (client *Client) createEventBulkMeta(version common.Version, event *beat.Ev
 	opType := events.GetOpType(*event)
 
 	meta := eslegclient.BulkMeta{
-		Index:    index,
-		DocType:  eventType,
-		Pipeline: pipeline,
-		ID:       id,
+		Index:        index,
+		DocType:      eventType,
+		Pipeline:     pipeline,
+		ID:           id,
+		RequireAlias: client.index.IsAlias(),
 	}
 
 	if opType == events.OpTypeDelete {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -338,7 +338,7 @@ func (client *Client) createEventBulkMeta(version common.Version, event *beat.Ev
 }
 
 func isRequireAliasSupported(version common.Version) bool {
-	return !version.LessThan(common.MustNewVersion("7.9.0"))
+	return !version.LessThan(common.MustNewVersion("7.10.0"))
 }
 
 func (client *Client) getPipeline(event *beat.Event) (string, error) {

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -310,12 +310,17 @@ func (client *Client) createEventBulkMeta(version common.Version, event *beat.Ev
 	id, _ := events.GetMetaStringValue(*event, events.FieldMetaID)
 	opType := events.GetOpType(*event)
 
+	alias := client.index.IsAlias()
+	if version.Major < 7 {
+		alias = false
+	}
+
 	meta := eslegclient.BulkMeta{
 		Index:        index,
 		DocType:      eventType,
 		Pipeline:     pipeline,
 		ID:           id,
-		RequireAlias: client.index.IsAlias(),
+		RequireAlias: alias,
 	}
 
 	if opType == events.OpTypeDelete {

--- a/libbeat/outputs/elasticsearch/client_integration_test.go
+++ b/libbeat/outputs/elasticsearch/client_integration_test.go
@@ -420,7 +420,8 @@ func connectTestEs(t *testing.T, cfg interface{}, stats outputs.Observer) (outpu
 	}
 
 	info := beat.Info{Beat: "libbeat"}
-	im, _ := idxmgmt.DefaultSupport(nil, info, nil)
+	// ILM must be disabled otherwise custom index settings are ignored.
+	im, _ := idxmgmt.DefaultSupport(nil, info, disabledILMConfig())
 	output, err := makeES(im, info, stats, config)
 	if err != nil {
 		t.Fatal(err)
@@ -436,6 +437,10 @@ func connectTestEs(t *testing.T, cfg interface{}, stats outputs.Observer) (outpu
 	client.Connect()
 
 	return client, client
+}
+
+func disabledILMConfig() *common.Config {
+	return common.MustNewConfigFrom(map[string]interface{}{"setup": map[string]interface{}{"ilm": map[string]interface{}{"enabled": false}}})
 }
 
 // setupRoleMapping sets up role mapping for the Kerberos user beats@ELASTIC

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -423,6 +423,21 @@ func TestBulkEncodeEvents(t *testing.T) {
 			ilmConfig: common.NewConfig(),
 			events:    []common.MapStr{{"message": "test"}},
 		},
+		"require_alias not supported": {
+			version:   "7.9.0",
+			docType:   "",
+			config:    common.MapStr{},
+			ilmConfig: common.NewConfig(),
+			events:    []common.MapStr{{"message": "test"}},
+		},
+		"require_alias is supported": {
+			version:   "7.10.0",
+			docType:   "",
+			config:    common.MapStr{},
+			ilmConfig: common.NewConfig(),
+			isAlias:   true,
+			events:    []common.MapStr{{"message": "test"}},
+		},
 		"latest with ILM": {
 			version:   version.GetDefaultVersion(),
 			docType:   "",

--- a/libbeat/outputs/elasticsearch/client_test.go
+++ b/libbeat/outputs/elasticsearch/client_test.go
@@ -409,22 +409,34 @@ func TestClientWithHeaders(t *testing.T) {
 
 func TestBulkEncodeEvents(t *testing.T) {
 	cases := map[string]struct {
-		version string
-		docType string
-		config  common.MapStr
-		events  []common.MapStr
+		version   string
+		docType   string
+		config    common.MapStr
+		ilmConfig *common.Config
+		isAlias   bool
+		events    []common.MapStr
 	}{
 		"6.x": {
-			version: "6.8.0",
-			docType: "doc",
-			config:  common.MapStr{},
-			events:  []common.MapStr{{"message": "test"}},
+			version:   "6.8.0",
+			docType:   "doc",
+			config:    common.MapStr{},
+			ilmConfig: common.NewConfig(),
+			events:    []common.MapStr{{"message": "test"}},
 		},
-		"latest": {
-			version: version.GetDefaultVersion(),
-			docType: "",
-			config:  common.MapStr{},
-			events:  []common.MapStr{{"message": "test"}},
+		"latest with ILM": {
+			version:   version.GetDefaultVersion(),
+			docType:   "",
+			config:    common.MapStr{},
+			ilmConfig: common.NewConfig(),
+			isAlias:   true,
+			events:    []common.MapStr{{"message": "test"}},
+		},
+		"latest without ILM": {
+			version:   version.GetDefaultVersion(),
+			docType:   "",
+			config:    common.MapStr{},
+			ilmConfig: disabledILMConfig(),
+			events:    []common.MapStr{{"message": "test"}},
 		},
 	}
 
@@ -437,7 +449,7 @@ func TestBulkEncodeEvents(t *testing.T) {
 				Version:     test.version,
 			}
 
-			im, err := idxmgmt.DefaultSupport(nil, info, common.NewConfig())
+			im, err := idxmgmt.DefaultSupport(nil, info, test.ilmConfig)
 			require.NoError(t, err)
 
 			index, pipeline, err := buildSelectors(im, info, cfg)
@@ -479,12 +491,17 @@ func TestBulkEncodeEvents(t *testing.T) {
 				}
 
 				assert.NotEqual(t, "", meta.Index)
+				assert.Equal(t, test.isAlias, meta.RequireAlias)
 				assert.Equal(t, test.docType, meta.DocType)
 			}
 
 			// TODO: customer per test case validation
 		})
 	}
+}
+
+func disabledILMConfig() *common.Config {
+	return common.MustNewConfigFrom(map[string]interface{}{"setup": map[string]interface{}{"ilm": map[string]interface{}{"enabled": false}}})
 }
 
 func TestBulkEncodeEventsWithOpType(t *testing.T) {

--- a/libbeat/outputs/elasticsearch/death_letter_selector.go
+++ b/libbeat/outputs/elasticsearch/death_letter_selector.go
@@ -34,3 +34,5 @@ func (d DeadLetterSelector) Select(event *beat.Event) (string, error) {
 	}
 	return d.Selector.Select(event)
 }
+
+func (d DeadLetterSelector) IsAlias() bool { return false }

--- a/libbeat/outputs/outil/select.go
+++ b/libbeat/outputs/outil/select.go
@@ -87,6 +87,8 @@ func (s Selector) Select(evt *beat.Event) (string, error) {
 	return s.sel.sel(evt)
 }
 
+func (s Selector) IsAlias() bool { return false }
+
 // IsEmpty checks if the selector is not configured and will always return an empty string.
 func (s Selector) IsEmpty() bool {
 	return s.sel == nilSelector || s.sel == nil

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -43,8 +43,10 @@ type IndexManager interface {
 }
 
 // IndexSelector is used to find the index name an event shall be indexed to.
+// It also used to check if during indexing required_alias should be set.
 type IndexSelector interface {
 	Select(event *beat.Event) (string, error)
+	IsAlias() bool
 }
 
 // Group configures and combines multiple clients into load-balanced group of clients


### PR DESCRIPTION
## What does this PR do?

This PR adds support for requiring alias when using ILM. From now on a `Selector` can tell Elasticsearch client if the target we are shipping events to is an alias or an index. By default, we consider everything an index, and only consider a target an alias when ILM is enabled.

The feature is only supported since ES 7.10, so if the user tries to connect to an older version, we cannot help them with this parameter.

## Why is it important?

We see issues around ILM sometimes where users have deleted their write alias causing running beats instances to auto-create an index where the write alias should (with auto-mappings to boot, since the template won't be applied). To a

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes https://github.com/elastic/beats/issues/27874
