### PR TITLE
Filebeat: Disable module loading under Elastic Agent

### DIFF
--- a/x-pack/elastic-agent/spec/filebeat.yml
+++ b/x-pack/elastic-agent/spec/filebeat.yml
@@ -6,7 +6,7 @@ args: [
   "-E", "management.enabled=true",
   "-E", "logging.level=debug",
   "-E", "gc_percent=${FILEBEAT_GOGC:100}",
-  "-E", "metricbeat.config.modules.enabled=false"
+  "-E", "filebeat.config.modules.enabled=false"
 ]
 artifact: beats/filebeat
 restart_on_output_change: true

--- a/x-pack/elastic-agent/spec/filebeat.yml
+++ b/x-pack/elastic-agent/spec/filebeat.yml
@@ -5,7 +5,8 @@ args: [
   "-E", "setup.template.enabled=false",
   "-E", "management.enabled=true",
   "-E", "logging.level=debug",
-  "-E", "gc_percent=${FILEBEAT_GOGC:100}"
+  "-E", "gc_percent=${FILEBEAT_GOGC:100}",
+  "-E", "metricbeat.config.modules.enabled=false"
 ]
 artifact: beats/filebeat
 restart_on_output_change: true


### PR DESCRIPTION
## What does this PR do?

This prevents Filebeat instances started by Elastic Agent to load modules.

## Why is it important?

Sometimes there can be some confusion on how to use integrations. We've observed a case of users enabling Filebeat modules inside the internal Filebeat used by Elastic Agent, instead of using the equivalent integration. This will cause an error like this one:

> error loading pipeline for fileset fortinet/firewall: couldn't load pipeline: couldn't load json. 
Error: 403 Forbidden: {\"error\":{\"root_cause\":[{\"type\":\"security_exception\",\"reason\":\"action [cluster:admin/ingest/pipeline/put] 
is unauthorized for API key id [...redacted...] of user [elastic/fleet-server], this action 
is granted by the cluster privileges [manage_ingest_pipelines,manage_pipeline,manage,all]\"}],\"type\":\"security_exception\",\"reason\":\"action [cluster:admin/ingest/pipeline/put] 
is unauthorized for API key id [...redacted...] of user [elastic/fleet-server], this action is 
granted by the cluster privileges [manage_ingest_pipelines,manage_pipeline,manage,all]\"},\"status\":403}.
