### PR TITLE
libbeat/common/transport: fix log message about TLS

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 *Affecting all Beats*
 
 - Fix field names with `add_network_direction` processor. {issue}29747[29747] {pull}29751[29751]
+- Fix a logging bug when `ssl.verification_mode` was set to `full` or `certificate`, the command `test output` incorrectly logged that TLS was disabled.
 
 *Auditbeat*
 

--- a/libbeat/common/transport/tls.go
+++ b/libbeat/common/transport/tls.go
@@ -154,7 +154,21 @@ func tlsDialWith(
 		}
 	}
 
-	if tlsConfig.InsecureSkipVerify {
+	// config might be nil, so get the zero-value and then read what is in config.
+	// We assume that the zero-value is the default value
+	var verification tlscommon.TLSVerificationMode
+	if config != nil {
+		verification = config.Verification
+	}
+
+	// We only check the status of config.Verification (`ssl.verification_mode`
+	// in the configuration file) because we have a custom verification logic
+	// implemented by setting tlsConfig.VerifyConnection that runs regardless of
+	// the status of tlsConfig.InsecureSkipVerify.
+	// For verification modes VerifyFull and VerifyCeritifcate we set
+	// tlsConfig.InsecureSkipVerify to true, hence it's not an indicator of
+	// whether TLS verification is enabled or not.
+	if verification == tlscommon.VerifyNone {
 		d.Warn("security", "server's certificate chain verification is disabled")
 	} else {
 		d.Info("security", "server's certificate chain verification is enabled")


### PR DESCRIPTION
## What does this PR do?

This commit fixes the log message issued by the `test output` command.
Our current TLS verification relies on more than the value of
`tlsConfig.InsecureSkipVerify`, so the previous implementation would
log that TLS was disabled when it was not.

This commit fixes it by checking the value of `config.Verification`.

## Why is it important?

It fixes a logging issue

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] Should we add some tests to the bug reported on the issues below?
    #30315
    #30314

## How to test this PR locally
To test using Filebeat, set the `ssl.verification_mode` on any Beat output to anything other than `none`, then run `filebeat test output`. You should see the correct log message based on the verification mode you set.

## Related issues

- Relates #30315
- Duplicates/Fixes https://github.com/elastic/beats/pull/30063

~~## Use cases~~
~~## Screenshots~~

## Logs
```
elasticsearch: https://somewhere-in-the-cloud:443...
  parse url... OK
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 42.42.42.42 42.42.42.43
    dial up... OK
  TLS...
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.2
    dial up... OK
  talk to server... OK
  version: 7.17.0
```