### PR TITLE
Heartbeat: set duration to zero for syntax errors

### DIFF
--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -471,7 +471,6 @@ func TestCreateSummaryEvent(t *testing.T) {
 			errorCount:      1,
 		},
 		expected: common.MapStr{
-			"monitor.duration.us": int64(0),
 			"summary": common.MapStr{
 				"down": 1,
 				"up":   0,

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -163,5 +163,4 @@ func (j Journey) ToMap() common.MapStr {
 		"name": j.Name,
 		"id":   j.Id,
 	}
-
 }


### PR DESCRIPTION
+ When there are syntax errors in the monitor script, the `journey/start` never fires as the Synthetics runner cannot register the journeys and node runs to completion with exit status 1.
+ In these cases, determining the duration between start/end event would be tricky and since the journeys never run in the first place, Its good to set the duration to `0` instead of setting false positive values. 
+ Added extensive test cases for summary event creation for various scenarios 
```yaml
heartbeat.run_once: true
# Configure monitors inline
heartbeat.monitors:
  - type: browser
    id: my-monitor
    name: My Monitor
    source:
      inline:
        script: step("load homepage", async () => {);
    schedule: "@every 1m"

output.console: ~
``

