### PR TITLE
Do not pass empty region configuration when deploying Lambdas using Functionbeat manager

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -119,6 +119,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Functionbeat*
 
+- Pass AWS region configuration correctly. {issue}28520[28520] {pull}30238[30238] 
+
 
 *Elastic Logging Plugin*
 

--- a/x-pack/functionbeat/manager/aws/cli_manager.go
+++ b/x-pack/functionbeat/manager/aws/cli_manager.go
@@ -219,7 +219,9 @@ func NewCLI(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get aws credentials, please check AWS credential in config: %+v", err)
 	}
-	awsCfg.Region = config.Region
+	if config.Region != "" {
+		awsCfg.Region = config.Region
+	}
 
 	builder, err := provider.TemplateBuilder()
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the problem when deploying Lambdas using the Functionbeat manager. Previously, the region was not passed correctly to the AWS client, so the Lambda couldn't be deployed.

## Why is it important?

Without the fix Functionbeat manager does not work. Lambdas can only be deployed manually.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #28520
