### PR TITLE
fix: report GitHub Check before the cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,8 +85,8 @@ pipeline {
         GOFLAGS = '-mod=readonly'
       }
       steps {
-        stageStatusCache(id: 'Lint'){
-          withGithubNotify(context: "Lint") {
+        withGithubNotify(context: "Lint") {
+          stageStatusCache(id: 'Lint'){
             withBeatsEnv(archive: false, id: "lint") {
               dumpVariables()
               whenTrue(env.ONLY_DOCS == 'true') {


### PR DESCRIPTION
When the lint stage is not reported for some reason and the CI success you can not merge the PR because the lint check is required. Due to we have a cache in place the stage is never reported as a GitHub check if there are no changes in code. By changing the order of the GitHub check, it is always returned.