### PR TITLE
Add infra-monitoring-ui team as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,18 +22,18 @@
 
 # Filebeat
 # /filebeat/module/ @elastic/integrations
-# /filebeat/module/elasticsearch/ @elastic/stack-monitoring
-# /filebeat/module/kibana/ @elastic/stack-monitoring
-# /filebeat/module/logstash/ @elastic/stack-monitoring
+/filebeat/module/elasticsearch/ @elastic/infra-monitoring-ui
+/filebeat/module/kibana/ @elastic/infra-monitoring-ui
+/filebeat/module/logstash/ @elastic/infra-monitoring-ui
 # /x-pack/filebeat/module/ @elastic/integrations
 # /x-pack/filebeat/module/suricata/ @elastic/security-external-integrations
 
 # Metricbeat
 # /metricbeat/module/ @elastic/integrations
-# /metricbeat/module/elasticsearch/ @elastic/stack-monitoring
-# /metricbeat/module/kibana/ @elastic/stack-monitoring
-# /metricbeat/module/logstash/ @elastic/stack-monitoring
-# /metricbeat/module/beat/ @elastic/stack-monitoring
+/metricbeat/module/elasticsearch/ @elastic/infra-monitoring-ui
+/metricbeat/module/kibana/ @elastic/infra-monitoring-ui
+/metricbeat/module/logstash/ @elastic/infra-monitoring-ui
+/metricbeat/module/beat/ @elastic/infra-monitoring-ui
 # /x-pack/metricbeat/module/ @elastic/integrations
 
 # Heartbeat


### PR DESCRIPTION
### Summary

Set @elastic/infra-monitoring-ui team as code owners for Stack Monitoring related modules