### PR TITLE
Curate k8s testing versions to only keep the actively maintained

### DIFF
--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: lint
     k8sTest:
-        k8sTest: "v1.23.0,v1.22.0,v1.21.1,v1.20.7,v1.19.11,v1.18.19"
+        k8sTest: "v1.23.0,v1.22.0,v1.21.1"
         stage: mandatory

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -155,7 +155,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
+1.21.x, 1.22.x, 1.23.x
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -146,7 +146,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x
+1.21.x, 1.22.x, 1.23.x
 
 [float]
 === Dashboard


### PR DESCRIPTION
## What does this PR do?

This PR keep only actively maintained versions in testing. This doesn't mean that we drop support for older ones but mostly that focus testing on newer ones.

Closes https://github.com/elastic/beats/issues/29604