### PR TITLE
Fix libbeat bulk for monitoring

### DIFF
--- a/libbeat/idxmgmt/std.go
+++ b/libbeat/idxmgmt/std.go
@@ -337,7 +337,7 @@ func (s *ilmIndexSelector) Select(evt *beat.Event) (string, error) {
 	return idx, err
 }
 
-func (s ilmIndexSelector) IsAlias() bool { return true }
+func (s ilmIndexSelector) IsAlias() bool { return s.st.withILM.Load() }
 
 func (s indexSelector) Select(evt *beat.Event) (string, error) {
 	if idx := getEventCustomIndex(evt, s.beatInfo); idx != "" {

--- a/metricbeat/mb/event.go
+++ b/metricbeat/mb/event.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/beat/events"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
@@ -93,7 +94,7 @@ func (e *Event) BeatEvent(module, metricSet string, modifiers ...EventModifier) 
 
 	// Set index prefix to overwrite default
 	if e.Index != "" {
-		b.Meta = common.MapStr{"index": e.Index}
+		b.Meta = common.MapStr{events.FieldMetaIndex: e.Index}
 	}
 
 	if e.ID != "" {


### PR DESCRIPTION
## What does this PR do?

Previously, if ILM was enabled in Metricbeat, `require_alias` was set for all Bulk API requests. However, when `xpack.enabled` is set to `true` in `beat`, `logstash`, `kibana` or `elasticsearch` modules, they overwrite the target indices of the events.  So Metricbeat can send the events to the monitoring indices. The monitoring indices are regular indices, not aliases. Hence, we got an error for Bulk API requests as they were not aliases.

## Why is it important?

Without this fix, Metricbeat cannot send monitoring events to Elasticsearch.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Enable Beat module in Metricbeat and set the events to the monitoring index:
```yml
 metricbeat.modules:
 - module: beat
   metricsets:
     - stats
     - state
   period: 10s
   hosts: ["http://localhost:5066"]
   xpack.enabled: true

 output.elasticsearch:
   hosts: ["localhost:9200"]
```

Start Filebeat with HTTP endpoint enabled:
```yml
http.enabled: true
```

Start Metricbeat and check if the events can be indexed.

## Related issues

Closes #29920