### PR TITLE
libbeat: Don't force an ignore_above limit on wildcard fields

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -59,6 +59,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Removed Beat generators. {pull}28816[28816]
 - libbeat.logp package forces ECS compliant logs. Logs are JSON formatted. Options to enable ECS/JSON have been removed. {issue}15544[15544] {pull}28573[28573]
 - Removed deprecated disk spool from Beats. Use disk queue instead. {pull}28869[28869]
+- Wildcard fields no longer have a default ignore_above setting of 1024. {issue}30096[30096] {pull}30668[30668]
 
 ==== Bugfixes
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -45,6 +45,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Update docker/distribution dependency library to fix a security issues concerning OCI Manifest Type Confusion Issue. {pull}30462[30462]
 - Fixes Beats crashing when glibc >= 2.35 is used {issue}30576[30576]
 - Log errors when parsing and applying config blocks and if the input is disabled. {pull}30534[30534]
+- Wildcard fields no longer have a default ignore_above setting of 1024. {issue}30096[30096] {pull}30668[30668]
 
 *Auditbeat*
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -317,11 +317,10 @@ func (p *Processor) wildcard(f *mapping.Field, analyzers common.MapStr) common.M
 
 	property["type"] = "wildcard"
 
-	switch f.IgnoreAbove {
-	case 0: // Use libbeat default
-		property["ignore_above"] = defaultIgnoreAbove
-	case -1: // Use ES default
-	default: // Use user value
+	/* For wildcard fields, unlike keyword, don't force a default ignore_above limit.
+	   The default in ES will be used unless an explicit limit is set.
+	*/
+	if f.IgnoreAbove > 0 {
 		property["ignore_above"] = f.IgnoreAbove
 	}
 

--- a/libbeat/template/processor.go
+++ b/libbeat/template/processor.go
@@ -317,8 +317,9 @@ func (p *Processor) wildcard(f *mapping.Field, analyzers common.MapStr) common.M
 
 	property["type"] = "wildcard"
 
-	/* For wildcard fields, unlike keyword, don't force a default ignore_above limit.
+	/* For wildcard fields, unlike keywords, don't force a default ignore_above limit.
 	   The default in ES will be used unless an explicit limit is set.
+	   This is to take advantage of wildcard type benefits when indexing large strings.
 	*/
 	if f.IgnoreAbove > 0 {
 		property["ignore_above"] = f.IgnoreAbove

--- a/libbeat/template/processor_test.go
+++ b/libbeat/template/processor_test.go
@@ -805,46 +805,77 @@ func TestProcessWildcardOSS(t *testing.T) {
 }
 
 func TestProcessWildcardElastic(t *testing.T) {
-	// Test common fields are combined even if they come from different objects
-	fields := mapping.Fields{
-		mapping.Field{
-			Name: "test",
-			Type: "group",
-			Fields: mapping.Fields{
+	for _, test := range []struct {
+		title    string
+		fields   mapping.Fields
+		expected common.MapStr
+	}{
+		{
+			title: "default",
+			fields: mapping.Fields{
 				mapping.Field{
-					Name: "one",
-					Type: "wildcard",
+					Name: "test",
+					Type: "group",
+					Fields: mapping.Fields{
+						mapping.Field{
+							Name: "one",
+							Type: "wildcard",
+						},
+					},
+				},
+			},
+			expected: common.MapStr{
+				"test": common.MapStr{
+					"properties": common.MapStr{
+						"one": common.MapStr{
+							"type": "wildcard",
+						},
+					},
 				},
 			},
 		},
-	}
-
-	output := common.MapStr{}
-	analyzers := common.MapStr{}
-	version, err := common.NewVersion("8.0.0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	p := Processor{EsVersion: *version, ElasticLicensed: true}
-	err = p.Process(fields, nil, output, analyzers)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Make sure fields without a name are skipped during template generation
-	expectedOutput := common.MapStr{
-		"test": common.MapStr{
-			"properties": common.MapStr{
-				"one": common.MapStr{
-					"ignore_above": 1024,
-					"type":         "wildcard",
+		{
+			title: "explicit ignore_above",
+			fields: mapping.Fields{
+				mapping.Field{
+					Name: "test",
+					Type: "group",
+					Fields: mapping.Fields{
+						mapping.Field{
+							Name:        "one",
+							Type:        "wildcard",
+							IgnoreAbove: 4096,
+						},
+					},
+				},
+			},
+			expected: common.MapStr{
+				"test": common.MapStr{
+					"properties": common.MapStr{
+						"one": common.MapStr{
+							"ignore_above": 4096,
+							"type":         "wildcard",
+						},
+					},
 				},
 			},
 		},
+	} {
+		t.Run(test.title, func(t *testing.T) {
+			output := common.MapStr{}
+			analyzers := common.MapStr{}
+			version, err := common.NewVersion("8.0.0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			p := Processor{EsVersion: *version, ElasticLicensed: true}
+			err = p.Process(test.fields, nil, output, analyzers)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, test.expected, output)
+		})
 	}
-
-	assert.Equal(t, expectedOutput, output)
 }
 
 func TestProcessWildcardPreSupport(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Modifies libbeat's template processor to stop hardcoding a default `ignore_above` limit of 1024 on wildcard fields. This behavior was inherited from keyword fields.

From the Beats users point of view, I've considered this a bugfix. (Bugfix under Affecting All Beats in CHANGELOG).
From the community Beat developers point of view, I consider this a breaking change as someone may be relying on the previous default behavior (Breaking under Affecting all Beats in CHANGELOG-developer).

## Why is it important?

Some important ECS wildcard fields are not being indexed properly. See related issue.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes #30096
