### PR TITLE
ci: split windows in mandatory and ext_win stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,6 +138,23 @@ pipeline {
         runBuildAndTest(filterStage: 'extended')
       }
     }
+    stage('ExtendedWin') {
+      options { skipDefaultCheckout() }
+      when {
+        // On a branches/tags, skip if changes are only related to docs.
+        // Always when forcing the input parameter
+        anyOf {
+          allOf {                                           // If no PR and no docs changes
+            expression { return env.ONLY_DOCS == "false" }
+            not { changeRequest() }
+          }
+          expression { return params.runAllStages }         // If UI forced
+        }
+      }
+      steps {
+        runBuildAndTest(filterStage: 'extended_win')
+      }
+    }
     stage('Packaging') {
       options { skipDefaultCheckout() }
       when {

--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -33,6 +33,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     unitTest:
         mage: "mage build unitTest"
@@ -51,6 +52,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -89,6 +91,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^auditbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss
@@ -101,6 +104,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^auditbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "auditbeat"
     parameters:                ## when parameter was selected in the UI.
         - "auditbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:

--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "auditbeat"
     parameters:                ## when parameter was selected in the UI.
         - "auditbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -33,8 +32,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
@@ -52,38 +50,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -91,7 +88,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^auditbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss
@@ -104,7 +100,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^auditbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -98,6 +98,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^filebeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "filebeat"
     parameters:                ## when parameter was selected in the UI.
         - "filebeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -33,8 +32,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
@@ -66,31 +64,31 @@ stages:
                 - "macosTest"
             tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -98,7 +96,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^filebeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss
@@ -111,7 +108,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^filebeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "filebeat"
     parameters:                ## when parameter was selected in the UI.
         - "filebeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -32,6 +33,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     unitTest:
         mage: "mage build unitTest"
@@ -108,6 +110,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^filebeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "heartbeat"
     parameters:                ## when parameter was selected in the UI.
         - "heartbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -32,6 +33,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     unitTest:
         mage: "mage build unitTest"
@@ -55,6 +57,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -93,6 +96,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^heartbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss
@@ -105,6 +109,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^heartbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "heartbeat"
     parameters:                ## when parameter was selected in the UI.
         - "heartbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -33,8 +32,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
@@ -57,38 +55,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -96,7 +93,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^heartbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss
@@ -109,7 +105,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^heartbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -48,21 +48,21 @@ stages:
                 - "macosTest"
             tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
         stage: extended
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "metricbeat"
     parameters:                ## when parameter was selected in the UI.
         - "metricbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -45,6 +46,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "metricbeat"
     parameters:                ## when parameter was selected in the UI.
         - "metricbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -46,7 +45,6 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -67,17 +65,17 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -34,8 +34,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
@@ -50,38 +49,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -89,7 +87,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^packetbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss
@@ -102,7 +99,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^packetbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -34,6 +34,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     unitTest:
         mage: "mage build unitTest"
@@ -49,6 +50,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -87,6 +89,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^packetbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss
@@ -99,6 +102,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^packetbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "winlogbeat"
     parameters:                ## when parameter was selected in the UI.
         - "winlogbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -55,6 +56,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^winlogbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "winlogbeat"
     parameters:                ## when parameter was selected in the UI.
         - "winlogbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -24,7 +23,7 @@ stages:
     crosscompile:
         make: "make -C winlogbeat crosscompile"
         stage: mandatory
-    windows:
+    windows-2019:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
@@ -33,22 +32,22 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -56,7 +55,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^winlogbeat/.*"
               - "@oss"               ## special token regarding the changeset for the oss

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-auditbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-auditbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -32,9 +31,7 @@ stages:
                 - "arm"
             parameters:
                 - "armTest"
-            branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     build:
         mage: "mage update build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.
@@ -50,38 +47,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -89,7 +85,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/auditbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -102,7 +97,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/auditbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-auditbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-auditbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -31,6 +32,8 @@ stages:
                 - "arm"
             parameters:
                 - "armTest"
+            branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     build:
         mage: "mage update build test"
@@ -47,6 +50,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -85,6 +89,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/auditbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -97,6 +102,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/auditbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-elastic-agent"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-elastic-agent"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -31,8 +30,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
@@ -49,11 +47,11 @@ stages:
                 - "macosTest"
             tags: true         ## for all the tags
         stage: extended
-    windows:
+    windows-2019:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-        stage: mandatory
+        stage: extended_win
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
@@ -63,22 +61,22 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -87,7 +85,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/elastic-agent/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -100,7 +97,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/elastic-agent/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-elastic-agent"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-elastic-agent"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -30,6 +31,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     unitTest:
         mage: "mage build unitTest"
@@ -85,6 +87,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/elastic-agent/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -97,6 +100,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/elastic-agent/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-filebeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-filebeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -33,8 +32,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
@@ -64,38 +62,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     cloud:
       cloud: "mage build test"
       withModule: true       ## run the ITs only if the changeset affects a specific module.
@@ -130,7 +127,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/filebeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -143,7 +139,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/filebeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-filebeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-filebeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -32,6 +33,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     unitTest:
         mage: "mage build unitTest"
@@ -62,6 +64,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -127,6 +130,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/filebeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -139,6 +143,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/filebeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-functionbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-functionbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -47,38 +46,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -86,7 +84,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/functionbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-functionbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-functionbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -46,6 +47,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -84,6 +86,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/functionbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-heartbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-heartbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -37,6 +38,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
 # TODO: there are windows test failures already reported
 # https://github.com/elastic/beats/issues/23957 and https://github.com/elastic/beats/issues/23958
@@ -73,6 +75,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/heartbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -85,6 +88,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/heartbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-heartbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-heartbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -38,36 +37,35 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
 # TODO: there are windows test failures already reported
 # https://github.com/elastic/beats/issues/23957 and https://github.com/elastic/beats/issues/23958
 # waiting for being fixed.
-#    windows:
+#    windows-2019:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-2019"
-#        stage: mandatory
+#        stage: extended_win
 #    windows-2016:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-2016"
-#        stage: extended
+#        stage: mandatory
 #    windows-2012:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-2012-r2"
-#        stage: extended
+#        stage: extended_win
 #    windows-10:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-10"
-#        stage: extended
+#        stage: extended_win
 #    windows-8:
 #        mage: "mage build test"
 #        platforms:             ## override default labels in this specific stage.
 #            - "windows-8"
-#        stage: extended
+#        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -75,7 +73,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/heartbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -88,7 +85,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/heartbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-metricbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-metricbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -68,38 +67,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -108,7 +106,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/metricbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -121,7 +118,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/metricbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-metricbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-metricbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -67,6 +68,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -106,6 +108,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/metricbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -118,6 +121,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/metricbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-osquerybeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-osquerybeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -36,38 +35,37 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -75,7 +73,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/osquerybeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-osquerybeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-osquerybeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -35,6 +36,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -73,6 +75,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/osquerybeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-packetbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-packetbeat"
+    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -33,6 +34,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
+            tags: true         ## for all the tags
         stage: mandatory
     unitTest:
         mage: "mage build unitTest"
@@ -48,6 +50,7 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
+            tags: true         ## for all the tags
         stage: extended
     windows-2022:
         mage: "mage build unitTest"
@@ -87,6 +90,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/packetbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -99,6 +103,7 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
+            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/packetbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-packetbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-packetbeat"
-    tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
     lint:
@@ -34,8 +33,7 @@ stages:
             parameters:
                 - "armTest"
             branches: true     ## for all the branches
-            tags: true         ## for all the tags
-        stage: extended
+        stage: mandatory
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory
@@ -50,39 +48,38 @@ stages:
                 - "macOS"
             parameters:
                 - "macosTest"
-            tags: true         ## for all the tags
         stage: extended
-    windows:
-        mage: "mage build unitTest"
-        withModule: true
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: mandatory
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
+    windows-2019:
+        mage: "mage build unitTest"
+        withModule: true
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
@@ -90,7 +87,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/packetbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack
@@ -103,7 +99,6 @@ stages:
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being
-            tags: false        ## packaging on branches/tags is already in place with the downstream build.
             changeset:         ## when PR contains any of those entries in the changeset
               - "^x-pack/packetbeat/.*"
               - "@xpack"             ## special token regarding the changeset for the xpack

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -10,6 +10,7 @@ when:
         - "x-pack-winlogbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-winlogbeat"
+    tags: true                 ## for all the tags
 platform: "windows-2019"       ## default label for all the stages
 stages:
     lint:

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -10,7 +10,6 @@ when:
         - "x-pack-winlogbeat"
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-winlogbeat"
-    tags: true                 ## for all the tags
 platform: "windows-2019"       ## default label for all the stages
 stages:
     lint:
@@ -28,32 +27,32 @@ stages:
         withModule: true
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-        stage: mandatory
+        stage: extended
     windows-2022:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2022"
-        stage: extended
+        stage: mandatory
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
-        stage: extended
+        stage: mandatory
     windows-2012:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended
+        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
-        stage: extended
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
-        stage: extended
+        stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"
         e2e:


### PR DESCRIPTION
## What does this PR do?

Split the Windows OS build/test stages in two meta-stages:
- Mandatory for `windows-2022` and `windows-2016`. This is mandatory for all the builds in the CI (PRs, branches, tags)
- Extended support for other windows versions. This is only available for branches or UI interactions with the parameter `runAllStages`)

`Windows-2019` is not anymore the default OS but `windows-2022` and `windows-2016`

Removed tag event builds, every commit in this project is validated in the CI, so there is no need to run a build for tags.

Move the `arm` stages to mandatory.

Mandatory stages run always. But extended support for other windows versions only run for branches.

## Why is it important?

Faster builds on a PR basis since the extended meta-stage has been simplified a bit by moving some stages to the `mandatory` meta-stage or the new `extended-win` meta-stage.

In other words, the existing meta-stages were:

`checkout` - `lint` - `mandatory` - `extended` - `package`

and now:

`checkout` - `lint` - `mandatory` - `extended` - `extended-win` - `package`


and each meta-stage runs in parallel a set of stages.


## Questions

- [ ] Is it required to run on Windows for each Beat? Or are there any Beats that are not windows supported? If so which should be disabled?