### PR TITLE
Agent: populate action_input_type for the .fleet-actions-results

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -92,6 +92,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add FIPS configuration option for all AWS API calls. {pull}[28899]
 - Add metadata change support for some processors {pull}30183[30183]
 - Add support for non-unique Kafka headers for output messages. {pull}30369[30369]
+- Add action_input_type for the .fleet-actions-results {pull}30562[30562]
 
 *Auditbeat*
 

--- a/x-pack/elastic-agent/pkg/fleetapi/ack_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/ack_cmd.go
@@ -27,12 +27,12 @@ type AckEvent struct {
 	Message   string `json:"message,omitempty"` // : 'hello2',
 	Payload   string `json:"payload,omitempty"` // : 'payload2',
 
-	InputType      string                 `json:"input_type,omitempty"`      // copy of original action input_type
-	ActionData     json.RawMessage        `json:"action_data,omitempty"`     // copy of original action data
-	ActionResponse map[string]interface{} `json:"action_response,omitempty"` // custom (per beat) response payload
-	StartedAt      string                 `json:"started_at,omitempty"`      // time action started
-	CompletedAt    string                 `json:"completed_at,omitempty"`    // time action completed
-	Error          string                 `json:"error,omitempty"`           // optional action error
+	ActionInputType string                 `json:"action_input_type,omitempty"` // copy of original action input_type
+	ActionData      json.RawMessage        `json:"action_data,omitempty"`       // copy of original action data
+	ActionResponse  map[string]interface{} `json:"action_response,omitempty"`   // custom (per beat) response payload
+	StartedAt       string                 `json:"started_at,omitempty"`        // time action started
+	CompletedAt     string                 `json:"completed_at,omitempty"`      // time action completed
+	Error           string                 `json:"error,omitempty"`             // optional action error
 }
 
 // AckRequest consists of multiple actions acked to fleet ui.

--- a/x-pack/elastic-agent/pkg/fleetapi/ack_cmd.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/ack_cmd.go
@@ -27,6 +27,7 @@ type AckEvent struct {
 	Message   string `json:"message,omitempty"` // : 'hello2',
 	Payload   string `json:"payload,omitempty"` // : 'payload2',
 
+	InputType      string                 `json:"input_type,omitempty"`      // copy of original action input_type
 	ActionData     json.RawMessage        `json:"action_data,omitempty"`     // copy of original action data
 	ActionResponse map[string]interface{} `json:"action_response,omitempty"` // custom (per beat) response payload
 	StartedAt      string                 `json:"started_at,omitempty"`      // time action started

--- a/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker.go
@@ -114,6 +114,7 @@ func constructEvent(action fleetapi.Action, agentID string) fleetapi.AckEvent {
 	}
 
 	if a, ok := action.(*fleetapi.ActionApp); ok {
+		ackev.InputType = a.InputType
 		ackev.ActionData = a.Data
 		ackev.ActionResponse = a.Response
 		ackev.StartedAt = a.StartedAt

--- a/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker.go
+++ b/x-pack/elastic-agent/pkg/fleetapi/acker/fleet/fleet_acker.go
@@ -114,7 +114,7 @@ func constructEvent(action fleetapi.Action, agentID string) fleetapi.AckEvent {
 	}
 
 	if a, ok := action.(*fleetapi.ActionApp); ok {
-		ackev.InputType = a.InputType
+		ackev.ActionInputType = a.InputType
 		ackev.ActionData = a.Data
 		ackev.ActionResponse = a.Response
 		ackev.StartedAt = a.StartedAt


### PR DESCRIPTION
## What does this PR do?

Populates input_type for the .fleet-actions-results. This allows to use kibana transformations on .fleet-actions-results for specific integration without a need to correlate them to the original .fleet-actions (via the action_id)

## Why is it important?

Allows to use kibana transformations on .fleet-actions-results for specific integration without a need to correlate them to the original .fleet-actions (via the action_id)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

One of the ways to test is with osquery integration, with corresponding change in fleet-server and elasticsearch fleet mapping. The .fleet-actions-results document should have the new field ```input_type```.


## Screenshots
<img width="605" alt="Screen Shot 2022-02-24 at 1 52 00 PM" src="https://user-images.githubusercontent.com/872351/155588623-21dc1fca-822f-459e-a7ca-c08c88534ed6.png">

