### PR TITLE
Note that filesets are disabled by default in Filebeat documentation

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -88,7 +88,7 @@ include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 --
 
 . In the module config under `modules.d`, enable the desired datasets and
-change the module settings to match your environment.
+change the module settings to match your environment. **Filesets are disabled by default.**
 +
 For example, log locations are set based on the OS. If your logs aren't in
 default locations, set the `paths` variable:

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -88,7 +88,7 @@ include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 --
 
 . In the module config under `modules.d`, enable the desired datasets and
-change the module settings to match your environment. **Filesets are disabled by default.**
+change the module settings to match your environment. **Datasets are disabled by default.**
 +
 For example, log locations are set based on the OS. If your logs aren't in
 default locations, set the `paths` variable:


### PR DESCRIPTION
## What does this PR do?

This PR clarifies that all filesets are disabled in module configuration files by default.

## Why is it important?

Enabling filesets manually is a breaking change in 8.0. We should tell users about the change, so they can adopt.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~