### PR TITLE
Add pipeline in FB's supported hints

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -157,6 +157,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add support for filtering in journald input with `unit`, `kernel`, `identifiers` and `include_matches`. {pull}29294[29294]
 - Add new `userAgent` and `beatInfo` template functions for httpjson input {pull}29528[29528]
 - threatintel module: Add new Recorded Future integration. {pull}30030[30030]
+- Add pipeline in FB's supported hints. {pull}30212[30212]
 
 *Heartbeat*
 
@@ -174,7 +175,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add `elasticsearch.cluster.id` field to Beat and Kibana modules. {pull}29577[29577]
 - Add `elasticsearch.cluster.id` field to Logstash module. {pull}29625[29625]
 - Add `xpack.enabled` support for Enterprise Search module. {pull}29871[29871]
-- Add gcp firestore metricset. {pull}29918[29918] 
+- Add gcp firestore metricset. {pull}29918[29918]
 - Remove strict parsing on RabbitMQ module {pull}30090[30090]
 
 *Packetbeat*

--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -44,6 +44,7 @@ const (
 	excludeLines = "exclude_lines"
 	processors   = "processors"
 	json         = "json"
+	pipeline     = "pipeline"
 )
 
 // validModuleNames to sanitize user input
@@ -121,6 +122,10 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*comm
 			tempCfg.Put(processors, procs)
 		}
 
+		if pip := l.getPipeline(h); len(pip) != 0 {
+			tempCfg.Put(pipeline, pip)
+		}
+
 		if jsonOpts := l.getJSONOptions(h); len(jsonOpts) != 0 {
 			tempCfg.Put(json, jsonOpts)
 		}
@@ -185,6 +190,10 @@ func (l *logHints) getInputsConfigs(hints common.MapStr) []common.MapStr {
 
 func (l *logHints) getProcessors(hints common.MapStr) []common.MapStr {
 	return builder.GetProcessors(hints, l.config.Key)
+}
+
+func (l *logHints) getPipeline(hints common.MapStr) string {
+	return builder.GetHintString(hints, l.config.Key, "pipeline")
 }
 
 func (l *logHints) getJSONOptions(hints common.MapStr) common.MapStr {

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -91,6 +91,16 @@ co.elastic.logs/processors.dissect.tokenizer: "%{key2} %{key1}"
 In the above sample the processor definition tagged with `1` would be executed first.
 
 [float]
+===== `co.elastic.logs/pipeline`
+
+Define an ingest pipeline ID to be added to the {beatname_uc} input/module configuration.
+
+[source,yaml]
+-----
+co.elastic.logs/pipeline: custom-pipeline
+-----
+
+[float]
 ==== Kubernetes
 
 Kubernetes autodiscover provider supports hints in Pod annotations. To enable it just set `hints.enabled`:


### PR DESCRIPTION
## What does this PR do?
This PR adds `co.elastic.logs/pipeline` hint to Filebeat's hints list. This setting sets the pipelineID to be used for the events.


# Related 

Closes https://github.com/elastic/beats/issues/20722

