### PR TITLE
x-pack/filebeat/input/httpjson: make sure interval data clearing happens before processing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -52,6 +52,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - auditd: Prevent mapping explosion when truncated EXECVE records are ingested. {pull}30382[30382]
 - elasticsearch: fix duplicate ingest when using a common appender configuration {issue}30428[30428] {pull}30440[30440]
 - Fix add_kubernetes_metadata matcher: support rotated logs when `resource_type: pod` {pull}30720[30720]
+- Prevent logic race on clearing data during request in httpjson. {pull}30730[30730]
 
 *Filebeat*
 - Fixes data duplication on restart when filestream inputs did not have an ID set. {issue}30061[30061]

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -183,12 +183,9 @@ func (r *requester) doRequest(stdCtx context.Context, trCtx *transformContext, p
 	}
 	defer httpResp.Body.Close()
 
-	eventsCh := r.responseProcessor.startProcessing(stdCtx, trCtx, httpResp)
-
-	trCtx.clearIntervalData()
-
 	var n int
-	for maybeMsg := range eventsCh {
+	events := r.responseProcessor.startProcessing(stdCtx, trCtx, httpResp)
+	for maybeMsg := range events {
 		if maybeMsg.failed() {
 			r.log.Errorf("error processing response: %v", maybeMsg)
 			continue

--- a/x-pack/filebeat/input/httpjson/response.go
+++ b/x-pack/filebeat/input/httpjson/response.go
@@ -75,8 +75,9 @@ func newResponseProcessor(config *responseConfig, pagination *pagination, log *l
 }
 
 func (rp *responseProcessor) startProcessing(stdCtx context.Context, trCtx *transformContext, resp *http.Response) <-chan maybeMsg {
-	ch := make(chan maybeMsg)
+	trCtx.clearIntervalData()
 
+	ch := make(chan maybeMsg)
 	go func() {
 		defer close(ch)
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This change ensures that request interval data is not cleared after a request has begun.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Although extremely unlikely, there is otherwise no happens before relationship between the clearing of request interval data and the processing of the obtained data. If the interval data has been cleared during a request, spurious default first and last event, and last response values in the transform context can be set in the resulting published event.

The conditions for this to happen are that the request manages to progress at least one page of the pagination iterator before the call to `trCtx.clearIntervalData()` can complete. The chances of this happening are vanishingly small. However...

```
[2022-02-27T03:07:14.640Z] === Failed
[2022-02-27T03:07:14.640Z] === FAIL: x-pack/filebeat/input/httpjson TestInput/Test_first_event (2.02s)
[2022-02-27T03:07:14.640Z]     input_test.go:441: 
[2022-02-27T03:07:14.640Z]         	Error Trace:	input_test.go:441
[2022-02-27T03:07:14.640Z]         	Error:      	Not equal: 
[2022-02-27T03:07:14.640Z]         	            	expected: map[string]interface {}{"first":"a", "foo":"b"}
[2022-02-27T03:07:14.640Z]         	            	actual  : map[string]interface {}{"first":"none", "foo":"b"}
[2022-02-27T03:07:14.640Z]         	            	
[2022-02-27T03:07:14.640Z]         	            	Diff:
[2022-02-27T03:07:14.640Z]         	            	--- Expected
[2022-02-27T03:07:14.640Z]         	            	+++ Actual
[2022-02-27T03:07:14.640Z]         	            	@@ -1,3 +1,3 @@
[2022-02-27T03:07:14.640Z]         	            	 (map[string]interface {}) (len=2) {
[2022-02-27T03:07:14.640Z]         	            	- (string) (len=5) "first": (string) (len=1) "a",
[2022-02-27T03:07:14.640Z]         	            	+ (string) (len=5) "first": (string) (len=4) "none",
[2022-02-27T03:07:14.640Z]         	            	  (string) (len=3) "foo": (string) (len=1) "b"
[2022-02-27T03:07:14.640Z]         	Test:       	TestInput/Test_first_event
[2022-02-27T03:07:14.640Z]     --- FAIL: TestInput/Test_first_event (2.02s)
[2022-02-27T03:07:14.640Z] 
[2022-02-27T03:07:14.640Z] === FAIL: x-pack/filebeat/input/httpjson TestInput (7.20s)
[2022-02-27T03:07:14.640Z] 
[2022-02-27T03:07:14.640Z] DONE 801 tests, 7 skipped, 2 failures in 189.135s
[2022-02-27T03:07:14.640Z] Error: go test returned a non-zero value: exit status 1
```

Placing the call within `(*responseProcessor).startProcessing` provides an HB relationship between the interval clearing and the initiation of the pagination iteration and so precludes clearing the data before the events have been published.

I have not been able to replicate the failure over ~1000 test iterations in the original state, which is consistent with the analysis, though still unsatisfying.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Backport prior to 7.17?

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
