### PR TITLE
[automation] update elastic stack version for testing 8.2.0-43df679f

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-74785f8b-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-43df679f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -21,7 +21,7 @@ services:
     - "script.context.template.cache_max_size=2000"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:8.2.0-74785f8b-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:8.2.0-43df679f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -31,7 +31,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-74785f8b-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-43df679f-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-74785f8b-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-43df679f-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-74785f8b-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-43df679f-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 1 Mar 2022 12:17:14 GMT, release_branch:master, prefix:, end_time:Tue, 1 Mar 2022 17:42:51 GMT, manifest_version:2.0.0, version:8.2.0-SNAPSHOT, branch:master, build_id:8.2.0-43df679f, build_duration_seconds:19537]