### PR TITLE
Alert elastic agent control team of elastic-agent changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,10 +42,13 @@
 # Winlogbeat
 /x-pack/winlogbeat/ @elastic/security-external-integrations
 
+# Elastic Agent
+/x-pack/elastic-agent/ @elastic/elastic-agent-control-plane
+
 # Beats Build Specific
 /dev-tools/mage/ @elastic/beats
-/dev-tools/make/ @elastic/beats 
-/dev-tools/packaging/ @elastic/beats 
+/dev-tools/make/ @elastic/beats
+/dev-tools/packaging/ @elastic/beats
 
 # CI Specific
 /.ci/ @elastic/observablt-robots


### PR DESCRIPTION
Alert elastic agent control team of `elastic-agent` directory changes. Will help us monitor any changes to the directory that will take place before/after switching to the new `elastic-agent` repo.
This directory will be removed in the future.

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


