### PR TITLE
[Elastic Agent] Keep debug symbols, no inline and no optimisations for dev builds

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -50,9 +50,6 @@ func DefaultBuildArgs() BuildArgs {
 	args := BuildArgs{
 		Name: BeatName,
 		CGO:  build.Default.CgoEnabled,
-		LDFlags: []string{
-			"-s", // Strip all debug symbols from binary (does not affect Go stack traces).
-		},
 		Vars: map[string]string{
 			elasticBeatsModulePath + "/libbeat/version.buildTime": "{{ date }}",
 			elasticBeatsModulePath + "/libbeat/version.commit":    "{{ commit }}",
@@ -63,18 +60,26 @@ func DefaultBuildArgs() BuildArgs {
 		args.Vars[elasticBeatsModulePath+"/libbeat/version.qualifier"] = "{{ .Qualifier }}"
 	}
 
-	if positionIndependendCodeSupported() {
+	if positionIndependentCodeSupported() {
 		args.ExtraFlags = append(args.ExtraFlags, "-buildmode", "pie")
+	}
+
+	if DevBuild {
+		// Disable optimizations (-N) and inlining (-l) for debugging.
+		args.ExtraFlags = append(args.ExtraFlags, `-gcflags`, `"all=-N -l"`)
+	} else {
+		// Strip all debug symbols from binary (does not affect Go stack traces).
+		args.LDFlags = append(args.LDFlags, "-s")
 	}
 
 	return args
 }
 
-// positionIndependendCodeSupported checks if the target platform support position independen code (or ASLR).
+// positionIndependentCodeSupported checks if the target platform support position independent code (or ASLR).
 //
 // The list of supported platforms is compiled based on the Go release notes: https://golang.org/doc/devel/release.html
 // The list has been updated according to the Go version: 1.16
-func positionIndependendCodeSupported() bool {
+func positionIndependentCodeSupported() bool {
 	return oneOf(Platform.GOOS, "darwin") ||
 		(Platform.GOOS == "linux" && oneOf(Platform.GOARCH, "riscv64", "amd64", "arm", "arm64", "ppc64le", "386")) ||
 		(Platform.GOOS == "aix" && Platform.GOARCH == "ppc64") ||


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When the agent is built for development it keeps the debug symbols, do not inline nor optimize so it's possible to debug using delve.

It also fixes a typo.

## Why is it important?

Improves developer experience by making it ready for debug when building for development.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ x] My code follows the style guidelines of this project
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Build with `DEV=true`, then run it with delve and connect to remote debug

Using GoLand, you can run the elastic-agent as below and use the _Go Remote_ to Run/Debug the agent. 
```
dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec ./elastic-agent
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

