### PR TITLE
libbeat/processors/add_process_metadata: place parent process information directly in parent object

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -10,6 +10,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Affecting all Beats*
 
+- Fix mapping of parent process information provided by add_process_metadata. {issue}29874[29874] {pull}30727[30727]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_process_metadata/add_process_metadata.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata.go
@@ -118,9 +118,7 @@ func newProcessMetadataProcessorWithProvider(cfg *common.Config, provider proces
 		return nil, errors.Wrapf(err, "error unpacking %v.target_fields", processorName)
 	}
 
-	var p addProcessMetadata
-
-	p = addProcessMetadata{
+	p := addProcessMetadata{
 		config:   config,
 		provider: provider,
 		log:      log,

--- a/libbeat/processors/add_process_metadata/add_process_metadata_test.go
+++ b/libbeat/processors/add_process_metadata/add_process_metadata_test.go
@@ -76,7 +76,6 @@ func TestAddProcessMetadata(t *testing.T) {
 
 	// mock of the cgroup processCgroupPaths
 	processCgroupPaths = func(_ resolve.Resolver, pid int) (cgroup.PathList, error) {
-
 		testMap := map[int]cgroup.PathList{
 			1: {
 				V1: map[string]cgroup.ControllerPath{
@@ -181,9 +180,7 @@ func TestAddProcessMetadata(t *testing.T) {
 					"process": common.MapStr{
 						"ppid": "1",
 						"parent": common.MapStr{
-							"process": common.MapStr{
-								"name": "systemd",
-							},
+							"name": "systemd",
 						},
 					},
 				},
@@ -342,13 +339,11 @@ func TestAddProcessMetadata(t *testing.T) {
 			expected: common.MapStr{
 				"ppid": "1",
 				"parent": common.MapStr{
-					"process": common.MapStr{
-						"env": map[string]string{
-							"HOME":       "/",
-							"TERM":       "linux",
-							"BOOT_IMAGE": "/boot/vmlinuz-4.11.8-300.fc26.x86_64",
-							"LANG":       "en_US.UTF-8",
-						},
+					"env": map[string]string{
+						"HOME":       "/",
+						"TERM":       "linux",
+						"BOOT_IMAGE": "/boot/vmlinuz-4.11.8-300.fc26.x86_64",
+						"LANG":       "en_US.UTF-8",
 					},
 				},
 			},
@@ -818,7 +813,7 @@ func TestUsingCache(t *testing.T) {
 			selfPID: testStruct,
 		}
 
-		//testMap :=
+		// testMap :=
 		return testMap[pid], nil
 	}
 
@@ -827,7 +822,6 @@ func TestUsingCache(t *testing.T) {
 		"include_fields": []string{"container.id"},
 		"target":         "meta",
 	})
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1097,7 +1091,7 @@ func TestV2CID(t *testing.T) {
 	processCgroupPaths = func(_ resolve.Resolver, _ int) (cgroup.PathList, error) {
 		testMap := cgroup.PathList{
 			V1: map[string]cgroup.ControllerPath{
-				"cpu": cgroup.ControllerPath{IsV2: true, ControllerPath: "system.slice/docker-2dcbab615aebfa9313feffc5cfdacd381543cfa04c6be3f39ac656e55ef34805.scope"},
+				"cpu": {IsV2: true, ControllerPath: "system.slice/docker-2dcbab615aebfa9313feffc5cfdacd381543cfa04c6be3f39ac656e55ef34805.scope"},
 			},
 		}
 		return testMap, nil

--- a/libbeat/processors/add_process_metadata/config.go
+++ b/libbeat/processors/add_process_metadata/config.go
@@ -19,6 +19,7 @@ package add_process_metadata
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -120,7 +121,7 @@ func (pf *config) getMappings() (mappings common.MapStr, err error) {
 		wantedFields = []string{"process", "container"}
 	}
 	for _, docSrc := range wantedFields {
-		dstField := fieldPrefix + docSrc
+		dstField := constructPath(fieldPrefix, docSrc)
 		reqField, err := validFields.GetValue(docSrc)
 		if err != nil {
 			return nil, fmt.Errorf("field '%v' not found", docSrc)
@@ -144,4 +145,14 @@ func (pf *config) getMappings() (mappings common.MapStr, err error) {
 		}
 	}
 	return mappings.Flatten(), nil
+}
+
+// constructPath returns a full JSON path given the prefix and target taking
+// care to ensure that parent process attributes are placed directly within the
+// parent object.
+func constructPath(prefix, target string) string {
+	if prefix == "parent." || strings.HasSuffix(prefix, ".parent.") {
+		return prefix + strings.TrimPrefix(target, "process.")
+	}
+	return prefix + target
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This changes the mapping for parent process information to reflect the ECS, so that the current output
```
"process": {
  "parent": {
    "process": {
      "pid": "1234"
      "name": "parent_process",
      [...]
    }
  }
}
```
would now be
```
"process": {
  "parent": {
    "pid": "1234"
    "name": "parent_process",
    [...]
  }
}
```

This is a breaking change.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It brings the document output into line with the ECS.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Query backport targets.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #29874.

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
