### PR TITLE
Fix/change the initialization manager

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -380,7 +380,9 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	adiscover.Start()
 
 	// We start the manager when all the subsystem are initialized and ready to received events.
-	b.Manager.Start(func() {})
+	if err := b.Manager.Start(); err != nil {
+		return err
+	}
 
 	// Add done channel to wait for shutdown signal
 	waitFinished.AddChan(fb.done)

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -379,6 +379,9 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 	adiscover.Start()
 
+	// We start the manager when all the subsystem are initialized and ready to received events.
+	b.Manager.Start(func() {})
+
 	// Add done channel to wait for shutdown signal
 	waitFinished.AddChan(fb.done)
 	waitFinished.Wait()
@@ -391,6 +394,9 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	modules.Stop()
 	adiscover.Stop()
 	crawler.Stop()
+
+	// We stop the manager and destroy his connection to Elastic Agent.
+	b.Manager.Stop()
 
 	timeout := fb.config.ShutdownTimeout
 	// Checks if on shutdown it should wait for all events to be published

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -124,6 +124,13 @@ func (bt *Heartbeat) Run(b *beat.Beat) error {
 		defer bt.autodiscover.Stop()
 	}
 
+	// Configure the beats Manager to start after all the reloadable hooks are initialized
+	// and shutdown when the function return.
+	if err := b.Manager.Start(); err != nil {
+		return err
+	}
+	defer b.Manager.Stop()
+
 	defer bt.scheduler.Stop()
 
 	<-bt.done

--- a/libbeat/management/management.go
+++ b/libbeat/management/management.go
@@ -74,9 +74,8 @@ type Manager interface {
 	// Enabled returns true if manager is enabled.
 	Enabled() bool
 
-	// Start the config manager giving it a stopFunc callback
-	// so the beat can be told when to stop.
-	Start(stopFunc func())
+	// Start the config manager.
+	Start() error
 
 	// Stop the config manager.
 	Stop()
@@ -152,7 +151,7 @@ func nilFactory(*common.Config, *reload.Registry, uuid.UUID) (Manager, error) {
 }
 
 func (*nilManager) Enabled() bool                           { return false }
-func (*nilManager) Start(_ func())                          {}
+func (*nilManager) Start() error                            { return nil }
 func (*nilManager) Stop()                                   {}
 func (*nilManager) CheckRawConfig(cfg *common.Config) error { return nil }
 func (n *nilManager) UpdateStatus(status Status, msg string) {

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -255,6 +255,19 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 		}()
 	}
 
+	// Start the manager after all the reload hooks are configured,
+	// the Manager is stopped at the end of the execution.
+	if err := b.Manager.Start(); err != nil {
+		return err
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-bt.done
+		b.Manager.Stop()
+	}()
+
 	wg.Wait()
 	return nil
 }

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -149,6 +149,13 @@ func (pb *packetbeat) runManaged(b *beat.Beat, factory *processorFactory) error 
 
 	logp.Debug("main", "Waiting for the runner to finish")
 
+	// Start the manager after all the hooks are registered and terminates when
+	// the function return.
+	if err := b.Manager.Start(); err != nil {
+		return err
+	}
+	defer b.Manager.Stop()
+
 	for {
 		select {
 		case <-pb.done:

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -264,6 +264,12 @@ func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.O
 		ah := bt.registerActionHandler(b, cli, configPlugin)
 		defer bt.unregisterActionHandler(b, ah)
 
+		// All the action are correctly configured Start the manager.
+		if err := b.Manager.Start(); err != nil {
+			return err
+		}
+		defer b.Manager.Stop()
+
 		// Process input
 		for {
 			select {


### PR DESCRIPTION
This fix an issue on Filebeat that makes the start sequence of Filebeat
non-deterministic. It was possible that not all the hooks were
configured correctly before the managed was receiving a configuration
from the Elastic Agent.

This causes inconsistency between the expected configuration state coming from Agent
and the actual running state. This situation can have one or many of the following symptoms:

- Having Filebeat runnings and not sending any data to Elasticsearch
- Having Filebeat partially configured, when only some inputs were
  sending data.
- Missing log from the Filebeat collector
- Having only Metricbeats running and sending logs.

This solves the issues by moving the `Start` and stop `Stop` of the
manager into the beats initialization process, each beat need to be
adjusted to support this new sequence. 

This is indeed a **breaking change for beats author**,
but the bootstrap process of beats and libbeat cannot easily be
extended to make the change into a unique place. 

**Every beats has a different code path.**

## How it was detected

This was detected on a log where log events were actually missing from the log.

### Working endpoint.
```
{"log.level":"info","@timestamp":"2022-03-03T15:21:46.739+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":109},"message":"Starting fleet management service","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T15:21:47.354+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":150},"message":"Status change to Configuring: Updating configuration","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T15:21:47.354+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":271},"message":"Applying settings for filebeat.inputs","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-03-03T15:21:47.354+0100","log.logger":"centralmgmt","log.origin":{"file.name":"cfgfile/list.go","file.line":63},"message":"Starting reload procedure, current runners: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-03-03T15:21:47.355+0100","log.logger":"centralmgmt","log.origin":{"file.name":"cfgfile/list.go","file.line":81},"message":"Start list: 2, Stop list: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-03-03T15:21:47.356+0100","log.logger":"centralmgmt","log.origin":{"file.name":"cfgfile/list.go","file.line":105},"message":"Starting runner: input [type=log]","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-03-03T15:21:47.358+0100","log.logger":"centralmgmt","log.origin":{"file.name":"cfgfile/list.go","file.line":105},"message":"Starting runner: input [type=log]","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T15:21:47.358+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":271},"message":"Applying settings for output","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T15:21:47.358+0100","log.logger":"esclientleg","log.origin":{"file.name":"eslegclient/connection.go","file.line":102},"message":"elasticsearch url: https://<redacted>:443","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T15:21:47.358+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":271},"message":"Applying settings for filebeat.modules","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-03-03T15:21:47.358+0100","log.logger":"centralmgmt","log.origin":{"file.name":"cfgfile/list.go","file.line":63},"message":"Starting reload procedure, current runners: 0","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-03-03T15:21:47.358+0100","log.logger":"centralmgmt","log.origin":{"file.name":"cfgfile/list.go","file.line":81},"message":"Start list: 0, Stop list: 0","service.name":"filebeat","ecs.version":"1.6.0"}
```

### Problematic endpoint
```
{"log.level":"info","@timestamp":"2022-03-03T11:20:41.207+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":109},"message":"Starting fleet management service","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T11:20:41.732+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":150},"message":"Status change to Configuring: Updating configuration","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T11:20:41.733+0100","log.logger":"centralmgmt.fleet","log.origin":{"file.name":"management/manager.go","file.line":271},"message":"Applying settings for output","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-03T11:20:41.733+0100","log.logger":"esclientleg","log.origin":{"file.name":"eslegclient/connection.go","file.line":102},"message":"elasticsearch url: https://<redacted>:443","service.name":"filebeat","ecs.version":"1.6.0"}
```


The later log extract only contains information about the outputs (`Applying settings...) nothing about the inputs.


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Since the problem is non-deterministic reproducing this issue really hard, I was able to reproduce a few times by having simulated load on agent virtual machine. 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- #30533
