### PR TITLE
[Heartbeat] Change size of data on ICMP packet

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Fix broken macOS ICMP python e2e test. {pull}29900[29900]
 - Only add monitor.status to browser events when summary. {pull}29460[29460]
 - Also add summary to journeys for which the synthetics runner crashes. {pull}29606[29606]
+- Update size of ICMP packets to adhere to standard min size. {pull}29948[29948]
 
 *Metricbeat*
 

--- a/heartbeat/monitors/active/icmp/stdloop.go
+++ b/heartbeat/monitors/active/icmp/stdloop.go
@@ -346,7 +346,7 @@ func (l *stdICMPLoop) sendEchoRequest(addr *net.IPAddr) (*requestContext, error)
 	l.requests[id] = ctx
 	l.mutex.Unlock()
 
-	payloadBuf := make([]byte, 0, 8)
+	payloadBuf := make([]byte, 48, 48)
 	payload := bytes.NewBuffer(payloadBuf)
 	ts := time.Now()
 	binary.Write(payload, binary.BigEndian, ts.UnixNano())


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Just change size of ICMP packet for Heartbeat. The recommanded size for a valid ICMP packet is 64 byte (with headers)

## Why is it important?

Some hosts don't respond with a small ICMP packet

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Compile & configure an ICMP monitor an check packet size with tcpdump
