### PR TITLE
Fix flaky test for the Filebeat Kafka input

### DIFF
--- a/filebeat/input/kafka/kafka_integration_test.go
+++ b/filebeat/input/kafka/kafka_integration_test.go
@@ -87,10 +87,9 @@ func TestInput(t *testing.T) {
 
 	// Setup the input config
 	config := common.MustNewConfigFrom(common.MapStr{
-		"hosts":      getTestKafkaHost(),
-		"topics":     []string{testTopic},
-		"group_id":   groupID,
-		"wait_close": 0,
+		"hosts":    getTestKafkaHost(),
+		"topics":   []string{testTopic},
+		"group_id": groupID,
 	})
 
 	client := beattest.NewChanClient(100)


### PR DESCRIPTION
## What does this PR do?

We need to wait before shutting down the client so the messages get acknowledged.
