### PR TITLE
[Filebeat] httpjson update docs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -56,6 +56,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - elasticsearch: fix duplicate ingest when using a common appender configuration {issue}30428[30428] {pull}30440[30440]
 - Fix compatibility with ECS by renaming `source` log key to `source_file` {issue}30667[30667]
 - Fix add_kubernetes_metadata matcher: support rotated logs when `resource_type: pod` {pull}30720[30720]
+- Update documentation for accessing `last_response.url.params` in httpjson input. {pull}30739[30739]
 
 *Filebeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -106,7 +106,7 @@ The `httpjson` input keeps a runtime state between requests. This state can be a
 The state has the following elements:
 
 - `last_response.url.value`: The full URL with params and fragments from the last request with a successful response.
-- `last_response.url.params`: A map containing the params from the URL in `last_response.url.value`.
+- `last_response.url.params`: A https://pkg.go.dev/net/url#Values[`url.Values`] of the params from the URL in `last_response.url.value`.  Can be queried with the https://pkg.go.dev/net/url#Values.Get[`Get`] function.
 - `last_response.header`: A map containing the headers from the last successful response.
 - `last_response.body`: A map containing the parsed JSON body from the last successful response. This is the response as it comes from the remote server.
 - `last_response.page`: A number indicating the page number of the last response.


### PR DESCRIPTION
## What does this PR do?

Updates documentation for accessing `last_response.url.params` in httpjson input.

## Why is it important?

Previous documentation had `params` as a map which wasn't correct and lead to confusion about accessing the values in the `params`.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #30477

## Screenshots
<img width="757" alt="Screen Shot 2022-03-08 at 11 52 13" src="https://user-images.githubusercontent.com/57081003/157320296-5d581df4-8105-4a0f-944c-c4ddfbc1dc21.png">

