### PR TITLE
Fix mutex unlocking in monitoring registry

### DIFF
--- a/libbeat/monitoring/registry.go
+++ b/libbeat/monitoring/registry.go
@@ -132,7 +132,7 @@ func (r *Registry) Remove(name string) {
 // Clear removes all entries from the current registry
 func (r *Registry) Clear() error {
 	r.mu.Lock()
-	r.mu.Unlock()
+	defer r.mu.Unlock()
 
 	if r.opts.publishExpvar {
 		return errors.New("Can not clear registry with metrics being exported via expvar")
@@ -244,7 +244,7 @@ func (r *Registry) removeNames(names []string) {
 	if ok {
 		sub.removeNames(names[1:])
 		sub.mu.RLock()
-		sub.mu.RUnlock()
+		defer sub.mu.RUnlock()
 
 		if len(sub.entries) == 0 {
 			delete(r.entries, names[0])


### PR DESCRIPTION
## What does this PR do?

This PR adds missing `defer` keywords so mutexes only after the real critical section.

The problem was reported by golangci linter we use in https://github.com/elastic/elastic-agent-libs.

## Why is it important?

Previously in the monitoring registry implementation two mutexes were unlocked right after locking. So the data structures they were supposed to protect were still subject to concurrent access.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
