### PR TITLE
Remove msitools install for windows build, using the latest docker image with msitools preinstalled

### DIFF
--- a/x-pack/osquerybeat/magefile.go
+++ b/x-pack/osquerybeat/magefile.go
@@ -101,17 +101,6 @@ func extractFromMSI() error {
 		return err
 	}
 
-	// Install msitools
-	err := execCommand("apt", "update")
-	if err != nil {
-		return err
-	}
-
-	err = execCommand("apt", "install", "-y", "msitools")
-	if err != nil {
-		return err
-	}
-
 	osArchs := osquerybeat.OSArchs(devtools.Platforms)
 
 	for _, osarch := range osArchs {
@@ -161,18 +150,12 @@ func GolangCrossBuild() error {
 	// Currently we can't reproduce this is issue, but here we can eliminate the need for calling msiexec
 	// if extract the osqueryd.exe binary during the build.
 	//
-	// The builder docker images are Debian so we need to install msitools for
-	// linux in order to extract the osqueryd.exe from MSI during build process.	// Install MSI tools in order to extract file from MSI
-	// Ideally we would want these to be a part of the build docker image,
-	// but doing this here for now due to limited time before 7.16.2
-	//
 	// The cross build is currently called for two binaries osquerybeat and osqquery-extension
-	// Only install msitools and extract osqueryd.exe during osquerybeat build on windows
+	// Only extract osqueryd.exe during osquerybeat build on windows
 	args := devtools.DefaultGolangCrossBuildArgs()
 
-	// Install msitools only
 	if !strings.HasPrefix(args.Name, "osquery-extension-") {
-		// Install msitools in the container and extract osqueryd.exe from MSI
+		// Extract osqueryd.exe from MSI
 		if err := extractFromMSI(); err != nil {
 			return err
 		}


### PR DESCRIPTION
## What does this PR do?

Removes the workaround that was put in place to install msitools on the build docker image during windows build.
Using the newer docker image for the builds with msitools preinstalled.

## Why is it important?

Closes https://github.com/elastic/beats/issues/29826

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Related issues

- Closes https://github.com/elastic/beats/issues/29826

