### PR TITLE
rsa2elk: fix unnecessarily noisy error message

### DIFF
--- a/x-pack/filebeat/module/barracuda/spamfirewall/config/liblogparser.js
+++ b/x-pack/filebeat/module/barracuda/spamfirewall/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/barracuda/waf/config/liblogparser.js
+++ b/x-pack/filebeat/module/barracuda/waf/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/bluecoat/director/config/liblogparser.js
+++ b/x-pack/filebeat/module/bluecoat/director/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/cisco/meraki/config/liblogparser.js
+++ b/x-pack/filebeat/module/cisco/meraki/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/cisco/nexus/config/liblogparser.js
+++ b/x-pack/filebeat/module/cisco/nexus/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/cylance/protect/config/liblogparser.js
+++ b/x-pack/filebeat/module/cylance/protect/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/f5/bigipafm/config/liblogparser.js
+++ b/x-pack/filebeat/module/f5/bigipafm/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/f5/bigipapm/config/liblogparser.js
+++ b/x-pack/filebeat/module/f5/bigipapm/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/fortinet/clientendpoint/config/liblogparser.js
+++ b/x-pack/filebeat/module/fortinet/clientendpoint/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/fortinet/fortimail/config/liblogparser.js
+++ b/x-pack/filebeat/module/fortinet/fortimail/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/fortinet/fortimanager/config/liblogparser.js
+++ b/x-pack/filebeat/module/fortinet/fortimanager/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/imperva/securesphere/config/liblogparser.js
+++ b/x-pack/filebeat/module/imperva/securesphere/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/infoblox/nios/config/liblogparser.js
+++ b/x-pack/filebeat/module/infoblox/nios/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/juniper/junos/config/liblogparser.js
+++ b/x-pack/filebeat/module/juniper/junos/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/juniper/netscreen/config/liblogparser.js
+++ b/x-pack/filebeat/module/juniper/netscreen/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/microsoft/dhcp/config/liblogparser.js
+++ b/x-pack/filebeat/module/microsoft/dhcp/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/netscout/sightline/config/liblogparser.js
+++ b/x-pack/filebeat/module/netscout/sightline/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/proofpoint/emailsecurity/config/liblogparser.js
+++ b/x-pack/filebeat/module/proofpoint/emailsecurity/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/radware/defensepro/config/liblogparser.js
+++ b/x-pack/filebeat/module/radware/defensepro/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/snort/log/config/liblogparser.js
+++ b/x-pack/filebeat/module/snort/log/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/sonicwall/firewall/config/liblogparser.js
+++ b/x-pack/filebeat/module/sonicwall/firewall/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/sophos/utm/config/liblogparser.js
+++ b/x-pack/filebeat/module/sophos/utm/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/squid/log/config/liblogparser.js
+++ b/x-pack/filebeat/module/squid/log/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/tomcat/log/config/liblogparser.js
+++ b/x-pack/filebeat/module/tomcat/log/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }

--- a/x-pack/filebeat/module/zscaler/zia/config/liblogparser.js
+++ b/x-pack/filebeat/module/zscaler/zia/config/liblogparser.js
@@ -795,7 +795,7 @@ function url_wrapper(dst, src, fn) {
         if (value != null && (result = fn(value))!== undefined) {
             evt.Put(FIELDS_PREFIX + dst, result);
         } else {
-            console.error(fn.name + " failed for '" + value + "'");
+            console.debug(fn.name + " failed for '" + value + "'");
         }
     };
 }


### PR DESCRIPTION
## What does this PR do?

Rsa parsers support different functions for extracting components from an URL in order to populate internal fields. Until now, if this operation resulted in an empty field because the given component didn't exist, or the URL was invalid, an error message would be printed to the log.

Due to some parsers' sloppy use of these functions, it's better to turn the error message into a debug log, to avoid generating too many unnecessary logs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes #24260

