### PR TITLE
Add BC about Homebrew no longer being available in 8.0

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-8.0.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-8.0.asciidoc
@@ -55,6 +55,14 @@ way to use operation types like "index" or "delete" when sending events to {es}.
 For more information, refer to the {es} documentation about
 {ref}/data-streams.html[data streams].
 
+[discrete]
+==== Homebrew formulae no longer available for {beats}
+
+Starting with version 8.0.0, Elastic no longer publishes Homebrew formulae for
+{beats}. You must use a different installation method. See
+the https://www.elastic.co/downloads/beats/[{beats} download pages]
+for available installation methods.
+
 // end::notable-breaking-changes[]
 
 


### PR DESCRIPTION
## What does this PR do?

Mention in Breaking Changes docs that Homebrew installation method no longer works.

## Why is it important?

This change is breaking for users who rely on Homebrew as part of their deployment strategy.

## Checklist
- [x] My code follows the style guidelines of this project

## Related issues

https://github.com/elastic/observability-docs/issues/1544
