### PR TITLE
[Auditbeat] Include the error message with auditd module events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -102,6 +102,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - system/socket: Fix process name and arg truncation for long names, paths and args lists. {issue}24667[24667] {pull}29410[29410]
 - system/socket: Fix startup errors on newer 5.x kernels due to missing _do_fork function. {issue}29607[29607] {pull}29744[29744]
 - libbeat/processors/add_process_metadata: Fix memory leak in process cache. {issue}24890[24890] {pull}29717[29717]
+- auditd: Add error.message to events when processing fails. {pull}30009[30009]
 
 *Filebeat*
 

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -512,7 +512,7 @@ func buildMetricbeatEvent(msgs []*auparse.AuditMessage, config Config) mb.Event 
 	auditEvent, err := aucoalesce.CoalesceMessages(msgs)
 	if err != nil {
 		// Add messages on error so that it's possible to debug the problem.
-		out := mb.Event{RootFields: common.MapStr{}}
+		out := mb.Event{RootFields: common.MapStr{}, Error: err}
 		addEventOriginal(msgs, out.RootFields)
 		return out
 	}


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Auditbeat adds `event.original` when there is a parse failure, but it wasn't
including the error message. Having the error helps you understand what
went wrong.

Example output:

`{"@timestamp":"2022-01-26T00:15:20.241Z","@metadata":{"beat":"auditbeat","type":"_doc","version":"8.1.0"},"error":{"message":"missing syscall message in compound event"},"event":{"original":["type=UNKNOWN[1333] msg=audit(1643156118.179:545): op=freq old=36792303616000 new=-176298262528000","type=UNKNOWN[1333] msg=audit(1643156118.179:545): op=tick old=9977 new=10000"],"module":"auditd"},"service":{"type":"auditd"},"host":{"name":"ubuntu-impish"},"agent":{"version":"8.1.0","ephemeral_id":"a6dd5138-f1b2-437a-8b83-324ec09bbaa3","id":"c127e0a1-be4b-4f9f-a5e4-97496699f75e","name":"ubuntu-impish","type":"auditbeat"},"ecs":{"version":"8.0.0"}}`

## Why is it important?

So you don't lose error details and can correct processing issues.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
