### PR TITLE
Revert "libbeat/common/transport: fix log message about TLS (#30063)"

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -38,7 +38,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Affecting all Beats*
 
-- Fix a logging bug when `ssl.verification_mode` was set to `full` or `certificate`, the command `test output` incorrectly logged that TLS was disabled.
 - Fix field names with `add_network_direction` processor. {issue}29747[29747] {pull}29751[29751]
 
 *Auditbeat*

--- a/libbeat/common/transport/tls.go
+++ b/libbeat/common/transport/tls.go
@@ -154,14 +154,7 @@ func tlsDialWith(
 		}
 	}
 
-	// We only check the status of config.Verification (`ssl.verification_mode`
-	// in the configuration file) because we have a custom verification logic
-	// implemented by setting tlsConfig.VerifyConnection that runs regardless of
-	// the status of tlsConfig.InsecureSkipVerify.
-	// For verification modes VerifyFull and VerifyCeritifcate we set
-	// tlsConfig.InsecureSkipVerify to true, hence it's not an indicator of
-	// whether TLS verification is enabled or not.
-	if config.Verification == tlscommon.VerifyNone {
+	if tlsConfig.InsecureSkipVerify {
 		d.Warn("security", "server's certificate chain verification is disabled")
 	} else {
 		d.Info("security", "server's certificate chain verification is enabled")


### PR DESCRIPTION
This reverts commit e208c22507890eb3633d55f1ba7d388f3076b2d6.

This commit caused the agent to crash on startup on Windows with a nil
pointer dereference.

## Related issues

- Relates #30315)


