### PR TITLE
Update testing to test agains Snapshot Logstash version

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -32,7 +32,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash@sha256:e01cf165142edf8d67485115b938c94deeda66153e9516aa2ce69ee417c5fc33
+    image: docker.elastic.co/logstash/logstash:8.2.0-a12f7069-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600


### PR DESCRIPTION
In https://github.com/elastic/beats/pull/15568 the testing of Logstash was changed to a specific hash because of some temporary issues with Logstash. Instead testing should happen against the SNAPSHOT releases like for Elasticsearch and Kibana.
