### PR TITLE
Add 8.1 Beats breaking changes

### DIFF
--- a/libbeat/docs/release-notes/breaking/breaking-8.1.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-8.1.asciidoc
@@ -1,0 +1,19 @@
+[[breaking-changes-8.1]]
+
+=== Breaking changes in 8.1
+++++
+<titleabbrev>8.1</titleabbrev>
+++++
+
+See the <<release-notes,release notes>> for a complete list of breaking changes,
+bug fixes, and enhancements, including changes to beta or experimental
+functionality.
+
+//NOTE: The notable-breaking-changes tagged regions are re-used in the
+//Installation and Upgrade Guide
+
+//tag::notable-breaking-changes[]
+
+There are no important breaking changes in this release.
+
+// end::notable-breaking-changes[]

--- a/libbeat/docs/release-notes/breaking/breaking.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking.asciidoc
@@ -11,6 +11,9 @@ changes, but there are breaking changes between major versions (e.g. 7.x to
 
 See the following topics for a description of breaking changes:
 
+* <<breaking-changes-8.1>>
 * <<breaking-changes-8.0>>
+
+include::breaking-8.1.asciidoc[]
 
 include::breaking-8.0.asciidoc[]


### PR DESCRIPTION
Adds breaking changes page for 8.1.

Let me know if you want me to describe https://github.com/elastic/beats/pull/30564 here. I didn't think it qualified as an "important" breaking change since the dataset wasn't working correctly and not likely to be used.