### PR TITLE
[Auditbeat] Add auditbeat.elastic-agent.yml config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -113,6 +113,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Auditbeat*
 
+- Include config file (`auditbeat.elastic-agent.yml`) in tar.gz and zip packages for use with Elastic Agent.
+
 
 *Filebeat*
 

--- a/auditbeat/scripts/mage/package.go
+++ b/auditbeat/scripts/mage/package.go
@@ -38,6 +38,7 @@ const (
 //
 // Customizations specific to Auditbeat:
 // - Include audit.rules.d directory in packages.
+// - Add elastic-agent specific config to x-pack tar.gz package.
 func CustomizePackaging(pkgFlavor PackagingFlavor) {
 	var (
 		shortConfig = devtools.PackageFile{
@@ -94,6 +95,14 @@ func CustomizePackaging(pkgFlavor PackagingFlavor) {
 		case devtools.TarGz, devtools.Zip:
 			args.Spec.ReplaceFile("{{.BeatName}}.yml", shortConfig)
 			args.Spec.ReplaceFile("{{.BeatName}}.reference.yml", referenceConfig)
+
+			// Add an Elastic Agent specific config to the Elastic licensed packages.
+			if XPackPackaging == pkgFlavor {
+				args.Spec.Files["{{.BeatName}}.elastic-agent.yml"] = devtools.PackageFile{
+					Mode:   0o644,
+					Source: "auditbeat.elastic-agent.yml",
+				}
+			}
 		case devtools.Deb, devtools.RPM:
 			args.Spec.ReplaceFile("/etc/{{.BeatName}}/{{.BeatName}}.yml", shortConfig)
 			args.Spec.ReplaceFile("/etc/{{.BeatName}}/{{.BeatName}}.reference.yml", referenceConfig)

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -49,7 +49,7 @@ const (
 )
 
 var (
-	configFilePattern      = regexp.MustCompile(`.*beat\.yml$|apm-server\.yml|elastic-agent\.yml$`)
+	configFilePattern      = regexp.MustCompile(`/(\w+beat\.yml|apm-server\.yml|elastic-agent\.yml)$`)
 	manifestFilePattern    = regexp.MustCompile(`manifest.yml`)
 	modulesDirPattern      = regexp.MustCompile(`module/.+`)
 	modulesDDirPattern     = regexp.MustCompile(`modules.d/$`)

--- a/x-pack/auditbeat/auditbeat.elastic-agent.yml
+++ b/x-pack/auditbeat/auditbeat.elastic-agent.yml
@@ -1,0 +1,3 @@
+# Auditbeat config for Elastic Agent
+---
+auditbeat.modules: [ ]


### PR DESCRIPTION

## What does this PR do?

Add a config file specifically for use by Elastic Agent. The default config file shipped
with Auditbeat enables several modules with example configs, but in Elastic Agent
we want Auditbeat to start without any modules enabled.

I think the cleanest approach is to ship an empty config that is specifically for Agent.
If we need to set Agent specific settings we can do that using this file in the future.

Another option I considered was to make Agent start Auditbeat with CLI flags
that disable the modules, but you have to do this per module (e.g. `-E auditbeat.modules.0.enabled=false`,
`-E auditbeat.modules.1.enabled=false`) and that is brittle given that the number of
modules varies by OS and someone could unknowingly change the default
config file.

Verification

```
$ tar tfv x-pack/auditbeat/build/distributions/auditbeat-8.2.0-SNAPSHOT-linux-x86_64.tar.gz | grep elastic-agent
-rw-r--r--  0 root   root      155 Mar 10 18:59 auditbeat-8.2.0-SNAPSHOT-linux-x86_64/auditbeat.elastic-agent.yml

$ unzip -t build/distributions/auditbeat-8.2.0-SNAPSHOT-*zip | grep elastic-agent
    testing: auditbeat-8.2.0-SNAPSHOT-windows-x86_64/auditbeat.elastic-agent.yml   OK
```

## Why is it important?

When running under Elastic Agent we want all config to come from Agent so we need a different config file that the default.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
