### PR TITLE
[libbeat][docs] Update perms docs for beats writers to match 8.0 datastream reqs

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -55,6 +55,10 @@ the following privileges:
 |`monitor`
 |Retrieve cluster details (e.g. version)
 
+|Cluster
+|`manage_index_templates`
+|Manage index templates
+
 ifndef::no_ilm[]
 |Cluster
 |`manage_ilm`


### PR DESCRIPTION
Our docs are currently incorrect for users transitioning from 7.x to 8.0 when following our permissions guidelines. 8.0 apparently requires additional permissions.

This was discovered in [this discuss thread](https://discuss.elastic.co/t/permissions-issues-after-upgrading-heartbeat-to-8-0/297383), where a user found that heartbeat couldn't write to indices after using the perms described in our docs on [privileges and roles needed for publishing](https://www.elastic.co/guide/en/beats/heartbeat/current/privileges-to-publish-events.html). This applies equally to all beats however as those docs are not beat specific.

This fixes the docs, but we should consider additional messaging as part of the upgrade process so other users are not bit by this.