### PR TITLE
mergify: auto-assign PR owner

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,15 @@ queue_rules:
     conditions:
       - check-success=beats-ci/pr-merge
 pull_request_rules:
+  - name: self-assign PRs
+    conditions:
+      - -merged
+      - -closed
+      - "#assignee=0"
+    actions:
+      assign:
+        add_users:
+          - "{{ author }}"
   - name: forward-port patches to main branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

Auto-assign the PR owner if the PR is not assigned yet

See https://docs.mergify.com/actions/assign/

## Why is it important?

See https://github.com/elastic/beats/discussions/29991

A similar implementation was done sometime ago -> https://github.com/elastic/apm-pipeline-library/blob/ff50b3b5f4fab47b89d61183f1f3d1bb58b8795a/.mergify.yml#L49-L57 for another project