### PR TITLE
Fix new Recorded Future dashboard

### DIFF
--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/dashboard/Filebeat-threatintel-recordedfuture.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/dashboard/Filebeat-threatintel-recordedfuture.json
@@ -335,7 +335,7 @@
                                                     "label": "Count of records",
                                                     "operationType": "count",
                                                     "scale": "ratio",
-                                                    "sourceField": "Records"
+                                                    "sourceField": "___records___"
                                                 },
                                                 "dac2417a-0b3b-430a-bd24-23abfcea4a4c": {
                                                     "dataType": "string",

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/037e2af0-df50-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/037e2af0-df50-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/06744e90-df52-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/06744e90-df52-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/139c7da0-df51-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/139c7da0-df51-11eb-8f2b-753caedf727d.json
@@ -17,7 +17,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 },
                                 "ebb0878f-715a-4987-85f1-87420428c88f": {
                                     "customLabel": true,

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/176bf800-df58-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/176bf800-df58-11eb-8f2b-753caedf727d.json
@@ -17,7 +17,7 @@
                                     "label": "Recorded Future Indicators",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/2d365f10-8479-11ec-8aa9-11bf914a1ef2.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/2d365f10-8479-11ec-8aa9-11bf914a1ef2.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/3c996410-df52-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/3c996410-df52-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/4bcc4cb0-df50-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/4bcc4cb0-df50-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/5e76ef90-df51-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/5e76ef90-df51-11eb-8f2b-753caedf727d.json
@@ -17,7 +17,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 },
                                 "ebb0878f-715a-4987-85f1-87420428c88f": {
                                     "customLabel": true,

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/6b33edb0-8478-11ec-8aa9-11bf914a1ef2.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/6b33edb0-8478-11ec-8aa9-11bf914a1ef2.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/739274d0-8479-11ec-8aa9-11bf914a1ef2.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/739274d0-8479-11ec-8aa9-11bf914a1ef2.json
@@ -17,7 +17,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 },
                                 "d5b0eba3-5cb3-40fe-adb6-8f1a1de50e57": {
                                     "customLabel": true,

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/790cd040-df51-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/790cd040-df51-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/7ed4ce00-df52-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/7ed4ce00-df52-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/82fa7420-df58-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/82fa7420-df58-11eb-8f2b-753caedf727d.json
@@ -17,7 +17,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 },
                                 "8f48381c-5786-43f4-8602-5c23ba146a60": {
                                     "customLabel": true,

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/8fb01a00-df51-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/8fb01a00-df51-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/949bc180-df52-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/949bc180-df52-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/a0a31740-df51-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/a0a31740-df51-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/b0837690-df52-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/b0837690-df52-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/c2a5c180-df51-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/c2a5c180-df51-11eb-8f2b-753caedf727d.json
@@ -36,7 +36,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 }
                             },
                             "incompleteColumns": {}

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/c6079390-8478-11ec-8aa9-11bf914a1ef2.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/c6079390-8478-11ec-8aa9-11bf914a1ef2.json
@@ -17,7 +17,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 },
                                 "dac2417a-0b3b-430a-bd24-23abfcea4a4c": {
                                     "customLabel": true,

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/dd4a3da0-df50-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/dd4a3da0-df50-11eb-8f2b-753caedf727d.json
@@ -17,7 +17,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 },
                                 "ebb0878f-715a-4987-85f1-87420428c88f": {
                                     "customLabel": true,

--- a/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/f37f8350-df50-11eb-8f2b-753caedf727d.json
+++ b/x-pack/filebeat/module/threatintel/_meta/kibana/7/lens/f37f8350-df50-11eb-8f2b-753caedf727d.json
@@ -17,7 +17,7 @@
                                     "label": "Count of records",
                                     "operationType": "count",
                                     "scale": "ratio",
-                                    "sourceField": "Records"
+                                    "sourceField": "___records___"
                                 },
                                 "ebb0878f-715a-4987-85f1-87420428c88f": {
                                     "customLabel": true,


### PR DESCRIPTION
## What does this PR do?

This updates the new Recorded Future dashboard to align with a recent change (https://github.com/elastic/kibana/pull/123894) in Kibana 8.1 that affects how the Lens visualisations are serialised.

## Why is it important?

The dashboard had been exported using an incompatible snapshot version of Kibana 8.1, and wouldn't work in newer versions. All visualisations would show _"Field Records not found"._

This fix is not necessary for other dashboards as those were exported with an older Kibana version. In this case, the older `Records` field placeholder is automatically translated to the new `___records___` by Kibana.
