### PR TITLE
[Winlogbeat] Improve registry error message

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -143,6 +143,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Winlogbeat*
 
+- Improve the error message when the registry file content is invalid. {pull}30543[30543]
+
 
 *Elastic Log Driver*
 

--- a/winlogbeat/beater/winlogbeat.go
+++ b/winlogbeat/beater/winlogbeat.go
@@ -126,7 +126,7 @@ func (eb *Winlogbeat) setup(b *beat.Beat) error {
 	var err error
 	eb.checkpoint, err = checkpoint.NewCheckpoint(config.RegistryFile, config.RegistryFlush)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to initialize checkpoint registry: %w", err)
 	}
 
 	eb.pipeline = b.Publisher

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -264,7 +264,7 @@ func (c *Checkpoint) read() (*PersistedState, error) {
 	ps := &PersistedState{}
 	err = yaml.Unmarshal(contents, ps)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read persisted state: %w", err)
 	}
 
 	return ps, nil


### PR DESCRIPTION
## What does this PR do?

If the registry file is invalid for some reason the error can be ambiguous given that
the config file is also in YAML. So give the errors more context. This is an example
of the ambiguous error:

    Exiting: yaml: control characters are not allowed

## Why is it important?

The original error message was confusing.

## Checklist



- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
