### PR TITLE
ci: refactor publishPackages main pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -399,32 +399,14 @@ def packagingLinux(Map args = [:]) {
 * @param beatsFolder beats folder
 */
 def publishPackages(beatsFolder){
-  def bucketUri = "gs://beats-ci-artifacts/snapshots"
-  if (isPR()) {
-    bucketUri = "gs://beats-ci-artifacts/pull-requests/pr-${env.CHANGE_ID}"
-  }
-  def beatsFolderName = getBeatsName(beatsFolder)
-  uploadPackages("${bucketUri}/${beatsFolderName}", beatsFolder)
-
-  // Copy those files to another location with the sha commit to test them
-  // afterward.
-  bucketUri = "gs://beats-ci-artifacts/commits/${env.GIT_BASE_COMMIT}"
-  uploadPackages("${bucketUri}/${beatsFolderName}", beatsFolder)
-}
-
-/**
-* Upload the distribution files to google cloud.
-* TODO: There is a known issue with Google Storage plugin.
-* @param bucketUri the buckets URI.
-* @param beatsFolder the beats folder.
-*/
-def uploadPackages(bucketUri, beatsFolder){
-  // sometimes google storage reports ResumableUploadException: 503 Server Error
-  retryWithSleep(retries: 3, seconds: 5, backoff: true) {
-    googleStorageUploadExt(bucket: bucketUri,
-      credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
-      pattern: "${beatsFolder}/build/distributions/**/*",
-      sharedPublicly: true)
+  dir(beatsFolder) {
+    uploadPackagesToGoogleBucket(
+      credentialsId: env.JOB_GCS_EXT_CREDENTIALS,
+      repo: env.REPO,
+      bucket: env.JOB_GCS_BUCKET,
+      folder: getBeatsName(env.BEATS_FOLDER),
+      pattern: "build/distributions/**/*"
+    )
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -404,7 +404,7 @@ def publishPackages(beatsFolder){
       credentialsId: env.JOB_GCS_EXT_CREDENTIALS,
       repo: env.REPO,
       bucket: env.JOB_GCS_BUCKET,
-      folder: getBeatsName(env.BEATS_FOLDER),
+      folder: getBeatsName(beatsFolder),
       pattern: "build/distributions/**/*"
     )
   }


### PR DESCRIPTION
## What does this PR do?

Apply https://github.com/elastic/beats/pull/30409 in the main pipeline.

## Why is it important?

`Packaging` pipeline is aimed to run on merge commits, while `main` pipeline runs on a PR basis too. Let's use the same implementation (see https://github.com/elastic/apm-pipeline-library/pull/1549)

## Test

I committed https://github.com/elastic/beats/pull/30796/commits/209979fd45d6122d5a931cc6ed7aca583cc9e3b0 to be able to trigger the package stage in the main pipeline:

<img width="1860" alt="image" src="https://user-images.githubusercontent.com/2871786/158577367-56b9b83c-d609-429c-96e0-0168467a324d.png">


<img width="312" alt="image" src="https://user-images.githubusercontent.com/2871786/158577390-b7078745-3a3c-49df-b3a7-6e7835a9a4ef.png">

<img width="1874" alt="image" src="https://user-images.githubusercontent.com/2871786/158577433-fa9b179a-5e76-490b-8e0a-916c7c7d3509.png">

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/2871786/158577471-06048717-454e-48db-97f8-1e35ef352697.png">

<img width="1430" alt="image" src="https://user-images.githubusercontent.com/2871786/158577609-2aece82a-d26b-4cef-8336-81da96ed1b56.png">

