### PR TITLE
input/filestream: filestream input ID is required

### DIFF
--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -241,6 +241,9 @@ filebeat.inputs:
 #--------------------------- Filestream input ----------------------------
 - type: filestream
 
+  # Unique ID among all inputs, an ID is required.
+  id: foo
+
   # Change to true to enable this input configuration.
   enabled: false
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -242,7 +242,7 @@ filebeat.inputs:
 - type: filestream
 
   # Unique ID among all inputs, an ID is required.
-  id: foo
+  id: my-filestream-id
 
   # Change to true to enable this input configuration.
   enabled: false

--- a/filebeat/_meta/config/filebeat.inputs.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.yml.tmpl
@@ -10,7 +10,7 @@ filebeat.inputs:
 - type: filestream
 
   # Unique ID among all inputs, an ID is required.
-  id: foo
+  id: my-filestream-id
 
   # Change to true to enable this input configuration.
   enabled: false

--- a/filebeat/_meta/config/filebeat.inputs.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.yml.tmpl
@@ -9,6 +9,9 @@ filebeat.inputs:
 # filestream is an input for collecting log messages from files.
 - type: filestream
 
+  # Unique ID among all inputs, an ID is required.
+  id: foo
+
   # Change to true to enable this input configuration.
   enabled: false
 

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -15,6 +15,19 @@ in the `paths` option. At the moment only simple file system scanning is
 supported.
 
 [float]
+[[filestream-input-id]]
+===== `id`
+
+A unique identifier for this filestream input. Each filestream input
+must have a unique ID.
+
+WARNING: If there are multiple inputs without an ID, there will be
+data duplication when {beatname_lc} is restarted.
+
+WARNING: Adding an ID to an existing configuration will read the files
+from the beginning.
+
+[float]
 [[filestream-input-paths]]
 ===== `paths`
 

--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -42,6 +42,7 @@ Example configuration:
 ----
 {beatname_lc}.inputs:
 - type: filestream
+  id: foo
   paths:
     - /var/log/messages
     - /var/log/*.log
@@ -61,10 +62,12 @@ multiple input sections:
 ----
 {beatname_lc}.inputs:
 - type: filestream <1>
+  id: foo
   paths:
     - /var/log/system.log
     - /var/log/wifi.log
 - type: filestream <2>
+  id: bar
   paths:
     - "/var/log/apache2/*"
   fields:
@@ -80,7 +83,7 @@ multiple input sections:
 [[filestream-file-identity]]
 ==== Reading files on network shares and cloud providers
 
-:WARNING: Filebeat does not support reading from network shares and cloud providers.
+WARNING: Filebeat does not support reading from network shares and cloud providers.
 
 However, one of the limitations of these data sources can be mitigated
 if you configure Filebeat adequately.
@@ -123,6 +126,7 @@ the input the following way:
 ----
 {beatname_lc}.inputs:
 - type: filestream
+  id: foo
   paths:
     - /logs/*.log
   file_identity.inode_marker.path: /logs/.filebeat-marker

--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -42,7 +42,7 @@ Example configuration:
 ----
 {beatname_lc}.inputs:
 - type: filestream
-  id: foo
+  id: my-filestream-id
   paths:
     - /var/log/messages
     - /var/log/*.log
@@ -62,7 +62,7 @@ multiple input sections:
 ----
 {beatname_lc}.inputs:
 - type: filestream <1>
-  id: foo
+  id: my-filestream-id
   paths:
     - /var/log/system.log
     - /var/log/wifi.log
@@ -126,7 +126,7 @@ the input the following way:
 ----
 {beatname_lc}.inputs:
 - type: filestream
-  id: foo
+  id: my-filestream-id
   paths:
     - /logs/*.log
   file_identity.inode_marker.path: /logs/.filebeat-marker

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -649,7 +649,7 @@ filebeat.inputs:
 - type: filestream
 
   # Unique ID among all inputs, an ID is required.
-  id: foo
+  id: my-filestream-id
 
   # Change to true to enable this input configuration.
   enabled: false

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -648,6 +648,9 @@ filebeat.inputs:
 #--------------------------- Filestream input ----------------------------
 - type: filestream
 
+  # Unique ID among all inputs, an ID is required.
+  id: foo
+
   # Change to true to enable this input configuration.
   enabled: false
 

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -21,6 +21,9 @@ filebeat.inputs:
 # filestream is an input for collecting log messages from files.
 - type: filestream
 
+  # Unique ID among all inputs, an ID is required.
+  id: foo
+
   # Change to true to enable this input configuration.
   enabled: false
 

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -22,7 +22,7 @@ filebeat.inputs:
 - type: filestream
 
   # Unique ID among all inputs, an ID is required.
-  id: foo
+  id: my-filestream-id
 
   # Change to true to enable this input configuration.
   enabled: false

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -170,9 +170,9 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 	}
 
 	if settings.ID == "" {
-		cim.Logger.Warn("not setting an ID for the filestream input may lead to " +
-			"duplicated data. Filestream input without an ID will not be supported in a future release. " +
-			"Adding an ID to an existing input will read all files from the beginning",
+		cim.Logger.Warn("creating a filestream input without an ID, which may lead to duplicated data." +
+			"Filestream inputs will require an ID in a future release." +
+			"NOTE: Adding an ID to an existing input will cause all files to be re-read from the beginning.",
 		)
 	}
 

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -164,9 +164,16 @@ func (cim *InputManager) Create(config *common.Config) (input.Input, error) {
 		ID             string        `config:"id"`
 		CleanTimeout   time.Duration `config:"clean_timeout"`
 		HarvesterLimit uint64        `config:"harvester_limit"`
-	}{ID: "", CleanTimeout: cim.DefaultCleanTimeout, HarvesterLimit: 0}
+	}{CleanTimeout: cim.DefaultCleanTimeout}
 	if err := config.Unpack(&settings); err != nil {
 		return nil, err
+	}
+
+	if settings.ID == "" {
+		cim.Logger.Warn("not setting an ID for the filestream input may lead to " +
+			"duplicated data. Filestream input without an ID will not be supported in a future release. " +
+			"Adding an ID to an existing input will read all files from the beginning",
+		)
 	}
 
 	prospector, harvester, err := cim.Configure(config)

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2707,6 +2707,9 @@ filebeat.inputs:
 #--------------------------- Filestream input ----------------------------
 - type: filestream
 
+  # Unique ID among all inputs, an ID is required.
+  id: foo
+
   # Change to true to enable this input configuration.
   enabled: false
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2708,7 +2708,7 @@ filebeat.inputs:
 - type: filestream
 
   # Unique ID among all inputs, an ID is required.
-  id: foo
+  id: my-filestream-id
 
   # Change to true to enable this input configuration.
   enabled: false

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -21,6 +21,9 @@ filebeat.inputs:
 # filestream is an input for collecting log messages from files.
 - type: filestream
 
+  # Unique ID among all inputs, an ID is required.
+  id: foo
+
   # Change to true to enable this input configuration.
   enabled: false
 

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -22,7 +22,7 @@ filebeat.inputs:
 - type: filestream
 
   # Unique ID among all inputs, an ID is required.
-  id: foo
+  id: my-filestream-id
 
   # Change to true to enable this input configuration.
   enabled: false


### PR DESCRIPTION
## What does this PR do?

It adds documentation and log warning when filestream inputs are used without IDs.

## Why is it important?

When using multiple filestream inputs without IDs, when Filebeat is restarted all the files are read from the beginning,
this PR adds documentation and warning about this issue.

The final issue will be fixed in a later PR.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally

- Setup a filestream input without an ID
- Start Filebeat
- You should see a log warning
Input configuration example:
```yaml
filebeat.inputs:
- type: filestream
  enabled: true
  paths:
    - /tmp//first.log
```

Log message:
```
{"log.level":"warn","@timestamp":"2022-02-21T19:56:17.494+0100","log.logger":"input","log.origin":{"file.name":"input-logfile/manager.go","file.line":173},"message":"not setting an ID for the filestream input may lead to duplicated data. Filestream input without an ID will not be supported in a future release. Adding an ID to an existing input will read all files from the beginning","service.name":"filebeat","ecs.version":"1.6.0"}
```

## Related issues

- Relates #30061
- Relates https://github.com/elastic/beats/pull/30386


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~