### PR TITLE
packetbeat/beater: make sure Npcap installation runs before interfaces are needed

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -137,7 +137,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Packetbeat*
 
-- Add automated OEM Npcap installation handling. {pull}29112[29112]
+- Add automated OEM Npcap installation handling. {pull}29112[29112] {pull}30396[30396]
 - Add support for capturing TLS random number and OCSP status request details. {issue}29962[29962] {pull}30102[30102]
 
 *Functionbeat*

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -111,12 +111,6 @@ func (pb *packetbeat) Run(b *beat.Beat) error {
 		}
 	}()
 
-	// Install Npcap if needed.
-	err := installNpcap(b)
-	if err != nil {
-		return err
-	}
-
 	if !b.Manager.Enabled() {
 		return pb.runStatic(b, pb.factory)
 	}

--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -113,6 +113,12 @@ func (p *processorFactory) Create(pipeline beat.PipelineConnector, cfg *common.C
 		return nil, err
 	}
 
+	// Install Npcap if needed.
+	err = installNpcap(p.beat)
+	if err != nil {
+		return nil, err
+	}
+
 	publisher, err := publish.NewTransactionPublisher(
 		p.beat.Info.Name,
 		p.beat.Publisher,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Previously installNpcap was run after Create, which depends on having interfaces up
to establish sniffers, and so was too late. So move the call to the front of Create
to ensure that the library is installed by the time that it is needed.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This fixes a required feature.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Run packetbeat on a windows VM with the 8.1 packetbeat.yml to confirm functionality.
- [ ] Check that the Npcap library has been correctly installed

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- [ ] Place the OEM installer in x-pack/packetbeat/npcap/installer/
- [ ] `mage build` in x-pack/packetbeat
- [ ] Obtain the current 8.1 snapshot for windows packetbeat and install
- [ ] Replace the executable with the freshly built one
- [ ] Run `packetbeat -v -e -d=* to confirm function`
- [ ] Check C:\Program Files\Npcap exists and contains the correct OEM version.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
