### PR TITLE
Add the Elastic product origin header when talking to Elasticsearch or Kibana.

### DIFF
--- a/libbeat/common/productorigin/productorigin.go
+++ b/libbeat/common/productorigin/productorigin.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package productorigin defines the Elastic product origin header.
+package productorigin
+
+const (
+	// Identifies a request as originating from an Elastic product. Has the side effect of
+	// suppressing Elasticsearch API deprecation warnings in Kibana when set.
+	Header = "X-Elastic-Product-Origin"
+
+	// Applicable values from https://github.com/elastic/kibana/blob/main/x-pack/plugins/upgrade_assistant/common/constants.ts#L50
+	Observability = "observability"
+	Beats         = "beats"
+	Fleet         = "fleet"
+)

--- a/libbeat/common/productorigin/productorigin.go
+++ b/libbeat/common/productorigin/productorigin.go
@@ -26,5 +26,4 @@ const (
 	// Applicable values from https://github.com/elastic/kibana/blob/main/x-pack/plugins/upgrade_assistant/common/constants.ts#L50
 	Observability = "observability"
 	Beats         = "beats"
-	Fleet         = "fleet"
 )

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -30,6 +30,7 @@ import (
 	"go.elastic.co/apm/module/apmelasticsearch"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 	"github.com/elastic/beats/v7/libbeat/common/transport"
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/beats/v7/libbeat/common/transport/kerberos"
@@ -37,13 +38,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/useragent"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/testing"
-)
-
-const (
-	// Identifies the request as originating from an Elastic product. Has the side effect of
-	// suppressing Elasticsearch API deprecation warnings in Kibana when set.
-	ProductOriginHeader = "X-Elastic-Product-Origin"
-	BeatsProductOrigin  = "beats"
 )
 
 type esHTTPClient interface {
@@ -127,11 +121,11 @@ func NewConnection(s ConnectionSettings) (*Connection, error) {
 	userAgent := useragent.UserAgent(s.Beatname)
 
 	// Default the product origin header to beats if it wasn't already set.
-	if _, ok := s.Headers[ProductOriginHeader]; !ok {
+	if _, ok := s.Headers[productorigin.Header]; !ok {
 		if s.Headers == nil {
 			s.Headers = make(map[string]string)
 		}
-		s.Headers[ProductOriginHeader] = BeatsProductOrigin
+		s.Headers[productorigin.Header] = productorigin.Beats
 	}
 
 	httpClient, err := s.Transport.Client(

--- a/libbeat/esleg/eslegclient/connection_test.go
+++ b/libbeat/esleg/eslegclient/connection_test.go
@@ -24,8 +24,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 )
 
 func TestAPIKeyEncoding(t *testing.T) {

--- a/libbeat/esleg/eslegclient/connection_test.go
+++ b/libbeat/esleg/eslegclient/connection_test.go
@@ -71,18 +71,21 @@ func TestHeaders(t *testing.T) {
 		expected map[string][]string
 	}{
 		{input: map[string]string{
-			"Accept":       "application/vnd.elasticsearch+json;compatible-with=7",
-			"Content-Type": "application/vnd.elasticsearch+json;compatible-with=7",
-			"X-My-Header":  "true"},
+			"Accept":            "application/vnd.elasticsearch+json;compatible-with=7",
+			"Content-Type":      "application/vnd.elasticsearch+json;compatible-with=7",
+			ProductOriginHeader: "elastic-product",
+			"X-My-Header":       "true"},
 			expected: map[string][]string{
-				"Accept":       {"application/vnd.elasticsearch+json;compatible-with=7"},
-				"Content-Type": {"application/vnd.elasticsearch+json;compatible-with=7"},
-				"X-My-Header":  {"true"}}},
+				"Accept":            {"application/vnd.elasticsearch+json;compatible-with=7"},
+				"Content-Type":      {"application/vnd.elasticsearch+json;compatible-with=7"},
+				ProductOriginHeader: {"elastic-product"},
+				"X-My-Header":       {"true"}}},
 		{input: map[string]string{
 			"X-My-Header": "true"},
 			expected: map[string][]string{
-				"Accept":      {"application/json"},
-				"X-My-Header": {"true"}}},
+				"Accept":            {"application/json"},
+				ProductOriginHeader: {BeatsProductOrigin},
+				"X-My-Header":       {"true"}}},
 	} {
 		conn, err := NewConnection(ConnectionSettings{
 			Headers: td.input,

--- a/libbeat/esleg/eslegclient/connection_test.go
+++ b/libbeat/esleg/eslegclient/connection_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -71,21 +72,21 @@ func TestHeaders(t *testing.T) {
 		expected map[string][]string
 	}{
 		{input: map[string]string{
-			"Accept":            "application/vnd.elasticsearch+json;compatible-with=7",
-			"Content-Type":      "application/vnd.elasticsearch+json;compatible-with=7",
-			ProductOriginHeader: "elastic-product",
-			"X-My-Header":       "true"},
+			"Accept":             "application/vnd.elasticsearch+json;compatible-with=7",
+			"Content-Type":       "application/vnd.elasticsearch+json;compatible-with=7",
+			productorigin.Header: "elastic-product",
+			"X-My-Header":        "true"},
 			expected: map[string][]string{
-				"Accept":            {"application/vnd.elasticsearch+json;compatible-with=7"},
-				"Content-Type":      {"application/vnd.elasticsearch+json;compatible-with=7"},
-				ProductOriginHeader: {"elastic-product"},
-				"X-My-Header":       {"true"}}},
+				"Accept":             {"application/vnd.elasticsearch+json;compatible-with=7"},
+				"Content-Type":       {"application/vnd.elasticsearch+json;compatible-with=7"},
+				productorigin.Header: {"elastic-product"},
+				"X-My-Header":        {"true"}}},
 		{input: map[string]string{
 			"X-My-Header": "true"},
 			expected: map[string][]string{
-				"Accept":            {"application/json"},
-				ProductOriginHeader: {BeatsProductOrigin},
-				"X-My-Header":       {"true"}}},
+				"Accept":             {"application/json"},
+				productorigin.Header: {productorigin.Beats},
+				"X-My-Header":        {"true"}}},
 	} {
 		conn, err := NewConnection(ConnectionSettings{
 			Headers: td.input,

--- a/metricbeat/module/elasticsearch/metricset.go
+++ b/metricbeat/module/elasticsearch/metricset.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -89,6 +90,8 @@ func NewMetricSet(base mb.BaseMetricSet, servicePath string) (*MetricSet, error)
 	if err != nil {
 		return nil, err
 	}
+
+	http.SetHeaderDefault(productorigin.Header, productorigin.Beats)
 
 	config := struct {
 		Scope        Scope `config:"scope"`

--- a/metricbeat/module/kibana/settings/settings.go
+++ b/metricbeat/module/kibana/settings/settings.go
@@ -20,6 +20,7 @@ package settings
 import (
 	"fmt"
 
+	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -76,6 +77,8 @@ func (m *MetricSet) init() (err error) {
 	if err != nil {
 		return err
 	}
+
+	httpHelper.SetHeaderDefault(productorigin.Header, productorigin.Beats)
 
 	kibanaVersion, err := kibana.GetVersion(httpHelper, kibana.SettingsPath)
 	if err != nil {

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -83,6 +84,8 @@ func (m *MetricSet) init() error {
 	if err != nil {
 		return err
 	}
+
+	statsHTTP.SetHeaderDefault(productorigin.Header, productorigin.Beats)
 
 	kibanaVersion, err := kibana.GetVersion(statsHTTP, kibana.StatsPath)
 	if err != nil {

--- a/metricbeat/module/kibana/status/status.go
+++ b/metricbeat/module/kibana/status/status.go
@@ -18,6 +18,7 @@
 package status
 
 import (
+	"github.com/elastic/beats/v7/libbeat/common/productorigin"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -58,6 +59,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	http.SetHeaderDefault(productorigin.Header, productorigin.Beats)
 
 	return &MetricSet{
 		ms,


### PR DESCRIPTION
## What does this PR do?

Adds the x-elastic-product-origin header when communicating with Elasticsearch or Kibana.

## Why is it important?

If Elasticsearch deprecates an API we use in the future, this header will prevent Kibana from presenting the warning to the user. It will also tag the Elasticsearch deprecation log message with the header value to more easily attribute deprecated API usage to products

Note that there is no known usage of deprecated Elasticsearch APIs in beats currently.

## Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [ x ] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

Run any beat and inspect the headers attached to requests. For example, `filebeat test output` will make a request that should have the new headers attached.

I ran filebeat (as an arbitrary choice) locally and inspected the HTTP requests to Elasticsearch with Wireshark to confirm the expected header was attached. I haven't exhaustively tested all beats, or all HTTP interactions.