### PR TITLE
jjbb: 6 major branch reached EOL

### DIFF
--- a/.ci/jobs/beats.yml
+++ b/.ci/jobs/beats.yml
@@ -17,7 +17,7 @@
         discover-pr-forks-strategy: 'merge-current'
         discover-pr-forks-trust: 'permission'
         discover-pr-origin: 'merge-current'
-        head-filter-regex: '(main|6\.[89]|7\.1[6789]|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
+        head-filter-regex: '(main|7\.1[6789]|8\.\d+|PR-.*|v\d+\.\d+\.\d+)'
         discover-tags: true
         notification-context: "beats-ci"
         repo: 'beats'


### PR DESCRIPTION
## What does this PR do?

Disable 6.x branches in the CI

## Why is it important?

6 major branch reached EOL
