### PR TITLE
Use absolute path in external config glob when looking for external configuration files in Elastic Agent

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/local_mode.go
+++ b/x-pack/elastic-agent/pkg/agent/application/local_mode.go
@@ -118,7 +118,7 @@ func newLocal(
 		return nil, errors.New(err, "failed to initialize composable controller")
 	}
 
-	discover := discoverer(pathConfigFile, cfg.Settings.Path, configuration.ExternalInputsPattern)
+	discover := discoverer(pathConfigFile, cfg.Settings.Path, externalConfigsGlob())
 	emit, err := emitter.New(
 		localApplication.bgContext,
 		log,


### PR DESCRIPTION
## What does this PR do?

In https://github.com/elastic/beats/pull/30087 we introduced loading inputs configuration from external folders in Agent. This PR changes the path to the external configuration files from relative to absolute.

## Why is it important?

Using absolute path makes the solution bit more stable. The feature works even without this change unless the user change `path.config` or the folder. But having this in covers all "cases".

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
