### PR TITLE
Fix add_kubernetes_metadata matcher: support rotated logs when 'resource_type: pod'

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -53,6 +53,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - auditd: Prevent mapping explosion when truncated EXECVE records are ingested. {pull}30382[30382]
 - elasticsearch: fix duplicate ingest when using a common appender configuration {issue}30428[30428] {pull}30440[30440]
 - Fix compatibility with ECS by renaming `source` log key to `source_file` {issue}30667[30667]
+- Fix add_kubernetes_metadata matcher: support rotated logs when `resource_type: pod`
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -53,7 +53,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - auditd: Prevent mapping explosion when truncated EXECVE records are ingested. {pull}30382[30382]
 - elasticsearch: fix duplicate ingest when using a common appender configuration {issue}30428[30428] {pull}30440[30440]
 - Fix compatibility with ECS by renaming `source` log key to `source_file` {issue}30667[30667]
-- Fix add_kubernetes_metadata matcher: support rotated logs when `resource_type: pod`
+- Fix add_kubernetes_metadata matcher: support rotated logs when `resource_type: pod` {pull}30720[30720]
 
 *Filebeat*
 

--- a/filebeat/processor/add_kubernetes_metadata/matchers_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers_test.go
@@ -128,7 +128,13 @@ func TestLogsPathMatcher_InvalidVarLogPodSource(t *testing.T) {
 func TestLogsPathMatcher_ValidVarLogPodSource(t *testing.T) {
 	cfgLogsPath := "/var/log/pods/"
 	cfgResourceType := "pod"
-	source := fmt.Sprintf("/var/log/pods/namespace_pod-name_%s/container/0.log.20220221-210912", puid)
+	sourcePath := "/var/log/pods/namespace_pod-name_%s/container/0.log.20220221-210912"
+
+	if runtime.GOOS == "windows" {
+		cfgLogsPath = "C:\\var\\log\\pods\\"
+		sourcePath = "C:\\var\\log\\pods\\namespace_pod-name_%s\\container\\0.log.20220221-210912"
+	}
+	source := fmt.Sprintf(sourcePath, puid)
 	expectedResult := puid
 	executeTestWithResourceType(t, cfgLogsPath, cfgResourceType, source, expectedResult)
 }

--- a/filebeat/processor/add_kubernetes_metadata/matchers_test.go
+++ b/filebeat/processor/add_kubernetes_metadata/matchers_test.go
@@ -125,6 +125,22 @@ func TestLogsPathMatcher_InvalidVarLogPodSource(t *testing.T) {
 	executeTestWithResourceType(t, cfgLogsPath, cfgResourceType, source, expectedResult)
 }
 
+func TestLogsPathMatcher_ValidVarLogPodSource(t *testing.T) {
+	cfgLogsPath := "/var/log/pods/"
+	cfgResourceType := "pod"
+	source := fmt.Sprintf("/var/log/pods/namespace_pod-name_%s/container/0.log.20220221-210912", puid)
+	expectedResult := puid
+	executeTestWithResourceType(t, cfgLogsPath, cfgResourceType, source, expectedResult)
+}
+
+func TestLogsPathMatcher_InvalidVarLogPodSource2(t *testing.T) {
+	cfgLogsPath := "/var/log/pods/"
+	cfgResourceType := "pod"
+	source := fmt.Sprintf("/var/log/pods/namespace_pod-name_%s/container/0.log.20220221-210526.gz", puid)
+	expectedResult := ""
+	executeTestWithResourceType(t, cfgLogsPath, cfgResourceType, source, expectedResult)
+}
+
 func TestLogsPathMatcher_InvalidVarLogPodIDFormat(t *testing.T) {
 	cfgLogsPath := "/var/log/pods/"
 	cfgResourceType := "pod"


### PR DESCRIPTION
Signed-off-by: Tetiana Kravchenko <tetiana.kravchenko@elastic.co>

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

According to https://www.elastic.co/guide/en/beats/filebeat/current/file-log-rotation.html#file-log-rotation, there might be cases when we need to read rotated log files:
```
Make sure Filebeat is configured to read from all rotated logs
```
This PR add possibility to get pod uid for the rotated log files when `resource_type` is set to `pod`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- https://discuss.elastic.co/t/filebeat-add-kubernetes-metadata-pod-uid-matcher-doesnt-match-poduid-for-rotated-file-on-aks/298938

## Use cases
Context:
According to [[kubernetes documentation](https://kubernetes.io/docs/concepts/cluster-administration/logging/#logging-at-the-node-level)]:

> Kubernetes is not responsible for rotating logs, but rather a deployment tool should set up a solution to address that.

In most cases where k8s uses docker as runtime the strategy is what docker sets through docker log-opt:
```
{
  "log-driver": "json-file",
  "log-opts": {
    "max-size": "10m",
    "max-file": "10"
  }
}
```

In some cases it is needed to set paths to `/var/log/pods/*/*/*.log*`: in some occasions, there are a very high volume of logs which caused the files to be quickly rotated without filebeat having time to harvest them. 
For this reason was removed check `strings.HasSuffix(source, ".log")` to support rotated log files.

At the same time compressed log files are not supported for now, `*.gz` files are excluded from the processing when `resource_type: pod`
example of `/var/log/pods/*/*/*.log*` content:
```
/var/log/pods/kube-system_metricbeat-56nf2_64e94e05-c377-4bcb-9cc2-5184c4f4b978/metricbeat# ls -l | awk -F " " '{print $9}'

0.log
0.log.20220221-203122.gz
0.log.20220221-203252.gz
0.log.20220221-210526.gz
0.log.20220221-210912
1.log
1.log.20220308-190811.gz
1.log.20220308-190916.gz
1.log.20220308-191043.gz
1.log.20220308-191159
```
in this case only `0.log`, `0.log.20220221-210912`, `1.log` and `1.log.20220308-191159` should be processed

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
