### PR TITLE
Fix Kafka input for filebeat

### DIFF
--- a/filebeat/input/kafka/input.go
+++ b/filebeat/input/kafka/input.go
@@ -318,6 +318,7 @@ func (h *groupHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim s
 			Timestamp: message.Ts,
 			Meta:      message.Meta,
 			Fields:    message.Fields,
+			Private:   message.Private,
 		})
 	}
 	return nil
@@ -458,8 +459,8 @@ func composeMessage(timestamp time.Time, content []byte, kafkaFields common.MapS
 			"kafka":   kafkaFields,
 			"message": string(content),
 		},
-		Meta: common.MapStr{
-			"ackHandler": ackHandler,
+		Private: eventMeta{
+			ackHandler: ackHandler,
 		},
 	}
 }


### PR DESCRIPTION
## What does this PR do?

The Kafka input was broken and had 2 issues:

A serialization error on filebeat output:

Looks like the ack function was put in the `reader.Message.Meta` map by mistake in
20d6038b8dd192c5239c7f78ffc076b18efe878b
`Meta` is a `MapStr` type that does not support function values, therefore fails to
serialize itself when requested later on output.

`ack` was not called for incoming messages:

The ack function was never used because it was supposed
to be a part of the `beat.Event.Private` and it was not put in there.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Why is it important?

We have reports from customers that the Kafka input is completely broken starting with v7.16.2

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Start kafka and zookeeper locally in their standard configurations.
2. Create a test topic:

```bash
kafka-topics --create --topic cyberark --bootstrap-server localhost:9092
```
3. Run filebeat with the following configuration

```yaml
filebeat.inputs:
  - type: kafka
    hosts:
      - localhost:9092
    topics: ["cyberark"]
    group_id: "filebeat"

output.file:
  path: "/Path/To/Your/LogDir"
logging.level: debug
```

mind the `"/Path/To/Your/LogDir"` path that you need to adjust

4. Publish a message (or a few) to the topic:

```bash
kafka-console-producer --topic cyberark --bootstrap-server localhost:9092
```

5. You can see the logs saying that the message passed through:

```json
{"log.level":"debug","@timestamp":"2022-02-08T12:16:15.724+0100","log.logger":"processors","log.origin":{"file.name":"processing/processors.go","file.line":209},"message":"Publish event: {\n  \"@timestamp\": \"2022-02-08T10:10:54.878Z\",\n  \"@metadata\": {\n    \"beat\": 
\"filebeat\",\n    \"type\": \"_doc\",\n    \"version\": \"8.2.0\"\n  },\n  \"message\": \"this should definitely not be json\",\n  \"input\": {\n    \"type\": \"kafka\"\n  },\n  \"ecs\": {\n    \"version\": \"8.0.0\"\n  },\n  \"host\": {\n    \"name\": \"MacBook-Pro.local
domain\"\n  },\n  \"agent\": {\n    \"ephemeral_id\": \"25448a31-5031-45bf-a051-5689b7cb4dd3\",\n    \"id\": \"4fd6b173-0f13-4792-888a-b54dcd85496c\",\n    \"name\": \"MacBook-Pro.localdomain\",\n    \"type\": \"filebeat\",\n    \"version\": \"8.2.0\"\n  },\n  \"kafka\": {
\n    \"topic\": \"cyberark\",\n    \"partition\": 0,\n    \"offset\": 0,\n    \"key\": \"\",\n    \"headers\": []\n  }\n}","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-02-08T12:16:15.724+0100","log.logger":"processors","log.origin":{"file.name":"processing/processors.go","file.line":209},"message":"Publish event: {\n  \"@timestamp\": \"2022-02-08T10:11:00.656Z\",\n  \"@metadata\": {\n    \"beat\": 
\"filebeat\",\n    \"type\": \"_doc\",\n    \"version\": \"8.2.0\"\n  },\n  \"input\": {\n    \"type\": \"kafka\"\n  },\n  \"ecs\": {\n    \"version\": \"8.0.0\"\n  },\n  \"host\": {\n    \"name\": \"MacBook-Pro.localdomain\"\n  },\n  \"agent\": {\n    \"ephemeral_id\": \"
25448a31-5031-45bf-a051-5689b7cb4dd3\",\n    \"id\": \"4fd6b173-0f13-4792-888a-b54dcd85496c\",\n    \"name\": \"MacBook-Pro.localdomain\",\n    \"type\": \"filebeat\",\n    \"version\": \"8.2.0\"\n  },\n  \"kafka\": {\n    \"headers\": [],\n    \"topic\": \"cyberark\",\n  
  \"partition\": 0,\n    \"offset\": 1,\n    \"key\": \"\"\n  },\n  \"message\": \"why is this failing?\"\n}","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-02-08T12:16:16.725+0100","log.logger":"rotator","log.origin":{"file.name":"file/rotator.go","file.line":440},"message":"Rotating file","service.name":"filebeat","rotator":{"filename":"/Users/rdner/Projects/tests/kfk.log/filebeat-2022
0208-2.ndjson","reason":"initializing","ecs.version":"1.6.0"}}                                                                           
{"log.level":"debug","@timestamp":"2022-02-08T12:16:16.727+0100","log.logger":"publisher","log.origin":{"file.name":"memqueue/ackloop.go","file.line":160},"message":"ackloop: receive ack [0: 0, 2]","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-02-08T12:16:16.727+0100","log.logger":"publisher","log.origin":{"file.name":"memqueue/eventloop.go","file.line":535},"message":"broker ACK events: count=2, start-seq=1, end-seq=2\n","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-02-08T12:16:16.727+0100","log.logger":"acker","log.origin":{"file.name":"beater/acker.go","file.line":64},"message":"stateless ack","service.name":"filebeat","count":2,"ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-02-08T12:16:16.727+0100","log.logger":"publisher","log.origin":{"file.name":"memqueue/ackloop.go","file.line":128},"message":"ackloop: return ack to broker loop:2","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-02-08T12:16:16.727+0100","log.logger":"publisher","log.origin":{"file.name":"memqueue/ackloop.go","file.line":131},"message":"ackloop:  done send ack","service.name":"filebeat","ecs.version":"1.6.0"}
```

Before this change this was failing with:

```json
{"log.level":"error","@timestamp":"2022-02-08T11:11:02.675+0100","log.logger":"file","log.origin":{"file.name":"fileout/file.go","file.line":128},"message":"Failed to serialize the event: unsupported","service.name":"filebeat","ecs.version":"1.6.0"}

{"log.level":"debug","@timestamp":"2022-02-08T11:11:02.675+0100","log.logger":"file","log.origin":{"file.name":"fileout/file.go","file.line":132},"message":"Failed event: &{{2022-02-08 11:11:00.656 +0100 CET Not valid json: json: unsupported type: func() {\"agent\":{\"ephe
meral_id\":\"8a333eee-02aa-45d7-9dde-af4d95571e5c\",\"id\":\"4fd6b173-0f13-4792-888a-b54dcd85496c\",\"name\":\"MacBook-Pro.localdomain\",\"type\":\"filebeat\",\"version\":\"8.2.0\"},\"ecs\":{\"version\":\"8.0.0\"},\"host\":\"xxxxx\",\"input\":{\"type\":\"kafka\"},\"kafka\"
:{\"headers\":[],\"key\":\"\",\"offset\":1,\"partition\":0,\"topic\":\"cyberark\"},\"message\":\"why is this failing?\"} <nil> false} 1 {map[]}}","service.name":"filebeat","ecs.version":"1.6.0"}
```

6. Stop filebeat
7. Verify that a log file with your message was created in `"/Path/To/Your/LogDir"` and remove all the files in that directory
8. Restart Filebeat and make sure the same messages don't get logged again (to verify that Kafka messages were acknowledged)


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #29746
