### PR TITLE
Ignore bugfix version when running version compatibility check against Elasticsearch

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -44,6 +44,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Fixes Beats crashing when glibc >= 2.35 is used {issue}30576[30576]
 - Log errors when parsing and applying config blocks and if the input is disabled. {pull}30534[30534]
 - Wildcard fields no longer have a default ignore_above setting of 1024. {issue}30096[30096] {pull}30668[30668]
+- Ignore bugfix version when running version compatibility check against Elasticsearch. {pull}30746[30746]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -883,7 +883,7 @@ func (b *Beat) checkElasticsearchVersion() {
 		if err != nil {
 			return err
 		}
-		if esVersion.LessThan(beatVersion) {
+		if esVersion.LessThanMajorMinor(beatVersion) {
 			return fmt.Errorf("%v ES=%s, Beat=%s.", elasticsearch.ErrTooOld, esVersion.String(), b.Info.Version)
 		}
 		return nil

--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -121,15 +121,28 @@ func (v *Version) LessThanOrEqual(withMeta bool, v1 *Version) bool {
 // LessThan returns true if v is strictly smaller than v1. When comparing, the major,
 // minor and bugfix numbers are compared in order. The meta part is not taken into account.
 func (v *Version) LessThan(v1 *Version) bool {
+	lessThan := v.LessThanMajorMinor(v1)
+	if lessThan {
+		return true
+	}
+
+	if v.Minor == v1.Minor {
+		if v.Bugfix < v1.Bugfix {
+			return true
+		}
+	}
+
+	return false
+}
+
+// LessThanMajorMinor returns true if v is strictly smaller than v1. When comparing, the major,
+// minor numbers are compared in order. The and bugfix version and meta part is not taken into account.
+func (v *Version) LessThanMajorMinor(v1 *Version) bool {
 	if v.Major < v1.Major {
 		return true
 	} else if v.Major == v1.Major {
 		if v.Minor < v1.Minor {
 			return true
-		} else if v.Minor == v1.Minor {
-			if v.Bugfix < v1.Bugfix {
-				return true
-			}
 		}
 	}
 	return false

--- a/libbeat/common/version.go
+++ b/libbeat/common/version.go
@@ -135,7 +135,7 @@ func (v *Version) LessThan(v1 *Version) bool {
 	return false
 }
 
-// LessThanMajorMinor returns true if v is strictly smaller than v1. When comparing, the major,
+// LessThanMajorMinor returns true if v is smaller or equal to v1 based on the major and minor version. The bugfix version and meta part are not taken into account.
 // minor numbers are compared in order. The and bugfix version and meta part is not taken into account.
 func (v *Version) LessThanMajorMinor(v1 *Version) bool {
 	if v.Major < v1.Major {

--- a/libbeat/common/version_test.go
+++ b/libbeat/common/version_test.go
@@ -207,3 +207,52 @@ func TestVersionLessThan(t *testing.T) {
 		assert.Equal(t, v.LessThan(v1), test.result, test.name)
 	}
 }
+
+func TestVersionLessThanMajorMinor(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		version1 string
+		result   bool
+	}{
+		{
+			name:     "1.2.x < 2.0.x",
+			version:  "1.2.3",
+			version1: "2.0.0",
+			result:   true,
+		},
+		{
+			name:     "1.2.3 = 1.2.3-beta1",
+			version:  "1.2.3",
+			version1: "1.2.3-beta1",
+			result:   false,
+		},
+		{
+			name:     "5.4.x == 5.4.x",
+			version:  "5.4.1",
+			version1: "5.4.2",
+			result:   false,
+		},
+		{
+			name:     "5.5.x > 5.4.x",
+			version:  "5.5.1",
+			version1: "5.4.2",
+			result:   false,
+		},
+		{
+			name:     "6.1.x < 6.2.x",
+			version:  "6.1.1-alpha3",
+			version1: "6.2.0",
+			result:   true,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := NewVersion(test.version)
+		assert.NoError(t, err)
+		v1, err := NewVersion(test.version1)
+		assert.NoError(t, err)
+
+		assert.Equal(t, v.LessThanMajorMinor(v1), test.result, test.name)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

In https://github.com/elastic/beats/pull/29683 we introduced a check to make sure we are not sending events to Elasticsearch instances that might be incompatible with Beats. However, the current check is too strict. Patch versions should not be considered during version checks. Beats 8.1.1 should be able to connect to Elasticsearch 8.1.0.

## Why is it important?

The check is too strict. This is not what we agreed on in the original issue. Furthermore, it interferes with our own release process.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

https://github.com/elastic/beats/pull/30157

