### PR TITLE
[libbeat] Fix script processor examples in docs

### DIFF
--- a/libbeat/processors/script/docs/script.asciidoc
+++ b/libbeat/processors/script/docs/script.asciidoc
@@ -18,7 +18,6 @@ file or by pointing the processor at external file(s).
 processors:
   - script:
       lang: javascript
-      id: my_filter
       source: >
         function process(event) {
             event.Tag("js");
@@ -32,7 +31,6 @@ This loads `filter.js` from disk.
 processors:
   - script:
       lang: javascript
-      id: my_filter
       file: ${path.config}/filter.js
 ----
 
@@ -45,7 +43,7 @@ code must define a `register(params)` function to receive the parameters.
 processors:
   - script:
       lang: javascript
-      id: my_filter
+      tag: my_filter
       params:
         threshold: 15
       source: >


### PR DESCRIPTION
## What does this PR do?

Fixes `script` processor examples in docs. The docs show `id` but the field is named `tag`.

## Why is it important?

Examples should be correct.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
