### PR TITLE
Implement `DeepUpdate` on event and use it in `add_fields` processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -198,9 +198,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `elasticsearch.cluster.id` field to Beat and Kibana modules. {pull}29577[29577]
 - Add `elasticsearch.cluster.id` field to Logstash module. {pull}29625[29625]
 - Add `xpack.enabled` support for Enterprise Search module. {pull}29871[29871]
-- Add gcp firestore metricset. {pull}29918[29918] 
-- Remove strict parsing on RabbitMQ module {pull}30090[30090]
 - Add gcp firestore metricset. {pull}29918[29918]
+- Remove strict parsing on RabbitMQ module {pull}30090[30090]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -198,7 +198,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `elasticsearch.cluster.id` field to Beat and Kibana modules. {pull}29577[29577]
 - Add `elasticsearch.cluster.id` field to Logstash module. {pull}29625[29625]
 - Add `xpack.enabled` support for Enterprise Search module. {pull}29871[29871]
-- Add gcp firestore metricset. {pull}29918[29918]
+- Add gcp firestore metricset. {pull}29918[29918] 
 - Remove strict parsing on RabbitMQ module {pull}30090[30090]
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,7 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Enrich kubernetes metadata with node annotations. {pull}29605[29605]
 - Allign kubernetes configuration settings. {pull}29908[29908]
 - Remove legacy support for SSLv3. {pull}30071[30071]
-- `add_fields` processer is now able to set metadata in events {pull}30092[30092]
+- `add_fields` processor is now able to set metadata in events {pull}30092[30092]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Enrich kubernetes metadata with node annotations. {pull}29605[29605]
 - Allign kubernetes configuration settings. {pull}29908[29908]
 - Remove legacy support for SSLv3. {pull}30071[30071]
+- `add_fields` processer is now able to set metadata in events {pull}30092[30092]
 
 *Auditbeat*
 
@@ -199,6 +200,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 - Add `xpack.enabled` support for Enterprise Search module. {pull}29871[29871]
 - Add gcp firestore metricset. {pull}29918[29918] 
 - Remove strict parsing on RabbitMQ module {pull}30090[30090]
+- Add gcp firestore metricset. {pull}29918[29918]
 
 *Packetbeat*
 

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -60,29 +60,15 @@ func (e *Event) SetID(id string) {
 }
 
 func (e *Event) GetValue(key string) (interface{}, error) {
-	if e == nil {
-		return nil, common.ErrKeyNotFound
-	}
-
 	if key == timestampFieldKey {
 		return e.Timestamp, nil
 	} else if subKey, ok := metadataKey(key); ok {
-		if subKey == "" {
+		if subKey == "" || e.Meta == nil {
 			return e.Meta, nil
 		}
-		if e.Meta == nil {
-			return nil, common.ErrKeyNotFound
-		}
-
 		return e.Meta.GetValue(subKey)
 	}
-
-	if e.Fields == nil {
-		return nil, common.ErrKeyNotFound
-	}
-
 	return e.Fields.GetValue(key)
-
 }
 
 func (e *Event) DeepUpdate(d common.MapStr) {
@@ -182,9 +168,7 @@ func (e *Event) PutValue(key string, v interface{}) (interface{}, error) {
 		}
 		return e.Meta.Put(subKey, v)
 	}
-	if e.Fields == nil {
-		e.Fields = common.MapStr{}
-	}
+
 	return e.Fields.Put(key, v)
 }
 

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -28,6 +28,11 @@ import (
 // FlagField fields used to keep information or errors when events are parsed.
 const FlagField = "log.flags"
 
+const (
+	timestampFieldKey = "@timestamp"
+	metadataFieldKey  = "@metadata"
+)
+
 // Event is the common event format shared by all beats.
 // Every event must have a timestamp and provide encodable Fields in `Fields`.
 // The `Meta`-fields can be used to pass additional meta-data to the outputs.
@@ -55,28 +60,113 @@ func (e *Event) SetID(id string) {
 }
 
 func (e *Event) GetValue(key string) (interface{}, error) {
-	if key == "@timestamp" {
+	if e == nil {
+		return nil, common.ErrKeyNotFound
+	}
+
+	if key == timestampFieldKey {
 		return e.Timestamp, nil
 	} else if subKey, ok := metadataKey(key); ok {
-		if subKey == "" || e.Meta == nil {
+		if subKey == "" {
 			return e.Meta, nil
 		}
+		if e.Meta == nil {
+			return nil, common.ErrKeyNotFound
+		}
+
 		return e.Meta.GetValue(subKey)
 	}
+
+	if e.Fields == nil {
+		return nil, common.ErrKeyNotFound
+	}
+
 	return e.Fields.GetValue(key)
+
+}
+
+func (e *Event) DeepUpdate(d common.MapStr) {
+	e.deepUpdate(d, true)
+}
+
+func (e *Event) DeepUpdateNoOverwrite(d common.MapStr) {
+	e.deepUpdate(d, false)
+}
+
+func (e *Event) deepUpdate(d common.MapStr, overwrite bool) {
+	if len(d) == 0 {
+		return
+	}
+	fieldsUpdate := d.Clone() // so we can delete redundant keys
+
+	var metaUpdate common.MapStr
+
+	for fieldKey, value := range d {
+		switch fieldKey {
+
+		// one of the updates is the timestamp which is not a part of the event fields
+		case timestampFieldKey:
+			if overwrite {
+				_ = e.setTimestamp(value)
+			}
+			delete(fieldsUpdate, fieldKey)
+
+		// some updates are addressed for the metadata not the fields
+		case metadataFieldKey:
+			switch meta := value.(type) {
+			case common.MapStr:
+				metaUpdate = meta
+			case map[string]interface{}:
+				metaUpdate = common.MapStr(meta)
+			}
+
+			delete(fieldsUpdate, fieldKey)
+		}
+	}
+
+	if metaUpdate != nil {
+		if e.Meta == nil {
+			e.Meta = common.MapStr{}
+		}
+		if overwrite {
+			e.Meta.DeepUpdate(metaUpdate)
+		} else {
+			e.Meta.DeepUpdateNoOverwrite(metaUpdate)
+		}
+	}
+
+	if len(fieldsUpdate) == 0 {
+		return
+	}
+
+	if e.Fields == nil {
+		e.Fields = common.MapStr{}
+	}
+
+	if overwrite {
+		e.Fields.DeepUpdate(fieldsUpdate)
+	} else {
+		e.Fields.DeepUpdateNoOverwrite(fieldsUpdate)
+	}
+}
+
+func (e *Event) setTimestamp(v interface{}) error {
+	switch ts := v.(type) {
+	case time.Time:
+		e.Timestamp = ts
+	case common.Time:
+		e.Timestamp = time.Time(ts)
+	default:
+		return errNoTimestamp
+	}
+
+	return nil
 }
 
 func (e *Event) PutValue(key string, v interface{}) (interface{}, error) {
-	if key == "@timestamp" {
-		switch ts := v.(type) {
-		case time.Time:
-			e.Timestamp = ts
-		case common.Time:
-			e.Timestamp = time.Time(ts)
-		default:
-			return nil, errNoTimestamp
-		}
-		return nil, nil
+	if key == timestampFieldKey {
+		err := e.setTimestamp(v)
+		return nil, err
 	} else if subKey, ok := metadataKey(key); ok {
 		if subKey == "" {
 			switch meta := v.(type) {
@@ -92,7 +182,9 @@ func (e *Event) PutValue(key string, v interface{}) (interface{}, error) {
 		}
 		return e.Meta.Put(subKey, v)
 	}
-
+	if e.Fields == nil {
+		e.Fields = common.MapStr{}
+	}
 	return e.Fields.Put(key, v)
 }
 
@@ -111,11 +203,11 @@ func (e *Event) Delete(key string) error {
 }
 
 func metadataKey(key string) (string, bool) {
-	if !strings.HasPrefix(key, "@metadata") {
+	if !strings.HasPrefix(key, metadataFieldKey) {
 		return "", false
 	}
 
-	subKey := key[len("@metadata"):]
+	subKey := key[len(metadataFieldKey):]
 	if subKey == "" {
 		return "", true
 	}

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -71,10 +71,25 @@ func (e *Event) GetValue(key string) (interface{}, error) {
 	return e.Fields.GetValue(key)
 }
 
+// DeepUpdate recursively copies the key-value pairs from `d` to various properties of the event.
+// When the key equals `@timestamp` it's set as the `Timestamp` property of the event.
+// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`
+// The rest of the keys are set to the `Fields` map.
+// If the key is present and the value is a map as well, the sub-map will be updated recursively
+// via `DeepUpdate`.
+// `DeepUpdateNoOverwrite` is a version of this function that does not
+// overwrite existing values.
 func (e *Event) DeepUpdate(d common.MapStr) {
 	e.deepUpdate(d, true)
 }
 
+// DeepUpdateNoOverwrite recursively copies the key-value pairs from `d` to various properties of the event.
+// The `@timestamp` update is ignored due to "no overwrite" behavior.
+// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`.
+// The rest of the keys are set to the `Fields` map.
+// If the key is present and the value is a map as well, the sub-map will be updated recursively
+// via `DeepUpdateNoOverwrite`.
+// `DeepUpdate` is a version of this function that overwrites existing values.
 func (e *Event) DeepUpdateNoOverwrite(d common.MapStr) {
 	e.deepUpdate(d, false)
 }

--- a/libbeat/processors/actions/add_fields.go
+++ b/libbeat/processors/actions/add_fields.go
@@ -71,7 +71,7 @@ func NewAddFields(fields common.MapStr, shared bool, overwrite bool) processors.
 	return &addFields{fields: fields, shared: shared, overwrite: overwrite}
 }
 
-func (af *addFields) Run(event *beat.Event) (_ *beat.Event, err error) {
+func (af *addFields) Run(event *beat.Event) (*beat.Event, error) {
 	if event == nil || len(af.fields) == 0 {
 		return event, nil
 	}

--- a/libbeat/processors/actions/add_fields.go
+++ b/libbeat/processors/actions/add_fields.go
@@ -71,18 +71,20 @@ func NewAddFields(fields common.MapStr, shared bool, overwrite bool) processors.
 	return &addFields{fields: fields, shared: shared, overwrite: overwrite}
 }
 
-func (af *addFields) Run(event *beat.Event) (*beat.Event, error) {
+func (af *addFields) Run(event *beat.Event) (_ *beat.Event, err error) {
+	if event == nil || len(af.fields) == 0 {
+		return event, nil
+	}
+
 	fields := af.fields
-	if af.shared || event.Fields == nil {
+	if af.shared {
 		fields = fields.Clone()
 	}
 
-	if event.Fields == nil {
-		event.Fields = fields
-	} else if af.overwrite {
-		event.Fields.DeepUpdate(fields)
+	if af.overwrite {
+		event.DeepUpdate(fields)
 	} else {
-		event.Fields.DeepUpdateNoOverwrite(fields)
+		event.DeepUpdateNoOverwrite(fields)
 	}
 
 	return event, nil

--- a/libbeat/processors/actions/add_fields_test.go
+++ b/libbeat/processors/actions/add_fields_test.go
@@ -29,38 +29,48 @@ func TestAddFields(t *testing.T) {
 
 	testProcessors(t, map[string]testCase{
 		"add field": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"fields": common.MapStr{"field": "test"},
 			},
 			cfg: single(`{add_fields: {fields: {field: test}}}`),
 		},
 		"custom target": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"my": common.MapStr{"field": "test"},
 			},
 			cfg: single(`{add_fields: {target: my, fields: {field: test}}}`),
 		},
 		"overwrite existing field": {
-			event: common.MapStr{
+			eventFields: common.MapStr{
 				"fields": common.MapStr{"field": "old"},
 			},
-			want: common.MapStr{"fields": common.MapStr{"field": "test"}},
-			cfg:  single(`{add_fields: {fields: {field: test}}}`),
+			wantFields: common.MapStr{"fields": common.MapStr{"field": "test"}},
+			cfg:        single(`{add_fields: {fields: {field: test}}}`),
+		},
+		"merge with existing meta": {
+			eventMeta: common.MapStr{
+				"_id": "unique",
+			},
+			wantMeta: common.MapStr{
+				"_id":     "unique",
+				"op_type": "index",
+			},
+			cfg: single(`{add_fields: {target: "@metadata", fields: {op_type: "index"}}}`),
 		},
 		"merge with existing fields": {
-			event: common.MapStr{
+			eventFields: common.MapStr{
 				"fields": common.MapStr{"existing": "a"},
 			},
-			want: common.MapStr{
+			wantFields: common.MapStr{
 				"fields": common.MapStr{"existing": "a", "field": "test"},
 			},
 			cfg: single(`{add_fields: {fields: {field: test}}}`),
 		},
 		"combine 2 processors": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"fields": common.MapStr{
 					"l1": "a",
 					"l2": "b",
@@ -72,8 +82,8 @@ func TestAddFields(t *testing.T) {
 			),
 		},
 		"different targets": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"a": common.MapStr{"l1": "a"},
 				"b": common.MapStr{"l2": "b"},
 			},
@@ -83,8 +93,8 @@ func TestAddFields(t *testing.T) {
 			),
 		},
 		"under root": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"a": common.MapStr{"b": "test"},
 			},
 			cfg: single(
@@ -92,10 +102,10 @@ func TestAddFields(t *testing.T) {
 			),
 		},
 		"merge under root": {
-			event: common.MapStr{
+			eventFields: common.MapStr{
 				"a": common.MapStr{"old": "value"},
 			},
-			want: common.MapStr{
+			wantFields: common.MapStr{
 				"a": common.MapStr{"old": "value", "new": "test"},
 			},
 			cfg: single(
@@ -103,10 +113,10 @@ func TestAddFields(t *testing.T) {
 			),
 		},
 		"overwrite existing under root": {
-			event: common.MapStr{
+			eventFields: common.MapStr{
 				"a": common.MapStr{"keep": "value", "change": "a"},
 			},
-			want: common.MapStr{
+			wantFields: common.MapStr{
 				"a": common.MapStr{"keep": "value", "change": "b"},
 			},
 			cfg: single(
@@ -114,8 +124,8 @@ func TestAddFields(t *testing.T) {
 			),
 		},
 		"add fields to nil event": {
-			event: nil,
-			want: common.MapStr{
+			eventFields: nil,
+			wantFields: common.MapStr{
 				"fields": common.MapStr{"field": "test"},
 			},
 			cfg: single(`{add_fields: {fields: {field: test}}}`),

--- a/libbeat/processors/actions/add_labels_test.go
+++ b/libbeat/processors/actions/add_labels_test.go
@@ -29,29 +29,29 @@ func TestAddLabels(t *testing.T) {
 
 	testProcessors(t, map[string]testCase{
 		"add label": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"labels": common.MapStr{"label": "test"},
 			},
 			cfg: single(`{add_labels: {labels: {label: test}}}`),
 		},
 		"add dotted label": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"labels": common.MapStr{"a.b": "test"},
 			},
 			cfg: single(`{add_labels: {labels: {a.b: test}}}`),
 		},
 		"add nested labels": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"labels": common.MapStr{"a.b": "test", "a.c": "test2"},
 			},
 			cfg: single(`{add_labels: {labels: {a: {b: test, c: test2}}}}`),
 		},
 		"merge labels": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"labels": common.MapStr{"l1": "a", "l2": "b", "lc": "b"},
 			},
 			cfg: multi(
@@ -60,8 +60,8 @@ func TestAddLabels(t *testing.T) {
 			),
 		},
 		"add array": {
-			event: common.MapStr{},
-			want: common.MapStr{
+			eventFields: common.MapStr{},
+			wantFields: common.MapStr{
 				"labels": common.MapStr{
 					"array.0":       "foo",
 					"array.1":       "bar",

--- a/libbeat/processors/actions/add_tags_test.go
+++ b/libbeat/processors/actions/add_tags_test.go
@@ -29,40 +29,40 @@ func TestAddTags(t *testing.T) {
 
 	testProcessors(t, map[string]testCase{
 		"create tags": {
-			event: common.MapStr{},
-			want:  common.MapStr{"tags": []string{"t1", "t2"}},
-			cfg:   single(`{add_tags: {tags: [t1, t2]}}`),
+			eventFields: common.MapStr{},
+			wantFields:  common.MapStr{"tags": []string{"t1", "t2"}},
+			cfg:         single(`{add_tags: {tags: [t1, t2]}}`),
 		},
 		"append to tags": {
-			event: common.MapStr{"tags": []string{"t1"}},
-			want:  common.MapStr{"tags": []string{"t1", "t2", "t3"}},
-			cfg:   single(`{add_tags: {tags: [t2, t3]}}`),
+			eventFields: common.MapStr{"tags": []string{"t1"}},
+			wantFields:  common.MapStr{"tags": []string{"t1", "t2", "t3"}},
+			cfg:         single(`{add_tags: {tags: [t2, t3]}}`),
 		},
 		"combine from 2 processors": {
-			event: common.MapStr{},
-			want:  common.MapStr{"tags": []string{"t1", "t2", "t3", "t4"}},
+			eventFields: common.MapStr{},
+			wantFields:  common.MapStr{"tags": []string{"t1", "t2", "t3", "t4"}},
 			cfg: multi(
 				`{add_tags: {tags: [t1, t2]}}`,
 				`{add_tags: {tags: [t3, t4]}}`,
 			),
 		},
 		"with custom target": {
-			event: common.MapStr{},
-			want:  common.MapStr{"custom": []string{"t1", "t2"}},
-			cfg:   single(`{add_tags: {tags: [t1, t2], target: custom}}`),
+			eventFields: common.MapStr{},
+			wantFields:  common.MapStr{"custom": []string{"t1", "t2"}},
+			cfg:         single(`{add_tags: {tags: [t1, t2], target: custom}}`),
 		},
 		"different targets": {
-			event: common.MapStr{},
-			want:  common.MapStr{"tags1": []string{"t1"}, "tags2": []string{"t2"}},
+			eventFields: common.MapStr{},
+			wantFields:  common.MapStr{"tags1": []string{"t1"}, "tags2": []string{"t2"}},
 			cfg: multi(
 				`{add_tags: {target: tags1, tags: [t1]}}`,
 				`{add_tags: {target: tags2, tags: [t2]}}`,
 			),
 		},
 		"single tag config without array notation": {
-			event: common.MapStr{},
-			want:  common.MapStr{"tags": []string{"t1"}},
-			cfg:   single(`{add_tags: {tags: t1}}`),
+			eventFields: common.MapStr{},
+			wantFields:  common.MapStr{"tags": []string{"t1"}},
+			cfg:         single(`{add_tags: {tags: t1}}`),
 		},
 	})
 }

--- a/libbeat/processors/actions/common_test.go
+++ b/libbeat/processors/actions/common_test.go
@@ -28,9 +28,11 @@ import (
 )
 
 type testCase struct {
-	event common.MapStr
-	want  common.MapStr
-	cfg   []string
+	eventFields common.MapStr
+	eventMeta   common.MapStr
+	wantFields  common.MapStr
+	wantMeta    common.MapStr
+	cfg         []string
 }
 
 func testProcessors(t *testing.T, cases map[string]testCase) {
@@ -51,8 +53,11 @@ func testProcessors(t *testing.T, cases map[string]testCase) {
 			}
 
 			current := &beat.Event{}
-			if test.event != nil {
-				current.Fields = test.event.Clone()
+			if test.eventFields != nil {
+				current.Fields = test.eventFields.Clone()
+			}
+			if test.eventMeta != nil {
+				current.Meta = test.eventMeta.Clone()
 			}
 			for i, processor := range ps {
 				var err error
@@ -65,7 +70,8 @@ func testProcessors(t *testing.T, cases map[string]testCase) {
 				}
 			}
 
-			assert.Equal(t, test.want, current.Fields)
+			assert.Equal(t, test.wantFields, current.Fields)
+			assert.Equal(t, test.wantMeta, current.Meta)
 		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

We have a couple of special cases when we set fields on the event
based on target field keys:

1. `@timestamp` must be set directly to the `Timestamp` property of
the event
2. `@metadata.*` must be put in the `Meta` map instead of `Fields`
3. The rest is put in `Fields`

Currently the `Event` struct has the `PutValue` function to account for
these special cases, however, some of the processors use
`event.Fields.DeepUpdate` which would not handle the special cases.

To make it easier to migrate those processors, the new function
`event.DeepUpdate` (that can be safely used with the
special cases) is introduced.

As an example, the `add_fields` processor is migrated to using this
new function and its tests have been updated to assert the correct behaviour.

**It's a partial solution just to demo the approach, if it's approved I will continue to migrate the rest of the processors to using the same function**

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Why is it important?

There was an issue reported earlier https://github.com/elastic/beats/issues/25425 which indicates that some customers are willing to set additional metadata with processors and not all the processors allow that. Particularly, the issue was about the `add_fields` processor.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run filebeat with this configuration:

```yaml
filebeat:
  inputs:
    - type: log
      paths:
        - /path/to/your/file

processors:
  - add_fields:
      target: "@metadata"
      fields:
        op_type: "index"

output:
  elasticsearch:
    allow_older_versions: true
    hosts: ["localhost:9200"]
```

And run Elasticsearch in its default configuration locally.

When you write to the log file (`/path/to/your/file` in the config) before this fix you'll see a new ingested document with the field `@metadata.op_type="index"`, after applying this fix the document ingestion should fail with the following error on the console:

```
{\"type\":\"illegal_argument_exception\",\"reason\":\"only write ops with an op_type of create are allowed in data streams\"}, dropping event!"
```

which is expected because starting with v8.0.0 beats use data streams and don't allow setting `op_type` to anything but `create`. But this also means that our field we configured `@metadata.op_type="index"` was set as a part of the document metadata and not its fields which is exactly what is tested here.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/issues/25425
