### PR TITLE
filebeat: rename `source` log key to `source_file`

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -58,6 +58,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - elasticsearch: fix duplicate ingest when using a common appender configuration {issue}30428[30428] {pull}30440[30440]
 - Fix ECS version string in threatintel to be consistent with other modules and add event.timezone. {issue}30499[30499] {pull}30570[30570]
 - Add default paths value to MySQL Enterprise module to prevent issues with pipeline installations {pull}30598[30598]
+- Fix compatibility with ECS by renaming `source` log key to `source_file` {issue}30667[30667]
 
 *Heartbeat*
 

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -141,7 +141,7 @@ type defaultHarvesterGroup struct {
 func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
 	sourceName := hg.identifier.ID(s)
 
-	ctx.Logger = ctx.Logger.With("source", sourceName)
+	ctx.Logger = ctx.Logger.With("source_file", sourceName)
 	ctx.Logger.Debug("Starting harvester for file")
 
 	hg.tg.Go(startHarvester(ctx, hg, s, false))
@@ -152,7 +152,7 @@ func (hg *defaultHarvesterGroup) Start(ctx input.Context, s Source) {
 func (hg *defaultHarvesterGroup) Restart(ctx input.Context, s Source) {
 	sourceName := hg.identifier.ID(s)
 
-	ctx.Logger = ctx.Logger.With("source", sourceName)
+	ctx.Logger = ctx.Logger.With("source_file", sourceName)
 	ctx.Logger.Debug("Restarting harvester for file")
 
 	hg.tg.Go(startHarvester(ctx, hg, s, true))

--- a/filebeat/input/log/logger.go
+++ b/filebeat/input/log/logger.go
@@ -24,7 +24,7 @@ import (
 
 func loggerWithState(logger *logp.Logger, state file.State) *logp.Logger {
 	return logger.With(
-		"source", state.Source,
+		"source_file", state.Source,
 		"state_id", state.Id,
 		"finished", state.Finished,
 		"os_id", state.FileStateOS,


### PR DESCRIPTION
## What does this PR do?

Renames the `source` field used in some log messages to `source_file`

## Why is it important?

This makes Filebeat compatible with ECS

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]  Double check the backport tags

## How to test this PR locally
Run Filebeat in a docker container with docker autodiscover enabled, Filebeat should be able to
ship its own logs to ES without any issues.

Configuration example
```yaml
filebeat.autodiscover:
  providers:
    - type: docker
      templates:
        - condition:
            regexp:
              docker.container.image: ".*"
          config:
            - type: container
              paths:
                - /var/lib/docker/containers/${data.docker.container.id}/*.log
              json.keys_under_root: true
              json.add_error_key: true
```

## Related issues

- Closes: #30667

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~