### PR TITLE
Add support for non-unique keys in Kafka output headers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -94,6 +94,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add support for kafka message headers. {pull}29940[29940]
 - Add FIPS configuration option for all AWS API calls. {pull}[28899]
 - Add metadata change support for some processors {pull}30183[30183]
+- Add support for non-unique Kafka headers for output messages. {pull}30369[30369]
 
 *Auditbeat*
 

--- a/libbeat/outputs/kafka/client.go
+++ b/libbeat/outputs/kafka/client.go
@@ -78,7 +78,7 @@ func newKafkaClient(
 	index string,
 	key *fmtstr.EventFormatString,
 	topic outil.Selector,
-	headers map[string]string,
+	headers []header,
 	writer codec.Codec,
 	cfg *sarama.Config,
 ) (*client, error) {
@@ -96,10 +96,13 @@ func newKafkaClient(
 
 	if len(headers) != 0 {
 		recordHeaders := make([]sarama.RecordHeader, 0, len(headers))
-		for k, v := range headers {
+		for _, h := range headers {
+			if h.Key == "" {
+				continue
+			}
 			recordHeader := sarama.RecordHeader{
-				Key:   []byte(k),
-				Value: []byte(v),
+				Key:   []byte(h.Key),
+				Value: []byte(h.Value),
 			}
 
 			recordHeaders = append(recordHeaders, recordHeader)

--- a/libbeat/outputs/kafka/config.go
+++ b/libbeat/outputs/kafka/config.go
@@ -44,6 +44,11 @@ type backoffConfig struct {
 	Max  time.Duration `config:"max"`
 }
 
+type header struct {
+	Key   string `config:"key"`
+	Value string `config:"value"`
+}
+
 type kafkaConfig struct {
 	Hosts              []string                  `config:"hosts"               validate:"required"`
 	TLS                *tlscommon.Config         `config:"ssl"`
@@ -62,7 +67,7 @@ type kafkaConfig struct {
 	BulkMaxSize        int                       `config:"bulk_max_size"`
 	BulkFlushFrequency time.Duration             `config:"bulk_flush_frequency"`
 	MaxRetries         int                       `config:"max_retries"         validate:"min=-1,nonzero"`
-	Headers            map[string]string         `config:"headers"`
+	Headers            []header                  `config:"headers"`
 	Backoff            backoffConfig             `config:"backoff"`
 	ClientID           string                    `config:"client_id"`
 	ChanBufferSize     int                       `config:"channel_buffer_size" validate:"min=1"`

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -195,6 +195,22 @@ available partitions only.
 
 NOTE: Publishing to a subset of available partitions potentially increases resource usage because events may become unevenly distributed.
 
+===== `headers`
+
+A header is a key-value pair, and multiple headers can be included with the same `key`. Only string values are supported. These headers will be included in each produced Kafka message.
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.kafka:
+  hosts: ["localhost:9092"]
+  topic: "logs-%{[agent.version]}"
+  headers:
+    - key: "some-key"
+      value: "some value"
+    - key: "another-key"
+      value: "another value"
+------------------------------------------------------------------------------
+
 ===== `client_id`
 
 The configurable ClientID used for logging, debugging, and auditing purposes. The default is "beats".


### PR DESCRIPTION
## What does this PR do?

According to the Kafka documentation, header keys are not supposed to
be unique, therefore we must support the headers in the same way.

Also, documented the headers configuration, so customers can start using it.

This is a follow up to https://github.com/elastic/beats/pull/29940

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Initially, it was a community PR hence for someone this functionality is important. This PR brings the implementation closer to the original Kafka feature as the documentation states:

> A [Header](https://kafka.apache.org/20/javadoc/org/apache/kafka/connect/header/Header.html) is a key-value pair, and multiple headers can be included with the key, value, and timestamp in each Kafka message.

source https://kafka.apache.org/20/javadoc/index.html?org/apache/kafka/connect/header/Header.html

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Run Kafka locally in its standard configuration

2. Run filebeat with the following configuration:

```yaml
filebeat.inputs:
  - type: log
    paths:
      - "/path/to/your/file.log"

output.kafka:
  hosts: ["localhost:9092"]
  topic: "test-topic"
  headers:
    - key: "same-key"
      value: "value1"
    - key: "same-key"
      value: "value2"
    - key: "another-key"
      value: "another value"
```

(replace `/path/to/your/file.log` with you real path)

3. Write a line to the file `/path/to/your/file.log`
4. Check that the message has headers with this command:

```bash
kafka-console-consumer --from-beginning --property print.headers=true --topic test-topic --bootstrap-server localhost:9092
```

For example, when I appended a line "test message" to my file I got this output:

```
same-key:value1,same-key:value2,another-key:another value       {"@timestamp":"2022-02-13T08:30:20.645Z","@metadata":{"beat":"filebeat","type":"_doc","version":"8.2.0"},"log":{"offset":0,"file":{"path":"/Users/rdner/Projects/tests/input.log"}},"message":"test message","input":{"type":"log"},"ecs":{"version":"8.0.0"},"host":{"name":"MacBook-Pro.localdomain"},"agent":{"ephemeral_id":"1ac3ddd7-c294-4f22-a081-e6baeab977eb","id":"4fd6b173-0f13-4792-888a-b54dcd85496c","name":"MacBook-Pro.localdomain","type":"filebeat","version":"8.2.0"}}
```

Mind the headers in the beginning of the line.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #29940
