### PR TITLE
[MySQL Enterprise] Adding default paths values to manifest.yml

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -54,6 +54,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - auditd: Prevent mapping explosion when truncated EXECVE records are ingested. {pull}30382[30382]
 - elasticsearch: fix duplicate ingest when using a common appender configuration {issue}30428[30428] {pull}30440[30440]
 - Fix ECS version string in threatintel to be consistent with other modules and add event.timezone. {issue}30499[30499] {pull}30570[30570]
+- Add default paths value to MySQL Enterprise module to prevent issues with pipeline installations {pull}30598[30598]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/mysqlenterprise/audit/manifest.yml
+++ b/x-pack/filebeat/module/mysqlenterprise/audit/manifest.yml
@@ -1,6 +1,9 @@
 module_version: 1.0
 
 var:
+  - name: paths
+    default:
+      - /home/user/mysqlauditlogs/audit.*.log
   - name: tags
     default: [mysqlenterprise-audit]
   - name: input


### PR DESCRIPTION
## What does this PR do?

Adds a default value to the manifest.yml, this is needed to run pipeline setup commands, as it ignores user input.

## Why is it important?

Fixes a bug when using filebeats setup command for this specific module

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

