### PR TITLE
[DOCS] Add redirect for GSuite module

### DIFF
--- a/filebeat/docs/redirects.asciidoc
+++ b/filebeat/docs/redirects.asciidoc
@@ -8,3 +8,7 @@ The following pages have moved or been deleted.
 
 See <<filebeat-module-gcp>>.
 
+[role="exclude",id="filebeat-module-gsuite"]
+== GSuite module
+
+The GSuite module has been replaced by the <<filebeat-module-google_workspace>>.


### PR DESCRIPTION
## What does this PR do?

Adds a redirect for the [GSuite module](https://www.elastic.co/guide/en/beats/filebeat/7.17/filebeat-module-gsuite.html) page, which has been removed in 8.0+.

## Preview

https://beats_30034.docs-preview.app.elstc.co/guide/en/beats/filebeat/master/filebeat-module-gsuite.html

## Why is it important?

We saw this missing page create several broken links in https://github.com/elastic/docs/pull/2312. I've opened https://github.com/elastic/security-docs/pull/1441 to update those links. This adds a redirect for anyone who otherwise lands on the page.

## Checklist

- [x] ~~My code follows the style guidelines of this project~~
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~