### PR TITLE
improve filebeat scan performance when symlinks is enabled

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -26,6 +26,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input/file"
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	"github.com/elastic/beats/v7/libbeat/common"
+	filelibbeat "github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-concert/timed"
@@ -308,6 +309,7 @@ func (s *fileScanner) normalizeGlobPatterns() error {
 // match the configured paths.
 func (s *fileScanner) GetFiles() map[string]os.FileInfo {
 	pathInfo := map[string]os.FileInfo{}
+	uniqFileID := map[string]os.FileInfo{}
 
 	for _, path := range s.paths {
 		matches, err := filepath.Glob(path)
@@ -323,7 +325,7 @@ func (s *fileScanner) GetFiles() map[string]os.FileInfo {
 
 			// If symlink is enabled, it is checked that original is not part of same input
 			// If original is harvested by other input, states will potentially overwrite each other
-			if s.isOriginalAndSymlinkConfigured(file, pathInfo) {
+			if s.isOriginalAndSymlinkConfigured(file, uniqFileID) {
 				continue
 			}
 
@@ -377,20 +379,19 @@ func (s *fileScanner) shouldSkipFile(file string) bool {
 	return false
 }
 
-func (s *fileScanner) isOriginalAndSymlinkConfigured(file string, paths map[string]os.FileInfo) bool {
+func (s *fileScanner) isOriginalAndSymlinkConfigured(file string, uniqFileID map[string]os.FileInfo) bool {
 	if s.symlinks {
 		fileInfo, err := os.Stat(file)
 		if err != nil {
 			s.log.Debugf("stat(%s) failed: %s", file, err)
 			return false
 		}
-
-		for _, finfo := range paths {
-			if os.SameFile(finfo, fileInfo) {
-				s.log.Info("Same file found as symlink and original. Skipping file: %s (as it same as %s)", file, finfo.Name())
-				return true
-			}
+		fileID := filelibbeat.GetOSState(fileInfo).String()
+		if finfo, exists := uniqFileID[fileID]; exists {
+			s.log.Info("Same file found as symlink and original. Skipping file: %s (as it same as %s)", file, finfo.Name())
+			return true
 		}
+		uniqFileID[fileID] = fileInfo
 	}
 	return false
 }

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -26,7 +26,7 @@ import (
 	"github.com/elastic/beats/v7/filebeat/input/file"
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	"github.com/elastic/beats/v7/libbeat/common"
-	filelibbeat "github.com/elastic/beats/v7/libbeat/common/file"
+	file_helper "github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/beats/v7/libbeat/common/match"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-concert/timed"
@@ -386,7 +386,7 @@ func (s *fileScanner) isOriginalAndSymlinkConfigured(file string, uniqFileID map
 			s.log.Debugf("stat(%s) failed: %s", file, err)
 			return false
 		}
-		fileID := filelibbeat.GetOSState(fileInfo).String()
+		fileID := file_helper.GetOSState(fileInfo).String()
 		if finfo, exists := uniqFileID[fileID]; exists {
 			s.log.Info("Same file found as symlink and original. Skipping file: %s (as it same as %s)", file, finfo.Name())
 			return true


### PR DESCRIPTION
## What does this PR do?

Improve filebeat file scanning performance when symlinks is enabled


## Why is it important?

On my machine, because it is a log server, the target file will reach tens of thousands or even millions. 
After filebeat is started, the CPU has been very high. 
Through golang pprof, most of the time is consumed in the scan->getFiles->os.SameFile function. 
(Symlinks is enabled in my configuration file)
I looked at the code carefully and found that there is an O(n2) performance loss when traversing `paths`.
On my machine, there are millions of files, and it takes more than 1 hour to run once here


#28328 