### PR TITLE
Re add the ability for container commands to access kibana env vars

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -94,7 +94,6 @@
 - Allow HTTP metrics to run in bootstrap mode. Add ability to adjust timeouts for Fleet Server. {pull}28260[28260]
 - Fix agent configuration overwritten by default fleet config. {pull}29297[29297]
 - Allow agent containers to use basic auth to create a service token. {pull}29651[29651]
-- Re-add the ability to use KIBANA_USERNAME/KIBANA_PASSWORD env vars when in container mode. {pull}29930[29930]
 
 ==== New features
 

--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -94,6 +94,7 @@
 - Allow HTTP metrics to run in bootstrap mode. Add ability to adjust timeouts for Fleet Server. {pull}28260[28260]
 - Fix agent configuration overwritten by default fleet config. {pull}29297[29297]
 - Allow agent containers to use basic auth to create a service token. {pull}29651[29651]
+- Re-add the ability to use KIBANA_USERNAME/KIBANA_PASSWORD env vars when in container mode. {pull}29930[29930]
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/agent/cmd/setup_config.go
+++ b/x-pack/elastic-agent/pkg/agent/cmd/setup_config.go
@@ -108,8 +108,8 @@ func defaultAccessConfig() (setupConfig, error) {
 			Fleet: kibanaFleetConfig{
 				Setup:        envBool("KIBANA_FLEET_SETUP"),
 				Host:         envWithDefault("http://kibana:5601", "KIBANA_FLEET_HOST", "KIBANA_HOST"),
-				Username:     envWithDefault("elastic", "KIBANA_FLEET_USERNAME", "ELASTICSEARCH_USERNAME"),
-				Password:     envWithDefault("changeme", "KIBANA_FLEET_PASSWORD", "ELASTICSEARCH_PASSWORD"),
+				Username:     envWithDefault("elastic", "KIBANA_FLEET_USERNAME", "KIBANA_USERNAME", "ELASTICSEARCH_USERNAME"),
+				Password:     envWithDefault("changeme", "KIBANA_FLEET_PASSWORD", "KIBANA_PASSWORD", "ELASTICSEARCH_PASSWORD"),
 				ServiceToken: envWithDefault("", "KIBANA_FLEET_SERVICE_TOKEN", "FLEET_SERVER_SERVICE_TOKEN"),
 				CA:           envWithDefault("", "KIBANA_FLEET_CA", "KIBANA_CA", "ELASTICSEARCH_CA"),
 			},


### PR DESCRIPTION
## What does this PR do?

Allow elastic-agent container to read KIBANA_USERNAME/KIBANA_PASSWORD as
credentials to use to generate a service_token as the env vars were
erroniously removed.

## Why is it important?

Be consistent with the Elastic Stack env vars.

## Checklist


- [x] My code follows the style guidelines of this project
- [] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation [PR here](https://github.com/elastic/observability-docs/pull/1475)
- [] ~~I have made corresponding change to the default configuration files~~
- [] ~~I have added tests that prove my fix is effective or that my feature works~~
- [] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Use `KIBANA_USERNAME`/`KIBANA_PASSWORD` env vars in container