### PR TITLE
Update doc with use of $ as escape char

### DIFF
--- a/libbeat/docs/shared-env-vars.asciidoc
+++ b/libbeat/docs/shared-env-vars.asciidoc
@@ -45,7 +45,7 @@ To specify custom error text, use:
 Where `error_text` is custom text that will be prepended to the error
 message if the environment variable cannot be expanded.
 
-If you need to use a special character in your configuration file, you can use `$` to escape the expansion. For example, you can escape `${` or `}` with `$${` or `$}`.
+If you need to use a special character in your configuration file, use `$` to escape the expansion. For example, you can escape `${` or `}` with `$${` or `$}`.
 
 After changing the value of an environment variable, you need to restart
 {beatname_uc} to pick up the new value.

--- a/libbeat/docs/shared-env-vars.asciidoc
+++ b/libbeat/docs/shared-env-vars.asciidoc
@@ -45,8 +45,7 @@ To specify custom error text, use:
 Where `error_text` is custom text that will be prepended to the error
 message if the environment variable cannot be expanded.
 
-If you need to use a literal `${` in your configuration file then you can write
-`$${` to escape the expansion.
+If you need to use a special character in your configuration file then you can use `$` to escape the expansion, e.g. `${` or `}` can be escaped with `$${` or `$}`.
 
 After changing the value of an environment variable, you need to restart
 {beatname_uc} to pick up the new value.

--- a/libbeat/docs/shared-env-vars.asciidoc
+++ b/libbeat/docs/shared-env-vars.asciidoc
@@ -45,7 +45,7 @@ To specify custom error text, use:
 Where `error_text` is custom text that will be prepended to the error
 message if the environment variable cannot be expanded.
 
-If you need to use a special character in your configuration file then you can use `$` to escape the expansion, e.g. `${` or `}` can be escaped with `$${` or `$}`.
+If you need to use a special character in your configuration file, you can use `$` to escape the expansion. For example, you can escape `${` or `}` with `$${` or `$}`.
 
 After changing the value of an environment variable, you need to restart
 {beatname_uc} to pick up the new value.


### PR DESCRIPTION
## What does this PR do?

Update doc to reflect that $ can used as a general escape char, not just to escape `$`.

## Why is it important?

Existing doc suggests only ${ can e escaped with a $ - this reduces confusion.

## Checklist

- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
