### PR TITLE
ci: docker login for pulling

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -307,8 +307,6 @@ def tagAndPush(Map args = [:]) {
     tagName = "pr-${env.CHANGE_ID}"
   }
 
-  dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
-
   // supported tags
   def tags = [tagName, "${env.GIT_BASE_COMMIT}"]
   if (!isPR() && aliasVersion != "") {
@@ -386,6 +384,7 @@ def release(){
     withEnv([
       "DEV=true"
     ]) {
+      dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       dir("${env.BEATS_FOLDER}") {
         sh(label: "Release ${env.BEATS_FOLDER} ${env.PLATFORMS}", script: 'mage package')
       }


### PR DESCRIPTION
## What does this PR do?

Run `docker login` earlier than when pushing

## Why is it important?

To allow pulling from a different docker registry
## Related issues

- Relates https://github.com/elastic/golang-crossbuild/pull/149/files#
