### PR TITLE
Bug okta filebeat module, fix field mapping

### DIFF
--- a/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/okta/system/ingest/pipeline.yml
@@ -341,7 +341,7 @@ processors:
       ignore_failure: true
   - rename:
       field: json.authenticationContext.interface
-      target_field: okta.authentication_context.authentication_provider
+      target_field: okta.authentication_context.interface
       ignore_missing: true
       ignore_failure: true
   - rename:


### PR DESCRIPTION
field: json.authenticationContext.interface
target_field: okta.authentication_context.interface

The former target field: okta.authentication_context.authentication_provider
seems to be already populated by something more reasonable a few lines up.



## What does this PR do?


map field: json.authenticationContext.interface
to target_field: okta.authentication_context.interface

The former target field: okta.authentication_context.authentication_provider
seems to be already populated by something more reasonable a few lines up.


## Why is it important?

It feels wrong

## Checklist



- [ X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


- [ ]

## How to test this PR locally



## Related issues


- 

## Use cases



## Screenshots



## Logs


