### PR TITLE
Filebeat pytest improvements

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -131,6 +131,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Whitelist `GCP_*` environment variables in dev tools {pull}28364[28364]
 - Add support for `credentials_json` in `gcp` module, all metricsets {pull}29584[29584]
 - Add gcp firestore metricset. {pull}29918[29918]
+- Added TESTING_FILEBEAT_FILEPATTERN option for filebeat module pytests {pull}30103[30103]
 
 ==== Deprecated
 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -216,7 +216,8 @@ class Test(BaseTest):
             error_line)
 
         # Make sure index exists
-        self.wait_until(lambda: self.es.indices.exists(self.index_name), name="indices present for {}".format(test_file))
+        self.wait_until(lambda: self.es.indices.exists(self.index_name),
+                        name="indices present for {}".format(test_file))
 
         self.es.indices.refresh(index=self.index_name)
         # Loads the first 100 events to be checked

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -107,7 +107,7 @@ def load_fileset_test_cases():
                 continue
 
             test_files = glob.glob(os.path.join(modules_dir, module,
-                                                fileset, "test", "*.log"))
+                                                fileset, "test", os.getenv("TESTING_FILEBEAT_FILEPATTERN", "*.log")))
             for test_file in test_files:
                 test_cases.append([module, fileset, test_file])
 

--- a/filebeat/tests/system/test_modules.py
+++ b/filebeat/tests/system/test_modules.py
@@ -216,7 +216,7 @@ class Test(BaseTest):
             error_line)
 
         # Make sure index exists
-        self.wait_until(lambda: self.es.indices.exists(self.index_name))
+        self.wait_until(lambda: self.es.indices.exists(self.index_name), name="indices present for {}".format(test_file))
 
         self.es.indices.refresh(index=self.index_name)
         # Loads the first 100 events to be checked

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -776,7 +776,7 @@ class TestCase(unittest.TestCase, ComposeMixin):
             # Range keys as used in 'date_range' etc will not have docs of course
             isRangeKey = key.split('.')[-1] in ['gte', 'gt', 'lte', 'lt']
             if not(is_documented(key, expected_fields) or metaKey or isRangeKey):
-                raise Exception("Key '{}' found in event is not documented!".format(key))
+                raise Exception("Key '{}' found in event ({}) is not documented!".format(key, str(evt)))
             if is_documented(key, aliases):
                 raise Exception("Key '{}' found in event is documented as an alias!".format(key))
 


### PR DESCRIPTION
## What does this PR do?

Provides a few improvements to the filebeat ingest pytests. 

- Include which file failed the "wait for docs" step
- Support TESTING_FILEBEAT_FILEPATTERN to ingest a single file
- Include the full event in the "not documented" case

## Why is it important?

Makes it easier to write and maintain filebeat pytests

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~I have commented my code, particularly in hard-to-understand areas~
- [x] I have made corresponding changes to the documentation (I'll put these in https://github.com/elastic/beats/pull/30014)
- ~I have made corresponding change to the default configuration files~
- ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
# Start an ES, give it an admin/changeme user)

# setup the test env
❯ cd filebeat
❯ make update filebeat.test
❯ make python-env
❯ source ./build/python-env/bin/activate

# Run a pattered test
❯ INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false TESTING_FILEBEAT_MODULES=elasticsearch TESTING_FILEBEAT_FILESETS=slowlog TESTING_FILEBEAT_FILEPATTERN=es_indexing_slowlog.800.log ES_PASS=changeme pytest tests/system/test_modules.py -v --full-trace

# Add a few field 
❯ echo '{"ecs.version": "1.2", "newfield": "matwazhere", "elasticsearch.slowlog.message": "need a message to grok"}' >> module/elasticsearch/slowlog/test/es_indexing_slowlog.800.log
❯ INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false TESTING_FILEBEAT_MODULES=elasticsearch TESTING_FILEBEAT_FILESETS=slowlog TESTING_FILEBEAT_FILEPATTERN=es_indexing_slowlog.800.log ES_PASS=changeme pytest tests/system/test_modules.py -v --full-trace
...
E               Exception: Key 'newfield' found in event ({'agent': {'name': 'matschaffer-mbp2019.lan', 'id': '4cda5c97-4168-4090-911e-3c34c1ae00aa', 'type': 'filebeat', 'ephemeral_id': '158a6d12-a3cc-4794-b14c-0c0cd424ad57', 'version': '8.1.0'}, 'log': {'file': {'path': '/Users/matschaffer/elastic/beats/filebeat/module/elasticsearch/slowlog/test/es_indexing_slowlog.800.log'}, 'offset': 1488}, 'fileset': {'name': 'slowlog'}, 'message': 'need a message to grok', 'newfield': 'matwazhere', 'input': {'type': 'log'}, '@timestamp': '2022-01-31T05:09:58.703Z', 'ecs': {'version': '1.2'}, 'elasticsearch': {'slowlog': {}}, 'service': {'type': 'elasticsearch'}, 'host': {'name': 'matschaffer-mbp2019.lan'}, 'event': {'ingested': '2022-01-31T05:09:59.729047Z', 'created': '2022-01-31T05:09:58.703Z', 'kind': 'event', 'module': 'elasticsearch', 'category': 'database', 'dataset': 'elasticsearch.slowlog'}}) is not documented!

# Kill all the docs
❯ echo '{"gonna get dropped": true}' > module/elasticsearch/slowlog/test/es_indexing_slowlog.800.log
❯ INTEGRATION_TESTS=1 BEAT_STRICT_PERMS=false TESTING_FILEBEAT_MODULES=elasticsearch TESTING_FILEBEAT_FILESETS=slowlog TESTING_FILEBEAT_FILEPATTERN=es_indexing_slowlog.800.log ES_PASS=changeme pytest tests/system/test_modules.py -v --full-trace
...
E               beat.beat.TimeoutError: Timeout waiting for 'indices present for /Users/matschaffer/elastic/beats/filebeat/tests/system/../../module/elasticsearch/slowlog/test/es_indexing_slowlog.800.log' to be true. Waited 10 seconds.

# Undo the changes
❯ git checkout module/elasticsearch/slowlog/test/es_indexing_slowlog.800.log
```

## Related issues

I ended up writing these as part of https://github.com/elastic/beats/pull/30018 but didn't want to mix them into that PR.