### PR TITLE
Remove temporary "Allow older" for 8.1

### DIFF
--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -43,7 +43,6 @@ stages:
         stage: mandatory
     pythonIntegTest:
       mage: >-
-        TESTING_FILEBEAT_ALLOW_OLDER=1  ## temporarly allow sending to older versions
         mage pythonIntegTest            ## run the ITs only if the changeset affects a specific module.
         stage: mandatory
     module-compat-prev-minor:

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -43,7 +43,6 @@ stages:
         stage: mandatory
     pythonIntegTest:
       mage: >-
-        TESTING_FILEBEAT_ALLOW_OLDER=1  ## temporarly allow sending to older versions
         mage pythonIntegTest            ## run the ITs only if the changeset affects a specific module.
         stage: mandatory
     module-compat-prev-minor:


### PR DESCRIPTION
The 8.1 builds did not work as the compatibilty check was too narrow for beats including bugfix releases. Because of this, the temporary fix to skip the check was introduced. This removes this temporary fix again.
