### PR TITLE
ci: refactor packaging with a new step

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/publish') _
+@Library('apm@current') _
 
 import groovy.transform.Field
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@test/publish') _
 
 import groovy.transform.Field
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -387,9 +387,15 @@ def release(){
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       dir("${env.BEATS_FOLDER}") {
         sh(label: "Release ${env.BEATS_FOLDER} ${env.PLATFORMS}", script: 'mage package')
+        uploadPackagesToGoogleBucket(
+          credentialsId: env.JOB_GCS_EXT_CREDENTIALS,
+          repo: env.REPO,
+          bucket: env.JOB_GCS_BUCKET,
+          folder: getBeatsName(env.BEATS_FOLDER),
+          pattern: "build/distributions/**/*"
+        )
       }
     }
-    publishPackages("${env.BEATS_FOLDER}")
   }
 }
 
@@ -426,27 +432,6 @@ def withMacOSEnv(Closure body){
   ]){
     body()
   }
-}
-
-def publishPackages(baseDir){
-  def bucketUri = "gs://${JOB_GCS_BUCKET}/snapshots"
-  if (isPR()) {
-    bucketUri = "gs://${JOB_GCS_BUCKET}/pull-requests/pr-${env.CHANGE_ID}"
-  }
-  def beatsFolderName = getBeatsName(baseDir)
-  uploadPackages("${bucketUri}/${beatsFolderName}", baseDir)
-
-  // Copy those files to another location with the sha commit to test them
-  // afterward.
-  bucketUri = "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}"
-  uploadPackages("${bucketUri}/${beatsFolderName}", baseDir)
-}
-
-def uploadPackages(bucketUri, beatsFolder){
-  googleStorageUploadExt(bucket: bucketUri,
-    credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
-    pattern: "${beatsFolder}/build/distributions/**/*",
-    sharedPublicly: true)
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Refactor packaging to use the shared library step:
- https://github.com/elastic/apm-pipeline-library/pull/1549

## Breaking change

Uses the repo name for the folder matching. Consumers should know this change (e2e-testing)

## Why is it important?

DRY, and in addition shared library steps are covered with UTs :)

## Test


<img width="715" alt="image" src="https://user-images.githubusercontent.com/2871786/154156700-90f85e6d-905a-400d-97d8-b2eb283fc249.png">

<img width="516" alt="image" src="https://user-images.githubusercontent.com/2871786/154156755-750e54f2-8f54-4a1a-9f10-8ad59bf34561.png">

