### PR TITLE
[automation] update elastic stack version for testing 7.17.0-e1efbe3a

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.17.0-68da5d12-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.17.0-e1efbe3a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -17,7 +17,7 @@ services:
     - "indices.id_field_data.enabled=true"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.17.0-68da5d12-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.17.0-e1efbe3a-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -27,7 +27,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.17.0-68da5d12-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.17.0-e1efbe3a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0-68da5d12-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0-e1efbe3a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -22,7 +22,7 @@ services:
     - "ingest.geoip.downloader.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.17.0-68da5d12-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.17.0-e1efbe3a-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -32,7 +32,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.0-68da5d12-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.0-e1efbe3a-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 20 Jan 2022 00:13:49 GMT, release_branch:7.17, prefix:, end_time:Thu, 20 Jan 2022 04:46:05 GMT, manifest_version:2.0.0, version:7.17.0-SNAPSHOT, branch:7.17, build_id:7.17.0-e1efbe3a, build_duration_seconds:16336]