### PR TITLE
Switch skip to use `CI`

### DIFF
--- a/auditbeat/tests/system/test_file_integrity.py
+++ b/auditbeat/tests/system/test_file_integrity.py
@@ -62,7 +62,7 @@ class Test(BaseTest):
             else:
                 break
 
-    @unittest.skipIf(os.getenv("BUILD_ID") is not None and platform.system() == 'Darwin',
+    @unittest.skipIf(os.getenv("CI") is not None and platform.system() == 'Darwin',
                      'Flaky test: https://github.com/elastic/beats/issues/24678')
     def test_non_recursive(self):
         """


### PR DESCRIPTION
## What does this PR do?

This test had a `BUILD_ID` skip that I'm fairly certain is jenkins-specific. You can see it running and failing a fair bit on https://github.com/elastic/beats/actions/workflows/macos-auditbeat.yml?query=is%3Afailure

I've replaced it with `CI` since that seems like a good generic option and [provided by github actions](https://docs.github.com/en/actions/learn-github-actions/environment-variables). I'm unclear on if jenkins will provide it or not. Hoping @andrewkroh or @v1v can confirm before merge.

## Why is it important?

The tests are running but flakey, causing error messages and (at best) wasted investigation cycles or (at worst) tendency to ignore test suite failures.

## Checklist

- ~~My code follows the style guidelines of this project~~
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## Related issues

- Relates https://github.com/elastic/beats/issues/30510
- Relates https://github.com/elastic/beats/pull/29032
- Relates https://github.com/elastic/beats/issues/24678