### PR TITLE
ci: use getBranchesFromAliases and support next-patch-8

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Nighly beats builds') {
       steps {
-        runBuilds(quietPeriodFactor: 2000, branches: ['main', '8.<minor>', '7.<minor>', '7.<next-minor>'])
+        runBuilds(quietPeriodFactor: 2000, branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
       }
     }
   }
@@ -32,14 +32,7 @@ pipeline {
 }
 
 def runBuilds(Map args = [:]) {
-  def branches = []
-  // Expand macros and filter duplicated matches.
-  args.branches.each { branch ->
-    def branchName = getBranchName(branch)
-    if (!branches.contains(branchName)) {
-      branches << branchName
-    }
-  }
+  def branches = getBranchesFromAliases(aliases: args.branches)
 
   def quietPeriod = 0
   branches.each { branch ->
@@ -47,21 +40,4 @@ def runBuilds(Map args = [:]) {
     // Increate the quiet period for the next iteration
     quietPeriod += args.quietPeriodFactor
   }
-}
-
-def getBranchName(branch) {
-  // special macro to look for the latest minor version
-  if (branch.contains('8.<minor>')) {
-   return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
-  }
-  if (branch.contains('8.<next-minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
-  }
-  if (branch.contains('7.<minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
-  }
-  if (branch.contains('7.<next-minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
-  }
-  return branch
 }

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Weekly beats builds') {
       steps {
-        runBuilds(quietPeriodFactor: 1000, branches: ['main', '8.<minor>', '7.<minor>', '7.<next-minor>'])
+        runBuilds(quietPeriodFactor: 1000, branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
       }
     }
   }
@@ -32,14 +32,7 @@ pipeline {
 }
 
 def runBuilds(Map args = [:]) {
-  def branches = []
-  // Expand macros and filter duplicated matches.
-  args.branches.each { branch ->
-    def branchName = getBranchName(branch)
-    if (!branches.contains(branchName)) {
-      branches << branchName
-    }
-  }
+  def branches = getBranchesFromAliases(aliases: args.branches)
 
   def quietPeriod = 0
   branches.each { branch ->
@@ -47,21 +40,4 @@ def runBuilds(Map args = [:]) {
     // Increate the quiet period for the next iteration
     quietPeriod += args.quietPeriodFactor
   }
-}
-
-def getBranchName(branch) {
-  // special macro to look for the latest minor version
-  if (branch.contains('8.<minor>')) {
-   return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
-  }
-  if (branch.contains('8.<next-minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
-  }
-  if (branch.contains('7.<minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
-  }
-  if (branch.contains('7.<next-minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
-  }
-  return branch
 }


### PR DESCRIPTION
## What does this PR do?

Support for the next patch fro the 8 major.
And refactor code with a shared library step

## Why is it important?

Support for 8.1 branch 

## Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1548