### PR TITLE
ci: configure kind/k8s for k8s in metricbeat only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,6 +24,8 @@ pipeline {
     SNAPSHOT = 'true'
     TERRAFORM_VERSION = "0.13.7"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
+    KIND_VERSION = 'v0.12.0'
+    K8S_VERSION = 'v1.23.4'
   }
   options {
     timeout(time: 6, unit: 'HOURS')
@@ -301,35 +303,50 @@ def k8sTest(Map args = [:]) {
   versions.each{ v ->
     withNode(labels: args.label, forceWorkspace: true){
       stage("${args.context} ${v}"){
-        withEnv(["K8S_VERSION=${v}", "KIND_VERSION=v0.12.0", "KUBECONFIG=${env.WORKSPACE}/kubecfg"]){
+        withEnv(["K8S_VERSION=${v}"]){
           withGithubNotify(context: "${args.context} ${v}") {
             withBeatsEnv(archive: false, withModule: false) {
-              retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kind", script: ".ci/scripts/install-kind.sh") }
-              retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kubectl", script: ".ci/scripts/install-kubectl.sh") }
-              try {
-                // Add some environmental resilience when setup does not work the very first time.
-                def i = 0
-                retryWithSleep(retries: 3, seconds: 5, backoff: true){
-                  try {
-                    sh(label: "Setup kind", script: ".ci/scripts/kind-setup.sh")
-                  } catch(err) {
-                    i++
-                    sh(label: 'Delete cluster', script: 'kind delete cluster')
-                    if (i > 2) {
-                      error("Setup kind failed with error '${err.toString()}'")
-                    }
-                  }
-                }
+              withTools(k8s: true) {
                 sh(label: "Integration tests", script: "MODULE=kubernetes make -C metricbeat integration-tests")
                 sh(label: "Deploy to kubernetes",script: "make -C deploy/kubernetes test")
-              } finally {
-                sh(label: 'Delete cluster', script: 'kind delete cluster')
               }
             }
           }
         }
       }
     }
+  }
+}
+
+/**
+* It relies on KIND_VERSION which it's defined in the top-level environment section
+*/
+def withTools(Map args = [:], Closure body) {
+  if (args.get('k8s', false)) {
+    withEnv(["KUBECONFIG=${env.WORKSPACE}/kubecfg"]){
+      retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kind", script: ".ci/scripts/install-kind.sh") }
+      retryWithSleep(retries: 2, seconds: 5, backoff: true){ sh(label: "Install kubectl", script: ".ci/scripts/install-kubectl.sh") }
+      try {
+        // Add some environmental resilience when setup does not work the very first time.
+        def i = 0
+        retryWithSleep(retries: 3, seconds: 5, backoff: true){
+          try {
+            sh(label: "Setup kind", script: ".ci/scripts/kind-setup.sh")
+          } catch(err) {
+            i++
+            sh(label: 'Delete cluster', script: 'kind delete cluster')
+            if (i > 2) {
+              error("Setup kind failed with error '${err.toString()}'")
+            }
+          }
+        }
+        body()
+      } finally {
+        sh(label: 'Delete cluster', script: 'kind delete cluster')
+      }
+    }
+  } else {
+    body()
   }
 }
 
@@ -582,23 +599,26 @@ def target(Map args = [:]) {
   def isMage = args.get('isMage', false)
   def isE2E = args.e2e?.get('enabled', false)
   def isPackaging = args.get('package', false)
+  def installK8s = args.get('installK8s', false)
   def dockerArch = args.get('dockerArch', 'amd64')
   def enableRetry = args.get('enableRetry', false)
   withNode(labels: args.label, forceWorkspace: true){
     withGithubNotify(context: "${context}") {
       withBeatsEnv(archive: true, withModule: withModule, directory: directory, id: args.id) {
         dumpVariables()
-        // make commands use -C <folder> while mage commands require the dir(folder)
-        // let's support this scenario with the location variable.
-        dir(isMage ? directory : '') {
-          if (enableRetry) {
-            // Retry the same command to bypass any kind of flakiness.
-            // Downside: genuine failures will be repeated.
-            retry(3) {
+        withTools(k8s: installK8s) {
+          // make commands use -C <folder> while mage commands require the dir(folder)
+          // let's support this scenario with the location variable.
+          dir(isMage ? directory : '') {
+            if (enableRetry) {
+              // Retry the same command to bypass any kind of flakiness.
+              // Downside: genuine failures will be repeated.
+              retry(3) {
+                cmd(label: "${args.id?.trim() ? args.id : env.STAGE_NAME} - ${command}", script: "${command}")
+              }
+            } else {
               cmd(label: "${args.id?.trim() ? args.id : env.STAGE_NAME} - ${command}", script: "${command}")
             }
-          } else {
-            cmd(label: "${args.id?.trim() ? args.id : env.STAGE_NAME} - ${command}", script: "${command}")
           }
         }
         // Publish packages should happen always to easily consume those artifacts if the
@@ -1076,6 +1096,7 @@ class RunCommand extends co.elastic.beats.BeatsFunction {
   public run(Map args = [:]){
     steps.stageStatusCache(args){
       def withModule = args.content.get('withModule', false)
+      def installK8s = args.content.get('installK8s', false)
       def withAWS = args.content.get('withAWS', false)
       //
       // What's the retry policy for fighting the flakiness:
@@ -1093,6 +1114,7 @@ class RunCommand extends co.elastic.beats.BeatsFunction {
                      directory: args.project,
                      label: args.label,
                      withModule: withModule,
+                     installK8s: installK8s,
                      isMage: false,
                      id: args.id,
                      enableRetry: enableRetry)
@@ -1102,6 +1124,7 @@ class RunCommand extends co.elastic.beats.BeatsFunction {
                      command: args.content.mage,
                      directory: args.project,
                      label: args.label,
+                     installK8s: installK8s,
                      withModule: withModule,
                      isMage: true,
                      id: args.id,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -319,7 +319,9 @@ def k8sTest(Map args = [:]) {
 }
 
 /**
-* It relies on KIND_VERSION which it's defined in the top-level environment section
+* It relies on:
+* - KIND_VERSION which it's defined in the top-level environment section.
+* - K8S_VERSION which it's defined by default in the top-level environment section or set in the withEnv.
 */
 def withTools(Map args = [:], Closure body) {
   if (args.get('k8s', false)) {

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -25,6 +25,7 @@ stages:
         mage: "mage build unitTest"
         stage: mandatory
     goIntegTest:
+        installK8s: true
         mage: "mage goIntegTest"
         withModule: true
         stage: mandatory


### PR DESCRIPTION
## What does this PR do?

Add support for installing `kind/k8s` only if running the metricbeat goIngTest stage.

**NOTE**: `kind/k8s` is only needed when testing the k8s module, so it might be installed for other modules, but this is the approach we can without much complexity in the CI.

## Why is it important?

The k8s module is tested in two places:

1) https://github.com/elastic/beats/blob/9e6536d964f0135940b9c416bcb1c0a41af99478/deploy/kubernetes/Jenkinsfile.yml#L20-L22 and https://github.com/elastic/beats/blob/9e6536d964f0135940b9c416bcb1c0a41af99478/Jenkinsfile#L323
2) https://github.com/elastic/beats/blob/9e6536d964f0135940b9c416bcb1c0a41af99478/metricbeat/Jenkinsfile.yml#L27-L30

Only `1` is in charge to install the given Kind and K8s versions. but `2` requires those tools. Those tools are installed in the CI workers as part of the default installed toolchain (kind version `v0.7.0` and k8s version `v0.12.0`.

This proposal is trying to leverage the IntTests for `metricbeat` by installing the k8s/kind when needed, unfortunately we cannot do only when the module is not k8s, unless the build system in metricbeat is in charge of preparing the environment.

## Related issues

- Relates https://github.com/elastic/beats/pull/30733
