### PR TITLE
filebeat/input/httpjson: drain and close response.Body

### DIFF
--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -48,7 +48,6 @@ func (c *httpClient) do(stdCtx context.Context, trCtx *transformContext, req *ht
 
 	if resp.StatusCode > 399 {
 		body, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
 		return nil, fmt.Errorf("server responded with status code %d: %s", resp.StatusCode, string(body))
 	}
 	return resp, nil


### PR DESCRIPTION
## What does this PR do?

httpClient.do now reads the whole response.Body into memory and
replaces it with the in-memory copy. This brings some advantages:
 * We can easily ensure the response.Body is always closed
 * We read the response as quick as possible, releasing the connection
   to be reused and avoiding possible timeouts or other errors caused
   by keeping the connection open and blocked.

This came as a improvement on #29816, however I believe it can be merged on its own.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

It helps to ensure the correctness of the code and to avoid leaking open sockets.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~

~~## How to test this PR locally~~

## Related issues
- #29816

~~## Use cases~~

~~## Screenshots~~

~~## Logs~~
