### PR TITLE
move event report into loop validDim loop

### DIFF
--- a/x-pack/metricbeat/module/azure/data.go
+++ b/x-pack/metricbeat/module/azure/data.go
@@ -84,6 +84,14 @@ func EventsMapping(metrics []Metric, client *Client, report mb.ReporterV2) error
 							vm = client.GetVMForMetaData(&resource, groupDimValues)
 							addCloudVMMetadata(&event, vm, resource.Subscription)
 						}
+						if client.Config.DefaultResourceType == "" {
+							event.ModuleFields.Put("metrics", metricList)
+						} else {
+							for key, metric := range metricList {
+								event.MetricSetFields.Put(key, metric)
+							}
+						}
+						report.Event(event)
 					}
 				}
 			} else {
@@ -92,15 +100,15 @@ func EventsMapping(metrics []Metric, client *Client, report mb.ReporterV2) error
 					vm = client.GetVMForMetaData(&resource, groupTimeValues)
 					addCloudVMMetadata(&event, vm, resource.Subscription)
 				}
-			}
-			if client.Config.DefaultResourceType == "" {
-				event.ModuleFields.Put("metrics", metricList)
-			} else {
-				for key, metric := range metricList {
-					event.MetricSetFields.Put(key, metric)
+				if client.Config.DefaultResourceType == "" {
+					event.ModuleFields.Put("metrics", metricList)
+				} else {
+					for key, metric := range metricList {
+						event.MetricSetFields.Put(key, metric)
+					}
 				}
+				report.Event(event)
 			}
-			report.Event(event)
 		}
 	}
 	return nil


### PR DESCRIPTION
## What does this PR do?
Moved the report.Event() function into the loop that iterates over all grouped Dimension in order to report all events instead of just a single one

## Why is it important?
Trying to fix the issue in https://github.com/elastic/beats/issues/27226 
If a azure metric endpoint with multiple dimensions is pulled only one dimension is send back to elastic


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues
Closes #27226 

Also relates to this
https://support.elastic.co/cases/5008X000023agMSQAY
