### PR TITLE
Add metadata change support for processors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - The extension of the log files of Beats and Elastic Agent is changed to `.ndjson`. If you are collecting the logs, you must change the path configuration to `/path/to/logs/{beatname}*.ndjson` to avoid any issues. {pull}28927[28927]
 - Remove legacy support for SSLv3. {pull}30071[30071]
 - `add_fields` processor is now able to set metadata in events {pull}30092[30092]
+- Add metadata change support for some processors {pull}30183[30183]
 
 *Auditbeat*
 

--- a/libbeat/beat/event.go
+++ b/libbeat/beat/event.go
@@ -71,6 +71,17 @@ func (e *Event) GetValue(key string) (interface{}, error) {
 	return e.Fields.GetValue(key)
 }
 
+// Clone creates an exact copy of the event
+func (e *Event) Clone() *Event {
+	return &Event{
+		Timestamp:  e.Timestamp,
+		Meta:       e.Meta.Clone(),
+		Fields:     e.Fields.Clone(),
+		Private:    e.Private,
+		TimeSeries: e.TimeSeries,
+	}
+}
+
 // DeepUpdate recursively copies the key-value pairs from `d` to various properties of the event.
 // When the key equals `@timestamp` it's set as the `Timestamp` property of the event.
 // When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`

--- a/libbeat/processors/actions/add_network_direction_test.go
+++ b/libbeat/processors/actions/add_network_direction_test.go
@@ -77,4 +77,30 @@ func TestNetworkDirection(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		evt := beat.Event{
+			Meta: common.MapStr{},
+			Fields: common.MapStr{
+				"source":      "1.1.1.1",
+				"destination": "8.8.8.8",
+			},
+		}
+		p, err := NewAddNetworkDirection(common.MustNewConfigFrom(map[string]interface{}{
+			"source":            "source",
+			"destination":       "destination",
+			"target":            "@metadata.direction",
+			"internal_networks": "private",
+		}))
+		require.NoError(t, err)
+
+		expectedMeta := common.MapStr{
+			"direction": "external",
+		}
+
+		observed, err := p.Run(&evt)
+		require.NoError(t, err)
+		require.Equal(t, expectedMeta, observed.Meta)
+		require.Equal(t, evt.Fields, observed.Fields)
+	})
 }

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -168,4 +168,35 @@ func TestCopyFields(t *testing.T) {
 			assert.Equal(t, test.Expected, newEvent.Fields)
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		p := copyFields{
+			copyFieldsConfig{
+				Fields: []fromTo{
+					{
+						From: "@metadata.message",
+						To:   "@metadata.message_copied",
+					},
+				},
+			},
+			log,
+		}
+
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"message": "please copy this line",
+			},
+		}
+
+		expMeta := common.MapStr{
+			"message":        "please copy this line",
+			"message_copied": "please copy this line",
+		}
+
+		newEvent, err := p.Run(event)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
 }

--- a/libbeat/processors/actions/decode_base64_field.go
+++ b/libbeat/processors/actions/decode_base64_field.go
@@ -74,10 +74,10 @@ func NewDecodeBase64Field(c *common.Config) (processors.Processor, error) {
 }
 
 func (f *decodeBase64Field) Run(event *beat.Event) (*beat.Event, error) {
-	var backup common.MapStr
+	var backup *beat.Event
 	// Creates a copy of the event to revert in case of failure
 	if f.config.FailOnError {
-		backup = event.Fields.Clone()
+		backup = event.Clone()
 	}
 
 	err := f.decodeField(event)
@@ -85,7 +85,7 @@ func (f *decodeBase64Field) Run(event *beat.Event) (*beat.Event, error) {
 		errMsg := fmt.Errorf("failed to decode base64 fields in processor: %v", err)
 		f.log.Debug(errMsg.Error())
 		if f.config.FailOnError {
-			event.Fields = backup
+			event = backup
 			event.PutValue("error.message", errMsg.Error())
 			return event, err
 		}

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -221,4 +221,37 @@ func TestDecodeBase64Run(t *testing.T) {
 			assert.Equal(t, test.Output, newEvent.Fields)
 		})
 	}
+
+	t.Run("supports a metadata field", func(t *testing.T) {
+		config := base64Config{
+			Field: fromTo{
+				From: "field1",
+				To:   "@metadata.field",
+			},
+		}
+
+		event := &beat.Event{
+			Meta: common.MapStr{},
+			Fields: common.MapStr{
+				"field1": "Y29ycmVjdCBkYXRh",
+			},
+		}
+
+		f := &decodeBase64Field{
+			log:    logp.NewLogger(processorName),
+			config: config,
+		}
+
+		expectedFields := common.MapStr{
+			"field1": "Y29ycmVjdCBkYXRh",
+		}
+		expectedMeta := common.MapStr{
+			"field": "correct data",
+		}
+
+		newEvent, err := f.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedFields, newEvent.Fields)
+		assert.Equal(t, expectedMeta, newEvent.Meta)
+	})
 }

--- a/libbeat/processors/actions/decompress_gzip_field.go
+++ b/libbeat/processors/actions/decompress_gzip_field.go
@@ -67,9 +67,9 @@ func NewDecompressGzipFields(c *common.Config) (processors.Processor, error) {
 
 // Run applies the decompress_gzip_fields processor to an event.
 func (f *decompressGzipField) Run(event *beat.Event) (*beat.Event, error) {
-	var backup common.MapStr
+	var backup *beat.Event
 	if f.config.FailOnError {
-		backup = event.Fields.Clone()
+		backup = event.Clone()
 	}
 
 	err := f.decompressGzipField(event)
@@ -77,7 +77,7 @@ func (f *decompressGzipField) Run(event *beat.Event) (*beat.Event, error) {
 		errMsg := fmt.Errorf("Failed to decompress field in decompress_gzip_field processor: %v", err)
 		f.log.Debug(errMsg.Error())
 		if f.config.FailOnError {
-			event.Fields = backup
+			event = backup
 			event.PutValue("error.message", errMsg.Error())
 			return event, err
 		}

--- a/libbeat/processors/actions/detect_mime_type.go
+++ b/libbeat/processors/actions/detect_mime_type.go
@@ -54,7 +54,7 @@ func NewDetectMimeType(cfg *common.Config) (processors.Processor, error) {
 func (m *mimeTypeProcessor) Run(event *beat.Event) (*beat.Event, error) {
 	valI, err := event.GetValue(m.Field)
 	if err != nil {
-		// doesn't have the required fieldd value to analyze
+		// doesn't have the required field value to analyze
 		return event, nil
 	}
 	val, _ := valI.(string)
@@ -63,11 +63,9 @@ func (m *mimeTypeProcessor) Run(event *beat.Event) (*beat.Event, error) {
 		return event, nil
 	}
 	if mimeType := mime.Detect(val); mimeType != "" {
-		event.Fields.DeepUpdate(common.MapStr{
-			m.Target: mimeType,
-		})
+		_, err = event.PutValue(m.Target, mimeType)
 	}
-	return event, nil
+	return event, err
 }
 
 func (m *mimeTypeProcessor) String() string {

--- a/libbeat/processors/actions/detect_mime_type_test.go
+++ b/libbeat/processors/actions/detect_mime_type_test.go
@@ -44,6 +44,28 @@ func TestMimeTypeFromTo(t *testing.T) {
 	require.Equal(t, "text/plain; charset=utf-8", enriched)
 }
 
+func TestMimeTypeFromToMetadata(t *testing.T) {
+	evt := beat.Event{
+		Meta: common.MapStr{},
+		Fields: common.MapStr{
+			"foo.bar.baz": "hello world!",
+		},
+	}
+	expectedMeta := common.MapStr{
+		"field": "text/plain; charset=utf-8",
+	}
+	p, err := NewDetectMimeType(common.MustNewConfigFrom(map[string]interface{}{
+		"field":  "foo.bar.baz",
+		"target": "@metadata.field",
+	}))
+	require.NoError(t, err)
+
+	observed, err := p.Run(&evt)
+	require.NoError(t, err)
+	require.Equal(t, expectedMeta, observed.Meta)
+	require.Equal(t, evt.Fields, observed.Fields)
+}
+
 func TestMimeTypeTestNoMatch(t *testing.T) {
 	evt := beat.Event{
 		Fields: common.MapStr{

--- a/libbeat/processors/actions/docs/add_fields.asciidoc
+++ b/libbeat/processors/actions/docs/add_fields.asciidoc
@@ -6,14 +6,14 @@
 ++++
 
 The `add_fields` processor adds additional fields to the event.  Fields can be
-scalar values, arrays, dictionaries, or any nested combination of these. 
-The `add_fields` processor will overwrite the target field if it already exists. 
+scalar values, arrays, dictionaries, or any nested combination of these.
+The `add_fields` processor will overwrite the target field if it already exists.
 By default the fields that you specify will be grouped under the `fields`
 sub-dictionary in the event. To group the fields under a different
 sub-dictionary, use the `target` setting. To store the fields as
 top-level fields, set `target: ''`.
 
-`target`:: (Optional) Sub-dictionary to put all fields into. Defaults to `fields`.
+`target`:: (Optional) Sub-dictionary to put all fields into. Defaults to `fields`. Setting this to `@metadata` will add values to the event metadata instead of fields.
 `fields`:: Fields to be added.
 
 
@@ -40,3 +40,16 @@ Adds these fields to any event:
   }
 }
 -------------------------------------------------------------------------------
+
+This configuration will alter the event metadata:
+
+[source,yaml]
+------------------------------------------------------------------------------
+processors:
+  - add_fields:
+      target: '@metadata'
+      fields:
+        op_type: "index"
+------------------------------------------------------------------------------
+
+When the event is ingested (e.g. by Elastisearch) the document will have `op_type: "index"` set as a metadata field.

--- a/libbeat/processors/actions/docs/add_tags.asciidoc
+++ b/libbeat/processors/actions/docs/add_tags.asciidoc
@@ -9,7 +9,7 @@ The `add_tags` processor adds tags to a list of tags. If the target field alread
 the tags are appended to the existing list of tags.
 
 `tags`:: List of tags to add.
-`target`:: (Optional) Field the tags will be added to. Defaults to `tags`.
+`target`:: (Optional) Field the tags will be added to. Defaults to `tags`. Setting tags in `@metadata` is not supported.
 
 For example, this configuration:
 

--- a/libbeat/processors/actions/docs/copy_fields.asciidoc
+++ b/libbeat/processors/actions/docs/copy_fields.asciidoc
@@ -7,7 +7,7 @@
 
 The `copy_fields` processor copies a field to another one.
 
-`fields`:: List of `from` and `to` pairs to copy from and to.
+`fields`:: List of `from` and `to` pairs to copy from and to. It's supported to use `@metadata.` prefix for `from` and `to` and copy values not just in/from/to the event fields but also in/from/to the event metadata.
 `fail_on_error`:: (Optional) If set to `true` and an error occurs, the changes are reverted and the original is returned. If set to `false`,
 processing continues if an error occurs. Default is `true`.
 `ignore_missing`:: (Optional) Indicates whether to ignore events that lack the source

--- a/libbeat/processors/actions/docs/detect_mime_type.asciidoc
+++ b/libbeat/processors/actions/docs/detect_mime_type.asciidoc
@@ -7,7 +7,7 @@
 
 The `detect_mime_type` processor attempts to detect a mime type for a field that
 contains a given stream of bytes. The `field` key contains the field used as
-the data source and the `target` key contains the field to populate with the detected type
+the data source and the `target` key contains the field to populate with the detected type. It's supported to use `@metadata.` prefix for `target` and set the value in the event metadata instead of fields.
 
 [source,yaml]
 -------

--- a/libbeat/processors/actions/docs/include_fields.asciidoc
+++ b/libbeat/processors/actions/docs/include_fields.asciidoc
@@ -7,7 +7,7 @@
 
 The `include_fields` processor specifies which fields to export if a certain
 condition is fulfilled. The condition is optional. If it's missing, the
-specified fields are always exported. The `@timestamp` and `type` fields are
+specified fields are always exported. The `@timestamp`, `@metadata` and `type` fields are
 always exported, even if they are not defined in the `include_fields` list.
 
 [source,yaml]

--- a/libbeat/processors/actions/docs/rename.asciidoc
+++ b/libbeat/processors/actions/docs/rename.asciidoc
@@ -8,7 +8,7 @@
 The `rename` processor specifies a list of fields to rename. Under the `fields`
 key, each entry contains a `from: old-key` and a `to: new-key` pair, where:
 
-* `from` is the original field name
+* `from` is the original field name. It's supported to use `@metadata.` prefix for `from` and rename keys in the event metadata instead of event fields.
 * `to` is the target field name
 
 The `rename` processor cannot be used to overwrite fields. To overwrite fields

--- a/libbeat/processors/actions/docs/replace.asciidoc
+++ b/libbeat/processors/actions/docs/replace.asciidoc
@@ -5,16 +5,16 @@
 <titleabbrev>replace</titleabbrev>
 ++++
 
-The `replace` processor takes a list of fields to replace the field value 
-matching a pattern with replacement string. Under the `fields` key, each entry 
-contains a `field: field-name`, `pattern: regex-pattern` and 
+The `replace` processor takes a list of fields to replace the field value
+matching a pattern with replacement string. Under the `fields` key, each entry
+contains a `field: field-name`, `pattern: regex-pattern` and
 `replacement: replacement-string`, where:
 
-* `field` is the original field name
+* `field` is the original field name. It's supported to use `@metadata.` prefix for the fields and replace values in the event metadata instead of event fields.
 * `pattern` is the regex pattern to match the field's value
 * `replacement` is the replacement string to use to update the field's value
 
-The `replace` processor cannot be used to replace value with a completely new value. 
+The `replace` processor cannot be used to replace value with a completely new value.
 
 TIP: The `replacement` field value can be used to truncate the `field` value or replace
 it with a new string. It can also be used for masking PII information.
@@ -35,7 +35,7 @@ processors:
 
 The `replace` processor has following configuration settings:
 
-`ignore_missing`:: (Optional) If set to `true`, no error is logged if the specified field 
+`ignore_missing`:: (Optional) If set to `true`, no error is logged if the specified field
 is missing. The default is `false`.
 
 `fail_on_error`:: (Optional) If set to `true` and there's an error, the replacement of

--- a/libbeat/processors/actions/docs/truncate_fields.asciidoc
+++ b/libbeat/processors/actions/docs/truncate_fields.asciidoc
@@ -8,7 +8,7 @@
 The `truncate_fields` processor truncates a field to a given size. If the size of the field is smaller than
 the limit, the field is left as is.
 
-`fields`:: List of fields to truncate.
+`fields`:: List of fields to truncate. It's supported to use `@metadata.` prefix for the fields and truncate values in the event metadata instead of event fields.
 `max_bytes`:: Maximum number of bytes in a field. Mutually exclusive with `max_characters`.
 `max_characters`:: Maximum number of characters in a field. Mutually exclusive with `max_bytes`.
 `fail_on_error`:: (Optional) If set to true, in case of an error the changes to

--- a/libbeat/processors/actions/drop_fields_test.go
+++ b/libbeat/processors/actions/drop_fields_test.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestDropFieldRun(t *testing.T) {
+	event := &beat.Event{
+		Fields: common.MapStr{
+			"field": "value",
+		},
+		Meta: common.MapStr{
+			"meta_field": "value",
+		},
+	}
+
+	t.Run("supports a normal field", func(t *testing.T) {
+		p := dropFields{
+			Fields: []string{"field"},
+		}
+
+		newEvent, err := p.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, common.MapStr{}, newEvent.Fields)
+		assert.Equal(t, event.Meta, newEvent.Meta)
+	})
+
+	t.Run("supports a metadata field", func(t *testing.T) {
+		p := dropFields{
+			Fields: []string{"@metadata.meta_field"},
+		}
+
+		newEvent, err := p.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, common.MapStr{}, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
+}

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -366,4 +366,32 @@ func TestRenameField(t *testing.T) {
 			assert.True(t, reflect.DeepEqual(test.Input, test.Output))
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"a": "c",
+			},
+		}
+
+		expMeta := common.MapStr{
+			"b": "c",
+		}
+
+		f := &renameFields{
+			config: renameFieldsConfig{
+				Fields: []fromTo{
+					{
+						From: "@metadata.a",
+						To:   "@metadata.b",
+					},
+				},
+			},
+		}
+
+		newEvent, err := f.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
 }

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -358,7 +358,7 @@ func TestRenameField(t *testing.T) {
 				},
 			}
 
-			err := f.renameField(test.From, test.To, test.Input)
+			err := f.renameField(test.From, test.To, &beat.Event{Fields: test.Input})
 			if err != nil {
 				assert.Equal(t, test.error, true)
 			}

--- a/libbeat/processors/actions/replace_test.go
+++ b/libbeat/processors/actions/replace_test.go
@@ -245,4 +245,33 @@ func TestReplaceField(t *testing.T) {
 			assert.True(t, reflect.DeepEqual(test.Input, test.Output))
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"f": "abc",
+			},
+		}
+
+		expectedMeta := common.MapStr{
+			"f": "bbc",
+		}
+
+		f := &replaceString{
+			config: replaceStringConfig{
+				Fields: []replaceConfig{
+					{
+						Field:       "@metadata.f",
+						Pattern:     regexp.MustCompile(`a`),
+						Replacement: "b",
+					},
+				},
+			},
+		}
+
+		newEvent, err := f.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedMeta, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
 }

--- a/libbeat/processors/actions/replace_test.go
+++ b/libbeat/processors/actions/replace_test.go
@@ -237,7 +237,7 @@ func TestReplaceField(t *testing.T) {
 				},
 			}
 
-			err := f.replaceField(test.Field, test.Pattern, test.Replacement, test.Input)
+			err := f.replaceField(test.Field, test.Pattern, test.Replacement, &beat.Event{Fields: test.Input})
 			if err != nil {
 				assert.Equal(t, test.error, true)
 			}

--- a/libbeat/processors/actions/truncate_fields.go
+++ b/libbeat/processors/actions/truncate_fields.go
@@ -82,9 +82,9 @@ func NewTruncateFields(c *common.Config) (processors.Processor, error) {
 }
 
 func (f *truncateFields) Run(event *beat.Event) (*beat.Event, error) {
-	var backup common.MapStr
+	var backup *beat.Event
 	if f.config.FailOnError {
-		backup = event.Fields.Clone()
+		backup = event.Clone()
 	}
 
 	for _, field := range f.config.Fields {
@@ -92,7 +92,7 @@ func (f *truncateFields) Run(event *beat.Event) (*beat.Event, error) {
 		if err != nil {
 			f.logger.Debugf("Failed to truncate fields: %s", err)
 			if f.config.FailOnError {
-				event.Fields = backup
+				event = backup
 				return event, err
 			}
 		}

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -132,8 +132,6 @@ func lazyCgroupCacheInit(d *addDockerMetadata) {
 	}
 }
 
-// Run runs the processor that adds container-related fields to the event
-// This processor does not modify any `Meta` fields in the event, it accesses and modifies `event.Fields` directly
 func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	if !d.dockerAvailable {
 		return event, nil
@@ -151,7 +149,7 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 				return event, nil
 			}
 
-			if v, err := event.Fields.GetValue(dockerContainerIDKey); err == nil {
+			if v, err := event.GetValue(dockerContainerIDKey); err == nil {
 				cid, _ = v.(string)
 			}
 		}
@@ -165,14 +163,14 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 		}
 		if id != "" {
 			cid = id
-			event.Fields.Put(dockerContainerIDKey, cid)
+			event.PutValue(dockerContainerIDKey, cid)
 		}
 	}
 
 	// Lookup CID from the user defined field names.
 	if cid == "" && len(d.fields) > 0 {
 		for _, field := range d.fields {
-			value, err := event.Fields.GetValue(field)
+			value, err := event.GetValue(field)
 			if err != nil {
 				continue
 			}

--- a/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -132,6 +132,8 @@ func lazyCgroupCacheInit(d *addDockerMetadata) {
 	}
 }
 
+// Run runs the processor that adds container-related fields to the event
+// This processor does not modify any `Meta` fields in the event, it accesses and modifies `event.Fields` directly
 func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	if !d.dockerAvailable {
 		return event, nil
@@ -149,7 +151,7 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 				return event, nil
 			}
 
-			if v, err := event.GetValue(dockerContainerIDKey); err == nil {
+			if v, err := event.Fields.GetValue(dockerContainerIDKey); err == nil {
 				cid, _ = v.(string)
 			}
 		}
@@ -163,14 +165,14 @@ func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 		}
 		if id != "" {
 			cid = id
-			event.PutValue(dockerContainerIDKey, cid)
+			event.Fields.Put(dockerContainerIDKey, cid)
 		}
 	}
 
 	// Lookup CID from the user defined field names.
 	if cid == "" && len(d.fields) > 0 {
 		for _, field := range d.fields {
-			value, err := event.GetValue(field)
+			value, err := event.Fields.GetValue(field)
 			if err != nil {
 				continue
 			}

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -80,6 +80,8 @@ func New(cfg *common.Config) (processors.Processor, error) {
 }
 
 // Run enriches the given event with the host meta data
+// This processor does not access or modify `Meta` of the event and
+// sets only pre-defined field names
 func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	// check replace_host_fields field
 	if !p.config.ReplaceFields && skipAddingHostMetadata(event) {

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -80,8 +80,6 @@ func New(cfg *common.Config) (processors.Processor, error) {
 }
 
 // Run enriches the given event with the host meta data
-// This processor does not access or modify `Meta` of the event and
-// sets only pre-defined field names
 func (p *addHostMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	// check replace_host_fields field
 	if !p.config.ReplaceFields && skipAddingHostMetadata(event) {

--- a/libbeat/processors/add_id/add_id_test.go
+++ b/libbeat/processors/add_id/add_id_test.go
@@ -63,3 +63,25 @@ func TestNonDefaultTargetField(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, v)
 }
+
+func TestNonDefaultMetadataTarget(t *testing.T) {
+	cfg := common.MustNewConfigFrom(common.MapStr{
+		"target_field": "@metadata.foo",
+	})
+	p, err := New(cfg)
+	assert.NoError(t, err)
+
+	testEvent := &beat.Event{
+		Meta: common.MapStr{},
+	}
+
+	newEvent, err := p.Run(testEvent)
+	assert.NoError(t, err)
+
+	v, err := newEvent.Meta.GetValue("foo")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, v)
+
+	v, err = newEvent.GetValue("@metadata._id")
+	assert.Error(t, err)
+}

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -90,8 +90,8 @@ func isKubernetesAvailableWithRetry(client k8sclient.Interface) bool {
 }
 
 // kubernetesMetadataExist checks whether an event is already enriched with kubernetes metadata
-func kubernetesMetadataExist(eventFields common.MapStr) bool {
-	if _, err := eventFields.GetValue("kubernetes"); err != nil {
+func kubernetesMetadataExist(event *beat.Event) bool {
+	if _, err := event.GetValue("kubernetes"); err != nil {
 		return false
 	}
 	return true
@@ -261,7 +261,7 @@ func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 	if !k.kubernetesAvailable {
 		return event, nil
 	}
-	if kubernetesMetadataExist(event.Fields) {
+	if kubernetesMetadataExist(event) {
 		k.log.Debug("Skipping add_kubernetes_metadata processor as kubernetes metadata already exist")
 		return event, nil
 	}

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -90,8 +90,8 @@ func isKubernetesAvailableWithRetry(client k8sclient.Interface) bool {
 }
 
 // kubernetesMetadataExist checks whether an event is already enriched with kubernetes metadata
-func kubernetesMetadataExist(event *beat.Event) bool {
-	if _, err := event.GetValue("kubernetes"); err != nil {
+func kubernetesMetadataExist(eventFields common.MapStr) bool {
+	if _, err := eventFields.GetValue("kubernetes"); err != nil {
 		return false
 	}
 	return true
@@ -254,11 +254,14 @@ func (k *kubernetesAnnotator) init(config kubeAnnotatorConfig, cfg *common.Confi
 	})
 }
 
+// Run runs the processor that adds a field `kubernetes` to the event fields that
+// contains a map with various Kubernetes metadata.
+// This processor does not access or modify the `Meta` of the event.
 func (k *kubernetesAnnotator) Run(event *beat.Event) (*beat.Event, error) {
 	if !k.kubernetesAvailable {
 		return event, nil
 	}
-	if kubernetesMetadataExist(event) {
+	if kubernetesMetadataExist(event.Fields) {
 		k.log.Debug("Skipping add_kubernetes_metadata processor as kubernetes metadata already exist")
 		return event, nil
 	}

--- a/libbeat/processors/add_kubernetes_metadata/matchers.go
+++ b/libbeat/processors/add_kubernetes_metadata/matchers.go
@@ -73,9 +73,9 @@ func NewMatchers(configs PluginConfig) *Matchers {
 }
 
 // MetadataIndex returns the index string for the first matcher from the Registry returning one
-func (m *Matchers) MetadataIndex(eventFields common.MapStr) string {
+func (m *Matchers) MetadataIndex(event common.MapStr) string {
 	for _, matcher := range m.matchers {
-		index := matcher.MetadataIndex(eventFields)
+		index := matcher.MetadataIndex(event)
 		if index != "" {
 			return index
 		}

--- a/libbeat/processors/add_kubernetes_metadata/matchers.go
+++ b/libbeat/processors/add_kubernetes_metadata/matchers.go
@@ -73,9 +73,9 @@ func NewMatchers(configs PluginConfig) *Matchers {
 }
 
 // MetadataIndex returns the index string for the first matcher from the Registry returning one
-func (m *Matchers) MetadataIndex(event common.MapStr) string {
+func (m *Matchers) MetadataIndex(eventFields common.MapStr) string {
 	for _, matcher := range m.matchers {
-		index := matcher.MetadataIndex(event)
+		index := matcher.MetadataIndex(eventFields)
 		if index != "" {
 			return index
 		}

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -89,7 +89,7 @@ func New(c *common.Config) (processors.Processor, error) {
 func (l addLocale) Run(event *beat.Event) (*beat.Event, error) {
 	zone, offset := time.Now().Zone()
 	format := l.Format(zone, offset)
-	event.Fields.Put("event.timezone", format)
+	event.PutValue("event.timezone", format)
 	return event, nil
 }
 

--- a/libbeat/processors/add_locale/add_locale.go
+++ b/libbeat/processors/add_locale/add_locale.go
@@ -89,7 +89,7 @@ func New(c *common.Config) (processors.Processor, error) {
 func (l addLocale) Run(event *beat.Event) (*beat.Event, error) {
 	zone, offset := time.Now().Zone()
 	format := l.Format(zone, offset)
-	event.PutValue("event.timezone", format)
+	event.Fields.Put("event.timezone", format)
 	return event, nil
 }
 

--- a/libbeat/processors/communityid/communityid_test.go
+++ b/libbeat/processors/communityid/communityid_test.go
@@ -147,6 +147,26 @@ func TestRun(t *testing.T) {
 		e.Put("network.iana_number", tcpProtocol)
 		testProcessor(t, 0, e, "1:LQU9qZlK+B5F3KDmev6m5PMibrg=")
 	})
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		event := &beat.Event{
+			Fields: evt(),
+			Meta:   common.MapStr{},
+		}
+		c := defaultConfig()
+		c.Target = "@metadata.community_id"
+		c.Seed = 0
+		p, err := newFromConfig(c)
+		assert.NoError(t, err)
+
+		out, err := p.Run(event)
+		assert.NoError(t, err)
+
+		id, err := out.Meta.GetValue("community_id")
+		assert.NoError(t, err)
+
+		assert.EqualValues(t, "1:LQU9qZlK+B5F3KDmev6m5PMibrg=", id)
+	})
 }
 
 func testProcessor(t testing.TB, seed uint16, fields common.MapStr, expectedHash interface{}) {

--- a/libbeat/processors/convert/convert.go
+++ b/libbeat/processors/convert/convert.go
@@ -80,19 +80,19 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 	}
 
 	// Backup original event.
-	saved := *event
+	saved := event
+
 	if len(p.Fields) > 1 && p.FailOnError {
 		// Clone the fields to allow the processor to undo the operation on
 		// failure (like a transaction). If there is only one conversion then
 		// cloning is unnecessary because there are no previous changes to
 		// rollback (so avoid the expensive clone operation).
-		saved.Fields = event.Fields.Clone()
-		saved.Meta = event.Meta.Clone()
+		saved = event.Clone()
 	}
 
 	// Update the event with the converted values.
 	if err := p.writeToEvent(event, converted); err != nil {
-		return &saved, err
+		return saved, err
 	}
 
 	return event, nil

--- a/libbeat/processors/convert/convert_test.go
+++ b/libbeat/processors/convert/convert_test.go
@@ -146,6 +146,30 @@ func TestConvert(t *testing.T) {
 			`"Tag":"convert_ip","IgnoreMissing":false,"FailOnError":true,"Mode":"copy"}`,
 			p.String())
 	})
+
+	t.Run("metadata as a target", func(t *testing.T) {
+		c := defaultConfig()
+		c.Tag = "convert_ip"
+		c.Fields = append(c.Fields, field{From: "@metadata.source", To: "@metadata.dest", Type: Integer})
+
+		evt := &beat.Event{
+			Meta: common.MapStr{
+				"source": "1",
+			},
+		}
+		expMeta := common.MapStr{
+			"source": "1",
+			"dest":   int32(1),
+		}
+
+		p, err := newConvert(c)
+		assert.NoError(t, err)
+
+		newEvt, err := p.Run(evt)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvt.Meta)
+		assert.Equal(t, evt.Fields, newEvt.Fields)
+	})
 }
 
 func TestConvertRun(t *testing.T) {

--- a/libbeat/processors/decode_csv_fields/decode_csv_fields.go
+++ b/libbeat/processors/decode_csv_fields/decode_csv_fields.go
@@ -100,14 +100,13 @@ func NewDecodeCSVField(c *common.Config) (processors.Processor, error) {
 
 // Run applies the decode_csv_field processor to an event.
 func (f *decodeCSVFields) Run(event *beat.Event) (*beat.Event, error) {
-	saved := *event
+	var saved *beat.Event
 	if f.FailOnError {
-		saved.Fields = event.Fields.Clone()
-		saved.Meta = event.Meta.Clone()
+		saved = event.Clone()
 	}
 	for src, dest := range f.fields {
 		if err := f.decodeCSVField(src, dest, event); err != nil && f.FailOnError {
-			return &saved, err
+			return saved, err
 		}
 	}
 	return event, nil

--- a/libbeat/processors/decode_csv_fields/decode_csv_fields_test.go
+++ b/libbeat/processors/decode_csv_fields/decode_csv_fields_test.go
@@ -338,6 +338,37 @@ func TestDecodeCSVField(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		config := common.MapStr{
+			"fields": common.MapStr{
+				"@metadata": common.MapStr{
+					"field": "@metadata.message",
+				},
+			},
+		}
+
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"field": "17,192.168.33.1,8.8.8.8",
+			},
+			Fields: common.MapStr{},
+		}
+		expMeta := common.MapStr{
+			"field":   "17,192.168.33.1,8.8.8.8",
+			"message": []string{"17", "192.168.33.1", "8.8.8.8"},
+		}
+
+		processor, err := NewDecodeCSVField(common.MustNewConfigFrom(config))
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := processor.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, result.Meta)
+		assert.Equal(t, event.Fields, result.Fields)
+	})
+
 }
 
 func TestDecodeCSVField_String(t *testing.T) {

--- a/libbeat/processors/decode_xml/decode_xml_test.go
+++ b/libbeat/processors/decode_xml/decode_xml_test.go
@@ -402,6 +402,54 @@ func TestDecodeXML(t *testing.T) {
 			assert.Equal(t, test.Output, newEvent.Fields)
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		t.Parallel()
+		target := "@metadata.xml"
+		config := decodeXMLConfig{
+			Field:  "@metadata.message",
+			Target: &target,
+		}
+
+		f, err := newDecodeXML(config)
+		require.NoError(t, err)
+
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"message": `<catalog>
+					<book seq="1">
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+				</catalog>`,
+			},
+		}
+		expMeta := common.MapStr{
+			"xml": common.MapStr{
+				"catalog": map[string]interface{}{
+					"book": map[string]interface{}{
+						"author": "William H. Gaddis",
+						"review": "One of the great seminal American novels of the 20th century.",
+						"seq":    "1",
+						"title":  "The Recognitions",
+					},
+				},
+			},
+			"message": `<catalog>
+					<book seq="1">
+						<author>William H. Gaddis</author>
+						<title>The Recognitions</title>
+						<review>One of the great seminal American novels of the 20th century.</review>
+					</book>
+				</catalog>`,
+		}
+
+		newEvent, err := f.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
 }
 
 func BenchmarkProcessor_Run(b *testing.B) {

--- a/libbeat/processors/decode_xml_wineventlog/processor_test.go
+++ b/libbeat/processors/decode_xml_wineventlog/processor_test.go
@@ -28,6 +28,68 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
+var testMessage = "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/>" +
+	"<EventID>4672</EventID><Version>0</Version><Level>0</Level><Task>12548</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2021-03-23T09:56:13.137310000Z'/>" +
+	"<EventRecordID>11303</EventRecordID><Correlation ActivityID='{ffb23523-1f32-0000-c335-b2ff321fd701}'/><Execution ProcessID='652' ThreadID='4660'/><Channel>Security</Channel><Computer>vagrant</Computer>" +
+	"<Security/></System><EventData><Data Name='SubjectUserSid'>S-1-5-18</Data><Data Name='SubjectUserName'>SYSTEM</Data><Data Name='SubjectDomainName'>NT AUTHORITY</Data><Data Name='SubjectLogonId'>0x3e7</Data>" +
+	"<Data Name='PrivilegeList'>SeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\t" +
+	"SeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Data></EventData>" +
+	"<RenderingInfo Culture='en-US'><Message>Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\n" +
+	"Privileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\t" +
+	"SeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Message><Level>Information</Level>" +
+	"<Task>Special Logon</Task><Opcode>Info</Opcode><Channel>Security</Channel><Provider>Microsoft Windows security auditing.</Provider><Keywords><Keyword>Audit Success</Keyword></Keywords></RenderingInfo></Event>"
+
+var testMessageOutput = common.MapStr{
+	"event": common.MapStr{
+		"action":   "Special Logon",
+		"code":     "4672",
+		"kind":     "event",
+		"outcome":  "success",
+		"provider": "Microsoft-Windows-Security-Auditing",
+	},
+	"host": common.MapStr{
+		"name": "vagrant",
+	},
+	"log": common.MapStr{
+		"level": "information",
+	},
+	"winlog": common.MapStr{
+		"channel":       "Security",
+		"outcome":       "success",
+		"activity_id":   "{ffb23523-1f32-0000-c335-b2ff321fd701}",
+		"level":         "information",
+		"event_id":      "4672",
+		"provider_name": "Microsoft-Windows-Security-Auditing",
+		"record_id":     uint64(11303),
+		"computer_name": "vagrant",
+		"time_created": func() time.Time {
+			t, _ := time.Parse(time.RFC3339Nano, "2021-03-23T09:56:13.137310000Z")
+			return t
+		}(),
+		"opcode":        "Info",
+		"provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+		"event_data": common.MapStr{
+			"SubjectUserSid":    "S-1-5-18",
+			"SubjectUserName":   "SYSTEM",
+			"SubjectDomainName": "NT AUTHORITY",
+			"SubjectLogonId":    "0x3e7",
+			"PrivilegeList":     "SeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
+		},
+		"task": "Special Logon",
+		"keywords": []string{
+			"Audit Success",
+		},
+		"message": "Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\nPrivileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
+		"process": common.MapStr{
+			"pid": uint32(652),
+			"thread": common.MapStr{
+				"id": uint32(4660),
+			},
+		},
+	},
+	"message": "Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\nPrivileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
+}
+
 func TestProcessor(t *testing.T) {
 	var testCases = []struct {
 		description  string
@@ -41,67 +103,9 @@ func TestProcessor(t *testing.T) {
 			description: "Decodes properly with default config",
 			config:      defaultConfig(),
 			Input: common.MapStr{
-				"message": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/>" +
-					"<EventID>4672</EventID><Version>0</Version><Level>0</Level><Task>12548</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2021-03-23T09:56:13.137310000Z'/>" +
-					"<EventRecordID>11303</EventRecordID><Correlation ActivityID='{ffb23523-1f32-0000-c335-b2ff321fd701}'/><Execution ProcessID='652' ThreadID='4660'/><Channel>Security</Channel><Computer>vagrant</Computer>" +
-					"<Security/></System><EventData><Data Name='SubjectUserSid'>S-1-5-18</Data><Data Name='SubjectUserName'>SYSTEM</Data><Data Name='SubjectDomainName'>NT AUTHORITY</Data><Data Name='SubjectLogonId'>0x3e7</Data>" +
-					"<Data Name='PrivilegeList'>SeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\t" +
-					"SeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Data></EventData>" +
-					"<RenderingInfo Culture='en-US'><Message>Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\n" +
-					"Privileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\t" +
-					"SeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Message><Level>Information</Level>" +
-					"<Task>Special Logon</Task><Opcode>Info</Opcode><Channel>Security</Channel><Provider>Microsoft Windows security auditing.</Provider><Keywords><Keyword>Audit Success</Keyword></Keywords></RenderingInfo></Event>",
+				"message": testMessage,
 			},
-			Output: common.MapStr{
-				"event": common.MapStr{
-					"action":   "Special Logon",
-					"code":     "4672",
-					"kind":     "event",
-					"outcome":  "success",
-					"provider": "Microsoft-Windows-Security-Auditing",
-				},
-				"host": common.MapStr{
-					"name": "vagrant",
-				},
-				"log": common.MapStr{
-					"level": "information",
-				},
-				"winlog": common.MapStr{
-					"channel":       "Security",
-					"outcome":       "success",
-					"activity_id":   "{ffb23523-1f32-0000-c335-b2ff321fd701}",
-					"level":         "information",
-					"event_id":      "4672",
-					"provider_name": "Microsoft-Windows-Security-Auditing",
-					"record_id":     uint64(11303),
-					"computer_name": "vagrant",
-					"time_created": func() time.Time {
-						t, _ := time.Parse(time.RFC3339Nano, "2021-03-23T09:56:13.137310000Z")
-						return t
-					}(),
-					"opcode":        "Info",
-					"provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
-					"event_data": common.MapStr{
-						"SubjectUserSid":    "S-1-5-18",
-						"SubjectUserName":   "SYSTEM",
-						"SubjectDomainName": "NT AUTHORITY",
-						"SubjectLogonId":    "0x3e7",
-						"PrivilegeList":     "SeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
-					},
-					"task": "Special Logon",
-					"keywords": []string{
-						"Audit Success",
-					},
-					"message": "Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\nPrivileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
-					"process": common.MapStr{
-						"pid": uint32(652),
-						"thread": common.MapStr{
-							"id": uint32(4660),
-						},
-					},
-				},
-				"message": "Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\nPrivileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
-			},
+			Output: testMessageOutput,
 		},
 		{
 			description: "Decodes without ECS",
@@ -112,62 +116,11 @@ func TestProcessor(t *testing.T) {
 				Target:        "winlog",
 			},
 			Input: common.MapStr{
-				"message": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/>" +
-					"<EventID>4672</EventID><Version>0</Version><Level>0</Level><Task>12548</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2021-03-23T09:56:13.137310000Z'/>" +
-					"<EventRecordID>11303</EventRecordID><Correlation ActivityID='{ffb23523-1f32-0000-c335-b2ff321fd701}'/><Execution ProcessID='652' ThreadID='4660'/><Channel>Security</Channel><Computer>vagrant</Computer>" +
-					"<Security/></System><EventData><Data Name='SubjectUserSid'>S-1-5-18</Data><Data Name='SubjectUserName'>SYSTEM</Data><Data Name='SubjectDomainName'>NT AUTHORITY</Data><Data Name='SubjectLogonId'>0x3e7</Data>" +
-					"<Data Name='PrivilegeList'>SeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\t" +
-					"SeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Data></EventData>" +
-					"<RenderingInfo Culture='en-US'><Message>Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\n" +
-					"Privileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\t" +
-					"SeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Message><Level>Information</Level>" +
-					"<Task>Special Logon</Task><Opcode>Info</Opcode><Channel>Security</Channel><Provider>Microsoft Windows security auditing.</Provider><Keywords><Keyword>Audit Success</Keyword></Keywords></RenderingInfo></Event>",
+				"message": testMessage,
 			},
 			Output: common.MapStr{
-				"winlog": common.MapStr{
-					"channel":       "Security",
-					"outcome":       "success",
-					"activity_id":   "{ffb23523-1f32-0000-c335-b2ff321fd701}",
-					"level":         "information",
-					"event_id":      "4672",
-					"provider_name": "Microsoft-Windows-Security-Auditing",
-					"record_id":     uint64(11303),
-					"computer_name": "vagrant",
-					"time_created": func() time.Time {
-						t, _ := time.Parse(time.RFC3339Nano, "2021-03-23T09:56:13.137310000Z")
-						return t
-					}(),
-					"opcode":        "Info",
-					"provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
-					"event_data": common.MapStr{
-						"SubjectUserSid":    "S-1-5-18",
-						"SubjectUserName":   "SYSTEM",
-						"SubjectDomainName": "NT AUTHORITY",
-						"SubjectLogonId":    "0x3e7",
-						"PrivilegeList":     "SeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
-					},
-					"task": "Special Logon",
-					"keywords": []string{
-						"Audit Success",
-					},
-					"message": "Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\nPrivileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege",
-					"process": common.MapStr{
-						"pid": uint32(652),
-						"thread": common.MapStr{
-							"id": uint32(4660),
-						},
-					},
-				},
-				"message": "<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'><System><Provider Name='Microsoft-Windows-Security-Auditing' Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}'/>" +
-					"<EventID>4672</EventID><Version>0</Version><Level>0</Level><Task>12548</Task><Opcode>0</Opcode><Keywords>0x8020000000000000</Keywords><TimeCreated SystemTime='2021-03-23T09:56:13.137310000Z'/>" +
-					"<EventRecordID>11303</EventRecordID><Correlation ActivityID='{ffb23523-1f32-0000-c335-b2ff321fd701}'/><Execution ProcessID='652' ThreadID='4660'/><Channel>Security</Channel><Computer>vagrant</Computer>" +
-					"<Security/></System><EventData><Data Name='SubjectUserSid'>S-1-5-18</Data><Data Name='SubjectUserName'>SYSTEM</Data><Data Name='SubjectDomainName'>NT AUTHORITY</Data><Data Name='SubjectLogonId'>0x3e7</Data>" +
-					"<Data Name='PrivilegeList'>SeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\t" +
-					"SeRestorePrivilege\n\t\t\tSeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Data></EventData>" +
-					"<RenderingInfo Culture='en-US'><Message>Special privileges assigned to new logon.\n\nSubject:\n\tSecurity ID:\t\tS-1-5-18\n\tAccount Name:\t\tSYSTEM\n\tAccount Domain:\t\tNT AUTHORITY\n\tLogon ID:\t\t0x3E7\n\n" +
-					"Privileges:\t\tSeAssignPrimaryTokenPrivilege\n\t\t\tSeTcbPrivilege\n\t\t\tSeSecurityPrivilege\n\t\t\tSeTakeOwnershipPrivilege\n\t\t\tSeLoadDriverPrivilege\n\t\t\tSeBackupPrivilege\n\t\t\tSeRestorePrivilege\n\t\t\t" +
-					"SeDebugPrivilege\n\t\t\tSeAuditPrivilege\n\t\t\tSeSystemEnvironmentPrivilege\n\t\t\tSeImpersonatePrivilege\n\t\t\tSeDelegateSessionUserImpersonatePrivilege</Message><Level>Information</Level>" +
-					"<Task>Special Logon</Task><Opcode>Info</Opcode><Channel>Security</Channel><Provider>Microsoft Windows security auditing.</Provider><Keywords><Keyword>Audit Success</Keyword></Keywords></RenderingInfo></Event>",
+				"winlog":  testMessageOutput["winlog"],
+				"message": testMessage,
 			},
 		},
 	}
@@ -194,4 +147,31 @@ func TestProcessor(t *testing.T) {
 			assert.Equal(t, test.Output, newEvent.Fields)
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		t.Parallel()
+
+		config := defaultConfig()
+		config.Field = "@metadata.message"
+		config.Target = "@metadata.target"
+
+		f, err := newProcessor(config)
+		require.NoError(t, err)
+
+		event := &beat.Event{
+			Fields: common.MapStr{},
+			Meta: common.MapStr{
+				"message": testMessage,
+			},
+		}
+
+		expMeta := common.MapStr{
+			"message": testMessage,
+			"target":  testMessageOutput["winlog"],
+		}
+		newEvent, err := f.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
 }

--- a/libbeat/processors/dissect/processor.go
+++ b/libbeat/processors/dissect/processor.go
@@ -104,21 +104,21 @@ func (p *processor) Run(event *beat.Event) (*beat.Event, error) {
 		return event, err
 	}
 
+	backup := event.Clone()
+
 	if convertDataType {
 		event, err = p.mapper(event, mapInterfaceToMapStr(mc))
 	} else {
 		event, err = p.mapper(event, mapToMapStr(m))
 	}
 	if err != nil {
-		return event, err
+		return backup, err
 	}
 
 	return event, nil
 }
 
 func (p *processor) mapper(event *beat.Event, m common.MapStr) (*beat.Event, error) {
-	copy := event.Fields.Clone()
-
 	prefix := ""
 	if p.config.TargetPrefix != "" {
 		prefix = p.config.TargetPrefix + "."
@@ -129,7 +129,6 @@ func (p *processor) mapper(event *beat.Event, m common.MapStr) (*beat.Event, err
 		if _, err := event.GetValue(prefixKey); err == common.ErrKeyNotFound || p.config.OverwriteKeys {
 			event.PutValue(prefixKey, v)
 		} else {
-			event.Fields = copy
 			// When the target key exists but is a string instead of a map.
 			if err != nil {
 				return event, errors.Wrapf(err, "cannot override existing key with `%s`", prefixKey)

--- a/libbeat/processors/dissect/processor_test.go
+++ b/libbeat/processors/dissect/processor_test.go
@@ -152,6 +152,34 @@ func TestProcessor(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		e := &beat.Event{
+			Meta: common.MapStr{
+				"message": "hello world",
+			},
+		}
+		expMeta := common.MapStr{
+			"message": "hello world",
+			"key":     "world",
+		}
+
+		c := map[string]interface{}{
+			"tokenizer":     "hello %{key}",
+			"field":         "@metadata.message",
+			"target_prefix": "@metadata",
+		}
+		cfg, err := common.NewConfigFrom(c)
+		assert.NoError(t, err)
+
+		processor, err := NewProcessor(cfg)
+		assert.NoError(t, err)
+
+		newEvent, err := processor.Run(e)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, e.Fields, newEvent.Fields)
+	})
 }
 
 func TestFieldDoesntExist(t *testing.T) {

--- a/libbeat/processors/dns/dns_test.go
+++ b/libbeat/processors/dns/dns_test.go
@@ -92,6 +92,36 @@ func TestDNSProcessorRun(t *testing.T) {
 		v, _ := event.GetValue("source.domain")
 		assert.Equal(t, gatewayName, v)
 	})
+
+	t.Run("metadata target", func(t *testing.T) {
+		config := defaultConfig
+		config.reverseFlat = map[string]string{
+			"@metadata.ip": "@metadata.domain",
+		}
+
+		p := &processor{
+			Config:   config,
+			resolver: &stubResolver{},
+			log:      logp.NewLogger(logName),
+		}
+
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"ip": gatewayIP,
+			},
+		}
+
+		expMeta := common.MapStr{
+			"ip":     gatewayIP,
+			"domain": gatewayName,
+		}
+
+		newEvent, err := p.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
+
 }
 
 func TestDNSProcessorTagOnFailure(t *testing.T) {

--- a/libbeat/processors/extract_array/extract_array_test.go
+++ b/libbeat/processors/extract_array/extract_array_test.go
@@ -267,4 +267,38 @@ func TestExtractArrayProcessor_Run(t *testing.T) {
 			t.Log(result)
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+
+		config := common.MapStr{
+			"field": "@metadata.array",
+			"mappings": common.MapStr{
+				"@metadata.first":  1,
+				"@metadata.second": 2,
+			},
+		}
+
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"array": []interface{}{"zero", 1, common.MapStr{"two": 2}},
+			},
+		}
+
+		expMeta := common.MapStr{
+			"array":  []interface{}{"zero", 1, common.MapStr{"two": 2}},
+			"first":  1,
+			"second": common.MapStr{"two": 2},
+		}
+
+		cfg := common.MustNewConfigFrom(config)
+		processor, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := processor.Run(event)
+		assert.NoError(t, err)
+
+		assert.Equal(t, expMeta, result.Meta)
+		assert.Equal(t, event.Fields, result.Fields)
+	})
 }

--- a/libbeat/processors/fingerprint/fingerprint_test.go
+++ b/libbeat/processors/fingerprint/fingerprint_test.go
@@ -81,6 +81,31 @@ func TestWithConfig(t *testing.T) {
 			assert.Equal(t, test.want, v)
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		config := common.MustNewConfigFrom(common.MapStr{
+			"fields":       []string{"@metadata.message"},
+			"target_field": "@metadata.fingerprint",
+		})
+		p, err := New(config)
+		require.NoError(t, err)
+
+		testEvent := &beat.Event{
+			Timestamp: time.Unix(1635443183, 0),
+			Meta: common.MapStr{
+				"message": "hello world",
+			},
+		}
+
+		expMeta := common.MapStr{
+			"message":     "hello world",
+			"fingerprint": "1a3fe8251076ed8de5fd99ce529d2b9971c54851d4d45f5a576bed91d0cc4202",
+		}
+		newEvent, err := p.Run(testEvent)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, testEvent.Fields, newEvent.Fields)
+	})
 }
 
 func TestHashMethods(t *testing.T) {

--- a/libbeat/processors/registered_domain/registered_domain_test.go
+++ b/libbeat/processors/registered_domain/registered_domain_test.go
@@ -93,4 +93,30 @@ func TestProcessorRun(t *testing.T) {
 			assert.Equal(t, tc.ETLD, etld)
 		}
 	}
+
+	t.Run("support metadata as a target", func(t *testing.T) {
+		c := defaultConfig()
+		c.Field = "@metadata.domain"
+		c.TargetField = "@metadata.registered_domain"
+		c.TargetSubdomainField = "@metadata.subdomain"
+		c.TargetETLDField = "@metadata.etld"
+		p, err := newRegisteredDomain(c)
+
+		evt := &beat.Event{
+			Meta: common.MapStr{
+				"domain": "www.google.com",
+			},
+		}
+		expMeta := common.MapStr{
+			"domain":            "www.google.com",
+			"registered_domain": "google.com",
+			"subdomain":         "www",
+			"etld":              "com",
+		}
+
+		newEvt, err := p.Run(evt)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvt.Meta)
+		assert.Equal(t, evt.Fields, newEvt.Fields)
+	})
 }

--- a/libbeat/processors/translate_sid/translatesid_test.go
+++ b/libbeat/processors/translate_sid/translatesid_test.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/sys/windows"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/winlogbeat/sys/winevent"
 )
 
@@ -83,6 +84,33 @@ func TestTranslateSID(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		p, err := newFromConfig(config{
+			Field:             "@metadata.sid",
+			DomainTarget:      "@metadata.domain",
+			AccountNameTarget: "@metadata.account",
+			AccountTypeTarget: "@metadata.type",
+		})
+		assert.NoError(t, err)
+		evt := &beat.Event{
+			Meta: common.MapStr{
+				"sid": "S-1-5-7",
+			},
+		}
+
+		expMeta := common.MapStr{
+			"sid":     "S-1-5-32-544",
+			"domain":  "BUILTIN",
+			"account": "Administrators",
+			"type":    winevent.SidTypeAlias,
+		}
+
+		newEvt, err := p.Run(evt)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvt.Meta)
+		assert.Equal(t, evt.Fields, newEvt.Fields)
+	})
 }
 
 func TestTranslateSIDEmptyTarget(t *testing.T) {

--- a/libbeat/processors/urldecode/urldecode.go
+++ b/libbeat/processors/urldecode/urldecode.go
@@ -73,9 +73,9 @@ func New(c *common.Config) (processors.Processor, error) {
 }
 
 func (p *urlDecode) Run(event *beat.Event) (*beat.Event, error) {
-	var backup common.MapStr
+	var backup *beat.Event
 	if p.config.FailOnError {
-		backup = event.Fields.Clone()
+		backup = event.Clone()
 	}
 
 	for _, field := range p.config.Fields {
@@ -84,7 +84,7 @@ func (p *urlDecode) Run(event *beat.Event) (*beat.Event, error) {
 			errMsg := fmt.Errorf("failed to decode fields in urldecode processor: %v", err)
 			p.log.Debug(errMsg.Error())
 			if p.config.FailOnError {
-				event.Fields = backup
+				event = backup
 				event.PutValue("error.message", errMsg.Error())
 				return event, err
 			}

--- a/libbeat/processors/urldecode/urldecode_test.go
+++ b/libbeat/processors/urldecode/urldecode_test.go
@@ -211,4 +211,32 @@ func TestURLDecode(t *testing.T) {
 		})
 	}
 
+	t.Run("supports metadata as a target", func(t *testing.T) {
+		t.Parallel()
+
+		config := urlDecodeConfig{
+			Fields: []fromTo{{
+				From: "@metadata.field", To: "@metadata.target",
+			}},
+		}
+
+		f := &urlDecode{
+			log:    logp.NewLogger("urldecode"),
+			config: config,
+		}
+
+		event := &beat.Event{
+			Meta: common.MapStr{
+				"field": "correct%20data",
+			},
+		}
+		expMeta := common.MapStr{
+			"field":  "correct%20data",
+			"target": "correct data",
+		}
+		newEvent, err := f.Run(event)
+		assert.NoError(t, err)
+		assert.Equal(t, expMeta, newEvent.Meta)
+		assert.Equal(t, event.Fields, newEvent.Fields)
+	})
 }


### PR DESCRIPTION
## What does this PR do?

Some of the processors that are configured with a target field didn't
support special cases such as when the target field is `@timestamp` or a field in `@metadata`. This change is to make it consistent across all processors or to document why a particular processor does not need this change.

This PR continues the work done in https://github.com/elastic/beats/pull/30092

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Why is it important?

Since some processors (e.g. `fingerprint`) support setting `@metadata.*` fields the users can expect the same behaviour from the rest of the processors too. To avoid this confusion we must either support the same behaviour across all the processors or document clearly when it's not supported.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ (existing tests pass, the existing behaviour should not change)
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Current state of all processors (after this change)

### Are not supposed to access `Meta` (have hard-coded field names):

* `./add_docker_metadata/add_docker_metadata.go` (sets `container.*` fields only)
* `./add_locale/add_locale.go` (the doc states "The processor adds the a `event.timezone` value to each event.")
* `./add_kubernetes_metadata/kubernetes.go` (sets `kubernetes.*` fields only)
* `./add_host_metadata/add_host_metadata.go` (sets `host.*` fields only)
* `./add_observer_metadata/add_observer_metadata.go` (sets `obverver.*` fields only)
* `./actions/include_fields.go` (the doc states "The `@timestamp` and type fields are always exported, even if they are not defined in the include_fields list.", so should be expected behaviour)
* `./actions/add_tags.go` (@kvch and I agreed that tags should be set only in fields and not metadata)
* `./actions/add_labels.go` (sets the `labels` field)
* `./add_cloud_metadata/add_cloud_metadata.go` (sets only cloud.* fields, not configurable to set `@metadata`)

### Do not modify anything:

* `./actions/drop_event.go`
* `./ratelimit/rate_limit.go`

### Use event-specific functions (support metadata change):
* `./actions/drop_fields.go` 
* `./actions/decode_base64_field.go`
* `./actions/decode_json_fields.go`
* `./actions/extract_field.go`
* `./actions/add_network_direction.go`
* `./actions/decompress_gzip_field.go`
* `./timestamp/timestamp.go`
* `./dns/dns.go`
* `./fingerprint/fingerprint.go`
* `./translate_sid/translatesid.go`
* `./add_id/add_id.go`
* `./urldecode/urldecode.go`
* `./registered_domain/registered_domain.go`
* `./decode_xml/decode_xml.go`
* `./convert/convert.go`
* `./communityid/communityid.go`
* `./extract_array/extract_array.go`
* `./decode_csv_fields/decode_csv_fields.go`
* `./dissect/processor.go`
* `./decode_xml_wineventlog/processor.go`
* `./script/processor.go`
* **`./actions/add_fields.go` [fixed in #30092]**
* **`./add_process_metadata/add_process_metadata.go` [fixed in this PR]**
* **`./actions/detect_mime_type.go` [fixed in this PR]**
* **`./actions/truncate_fields.go` [fixed in this PR]**
* **`./actions/replace.go` [fixed in this PR]**
* **`./actions/rename.go` [fixed in this PR]**
* **`./actions/copy_fields.go` [fixed in this PR]**

## Related issues

- Relates #30092
- Closes #25425
