### PR TITLE
Copy `@timestamp` to make sure we always have a timestamp in the event

### DIFF
--- a/filebeat/module/apache/access/ingest/pipeline.yml
+++ b/filebeat/module/apache/access/ingest/pipeline.yml
@@ -54,9 +54,9 @@ processors:
     ignore_missing: true
     patterns:
     - ^(%{IP:source.ip}|%{HOSTNAME:source.domain})$
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     field: apache.access.time
     target_field: '@timestamp'

--- a/filebeat/module/elasticsearch/server/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/server/ingest/pipeline.yml
@@ -1,4 +1,4 @@
-description: Pipeline for parsing elasticsearch server logs
+dpacheescription: Pipeline for parsing elasticsearch server logs
 processors:
 - set:
     field: event.ingested

--- a/filebeat/module/elasticsearch/server/ingest/pipeline.yml
+++ b/filebeat/module/elasticsearch/server/ingest/pipeline.yml
@@ -1,4 +1,4 @@
-dpacheescription: Pipeline for parsing elasticsearch server logs
+description: Pipeline for parsing elasticsearch server logs
 processors:
 - set:
     field: event.ingested

--- a/filebeat/module/iis/access/ingest/pipeline.yml
+++ b/filebeat/module/iis/access/ingest/pipeline.yml
@@ -63,9 +63,9 @@ processors:
     field:
       - _tmp
     ignore_missing: true
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     field: iis.access.time
     target_field: '@timestamp'

--- a/filebeat/module/iis/error/ingest/pipeline.yml
+++ b/filebeat/module/iis/error/ingest/pipeline.yml
@@ -31,9 +31,9 @@ processors:
     field:
       - _tmp
     ignore_missing: true
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     field: iis.error.time
     target_field: '@timestamp'

--- a/filebeat/module/kafka/log/ingest/pipeline.yml
+++ b/filebeat/module/kafka/log/ingest/pipeline.yml
@@ -31,9 +31,9 @@ processors:
 - remove:
     field: kafka.log.trace.full
     ignore_missing: true
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     if: ctx.event.timezone == null
     field: kafka.log.timestamp

--- a/filebeat/module/kibana/audit/ingest/pipeline.yml
+++ b/filebeat/module/kibana/audit/ingest/pipeline.yml
@@ -3,9 +3,9 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - pipeline:
     name: '{< IngestPipeline "pipeline-json" >}'
 - set:

--- a/filebeat/module/kibana/log/ingest/pipeline.yml
+++ b/filebeat/module/kibana/log/ingest/pipeline.yml
@@ -7,9 +7,9 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - rename:
     field: json
     target_field: kibana.log.meta

--- a/filebeat/module/logstash/log/ingest/pipeline.yml
+++ b/filebeat/module/logstash/log/ingest/pipeline.yml
@@ -3,9 +3,9 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - grok:
     field: message
     patterns:

--- a/filebeat/module/logstash/slowlog/ingest/pipeline.yml
+++ b/filebeat/module/logstash/slowlog/ingest/pipeline.yml
@@ -3,9 +3,9 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - grok:
     field: message
     patterns:

--- a/filebeat/module/mongodb/log/ingest/pipeline.yml
+++ b/filebeat/module/mongodb/log/ingest/pipeline.yml
@@ -3,9 +3,9 @@ processors:
 - set:
     field: event.ingested
     value: '{{_ingest.timestamp}}'
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - grok:
     field: message
     patterns:

--- a/filebeat/module/mysql/error/ingest/pipeline.yml
+++ b/filebeat/module/mysql/error/ingest/pipeline.yml
@@ -26,9 +26,9 @@ processors:
       GREEDYMULTILINE: |-
         (.|
         )+
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     if: ctx._tmp?.local_timestamp != null && ctx.event?.timezone == null
     field: _tmp.local_timestamp

--- a/filebeat/module/nats/log/ingest/pipeline.yml
+++ b/filebeat/module/nats/log/ingest/pipeline.yml
@@ -154,9 +154,9 @@ processors:
       out: ->>
       outbound: outbound
     if: ctx.network?.direction != null
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     field: nats.log.timestamp
     target_field: '@timestamp'

--- a/filebeat/module/nginx/access/ingest/pipeline.yml
+++ b/filebeat/module/nginx/access/ingest/pipeline.yml
@@ -106,9 +106,9 @@ processors:
     patterns:
     - ^%{IP:source.ip}$
     ignore_failure: true
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     field: nginx.access.time
     target_field: '@timestamp'

--- a/filebeat/module/nginx/error/ingest/pipeline.yml
+++ b/filebeat/module/nginx/error/ingest/pipeline.yml
@@ -16,9 +16,9 @@ processors:
         (.|
         |	)*
     ignore_missing: true
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     if: ctx.event.timezone == null
     field: nginx.error.time

--- a/filebeat/module/osquery/result/ingest/pipeline.json
+++ b/filebeat/module/osquery/result/ingest/pipeline.json
@@ -7,9 +7,9 @@
         "value": "{{_ingest.timestamp}}"
       }
     }, {
-      "rename": {
-        "field": "@timestamp",
-        "target_field": "event.created"
+      "set": {
+        "copy_from": "@timestamp",
+        "field": "event.created"
       }
     }, {
       "date": {

--- a/filebeat/module/redis/log/ingest/pipeline.yml
+++ b/filebeat/module/redis/log/ingest/pipeline.yml
@@ -57,9 +57,9 @@ processors:
       child: child
       sentinel_abbrev: X
       sentinel: sentinel
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     field: redis.log.timestamp
     target_field: '@timestamp'

--- a/filebeat/module/santa/log/test/santa.log-expected.json
+++ b/filebeat/module/santa/log/test/santa.log-expected.json
@@ -69,8 +69,8 @@
         "log.offset": 360,
         "process.args": [
             "/usr/libexec/xpcproxy",
-            "com.apple.systemstats.daily",
-            "xpcproxy"
+            "xpcproxy",
+            "com.apple.systemstats.daily"
         ],
         "process.executable": "/usr/libexec/xpcproxy",
         "process.hash.sha256": "c4bc09fd2f248534552f517acf3edb9a635aba2b02e46f49df683ea9b778e5b4",
@@ -163,9 +163,9 @@
         "log.level": "I",
         "log.offset": 1095,
         "process.args": [
-            "--daily",
             "/usr/sbin/systemstats",
-            "/usr/sbin/systemstats"
+            "/usr/sbin/systemstats",
+            "--daily"
         ],
         "process.executable": "/usr/sbin/systemstats",
         "process.hash.sha256": "d6be9bfbd777ac5dcd30488014acc787a2df5ce840f1fe4d5742d323ee00392f",
@@ -259,8 +259,8 @@
         "log.offset": 1825,
         "process.args": [
             "/usr/libexec/xpcproxy",
-            "com.adobe.AAM.Scheduler-1.0",
-            "xpcproxy"
+            "xpcproxy",
+            "com.adobe.AAM.Scheduler-1.0"
         ],
         "process.executable": "/usr/libexec/xpcproxy",
         "process.hash.sha256": "c4bc09fd2f248534552f517acf3edb9a635aba2b02e46f49df683ea9b778e5b4",
@@ -305,10 +305,10 @@
         "log.level": "I",
         "log.offset": 2202,
         "process.args": [
-            "--flagfile=/private/var/osquery/osquery.flags",
-            "--logger_min_stderr=1",
             "/usr/local/Cellar/osquery/3.3.0_1/bin/osqueryd",
-            "/usr/local/bin/osqueryd"
+            "/usr/local/bin/osqueryd",
+            "--flagfile=/private/var/osquery/osquery.flags",
+            "--logger_min_stderr=1"
         ],
         "process.executable": "/usr/local/Cellar/osquery/3.3.0_1/bin/osqueryd",
         "process.hash.sha256": "08bd61582657cd6d78c9e071d34d79a32bb59e7210077a44919d2c5477e988a1",
@@ -397,19 +397,19 @@
         "log.level": "I",
         "log.offset": 2899,
         "process.args": [
+            "/Applications/Google Chrome.app/Contents/Versions/70.0.3538.110/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper",
+            "/Applications/Google",
+            "Chrome.app/Contents/Versions/70.0.3538.110/Google",
+            "Chrome",
+            "Helper.app/Contents/MacOS/Google",
+            "Chrome",
+            "Helper",
+            "--type=utility",
             "--field-trial-handle=120122713615061869,9401617251746517350,131072",
             "--lang=en-US",
-            "--seatbelt-client=262",
-            "--service-request-channel-token=10458143409865682077",
             "--service-sandbox-type=utility",
-            "--type=utility",
-            "/Applications/Google",
-            "/Applications/Google Chrome.app/Contents/Versions/70.0.3538.110/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper",
-            "Chrome",
-            "Chrome",
-            "Chrome.app/Contents/Versions/70.0.3538.110/Google",
-            "Helper",
-            "Helper.app/Contents/MacOS/Google"
+            "--service-request-channel-token=10458143409865682077",
+            "--seatbelt-client=262"
         ],
         "process.executable": "/Applications/Google Chrome.app/Contents/Versions/70.0.3538.110/Google Chrome Helper.app/Contents/MacOS/Google Chrome Helper",
         "process.hash.sha256": "a8defc1b24c45f6dabeb8298af5f8e1daf39e1504e16f878345f15ac94ae96d7",

--- a/filebeat/module/traefik/access/ingest/pipeline.yml
+++ b/filebeat/module/traefik/access/ingest/pipeline.yml
@@ -23,9 +23,9 @@ processors:
 - uri_parts:
     field: temp.url_orig
     ignore_failure: true
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     field: traefik.access.time
     target_field: '@timestamp'

--- a/x-pack/filebeat/module/zookeeper/audit/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zookeeper/audit/ingest/pipeline.yml
@@ -13,9 +13,9 @@ processors:
       - '%{TIMESTAMP_ISO8601:zookeeper.audit.timestamp}%{SPACE}%{LOGLEVEL:log.level}%{SPACE}%{CALLER_CLASS:log.logger}:%{SPACE}%{GREEDYDATA:message}'
     pattern_definitions:
       CALLER_CLASS: (%{JAVACLASS}|%{NOTSPACE})
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
     if: ctx?.zookeeper?.audit?.timestamp != null
 - date:
     if: ctx?.zookeeper?.audit?.timestamp != null && ctx.event.timezone == null

--- a/x-pack/filebeat/module/zookeeper/log/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/zookeeper/log/ingest/pipeline.yml
@@ -22,9 +22,9 @@ processors:
 - remove:
     field: zookeeper.log.process
     ignore_missing: true
-- rename:
-    field: '@timestamp'
-    target_field: event.created
+- set:
+    copy_from: '@timestamp'
+    field: event.created
 - date:
     if: ctx.event.timezone == null
     field: zookeeper.log.timestamp


### PR DESCRIPTION
## What does this PR do?

In this PR I changed renaming `@timestamp` field to copying it to a new field in all of our existing modules.

## Why is it important?

Since 8.0, Beats is sending events to data streams. Data streams require that all events have `@timestamp` fields. Beats always add `@timestamp` field to events. However, we sometimes have problems in Ingest pipelines. Renaming or later processors might fail during ingest, leaving the event without `@timestamp` field. If that field is missing the event cannot be indexed and Beats drop them. To avoid such cases, we have to make sure we always have the field.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
