### PR TITLE
github-actions: use main

### DIFF
--- a/.github/workflows/macos-auditbeat.yml
+++ b/.github/workflows/macos-auditbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-auditbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-filebeat.yml
+++ b/.github/workflows/macos-filebeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-filebeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-heartbeat.yml
+++ b/.github/workflows/macos-heartbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-heartbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-metricbeat.yml
+++ b/.github/workflows/macos-metricbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-metricbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-packetbeat.yml
+++ b/.github/workflows/macos-packetbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-packetbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-xpack-auditbeat.yml
+++ b/.github/workflows/macos-xpack-auditbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-xpack-auditbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-xpack-filebeat.yml
+++ b/.github/workflows/macos-xpack-filebeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-xpack-filebeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-xpack-functionbeat.yml
+++ b/.github/workflows/macos-xpack-functionbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-xpack-functionbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-xpack-heartbeat.yml
+++ b/.github/workflows/macos-xpack-heartbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-xpack-heartbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-xpack-metricbeat.yml
+++ b/.github/workflows/macos-xpack-metricbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-xpack-metricbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-xpack-osquerybeat.yml
+++ b/.github/workflows/macos-xpack-osquerybeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-xpack-osquerybeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 

--- a/.github/workflows/macos-xpack-packetbeat.yml
+++ b/.github/workflows/macos-xpack-packetbeat.yml
@@ -6,7 +6,7 @@ on:
       - '.github/workflows/macos-xpack-packetbeat.yml'
   push:
     branches:
-      - master
+      - main
       - 7.1*
       - 8.*
 


### PR DESCRIPTION
## What does this PR do?

Update GitHub actions to run when merge to `main`

## Why is it important?

Finishing the `main` migration