### PR TITLE
[Metricbeat] Remove strict parsing on RabbitMQ module

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -196,6 +196,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `elasticsearch.cluster.id` field to Logstash module. {pull}29625[29625]
 - Add `xpack.enabled` support for Enterprise Search module. {pull}29871[29871]
 - Add gcp firestore metricset. {pull}29918[29918] 
+- Remove strict parsing on RabbitMQ module {pull}30090[30090]
 
 *Packetbeat*
 

--- a/metricbeat/module/rabbitmq/connection/connection.go
+++ b/metricbeat/module/rabbitmq/connection/connection.go
@@ -53,5 +53,5 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error in fetch")
 	}
 
-	return eventsMapping(content, r, m)
+	return eventsMapping(content, r)
 }

--- a/metricbeat/module/rabbitmq/exchange/data.go
+++ b/metricbeat/module/rabbitmq/exchange/data.go
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func eventsMapping(content []byte, r mb.ReporterV2, m *MetricSet) error {
+func eventsMapping(content []byte, r mb.ReporterV2) error {
 	var exchanges []map[string]interface{}
 	err := json.Unmarshal(content, &exchanges)
 	if err != nil {
@@ -63,24 +63,14 @@ func eventsMapping(content []byte, r mb.ReporterV2, m *MetricSet) error {
 	}
 
 	for _, exchange := range exchanges {
-		evt, err := eventMapping(exchange)
-		if err != nil {
-			m.Logger().Errorf("error in mapping: %s", err)
-			r.Error(err)
-			continue
-		}
-		if !r.Event(evt) {
-			return nil
-		}
+		evt := eventMapping(exchange)
+		r.Event(evt)
 	}
 	return nil
 }
 
-func eventMapping(exchange map[string]interface{}) (mb.Event, error) {
-	fields, err := schema.Apply(exchange)
-	if err != nil {
-		return mb.Event{}, err
-	}
+func eventMapping(exchange map[string]interface{}) mb.Event {
+	fields, _ := schema.Apply(exchange)
 
 	rootFields := common.MapStr{}
 	if v, err := fields.GetValue("user"); err == nil {
@@ -99,6 +89,6 @@ func eventMapping(exchange map[string]interface{}) (mb.Event, error) {
 		RootFields:      rootFields,
 		ModuleFields:    moduleFields,
 	}
-	return event, nil
+	return event
 
 }

--- a/metricbeat/module/rabbitmq/exchange/exchange.go
+++ b/metricbeat/module/rabbitmq/exchange/exchange.go
@@ -55,5 +55,5 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error in fetch")
 	}
 
-	return eventsMapping(content, r, m)
+	return eventsMapping(content, r)
 }

--- a/metricbeat/module/rabbitmq/node/data.go
+++ b/metricbeat/module/rabbitmq/node/data.go
@@ -147,7 +147,7 @@ var (
 	}
 )
 
-func eventsMapping(r mb.ReporterV2, content []byte, m *ClusterMetricSet) error {
+func eventsMapping(r mb.ReporterV2, content []byte) error {
 	var nodes []map[string]interface{}
 	err := json.Unmarshal(content, &nodes)
 	if err != nil {
@@ -155,26 +155,16 @@ func eventsMapping(r mb.ReporterV2, content []byte, m *ClusterMetricSet) error {
 	}
 
 	for _, node := range nodes {
-		evt, err := eventMapping(node)
-		if err != nil {
-			m.Logger().Errorf("error in mapping: %s", err)
-			r.Error(err)
-			continue
-		}
-		if !r.Event(evt) {
-			return nil
-		}
+		evt := eventMapping(node)
+		r.Event(evt)
 	}
 	return nil
 }
 
-func eventMapping(node map[string]interface{}) (mb.Event, error) {
-	event, err := schema.Apply(node)
-	if err != nil {
-		return mb.Event{}, errors.Wrap(err, "error applying schema")
-	}
+func eventMapping(node map[string]interface{}) mb.Event {
+	event, _ := schema.Apply(node)
 	return mb.Event{
 		MetricSetFields: event,
-	}, nil
+	}
 
 }

--- a/metricbeat/module/rabbitmq/node/node.go
+++ b/metricbeat/module/rabbitmq/node/node.go
@@ -105,10 +105,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error in fetch")
 	}
 
-	evt, err := eventMapping(content)
-	if err != nil {
-		return errors.Wrap(err, "error in mapping")
-	}
+	evt := eventMapping(content)
 	r.Event(evt)
 	return nil
 }
@@ -120,5 +117,5 @@ func (m *ClusterMetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error in fetch")
 	}
 
-	return eventsMapping(r, content, m)
+	return eventsMapping(r, content)
 }

--- a/metricbeat/module/rabbitmq/queue/queue.go
+++ b/metricbeat/module/rabbitmq/queue/queue.go
@@ -53,5 +53,5 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "error in fetch")
 	}
 
-	return eventsMapping(content, r, m)
+	return eventsMapping(content, r)
 }


### PR DESCRIPTION
## What does this PR do?

RabbitMQ uses strict parsing for fields. If a single field is missing, the entire event is discarded, regardless of having another 100 found fields in there. 

This PR removes this strict checking, allowing partial events of RabbitMQ.


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
