### PR TITLE
mage: add -trimpath flag to build process

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -70,6 +70,8 @@ func DefaultBuildArgs() BuildArgs {
 	} else {
 		// Strip all debug symbols from binary (does not affect Go stack traces).
 		args.LDFlags = append(args.LDFlags, "-s")
+		// Remove all file system paths from the compiled executable, to improve build reproducibility
+		args.ExtraFlags = append(args.ExtraFlags, "-trimpath")
 	}
 
 	return args


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

## What does this PR do?

Remove file system paths from the compiled executable. This results in
slimmer executable and makes it easier to compare stack traces.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

BEFORE:
```
$ cd x-pack/elastic-agent/
$ mage clean
$ mage build
$ strings build/elastic-agent | grep github
/home/foobar/src/github.com/elastic/beats/libbeat/conditions/not.go
/home/foobar/src/github.com/elastic/beats/libbeat/conditions/equals.go
/home/foobar/src/github.com/elastic/beats/libbeat/conditions/extractors.go
/home/foobar/src/github.com/elastic/beats/libbeat/conditions/fields.go
/home/foobar/src/github.com/elastic/beats/libbeat/conditions/has_fields.go
/home/foobar/src/github.com/elastic/beats/libbeat/conditions/matcher.go
[...]
```

AFTER:
```
$ cd x-pack/elastic-agent/
$ mage clean
$ mage build
$ strings build/elastic-agent | grep github
github.com/elastic/beats/v7/libbeat/common/match/cmp.go
github.com/elastic/beats/v7/libbeat/common/match/compile.go
[...]
```



