### PR TITLE
Remove SSL3 support from libbeat and its documentation.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Change Docker base image from CentOS 7 to Ubuntu 20.04 {pull}29681[29681]
 - Enrich kubernetes metadata with node annotations. {pull}29605[29605]
 - Allign kubernetes configuration settings. {pull}29908[29908]
+- Remove legacy support for SSLv3. {pull}30071[30071]
 
 *Auditbeat*
 

--- a/libbeat/common/transport/tlscommon/versions_default.go
+++ b/libbeat/common/transport/tlscommon/versions_default.go
@@ -26,14 +26,13 @@ import (
 
 // Define all the possible TLS version.
 const (
-	TLSVersionSSL30 TLSVersion = tls.VersionSSL30
-	TLSVersion10    TLSVersion = tls.VersionTLS10
-	TLSVersion11    TLSVersion = tls.VersionTLS11
-	TLSVersion12    TLSVersion = tls.VersionTLS12
-	TLSVersion13    TLSVersion = tls.VersionTLS13
+	TLSVersion10 TLSVersion = tls.VersionTLS10
+	TLSVersion11 TLSVersion = tls.VersionTLS11
+	TLSVersion12 TLSVersion = tls.VersionTLS12
+	TLSVersion13 TLSVersion = tls.VersionTLS13
 
 	// TLSVersionMin is the min TLS version supported.
-	TLSVersionMin = TLSVersionSSL30
+	TLSVersionMin = TLSVersion10
 
 	// TLSVersionMax is the max TLS version supported.
 	TLSVersionMax = TLSVersion13
@@ -55,8 +54,6 @@ var TLSDefaultVersions = []TLSVersion{
 }
 
 var tlsProtocolVersions = map[string]TLSVersion{
-	"SSLv3":   TLSVersionSSL30,
-	"SSLv3.0": TLSVersionSSL30,
 	"TLSv1":   TLSVersion10,
 	"TLSv1.0": TLSVersion10,
 	"TLSv1.1": TLSVersion11,
@@ -77,9 +74,8 @@ func (pv TLSVersionDetails) String() string {
 }
 
 var tlsInverseLookup = map[TLSVersion]TLSVersionDetails{
-	TLSVersionSSL30: TLSVersionDetails{Version: "3.0", Protocol: "ssl", Combined: "SSLv3"},
-	TLSVersion10:    TLSVersionDetails{Version: "1.0", Protocol: "tls", Combined: "TLSv1.0"},
-	TLSVersion11:    TLSVersionDetails{Version: "1.1", Protocol: "tls", Combined: "TLSv1.1"},
-	TLSVersion12:    TLSVersionDetails{Version: "1.2", Protocol: "tls", Combined: "TLSv1.2"},
-	TLSVersion13:    TLSVersionDetails{Version: "1.3", Protocol: "tls", Combined: "TLSv1.3"},
+	TLSVersion10: TLSVersionDetails{Version: "1.0", Protocol: "tls", Combined: "TLSv1.0"},
+	TLSVersion11: TLSVersionDetails{Version: "1.1", Protocol: "tls", Combined: "TLSv1.1"},
+	TLSVersion12: TLSVersionDetails{Version: "1.2", Protocol: "tls", Combined: "TLSv1.2"},
+	TLSVersion13: TLSVersionDetails{Version: "1.3", Protocol: "tls", Combined: "TLSv1.3"},
 }

--- a/libbeat/common/transport/tlscommon/versions_legacy.go
+++ b/libbeat/common/transport/tlscommon/versions_legacy.go
@@ -23,13 +23,12 @@ package tlscommon
 import "crypto/tls"
 
 const (
-	TLSVersionSSL30 TLSVersion = tls.VersionSSL30
-	TLSVersion10    TLSVersion = tls.VersionTLS10
-	TLSVersion11    TLSVersion = tls.VersionTLS11
-	TLSVersion12    TLSVersion = tls.VersionTLS12
+	TLSVersion10 TLSVersion = tls.VersionTLS10
+	TLSVersion11 TLSVersion = tls.VersionTLS11
+	TLSVersion12 TLSVersion = tls.VersionTLS12
 
 	// TLSVersionMin is the min TLS version supported.
-	TLSVersionMin = TLSVersionSSL30
+	TLSVersionMin = TLSVersion10
 
 	// TLSVersionMax is the max TLS version supported.
 	TLSVersionMax = TLSVersion12
@@ -51,8 +50,6 @@ var TLSDefaultVersions = []TLSVersion{
 }
 
 var tlsProtocolVersions = map[string]TLSVersion{
-	"SSLv3":   TLSVersionSSL30,
-	"SSLv3.0": TLSVersionSSL30,
 	"TLSv1":   TLSVersion10,
 	"TLSv1.0": TLSVersion10,
 	"TLSv1.1": TLSVersion11,
@@ -60,8 +57,7 @@ var tlsProtocolVersions = map[string]TLSVersion{
 }
 
 var tlsProtocolVersionsInverse = map[TLSVersion]string{
-	TLSVersionSSL30: "SSLv3",
-	TLSVersion10:    "TLSv1.0",
-	TLSVersion11:    "TLSv1.1",
-	TLSVersion12:    "TLSv1.2",
+	TLSVersion10: "TLSv1.0",
+	TLSVersion11: "TLSv1.1",
+	TLSVersion12: "TLSv1.2",
 }

--- a/libbeat/common/transport/tlscommon/versions_test.go
+++ b/libbeat/common/transport/tlscommon/versions_test.go
@@ -37,11 +37,6 @@ func TestTLSVersion(t *testing.T) {
 			nil,
 		},
 		{
-			"SSLv3",
-			tls.VersionSSL30,
-			&TLSVersionDetails{Version: "3.0", Protocol: "ssl", Combined: "SSLv3"},
-		},
-		{
 			"TLSv1.0",
 			tls.VersionTLS10,
 			&TLSVersionDetails{Version: "1.0", Protocol: "tls", Combined: "TLSv1.0"},

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -120,7 +120,7 @@ SSL settings are disabled if either `enabled` is set to `false` or the
 List of allowed SSL/TLS versions. If SSL/TLS server decides for protocol versions
 not configured, the connection will be dropped during or after the handshake. The
 setting is a list of allowed protocol versions:
-`SSLv3`, `TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, and
+`TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, and
 `TLSv1.3`.
 
 The default value is `[TLSv1.1, TLSv1.2, TLSv1.3]`.

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -1235,8 +1235,7 @@ Packetbeat intercepts the initial handshake in a TLS connection and extracts
 useful information that helps operators diagnose problems and
 strengthen the security of their network and systems. It does not
 decrypt any information from the encapsulated protocol, nor does it reveal any
-sensitive information such as cryptographic keys. TLS versions 1.0 to 1.3 and
-SSL 3.0 are supported.
+sensitive information such as cryptographic keys. TLS versions 1.0 to 1.3 are supported.
 
 It works by intercepting the client and server "hello" messages, which contain
 the negotiated parameters for the connection such as cryptographic ciphers and


### PR DESCRIPTION
## What does this PR do?

Remove SSLv3 as an option in libbeat configurations and update the minimum version in the code and documentation.

## Why is it important?

SSL3 is old, deprecated, and should not be used for secure communication.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

