### PR TITLE
[auditbeat] Flaky: use CI=true to skip test

### DIFF
--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -988,7 +988,7 @@ func getConfig(path ...string) map[string]interface{} {
 }
 
 func skipOnCIForDarwinAMD64(t testing.TB) {
-	if os.Getenv("BUILD_ID") != "" && runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
+	if os.Getenv("CI") == "true" && runtime.GOOS == "darwin" && runtime.GOARCH == "amd64" {
 		t.Skip("Skip test on CI for darwin/amd64")
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/elastic/beats/issues/29992

Use `CI=true` to skip the test. It looks like `BUILD_ID` is not being set in [this](https://github.com/elastic/beats/runs/4885891319?check_suite_focus=true) execution.