### PR TITLE
{,x-pack/}auditbeat: replace uses of github.com/pkg/errors with stdlib equivalents

### DIFF
--- a/auditbeat/cmd/root.go
+++ b/auditbeat/cmd/root.go
@@ -54,7 +54,7 @@ var withECSVersion = processing.WithFields(common.MapStr{
 
 // AuditbeatSettings contains the default settings for auditbeat
 func AuditbeatSettings() instance.Settings {
-	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
+	runFlags := pflag.NewFlagSet(Name, pflag.ExitOnError)
 	return instance.Settings{
 		RunFlags:      runFlags,
 		Name:          Name,

--- a/auditbeat/datastore/datastore.go
+++ b/auditbeat/datastore/datastore.go
@@ -39,7 +39,7 @@ func OpenBucket(name string) (Bucket, error) {
 	initDatastoreOnce.Do(func() {
 		ds = &boltDatastore{
 			path: paths.Resolve(paths.Data, "beat.db"),
-			mode: 0600,
+			mode: 0o600,
 		}
 	})
 

--- a/auditbeat/helper/hasher/hasher_test.go
+++ b/auditbeat/helper/hasher/hasher_test.go
@@ -87,5 +87,20 @@ func TestHasherLimits(t *testing.T) {
 	hashes, err := hasher.HashFile(file)
 	assert.Empty(t, hashes)
 	assert.Error(t, err)
-	assert.IsType(t, FileTooLargeError{}, errors.Cause(err))
+	assert.IsType(t, FileTooLargeError{}, cause(err))
+}
+
+func cause(err error) error {
+	type unwrapper interface {
+		Unwrap() error
+	}
+
+	for err != nil {
+		w, ok := err.(unwrapper)
+		if !ok {
+			break
+		}
+		err = w.Unwrap()
+	}
+	return err
 }

--- a/auditbeat/helper/hasher/hasher_test.go
+++ b/auditbeat/helper/hasher/hasher_test.go
@@ -18,6 +18,7 @@
 package hasher
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -87,20 +88,5 @@ func TestHasherLimits(t *testing.T) {
 	hashes, err := hasher.HashFile(file)
 	assert.Empty(t, hashes)
 	assert.Error(t, err)
-	assert.IsType(t, FileTooLargeError{}, cause(err))
-}
-
-func cause(err error) error {
-	type unwrapper interface {
-		Unwrap() error
-	}
-
-	for err != nil {
-		w, ok := err.(unwrapper)
-		if !ok {
-			break
-		}
-		err = w.Unwrap()
-	}
-	return err
+	assert.True(t, errors.As(err, &FileTooLargeError{}))
 }

--- a/auditbeat/helper/hasher/hasher_test.go
+++ b/auditbeat/helper/hasher/hasher_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,7 +34,7 @@ func TestHasher(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	file := filepath.Join(dir, "exe")
-	if err = ioutil.WriteFile(file, []byte("test exe\n"), 0600); err != nil {
+	if err = ioutil.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,7 +68,7 @@ func TestHasherLimits(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	file := filepath.Join(dir, "exe")
-	if err = ioutil.WriteFile(file, []byte("test exe\n"), 0600); err != nil {
+	if err = ioutil.WriteFile(file, []byte("test exe\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auditbeat/module/auditd/audit_linux.go
+++ b/auditbeat/module/auditd/audit_linux.go
@@ -306,7 +306,10 @@ func (ms *MetricSet) initClient() error {
 		// required to ensure that auditing is enabled if the process is only
 		// given CAP_AUDIT_READ.
 		err := ms.client.SetEnabled(true, libaudit.NoWait)
-		return errors.Wrap(err, "failed to enable auditing in the kernel")
+		if err != nil {
+			return fmt.Errorf("failed to enable auditing in the kernel: %w", err)
+		}
+		return nil
 	}
 
 	// Unicast client initialization (requires CAP_AUDIT_CONTROL and that the

--- a/auditbeat/module/auditd/audit_linux_test.go
+++ b/auditbeat/module/auditd/audit_linux_test.go
@@ -329,7 +329,7 @@ func buildSampleEvent(t testing.TB, lines []string, filename string) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filename, output, 0644); err != nil {
+	if err := ioutil.WriteFile(filename, output, 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/auditbeat/module/auditd/audit_unsupported.go
+++ b/auditbeat/module/auditd/audit_unsupported.go
@@ -21,7 +21,7 @@
 package auditd
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -36,5 +36,5 @@ func init() {
 
 // New constructs a new MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	return nil, errors.Errorf("the %v module is only supported on Linux", metricsetName)
+	return nil, fmt.Errorf("the %v module is only supported on Linux", metricsetName)
 }

--- a/auditbeat/module/auditd/config_linux_test.go
+++ b/auditbeat/module/auditd/config_linux_test.go
@@ -94,7 +94,7 @@ func TestConfigValidateConnectionType(t *testing.T) {
 }
 
 func TestConfigRuleOrdering(t *testing.T) {
-	const fileMode = 0644
+	const fileMode = 0o644
 	config := defaultConfig
 	config.RulesBlob = strings.Join([]string{
 		makeRuleFlags(0, 0),

--- a/auditbeat/module/auditd/golden_files_test.go
+++ b/auditbeat/module/auditd/golden_files_test.go
@@ -124,14 +124,16 @@ func configForGolden() map[string]interface{} {
 	}
 }
 
-type TerminateFn func(mb.Event) bool
-type terminableReporter struct {
-	events []mb.Event
-	ctx    context.Context
-	cancel context.CancelFunc
-	err    error
-	isLast TerminateFn
-}
+type (
+	TerminateFn        func(mb.Event) bool
+	terminableReporter struct {
+		events []mb.Event
+		ctx    context.Context
+		cancel context.CancelFunc
+		err    error
+		isLast TerminateFn
+	}
+)
 
 func (r *terminableReporter) Event(event mb.Event) bool {
 	if r.ctx.Err() != nil {
@@ -215,7 +217,7 @@ func TestGoldenFiles(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if err = ioutil.WriteFile(goldenPath, data, 0644); err != nil {
+				if err = ioutil.WriteFile(goldenPath, data, 0o644); err != nil {
 					t.Fatalf("failed writing golden file '%s': %v", goldenPath, err)
 				}
 			}

--- a/auditbeat/module/auditd/show_linux.go
+++ b/auditbeat/module/auditd/show_linux.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/elastic/go-libaudit/v2"
@@ -69,13 +68,13 @@ func init() {
 func showAuditdRules() error {
 	client, err := libaudit.NewAuditClient(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to create audit client")
+		return fmt.Errorf("failed to create audit client: %w", err)
 	}
 	defer client.Close()
 
 	rules, err := client.GetRules()
 	if err != nil {
-		return errors.Wrap(err, "failed to list existing rules")
+		return fmt.Errorf("failed to list existing rules: %w", err)
 	}
 
 	for idx, raw := range rules {
@@ -96,13 +95,13 @@ func showAuditdRules() error {
 func showAuditdStatus() error {
 	client, err := libaudit.NewAuditClient(nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to create audit client")
+		return fmt.Errorf("failed to create audit client: %w", err)
 	}
 	defer client.Close()
 
 	status, err := client.GetStatus()
 	if err != nil {
-		return errors.Wrap(err, "failed to get audit status")
+		return fmt.Errorf("failed to get audit status: %w", err)
 	}
 
 	if status.FeatureBitmap == libaudit.AuditFeatureBitmapBacklogWaitTime {

--- a/auditbeat/module/file_integrity/config.go
+++ b/auditbeat/module/file_integrity/config.go
@@ -18,6 +18,7 @@
 package file_integrity
 
 import (
+	"fmt"
 	"math"
 	"path/filepath"
 	"sort"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common/match"
 )
@@ -110,7 +110,7 @@ nextHash:
 				continue nextHash
 			}
 		}
-		errs = append(errs, errors.Errorf("invalid hash_types value '%v'", ht))
+		errs = append(errs, fmt.Errorf("invalid hash_types value '%v'", ht))
 	}
 
 	c.MaxFileSizeBytes, err = humanize.ParseBytes(c.MaxFileSize)
@@ -122,7 +122,7 @@ nextHash:
 
 	c.ScanRateBytesPerSec, err = humanize.ParseBytes(c.ScanRatePerSec)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "invalid scan_rate_per_sec value"))
+		errs = append(errs, fmt.Errorf("invalid scan_rate_per_sec value: %w", err))
 	}
 	return errs.Err()
 }

--- a/auditbeat/module/file_integrity/config.go
+++ b/auditbeat/module/file_integrity/config.go
@@ -114,10 +114,12 @@ nextHash:
 	}
 
 	c.MaxFileSizeBytes, err = humanize.ParseBytes(c.MaxFileSize)
-	if err != nil || c.MaxFileSizeBytes > MaxValidFileSizeLimit {
-		errs = append(errs, errors.Wrap(err, "invalid max_file_size value"))
+	if err != nil {
+		errs = append(errs, fmt.Errorf("invalid max_file_size value: %w", err))
+	} else if c.MaxFileSizeBytes > MaxValidFileSizeLimit {
+		errs = append(errs, fmt.Errorf("invalid max_file_size value: %s is too large (max=%s)", c.MaxFileSize, humanize.Bytes(MaxValidFileSizeLimit)))
 	} else if c.MaxFileSizeBytes <= 0 {
-		errs = append(errs, errors.Errorf("max_file_size value (%v) must be positive", c.MaxFileSize))
+		errs = append(errs, fmt.Errorf("max_file_size value (%v) must be positive", c.MaxFileSize))
 	}
 
 	c.ScanRateBytesPerSec, err = humanize.ParseBytes(c.ScanRatePerSec)

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/sha3"
 
@@ -449,13 +448,13 @@ func hashFile(name string, maxSize uint64, hashType ...HashType) (nameToHash map
 		case XXH64:
 			hashes = append(hashes, xxhash.New())
 		default:
-			return nil, 0, errors.Errorf("unknown hash type '%v'", name)
+			return nil, 0, fmt.Errorf("unknown hash type '%v'", name)
 		}
 	}
 
 	f, err := file.ReadOpen(name)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to open file for hashing")
+		return nil, 0, fmt.Errorf("failed to open file for hashing: %w", err)
 	}
 	defer f.Close()
 
@@ -469,7 +468,7 @@ func hashFile(name string, maxSize uint64, hashType ...HashType) (nameToHash map
 	}
 	written, err := io.Copy(hashWriter, r)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "failed to calculate file hashes")
+		return nil, 0, fmt.Errorf("failed to calculate file hashes: %w", err)
 	}
 
 	// The file grew larger than configured limit.

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -213,11 +213,14 @@ func NewEvent(
 	hashTypes []HashType,
 ) Event {
 	info, err := os.Lstat(path)
-	if err != nil && os.IsNotExist(err) {
-		// deleted file is signaled by info == nil
-		err = nil
+	if err != nil {
+		if os.IsNotExist(err) {
+			// deleted file is signaled by info == nil
+			err = nil
+		} else {
+			err = fmt.Errorf("failed to lstat: %w", err)
+		}
 	}
-	err = errors.Wrap(err, "failed to lstat")
 	return NewEventFromFileInfo(path, info, err, action, source, maxFileSize, hashTypes)
 }
 

--- a/auditbeat/module/file_integrity/event_test.go
+++ b/auditbeat/module/file_integrity/event_test.go
@@ -47,7 +47,7 @@ func testEvent() *Event {
 			Inode:  123,
 			UID:    500,
 			GID:    500,
-			Mode:   0600,
+			Mode:   0o600,
 			CTime:  testEventTime,
 			MTime:  testEventTime,
 			SetGID: true,
@@ -94,7 +94,7 @@ func TestDiffEvents(t *testing.T) {
 
 	t.Run("updated metadata", func(t *testing.T) {
 		e := testEvent()
-		e.Info.Mode = 0644
+		e.Info.Mode = 0o644
 
 		action, changed := diffEvents(testEvent(), e)
 		assert.True(t, changed)

--- a/auditbeat/module/file_integrity/eventreader_fsevents.go
+++ b/auditbeat/module/file_integrity/eventreader_fsevents.go
@@ -21,13 +21,13 @@
 package file_integrity
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/fsnotify/fsevents"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
@@ -204,7 +204,7 @@ func getFileInfo(path string) (os.FileInfo, error) {
 		path = resolved
 	}
 	info, err := os.Lstat(path)
-	return info, errors.Wrap(err, "failed to stat")
+	return info, fmt.Errorf("failed to stat: %w", err)
 }
 
 func (r *fsreader) isWatched(path string) bool {

--- a/auditbeat/module/file_integrity/eventreader_fsnotify.go
+++ b/auditbeat/module/file_integrity/eventreader_fsnotify.go
@@ -21,12 +21,12 @@
 package file_integrity
 
 import (
+	"fmt"
 	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/auditbeat/module/file_integrity/monitor"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -57,7 +57,7 @@ func (r *reader) Start(done <-chan struct{}) (<-chan Event, error) {
 	if err := r.watcher.Start(); err != nil {
 		// Ensure that watcher is closed so that we don't leak watchers
 		r.watcher.Close()
-		return nil, errors.Wrap(err, "unable to start watcher")
+		return nil, fmt.Errorf("unable to start watcher: %w", err)
 	}
 
 	queueDone := make(chan struct{})

--- a/auditbeat/module/file_integrity/eventreader_test.go
+++ b/auditbeat/module/file_integrity/eventreader_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -73,7 +72,7 @@ func TestEventReader(t *testing.T) {
 
 	// Create a new file.
 	txt1 := filepath.Join(dir, "test1.txt")
-	var fileMode os.FileMode = 0640
+	var fileMode os.FileMode = 0o640
 	mustRun(t, "created", func(t *testing.T) {
 		if err = ioutil.WriteFile(txt1, []byte("hello"), fileMode); err != nil {
 			t.Fatal(err)
@@ -129,14 +128,14 @@ func TestEventReader(t *testing.T) {
 			t.Skip()
 		}
 
-		if err = os.Chmod(txt2, 0644); err != nil {
+		if err = os.Chmod(txt2, 0o644); err != nil {
 			t.Fatal(err)
 		}
 
 		event := readTimeout(t, events)
 		assertSameFile(t, txt2, event.Path)
 		assert.EqualValues(t, AttributesModified, AttributesModified&event.Action)
-		assert.EqualValues(t, 0644, event.Info.Mode)
+		assert.EqualValues(t, 0o644, event.Info.Mode)
 	})
 
 	// Append data to the file.
@@ -153,7 +152,7 @@ func TestEventReader(t *testing.T) {
 		assertSameFile(t, txt2, event.Path)
 		assert.EqualValues(t, Updated, Updated&event.Action)
 		if runtime.GOOS != "windows" {
-			assert.EqualValues(t, 0644, event.Info.Mode)
+			assert.EqualValues(t, 0o644, event.Info.Mode)
 		}
 	})
 
@@ -182,7 +181,7 @@ func TestEventReader(t *testing.T) {
 	// Create a sub-directory.
 	subDir := filepath.Join(dir, "subdir")
 	mustRun(t, "dir created", func(t *testing.T) {
-		if err = os.Mkdir(subDir, 0755); err != nil {
+		if err = os.Mkdir(subDir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 
@@ -243,7 +242,7 @@ func TestEventReader(t *testing.T) {
 func TestRaces(t *testing.T) {
 	t.Skip("Flaky test: about 1/20 of builds fails https://github.com/elastic/beats/issues/21303")
 	const (
-		fileMode os.FileMode = 0640
+		fileMode os.FileMode = 0o640
 		N                    = 100
 	)
 

--- a/auditbeat/module/file_integrity/eventreader_test.go
+++ b/auditbeat/module/file_integrity/eventreader_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"syscall"
 	"testing"
@@ -313,7 +314,7 @@ func TestRaces(t *testing.T) {
 func readTimeout(t testing.TB, events <-chan Event) Event {
 	select {
 	case <-time.After(time.Second):
-		t.Fatalf("%+v", errors.Errorf("timed-out waiting for event"))
+		t.Fatalf("timed-out waiting for event:\n%s", debug.Stack())
 	case e, ok := <-events:
 		if !ok {
 			t.Fatal("failed reading from event channel")

--- a/auditbeat/module/file_integrity/eventreader_unsupported.go
+++ b/auditbeat/module/file_integrity/eventreader_unsupported.go
@@ -20,7 +20,7 @@
 
 package file_integrity
 
-import "github.com/pkg/errors"
+import "errors"
 
 func NewEventReader(c Config) (EventProducer, error) {
 	return errors.New("file auditing metricset is not implemented on this system")

--- a/auditbeat/module/file_integrity/fileinfo_posix.go
+++ b/auditbeat/module/file_integrity/fileinfo_posix.go
@@ -21,13 +21,13 @@
 package file_integrity
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"strconv"
 	"syscall"
 
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 )
 
 // NewMetadata returns a new Metadata object. If an error is returned it is
@@ -36,7 +36,7 @@ import (
 func NewMetadata(path string, info os.FileInfo) (*Metadata, error) {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return nil, errors.Errorf("unexpected fileinfo sys type %T for %v", info.Sys(), path)
+		return nil, fmt.Errorf("unexpected fileinfo sys type %T for %v", info.Sys(), path)
 	}
 
 	fileInfo := &Metadata{

--- a/auditbeat/module/file_integrity/fileinfo_test.go
+++ b/auditbeat/module/file_integrity/fileinfo_test.go
@@ -86,7 +86,7 @@ func TestNewMetadata(t *testing.T) {
 		assert.Equal(t, group.Name, meta.Group)
 		assert.Empty(t, meta.SID)
 
-		assert.EqualValues(t, 0600, meta.Mode)
+		assert.EqualValues(t, 0o600, meta.Mode)
 	}
 
 	assert.EqualValues(t, len("metadata test"), meta.Size, "size")
@@ -127,9 +127,9 @@ func TestSetUIDSetGIDBits(t *testing.T) {
 	}
 
 	for _, flags := range []os.FileMode{
-		0600 | os.ModeSetuid,
-		0600 | os.ModeSetgid,
-		0600 | os.ModeSetuid | os.ModeSetuid,
+		0o600 | os.ModeSetuid,
+		0o600 | os.ModeSetgid,
+		0o600 | os.ModeSetuid | os.ModeSetuid,
 	} {
 		msg := fmt.Sprintf("checking flags %04o", flags)
 		if err = os.Chmod(f.Name(), flags); err != nil {

--- a/auditbeat/module/file_integrity/fileinfo_windows.go
+++ b/auditbeat/module/file_integrity/fileinfo_windows.go
@@ -28,7 +28,6 @@ import (
 	"unsafe"
 
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common/file"
 )
@@ -39,7 +38,7 @@ import (
 func NewMetadata(path string, info os.FileInfo) (*Metadata, error) {
 	attrs, ok := info.Sys().(*syscall.Win32FileAttributeData)
 	if !ok {
-		return nil, errors.Errorf("unexpected fileinfo sys type %T for %v", info.Sys(), path)
+		return nil, fmt.Errorf("unexpected fileinfo sys type %T for %v", info.Sys(), path)
 	}
 
 	var errs multierror.Errors
@@ -69,12 +68,11 @@ func NewMetadata(path string, info os.FileInfo) (*Metadata, error) {
 	var err error
 	if !info.IsDir() {
 		if fileInfo.SID, fileInfo.Owner, err = fileOwner(path); err != nil {
-			errs = append(errs, errors.Wrap(err, "fileOwner failed"))
+			errs = append(errs, fmt.Errorf("fileOwner failed: %w", err))
 		}
-
 	}
 	if fileInfo.Origin, err = GetFileOrigin(path); err != nil {
-		errs = append(errs, errors.Wrap(err, "GetFileOrigin failed"))
+		errs = append(errs, fmt.Errorf("GetFileOrigin failed: %w", err))
 	}
 	return fileInfo, errs.Err()
 }
@@ -86,11 +84,11 @@ func fileOwner(path string) (sid, owner string, err error) {
 
 	pathW, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
-		return sid, owner, errors.Wrapf(err, "failed to convert path:'%s' to UTF16", path)
+		return sid, owner, fmt.Errorf("failed to convert path:'%s' to UTF16: %w", path, err)
 	}
 	if err = GetNamedSecurityInfo(pathW, FileObject,
 		OwnerSecurityInformation, &securityID, nil, nil, nil, &securityDescriptor); err != nil {
-		return "", "", errors.Wrapf(err, "failed on GetSecurityInfo for %v", path)
+		return "", "", fmt.Errorf("failed on GetSecurityInfo for %v: %w", path, err)
 	}
 	defer syscall.LocalFree((syscall.Handle)(unsafe.Pointer(securityDescriptor)))
 

--- a/auditbeat/module/file_integrity/fileorigin_darwin.go
+++ b/auditbeat/module/file_integrity/fileorigin_darwin.go
@@ -74,9 +74,13 @@ func GetFileOrigin(path string) ([]string, error) {
 	defer C.free(unsafe.Pointer(cPath))
 
 	// Query length kMDItemWhereFroms extended-attribute
-	attrSize, err := C.getxattr(cPath, kMDItemWhereFroms, nil, 0, 0, 0)
+	attrSize, errno := C.getxattr(cPath, kMDItemWhereFroms, nil, 0, 0, 0)
 	if attrSize == -1 {
-		return nil, errors.Wrap(filterErrno(err), "getxattr: query attribute length failed")
+		err := filterErrno(errno)
+		if err != nil {
+			return nil, fmt.Errorf("getxattr: query attribute length failed: %w", err)
+		}
+		return nil, nil
 	}
 	if attrSize == 0 {
 		return nil, nil
@@ -84,9 +88,13 @@ func GetFileOrigin(path string) ([]string, error) {
 
 	// Read the kMDItemWhereFroms attribute
 	data := make([]byte, attrSize)
-	newSize, err := C.getxattr(cPath, kMDItemWhereFroms, unsafe.Pointer(&data[0]), C.size_t(attrSize), 0, 0)
+	newSize, errno := C.getxattr(cPath, kMDItemWhereFroms, unsafe.Pointer(&data[0]), C.size_t(attrSize), 0, 0)
 	if newSize == -1 {
-		return nil, errors.Wrap(filterErrno(err), "getxattr failed")
+		err := filterErrno(errno)
+		if err != nil {
+			return nil, fmt.Errorf("getxattr failed: %w", filterErrno(err))
+		}
+		return nil, nil
 	}
 	if newSize != attrSize {
 		return nil, errors.New("getxattr: attribute changed while reading")

--- a/auditbeat/module/file_integrity/fileorigin_darwin.go
+++ b/auditbeat/module/file_integrity/fileorigin_darwin.go
@@ -27,10 +27,11 @@ package file_integrity
 import "C"
 
 import (
+	"errors"
+	"fmt"
 	"syscall"
 	"unsafe"
 
-	"github.com/pkg/errors"
 	"howett.net/plist"
 )
 
@@ -93,8 +94,8 @@ func GetFileOrigin(path string) ([]string, error) {
 
 	// Decode plist format. A list of strings is expected
 	var urls []string
-	if _, err = plist.Unmarshal(data, &urls); err != nil {
-		return nil, errors.Wrap(err, "plist unmarshal failed")
+	if _, err := plist.Unmarshal(data, &urls); err != nil {
+		return nil, fmt.Errorf("plist unmarshal failed: %w", err)
 	}
 
 	// The returned list seems to be padded with empty strings when some of

--- a/auditbeat/module/file_integrity/flatbuffers.go
+++ b/auditbeat/module/file_integrity/flatbuffers.go
@@ -18,12 +18,12 @@
 package file_integrity
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"time"
 
 	flatbuffers "github.com/google/flatbuffers/go"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/auditbeat/module/file_integrity/schema"
 )
@@ -332,7 +332,7 @@ func fbDecodeHash(e *schema.Event) map[HashType]Digest {
 			length = hash.Xxh64Length()
 			producer = hash.Xxh64
 		default:
-			panic(errors.Errorf("unhandled hash type: %v", hashType))
+			panic(fmt.Errorf("unhandled hash type: %v", hashType))
 		}
 
 		if length > 0 {

--- a/auditbeat/module/file_integrity/metricset_test.go
+++ b/auditbeat/module/file_integrity/metricset_test.go
@@ -49,7 +49,7 @@ func TestData(t *testing.T) {
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 		file := filepath.Join(dir, "file.data")
-		ioutil.WriteFile(file, []byte("hello world"), 0600)
+		ioutil.WriteFile(file, []byte("hello world"), 0o600)
 	}()
 
 	ms := mbtest.NewPushMetricSetV2(t, getConfig(dir))
@@ -136,8 +136,8 @@ func TestActions(t *testing.T) {
 	}
 
 	// Create some files in first directory
-	ioutil.WriteFile(createdFilepath, []byte("hello world"), 0600)
-	ioutil.WriteFile(updatedFilepath, []byte("hello world"), 0600)
+	ioutil.WriteFile(createdFilepath, []byte("hello world"), 0o600)
+	ioutil.WriteFile(updatedFilepath, []byte("hello world"), 0o600)
 
 	ms := mbtest.NewPushMetricSetV2(t, getConfig(dir, newDir))
 	events := mbtest.RunPushMetricSetV2(10*time.Second, 5, ms)
@@ -201,7 +201,7 @@ func TestExcludedFiles(t *testing.T) {
 	go func() {
 		for _, f := range []string{"FILE.TXT", "FILE.TXT.SWP", "file.txt.swo", ".git/HEAD", ".gitignore"} {
 			file := filepath.Join(dir, f)
-			ioutil.WriteFile(file, []byte("hello world"), 0600)
+			ioutil.WriteFile(file, []byte("hello world"), 0o600)
 		}
 	}()
 
@@ -252,7 +252,7 @@ func TestIncludedExcludedFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = os.Mkdir(filepath.Join(dir, ".ssh"), 0700)
+	err = os.Mkdir(filepath.Join(dir, ".ssh"), 0o700)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +264,7 @@ func TestIncludedExcludedFiles(t *testing.T) {
 
 	for _, f := range []string{"FILE.TXT", ".ssh/known_hosts", ".ssh/known_hosts.swp"} {
 		file := filepath.Join(dir, f)
-		err := ioutil.WriteFile(file, []byte("hello world"), 0600)
+		err := ioutil.WriteFile(file, []byte("hello world"), 0o600)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -493,7 +493,7 @@ func (e expectedEvents) validate(t *testing.T) {
 	}
 	defer store.Close()
 	defer os.Remove(store.Name())
-	ds := datastore.New(store.Name(), 0644)
+	ds := datastore.New(store.Name(), 0o644)
 	bucket, err := ds.OpenBucket(bucketName)
 	if err != nil {
 		t.Fatal(err)
@@ -765,7 +765,7 @@ func TestEventDelete(t *testing.T) {
 	}
 	defer store.Close()
 	defer os.Remove(store.Name())
-	ds := datastore.New(store.Name(), 0644)
+	ds := datastore.New(store.Name(), 0o644)
 	bucket, err := ds.OpenBucket(bucketName)
 	if err != nil {
 		t.Fatal(err)

--- a/auditbeat/module/file_integrity/mime_test.go
+++ b/auditbeat/module/file_integrity/mime_test.go
@@ -54,7 +54,7 @@ func TestGetMimeType(t *testing.T) {
 
 	for extension, sample := range mimeSamples {
 		samplePath := filepath.Join(dir, "sample."+extension)
-		if err := ioutil.WriteFile(samplePath, sample, 0700); err != nil {
+		if err := ioutil.WriteFile(samplePath, sample, 0o700); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/auditbeat/module/file_integrity/monitor/filetree.go
+++ b/auditbeat/module/file_integrity/monitor/filetree.go
@@ -34,10 +34,8 @@ const (
 	PostOrder
 )
 
-var (
-	// PathSeparator can be used to override the operating system separator.
-	PathSeparator = string(os.PathSeparator)
-)
+// PathSeparator can be used to override the operating system separator.
+var PathSeparator = string(os.PathSeparator)
 
 // FileTree represents a directory in a filesystem-tree structure.
 type FileTree map[string]FileTree

--- a/auditbeat/module/file_integrity/monitor/filetree_test.go
+++ b/auditbeat/module/file_integrity/monitor/filetree_test.go
@@ -50,24 +50,36 @@ func TestVisit(t *testing.T) {
 		result []string
 		isDir  []bool
 	}{
-		{"/",
+		{
+			"/",
 			[]string{"/", "/tmp", "/usr", "/usr/bin", "/usr/bin/python", "/usr/bin/tar", "/usr/lib", "/usr/lib/libz.a"},
-			[]bool{true, true, true, true, false, false, true, false}},
-		{"/usr",
+			[]bool{true, true, true, true, false, false, true, false},
+		},
+		{
+			"/usr",
 			[]string{"/usr", "/usr/bin", "/usr/bin/python", "/usr/bin/tar", "/usr/lib", "/usr/lib/libz.a"},
-			[]bool{true, true, false, false, true, false}},
-		{"/usr/bin",
+			[]bool{true, true, false, false, true, false},
+		},
+		{
+			"/usr/bin",
 			[]string{"/usr/bin", "/usr/bin/python", "/usr/bin/tar"},
-			[]bool{true, false, false}},
-		{"/usr/lib",
+			[]bool{true, false, false},
+		},
+		{
+			"/usr/lib",
 			[]string{"/usr/lib", "/usr/lib/libz.a"},
-			[]bool{true, false}},
-		{"/tmp/",
+			[]bool{true, false},
+		},
+		{
+			"/tmp/",
 			[]string{"/tmp"},
-			[]bool{true}},
-		{"/usr/bin/python",
+			[]bool{true},
+		},
+		{
+			"/usr/bin/python",
 			[]string{"/usr/bin/python"},
-			[]bool{false}},
+			[]bool{false},
+		},
 	} {
 		for _, order := range []VisitOrder{PreOrder, PostOrder} {
 			failMsg := fmt.Sprintf("test entry %d for path '%s' order:%v", testIdx, testData.dir, order)
@@ -148,14 +160,17 @@ func TestVisitCancel(t *testing.T) {
 		expected []visitParams
 	}{
 		{PreOrder, "/a", []visitParams{
-			{"/", true}}},
+			{"/", true},
+		}},
 		{PostOrder, "/a", []visitParams{
 			{"/a/b/file", false},
-			{"/a/b", true}}},
+			{"/a/b", true},
+		}},
 		{PreOrder, "/a/b/file", []visitParams{
 			{"/", true},
 			{"/a", true},
-			{"/a/b", true}}},
+			{"/a/b", true},
+		}},
 	} {
 		failMsg := fmt.Sprintf("test at index %d", idx)
 		var result []visitParams

--- a/auditbeat/module/file_integrity/monitor/monitor_test.go
+++ b/auditbeat/module/file_integrity/monitor/monitor_test.go
@@ -59,7 +59,7 @@ func TestNonRecursive(t *testing.T) {
 	testDirOps(t, dir, watcher)
 
 	subdir := filepath.Join(dir, "subdir")
-	os.Mkdir(subdir, 0750)
+	os.Mkdir(subdir, 0o750)
 
 	ev, err := readTimeout(t, watcher)
 	assertNoError(t, err)
@@ -68,7 +68,7 @@ func TestNonRecursive(t *testing.T) {
 
 	// subdirs are not watched
 	subfile := filepath.Join(subdir, "file.dat")
-	assertNoError(t, ioutil.WriteFile(subfile, []byte("foo"), 0640))
+	assertNoError(t, ioutil.WriteFile(subfile, []byte("foo"), 0o640))
 
 	_, err = readTimeout(t, watcher)
 	assert.Error(t, err)
@@ -107,7 +107,7 @@ func TestRecursive(t *testing.T) {
 	testDirOps(t, dir, watcher)
 
 	subdir := filepath.Join(dir, "subdir")
-	os.Mkdir(subdir, 0750)
+	os.Mkdir(subdir, 0o750)
 
 	ev, err := readTimeout(t, watcher)
 	assertNoError(t, err)
@@ -161,7 +161,7 @@ func TestRecursiveNoFollowSymlink(t *testing.T) {
 	// Create a file in the other dir
 
 	file := filepath.Join(linkedDir, "not.seen")
-	assertNoError(t, ioutil.WriteFile(file, []byte("hello"), 0640))
+	assertNoError(t, ioutil.WriteFile(file, []byte("hello"), 0o640))
 
 	// No event is received
 	ev, err := readTimeout(t, watcher)
@@ -203,8 +203,8 @@ func TestRecursiveSubdirPermissions(t *testing.T) {
 
 	for _, name := range []string{"a", "b", "c"} {
 		path := filepath.Join(outDir, name)
-		assertNoError(t, os.Mkdir(path, 0755))
-		assertNoError(t, ioutil.WriteFile(filepath.Join(path, name), []byte("Hello"), 0644))
+		assertNoError(t, os.Mkdir(path, 0o755))
+		assertNoError(t, ioutil.WriteFile(filepath.Join(path, name), []byte("Hello"), 0o644))
 	}
 
 	// Make a subdir not accessible
@@ -299,8 +299,8 @@ func TestRecursiveExcludedPaths(t *testing.T) {
 
 	for _, name := range []string{"a", "b", "c"} {
 		path := filepath.Join(outDir, name)
-		assertNoError(t, os.Mkdir(path, 0755))
-		assertNoError(t, ioutil.WriteFile(filepath.Join(path, name), []byte("Hello"), 0644))
+		assertNoError(t, os.Mkdir(path, 0o755))
+		assertNoError(t, ioutil.WriteFile(filepath.Join(path, name), []byte("Hello"), 0o644))
 	}
 
 	// excludes file/dir named "b"
@@ -371,7 +371,7 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	fpath2 := filepath.Join(dir, "file2.txt")
 
 	// Create
-	assertNoError(t, ioutil.WriteFile(fpath, []byte("hello"), 0640))
+	assertNoError(t, ioutil.WriteFile(fpath, []byte("hello"), 0o640))
 
 	ev, err := readTimeout(t, watcher)
 	assertNoError(t, err)
@@ -382,7 +382,7 @@ func testDirOps(t *testing.T, dir string, watcher Watcher) {
 	// Repeat the write if no event is received. Under macOS often
 	// the write fails to generate a write event for non-recursive watcher
 	for i := 0; i < 3; i++ {
-		f, err := os.OpenFile(fpath, os.O_RDWR|os.O_APPEND, 0640)
+		f, err := os.OpenFile(fpath, os.O_RDWR|os.O_APPEND, 0o640)
 		assertNoError(t, err)
 		f.WriteString(" world\n")
 		f.Sync()

--- a/auditbeat/module/file_integrity/scanner_test.go
+++ b/auditbeat/module/file_integrity/scanner_test.go
@@ -126,11 +126,11 @@ func setupTestDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(dir, "a"), []byte("file a"), 0600); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(dir, "a"), []byte("file a"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(dir, "b"), []byte("file b"), 0600); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(dir, "b"), []byte("file b"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,11 +138,11 @@ func setupTestDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 
-	if err = os.Mkdir(filepath.Join(dir, "subdir"), 0700); err != nil {
+	if err = os.Mkdir(filepath.Join(dir, "subdir"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(dir, "subdir", "c"), []byte("file c"), 0600); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(dir, "subdir", "c"), []byte("file c"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/auditbeat/scripts/mage/config.go
+++ b/auditbeat/scripts/mage/config.go
@@ -18,9 +18,8 @@
 package mage
 
 import (
+	"fmt"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 )
@@ -56,12 +55,12 @@ func configFileParams(dirs ...string) (devtools.ConfigFileParams, error) {
 
 	configFiles, err := devtools.FindFiles(globs...)
 	if err != nil {
-		return devtools.ConfigFileParams{}, errors.Wrap(err, "failed to find config templates")
+		return devtools.ConfigFileParams{}, fmt.Errorf("failed to find config templates: %w", err)
 	}
 	if len(configFiles) == 0 {
-		return devtools.ConfigFileParams{}, errors.Errorf("no config files found in %v", globs)
+		return devtools.ConfigFileParams{}, fmt.Errorf("no config files found in %v", globs)
 	}
-	devtools.MustFileConcat("build/config.modules.yml.tmpl", 0644, configFiles...)
+	devtools.MustFileConcat("build/config.modules.yml.tmpl", 0o644, configFiles...)
 
 	p := devtools.DefaultConfigFileParams()
 	p.Templates = append(p.Templates, devtools.OSSBeatDir("_meta/config/*.tmpl"))

--- a/auditbeat/scripts/mage/docs.go
+++ b/auditbeat/scripts/mage/docs.go
@@ -18,12 +18,12 @@
 package mage
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/magefile/mage/sh"
-	"github.com/pkg/errors"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 )
@@ -40,7 +40,7 @@ func ModuleDocs() error {
 	for _, path := range dirsWithModules {
 		files, err := devtools.FindFiles(filepath.Join(path, configTemplateGlob))
 		if err != nil {
-			return errors.Wrap(err, "failed to find config templates")
+			return fmt.Errorf("failed to find config templates: %w", err)
 		}
 
 		configFiles = append(configFiles, files...)
@@ -65,7 +65,7 @@ func ModuleDocs() error {
 		if err := os.RemoveAll(filepath.Join(path, "docs/modules")); err != nil {
 			return err
 		}
-		if err := os.MkdirAll(filepath.Join(path, "docs/modules"), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(path, "docs/modules"), 0o755); err != nil {
 			return err
 		}
 	}

--- a/auditbeat/scripts/mage/package.go
+++ b/auditbeat/scripts/mage/package.go
@@ -18,7 +18,8 @@
 package mage
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 )
@@ -40,7 +41,7 @@ const (
 func CustomizePackaging(pkgFlavor PackagingFlavor) {
 	var (
 		shortConfig = devtools.PackageFile{
-			Mode:   0600,
+			Mode:   0o600,
 			Source: "{{.PackageDir}}/auditbeat.yml",
 			Dep: func(spec devtools.PackageSpec) error {
 				return generateConfig(pkgFlavor, devtools.ShortConfigType, spec)
@@ -48,7 +49,7 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 			Config: true,
 		}
 		referenceConfig = devtools.PackageFile{
-			Mode:   0644,
+			Mode:   0o644,
 			Source: "{{.PackageDir}}/auditbeat.reference.yml",
 			Dep: func(spec devtools.PackageSpec) error {
 				return generateConfig(pkgFlavor, devtools.ReferenceConfigType, spec)
@@ -61,7 +62,7 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 		defaultSampleRulesTarget = "audit.rules.d/sample-rules.conf.disabled"
 	)
 	sampleRules := devtools.PackageFile{
-		Mode:   0644,
+		Mode:   0o644,
 		Source: sampleRulesSource,
 		Dep: func(spec devtools.PackageSpec) error {
 			if spec.OS != "linux" {
@@ -76,7 +77,7 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 			)
 
 			if err := devtools.Copy(origin, spec.MustExpand(sampleRulesSource)); err != nil {
-				return errors.Wrap(err, "failed to copy sample rules")
+				return fmt.Errorf("failed to copy sample rules: %w", err)
 			}
 			return nil
 		},
@@ -96,7 +97,7 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 				sampleRulesTarget = "/etc/{{.BeatName}}/" + defaultSampleRulesTarget
 			case devtools.Docker:
 			default:
-				panic(errors.Errorf("unhandled package type: %v", pkgType))
+				panic(fmt.Errorf("unhandled package type: %v", pkgType))
 			}
 
 			if args.OS == "linux" {
@@ -115,7 +116,7 @@ func generateConfig(pkgFlavor PackagingFlavor, ct devtools.ConfigFileType, spec 
 	case XPackPackaging:
 		args = XPackConfigFileParams()
 	default:
-		panic(errors.Errorf("Invalid packaging flavor (either oss or xpack): %v", pkgFlavor))
+		panic(fmt.Errorf("Invalid packaging flavor (either oss or xpack): %v", pkgFlavor))
 	}
 
 	// PackageDir isn't exported but we can grab it's value this way.

--- a/x-pack/auditbeat/module/system/login/login.go
+++ b/x-pack/auditbeat/module/system/login/login.go
@@ -12,8 +12,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/auditbeat/datastore"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
@@ -97,12 +95,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	config := defaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
-		return nil, errors.Wrapf(err, "failed to unpack the %v/%v config", moduleName, metricsetName)
+		return nil, fmt.Errorf("failed to unpack the %v/%v config: %w", moduleName, metricsetName, err)
 	}
 
 	bucket, err := datastore.OpenBucket(bucketName)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open persistent datastore")
+		return nil, fmt.Errorf("failed to open persistent datastore: %w", err)
 	}
 
 	ms := &MetricSet{

--- a/x-pack/auditbeat/module/system/login/login_test.go
+++ b/x-pack/auditbeat/module/system/login/login_test.go
@@ -97,7 +97,7 @@ func TestWtmp(t *testing.T) {
 		"Timestamp is not equal: %+v", events[0].Timestamp)
 
 	// Append logout event to wtmp file and check that it's read
-	wtmpFile, err := os.OpenFile(wtmpFilepath, os.O_APPEND|os.O_WRONLY, 0644)
+	wtmpFile, err := os.OpenFile(wtmpFilepath, os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		t.Fatalf("error opening %v: %v", wtmpFilepath, err)
 	}
@@ -264,7 +264,6 @@ func checkFieldValue(t *testing.T, mapstr common.MapStr, fieldName string, field
 		default:
 			assert.Equal(t, fieldValue, v)
 		}
-
 	}
 }
 

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/gofrs/uuid"
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/auditbeat/datastore"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -203,12 +202,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	config := defaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
-		return nil, errors.Wrapf(err, "failed to unpack the %v/%v config", moduleName, metricsetName)
+		return nil, fmt.Errorf("failed to unpack the %v/%v config: %w", moduleName, metricsetName, err)
 	}
 
 	bucket, err := datastore.OpenBucket(bucketName)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open persistent datastore")
+		return nil, fmt.Errorf("failed to open persistent datastore: %w", err)
 	}
 
 	ms := &MetricSet{
@@ -238,7 +237,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	// Load from disk: Packages
 	packages, err := ms.restorePackagesFromDisk()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to restore packages from disk")
+		return nil, fmt.Errorf("failed to restore packages from disk: %w", err)
 	}
 	ms.log.Debugf("Restored %d packages from disk", len(packages))
 
@@ -286,12 +285,12 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 
 	packages, err := ms.getPackages()
 	if err != nil {
-		return errors.Wrap(err, "failed to get packages")
+		return fmt.Errorf("failed to get packages: %w", err)
 	}
 
 	stateID, err := uuid.NewV4()
 	if err != nil {
-		return errors.Wrap(err, "error generating state ID")
+		return fmt.Errorf("error generating state ID: %w", err)
 	}
 	for _, pkg := range packages {
 		event := ms.packageEvent(pkg, eventTypeState, eventActionExistingPackage)
@@ -309,7 +308,7 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 	}
 	err = ms.bucket.Store(bucketKeyStateTimestamp, timeBytes)
 	if err != nil {
-		return errors.Wrap(err, "error writing state timestamp to disk")
+		return fmt.Errorf("error writing state timestamp to disk: %w", err)
 	}
 
 	return ms.savePackagesToDisk(packages)
@@ -319,7 +318,7 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 	packages, err := ms.getPackages()
 	if err != nil {
-		return errors.Wrap(err, "failed to get packages")
+		return fmt.Errorf("failed to get packages: %w", err)
 	}
 
 	newInCache, missingFromCache := ms.cache.DiffAndUpdateCache(convertToCacheable(packages))
@@ -449,7 +448,7 @@ func (ms *MetricSet) restorePackagesFromDisk() (packages []*Package, err error) 
 				// Read all packages
 				break
 			} else {
-				return nil, errors.Wrap(err, "error decoding packages")
+				return nil, fmt.Errorf("error decoding packages: %w", err)
 			}
 		}
 	}
@@ -465,13 +464,13 @@ func (ms *MetricSet) savePackagesToDisk(packages []*Package) error {
 	for _, pkg := range packages {
 		err := encoder.Encode(*pkg)
 		if err != nil {
-			return errors.Wrap(err, "error encoding packages")
+			return fmt.Errorf("error encoding packages: %w", err)
 		}
 	}
 
 	err := ms.bucket.Store(bucketKeyPackages, buf.Bytes())
 	if err != nil {
-		return errors.Wrap(err, "error writing packages to disk")
+		return fmt.Errorf("error writing packages to disk: %w", err)
 	}
 	return nil
 }
@@ -485,13 +484,13 @@ func (ms *MetricSet) getPackages() (packages []*Package, err error) {
 
 		rpmPackages, err := listRPMPackages()
 		if err != nil {
-			return nil, errors.Wrap(err, "error getting RPM packages")
+			return nil, fmt.Errorf("error getting RPM packages: %w", err)
 		}
 		ms.log.Debugf("RPM packages: %v", len(rpmPackages))
 
 		packages = append(packages, rpmPackages...)
 	} else if err != nil && !os.IsNotExist(err) {
-		return nil, errors.Wrapf(err, "error opening %v", rpmPath)
+		return nil, fmt.Errorf("error opening %v: %w", rpmPath, err)
 	}
 
 	_, err = os.Stat(dpkgPath)
@@ -500,13 +499,13 @@ func (ms *MetricSet) getPackages() (packages []*Package, err error) {
 
 		dpkgPackages, err := ms.listDebPackages()
 		if err != nil {
-			return nil, errors.Wrap(err, "error getting DEB packages")
+			return nil, fmt.Errorf("error getting DEB packages: %w", err)
 		}
 		ms.log.Debugf("DEB packages: %v", len(dpkgPackages))
 
 		packages = append(packages, dpkgPackages...)
 	} else if err != nil && !os.IsNotExist(err) {
-		return nil, errors.Wrapf(err, "error opening %v", dpkgPath)
+		return nil, fmt.Errorf("error opening %v: %w", dpkgPath, err)
 	}
 
 	_, err = os.Stat(homebrewCellarPath)
@@ -515,13 +514,13 @@ func (ms *MetricSet) getPackages() (packages []*Package, err error) {
 
 		homebrewPackages, err := listBrewPackages()
 		if err != nil {
-			return nil, errors.Wrap(err, "error getting Homebrew packages")
+			return nil, fmt.Errorf("error getting Homebrew packages: %w", err)
 		}
 		ms.log.Debugf("Homebrew packages: %v", len(homebrewPackages))
 
 		packages = append(packages, homebrewPackages...)
 	} else if err != nil && !os.IsNotExist(err) {
-		return nil, errors.Wrapf(err, "error opening %v", homebrewCellarPath)
+		return nil, fmt.Errorf("error opening %v: %w", homebrewCellarPath, err)
 	}
 
 	if !foundPackageManager && !ms.suppressNoPackageWarnings {
@@ -540,7 +539,7 @@ func (ms *MetricSet) listDebPackages() ([]*Package, error) {
 
 	file, err := os.Open(dpkgStatusFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error opening %s", dpkgStatusFile)
+		return nil, fmt.Errorf("error opening %s: %w", dpkgStatusFile, err)
 	}
 	defer file.Close()
 
@@ -611,7 +610,7 @@ func (ms *MetricSet) listDebPackages() ([]*Package, error) {
 	}
 
 	if err = scanner.Err(); err != nil {
-		return nil, errors.Wrapf(err, "error scanning file %v", dpkgStatusFile)
+		return nil, fmt.Errorf("error scanning file %v: %w", dpkgStatusFile, err)
 	}
 
 	// Append last package if file ends without newline

--- a/x-pack/auditbeat/module/system/package/package_homebrew.go
+++ b/x-pack/auditbeat/module/system/package/package_homebrew.go
@@ -10,12 +10,11 @@ package pkg
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // InstallReceiptSource represents the "source" object in Homebrew's INSTALL_RECEIPT.json.
@@ -42,7 +41,7 @@ func listBrewPackages() ([]*Package, error) {
 		pkgPath := path.Join(homebrewCellarPath, packageDir.Name())
 		versions, err := ioutil.ReadDir(pkgPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error reading directory: %s", pkgPath)
+			return nil, fmt.Errorf("error reading directory: %s: %w", pkgPath, err)
 		}
 
 		for _, version := range versions {
@@ -61,12 +60,12 @@ func listBrewPackages() ([]*Package, error) {
 			installReceiptPath := path.Join(homebrewCellarPath, pkg.Name, pkg.Version, "INSTALL_RECEIPT.json")
 			contents, err := ioutil.ReadFile(installReceiptPath)
 			if err != nil {
-				pkg.error = errors.Wrapf(err, "error reading %v", installReceiptPath)
+				pkg.error = fmt.Errorf("error reading %v: %w", installReceiptPath, err)
 			} else {
 				var installReceipt InstallReceipt
 				err = json.Unmarshal(contents, &installReceipt)
 				if err != nil {
-					pkg.error = errors.Wrapf(err, "error unmarshalling JSON in %v", installReceiptPath)
+					pkg.error = fmt.Errorf("error unmarshalling JSON in %v: %w", installReceiptPath, err)
 				} else {
 					formulaPath = installReceipt.Source.Path
 				}
@@ -79,7 +78,7 @@ func listBrewPackages() ([]*Package, error) {
 
 			file, err := os.Open(formulaPath)
 			if err != nil {
-				pkg.error = errors.Wrapf(err, "error reading %v", formulaPath)
+				pkg.error = fmt.Errorf("error reading %v: %w", formulaPath, err)
 			} else {
 				defer file.Close()
 
@@ -98,7 +97,7 @@ func listBrewPackages() ([]*Package, error) {
 					}
 				}
 				if err = scanner.Err(); err != nil {
-					pkg.error = errors.Wrapf(err, "error parsing %v", formulaPath)
+					pkg.error = fmt.Errorf("error parsing %v: %w", formulaPath, err)
 				}
 			}
 

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -193,7 +193,7 @@ func TestPackageGobEncodeDecode(t *testing.T) {
 	if *flagUpdateGob {
 		// NOTE: If you are updating this file then you may have introduced a
 		// a breaking change.
-		if err := ioutil.WriteFile(gobTestFile, buf.Bytes(), 0644); err != nil {
+		if err := ioutil.WriteFile(gobTestFile, buf.Bytes(), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/x-pack/auditbeat/module/system/package/rpm_linux.go
+++ b/x-pack/auditbeat/module/system/package/rpm_linux.go
@@ -214,11 +214,11 @@ func (lib *librpm) close() error {
 // version number.  getLibrpmNames looks at the elf header for the rpm
 // binary to determine what version of librpm.so it is linked against.
 func getLibrpmNames() []string {
-	var rpmPaths = []string{
+	rpmPaths := []string{
 		"/usr/bin/rpm",
 		"/bin/rpm",
 	}
-	var libNames = []string{
+	libNames := []string{
 		"librpm.so",
 	}
 	var rpmElf *elf.File
@@ -249,7 +249,6 @@ func getLibrpmNames() []string {
 }
 
 func openLibrpm() (*librpm, error) {
-
 	var librpm librpm
 	var err error
 
@@ -383,7 +382,6 @@ func listRPMPackages() ([]*Package, error) {
 }
 
 func packageFromHeader(header C.Header, openedLibrpm *librpm) (*Package, error) {
-
 	header = C.my_headerLink(openedLibrpm.headerLink, header)
 	if header == nil {
 		return nil, fmt.Errorf("Error calling headerLink")

--- a/x-pack/auditbeat/module/system/package/rpm_others.go
+++ b/x-pack/auditbeat/module/system/package/rpm_others.go
@@ -8,7 +8,7 @@
 
 package pkg
 
-import "github.com/pkg/errors"
+import "errors"
 
 func listRPMPackages() ([]*Package, error) {
 	return nil, errors.New("listing RPM packages is only supported on Linux")

--- a/x-pack/auditbeat/module/system/process/namepace_linux.go
+++ b/x-pack/auditbeat/module/system/process/namepace_linux.go
@@ -8,11 +8,10 @@
 package process
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
-
-	"github.com/pkg/errors"
 )
 
 // isNsSharedWith returns whether the process with the given pid shares the

--- a/x-pack/auditbeat/module/system/socket/dns/afpacket/afpacket.go
+++ b/x-pack/auditbeat/module/system/socket/dns/afpacket/afpacket.go
@@ -9,13 +9,14 @@ package afpacket
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/miekg/dns"
-	"github.com/pkg/errors"
 	"golang.org/x/net/bpf"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -59,7 +60,7 @@ func init() {
 func newAFPacketSniffer(base mb.BaseMetricSet, log *logp.Logger) (parent.Sniffer, error) {
 	config := defaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
-		return nil, errors.Wrap(err, "failed to unpack af_packet config")
+		return nil, fmt.Errorf("failed to unpack af_packet config: %w", err)
 	}
 
 	frameSize, blockSize, numBlocks, err := afpacketComputeSize(8*humanize.MiByte, config.Snaplen, os.Getpagesize())
@@ -83,12 +84,12 @@ func newAFPacketSniffer(base mb.BaseMetricSet, log *logp.Logger) (parent.Sniffer
 
 	tPacket, err := afpacket.NewTPacket(opts...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed creating af_packet sniffer")
+		return nil, fmt.Errorf("failed creating af_packet sniffer: %w", err)
 	}
 
 	if err = tPacket.SetBPF(udpSrcPort53Filter); err != nil {
 		tPacket.Close()
-		return nil, errors.Wrapf(err, "failed setting BPF filter")
+		return nil, fmt.Errorf("failed setting BPF filter: %w", err)
 	}
 
 	c := &dnsCapture{
@@ -226,8 +227,8 @@ func (c *dnsCapture) run(ctx context.Context, consumer parent.Consumer) {
 // The restriction is that the block_size must be divisible by both the
 // frame size and page size.
 func afpacketComputeSize(targetSize int, snaplen int, pageSize int) (
-	frameSize int, blockSize int, numBlocks int, err error) {
-
+	frameSize int, blockSize int, numBlocks int, err error,
+) {
 	if snaplen < pageSize {
 		frameSize = pageSize / (pageSize / snaplen)
 	} else {

--- a/x-pack/auditbeat/module/system/socket/dns/dns.go
+++ b/x-pack/auditbeat/module/system/socket/dns/dns.go
@@ -6,9 +6,8 @@ package dns
 
 import (
 	"context"
+	"fmt"
 	"net"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -52,7 +51,7 @@ func (noopSniffer) Monitor(context.Context, Consumer) error {
 func NewSniffer(base mb.BaseMetricSet, log *logp.Logger) (Sniffer, error) {
 	config := defaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
-		return nil, errors.Wrap(err, "failed to unpack dns config")
+		return nil, fmt.Errorf("failed to unpack dns config: %w", err)
 	}
 	if !config.Enabled {
 		return noopSniffer{}, nil

--- a/x-pack/auditbeat/module/system/socket/guess/guess.go
+++ b/x-pack/auditbeat/module/system/socket/guess/guess.go
@@ -236,9 +236,6 @@ func guessOnce(guesser Guesser, installer helper.ProbeInstaller, ctx Context) (r
 			}
 
 		case <-perfchan.LostC():
-			if err != nil {
-				return nil, fmt.Errorf("event loss in perf channel: %w", err)
-			}
 			return nil, errors.New("event loss in perf channel")
 		}
 	}

--- a/x-pack/auditbeat/module/system/socket/guess/guess.go
+++ b/x-pack/auditbeat/module/system/socket/guess/guess.go
@@ -236,7 +236,10 @@ func guessOnce(guesser Guesser, installer helper.ProbeInstaller, ctx Context) (r
 			}
 
 		case <-perfchan.LostC():
-			return nil, errors.Wrap(err, "event loss in perf channel")
+			if err != nil {
+				return nil, fmt.Errorf("event loss in perf channel: %w", err)
+			}
+			return nil, errors.New("event loss in perf channel")
 		}
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/guess/helpers.go
+++ b/x-pack/auditbeat/module/system/socket/guess/helpers.go
@@ -9,10 +9,10 @@ package guess
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/rand"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -29,17 +29,17 @@ func createSocketWithProto(proto int, bindAddr unix.SockaddrInet4) (fd int, addr
 	}
 	if err = unix.Bind(fd, &bindAddr); err != nil {
 		unix.Close(fd)
-		return -1, addr, errors.Wrap(err, "bind failed")
+		return -1, addr, fmt.Errorf("bind failed: %w", err)
 	}
 	sa, err := unix.Getsockname(fd)
 	if err != nil {
 		unix.Close(fd)
-		return -1, addr, errors.Wrap(err, "getsockname failed")
+		return -1, addr, fmt.Errorf("getsockname failed: %w", err)
 	}
 	addrptr, ok := sa.(*unix.SockaddrInet4)
 	if !ok {
 		unix.Close(fd)
-		return -1, addr, errors.Wrap(err, "getsockname didn't return a struct sockaddr_in")
+		return -1, addr, errors.New("getsockname didn't return a struct sockaddr_in")
 	}
 	return fd, *addrptr, nil
 }
@@ -56,15 +56,15 @@ func createSocket6WithProto(proto int, bindAddr unix.SockaddrInet6) (fd int, add
 		}
 	}()
 	if err = unix.Bind(fd, &bindAddr); err != nil {
-		return -1, addr, errors.Wrap(err, "bind failed")
+		return -1, addr, fmt.Errorf("bind failed: %w", err)
 	}
 	sa, err := unix.Getsockname(fd)
 	if err != nil {
-		return -1, addr, errors.Wrap(err, "getsockname failed")
+		return -1, addr, fmt.Errorf("getsockname failed: %w", err)
 	}
 	addrptr, ok := sa.(*unix.SockaddrInet6)
 	if !ok {
-		return -1, addr, errors.Wrap(err, "getsockname didn't return a struct sockaddr_in")
+		return -1, addr, errors.New("getsockname didn't return a struct sockaddr_in")
 	}
 	return fd, *addrptr, nil
 }

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock.go
@@ -10,8 +10,8 @@ package guess
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -105,13 +105,13 @@ func (g *guessInetSockIPv4) Prepare(ctx Context) (err error) {
 		g.remote.Addr = randomLocalIP()
 	}
 	if g.server, g.local, err = createSocket(g.local); err != nil {
-		return errors.Wrap(err, "error creating server")
+		return fmt.Errorf("error creating server: %w", err)
 	}
 	if g.client, g.remote, err = createSocket(g.remote); err != nil {
-		return errors.Wrap(err, "error creating client")
+		return fmt.Errorf("error creating client: %w", err)
 	}
 	if err = unix.Listen(g.server, 1); err != nil {
-		return errors.Wrap(err, "error in listen")
+		return fmt.Errorf("error in listen: %w", err)
 	}
 	return nil
 }
@@ -204,7 +204,8 @@ func (g *guessInetSockIPv4) Reduce(results []common.MapStr) (result common.MapSt
 
 	for _, key := range []string{
 		"INET_SOCK_LADDR", "INET_SOCK_LPORT",
-		"INET_SOCK_RADDR", "INET_SOCK_RPORT"} {
+		"INET_SOCK_RADDR", "INET_SOCK_RPORT",
+	} {
 		list, err := getListField(result, key)
 		if err != nil {
 			return nil, err

--- a/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsock6.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -234,7 +233,7 @@ func (g *guessInetSockIPv6) Prepare(ctx Context) (err error) {
 	}
 	g.loopback, err = helper.NewIPv6Loopback()
 	if err != nil {
-		return errors.Wrap(err, "detect IPv6 loopback failed")
+		return fmt.Errorf("detect IPv6 loopback failed: %w", err)
 	}
 	defer func() {
 		if err != nil {
@@ -243,23 +242,23 @@ func (g *guessInetSockIPv6) Prepare(ctx Context) (err error) {
 	}()
 	clientIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
-		return errors.Wrap(err, "failed adding first device address")
+		return fmt.Errorf("failed adding first device address: %w", err)
 	}
 	serverIP, err := g.loopback.AddRandomAddress()
 	if err != nil {
-		return errors.Wrap(err, "failed adding second device address")
+		return fmt.Errorf("failed adding second device address: %w", err)
 	}
 	copy(g.clientAddr.Addr[:], clientIP)
 	copy(g.serverAddr.Addr[:], serverIP)
 
 	if g.client, g.clientAddr, err = createSocket6WithProto(unix.SOCK_STREAM, g.clientAddr); err != nil {
-		return errors.Wrap(err, "error creating server")
+		return fmt.Errorf("error creating server: %w", err)
 	}
 	if g.server, g.serverAddr, err = createSocket6WithProto(unix.SOCK_STREAM, g.serverAddr); err != nil {
-		return errors.Wrap(err, "error creating client")
+		return fmt.Errorf("error creating client: %w", err)
 	}
 	if err = unix.Listen(g.server, 1); err != nil {
-		return errors.Wrap(err, "error in listen")
+		return fmt.Errorf("error in listen: %w", err)
 	}
 	return nil
 }
@@ -267,11 +266,11 @@ func (g *guessInetSockIPv6) Prepare(ctx Context) (err error) {
 // Trigger connects the client to the server, causing an inet_csk_accept call.
 func (g *guessInetSockIPv6) Trigger() error {
 	if err := unix.Connect(g.client, &g.serverAddr); err != nil {
-		return errors.Wrap(err, "connect failed")
+		return fmt.Errorf("connect failed: %w", err)
 	}
 	fd, _, err := unix.Accept(g.server)
 	if err != nil {
-		return errors.Wrap(err, "accept failed")
+		return fmt.Errorf("accept failed: %w", err)
 	}
 	unix.Close(fd)
 	return nil

--- a/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
+++ b/x-pack/auditbeat/module/system/socket/guess/inetsockaf.go
@@ -8,7 +8,8 @@
 package guess
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"

--- a/x-pack/auditbeat/module/system/socket/guess/skbuff.go
+++ b/x-pack/auditbeat/module/system/socket/guess/skbuff.go
@@ -10,11 +10,11 @@ package guess
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/rand"
 	"unsafe"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -135,7 +135,7 @@ func (g *guessSkBuffLen) Extract(ev interface{}) (common.MapStr, bool) {
 		uIntSize          = 4
 		n                 = skbuffDumpSize / uIntSize
 		maxOverhead       = 128
-		minHeadersSize    = 0 //20 /* min IP*/ + 20 /* min TCP */
+		minHeadersSize    = 0 // 20 /* min IP*/ + 20 /* min TCP */
 		ipHeaderSizeChunk = 4
 	)
 	target := uint32(g.written)
@@ -281,14 +281,14 @@ func (g *guessSkBuffProto) Prepare(ctx Context) (err error) {
 	g.ctx = ctx
 	g.hasIPv6, err = isIPv6Enabled(ctx.Vars)
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if IPv6 is enabled")
+		return fmt.Errorf("unable to determine if IPv6 is enabled: %w", err)
 	}
 	g.doIPv6 = g.hasIPv6 && !g.doIPv6
 	g.msg = make([]byte, 0x123)
 	if g.doIPv6 {
 		g.loopback, err = helper.NewIPv6Loopback()
 		if err != nil {
-			return errors.Wrap(err, "detect IPv6 loopback failed")
+			return fmt.Errorf("detect IPv6 loopback failed: %w", err)
 		}
 		defer func() {
 			if err != nil {
@@ -297,20 +297,20 @@ func (g *guessSkBuffProto) Prepare(ctx Context) (err error) {
 		}()
 		clientIP, err := g.loopback.AddRandomAddress()
 		if err != nil {
-			return errors.Wrap(err, "failed adding first device address")
+			return fmt.Errorf("failed adding first device address: %w", err)
 		}
 		serverIP, err := g.loopback.AddRandomAddress()
 		if err != nil {
-			return errors.Wrap(err, "failed adding second device address")
+			return fmt.Errorf("failed adding second device address: %w", err)
 		}
 		copy(g.clientAddr.Addr[:], clientIP)
 		copy(g.serverAddr.Addr[:], serverIP)
 
 		if g.client, g.clientAddr, err = createSocket6WithProto(unix.SOCK_DGRAM, g.clientAddr); err != nil {
-			return errors.Wrap(err, "error creating server")
+			return fmt.Errorf("error creating server: %w", err)
 		}
 		if g.server, g.serverAddr, err = createSocket6WithProto(unix.SOCK_DGRAM, g.serverAddr); err != nil {
-			return errors.Wrap(err, "error creating client")
+			return fmt.Errorf("error creating client: %w", err)
 		}
 	} else {
 		g.cs.SetupUDP()
@@ -334,17 +334,17 @@ func (g *guessSkBuffProto) Terminate() (err error) {
 func (g *guessSkBuffProto) Trigger() error {
 	if g.doIPv6 {
 		if err := unix.Sendto(g.client, g.msg, 0, &g.serverAddr); err != nil {
-			return errors.Wrap(err, "failed to send ipv4")
+			return fmt.Errorf("failed to send ipv4: %w", err)
 		}
 		if _, _, err := unix.Recvfrom(g.server, g.msg, 0); err != nil {
-			return errors.Wrap(err, "failed to receive ipv4")
+			return fmt.Errorf("failed to receive ipv4: %w", err)
 		}
 	} else {
 		if err := unix.Sendto(g.cs.client, g.msg, 0, &g.cs.srvAddr); err != nil {
-			return errors.Wrap(err, "failed to send ipv4")
+			return fmt.Errorf("failed to send ipv4: %w", err)
 		}
 		if _, _, err := unix.Recvfrom(g.cs.server, g.msg, 0); err != nil {
-			return errors.Wrap(err, "failed to receive ipv4")
+			return fmt.Errorf("failed to receive ipv4: %w", err)
 		}
 	}
 	return nil
@@ -591,10 +591,10 @@ func (g *guessSkBuffDataPtr) Terminate() error {
 // Trigger causes a packet to be received at server socket.
 func (g *guessSkBuffDataPtr) Trigger() error {
 	if err := unix.Sendto(g.cs.client, g.payload, 0, &g.cs.srvAddr); err != nil {
-		return errors.Wrap(err, "failed to send ipv4")
+		return fmt.Errorf("failed to send ipv4: %w", err)
 	}
 	if _, _, err := unix.Recvfrom(g.cs.server, g.payload, 0); err != nil {
-		return errors.Wrap(err, "failed to receive ipv4")
+		return fmt.Errorf("failed to receive ipv4: %w", err)
 	}
 	return nil
 }

--- a/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
+++ b/x-pack/auditbeat/module/system/socket/guess/sockaddrin.go
@@ -10,8 +10,8 @@ package guess
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -92,13 +92,13 @@ func (g *guessSockaddrIn) Prepare(ctx Context) (err error) {
 		g.remote.Addr = randomLocalIP()
 	}
 	if g.server, g.local, err = createSocket(g.local); err != nil {
-		return errors.Wrap(err, "error creating server")
+		return fmt.Errorf("error creating server: %w", err)
 	}
 	if g.client, g.remote, err = createSocket(g.remote); err != nil {
-		return errors.Wrap(err, "error creating client")
+		return fmt.Errorf("error creating client: %w", err)
 	}
 	if err = unix.Listen(g.server, 1); err != nil {
-		return errors.Wrap(err, "error in listen")
+		return fmt.Errorf("error in listen: %w", err)
 	}
 	return nil
 }

--- a/x-pack/auditbeat/module/system/socket/helper/loopback.go
+++ b/x-pack/auditbeat/module/system/socket/helper/loopback.go
@@ -112,7 +112,10 @@ func (lo *IPv6Loopback) AddRandomAddress() (addr net.IP, err error) {
 		}
 		time.Sleep(time.Millisecond * time.Duration(i))
 	}
-	return addr, errors.Wrap(err, "bind failed")
+	if err != nil {
+		err = fmt.Errorf("bind failed: %w", err)
+	}
+	return addr, err
 }
 
 // Cleanup removes the addresses registered to this loopback.

--- a/x-pack/auditbeat/module/system/socket/helper/loopback.go
+++ b/x-pack/auditbeat/module/system/socket/helper/loopback.go
@@ -8,13 +8,14 @@
 package helper
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
 	"net"
 	"time"
 	"unsafe"
 
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -47,7 +48,7 @@ func NewIPv6Loopback() (lo IPv6Loopback, err error) {
 	lo.fd = -1
 	devs, err := net.Interfaces()
 	if err != nil {
-		return lo, errors.Wrap(err, "cannot list interfaces")
+		return lo, fmt.Errorf("cannot list interfaces: %w", err)
 	}
 	for _, dev := range devs {
 		addrs, err := dev.Addrs()
@@ -60,14 +61,14 @@ func NewIPv6Loopback() (lo IPv6Loopback, err error) {
 				lo.fd, err = unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_IP)
 				if err != nil {
 					lo.fd = -1
-					return lo, errors.Wrap(err, "ipv6 socket failed")
+					return lo, fmt.Errorf("ipv6 socket failed: %w", err)
 				}
 				copy(lo.ifreq.name[:], dev.Name)
 				lo.ifreq.name[len(dev.Name)] = 0
 				_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCGIFINDEX, uintptr(unsafe.Pointer(&lo.ifreq)))
 				if errno != 0 {
 					unix.Close(lo.fd)
-					return lo, errors.Wrap(errno, "ioctl(SIOCGIFINDEX) failed")
+					return lo, fmt.Errorf("ioctl(SIOCGIFINDEX) failed: %w", errno)
 				}
 				return lo, nil
 			}
@@ -88,7 +89,7 @@ func (lo *IPv6Loopback) AddRandomAddress() (addr net.IP, err error) {
 	req.prefix = 128
 	_, _, e := unix.Syscall(unix.SYS_IOCTL, uintptr(lo.fd), unix.SIOCSIFADDR, uintptr(unsafe.Pointer(&req)))
 	if e != 0 {
-		return nil, errors.Wrap(e, "ioctl SIOCSIFADDR failed")
+		return nil, fmt.Errorf("ioctl SIOCSIFADDR failed: %w", e)
 	}
 	lo.addresses = append(lo.addresses, addr)
 
@@ -97,7 +98,7 @@ func (lo *IPv6Loopback) AddRandomAddress() (addr net.IP, err error) {
 	// available to bind.
 	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, 0)
 	if err != nil {
-		return addr, errors.Wrap(err, "socket ipv6 dgram failed")
+		return addr, fmt.Errorf("socket ipv6 dgram failed: %w", err)
 	}
 	defer unix.Close(fd)
 	var bindAddr unix.SockaddrInet6

--- a/x-pack/auditbeat/module/system/socket/kprobes.go
+++ b/x-pack/auditbeat/module/system/socket/kprobes.go
@@ -8,12 +8,12 @@
 package socket
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unsafe"
 
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/x-pack/auditbeat/module/system/socket/helper"
@@ -51,14 +51,14 @@ func (p *probeInstaller) Install(pdef helper.ProbeDef) (format tracing.ProbeForm
 		return format, decoder, errors.New("nil decoder in probe definition")
 	}
 	if err = p.traceFS.AddKProbe(pdef.Probe); err != nil {
-		return format, decoder, errors.Wrapf(err, "failed installing probe '%s'", pdef.Probe.String())
+		return format, decoder, fmt.Errorf("failed installing probe '%s': %w", pdef.Probe.String(), err)
 	}
 	p.installed = append(p.installed, pdef.Probe)
 	if format, err = p.traceFS.LoadProbeFormat(pdef.Probe); err != nil {
-		return format, decoder, errors.Wrap(err, "failed to load probe format")
+		return format, decoder, fmt.Errorf("failed to load probe format: %w", err)
 	}
 	if decoder, err = pdef.Decoder(format); err != nil {
-		return format, decoder, errors.Wrap(err, "failed to create decoder")
+		return format, decoder, fmt.Errorf("failed to create decoder: %w", err)
 	}
 	return
 }
@@ -79,13 +79,13 @@ func (p *probeInstaller) UninstallInstalled() error {
 func (p *probeInstaller) UninstallIf(condition helper.ProbeCondition) error {
 	kprobes, err := p.traceFS.ListKProbes()
 	if err != nil {
-		return errors.Wrap(err, "failed to list installed kprobes")
+		return fmt.Errorf("failed to list installed kprobes: %w", err)
 	}
 	var errs multierror.Errors
 	for _, probe := range kprobes {
 		if condition(probe) {
 			if err := p.traceFS.RemoveKProbe(probe); err != nil {
-				errs = append(errs, errors.Wrapf(err, "unable to remove kprobe '%s'", probe.String()))
+				errs = append(errs, fmt.Errorf("unable to remove kprobe '%s': %w", probe.String(), err))
 			}
 		}
 	}
@@ -137,10 +137,9 @@ func WithFilterPort(portnum uint16) ProbeTransform {
 
 // KProbes shared with IPv4 and IPv6.
 var sharedKProbes = []helper.ProbeDef{
-
-	/***************************************************************************
-	 * RUNNING PROCESSES
-	 **************************************************************************/
+	//***************************************************************************
+	//* RUNNING PROCESSES
+	//***************************************************************************
 
 	{
 		Probe: tracing.Probe{
@@ -370,9 +369,9 @@ var ipv4OnlyKProbes = []helper.ProbeDef{
 
 // KProbes used when IPv6 is enabled.
 var ipv6KProbes = []helper.ProbeDef{
-	/***************************************************************************
-	 * IPv6
-	 **************************************************************************/
+	//***************************************************************************
+	//* IPv6
+	//***************************************************************************
 
 	// IPv6 socket created. Good for associating sockets with pids.
 	// ** This is a struct socket* not a struct sock* **

--- a/x-pack/auditbeat/module/system/socket/socket_linux.go
+++ b/x-pack/auditbeat/module/system/socket/socket_linux.go
@@ -10,6 +10,7 @@ package socket
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -103,7 +103,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	config := defaultConfig
 	if err := base.Module().UnpackConfig(&config); err != nil {
-		return nil, errors.Wrapf(err, "failed to unpack the %s config", fullName)
+		return nil, fmt.Errorf("failed to unpack the %s config: %w", fullName, err)
 	}
 	if instance != nil {
 		// Do not instantiate a new dataset if the config hasn't changed.
@@ -127,7 +127,7 @@ func newSocketMetricset(config Config, base mb.BaseMetricSet) (*MetricSet, error
 	logger := logp.NewLogger(metricsetName)
 	sniffer, err := dns.NewSniffer(base, logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to create DNS sniffer")
+		return nil, fmt.Errorf("unable to create DNS sniffer: %w", err)
 	}
 	ms := &MetricSet{
 		SystemMetricSet: system.NewSystemMetricSet(base),
@@ -142,7 +142,7 @@ func newSocketMetricset(config Config, base mb.BaseMetricSet) (*MetricSet, error
 	// Setup the metricset before Run() so that startup can be halted in case of
 	// error.
 	if err = ms.Setup(); err != nil {
-		return nil, errors.Wrapf(err, "%s dataset setup failed", fullName)
+		return nil, fmt.Errorf("%s dataset setup failed: %w", fullName, err)
 	}
 	return ms, nil
 }
@@ -168,14 +168,14 @@ func (m *MetricSet) Run(r mb.PushReporterV2) {
 			m.log.Errorf("Unable to store DNS transaction %+v: %v", tr, err)
 		}
 	}); err != nil {
-		err = errors.Wrap(err, "unable to start DNS sniffer")
+		err = fmt.Errorf("unable to start DNS sniffer: %w", err)
 		r.Error(err)
 		m.log.Error(err)
 		return
 	}
 
 	if err := m.perfChannel.Run(); err != nil {
-		err = errors.Wrap(err, "unable to start perf channel")
+		err = fmt.Errorf("unable to start perf channel: %w", err)
 		r.Error(err)
 		m.log.Error(err)
 		return
@@ -309,7 +309,7 @@ func (m *MetricSet) Setup() (err error) {
 		traceFS, err = tracing.NewTraceFSWithPath(*m.config.TraceFSPath)
 	}
 	if err != nil {
-		return errors.Wrap(err, "tracefs/debugfs is not mounted or not writeable")
+		return fmt.Errorf("tracefs/debugfs is not mounted or not writeable: %w", err)
 	}
 
 	//
@@ -366,7 +366,7 @@ func (m *MetricSet) Setup() (err error) {
 	// remove existing Auditbeat KProbes that match the current PID.
 	//
 	if err = m.installer.UninstallIf(isThisAuditbeat); err != nil {
-		return errors.Wrapf(err, "unable to delete existing KProbes for group %s", groupName)
+		return fmt.Errorf("unable to delete existing KProbes for group %s: %w", groupName, err)
 	}
 
 	//
@@ -420,7 +420,7 @@ func (m *MetricSet) Setup() (err error) {
 			Vars:    m.templateVars,
 			Timeout: m.config.GuessTimeout,
 		}); err != nil {
-		return errors.Wrap(err, "unable to guess one or more required parameters")
+		return fmt.Errorf("unable to guess one or more required parameters: %w", err)
 	}
 
 	if m.isDebug {
@@ -446,7 +446,7 @@ func (m *MetricSet) Setup() (err error) {
 		tracing.WithTID(perf.AllThreads),
 		tracing.WithTimestamp())
 	if err != nil {
-		return errors.Wrapf(err, "unable to create perf channel")
+		return fmt.Errorf("unable to create perf channel: %w", err)
 	}
 
 	//
@@ -455,10 +455,10 @@ func (m *MetricSet) Setup() (err error) {
 	for _, probeDef := range getKProbes(hasIPv6) {
 		format, decoder, err := m.installer.Install(probeDef)
 		if err != nil {
-			return errors.Wrapf(err, "unable to register probe %s", probeDef.Probe.String())
+			return fmt.Errorf("unable to register probe %s: %w", probeDef.Probe.String(), err)
 		}
 		if err = m.perfChannel.MonitorProbe(format, decoder); err != nil {
-			return errors.Wrapf(err, "unable to monitor probe %s", probeDef.Probe.String())
+			return fmt.Errorf("unable to monitor probe %s: %w", probeDef.Probe.String(), err)
 		}
 	}
 	return nil

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -9,6 +9,7 @@ package socket
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -438,8 +438,10 @@ func (s *state) DoneFlows() linkedList {
 	return r
 }
 
-var lastEvents uint64
-var lastTime time.Time
+var (
+	lastEvents uint64
+	lastTime   time.Time
+)
 
 func (s *state) logState() {
 	s.Lock()
@@ -470,7 +472,6 @@ func (s *state) logState() {
 	} else {
 		s.log.Warnf("%s. Warnings: %v", msg, errs)
 	}
-
 }
 
 func (s *state) reapLoop() {

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -9,6 +9,7 @@ package socket
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"time"
 
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 
@@ -511,7 +511,7 @@ func feedEvents(evs []event, st *state, t *testing.T) error {
 		t.Logf("Delivering event %d: %s", idx, ev.String())
 		// TODO: err
 		if err := ev.Update(st); err != nil {
-			return errors.Wrapf(err, "error feeding event '%s'", ev.String())
+			return fmt.Errorf("error feeding event '%s': %w", ev.String(), err)
 		}
 	}
 	return nil

--- a/x-pack/auditbeat/module/system/user/user.go
+++ b/x-pack/auditbeat/module/system/user/user.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/gofrs/uuid"
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/auditbeat/datastore"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -237,12 +236,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	config := defaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
-		return nil, errors.Wrapf(err, "failed to unpack the %v/%v config", moduleName, metricsetName)
+		return nil, fmt.Errorf("failed to unpack the %v/%v config: %w", moduleName, metricsetName, err)
 	}
 
 	bucket, err := datastore.OpenBucket(bucketName)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to open persistent datastore")
+		return nil, fmt.Errorf("failed to open persistent datastore: %w", err)
 	}
 
 	ms := &MetricSet{
@@ -278,7 +277,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	// Load from disk: Users
 	users, err := ms.restoreUsersFromDisk()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to restore users from disk")
+		return nil, fmt.Errorf("failed to restore users from disk: %w", err)
 	}
 	ms.log.Debugf("Restored %d users from disk", len(users))
 
@@ -322,14 +321,14 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 
 	users, err := GetUsers(ms.config.DetectPasswordChanges)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "error while getting users"))
+		errs = append(errs, fmt.Errorf("error while getting users: %w", err))
 	}
 
 	ms.log.Debugf("Found %v users", len(users))
 	if len(users) > 0 {
 		stateID, err := uuid.NewV4()
 		if err != nil {
-			errs = append(errs, errors.Wrap(err, "error generating state ID"))
+			errs = append(errs, fmt.Errorf("error generating state ID: %w", err))
 		}
 
 		for _, user := range users {
@@ -350,7 +349,7 @@ func (ms *MetricSet) reportState(report mb.ReporterV2) error {
 		} else {
 			err = ms.bucket.Store(bucketKeyStateTimestamp, timeBytes)
 			if err != nil {
-				errs = append(errs, errors.Wrap(err, "error writing state timestamp to disk"))
+				errs = append(errs, fmt.Errorf("error writing state timestamp to disk: %w", err))
 			}
 		}
 
@@ -383,7 +382,7 @@ func (ms *MetricSet) reportChanges(report mb.ReporterV2) error {
 
 	users, err := GetUsers(ms.config.DetectPasswordChanges)
 	if err != nil {
-		errs = append(errs, errors.Wrap(err, "error while getting users"))
+		errs = append(errs, fmt.Errorf("error while getting users: %w", err))
 	}
 	ms.log.Debugf("Found %v users", len(users))
 
@@ -561,7 +560,7 @@ func (ms *MetricSet) restoreUsersFromDisk() (users []*User, err error) {
 				// Read all users
 				break
 			} else {
-				return nil, errors.Wrap(err, "error decoding users")
+				return nil, fmt.Errorf("error decoding users: %w", err)
 			}
 		}
 	}
@@ -577,13 +576,13 @@ func (ms *MetricSet) saveUsersToDisk(users []*User) error {
 	for _, user := range users {
 		err := encoder.Encode(*user)
 		if err != nil {
-			return errors.Wrap(err, "error encoding users")
+			return fmt.Errorf("error encoding users: %w", err)
 		}
 	}
 
 	err := ms.bucket.Store(bucketKeyUsers, buf.Bytes())
 	if err != nil {
-		return errors.Wrap(err, "error writing users to disk")
+		return fmt.Errorf("error writing users to disk: %w", err)
 	}
 	return nil
 }
@@ -593,7 +592,7 @@ func (ms *MetricSet) haveFilesChanged() (bool, error) {
 	var stats syscall.Stat_t
 	for _, path := range ms.userFiles {
 		if err := syscall.Stat(path, &stats); err != nil {
-			return true, errors.Wrapf(err, "failed to stat %v", path)
+			return true, fmt.Errorf("failed to stat %v: %w", path, err)
 		}
 
 		ctime := time.Unix(int64(stats.Ctim.Sec), int64(stats.Ctim.Nsec))

--- a/x-pack/auditbeat/module/system/user/user_test.go
+++ b/x-pack/auditbeat/module/system/user/user_test.go
@@ -64,11 +64,11 @@ func testUser() *User {
 		UID:  "9999",
 		GID:  "1001",
 		Groups: []*user.Group{
-			&user.Group{
+			{
 				Gid:  "1001",
 				Name: "__elastic",
 			},
-			&user.Group{
+			{
 				Gid:  "1002",
 				Name: "docker",
 			},

--- a/x-pack/auditbeat/tracing/cpu.go
+++ b/x-pack/auditbeat/tracing/cpu.go
@@ -9,11 +9,10 @@ package tracing
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -97,7 +96,7 @@ func NewCPUSetFromExpression(contents string) (CPUSet, error) {
 		for _, numStr := range parts {
 			num16, err := strconv.ParseInt(numStr, 10, 16)
 			if err != nil || num16 < 0 {
-				return CPUSet{}, errors.Errorf("failed to parse integer '%s' from range '%s' at '%s'", numStr, expr, contents)
+				return CPUSet{}, fmt.Errorf("failed to parse integer '%s' from range '%s' at '%s'", numStr, expr, contents)
 			}
 			num := int(num16)
 			r = append(r, num)
@@ -124,7 +123,7 @@ func NewCPUSetFromExpression(contents string) (CPUSet, error) {
 			to = r[1]
 		}
 		if from == -1 || to < from {
-			return CPUSet{}, errors.Errorf("invalid cpu range %v in '%s'", r, contents)
+			return CPUSet{}, fmt.Errorf("invalid cpu range %v in '%s'", r, contents)
 		}
 		for i := from; i <= to; i++ {
 			if !mask[i] {

--- a/x-pack/auditbeat/tracing/events_test.go
+++ b/x-pack/auditbeat/tracing/events_test.go
@@ -209,7 +209,7 @@ func TestKProbeReal(t *testing.T) {
 	probe := Probe{
 		Name:    "test_kprobe",
 		Address: "sys_connect",
-		//Fetchargs: "exe=$comm fd=%di +0(%si) +8(%si) +16(%si) +24(%si) +99999(%ax):string",
+		// Fetchargs: "exe=$comm fd=%di +0(%si) +8(%si) +16(%si) +24(%si) +99999(%ax):string",
 		Fetchargs: "ax=%ax bx=%bx:u8 cx=%cx:u32 dx=%dx:s16",
 	}
 	err = evs.AddKProbe(probe)
@@ -220,19 +220,19 @@ func TestKProbeReal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	//fmt.Fprintf(os.Stderr, "desc=%+v\n", desc)
+	// fmt.Fprintf(os.Stderr, "desc=%+v\n", desc)
 	var decoder Decoder
 	const useStructDecoder = false
 	if useStructDecoder {
 		type myStruct struct {
-			//Exe string `kprobe:"exe"`
+			// Exe string `kprobe:"exe"`
 			PID uint32 `kprobe:"common_pid"`
 			AX  int64  `kprobe:"ax"`
 			BX  uint8  `kprobe:"bx"`
 			CX  int32  `kprobe:"cx"`
 			DX  uint16 `kprobe:"dx"`
 		}
-		var allocFn = func() interface{} {
+		allocFn := func() interface{} {
 			return new(myStruct)
 		}
 		if decoder, err = NewStructDecoder(desc, allocFn); err != nil {
@@ -308,7 +308,7 @@ func TestKProbeEventsList(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	if err := os.MkdirAll(tmpDir, 0700); err != nil {
+	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	file, err := os.Create(filepath.Join(tmpDir, "kprobe_events"))
@@ -365,7 +365,7 @@ func TestKProbeEventsAddRemoveKProbe(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	if err := os.MkdirAll(tmpDir, 0700); err != nil {
+	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	file, err := os.Create(filepath.Join(tmpDir, "kprobe_events"))

--- a/x-pack/auditbeat/tracing/perfevent.go
+++ b/x-pack/auditbeat/tracing/perfevent.go
@@ -9,6 +9,7 @@ package tracing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -17,7 +18,6 @@ import (
 	"unsafe"
 
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/go-perf"
@@ -120,7 +120,7 @@ func NewPerfChannel(cfg ...PerfChannelConf) (channel *PerfChannel, err error) {
 	// at runtime (CPU hotplug).
 	channel.cpus, err = NewCPUSetFromFile(OnlineCPUsPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "error listing online CPUs")
+		return nil, fmt.Errorf("error listing online CPUs: %w", err)
 	}
 	if channel.cpus.NumCPU() < 1 {
 		return nil, errors.New("couldn't list online CPUs")
@@ -247,7 +247,7 @@ func (c *PerfChannel) MonitorProbe(format ProbeFormat, decoder Decoder) error {
 			fbytes := []byte(format.Probe.Filter + "\x00")
 			_, _, errNo := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), unix.PERF_EVENT_IOC_SET_FILTER, uintptr(unsafe.Pointer(&fbytes[0])))
 			if errNo != 0 {
-				return errors.Wrapf(errNo, "unable to set filter '%s'", format.Probe.Filter)
+				return fmt.Errorf("unable to set filter '%s': %w", format.Probe.Filter, errNo)
 			}
 		}
 		c.streams[cid] = stream{probeID: format.ID, decoder: decoder}
@@ -255,7 +255,7 @@ func (c *PerfChannel) MonitorProbe(format ProbeFormat, decoder Decoder) error {
 
 		if !doGroup {
 			if err := ev.MapRingNumPages(c.mappedPages); err != nil {
-				return errors.Wrap(err, "perf channel mapring failed")
+				return fmt.Errorf("perf channel mapring failed: %w", err)
 			}
 		}
 	}
@@ -292,7 +292,7 @@ func (c *PerfChannel) Run() error {
 
 	for _, ev := range c.events {
 		if err := ev.Enable(); err != nil {
-			return errors.Wrap(err, "perf channel enable failed")
+			return fmt.Errorf("perf channel enable failed: %w", err)
 		}
 	}
 	c.wg.Add(1)
@@ -312,10 +312,10 @@ func (c *PerfChannel) Close() error {
 	var errs multierror.Errors
 	for _, ev := range c.events {
 		if err := ev.Disable(); err != nil {
-			errs = append(errs, errors.Wrap(err, "failed to disable event channel"))
+			errs = append(errs, fmt.Errorf("failed to disable event channel: %w", err))
 		}
 		if err := ev.Close(); err != nil {
-			errs = append(errs, errors.Wrap(err, "failed to close event channel"))
+			errs = append(errs, fmt.Errorf("failed to close event channel: %w", err))
 		}
 	}
 	return errs.Err()
@@ -446,7 +446,7 @@ func (m *recordMerger) nextSample(ctx context.Context) (sr *perf.SampleRecord, o
 		// No sample was available. Block until one of the ringbuffers has data.
 		_, closed, err := pollAll(m.evs, m.timeout)
 		if err != nil {
-			m.channel.errC <- errors.Wrap(err, "poll failed")
+			m.channel.errC <- fmt.Errorf("poll failed: %w", err)
 			return nil, false
 		}
 		// Some of the ring buffers closed. Report termination.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This replaces uses of github.com/pkg/errors with their standard library equivalents.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

github.com/pkg/errors is now archived and additionally does work that we almost never use (see elastic/go-libaudit#99 for background); the one place where this work is used is replaced with a stdlib call.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Run the commands in the first commit in auditbeat and x-pack/auditbeat to confirm mechanical changes.
- [ ] Check first commit for uses of `%w` in `fmt.Errorf` calls where the error has not been confirmed to be non-nil.
- [ ] Check the semantics remain unaltered or corrected in the second commit.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates elastic/go-libaudit#99

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
