### PR TITLE
testing: Update docker and docker-compose versions

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -5,8 +5,8 @@ cached-property==1.4.2
 certifi==2018.1.18
 chardet==3.0.4
 deepdiff==4.2.0
-docker==4.1.0
-docker-compose==1.25.3
+docker==5.0.3
+docker-compose==1.29.2
 docker-pycreds==0.4.0
 dockerpty==0.4.1
 docopt==0.6.2

--- a/metricbeat/module/prometheus/docker-compose.yml
+++ b/metricbeat/module/prometheus/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       context: ./_meta
       args:
         PROMETHEUS_VERSION: ${PROMETHEUS_VERSION:-2.6.0}
-    ports:
-      - 9090
   # this service is to be used by system-tests for remote_write metricset, so as
   # Prometheus service to send metrics to Metricbeat running on the host.
   prometheus-host-network:

--- a/metricbeat/module/prometheus/docker-compose.yml
+++ b/metricbeat/module/prometheus/docker-compose.yml
@@ -1,15 +1,20 @@
 version: '2.3'
 
 services:
-  prometheus:
+  prometheus_base:
     image: docker.elastic.co/integrations-ci/beats-prometheus:${PROMETHEUS_VERSION:-2.6.0}-2
     build:
       context: ./_meta
       args:
         PROMETHEUS_VERSION: ${PROMETHEUS_VERSION:-2.6.0}
+  prometheus:
+    extends:
+      service: prometheus_base
+    ports:
+      - 9090
   # this service is to be used by system-tests for remote_write metricset, so as
   # Prometheus service to send metrics to Metricbeat running on the host.
   prometheus-host-network:
     extends:
-      service: prometheus
+      service: prometheus_base
     network_mode: host


### PR DESCRIPTION
## What does this PR do?

Updates the `docker` and `docker-compose` to support newer versions of
the docker-compose file and newer docker-compose features like profiles.

## Why is it important?

To allow tests in projects that depend on beats, like APM Server to use more up-to-date versions of Docker Compose and leverage new docker-compose features.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

N/A.

## Author's Checklist

## How to test this PR locally

Ensure that `pip -r libbeat/tests/system/requirements.txt` works in a venv.

## Related issues

Unblocks elastic/apm-server#7453

## Use cases

Use [`docker-compose --profile`](https://docs.docker.com/compose/profiles/) to enable docker-compose files to have disabled services by default, yet allow them to be spun up by specifying a profile. 

