### PR TITLE
Add beat/process config to elastic agent diagnostics collect

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -157,3 +157,4 @@
 - Allow pprof endpoints for elastic-agent or beats if enabled. {pull}28983[28983] {pull}29155[29155]
 - Add --fleet-server-es-ca-trusted-fingerprint flag to allow agent/fleet-server to work with elasticsearch clusters using self signed certs. {pull}29128[29128]
 - Discover changes in Kubernetes nodes metadata as soon as they happen. {pull}23139[23139]
+- Add results of inspect output command into archive produced by diagnostics collect. {pull}29902[29902]

--- a/x-pack/elastic-agent/pkg/agent/cmd/diagnostics.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/diagnostics.go
@@ -366,24 +366,24 @@ func gatherConfig() (AgentConfig, error) {
 	// Gather vars to render process config
 	isStandalone, err := isStandalone(renderedCFG)
 	if err != nil {
-		return cfg, err
+		return AgentConfig{}, err
 	}
 
 	agentInfo, err := info.NewAgentInfo(false)
 	if err != nil {
-		return cfg, err
+		return AgentConfig{}, err
 	}
 
 	log, err := newErrorLogger()
 	if err != nil {
-		return cfg, err
+		return AgentConfig{}, err
 	}
 
-	// get process config - uses same approach as inspect output command
-	// does not contact server process to request configs
+	// Get process config - uses same approach as inspect output command.
+	// Does not contact server process to request configs.
 	pMap, err := getProgramsFromConfig(log, agentInfo, renderedCFG, isStandalone)
 	if err != nil {
-		return cfg, err
+		return AgentConfig{}, err
 	}
 	cfg.AppConfig = make(map[string]interface{}, 0)
 	for rk, programs := range pMap {

--- a/x-pack/elastic-agent/pkg/agent/cmd/diagnostics.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/diagnostics.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/info"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/application/paths"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/configuration"
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/agent/control/client"
@@ -47,6 +48,7 @@ type DiagnosticsInfo struct {
 type AgentConfig struct {
 	ConfigLocal    *configuration.Configuration
 	ConfigRendered map[string]interface{}
+	AppConfig      map[string]interface{} // map of processName_rk:config
 }
 
 func newDiagnosticsCommand(s []string, streams *cli.IOStreams) *cobra.Command {
@@ -361,6 +363,35 @@ func gatherConfig() (AgentConfig, error) {
 	}
 	cfg.ConfigRendered = mapCFG
 
+	// Gather vars to render process config
+	isStandalone, err := isStandalone(renderedCFG)
+	if err != nil {
+		return cfg, err
+	}
+
+	agentInfo, err := info.NewAgentInfo(false)
+	if err != nil {
+		return cfg, err
+	}
+
+	log, err := newErrorLogger()
+	if err != nil {
+		return cfg, err
+	}
+
+	// get process config - uses same approach as inspect output command
+	// does not contact server process to request configs
+	pMap, err := getProgramsFromConfig(log, agentInfo, renderedCFG, isStandalone)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.AppConfig = make(map[string]interface{}, 0)
+	for rk, programs := range pMap {
+		for _, p := range programs {
+			cfg.AppConfig[p.Identifier()+"_"+rk] = p.Configuration()
+		}
+	}
+
 	return cfg, nil
 }
 
@@ -418,6 +449,15 @@ func createZip(fileName, outputFormat string, diag DiagnosticsInfo, cfg AgentCon
 	}
 	if err := writeFile(zf, outputFormat, cfg.ConfigRendered); err != nil {
 		return closeHandlers(err, zw, f)
+	}
+	for name, appCfg := range cfg.AppConfig {
+		zf, err := zw.Create("config/" + name + "." + outputFormat)
+		if err != nil {
+			return closeHandlers(err, zw, f)
+		}
+		if err := writeFile(zf, outputFormat, appCfg); err != nil {
+			return closeHandlers(err, zw, f)
+		}
 	}
 
 	if err := zipLogs(zw); err != nil {


### PR DESCRIPTION
## What does this PR do?

Add the configs that are output from elastic-agent inspect output to the
bundle generated by elastic-agent diagnostics collect. Files are named
as ProcID_RouteKey.

## Why is it important?

Include the config that's sent from the agent to underlying processes in the diagnostic bundles to allow us to more easily debug config errors.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Start an agent.
Run `elastic-agent diagnostics collect` once the agent is healthy
Inspect archive's config files.

## Related issues

- Closes #29898 