### PR TITLE
Add `parsers` examples to `filestream` reference configuration

### DIFF
--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -335,7 +335,7 @@ filebeat.inputs:
       # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
       #pattern: ^\[
 
-      # Defines if the pattern set under pattern should be negated or not. Default is false.
+      # Defines if the pattern set under the pattern setting should be negated or not. Default is false.
       #negate: false
 
       # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -306,7 +306,7 @@ filebeat.inputs:
       #message_key:
 
       # By default, the decoded JSON is placed under a "json" key in the output document.
-      # If you enable this setting, the keys are copied top level in the output document.
+      # If you enable this setting, the keys are copied to the top level of the output document.
       #keys_under_root: false
 
       # If keys_under_root and this setting are enabled, then the values from the decoded

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -293,6 +293,101 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
+  ### Parsers configuration
+
+  #### JSON configuration
+
+  #parsers:
+    #- ndjson:
+      # Decode JSON options. Enable this if your logs are structured in JSON.
+      # JSON key on which to apply the line filtering and multiline settings. This key
+      # must be top level and its value must be string, otherwise it is ignored. If
+      # no text key is defined, the line filtering and multiline features cannot be used.
+      #message_key:
+
+      # By default, the decoded JSON is placed under a "json" key in the output document.
+      # If you enable this setting, the keys are copied top level in the output document.
+      #keys_under_root: false
+
+      # If keys_under_root and this setting are enabled, then the values from the decoded
+      # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+      # in case of conflicts.
+      #overwrite_keys: false
+
+      # If this setting is enabled, then keys in the decoded JSON object will be recursively
+      # de-dotted, and expanded into a hierarchical object structure.
+      # For example, `{"a.b.c": 123}` would be expanded into `{"a":{"b":{"c":123}}}`.
+      #expand_keys: false
+
+      # If this setting is enabled, Filebeat adds a "error.message" and "error.key: json" key in case of JSON
+      # unmarshaling errors or when a text key is defined in the configuration but cannot
+      # be used.
+      #add_error_key: false
+
+  #### Multiline options
+
+  # Multiline can be used for log messages spanning multiple lines. This is common
+  # for Java Stack Traces or C-Line Continuation
+
+  #parsers:
+    #- multiline:
+      #type: pattern
+      # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
+      #pattern: ^\[
+
+      # Defines if the pattern set under pattern should be negated or not. Default is false.
+      #negate: false
+
+      # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
+      # that was (not) matched before or after or as long as a pattern is not matched based on negate.
+      # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+      #match: after
+
+      # The maximum number of lines that are combined to one event.
+      # In case there are more the max_lines the additional lines are discarded.
+      # Default is 500
+      #max_lines: 500
+
+      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # Default is 5s.
+      #timeout: 5s
+
+      # Do not add new line character when concatenating lines.
+      #skip_newline: false
+
+  # To aggregate constant number of lines into a single event use the count mode of multiline.
+
+  #parsers:
+    #- multiline:
+      #type: count
+
+      # The number of lines to aggregate into a single event.
+      #count_lines: 3
+
+      # The maximum number of lines that are combined to one event.
+      # In case there are more the max_lines the additional lines are discarded.
+      # Default is 500
+      #max_lines: 500
+
+      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # Default is 5s.
+      #timeout: 5s
+
+      # Do not add new line character when concatenating lines.
+      #skip_newline: false
+
+  #### Parsing container events
+
+  # You can parse container events with different formats from all streams.
+
+  #parsers:
+    #- container:
+       # Source of container events. Available options: all, stdin, stderr.
+       #stream: all
+
+       # Format of the container events. Available options: auto, cri, docker, json-file 
+       #format: auto
+
   ### Log rotation
 
   # When an external tool rotates the input files with copytruncate strategy

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -348,7 +348,7 @@ filebeat.inputs:
       # Default is 500
       #max_lines: 500
 
-      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # After the defined timeout, a multiline event is sent even if no new pattern was found to start a new event
       # Default is 5s.
       #timeout: 5s
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -344,7 +344,7 @@ filebeat.inputs:
       #match: after
 
       # The maximum number of lines that are combined to one event.
-      # In case there are more the max_lines the additional lines are discarded.
+      # In case there are more than max_lines the additional lines are discarded.
       # Default is 500
       #max_lines: 500
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -301,7 +301,7 @@ filebeat.inputs:
     #- ndjson:
       # Decode JSON options. Enable this if your logs are structured in JSON.
       # JSON key on which to apply the line filtering and multiline settings. This key
-      # must be top level and its value must be string, otherwise it is ignored. If
+      # must be top level and its value must be a string, otherwise it is ignored. If
       # no text key is defined, the line filtering and multiline features cannot be used.
       #message_key:
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -340,7 +340,7 @@ filebeat.inputs:
 
       # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
       # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-      # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+      # Note: After is the equivalent to previous and before is the equivalent to next in Logstash
       #match: after
 
       # The maximum number of lines that are combined to one event.

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -319,7 +319,7 @@ filebeat.inputs:
       # For example, `{"a.b.c": 123}` would be expanded into `{"a":{"b":{"c":123}}}`.
       #expand_keys: false
 
-      # If this setting is enabled, Filebeat adds a "error.message" and "error.key: json" key in case of JSON
+      # If this setting is enabled, Filebeat adds an "error.message" and "error.key: json" key in case of JSON
       # unmarshaling errors or when a text key is defined in the configuration but cannot
       # be used.
       #add_error_key: false

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -365,7 +365,7 @@ filebeat.inputs:
       #count_lines: 3
 
       # The maximum number of lines that are combined to one event.
-      # In case there are more the max_lines the additional lines are discarded.
+      # In case there are more than max_lines the additional lines are discarded.
       # Default is 500
       #max_lines: 500
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -708,12 +708,12 @@ filebeat.inputs:
     #- ndjson:
       # Decode JSON options. Enable this if your logs are structured in JSON.
       # JSON key on which to apply the line filtering and multiline settings. This key
-      # must be top level and its value must be string, otherwise it is ignored. If
+      # must be top level and its value must be a string, otherwise it is ignored. If
       # no text key is defined, the line filtering and multiline features cannot be used.
       #message_key:
 
       # By default, the decoded JSON is placed under a "json" key in the output document.
-      # If you enable this setting, the keys are copied top level in the output document.
+      # If you enable this setting, the keys are copied to the top level of the output document.
       #keys_under_root: false
 
       # If keys_under_root and this setting are enabled, then the values from the decoded
@@ -726,7 +726,7 @@ filebeat.inputs:
       # For example, `{"a.b.c": 123}` would be expanded into `{"a":{"b":{"c":123}}}`.
       #expand_keys: false
 
-      # If this setting is enabled, Filebeat adds a "error.message" and "error.key: json" key in case of JSON
+      # If this setting is enabled, Filebeat adds an "error.message" and "error.key: json" key in case of JSON
       # unmarshaling errors or when a text key is defined in the configuration but cannot
       # be used.
       #add_error_key: false
@@ -742,20 +742,20 @@ filebeat.inputs:
       # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
       #pattern: ^\[
 
-      # Defines if the pattern set under pattern should be negated or not. Default is false.
+      # Defines if the pattern set under the pattern setting should be negated or not. Default is false.
       #negate: false
 
       # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
       # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-      # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+      # Note: After is the equivalent to previous and before is the equivalent to next in Logstash
       #match: after
 
       # The maximum number of lines that are combined to one event.
-      # In case there are more the max_lines the additional lines are discarded.
+      # In case there are more than max_lines the additional lines are discarded.
       # Default is 500
       #max_lines: 500
 
-      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # After the defined timeout, a multiline event is sent even if no new pattern was found to start a new event
       # Default is 5s.
       #timeout: 5s
 
@@ -772,7 +772,7 @@ filebeat.inputs:
       #count_lines: 3
 
       # The maximum number of lines that are combined to one event.
-      # In case there are more the max_lines the additional lines are discarded.
+      # In case there are more than max_lines the additional lines are discarded.
       # Default is 500
       #max_lines: 500
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -700,6 +700,101 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
+  ### Parsers configuration
+
+  #### JSON configuration
+
+  #parsers:
+    #- ndjson:
+      # Decode JSON options. Enable this if your logs are structured in JSON.
+      # JSON key on which to apply the line filtering and multiline settings. This key
+      # must be top level and its value must be string, otherwise it is ignored. If
+      # no text key is defined, the line filtering and multiline features cannot be used.
+      #message_key:
+
+      # By default, the decoded JSON is placed under a "json" key in the output document.
+      # If you enable this setting, the keys are copied top level in the output document.
+      #keys_under_root: false
+
+      # If keys_under_root and this setting are enabled, then the values from the decoded
+      # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+      # in case of conflicts.
+      #overwrite_keys: false
+
+      # If this setting is enabled, then keys in the decoded JSON object will be recursively
+      # de-dotted, and expanded into a hierarchical object structure.
+      # For example, `{"a.b.c": 123}` would be expanded into `{"a":{"b":{"c":123}}}`.
+      #expand_keys: false
+
+      # If this setting is enabled, Filebeat adds a "error.message" and "error.key: json" key in case of JSON
+      # unmarshaling errors or when a text key is defined in the configuration but cannot
+      # be used.
+      #add_error_key: false
+
+  #### Multiline options
+
+  # Multiline can be used for log messages spanning multiple lines. This is common
+  # for Java Stack Traces or C-Line Continuation
+
+  #parsers:
+    #- multiline:
+      #type: pattern
+      # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
+      #pattern: ^\[
+
+      # Defines if the pattern set under pattern should be negated or not. Default is false.
+      #negate: false
+
+      # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
+      # that was (not) matched before or after or as long as a pattern is not matched based on negate.
+      # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+      #match: after
+
+      # The maximum number of lines that are combined to one event.
+      # In case there are more the max_lines the additional lines are discarded.
+      # Default is 500
+      #max_lines: 500
+
+      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # Default is 5s.
+      #timeout: 5s
+
+      # Do not add new line character when concatenating lines.
+      #skip_newline: false
+
+  # To aggregate constant number of lines into a single event use the count mode of multiline.
+
+  #parsers:
+    #- multiline:
+      #type: count
+
+      # The number of lines to aggregate into a single event.
+      #count_lines: 3
+
+      # The maximum number of lines that are combined to one event.
+      # In case there are more the max_lines the additional lines are discarded.
+      # Default is 500
+      #max_lines: 500
+
+      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # Default is 5s.
+      #timeout: 5s
+
+      # Do not add new line character when concatenating lines.
+      #skip_newline: false
+
+  #### Parsing container events
+
+  # You can parse container events with different formats from all streams.
+
+  #parsers:
+    #- container:
+       # Source of container events. Available options: all, stdin, stderr.
+       #stream: all
+
+       # Format of the container events. Available options: auto, cri, docker, json-file 
+       #format: auto
+
   ### Log rotation
 
   # When an external tool rotates the input files with copytruncate strategy

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2767,12 +2767,12 @@ filebeat.inputs:
     #- ndjson:
       # Decode JSON options. Enable this if your logs are structured in JSON.
       # JSON key on which to apply the line filtering and multiline settings. This key
-      # must be top level and its value must be string, otherwise it is ignored. If
+      # must be top level and its value must be a string, otherwise it is ignored. If
       # no text key is defined, the line filtering and multiline features cannot be used.
       #message_key:
 
       # By default, the decoded JSON is placed under a "json" key in the output document.
-      # If you enable this setting, the keys are copied top level in the output document.
+      # If you enable this setting, the keys are copied to the top level of the output document.
       #keys_under_root: false
 
       # If keys_under_root and this setting are enabled, then the values from the decoded
@@ -2785,7 +2785,7 @@ filebeat.inputs:
       # For example, `{"a.b.c": 123}` would be expanded into `{"a":{"b":{"c":123}}}`.
       #expand_keys: false
 
-      # If this setting is enabled, Filebeat adds a "error.message" and "error.key: json" key in case of JSON
+      # If this setting is enabled, Filebeat adds an "error.message" and "error.key: json" key in case of JSON
       # unmarshaling errors or when a text key is defined in the configuration but cannot
       # be used.
       #add_error_key: false
@@ -2801,20 +2801,20 @@ filebeat.inputs:
       # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
       #pattern: ^\[
 
-      # Defines if the pattern set under pattern should be negated or not. Default is false.
+      # Defines if the pattern set under the pattern setting should be negated or not. Default is false.
       #negate: false
 
       # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
       # that was (not) matched before or after or as long as a pattern is not matched based on negate.
-      # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+      # Note: After is the equivalent to previous and before is the equivalent to next in Logstash
       #match: after
 
       # The maximum number of lines that are combined to one event.
-      # In case there are more the max_lines the additional lines are discarded.
+      # In case there are more than max_lines the additional lines are discarded.
       # Default is 500
       #max_lines: 500
 
-      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # After the defined timeout, a multiline event is sent even if no new pattern was found to start a new event
       # Default is 5s.
       #timeout: 5s
 
@@ -2831,7 +2831,7 @@ filebeat.inputs:
       #count_lines: 3
 
       # The maximum number of lines that are combined to one event.
-      # In case there are more the max_lines the additional lines are discarded.
+      # In case there are more than max_lines the additional lines are discarded.
       # Default is 500
       #max_lines: 500
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2759,6 +2759,101 @@ filebeat.inputs:
   # original for harvesting but will report the symlink name as source.
   #prospector.scanner.symlinks: false
 
+  ### Parsers configuration
+
+  #### JSON configuration
+
+  #parsers:
+    #- ndjson:
+      # Decode JSON options. Enable this if your logs are structured in JSON.
+      # JSON key on which to apply the line filtering and multiline settings. This key
+      # must be top level and its value must be string, otherwise it is ignored. If
+      # no text key is defined, the line filtering and multiline features cannot be used.
+      #message_key:
+
+      # By default, the decoded JSON is placed under a "json" key in the output document.
+      # If you enable this setting, the keys are copied top level in the output document.
+      #keys_under_root: false
+
+      # If keys_under_root and this setting are enabled, then the values from the decoded
+      # JSON object overwrite the fields that Filebeat normally adds (type, source, offset, etc.)
+      # in case of conflicts.
+      #overwrite_keys: false
+
+      # If this setting is enabled, then keys in the decoded JSON object will be recursively
+      # de-dotted, and expanded into a hierarchical object structure.
+      # For example, `{"a.b.c": 123}` would be expanded into `{"a":{"b":{"c":123}}}`.
+      #expand_keys: false
+
+      # If this setting is enabled, Filebeat adds a "error.message" and "error.key: json" key in case of JSON
+      # unmarshaling errors or when a text key is defined in the configuration but cannot
+      # be used.
+      #add_error_key: false
+
+  #### Multiline options
+
+  # Multiline can be used for log messages spanning multiple lines. This is common
+  # for Java Stack Traces or C-Line Continuation
+
+  #parsers:
+    #- multiline:
+      #type: pattern
+      # The regexp Pattern that has to be matched. The example pattern matches all lines starting with [
+      #pattern: ^\[
+
+      # Defines if the pattern set under pattern should be negated or not. Default is false.
+      #negate: false
+
+      # Match can be set to "after" or "before". It is used to define if lines should be append to a pattern
+      # that was (not) matched before or after or as long as a pattern is not matched based on negate.
+      # Note: After is the equivalent to previous and before is the equivalent to to next in Logstash
+      #match: after
+
+      # The maximum number of lines that are combined to one event.
+      # In case there are more the max_lines the additional lines are discarded.
+      # Default is 500
+      #max_lines: 500
+
+      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # Default is 5s.
+      #timeout: 5s
+
+      # Do not add new line character when concatenating lines.
+      #skip_newline: false
+
+  # To aggregate constant number of lines into a single event use the count mode of multiline.
+
+  #parsers:
+    #- multiline:
+      #type: count
+
+      # The number of lines to aggregate into a single event.
+      #count_lines: 3
+
+      # The maximum number of lines that are combined to one event.
+      # In case there are more the max_lines the additional lines are discarded.
+      # Default is 500
+      #max_lines: 500
+
+      # After the defined timeout, an multiline event is sent even if no new pattern was found to start a new event
+      # Default is 5s.
+      #timeout: 5s
+
+      # Do not add new line character when concatenating lines.
+      #skip_newline: false
+
+  #### Parsing container events
+
+  # You can parse container events with different formats from all streams.
+
+  #parsers:
+    #- container:
+       # Source of container events. Available options: all, stdin, stderr.
+       #stream: all
+
+       # Format of the container events. Available options: auto, cri, docker, json-file 
+       #format: auto
+
   ### Log rotation
 
   # When an external tool rotates the input files with copytruncate strategy


### PR DESCRIPTION
## What does this PR do?

This PR adds the missing `parsers` sections to the reference configuration of Filebeat.

## Why is it important?

One recurring issue in filestream is users misconfiguring parsers. The documentation is somewhat detailed on the topic. However, `parsers` were missing from the reference configuration. I am adding more `parser` examples to ease adoption of filestream and decrease user frustration/confusion.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
