### PR TITLE
libbeat/processors/add_process_metadata: backport process.parent.pid field from 8.0

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -92,6 +92,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 *Affecting all Beats*
 
 - SASL/SCRAM in the Kafka output is no longer beta. {pull}29126[29126]
+- add_process_metadata processor: add `process.parent.pid` to reflect `process.ppid`. {issue}30070[30070] {pull}30077[30077]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_process_metadata/add_process_metadata.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata.go
@@ -111,7 +111,6 @@ func newProcessMetadataProcessorWithProvider(cfg *common.Config, provider proces
 	}
 
 	mappings, err := config.getMappings()
-
 	if err != nil {
 		return nil, errors.Wrapf(err, "error unpacking %v.target_fields", processorName)
 	}
@@ -138,7 +137,6 @@ func newProcessMetadataProcessorWithProvider(cfg *common.Config, provider proces
 		} else {
 			p.cidProvider = newCidProvider(config.HostPath, config.CgroupPrefixes, config.CgroupRegex, processCgroupPaths, nil)
 		}
-
 	}
 
 	if withCache {
@@ -310,6 +308,9 @@ func (p *processMetadata) toMap() common.MapStr {
 			"env":        p.env,
 			"pid":        p.pid,
 			"ppid":       p.ppid,
+			"parent": common.MapStr{
+				"pid": p.ppid,
+			},
 			"start_time": p.startTime,
 		},
 	}

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -71,7 +71,6 @@ func TestAddProcessMetadata(t *testing.T) {
 
 	// mock of the cgroup processCgroupPaths
 	processCgroupPaths = func(_ string, pid int) (cgroup.PathList, error) {
-
 		testMap := map[int]cgroup.PathList{
 			1: {
 				V1: map[string]cgroup.ControllerPath{
@@ -144,6 +143,9 @@ func TestAddProcessMetadata(t *testing.T) {
 					"args":       []string{"/usr/lib/systemd/systemd", "--switched-root", "--system", "--deserialize", "22"},
 					"pid":        1,
 					"ppid":       0,
+					"parent": common.MapStr{
+						"pid": 0,
+					},
 					"start_time": startTime,
 				},
 				"container": common.MapStr{
@@ -225,6 +227,9 @@ func TestAddProcessMetadata(t *testing.T) {
 						"args":       []string{"/usr/lib/systemd/systemd", "--switched-root", "--system", "--deserialize", "22"},
 						"pid":        1,
 						"ppid":       0,
+						"parent": common.MapStr{
+							"pid": 0,
+						},
 						"start_time": startTime,
 					},
 					"container": common.MapStr{
@@ -253,6 +258,9 @@ func TestAddProcessMetadata(t *testing.T) {
 						"args":       []string{"/usr/lib/systemd/systemd", "--switched-root", "--system", "--deserialize", "22"},
 						"pid":        1,
 						"ppid":       0,
+						"parent": common.MapStr{
+							"pid": 0,
+						},
 						"start_time": startTime,
 						"env": map[string]string{
 							"HOME":       "/",
@@ -288,6 +296,9 @@ func TestAddProcessMetadata(t *testing.T) {
 						"args":       []string{"/usr/lib/systemd/systemd", "--switched-root", "--system", "--deserialize", "22"},
 						"pid":        1,
 						"ppid":       0,
+						"parent": common.MapStr{
+							"pid": 0,
+						},
 						"start_time": startTime,
 						"env": map[string]string{
 							"HOME":       "/",
@@ -482,6 +493,9 @@ func TestAddProcessMetadata(t *testing.T) {
 					"args":       []string{"/usr/lib/systemd/systemd", "--switched-root", "--system", "--deserialize", "22"},
 					"pid":        1,
 					"ppid":       0,
+					"parent": common.MapStr{
+						"pid": 0,
+					},
 					"start_time": startTime,
 				},
 				"container": common.MapStr{
@@ -601,6 +615,9 @@ func TestAddProcessMetadata(t *testing.T) {
 					"args":       []string{"/usr/lib/systemd/systemd", "--switched-root", "--system", "--deserialize", "22"},
 					"pid":        1,
 					"ppid":       0,
+					"parent": common.MapStr{
+						"pid": 0,
+					},
 					"start_time": startTime,
 				},
 			},
@@ -721,7 +738,7 @@ func TestUsingCache(t *testing.T) {
 			selfPID: testStruct,
 		}
 
-		//testMap :=
+		// testMap :=
 		return testMap[pid], nil
 	}
 
@@ -730,7 +747,6 @@ func TestUsingCache(t *testing.T) {
 		"include_fields": []string{"container.id"},
 		"target":         "meta",
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1000,7 +1016,7 @@ func TestV2CID(t *testing.T) {
 	processCgroupPaths = func(_ string, _ int) (cgroup.PathList, error) {
 		testMap := cgroup.PathList{
 			V1: map[string]cgroup.ControllerPath{
-				"cpu": cgroup.ControllerPath{IsV2: true, ControllerPath: "system.slice/docker-2dcbab615aebfa9313feffc5cfdacd381543cfa04c6be3f39ac656e55ef34805.scope"},
+				"cpu": {IsV2: true, ControllerPath: "system.slice/docker-2dcbab615aebfa9313feffc5cfdacd381543cfa04c6be3f39ac656e55ef34805.scope"},
 			},
 		}
 		return testMap, nil

--- a/libbeat/processors/add_process_metadata/config.go
+++ b/libbeat/processors/add_process_metadata/config.go
@@ -68,6 +68,9 @@ var defaultFields = common.MapStr{
 		"args":       nil,
 		"pid":        nil,
 		"ppid":       nil,
+		"parent": common.MapStr{
+			"pid": nil,
+		},
 		"start_time": nil,
 	},
 	"container": common.MapStr{

--- a/libbeat/processors/add_process_metadata/docs/add_process_metadata.asciidoc
+++ b/libbeat/processors/add_process_metadata/docs/add_process_metadata.asciidoc
@@ -26,6 +26,9 @@ The fields added to the event look as follows:
   "args":  ["/usr/lib/systemd/systemd", "--switched-root", "--system", "--deserialize", "22"],
   "pid":   1,
   "ppid":  0,
+  "parent": {
+    "pid": 0
+  },
   "start_time": "2018-08-22T08:44:50.684Z",
 },
 "container": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This replays the additions in libbeat/processors/add_process_metadata and related
changes from dde7a1f.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This is intended to ease user transition to 8.0 when `process.ppid` will no longer exist.
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #30070.

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
