### PR TITLE
docs: add statement about config file encoding

### DIFF
--- a/libbeat/docs/config-file-format.asciidoc
+++ b/libbeat/docs/config-file-format.asciidoc
@@ -3,6 +3,7 @@
 
 Beats config files are based on http://www.yaml.org[YAML], a file format that is
 easier to read and write than other common data formats like XML or JSON.
+Config files must be encoded in UTF-8.
 
 In beats all YAML files start with a dictionary, an unordered collection of
 name/value pairs. In addition to dictionaries, YAML also supports lists, numbers,


### PR DESCRIPTION
## What does this PR do?

Beats config files must be UTF-8, if they're not UTF-8 there will be
problems with special characters.

## Why is it important?

It clarifies our documentation

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [X] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
## Related issues

- Closes #30053

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~