### PR TITLE
ci: notify only when builds for branches/tags have failed 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,7 +187,7 @@ VERSION=${env.VERSION}-SNAPSHOT""")
       // Required to enable the flaky test reporting with GitHub. Workspace exists since the post/always runs earlier
       dir("${BASE_DIR}"){
         notifyBuildResult(prComment: true,
-                          slackComment: true, slackNotify: (isBranch() || isTag()),
+                          slackComment: true,
                           analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: getFlakyBranch()))
       }
     }


### PR DESCRIPTION
## What does this PR do?

Update the slack channel to a more widely one.

## Why is it important?

@jlind23 asked to update this channel and when

>> we should then act quickly and investigate if a nightly build is failing, that's something to be done by the Beats teams, am I correct? There is a slack channel [#beats-build](https://elastic.slack.com/archives/C0PR0767M) that notifies the builds for each branch.

> @v1v I do not see this channel as being widely used. Can we rather have a notification in the beats channel when it's failing only?

As requested let's use a different slack channel.