### PR TITLE
Fix double-counted metrics in docker/diskio

### DIFF
--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -61,6 +61,7 @@ metricbeat.modules:
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
+  # By default, it will skip devices with major numbers 9 or 253.
   #skip_major: []
 
   # If set to true, collects metrics per core.

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -58,7 +58,7 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
-  # Skip metrics certain device major numbers in docker/diskio. 
+  # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
   #skip_major: []

--- a/metricbeat/docs/modules/docker.asciidoc
+++ b/metricbeat/docs/modules/docker.asciidoc
@@ -58,6 +58,11 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Skip metrics certain device major numbers in docker/diskio. 
+  # Necessary on systems with software RAID, device mappers, 
+  # or other configurations where virtual disks will sum metrics from other disks.
+  #skip_major: []
+
   # If set to true, collects metrics per core.
   #cpu.cores: true
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -243,6 +243,11 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Skip metrics certain device major numbers in docker/diskio. 
+  # Necessary on systems with software RAID, device mappers, 
+  # or other configurations where virtual disks will sum metrics from other disks.
+  #skip_major: []
+
   # If set to true, collects metrics per core.
   #cpu.cores: true
 

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -246,6 +246,7 @@ metricbeat.modules:
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
+  # By default, it will skip devices with major numbers 9 or 253.
   #skip_major: []
 
   # If set to true, collects metrics per core.

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -243,7 +243,7 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
-  # Skip metrics certain device major numbers in docker/diskio. 
+  # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
   #skip_major: []

--- a/metricbeat/module/docker/_meta/config.reference.yml
+++ b/metricbeat/module/docker/_meta/config.reference.yml
@@ -17,6 +17,11 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Skip metrics certain device major numbers in docker/diskio. 
+  # Necessary on systems with software RAID, device mappers, 
+  # or other configurations where virtual disks will sum metrics from other disks.
+  #skip_major: []
+
   # If set to true, collects metrics per core.
   #cpu.cores: true
 

--- a/metricbeat/module/docker/_meta/config.reference.yml
+++ b/metricbeat/module/docker/_meta/config.reference.yml
@@ -17,9 +17,10 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
-  # Skip metrics certain device major numbers in docker/diskio. 
+  # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
+  # By default, it will skip devices with major numbers 9 or 253.
   #skip_major: []
 
   # If set to true, collects metrics per core.

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -15,6 +15,11 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Skip metrics certain device major numbers in docker/diskio. 
+  # Necessary on systems with software RAID, device mappers, 
+  # or other configurations where virtual disks will sum metrics from other disks.
+  #skip_major: []
+  
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/module/docker/_meta/config.yml
+++ b/metricbeat/module/docker/_meta/config.yml
@@ -15,11 +15,12 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
-  # Skip metrics certain device major numbers in docker/diskio. 
+  # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
+  # By default, it will skip devices with major numbers 9 or 253.
   #skip_major: []
-  
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/module/docker/diskio/_meta/data.json
+++ b/metricbeat/module/docker/diskio/_meta/data.json
@@ -1,42 +1,45 @@
 {
     "@timestamp": "2017-10-12T08:05:34.853Z",
     "container": {
-        "id": "8abaa1f3514d3554503034a1df6ee09457f328757bbc9555245244ee853c0b44",
+        "id": "ca30d1e2be38876c2a2e9ebb6007bbb295651b7468116e367212311fecf8ce8c",
         "image": {
-            "name": "zookeeper"
+            "name": "kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
         },
-        "name": "some-zookeeper",
+        "name": "kind-control-plane",
         "runtime": "docker"
     },
     "docker": {
+        "container": {
+            "labels": {
+                "io_x-k8s_kind_cluster": "kind",
+                "io_x-k8s_kind_role": "control-plane"
+            }
+        },
         "diskio": {
             "read": {
-                "bytes": 42409984,
-                "ops": 1823,
+                "bytes": 0,
+                "ops": 0,
                 "queued": 0,
                 "rate": 0,
                 "service_time": 0,
                 "wait_time": 0
             },
-            "reads": 0,
             "summary": {
-                "bytes": 42414080,
-                "ops": 1824,
+                "bytes": 0,
+                "ops": 0,
                 "queued": 0,
                 "rate": 0,
                 "service_time": 0,
                 "wait_time": 0
             },
-            "total": 0,
             "write": {
-                "bytes": 4096,
-                "ops": 1,
+                "bytes": 0,
+                "ops": 0,
                 "queued": 0,
                 "rate": 0,
                 "service_time": 0,
                 "wait_time": 0
-            },
-            "writes": 0
+            }
         }
     },
     "event": {

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -42,7 +42,7 @@ type Config struct {
 	SkipMajor []uint64          `config:"skip_major"`
 }
 
-// The major devices we'll skip by default. 9 == mdraid, 253= device-mapper
+// The major devices we'll skip by default. 9 == mdraid, 253 == device-mapper
 var defaultMajorDev = []uint64{9, 253}
 
 func defaultConfig() Config {

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -35,22 +35,44 @@ func init() {
 	)
 }
 
+// Config "imports" the base module-level config, plus our metricset options
+type Config struct {
+	TLS       *docker.TLSConfig `config:"ssl"`
+	DeDot     bool              `config:"labels.dedot"`
+	SkipMajor []uint64          `config:"skip_major"`
+}
+
+var defaultMajorDev = []uint64{9, 253}
+
+func defaultConfig() Config {
+	//This is a bit awkward, but the config Unwrap() function is a bit awkward in that it will only partly overwrite
+	// an array value, which makes handling the `skip_major` array a bit annoying.
+	parentDefault := docker.DefaultConfig()
+	return Config{
+		TLS:   parentDefault.TLS,
+		DeDot: parentDefault.DeDot,
+	}
+}
+
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	mb.BaseMetricSet
 	blkioService *BlkioService
 	dockerClient *client.Client
-	dedot        bool
+	config       Config
 }
 
 // New create a new instance of the docker diskio MetricSet.
 func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	config := docker.DefaultConfig()
+	config := defaultConfig()
 	if err := base.Module().UnpackConfig(&config); err != nil {
 		return nil, err
 	}
+	if config.SkipMajor == nil {
+		config.SkipMajor = defaultMajorDev
+	}
 
-	client, err := docker.NewDockerClient(base.HostData().URI, config)
+	client, err := docker.NewDockerClient(base.HostData().URI, docker.Config{TLS: config.TLS, DeDot: config.DeDot})
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +81,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		BaseMetricSet: base,
 		dockerClient:  client,
 		blkioService:  NewBlkioService(),
-		dedot:         config.DeDot,
+		config:        config,
 	}, nil
 }
 
@@ -70,7 +92,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return errors.Wrap(err, "failed to get docker stats")
 	}
 
-	formattedStats := m.blkioService.getBlkioStatsList(stats, m.dedot)
+	formattedStats := m.blkioService.getBlkioStatsList(stats, m.config.DeDot, m.config.SkipMajor)
 	eventsMapping(r, formattedStats)
 
 	return nil

--- a/metricbeat/module/docker/diskio/diskio.go
+++ b/metricbeat/module/docker/diskio/diskio.go
@@ -42,6 +42,7 @@ type Config struct {
 	SkipMajor []uint64          `config:"skip_major"`
 }
 
+// The major devices we'll skip by default. 9 == mdraid, 253= device-mapper
 var defaultMajorDev = []uint64{9, 253}
 
 func defaultConfig() Config {

--- a/metricbeat/module/docker/diskio/diskio_test.go
+++ b/metricbeat/module/docker/diskio/diskio_test.go
@@ -62,7 +62,7 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	apiContainer2.Container = &containers[1]
 	apiContainer2.Stats.BlkioStats.IoServicedRecursive = append(apiContainer2.Stats.BlkioStats.IoServicedRecursive, metrics)
 	dockerStats := []docker.Stat{apiContainer1, apiContainer2}
-	stats := blkioService.getBlkioStatsList(dockerStats, true)
+	stats := blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	totals := make([]float64, 2)
 	for _, stat := range stats {
 		totals[0] = stat.totals
@@ -72,7 +72,7 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
 	dockerStats[1].Stats.BlkioStats.IoServicedRecursive[0].Value = 1000
 	dockerStats[1].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
-	stats = blkioService.getBlkioStatsList(dockerStats, true)
+	stats = blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	for _, stat := range stats {
 		totals[1] = stat.totals
 		if stat.totals < totals[0] {
@@ -84,12 +84,81 @@ func TestDeltaMultipleContainers(t *testing.T) {
 	dockerStats[0].Stats.BlkioStats.IoServicedRecursive[0].Value = 2000
 	dockerStats[1].Stats.BlkioStats.IoServicedRecursive[0].Value = 2000
 	dockerStats[1].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 15)
-	stats = blkioService.getBlkioStatsList(dockerStats, true)
+	stats = blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	for _, stat := range stats {
 		if stat.totals < totals[1] || stat.totals < totals[0] {
 			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[1])
 		}
 	}
+
+}
+
+func TestBlkIOSkip(t *testing.T) {
+	/*
+	   For context, here's what a "raw" event looks like coming in from the docker stats API.
+	   Note the repeated values across the two different major devices. Here 8:0 is a /dev/sda disk, 253:0 is the device mapper that exposes that disk's storage space.
+	           "io_service_bytes_recursive": [
+	               {
+	                   "major": 8,
+	                   "minor": 0,
+	                   "op": "read",
+	                   "value": 2359296
+	               },
+	               {
+	                   "major": 8,
+	                   "minor": 0,
+	                   "op": "write",
+	                   "value": 94544896
+	               },
+	               {
+	                   "major": 253,
+	                   "minor": 0,
+	                   "op": "read",
+	                   "value": 2359296
+	               },
+	               {
+	                   "major": 253,
+	                   "minor": 0,
+	                   "op": "write",
+	                   "value": 94544896
+	               }
+	           ],
+	*/
+
+	var readVal uint64 = 2359296
+	var writeVal uint64 = 94544896
+	testInt := []types.BlkioStatEntry{
+		{
+			Major: 8,
+			Minor: 0,
+			Op:    "Read",
+			Value: readVal,
+		},
+		{
+			Major: 8,
+			Minor: 0,
+			Op:    "Write",
+			Value: writeVal,
+		},
+		{
+			Major: 253,
+			Minor: 0,
+			Op:    "Read",
+			Value: readVal,
+		},
+		{
+			Major: 253,
+			Minor: 0,
+			Op:    "Write",
+			Value: writeVal,
+		},
+	}
+
+	skip := []uint64{253}
+
+	combined := getNewStats(skip, time.Now(), testInt)
+	assert.Equal(t, readVal, combined.reads)
+	assert.Equal(t, writeVal, combined.writes)
 
 }
 
@@ -116,7 +185,7 @@ func TestDeltaOneContainer(t *testing.T) {
 	apiContainer.Container = &containers
 	apiContainer.Stats.BlkioStats.IoServicedRecursive = append(apiContainer.Stats.BlkioStats.IoServicedRecursive, metrics)
 	dockerStats := []docker.Stat{apiContainer}
-	stats := blkioService.getBlkioStatsList(dockerStats, true)
+	stats := blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	totals := make([]float64, 2)
 	for _, stat := range stats {
 		totals[0] = stat.totals
@@ -124,7 +193,7 @@ func TestDeltaOneContainer(t *testing.T) {
 
 	dockerStats[0].Stats.BlkioStats.IoServicedRecursive[0].Value = 1000
 	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 10)
-	stats = blkioService.getBlkioStatsList(dockerStats, true)
+	stats = blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	for _, stat := range stats {
 		if stat.totals < totals[0] {
 			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[0])
@@ -133,7 +202,7 @@ func TestDeltaOneContainer(t *testing.T) {
 
 	dockerStats[0].Stats.BlkioStats.IoServicedRecursive[0].Value = 2000
 	dockerStats[0].Stats.Read = dockerStats[0].Stats.Read.Add(time.Second * 15)
-	stats = blkioService.getBlkioStatsList(dockerStats, true)
+	stats = blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	for _, stat := range stats {
 		if stat.totals < totals[1] || stat.totals < totals[0] {
 			t.Errorf("getBlkioStatsList(%v) => %v, want value bigger than %v", dockerStats, stat.totals, totals[1])
@@ -284,7 +353,7 @@ func TestGetBlkioStatsList(t *testing.T) {
 		}},
 	}}
 
-	statsList := blkioService.getBlkioStatsList(dockerStats, true)
+	statsList := blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	stats := statsList[0]
 	assert.Equal(t, float64(5), stats.reads)
 	assert.Equal(t, float64(10), stats.writes)
@@ -332,7 +401,7 @@ func TestGetBlkioStatsListWindows(t *testing.T) {
 		}},
 	}}
 
-	statsList := blkioService.getBlkioStatsList(dockerStats, true)
+	statsList := blkioService.getBlkioStatsList(dockerStats, true, []uint64{})
 	stats := statsList[0]
 	assert.Equal(t, float64(5), stats.reads)
 	assert.Equal(t, float64(10), stats.writes)

--- a/metricbeat/module/docker/diskio/diskio_test.go
+++ b/metricbeat/module/docker/diskio/diskio_test.go
@@ -160,6 +160,10 @@ func TestBlkIOSkip(t *testing.T) {
 	assert.Equal(t, readVal, combined.reads)
 	assert.Equal(t, writeVal, combined.writes)
 
+	noskip := getNewStats([]uint64{}, time.Now(), testInt)
+	assert.Equal(t, readVal*2, noskip.reads)
+	assert.Equal(t, writeVal*2, noskip.writes)
+
 }
 
 func TestDeltaOneContainer(t *testing.T) {

--- a/metricbeat/module/docker/diskio/helper.go
+++ b/metricbeat/module/docker/diskio/helper.go
@@ -18,6 +18,7 @@
 package diskio
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -77,12 +78,12 @@ func NewBlkioService() *BlkioService {
 	}
 }
 
-func (io *BlkioService) getBlkioStatsList(rawStats []docker.Stat, dedot bool) []BlkioStats {
+func (io *BlkioService) getBlkioStatsList(rawStats []docker.Stat, dedot bool, skipDev []uint64) []BlkioStats {
 	formattedStats := []BlkioStats{}
 
 	statsPerContainer := make(map[string]BlkioRaw)
 	for _, myRawStats := range rawStats {
-		stats := io.getBlkioStats(&myRawStats, dedot)
+		stats := io.getBlkioStats(&myRawStats, dedot, skipDev)
 		storageStats := io.getStorageStats(&myRawStats, dedot)
 		stats.Add(&storageStats)
 
@@ -124,30 +125,36 @@ func (io *BlkioService) getStorageStats(myRawStats *docker.Stat, dedot bool) Blk
 
 // getBlkioStats collects diskio metrics from BlkioStats structures, that
 // are not populated in Windows
-func (io *BlkioService) getBlkioStats(myRawStat *docker.Stat, dedot bool) BlkioStats {
+func (io *BlkioService) getBlkioStats(myRawStat *docker.Stat, dedot bool, skipDev []uint64) BlkioStats {
 	return BlkioStats{
 		Time:      myRawStat.Stats.Read,
 		Container: docker.NewContainer(myRawStat.Container, dedot),
 
-		serviced: io.getNewStats(
+		serviced: getNewStats(
+			skipDev,
 			myRawStat.Stats.Read,
 			myRawStat.Stats.BlkioStats.IoServicedRecursive),
-		servicedBytes: io.getNewStats(
+		servicedBytes: getNewStats(
+			skipDev,
 			myRawStat.Stats.Read,
 			myRawStat.Stats.BlkioStats.IoServiceBytesRecursive),
-		servicedTime: io.getNewStats(
+		servicedTime: getNewStats(
+			skipDev,
 			myRawStat.Stats.Read,
 			myRawStat.Stats.BlkioStats.IoServiceTimeRecursive),
-		waitTime: io.getNewStats(
+		waitTime: getNewStats(
+			skipDev,
 			myRawStat.Stats.Read,
 			myRawStat.Stats.BlkioStats.IoWaitTimeRecursive),
-		queued: io.getNewStats(
+		queued: getNewStats(
+			skipDev,
 			myRawStat.Stats.Read,
 			myRawStat.Stats.BlkioStats.IoQueuedRecursive),
 	}
 }
 
-func (io *BlkioService) getNewStats(time time.Time, blkioEntry []types.BlkioStatEntry) BlkioRaw {
+func getNewStats(skip []uint64, time time.Time, blkioEntry []types.BlkioStatEntry) BlkioRaw {
+	fmt.Printf("Skip devices: %#v\n", skip)
 	stats := BlkioRaw{
 		Time:   time,
 		reads:  0,
@@ -156,6 +163,11 @@ func (io *BlkioService) getNewStats(time time.Time, blkioEntry []types.BlkioStat
 	}
 
 	for _, myEntry := range blkioEntry {
+		// certain devices, like software raid and device-mapper devices, will just control and re-report the disks
+		// under them in the hierarchy. We want to skip them, lest we merely duplicate the metrics.
+		if skipDev(myEntry.Major, skip) {
+			continue
+		}
 		switch myEntry.Op {
 		case "Write":
 			stats.writes += myEntry.Value
@@ -166,6 +178,15 @@ func (io *BlkioService) getNewStats(time time.Time, blkioEntry []types.BlkioStat
 		}
 	}
 	return stats
+}
+
+func skipDev(major uint64, skipList []uint64) bool {
+	for _, dev := range skipList {
+		if major == dev {
+			return true
+		}
+	}
+	return false
 }
 
 func (io *BlkioService) getReadPs(old *BlkioRaw, new *BlkioRaw) float64 {

--- a/metricbeat/module/docker/diskio/helper.go
+++ b/metricbeat/module/docker/diskio/helper.go
@@ -18,7 +18,6 @@
 package diskio
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -154,7 +153,6 @@ func (io *BlkioService) getBlkioStats(myRawStat *docker.Stat, dedot bool, skipDe
 }
 
 func getNewStats(skip []uint64, time time.Time, blkioEntry []types.BlkioStatEntry) BlkioRaw {
-	fmt.Printf("Skip devices: %#v\n", skip)
 	stats := BlkioRaw{
 		Time:   time,
 		reads:  0,

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -18,11 +18,11 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
-  # Skip metrics certain device major numbers in docker/diskio. 
+  # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
   #skip_major: []
-  
+
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -21,6 +21,7 @@
   # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
+  # By default, it will skip devices with major numbers 9 or 253.
   #skip_major: []
 
   # To connect to Docker over TLS you must specify a client and CA certificate.

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -18,6 +18,11 @@
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Skip metrics certain device major numbers in docker/diskio. 
+  # Necessary on systems with software RAID, device mappers, 
+  # or other configurations where virtual disks will sum metrics from other disks.
+  #skip_major: []
+  
   # To connect to Docker over TLS you must specify a client and CA certificate.
   #ssl:
     #certificate_authority: "/etc/pki/root/ca.pem"

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -480,6 +480,11 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
+  # Skip metrics certain device major numbers in docker/diskio. 
+  # Necessary on systems with software RAID, device mappers, 
+  # or other configurations where virtual disks will sum metrics from other disks.
+  #skip_major: []
+
   # If set to true, collects metrics per core.
   #cpu.cores: true
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -480,9 +480,10 @@ metricbeat.modules:
   # If set to true, replace dots in labels with `_`.
   #labels.dedot: false
 
-  # Skip metrics certain device major numbers in docker/diskio. 
+  # Skip metrics for certain device major numbers in docker/diskio. 
   # Necessary on systems with software RAID, device mappers, 
   # or other configurations where virtual disks will sum metrics from other disks.
+  # By default, it will skip devices with major numbers 9 or 253.
   #skip_major: []
 
   # If set to true, collects metrics per core.


### PR DESCRIPTION
## What does this PR do?

This fixes: https://github.com/elastic/beats/issues/19766

Basically, the `diskio` metricset was blindly summing read/write counts for all the devices reported by the docker stat API. This can produce incorrect results on systems where There's disks manage various child disks, and will sum the metrics from its children. For example, on a system running linux software RAID, we'll end up summing the metrics from both the raid device, and the metrics of the disks in the RAID array, effectively doubling the metrics. This Adds a "disks to skip" list, set to `9` and `253` (md raid devices and `device-mapper`) based on the major device number.

I added this as a configurable value out of paranoia, as this _technically_ changes how metrics are reported, and users may want to change it, or only skip certain disk types.

## Why is it important?
This stops docker/diskio from double-counting metrics under certain conditions.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

