### PR TITLE
libbeat/reader: Fix messge conversion to beat.Event

### DIFF
--- a/libbeat/reader/message.go
+++ b/libbeat/reader/message.go
@@ -93,5 +93,6 @@ func (m *Message) ToEvent() beat.Event {
 		Timestamp: m.Ts,
 		Meta:      m.Meta,
 		Fields:    m.Fields,
+		Private:   m.Private,
 	}
 }

--- a/libbeat/reader/message_test.go
+++ b/libbeat/reader/message_test.go
@@ -19,6 +19,7 @@ package reader
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -54,6 +55,20 @@ func TestToEvent(t *testing.T) {
 		"content, meta, message field": {
 			Message{Content: []byte("my message"), Fields: common.MapStr{"my_field": "my_value"}, Meta: common.MapStr{"meta": "id"}},
 			beat.Event{Fields: common.MapStr{"message": "my message", "my_field": "my_value"}, Meta: common.MapStr{"meta": "id"}},
+		},
+		"content, meta, message and private fields": {
+			Message{
+				Ts:      time.Date(2022, 1, 9, 10, 42, 0, 0, time.UTC),
+				Content: []byte("my message"),
+				Meta:    common.MapStr{"foo": "bar"},
+				Private: 42,
+			},
+			beat.Event{
+				Timestamp: time.Date(2022, 1, 9, 10, 42, 0, 0, time.UTC),
+				Fields:    common.MapStr{"message": "my message"},
+				Meta:      common.MapStr{"foo": "bar"},
+				Private:   42,
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

`Message.ToEvent` was not copying the `Message.Privage` field when
converting a Message to `beat.Event`. This commit fixes it.

Fixes: #30031
## Why is it important?

It fixes the journald input
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Use journald input and console output, the events outputted should look like the one described on #30031

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes: #30031

~~## Use cases~~

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

~~## Screenshots~~

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

~~## Logs~~

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
