### PR TITLE
Give more time to multiline parser to aggregate logs into events during testing

### DIFF
--- a/filebeat/input/filestream/parsers_integration_test.go
+++ b/filebeat/input/filestream/parsers_integration_test.go
@@ -248,8 +248,6 @@ The total should be 4 lines covered
 
 // test_rabbitmq_multiline_log from test_multiline.py
 func TestParsersRabbitMQMultilineLog(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/27893")
-
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"
@@ -263,7 +261,7 @@ func TestParsersRabbitMQMultilineLog(t *testing.T) {
 					"pattern": "^=[A-Z]+",
 					"negate":  true,
 					"match":   "after",
-					"timeout": "100ms", // set to lower value to speed up test
+					"timeout": "3s", // set to lower value to speed up test
 				},
 			},
 		},
@@ -294,8 +292,6 @@ connection <0.23893.109>, channel 3 - soft error:
 
 // test_max_lines from test_multiline.py
 func TestParsersMultilineMaxLines(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/27894")
-
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"
@@ -310,7 +306,7 @@ func TestParsersMultilineMaxLines(t *testing.T) {
 					"negate":    true,
 					"match":     "after",
 					"max_lines": 3,
-					"timeout":   "100ms", // set to lower value to speed up test
+					"timeout":   "3s", // set to lower value to speed up test
 				},
 			},
 		},
@@ -402,7 +398,6 @@ func TestParsersMultilineTimeout(t *testing.T) {
 
 // test_max_bytes from test_multiline.py
 func TestParsersMultilineMaxBytes(t *testing.T) {
-	t.Skip("Flaky test https://github.com/elastic/beats/issues/28088")
 	env := newInputTestingEnvironment(t)
 
 	testlogName := "test.log"
@@ -417,7 +412,7 @@ func TestParsersMultilineMaxBytes(t *testing.T) {
 					"pattern": "^\\[",
 					"negate":  true,
 					"match":   "after",
-					"timeout": "100ms", // set to lower value to speed up test
+					"timeout": "3s", // set to lower value to speed up test
 				},
 			},
 		},
@@ -450,7 +445,7 @@ func TestParsersCloseTimeoutWithMultiline(t *testing.T) {
 	inp := env.mustCreateInput(map[string]interface{}{
 		"paths":                             []string{env.abspath(testlogName)},
 		"prospector.scanner.check_interval": "1ms",
-		"close.reader.after_interval":       "100ms",
+		"close.reader.after_interval":       "1s",
 		"parsers": []map[string]interface{}{
 			map[string]interface{}{
 				"multiline": map[string]interface{}{
@@ -507,7 +502,6 @@ func TestParsersCloseTimeoutWithMultiline(t *testing.T) {
 
 // test_consecutive_newline from test_multiline.py
 func TestParsersConsecutiveNewline(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/27085")
 
 	env := newInputTestingEnvironment(t)
 
@@ -515,6 +509,7 @@ func TestParsersConsecutiveNewline(t *testing.T) {
 	inp := env.mustCreateInput(map[string]interface{}{
 		"paths":                             []string{env.abspath(testlogName)},
 		"prospector.scanner.check_interval": "1ms",
+		"close.reader.after_interval":       "1s",
 		"parsers": []map[string]interface{}{
 			map[string]interface{}{
 				"multiline": map[string]interface{}{
@@ -522,7 +517,7 @@ func TestParsersConsecutiveNewline(t *testing.T) {
 					"pattern": "^\\[",
 					"negate":  true,
 					"match":   "after",
-					"timeout": "100ms", // set to lower value to speed up test
+					"timeout": "3s", // set to lower value to speed up test
 				},
 			},
 		},


### PR DESCRIPTION
## What does this PR do?

This PR reenables previous flaky tests. The problem was that we did not leave enough time for the multiline parser to aggregate log lines into a single message. So we ended up with incomplete events, saving unexpected offsets to the registry.
The fix is to increase the timeout of the multiline parser. The default value is 5 seconds, but I set it to 3, so we still save some time during testing.

## Why is it important?

Run existing tests to make sure we do not introduce regressions.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

Closes https://github.com/elastic/beats/issues/27893
Closes https://github.com/elastic/beats/issues/27894
Closes https://github.com/elastic/beats/issues/28088
Closes https://github.com/elastic/beats/issues/27085