### PR TITLE
update windows matrix support

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -79,21 +79,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
         stage: extended
-    #windows-2008:  See https://github.com/elastic/beats/issues/19799
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-2008-r2"
-    #    stage: extended
-    #windows-7:  See https://github.com/elastic/beats/issues/19831
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7"
-    #    stage: extended
-    #windows-7-32:  See https://github.com/elastic/beats/issues/19831
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7-32-bit"
-    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -70,7 +70,6 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-            #- "windows-2008-r2"  https://github.com/elastic/beats/issues/19795
         stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
@@ -86,17 +85,6 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    #windows-7:  See https://github.com/elastic/beats/issues/22317
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7"
-    #    when:                  ## Override the top-level when.
-    #    stage: packaging
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -84,16 +84,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
         stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
-        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -73,21 +73,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
-        stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -72,25 +72,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -39,11 +39,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
@@ -53,16 +48,6 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -72,25 +72,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -69,26 +69,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
         stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    #windows-7-32:  See https://github.com/elastic/beats/issues/22316
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7-32-bit"
-    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -86,20 +86,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
         stage: extended
     cloud:
       cloud: "mage build test"
@@ -128,11 +118,6 @@ stages:
             - "^x-pack/filebeat/Jenkinsfile.yml"
             - "^x-pack/libbeat/common/aws/.*"
         stage: extended
-    #windows-7-32:  See https://github.com/elastic/beats/issues/22315
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7-32-bit"
-    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -69,25 +69,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -63,25 +63,10 @@ stages:
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-10"
 #        stage: extended
-#    windows-2008:
-#        mage: "mage build test"
-#        platforms:             ## override default labels in this specific stage.
-#            - "windows-2008-r2"
-#        stage: extended
 #    windows-8:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-8"
-#        stage: extended
-#    windows-7:
-#        mage: "mage build test"
-#        platforms:             ## override default labels in this specific stage.
-#            - "windows-7"
-#        stage: extended
-#    windows-7-32:
-#        mage: "mage build test"
-#        platforms:             ## override default labels in this specific stage.
-#            - "windows-7-32-bit"
 #        stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -90,27 +90,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
         stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    # windows-7-32 builder has been disabled due to https://github.com/elastic/beats/issues/24337
-    #windows-7-32:
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-7-32-bit"
-    #    stage: extended
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -58,20 +58,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -73,25 +73,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -44,25 +44,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
-    windows-7:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7"
-        stage: extended
-    windows-7-32:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-7-32-bit"
         stage: extended
     packaging-linux:
         packaging-linux: "mage package"


### PR DESCRIPTION
## What does this PR do?

Remove `windows-7`, `windows-7-32` and `windows-2008-r2` from the matrix support in the CI


## Why is it important?

>= 8.0 don't support those versions anymore.
