### PR TITLE
Disable core dumps in docker containers

### DIFF
--- a/dev-tools/packaging/templates/docker/docker-entrypoint.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.tmpl
@@ -20,6 +20,9 @@ else
   done
 fi
 
+# Disable core dumps
+ulimit -c 0
+
 # If neither of those worked, then they have specified the binary they want, so
 # just do exactly as they say.
 exec "$@"


### PR DESCRIPTION
# !! DONOTMERGE !!

per https://github.com/elastic/beats/issues/30426#issuecomment-1050393266 this doesn't actually do anything


## What does this PR do?

Disables core dumps in docker containers by default. @ruflin @cmacknz @blakerouse do you see any issues with this?

We could alternatively *just* do this for heartbeat ,since the main issue seems to be with tricky subprocesses like chrome. However, if other beats benefit this is the simplest thing we can do.

## Why is it important?

Fixes https://github.com/elastic/beats/issues/30426 where a user had core dumps filling up their disk.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Run the following journey in a heartbeat container. The easiest way to do it is to use `run.sh` and `monitors.d/browser-inline` in the [synthetics-demo heartbeat directory](https://github.com/elastic/synthetics-demo/tree/main/heartbeat)

```js
step("load homepage", async () => {
    await page.goto('https://blog.andrewvc.com');
    process.kill(process.pid, 'SIGABRT');
});
```


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
