### PR TITLE
docs: correct example of --strict.perms usage

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -146,7 +146,7 @@ docker run -d \
   --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
-  {dockerimage} {beatname_lc} -e -strict.perms=false \
+  {dockerimage} {beatname_lc} -e --strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
 endif::[]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprec- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanupation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes typo in CLI flags used to run Filebeat. `--strict.perms` requires double dashes

## Why is it important?

The docs should be ready to use and should not require investigation why something doesn't work.

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
