### PR TITLE
tlscommon: fix race condition on TLS hostname validation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 *Affecting all Beats*
 
+- Fix mixup of TLS validation on multiple hosts configuration {pull}30305[30305]
 
 *Auditbeat*
 

--- a/libbeat/common/transport/tlscommon/tls_config.go
+++ b/libbeat/common/transport/tlscommon/tls_config.go
@@ -131,13 +131,20 @@ func (c *TLSConfig) BuildModuleClientConfig(host string) *tls.Config {
 		}
 	}
 
-	config := c.ToConfig()
-	// config.ServerName does not verify IP addresses
-	config.ServerName = host
+	// Make a copy of c, because we're gonna mutate it after
+	// calling ToConfig. ToConfig calls a function that creates
+	// a closure that needs to access cc. A shallow copy is enough
+	// because all slice/pointer fields won't be modified.
+	cc := *c
 
 	// Keep a copy of the host (wheather an IP or hostname)
 	// for later validation. It is used by makeVerifyConnection
-	c.ServerName = host
+	cc.ServerName = host
+	config := cc.ToConfig()
+
+	// config.ServerName does not verify IP addresses
+	config.ServerName = host
+
 	return config
 }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a race condition on hostname/IP validation for TLS
certificates. We were relying on a field on TLSConfig, but this struct
is shared between different hosts. Now we pass the server name as a
parameter, thus avoiding any race condition.

The error seen in the logs looks like this:
```
Get "https://bitbucket.corp.internal/status": x509: certificate is valid for bitbucket.corp.internal, not jira.corp.internal
```
Where both hostnames are used together on a output (like ES, Logstash, etc), a monitor in Heartbeat, etc). See the testing section for a more detailed example.

## Why is it important?

It fixes a bug.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~

## How to test this PR locally
Because it's a race condition, it's tricky to test, however you can setup Heartbit with one monitor checking different hosts that do not share the same TLS certificate, the easiest way is to setup Nginx running on docker and edit your `/etc/hosts` (on Linux or the equivalent for your platform) so you can use hostnames to point to those containers. Here is a sample Heartbeat monitor config:
```yaml
- type: http
  id: now-it-works
  name: It will not break
  enabled: true
  urls:
    - https://bitbucket.corp.internal
    - https://jira.corp.internal
  check.response.status: [200]
  max_redirects: 3
  schedule: '@every 5s'
  ssl:
    certificate_authorities:
      - /home/the-doctor/tardis/rootCA.crt
```

With this fix you should see no TLS validation issues.

## Related issues

- Fixes #30290
- Fixes #30240
- [Discuss thread](https://discuss.elastic.co/t/multiple-hosts-per-monitor-confuses-certificate-validation-since-7-17-0/296062)

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

## Workaround
To workaround this issue on `7.17.0`, one can set `ssl.verification_mode: certificate` anywhere that accepts SSL configuration and is failing due to this bug.