### PR TITLE
Fix TestNewModuleRegistry flaky test

### DIFF
--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,6 +102,8 @@ func TestNewModuleRegistry(t *testing.T) {
 		for _, fileset := range module.filesets {
 			filesetList = append(filesetList, fileset.name)
 		}
+		sort.Strings(filesetList)
+		sort.Strings(expectedFilesets)
 		assert.Equal(t, filesetList, expectedFilesets)
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fixes flaky unit test _TestNewModuleRegistry._

Filesets must be sorted before comparing them, as they are originally populated by iterating on a map, which returns the keys in random order.

## Why is it important?

So tests pass.

## Logs

```
    modules_test.go:104: 
        	Error Trace:	modules_test.go:104
        	Error:      	Not equal: 
        	            	expected: []string{"error", "access"}
        	            	actual  : []string{"access", "error"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,4 +1,4 @@
        	            	 ([]string) (len=2) {
        	            	- (string) (len=5) "error",
        	            	- (string) (len=6) "access"
        	            	+ (string) (len=6) "access",
        	            	+ (string) (len=5) "error"
        	            	 }
        	Test:       	TestNewModuleRegistry
--- FAIL: TestNewModuleRegistry (0.02s)
```