### PR TITLE
[Filebeat] Add message to register encode/decode debug logs

### DIFF
--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -130,7 +130,7 @@ func (c *crawler) startInput(
 
 	runner, err := c.inputsFactory.Create(pipeline, config)
 	if err != nil {
-		return fmt.Errorf("error while initializing input: %+v", err)
+		return fmt.Errorf("error while initializing input: %v", err)
 	}
 	if inputRunner, ok := runner.(*input.Runner); ok {
 		inputRunner.Once = c.once

--- a/filebeat/beater/crawler.go
+++ b/filebeat/beater/crawler.go
@@ -130,7 +130,7 @@ func (c *crawler) startInput(
 
 	runner, err := c.inputsFactory.Create(pipeline, config)
 	if err != nil {
-		return fmt.Errorf("Error while initializing input: %+v", err)
+		return fmt.Errorf("error while initializing input: %+v", err)
 	}
 	if inputRunner, ok := runner.(*input.Runner); ok {
 		inputRunner.Once = c.once

--- a/x-pack/filebeat/input/httpjson/encoding.go
+++ b/x-pack/filebeat/input/httpjson/encoding.go
@@ -79,15 +79,23 @@ func decode(contentType string, p []byte, dst *response) error {
 
 func registerEncoders() {
 	log := logp.L().Named(logName)
-	log.Debug(registerEncoder("application/json", encodeAsJSON))
-	log.Debug(registerEncoder("application/x-www-form-urlencoded", encodeAsForm))
+	log.Debugf("registering encoder 'application/json': returned error: %#v",
+		registerEncoder("application/json", encodeAsJSON))
+
+	log.Debugf("registering encoder 'application/x-www-form-urlencoded': returned error: %#v",
+		registerEncoder("application/x-www-form-urlencoded", encodeAsForm))
 }
 
 func registerDecoders() {
 	log := logp.L().Named(logName)
-	log.Debug(registerDecoder("application/json", decodeAsJSON))
-	log.Debug(registerDecoder("application/x-ndjson", decodeAsNdjson))
-	log.Debug(registerDecoder("text/csv", decodeAsCSV))
+	log.Debugf("registering decoder 'application/json': returned error: %#v",
+		registerDecoder("application/json", decodeAsJSON))
+
+	log.Debugf("registering decoder 'application/x-ndjson': returned error: %#v",
+		registerDecoder("application/x-ndjson", decodeAsNdjson))
+
+	log.Debugf("registering decoder 'text/csv': returned error: %#v",
+		registerDecoder("text/csv", decodeAsCSV))
 }
 
 func encodeAsJSON(trReq transformable) ([]byte, error) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Add message to the debug log indicating which encoder/decoder is being registered instead of only logging the error (nil or not) returned.

## Why is it important?

A log message `<nil>` is unclear.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x ] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~



## Logs

Current behaviour
```
Jan 26, 2022 @ 07:03:24.636 | debug | <nil> | filebeat
```

After changes:

```
Jan 26, 2022 @ 07:03:24.636 | debug | registering encoder 'application/json': returned error: <nil> | filebeat
```