### PR TITLE
probot[stale]: ignore issues with the tag flaky-test

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,7 +11,8 @@ daysUntilClose: 30
 onlyLabels: []
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+exemptLabels:
+  - flaky-test
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
## What does this PR do?

Skip issues/prs with the `flaky-test` label from the stale automation

## Why is it important?

Issues with flaky test might be idling for some time but they should not be automatically closed.

## Checklist

https://github.com/probot/stale