### PR TITLE
Allign k8s configuration settings

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add job.name in pods controlled by Jobs {pull}28954[28954]
 - Change Docker base image from CentOS 7 to Ubuntu 20.04 {pull}29681[29681]
 - Enrich kubernetes metadata with node annotations. {pull}29605[29605]
+- Allign kubernetes configuration settings. {pull}29908[29908]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/providers/kubernetes/config.go
+++ b/libbeat/autodiscover/providers/kubernetes/config.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/autodiscover/template"
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
@@ -43,8 +42,7 @@ type Config struct {
 	CleanupTimeout time.Duration `config:"cleanup_timeout" validate:"positive"`
 
 	// Needed when resource is a pod
-	HostDeprecated string `config:"host"`
-	Node           string `config:"node"`
+	Node string `config:"node"`
 	// Scope can be either node or cluster.
 	Scope    string `config:"scope"`
 	Resource string `config:"resource"`
@@ -84,12 +82,6 @@ func (c *Config) Validate() error {
 
 	if len(c.Templates) == 0 && !c.Hints.Enabled() && len(c.Builders) == 0 {
 		return fmt.Errorf("no configs or hints defined for autodiscover provider")
-	}
-
-	// Check if host is being defined and change it to node instead.
-	if c.Node == "" && c.HostDeprecated != "" {
-		c.Node = c.HostDeprecated
-		cfgwarn.Deprecate("8.0", "`host` will be deprecated, use `node` instead")
 	}
 
 	// Check if resource is either node or pod. If yes then default the scope to "node" if not provided.

--- a/libbeat/autodiscover/providers/kubernetes/pod.go
+++ b/libbeat/autodiscover/providers/kubernetes/pod.go
@@ -94,10 +94,9 @@ func NewPodEventer(uuid uuid.UUID, cfg *common.Config, client k8s.Interface, pub
 	options := kubernetes.WatchOptions{
 		SyncTimeout: config.SyncPeriod,
 		Node:        config.Node,
+		Namespace:   config.Namespace,
 	}
-	if config.Namespace != "" {
-		options.Namespace = config.Namespace
-	}
+
 	metaConf := config.AddResourceMetadata
 	nodeWatcher, err := kubernetes.NewNamedWatcher("node", client, &kubernetes.Node{}, options, nil)
 	if err != nil {

--- a/libbeat/processors/add_kubernetes_metadata/config.go
+++ b/libbeat/processors/add_kubernetes_metadata/config.go
@@ -29,7 +29,7 @@ import (
 type kubeAnnotatorConfig struct {
 	KubeConfig        string                       `config:"kube_config"`
 	KubeClientOptions kubernetes.KubeClientOptions `config:"kube_client_options"`
-	Host              string                       `config:"host"`
+	Node              string                       `config:"node"`
 	Scope             string                       `config:"scope"`
 	Namespace         string                       `config:"namespace"`
 	SyncPeriod        time.Duration                `config:"sync_period"`
@@ -67,7 +67,7 @@ func (k *kubeAnnotatorConfig) Validate() error {
 	}
 
 	if k.Scope == "cluster" {
-		k.Host = ""
+		k.Node = ""
 	}
 
 	// Checks below were added to warn the users early on and avoid initialising the processor in case the `logs_path`

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -195,10 +195,9 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Confi
 		options := kubernetes.WatchOptions{
 			SyncTimeout: config.SyncPeriod,
 			Node:        config.Node,
+			Namespace:   config.Namespace,
 		}
-		if config.Namespace != "" {
-			options.Namespace = config.Namespace
-		}
+
 		nodeWatcher, err := kubernetes.NewNamedWatcher("add_kubernetes_metadata_node", client, &kubernetes.Node{}, options, nil)
 		if err != nil {
 			k.log.Errorf("couldn't create watcher for %T due to error %+v", &kubernetes.Node{}, err)

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -166,23 +166,23 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Confi
 
 		k.matchers = matchers
 		nd := &kubernetes.DiscoverKubernetesNodeParams{
-			ConfigHost:  config.Host,
+			ConfigHost:  config.Node,
 			Client:      client,
 			IsInCluster: kubernetes.IsInCluster(config.KubeConfig),
 			HostUtils:   &kubernetes.DefaultDiscoveryUtils{},
 		}
 		if config.Scope == "node" {
-			config.Host, err = kubernetes.DiscoverKubernetesNode(k.log, nd)
+			config.Node, err = kubernetes.DiscoverKubernetesNode(k.log, nd)
 			if err != nil {
 				k.log.Errorf("Couldn't discover Kubernetes node: %w", err)
 				return
 			}
-			k.log.Debugf("Initializing a new Kubernetes watcher using host: %s", config.Host)
+			k.log.Debugf("Initializing a new Kubernetes watcher using host: %s", config.Node)
 		}
 
 		watcher, err := kubernetes.NewNamedWatcher("add_kubernetes_metadata_pod", client, &kubernetes.Pod{}, kubernetes.WatchOptions{
 			SyncTimeout: config.SyncPeriod,
-			Node:        config.Host,
+			Node:        config.Node,
 			Namespace:   config.Namespace,
 		}, nil)
 		if err != nil {
@@ -194,7 +194,7 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Confi
 
 		options := kubernetes.WatchOptions{
 			SyncTimeout: config.SyncPeriod,
-			Node:        config.Host,
+			Node:        config.Node,
 		}
 		if config.Namespace != "" {
 			options.Namespace = config.Namespace

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -218,7 +218,7 @@ metricbeat.modules:
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
@@ -262,10 +262,12 @@ metricbeat.modules:
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
+  # Set the namespace to watch for resources
+  #namespace: staging
   # To configure additionally node and namespace metadata, added to pod, service and container resource types,
   # `add_resource_metadata` can be defined.
   # By default all labels will be included while annotations are not added by default.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -496,7 +496,7 @@ metricbeat.modules:
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
@@ -540,10 +540,12 @@ metricbeat.modules:
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
+  # Set the namespace to watch for resources
+  #namespace: staging
   # To configure additionally node and namespace metadata, added to pod, service and container resource types,
   # `add_resource_metadata` can be defined.
   # By default all labels will be included while annotations are not added by default.

--- a/metricbeat/module/kubernetes/_meta/config.reference.yml
+++ b/metricbeat/module/kubernetes/_meta/config.reference.yml
@@ -19,7 +19,7 @@
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
@@ -63,10 +63,12 @@
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
+  # Set the namespace to watch for resources
+  #namespace: staging
   # To configure additionally node and namespace metadata, added to pod, service and container resource types,
   # `add_resource_metadata` can be defined.
   # By default all labels will be included while annotations are not added by default.

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -19,9 +19,12 @@
   #labels.dedot: true
   #annotations.dedot: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
+  #kube_config: ~/.kube/config
+  # Set the namespace to watch for resources
+  #namespace: staging
   # To configure additionally node and namespace metadata, added to pod, service and container resource types,
   # `add_resource_metadata` can be defined.
   # By default all labels will be included while annotations are not added by default.

--- a/metricbeat/module/kubernetes/_meta/config.yml
+++ b/metricbeat/module/kubernetes/_meta/config.yml
@@ -35,7 +35,6 @@
   #     include_labels: ["nodelabel2"]
   #     include_annotations: ["nodeannotation1"]
   #   deployment: false
-  #kube_config: ~/.kube/config
   # Kubernetes client QPS and burst can be configured additionally
   #kube_client_options:
   #  qps: 5

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -22,9 +22,12 @@
   #labels.dedot: true
   #annotations.dedot: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
+  #kube_config: ~/.kube/config
+  # Set the namespace to watch for resources
+  #namespace: staging
   # To configure additionally node and namespace metadata, added to pod, service and container resource types,
   # `add_resource_metadata` can be defined.
   # By default all labels will be included while annotations are not added by default.

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -38,7 +38,6 @@
   #     include_labels: ["nodelabel2"]
   #     include_annotations: ["nodeannotation1"]
   #   deployment: false
-  #kube_config: ~/.kube/config
   # Kubernetes client QPS and burst can be configured additionally
   #kube_client_options:
   #  qps: 5

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -881,7 +881,7 @@ metricbeat.modules:
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
@@ -925,10 +925,12 @@ metricbeat.modules:
   # Enriching parameters:
   add_metadata: true
   # When used outside the cluster:
-  #host: node_name
+  #node: node_name
   # If kube_config is not set, KUBECONFIG environment variable will be checked
   # and if not present it will fall back to InCluster
   #kube_config: ~/.kube/config
+  # Set the namespace to watch for resources
+  #namespace: staging
   # To configure additionally node and namespace metadata, added to pod, service and container resource types,
   # `add_resource_metadata` can be defined.
   # By default all labels will be included while annotations are not added by default.


### PR DESCRIPTION
## What does this PR do?

This PR adds `namespace` and moves `host` to `node` settings under the `kubernetes` module. 

## Why is it important?

In order to have alignment between the metadata configurations.

## Related issues

Closes https://github.com/elastic/beats/issues/29132