### PR TITLE
[DOC] labels.dedot option for add_kubernetes_metadata processor

### DIFF
--- a/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
+++ b/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
@@ -67,6 +67,8 @@ ifndef::kubernetes_default_indexers[]
       #  - fields:
       #      lookup_fields: ["metricset.host"]
 endif::kubernetes_default_indexers[]
+      #labels.dedot: true
+      #annotations.dedot: true
 -------------------------------------------------------------------------------
 
 The configuration below enables the processor on a Beat running as a process on
@@ -89,6 +91,7 @@ ifndef::kubernetes_default_indexers[]
       #      lookup_fields: ["metricset.host"]
 endif::kubernetes_default_indexers[]
       #labels.dedot: true
+      #annotations.dedot: true
 -------------------------------------------------------------------------------
 
 The configuration below has the default indexers and matchers disabled and
@@ -110,6 +113,7 @@ processors:
         - fields:
             lookup_fields: ["metricset.host"]
       #labels.dedot: true
+      #annotations.dedot: true
 -------------------------------------------------------------------------------
 
 The `add_kubernetes_metadata` processor has the following configuration settings:
@@ -135,10 +139,12 @@ Example:
         namespace:
           include_labels: ["namespacelabel1"]
           #labels.dedot: true
+          #annotations.dedot: true
         node:
           include_labels: ["nodelabel2"]
           include_annotations: ["nodeannotation1"]
           #labels.dedot: true
+          #annotations.dedot: true
 -------------------------------------------------------------------------------------
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
 client. It defaults to `KUBECONFIG` environment variable if present.
@@ -149,3 +155,5 @@ running configuration for a container. This is `60s` by default.
 `default_matchers.enabled`:: (Optional) Enable or disable default pod matchers when you want to specify your own.
 `labels.dedot`:: (Optional) Default to be true. If set to true, replace dots in
  labels with `_`.
+ `annotations.dedot`:: (Optional) Default to be true. If set to true, replace dots in
+ annotations with `_`.

--- a/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
+++ b/libbeat/processors/add_kubernetes_metadata/docs/add_kubernetes_metadata.asciidoc
@@ -88,6 +88,7 @@ ifndef::kubernetes_default_indexers[]
       #  - fields:
       #      lookup_fields: ["metricset.host"]
 endif::kubernetes_default_indexers[]
+      #labels.dedot: true
 -------------------------------------------------------------------------------
 
 The configuration below has the default indexers and matchers disabled and
@@ -108,6 +109,7 @@ processors:
       matchers:
         - fields:
             lookup_fields: ["metricset.host"]
+      #labels.dedot: true
 -------------------------------------------------------------------------------
 
 The `add_kubernetes_metadata` processor has the following configuration settings:
@@ -132,9 +134,11 @@ Example:
       add_resource_metadata:
         namespace:
           include_labels: ["namespacelabel1"]
+          #labels.dedot: true
         node:
           include_labels: ["nodelabel2"]
           include_annotations: ["nodeannotation1"]
+          #labels.dedot: true
 -------------------------------------------------------------------------------------
 `kube_config`:: (Optional) Use given config file as configuration for Kubernetes
 client. It defaults to `KUBECONFIG` environment variable if present.
@@ -143,3 +147,5 @@ running configuration for a container. This is `60s` by default.
 `sync_period`:: (Optional) Specify the timeout for listing historical resources.
 `default_indexers.enabled`:: (Optional) Enable or disable default pod indexers when you want to specify your own.
 `default_matchers.enabled`:: (Optional) Enable or disable default pod matchers when you want to specify your own.
+`labels.dedot`:: (Optional) Default to be true. If set to true, replace dots in
+ labels with `_`.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
- Docs

## What does this PR do?

Following source code, it seems the `labels.dedot` and `annotations.dedot`options are undocumented. This PR is a documentation improvement.

It was needed for our filebeat migration from 6.6 to 7.16, because their default behavior changed starting 7.0.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #9939
- Relates  #10338
