### PR TITLE
Add note to documentation about dashboard loading in Beats

### DIFF
--- a/libbeat/docs/dashboardsconfig.asciidoc
+++ b/libbeat/docs/dashboardsconfig.asciidoc
@@ -46,6 +46,9 @@ You can specify the following options in the `setup.dashboards` section of the
 If this option is set to true, {beatname_uc} loads the sample Kibana dashboards
 from the local `kibana` directory in the home path of the {beatname_uc} installation.
 
+NOTE: {beatname_uc} loads dashboards on startup if either `enabled` is set to `true`
+or the `setup.dashboards` section is included in the configuration.
+
 NOTE: When dashboard loading is enabled, {beatname_uc} overwrites any existing
 dashboards that match the names of the dashboards you are loading. This happens
 every time {beatname_uc} starts. 


### PR DESCRIPTION
## What does this PR do?

This PR adds clarifications about the behaviour of dashboard loading in Beats.

## Why is it important?

Previously, it was not clearly communicated in the documentation that dashboard loading is automatically enabled if any of the settings under `setup.dashboards` is configured. To avoid further confusion, I am adding a similar note to SSL settings: https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#enabled

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes #29970