### PR TITLE
Add docs about hints and templates autodiscovery priority

### DIFF
--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -100,6 +100,33 @@ Define an ingest pipeline ID to be added to the {beatname_uc} input/module confi
 co.elastic.logs/pipeline: custom-pipeline
 -----
 
+When hints are used along with templates, then hints will be evaluated only in case
+there is no template's condition that resolve to true. For example:
+
+[source,yaml]
+-----
+filebeat.autodiscover.providers:
+  - type: docker
+    hints.enabled: true
+    hints.default_config:
+      type: container
+      paths:
+        - /var/lib/docker/containers/${data.container.id}/*.log
+    templates:
+      - condition:
+          equals:
+            docker.container.labels.type: "pipeline"
+        config:
+          - type: container
+            paths:
+              - "/var/lib/docker/containers/${data.docker.container.id}/*.log"
+            pipeline: my-pipeline
+-----
+
+In this example first the condition `docker.container.labels.type: "pipeline"` is evaluated
+and if not matched the hints will be processed and if there is again no valid config
+the `hints.default_config` will be used.
+
 [float]
 ==== Kubernetes
 

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -101,7 +101,7 @@ co.elastic.logs/pipeline: custom-pipeline
 -----
 
 When hints are used along with templates, then hints will be evaluated only in case
-there is no template's condition that resolve to true. For example:
+there is no template's condition that resolves to true. For example:
 
 [source,yaml]
 -----

--- a/heartbeat/docs/autodiscover-hints.asciidoc
+++ b/heartbeat/docs/autodiscover-hints.asciidoc
@@ -48,6 +48,29 @@ co.elastic.monitor/processors.drop_fields.fields: "field3"
 
 In the above sample the processor definition tagged with `1` would be executed first.
 
+When hints are used along with templates, then hints will be evaluated only in case
+there is no template's condition that resolve to true. For example:
+
+[source,yaml]
+-----
+heartbeat.autodiscover:
+    - type: docker
+      hints.enabled: true
+      templates:
+        - condition:
+            contains:
+              docker.container.image: redis
+          config:
+            - type: tcp
+              hosts: ["${data.host}:${data.port}"]
+              schedule: "@every 1s"
+              timeout: 1s
+-----
+
+In this example first the condition `docker.container.image: redis` is evaluated
+and if not matched the hints will be processed and if there is again no valid config
+the `hints.default_config` will be used.
+
 [float]
 ==== Kubernetes
 

--- a/heartbeat/docs/autodiscover-hints.asciidoc
+++ b/heartbeat/docs/autodiscover-hints.asciidoc
@@ -49,7 +49,7 @@ co.elastic.monitor/processors.drop_fields.fields: "field3"
 In the above sample the processor definition tagged with `1` would be executed first.
 
 When hints are used along with templates, then hints will be evaluated only in case
-there is no template's condition that resolve to true. For example:
+there is no template's condition that resolves to true. For example:
 
 [source,yaml]
 -----

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -96,6 +96,28 @@ co.elastic.logs/processors.add_locale.abbrevation: "PST"
 
 In the above sample the processor definition tagged with `1` would be executed first.
 
+When hints are used along with templates, then hints will be evaluated only in case
+there is no template's condition that resolve to true. For example:
+
+[source,yaml]
+-----
+metricbeat.autodiscover.providers:
+  - type: kubernetes
+    hints.enabled: true
+    templates:
+        - condition:
+            contains:
+              kubernetes.annotations.prometheus.io/scrape: "true"
+          config:
+            - module: prometheus
+              metricsets: ["collector"]
+              hosts: "${data.host}:${data.port}"
+-----
+
+In this example first the condition `kubernetes.annotations.prometheus.io/scrape: "true"`
+is evaluated and if not matched the hints will be processed.
+
+
 [float]
 === Kubernetes
 

--- a/metricbeat/docs/autodiscover-hints.asciidoc
+++ b/metricbeat/docs/autodiscover-hints.asciidoc
@@ -97,7 +97,7 @@ co.elastic.logs/processors.add_locale.abbrevation: "PST"
 In the above sample the processor definition tagged with `1` would be executed first.
 
 When hints are used along with templates, then hints will be evaluated only in case
-there is no template's condition that resolve to true. For example:
+there is no template's condition that resolves to true. For example:
 
 [source,yaml]
 -----


### PR DESCRIPTION
## What does this PR do?
Adds documentation to state that it's possible to use [autodiscover templating](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover.html) + [hints based autodiscover](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-autodiscover-hints.html) together in a single Filebeat (and others) configuration.

Closes https://github.com/elastic/beats/issues/26397