### PR TITLE
Containerd populate ecs fields

### DIFF
--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -114,8 +114,14 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		// Enrich event with container ECS fields
 		containerEcsFields := ecsfields(event)
 		if len(containerEcsFields) != 0 {
-			e.RootFields = common.MapStr{
-				"container": containerEcsFields,
+			if e.RootFields != nil {
+				e.RootFields.DeepUpdate(common.MapStr{
+					"container": containerEcsFields,
+				})
+			} else {
+				e.RootFields = common.MapStr{
+					"container": containerEcsFields,
+				}
 			}
 		}
 

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -20,6 +20,7 @@ package container
 import (
 	"fmt"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -109,6 +110,13 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		e, err := util.CreateEvent(event, "kubernetes.container")
 		if err != nil {
 			m.Logger().Error(err)
+		}
+		// Enrich event with container ECS fields
+		containerEcsFields := ecsfields(event)
+		if len(containerEcsFields) != 0 {
+			e.RootFields = common.MapStr{
+				"container": containerEcsFields,
+			}
 		}
 
 		if reported := reporter.Event(e); !reported {

--- a/metricbeat/module/kubernetes/container/container_test.go
+++ b/metricbeat/module/kubernetes/container/container_test.go
@@ -86,6 +86,16 @@ func TestEventMapping(t *testing.T) {
 	for k, v := range testCases {
 		testValue(t, events[0], k, v)
 	}
+
+	containerEcsFields := ecsfields(events[0])
+	testEcs := map[string]interface{}{
+		"cpu.usage":    0.005631997,
+		"memory.usage": 0.01,
+		"name":         "nginx",
+	}
+	for k, v := range testEcs {
+		testValue(t, containerEcsFields, k, v)
+	}
 }
 
 func testValue(t *testing.T, event common.MapStr, field string, value interface{}) {

--- a/metricbeat/module/kubernetes/container/data.go
+++ b/metricbeat/module/kubernetes/container/data.go
@@ -145,3 +145,28 @@ func eventMapping(content []byte, perfMetrics *util.PerfMetricsCache) ([]common.
 
 	return events, nil
 }
+
+// ecsfields maps container events fields to container ecs fields
+func ecsfields(containerEvent common.MapStr) common.MapStr {
+	ecsfields := common.MapStr{}
+
+	name, err := containerEvent.GetValue("name")
+	if err == nil {
+		ecsfields.Put("name", name)
+
+	}
+
+	cpuUsage, err := containerEvent.GetValue("cpu.usage.node.pct")
+	if err == nil {
+		ecsfields.Put("cpu.usage", cpuUsage)
+
+	}
+
+	memUsage, err := containerEvent.GetValue("memory.usage.node.pct")
+	if err == nil {
+		ecsfields.Put("memory.usage", memUsage)
+
+	}
+
+	return ecsfields
+}

--- a/metricbeat/module/kubernetes/pod/data.go
+++ b/metricbeat/module/kubernetes/pod/data.go
@@ -147,3 +147,22 @@ func eventMapping(content []byte, perfMetrics *util.PerfMetricsCache) ([]common.
 	}
 	return events, nil
 }
+
+// ecsfields maps pod events fields to container ecs fields
+func ecsfields(podEvent common.MapStr) common.MapStr {
+	ecsfields := common.MapStr{}
+
+	egressBytes, err := podEvent.GetValue("network.tx.bytes")
+	if err == nil {
+		ecsfields.Put("network.egress.bytes", egressBytes)
+
+	}
+
+	ingressBytes, err := podEvent.GetValue("network.rx.bytes")
+	if err == nil {
+		ecsfields.Put("network.ingress.bytes", ingressBytes)
+
+	}
+
+	return ecsfields
+}

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -116,8 +116,16 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		// Enrich event with container ECS fields
 		containerEcsFields := ecsfields(event)
 		if len(containerEcsFields) != 0 {
-			e.RootFields = common.MapStr{
-				"container": containerEcsFields,
+			if len(containerEcsFields) != 0 {
+				if e.RootFields != nil {
+					e.RootFields.DeepUpdate(common.MapStr{
+						"container": containerEcsFields,
+					})
+				} else {
+					e.RootFields = common.MapStr{
+						"container": containerEcsFields,
+					}
+				}
 			}
 		}
 

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -20,6 +20,7 @@ package pod
 import (
 	"fmt"
 
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
@@ -110,6 +111,14 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		e, err := util.CreateEvent(event, "kubernetes.pod")
 		if err != nil {
 			m.Logger().Error(err)
+		}
+
+		// Enrich event with container ECS fields
+		containerEcsFields := ecsfields(event)
+		if len(containerEcsFields) != 0 {
+			e.RootFields = common.MapStr{
+				"container": containerEcsFields,
+			}
 		}
 
 		if reported := reporter.Event(e); !reported {

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -116,15 +116,13 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		// Enrich event with container ECS fields
 		containerEcsFields := ecsfields(event)
 		if len(containerEcsFields) != 0 {
-			if len(containerEcsFields) != 0 {
-				if e.RootFields != nil {
-					e.RootFields.DeepUpdate(common.MapStr{
-						"container": containerEcsFields,
-					})
-				} else {
-					e.RootFields = common.MapStr{
-						"container": containerEcsFields,
-					}
+			if e.RootFields != nil {
+				e.RootFields.DeepUpdate(common.MapStr{
+					"container": containerEcsFields,
+				})
+			} else {
+				e.RootFields = common.MapStr{
+					"container": containerEcsFields,
 				}
 			}
 		}

--- a/x-pack/metricbeat/module/containerd/blkio/_meta/test/containerd.v1.5.2.expected
+++ b/x-pack/metricbeat/module/containerd/blkio/_meta/test/containerd.v1.5.2.expected
@@ -2,6 +2,14 @@
 	{
 		"RootFields": {
 			"container": {
+				"disk": {
+					"read": {
+						"bytes": 69246976
+					},
+					"write": {
+						"bytes": 24576
+					}
+				},
 				"id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
 			}
 		},

--- a/x-pack/metricbeat/module/containerd/blkio/_meta/testdata/docs.plain-expected.json
+++ b/x-pack/metricbeat/module/containerd/blkio/_meta/testdata/docs.plain-expected.json
@@ -1,6 +1,14 @@
 [
     {
         "container": {
+            "disk": {
+                "read": {
+                    "bytes": 69246976
+                },
+                "write": {
+                    "bytes": 24576
+                }
+            },
             "id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
         },
         "containerd": {

--- a/x-pack/metricbeat/module/containerd/blkio/blkio.go
+++ b/x-pack/metricbeat/module/containerd/blkio/blkio.go
@@ -115,7 +115,19 @@ func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 		cID := containerd.GetAndDeleteCid(event)
 		namespace := containerd.GetAndDeleteNamespace(event)
 
+		// Add container.id ECS field
 		containerFields.Put("id", cID)
+		// Add disk.read.bytes ECS field
+		diskReadBytes, err := event.GetValue("read.bytes")
+		if err == nil {
+			containerFields.Put("disk.read.bytes", diskReadBytes)
+		}
+		// Add disk.write.bytes ECS field
+		diskWriteBytes, err := event.GetValue("write.bytes")
+		if err == nil {
+			containerFields.Put("disk.write.bytes", diskWriteBytes)
+		}
+
 		rootFields.Put("container", containerFields)
 		moduleFields.Put("namespace", namespace)
 

--- a/x-pack/metricbeat/module/containerd/cpu/_meta/test/containerd.v1.5.2.expected
+++ b/x-pack/metricbeat/module/containerd/cpu/_meta/test/containerd.v1.5.2.expected
@@ -362,6 +362,9 @@
 	{
 		"RootFields": {
 			"container": {
+				"cpu": {
+					"usage": 0
+				},
 				"id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
 			}
 		},

--- a/x-pack/metricbeat/module/containerd/cpu/_meta/testdata/docs.plain-expected.json
+++ b/x-pack/metricbeat/module/containerd/cpu/_meta/testdata/docs.plain-expected.json
@@ -94,6 +94,46 @@
     },
     {
         "container": {
+            "cpu": {
+                "usage": 0
+            },
+            "id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
+        },
+        "containerd": {
+            "cpu": {
+                "usage": {
+                    "kernel": {
+                        "ns": 532180000000,
+                        "pct": 0
+                    },
+                    "total": {
+                        "ns": 1236339003984,
+                        "pct": 0
+                    },
+                    "user": {
+                        "ns": 525470000000,
+                        "pct": 0
+                    }
+                }
+            },
+            "namespace": "k8s.io"
+        },
+        "event": {
+            "dataset": "containerd.cpu",
+            "duration": 115000,
+            "module": "containerd"
+        },
+        "metricset": {
+            "name": "cpu",
+            "period": 10000
+        },
+        "service": {
+            "address": "127.0.0.1:55555",
+            "type": "containerd"
+        }
+    },
+    {
+        "container": {
             "id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
         },
         "containerd": {
@@ -291,43 +331,6 @@
                         }
                     },
                     "percpu": {}
-                }
-            },
-            "namespace": "k8s.io"
-        },
-        "event": {
-            "dataset": "containerd.cpu",
-            "duration": 115000,
-            "module": "containerd"
-        },
-        "metricset": {
-            "name": "cpu",
-            "period": 10000
-        },
-        "service": {
-            "address": "127.0.0.1:55555",
-            "type": "containerd"
-        }
-    },
-    {
-        "container": {
-            "id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
-        },
-        "containerd": {
-            "cpu": {
-                "usage": {
-                    "kernel": {
-                        "ns": 532180000000,
-                        "pct": 0
-                    },
-                    "total": {
-                        "ns": 1236339003984,
-                        "pct": 0
-                    },
-                    "user": {
-                        "ns": 525470000000,
-                        "pct": 0
-                    }
                 }
             },
             "namespace": "k8s.io"

--- a/x-pack/metricbeat/module/containerd/cpu/cpu.go
+++ b/x-pack/metricbeat/module/containerd/cpu/cpu.go
@@ -152,6 +152,8 @@ func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 					float64(contCpus), cID, m.preContainerCpuTotalUsage)
 				m.Logger().Debugf("cpuUsageTotalPct for %+v is %+v", cID, cpuUsageTotalPct)
 				event.Put("usage.total.pct", cpuUsageTotalPct)
+				// Update container.cpu.usage ECS field
+				containerFields.Put("cpu.usage", cpuUsageTotalPct)
 				// Update values
 				m.preContainerCpuTotalUsage[cID] = cpuUsageTotal.(float64)
 			}

--- a/x-pack/metricbeat/module/containerd/memory/_meta/test/containerd.v1.5.2.expected
+++ b/x-pack/metricbeat/module/containerd/memory/_meta/test/containerd.v1.5.2.expected
@@ -2,7 +2,10 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
+				"id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d",
+				"memory": {
+					"usage": 0.9148046875
+				}
 			}
 		},
 		"ModuleFields": {

--- a/x-pack/metricbeat/module/containerd/memory/_meta/testdata/docs.plain-expected.json
+++ b/x-pack/metricbeat/module/containerd/memory/_meta/testdata/docs.plain-expected.json
@@ -1,7 +1,10 @@
 [
     {
         "container": {
-            "id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d"
+            "id": "7434687dbe3684407afa899582f2909203b9dc5537632b512f76798db5c0787d",
+            "memory": {
+                "usage": 0.9148046875
+            }
         },
         "containerd": {
             "memory": {

--- a/x-pack/metricbeat/module/containerd/memory/memory.go
+++ b/x-pack/metricbeat/module/containerd/memory/memory.go
@@ -153,6 +153,8 @@ func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 
 				memoryUsagePct := usageTotal.(float64) / mLfloat
 				event.Put("usage.pct", memoryUsagePct)
+				// Update container.memory.usage ECS field
+				containerFields.Put("memory.usage", memoryUsagePct)
 				m.Logger().Debugf("memoryUsagePct for %+v is %+v", cID, memoryUsagePct)
 			}
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

After new container ECS fields get GA (https://github.com/elastic/ecs/pull/1747) containerd module need to start populating those fields.

The new fields are

container.cpu.usage
container.memory.usage
container.disk.write.bytes
container.disk.read.bytes
These fields map to containerd fields:

containerd.cpu.usage.total.pct by cpu metricset
containerd.memory.usage.pct by memory metricset
containerd.blkio.write.bytes by blkio metricset
containerd.blkio.read.bytes by blkio metricset

respectively.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
