### PR TITLE
ci: add windows-2022 in the extended meta-stage

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -59,6 +59,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -71,6 +71,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -64,6 +64,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -53,6 +53,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -57,6 +57,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -29,11 +29,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
-    windows-2022:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2022"
-        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -29,6 +29,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -57,6 +57,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -54,6 +54,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -71,6 +71,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -54,6 +54,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -75,6 +75,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -43,6 +43,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -58,6 +58,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -29,12 +29,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
-    # https://github.com/elastic/beats/issues/30621
-    #windows-2022:
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-2022"
-    #    stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -29,12 +29,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
-    # https://github.com/elastic/beats/issues/30621
-    #windows-2022:
-    #    mage: "mage build unitTest"
-    #    platforms:             ## override default labels in this specific stage.
-    #        - "windows-2022"
-    #    stage: extended
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -29,6 +29,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    # https://github.com/elastic/beats/issues/30621
+    #windows-2022:
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-2022"
+    #    stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -29,6 +29,11 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
+    windows-2022:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2022"
+        stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -29,11 +29,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
         stage: mandatory
-    windows-2022:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2022"
-        stage: extended
+    # https://github.com/elastic/beats/issues/30621
+    #windows-2022:
+    #    mage: "mage build unitTest"
+    #    platforms:             ## override default labels in this specific stage.
+    #        - "windows-2022"
+    #    stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

Add windows-2022 support in the extended meta-stage.

Extended meta-stage is the one that runs after the mandatory stage.

## Why is it important?

Windows-2022 is supported in `8.x`

## Follow ups

https://github.com/elastic/beats/pull/30622 is the one for Winlogbeat since there are test failures already reported in https://github.com/elastic/beats/issues/30621