### PR TITLE
refactor code to support fsFS

### DIFF
--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline.go
@@ -11,14 +11,15 @@ import (
 	"strings"
 )
 
+// ReadCmdLine Reads process CmdLine from <root>/proc/<pid>/cmdline
 func ReadCmdLine(root string, pid string) (string, error) {
 	return ReadCmdLineFS(os.DirFS("/"), root, pid)
 }
 
-func ReadCmdLineFS(fsys fs.FS, root string, pid string) (string, error) {
+func ReadCmdLineFS(sysfs fs.FS, root string, pid string) (string, error) {
 	fn := getProcAttr(root, pid, "cmdline")
 
-	b, err := fs.ReadFile(fsys, fn)
+	b, err := fs.ReadFile(sysfs, fn)
 	if err != nil {
 		return "", err
 	}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline.go
@@ -6,14 +6,19 @@ package proc
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io/fs"
+	"os"
 	"strings"
 )
 
 func ReadCmdLine(root string, pid string) (string, error) {
+	return ReadCmdLineFS(os.DirFS("/"), root, pid)
+}
+
+func ReadCmdLineFS(fsys fs.FS, root string, pid string) (string, error) {
 	fn := getProcAttr(root, pid, "cmdline")
 
-	b, err := ioutil.ReadFile(fn)
+	b, err := fs.ReadFile(fsys, fn)
 	if err != nil {
 		return "", err
 	}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline.go
@@ -13,11 +13,11 @@ import (
 
 // ReadCmdLine Reads process CmdLine from <root>/proc/<pid>/cmdline
 func ReadCmdLine(root string, pid string) (string, error) {
-	return ReadCmdLineFS(os.DirFS("/"), root, pid)
+	return ReadCmdLineFS(os.DirFS(root), pid)
 }
 
-func ReadCmdLineFS(sysfs fs.FS, root string, pid string) (string, error) {
-	fn := getProcAttr(root, pid, "cmdline")
+func ReadCmdLineFS(sysfs fs.FS, pid string) (string, error) {
+	fn := getProcAttr(pid, "cmdline")
 
 	b, err := fs.ReadFile(sysfs, fn)
 	if err != nil {

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package proc
 
 import (

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
@@ -1,0 +1,49 @@
+package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
+
+var cmdData = `/usr/bin/processName --config=/etc/conf/config.conf`
+
+func TestReadCmdLineFS(t *testing.T) {
+	pid := "1"
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func(string, error)
+	}{
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+				"proc/1/cmdline": {
+					Data: []byte(cmdData),
+				},
+				"proc/1/stat": {
+					Data: []byte("some data"),
+				},
+			},
+			func(result string, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result, cmdData)
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result string, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, result, "")
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ReadCmdLineFS(testCase.fstest, pid)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !windows
+// +build !windows
+
 package proc
 
 import (
@@ -34,16 +37,16 @@ func TestReadCmdLineFS(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, result, cmdData)
 			}},
-		//{
-		//	fstest.MapFS{
-		//		"hello.txt": {
-		//			Data: []byte("hello, world"),
-		//		},
-		//	},
-		//	func(result string, err error) {
-		//		assert.Error(t, err)
-		//		assert.Equal(t, result, "")
-		//	}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result string, err error) {
+				assert.Error(t, err)
+				assert.Equal(t, result, "")
+			}},
 	}
 
 	for _, testCase := range testCases {

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/cmdline_test.go
@@ -34,16 +34,16 @@ func TestReadCmdLineFS(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, result, cmdData)
 			}},
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-			},
-			func(result string, err error) {
-				assert.Error(t, err)
-				assert.Equal(t, result, "")
-			}},
+		//{
+		//	fstest.MapFS{
+		//		"hello.txt": {
+		//			Data: []byte("hello, world"),
+		//		},
+		//	},
+		//	func(result string, err error) {
+		//		assert.Error(t, err)
+		//		assert.Equal(t, result, "")
+		//	}},
 	}
 
 	for _, testCase := range testCases {

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
@@ -17,6 +17,11 @@ type ProcIO struct {
 	CancelledWriteBytes string
 }
 
+// ReadIO ReadProcStat reads process io from /proc/<pid>/io.
+// The parsing code logic is borrowed from osquery C++ implementation and translated to Go.
+// This makes the data returned from the `host_processes` table
+// consistent with data returned from the original osquery `processes` table.
+// https://github.com/osquery/osquery/blob/master/osquery/tables/system/linux/processes.cpp
 func ReadIO(root string, pid string) (procio ProcIO, err error) {
 	return ReadIOFS(os.DirFS(root), pid)
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
@@ -6,7 +6,8 @@ package proc
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io/fs"
+	"os"
 	"strings"
 )
 
@@ -16,12 +17,11 @@ type ProcIO struct {
 	CancelledWriteBytes string
 }
 
-// ReadProcStat reads proccess stats from /proc/<pid>/io.
-// The parsing code logic is borrowed from osquery C++ implementation and translated to Go.
-// This makes the data returned from the `host_processes` table
-// consistent with data returned from the original osquery `processes` table.
-// https://github.com/osquery/osquery/blob/master/osquery/tables/system/linux/processes.cpp
 func ReadIO(root string, pid string) (procio ProcIO, err error) {
+	return ReadIOFS(os.DirFS("/"), root, pid)
+}
+
+func ReadIOFS(fsys fs.FS, root string, pid string) (procio ProcIO, err error) {
 	// Proc IO example
 	// rchar: 1527371144
 	// wchar: 1495591102
@@ -31,7 +31,7 @@ func ReadIO(root string, pid string) (procio ProcIO, err error) {
 	// write_bytes: 815329280
 	// cancelled_write_bytes: 40976384
 	fn := getProcAttr(root, pid, "io")
-	b, err := ioutil.ReadFile(fn)
+	b, err := fs.ReadFile(fsys, fn)
 	if err != nil {
 		return
 	}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io.go
@@ -18,10 +18,10 @@ type ProcIO struct {
 }
 
 func ReadIO(root string, pid string) (procio ProcIO, err error) {
-	return ReadIOFS(os.DirFS("/"), root, pid)
+	return ReadIOFS(os.DirFS(root), pid)
 }
 
-func ReadIOFS(fsys fs.FS, root string, pid string) (procio ProcIO, err error) {
+func ReadIOFS(fsys fs.FS, pid string) (procio ProcIO, err error) {
 	// Proc IO example
 	// rchar: 1527371144
 	// wchar: 1495591102
@@ -30,7 +30,7 @@ func ReadIOFS(fsys fs.FS, root string, pid string) (procio ProcIO, err error) {
 	// read_bytes: 14401536
 	// write_bytes: 815329280
 	// cancelled_write_bytes: 40976384
-	fn := getProcAttr(root, pid, "io")
+	fn := getProcAttr(pid, "io")
 	b, err := fs.ReadFile(fsys, fn)
 	if err != nil {
 		return

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
@@ -2,7 +2,16 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !windows
+// +build !windows
+
 package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
 
 var io = `rchar: 45479191
 wchar: 42997831
@@ -11,42 +20,42 @@ syscw: 582115
 read_bytes: 3784704
 write_bytes: 8192`
 
-//func TestReadIOFS(t *testing.T) {
-//	pid := "1"
-//	testCases := []struct {
-//		fstest fstest.MapFS
-//		assert func(ProcIO, error)
-//	}{
-//		{
-//			fstest.MapFS{
-//				"hello.txt": {
-//					Data: []byte("hello, world"),
-//				},
-//				"proc/1/io": {
-//					Data: []byte(io),
-//				},
-//				"proc/1/stat": {
-//					Data: []byte("some data"),
-//				},
-//			},
-//			func(result ProcIO, err error) {
-//				assert.Nil(t, err)
-//				assert.Equal(t, result.ReadBytes, "3784704")
-//				assert.Equal(t, result.WriteBytes, "8192")
-//			}},
-//		{
-//			fstest.MapFS{
-//				"hello.txt": {
-//					Data: []byte("hello, world"),
-//				},
-//			},
-//			func(result ProcIO, err error) {
-//				assert.Error(t, err)
-//			}},
-//	}
-//
-//	for _, testCase := range testCases {
-//		result, err := ReadIOFS(testCase.fstest, pid)
-//		testCase.assert(result, err)
-//	}
-//}
+func TestReadIOFS(t *testing.T) {
+	pid := "1"
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func(ProcIO, error)
+	}{
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+				"proc/1/io": {
+					Data: []byte(io),
+				},
+				"proc/1/stat": {
+					Data: []byte("some data"),
+				},
+			},
+			func(result ProcIO, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result.ReadBytes, "3784704")
+				assert.Equal(t, result.WriteBytes, "8192")
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result ProcIO, err error) {
+				assert.Error(t, err)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ReadIOFS(testCase.fstest, pid)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package proc
 
 import (

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
@@ -4,12 +4,6 @@
 
 package proc
 
-import (
-	"github.com/stretchr/testify/assert"
-	"testing"
-	"testing/fstest"
-)
-
 var io = `rchar: 45479191
 wchar: 42997831
 syscr: 1327670
@@ -17,42 +11,42 @@ syscw: 582115
 read_bytes: 3784704
 write_bytes: 8192`
 
-func TestReadIOFS(t *testing.T) {
-	pid := "1"
-	testCases := []struct {
-		fstest fstest.MapFS
-		assert func(ProcIO, error)
-	}{
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-				"proc/1/io": {
-					Data: []byte(io),
-				},
-				"proc/1/stat": {
-					Data: []byte("some data"),
-				},
-			},
-			func(result ProcIO, err error) {
-				assert.Nil(t, err)
-				assert.Equal(t, result.ReadBytes, "3784704")
-				assert.Equal(t, result.WriteBytes, "8192")
-			}},
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-			},
-			func(result ProcIO, err error) {
-				assert.Error(t, err)
-			}},
-	}
-
-	for _, testCase := range testCases {
-		result, err := ReadIOFS(testCase.fstest, pid)
-		testCase.assert(result, err)
-	}
-}
+//func TestReadIOFS(t *testing.T) {
+//	pid := "1"
+//	testCases := []struct {
+//		fstest fstest.MapFS
+//		assert func(ProcIO, error)
+//	}{
+//		{
+//			fstest.MapFS{
+//				"hello.txt": {
+//					Data: []byte("hello, world"),
+//				},
+//				"proc/1/io": {
+//					Data: []byte(io),
+//				},
+//				"proc/1/stat": {
+//					Data: []byte("some data"),
+//				},
+//			},
+//			func(result ProcIO, err error) {
+//				assert.Nil(t, err)
+//				assert.Equal(t, result.ReadBytes, "3784704")
+//				assert.Equal(t, result.WriteBytes, "8192")
+//			}},
+//		{
+//			fstest.MapFS{
+//				"hello.txt": {
+//					Data: []byte("hello, world"),
+//				},
+//			},
+//			func(result ProcIO, err error) {
+//				assert.Error(t, err)
+//			}},
+//	}
+//
+//	for _, testCase := range testCases {
+//		result, err := ReadIOFS(testCase.fstest, pid)
+//		testCase.assert(result, err)
+//	}
+//}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/io_test.go
@@ -1,0 +1,54 @@
+package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
+
+var io = `rchar: 45479191
+wchar: 42997831
+syscr: 1327670
+syscw: 582115
+read_bytes: 3784704
+write_bytes: 8192`
+
+func TestReadIOFS(t *testing.T) {
+	pid := "1"
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func(ProcIO, error)
+	}{
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+				"proc/1/io": {
+					Data: []byte(io),
+				},
+				"proc/1/stat": {
+					Data: []byte("some data"),
+				},
+			},
+			func(result ProcIO, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result.ReadBytes, "3784704")
+				assert.Equal(t, result.WriteBytes, "8192")
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result ProcIO, err error) {
+				assert.Error(t, err)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ReadIOFS(testCase.fstest, pid)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/link.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/link.go
@@ -6,10 +6,11 @@ package proc
 
 import (
 	"os"
+	"path/filepath"
 )
 
 func ReadLink(root string, pid string, attr string) (string, error) {
-	fn := getProcAttr(root, pid, attr)
+	fn := filepath.Join(root, pid, attr)
 
 	s, err := os.Readlink(fn)
 	if err != nil {

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
@@ -5,17 +5,22 @@
 package proc
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
 )
 
 func List(root string) ([]string, error) {
+	return ListFS(os.DirFS("/"), root)
+}
+
+func ListFS(fsys fs.FS, root string) ([]string, error) {
 	var pids []string
 
 	root = filepath.Join(root, "/proc")
 
-	dirs, err := os.ReadDir(root)
+	dirs, err := fs.ReadDir(fsys, root)
 
 	if err != nil {
 		return nil, err

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
@@ -7,21 +7,18 @@ package proc
 import (
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strconv"
 )
 
 // List returns all the processes in the proc folder
 func List(root string) ([]string, error) {
-	return ListFS(os.DirFS("/"), root)
+	return ListFS(os.DirFS(root))
 }
 
-func ListFS(sysfs fs.FS, root string) ([]string, error) {
+func ListFS(sysfs fs.FS) ([]string, error) {
 	var pids []string
 
-	root = filepath.Join(root, "/proc")
-
-	dirs, err := fs.ReadDir(sysfs, root)
+	dirs, err := fs.ReadDir(sysfs, "proc")
 
 	if err != nil {
 		return nil, err

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
@@ -11,16 +11,17 @@ import (
 	"strconv"
 )
 
+// List returns all the processes in the proc folder
 func List(root string) ([]string, error) {
 	return ListFS(os.DirFS("/"), root)
 }
 
-func ListFS(fsys fs.FS, root string) ([]string, error) {
+func ListFS(sysfs fs.FS, root string) ([]string, error) {
 	var pids []string
 
 	root = filepath.Join(root, "/proc")
 
-	dirs, err := fs.ReadDir(fsys, root)
+	dirs, err := fs.ReadDir(sysfs, root)
 
 	if err != nil {
 		return nil, err

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
@@ -2,58 +2,67 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !windows
+// +build !windows
+
 package proc
 
-//func TestList(t *testing.T) {
-//	testCases := []struct {
-//		fstest fstest.MapFS
-//		assert func([]string, error)
-//	}{
-//		{
-//			fstest.MapFS{
-//				"hello.txt": {
-//					Data: []byte("hello, world"),
-//				},
-//				"proc/1/cmdline": {
-//					Data: []byte("some data"),
-//				},
-//				"proc/1/stat": {
-//					Data: []byte("some data"),
-//				},
-//				"proc/2/stat": {
-//					Data: []byte("some data"),
-//				},
-//			},
-//			func(results []string, err error) {
-//				assert.Nil(t, err)
-//				assert.Len(t, results, 2)
-//				assert.Contains(t, results, "1")
-//				assert.Contains(t, results, "2")
-//			}},
-//		{
-//			fstest.MapFS{
-//				"hello.txt": {
-//					Data: []byte("hello, world"),
-//				},
-//			},
-//			func(results []string, err error) {
-//				assert.Error(t, err)
-//				assert.Nil(t, results)
-//			}},
-//		{
-//			fstest.MapFS{
-//				"proc/uptime": {
-//					Data: []byte("hello, world"),
-//				},
-//			},
-//			func(results []string, err error) {
-//				assert.Nil(t, err)
-//				assert.Nil(t, results)
-//			}},
-//	}
-//
-//	for _, testCase := range testCases {
-//		result, err := ListFS(testCase.fstest)
-//		testCase.assert(result, err)
-//	}
-//}
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
+
+func TestList(t *testing.T) {
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func([]string, error)
+	}{
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+				"proc/1/cmdline": {
+					Data: []byte("some data"),
+				},
+				"proc/1/stat": {
+					Data: []byte("some data"),
+				},
+				"proc/2/stat": {
+					Data: []byte("some data"),
+				},
+			},
+			func(results []string, err error) {
+				assert.Nil(t, err)
+				assert.Len(t, results, 2)
+				assert.Contains(t, results, "1")
+				assert.Contains(t, results, "2")
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(results []string, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, results)
+			}},
+		{
+			fstest.MapFS{
+				"proc/uptime": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(results []string, err error) {
+				assert.Nil(t, err)
+				assert.Nil(t, results)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ListFS(testCase.fstest)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package proc
 
 import (

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
@@ -4,62 +4,56 @@
 
 package proc
 
-import (
-	"github.com/stretchr/testify/assert"
-	"testing"
-	"testing/fstest"
-)
-
-func TestList(t *testing.T) {
-	testCases := []struct {
-		fstest fstest.MapFS
-		assert func([]string, error)
-	}{
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-				"proc/1/cmdline": {
-					Data: []byte("some data"),
-				},
-				"proc/1/stat": {
-					Data: []byte("some data"),
-				},
-				"proc/2/stat": {
-					Data: []byte("some data"),
-				},
-			},
-			func(results []string, err error) {
-				assert.Nil(t, err)
-				assert.Len(t, results, 2)
-				assert.Contains(t, results, "1")
-				assert.Contains(t, results, "2")
-			}},
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-			},
-			func(results []string, err error) {
-				assert.Error(t, err)
-				assert.Nil(t, results)
-			}},
-		{
-			fstest.MapFS{
-				"proc/uptime": {
-					Data: []byte("hello, world"),
-				},
-			},
-			func(results []string, err error) {
-				assert.Nil(t, err)
-				assert.Nil(t, results)
-			}},
-	}
-
-	for _, testCase := range testCases {
-		result, err := ListFS(testCase.fstest)
-		testCase.assert(result, err)
-	}
-}
+//func TestList(t *testing.T) {
+//	testCases := []struct {
+//		fstest fstest.MapFS
+//		assert func([]string, error)
+//	}{
+//		{
+//			fstest.MapFS{
+//				"hello.txt": {
+//					Data: []byte("hello, world"),
+//				},
+//				"proc/1/cmdline": {
+//					Data: []byte("some data"),
+//				},
+//				"proc/1/stat": {
+//					Data: []byte("some data"),
+//				},
+//				"proc/2/stat": {
+//					Data: []byte("some data"),
+//				},
+//			},
+//			func(results []string, err error) {
+//				assert.Nil(t, err)
+//				assert.Len(t, results, 2)
+//				assert.Contains(t, results, "1")
+//				assert.Contains(t, results, "2")
+//			}},
+//		{
+//			fstest.MapFS{
+//				"hello.txt": {
+//					Data: []byte("hello, world"),
+//				},
+//			},
+//			func(results []string, err error) {
+//				assert.Error(t, err)
+//				assert.Nil(t, results)
+//			}},
+//		{
+//			fstest.MapFS{
+//				"proc/uptime": {
+//					Data: []byte("hello, world"),
+//				},
+//			},
+//			func(results []string, err error) {
+//				assert.Nil(t, err)
+//				assert.Nil(t, results)
+//			}},
+//	}
+//
+//	for _, testCase := range testCases {
+//		result, err := ListFS(testCase.fstest)
+//		testCase.assert(result, err)
+//	}
+//}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list_test.go
@@ -1,0 +1,61 @@
+package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
+
+func TestList(t *testing.T) {
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func([]string, error)
+	}{
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+				"proc/1/cmdline": {
+					Data: []byte("some data"),
+				},
+				"proc/1/stat": {
+					Data: []byte("some data"),
+				},
+				"proc/2/stat": {
+					Data: []byte("some data"),
+				},
+			},
+			func(results []string, err error) {
+				assert.Nil(t, err)
+				assert.Len(t, results, 2)
+				assert.Contains(t, results, "1")
+				assert.Contains(t, results, "2")
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(results []string, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, results)
+			}},
+		{
+			fstest.MapFS{
+				"proc/uptime": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(results []string, err error) {
+				assert.Nil(t, err)
+				assert.Nil(t, results)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ListFS(testCase.fstest)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
@@ -42,7 +42,7 @@ func getProcAttr(root, pid, attr string) string {
 	return filepath.Join(root, "/proc", pid, attr)
 }
 
-// ReadStat ReadProcStat reads proccess stats from /proc/<pid>/stat.
+// ReadStat reads process stats from /proc/<pid>/stat.
 // The parsing code logic is borrowed from osquery C++ implementation and translated to Go.
 // This makes the data returned from the `host_processes` table
 // consistent with data returned from the original osquery `processes` table.

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat.go
@@ -38,8 +38,8 @@ type ProcStat struct {
 	StartTime    string
 }
 
-func getProcAttr(root, pid, attr string) string {
-	return filepath.Join(root, "/proc", pid, attr)
+func getProcAttr(pid, attr string) string {
+	return filepath.Join("proc", pid, attr)
 }
 
 // ReadStat reads process stats from /proc/<pid>/stat.
@@ -48,11 +48,11 @@ func getProcAttr(root, pid, attr string) string {
 // consistent with data returned from the original osquery `processes` table.
 // https://github.com/osquery/osquery/blob/master/osquery/tables/system/linux/processes.cpp
 func ReadStat(root string, pid string) (stat ProcStat, err error) {
-	return ReadStatFS(os.DirFS("/"), root, pid)
+	return ReadStatFS(os.DirFS(root), pid)
 }
 
-func ReadStatFS(sysfs fs.FS, root string, pid string) (stat ProcStat, err error) {
-	fn := getProcAttr(root, pid, "stat")
+func ReadStatFS(sysfs fs.FS, pid string) (stat ProcStat, err error) {
+	fn := getProcAttr(pid, "stat")
 	b, err := fs.ReadFile(sysfs, fn)
 	if err != nil {
 		return
@@ -79,7 +79,7 @@ func ReadStatFS(sysfs fs.FS, root string, pid string) (stat ProcStat, err error)
 	stat.Threads = details[17]
 	stat.StartTime = details[19]
 
-	fn = getProcAttr(root, pid, "status")
+	fn = getProcAttr(pid, "status")
 	b, err = fs.ReadFile(sysfs, fn)
 	if err != nil {
 		return

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
@@ -4,65 +4,59 @@
 
 package proc
 
-import (
-	"github.com/stretchr/testify/assert"
-	"testing"
-	"testing/fstest"
-)
-
 var stat = "6462 (bash) S 6402 6462 6462 34817 37849 4194304 14126 901131 0 191 15 9 3401 725 20 0 1 0 134150 20156416 1369 18446744073709551615 94186936238080 94186936960773 140723699470016 0 0 0 65536 3670020 1266777851 1 0 0 17 7 0 0 0 0 0 94186937191664 94186937239044 94186967023616 140723699476902 140723699476912 140723699476912 140723699478510 0"
 var status = `Name:   myProcess`
 
-func TestReadStatFS(t *testing.T) {
-	pid := "1"
-	testCases := []struct {
-		fstest fstest.MapFS
-		assert func(ProcStat, error)
-	}{
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-				"proc/1/cmdline": {
-					Data: []byte("some data"),
-				},
-				"proc/1/stat": {
-					Data: []byte(stat),
-				},
-				"proc/1/status": {
-					Data: []byte(status),
-				},
-				"proc/2/stat": {
-					Data: []byte("some data"),
-				},
-			},
-			func(result ProcStat, err error) {
-				assert.Nil(t, err)
-				assert.Equal(t, result.Name, "myProcess")
-			}},
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-			},
-			func(result ProcStat, err error) {
-				assert.Error(t, err)
-			}},
-		{
-			fstest.MapFS{
-				"proc/1/stat": {
-					Data: []byte(stat),
-				},
-			},
-			func(results ProcStat, err error) {
-				assert.Error(t, err)
-			}},
-	}
-
-	for _, testCase := range testCases {
-		result, err := ReadStatFS(testCase.fstest, pid)
-		testCase.assert(result, err)
-	}
-}
+//func TestReadStatFS(t *testing.T) {
+//	pid := "1"
+//	testCases := []struct {
+//		fstest fstest.MapFS
+//		assert func(ProcStat, error)
+//	}{
+//		{
+//			fstest.MapFS{
+//				"hello.txt": {
+//					Data: []byte("hello, world"),
+//				},
+//				"proc/1/cmdline": {
+//					Data: []byte("some data"),
+//				},
+//				"proc/1/stat": {
+//					Data: []byte(stat),
+//				},
+//				"proc/1/status": {
+//					Data: []byte(status),
+//				},
+//				"proc/2/stat": {
+//					Data: []byte("some data"),
+//				},
+//			},
+//			func(result ProcStat, err error) {
+//				assert.Nil(t, err)
+//				assert.Equal(t, result.Name, "myProcess")
+//			}},
+//		{
+//			fstest.MapFS{
+//				"hello.txt": {
+//					Data: []byte("hello, world"),
+//				},
+//			},
+//			func(result ProcStat, err error) {
+//				assert.Error(t, err)
+//			}},
+//		{
+//			fstest.MapFS{
+//				"proc/1/stat": {
+//					Data: []byte(stat),
+//				},
+//			},
+//			func(results ProcStat, err error) {
+//				assert.Error(t, err)
+//			}},
+//	}
+//
+//	for _, testCase := range testCases {
+//		result, err := ReadStatFS(testCase.fstest, pid)
+//		testCase.assert(result, err)
+//	}
+//}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package proc
 
 import (

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
@@ -1,0 +1,64 @@
+package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
+
+var stat = "6462 (bash) S 6402 6462 6462 34817 37849 4194304 14126 901131 0 191 15 9 3401 725 20 0 1 0 134150 20156416 1369 18446744073709551615 94186936238080 94186936960773 140723699470016 0 0 0 65536 3670020 1266777851 1 0 0 17 7 0 0 0 0 0 94186937191664 94186937239044 94186967023616 140723699476902 140723699476912 140723699476912 140723699478510 0"
+var status = `Name:   myProcess`
+
+func TestReadStatFS(t *testing.T) {
+	pid := "1"
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func(ProcStat, error)
+	}{
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+				"proc/1/cmdline": {
+					Data: []byte("some data"),
+				},
+				"proc/1/stat": {
+					Data: []byte(stat),
+				},
+				"proc/1/status": {
+					Data: []byte(status),
+				},
+				"proc/2/stat": {
+					Data: []byte("some data"),
+				},
+			},
+			func(result ProcStat, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result.Name, "myProcess")
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result ProcStat, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			fstest.MapFS{
+				"proc/1/stat": {
+					Data: []byte(stat),
+				},
+			},
+			func(results ProcStat, err error) {
+				assert.Error(t, err)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ReadStatFS(testCase.fstest, pid)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/stat_test.go
@@ -2,61 +2,70 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !windows
+// +build !windows
+
 package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
 
 var stat = "6462 (bash) S 6402 6462 6462 34817 37849 4194304 14126 901131 0 191 15 9 3401 725 20 0 1 0 134150 20156416 1369 18446744073709551615 94186936238080 94186936960773 140723699470016 0 0 0 65536 3670020 1266777851 1 0 0 17 7 0 0 0 0 0 94186937191664 94186937239044 94186967023616 140723699476902 140723699476912 140723699476912 140723699478510 0"
 var status = `Name:   myProcess`
 
-//func TestReadStatFS(t *testing.T) {
-//	pid := "1"
-//	testCases := []struct {
-//		fstest fstest.MapFS
-//		assert func(ProcStat, error)
-//	}{
-//		{
-//			fstest.MapFS{
-//				"hello.txt": {
-//					Data: []byte("hello, world"),
-//				},
-//				"proc/1/cmdline": {
-//					Data: []byte("some data"),
-//				},
-//				"proc/1/stat": {
-//					Data: []byte(stat),
-//				},
-//				"proc/1/status": {
-//					Data: []byte(status),
-//				},
-//				"proc/2/stat": {
-//					Data: []byte("some data"),
-//				},
-//			},
-//			func(result ProcStat, err error) {
-//				assert.Nil(t, err)
-//				assert.Equal(t, result.Name, "myProcess")
-//			}},
-//		{
-//			fstest.MapFS{
-//				"hello.txt": {
-//					Data: []byte("hello, world"),
-//				},
-//			},
-//			func(result ProcStat, err error) {
-//				assert.Error(t, err)
-//			}},
-//		{
-//			fstest.MapFS{
-//				"proc/1/stat": {
-//					Data: []byte(stat),
-//				},
-//			},
-//			func(results ProcStat, err error) {
-//				assert.Error(t, err)
-//			}},
-//	}
-//
-//	for _, testCase := range testCases {
-//		result, err := ReadStatFS(testCase.fstest, pid)
-//		testCase.assert(result, err)
-//	}
-//}
+func TestReadStatFS(t *testing.T) {
+	pid := "1"
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func(ProcStat, error)
+	}{
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+				"proc/1/cmdline": {
+					Data: []byte("some data"),
+				},
+				"proc/1/stat": {
+					Data: []byte(stat),
+				},
+				"proc/1/status": {
+					Data: []byte(status),
+				},
+				"proc/2/stat": {
+					Data: []byte("some data"),
+				},
+			},
+			func(result ProcStat, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result.Name, "myProcess")
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result ProcStat, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			fstest.MapFS{
+				"proc/1/stat": {
+					Data: []byte(stat),
+				},
+			},
+			func(results ProcStat, err error) {
+				assert.Error(t, err)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ReadStatFS(testCase.fstest, pid)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
@@ -7,7 +7,8 @@ package proc
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"strconv"
 )
@@ -16,10 +17,14 @@ var (
 	ErrInvalidProcUptimecontent = errors.New("invalid /proc/uptime content")
 )
 
-// Reads system uptime from <root>/proc/uptime
+// ReadUptime Reads system uptime from <root>/proc/uptime
 func ReadUptime(root string) (secs int64, err error) {
+	return ReadUptimeFS(os.DirFS("/"), root)
+}
+
+func ReadUptimeFS(fsys fs.FS, root string) (secs int64, err error) {
 	fp := filepath.Join(root, "/proc/uptime")
-	b, err := ioutil.ReadFile(fp)
+	b, err := fs.ReadFile(fsys, fp)
 	if err != nil {
 		return
 	}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
@@ -22,9 +22,9 @@ func ReadUptime(root string) (secs int64, err error) {
 	return ReadUptimeFS(os.DirFS("/"), root)
 }
 
-func ReadUptimeFS(fsys fs.FS, root string) (secs int64, err error) {
+func ReadUptimeFS(sysfs fs.FS, root string) (secs int64, err error) {
 	fp := filepath.Join(root, "/proc/uptime")
-	b, err := fs.ReadFile(fsys, fp)
+	b, err := fs.ReadFile(sysfs, fp)
 	if err != nil {
 		return
 	}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strconv"
 )
 
@@ -19,12 +18,11 @@ var (
 
 // ReadUptime Reads system uptime from <root>/proc/uptime
 func ReadUptime(root string) (secs int64, err error) {
-	return ReadUptimeFS(os.DirFS("/"), root)
+	return ReadUptimeFS(os.DirFS(root))
 }
 
-func ReadUptimeFS(sysfs fs.FS, root string) (secs int64, err error) {
-	fp := filepath.Join(root, "/proc/uptime")
-	b, err := fs.ReadFile(sysfs, fp)
+func ReadUptimeFS(sysfs fs.FS) (secs int64, err error) {
+	b, err := fs.ReadFile(sysfs, "/proc/uptime")
 	if err != nil {
 		return
 	}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime.go
@@ -22,7 +22,7 @@ func ReadUptime(root string) (secs int64, err error) {
 }
 
 func ReadUptimeFS(sysfs fs.FS) (secs int64, err error) {
-	b, err := fs.ReadFile(sysfs, "/proc/uptime")
+	b, err := fs.ReadFile(sysfs, "proc/uptime")
 	if err != nil {
 		return
 	}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
@@ -1,0 +1,41 @@
+package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
+
+var uptime = "179118.54 1008710.15"
+
+func TestReadUpTimeFS(t *testing.T) {
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func(int64, error)
+	}{
+		{
+			fstest.MapFS{
+				"proc/uptime": {
+					Data: []byte(uptime),
+				},
+			},
+			func(result int64, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result, 179118)
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result int64, err error) {
+				assert.Error(t, err)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ReadUptimeFS(testCase.fstest)
+		testCase.assert(result, err)
+	}
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package proc
 
 import (

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
@@ -25,7 +25,7 @@ func TestReadUpTimeFS(t *testing.T) {
 			},
 			func(result int64, err error) {
 				assert.Nil(t, err)
-				assert.Equal(t, result, 179118)
+				assert.Equal(t, result, int64(179118))
 			}},
 		{
 			fstest.MapFS{

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
@@ -4,42 +4,36 @@
 
 package proc
 
-import (
-	"github.com/stretchr/testify/assert"
-	"testing"
-	"testing/fstest"
-)
-
 var uptime = "179118.54 1008710.15"
 
-func TestReadUpTimeFS(t *testing.T) {
-	testCases := []struct {
-		fstest fstest.MapFS
-		assert func(int64, error)
-	}{
-		{
-			fstest.MapFS{
-				"proc/uptime": {
-					Data: []byte(uptime),
-				},
-			},
-			func(result int64, err error) {
-				assert.Nil(t, err)
-				assert.Equal(t, result, int64(179118))
-			}},
-		{
-			fstest.MapFS{
-				"hello.txt": {
-					Data: []byte("hello, world"),
-				},
-			},
-			func(result int64, err error) {
-				assert.Error(t, err)
-			}},
-	}
-
-	for _, testCase := range testCases {
-		result, err := ReadUptimeFS(testCase.fstest)
-		testCase.assert(result, err)
-	}
-}
+//func TestReadUpTimeFS(t *testing.T) {
+//	testCases := []struct {
+//		fstest fstest.MapFS
+//		assert func(int64, error)
+//	}{
+//		{
+//			fstest.MapFS{
+//				"proc/uptime": {
+//					Data: []byte(uptime),
+//				},
+//			},
+//			func(result int64, err error) {
+//				assert.Nil(t, err)
+//				assert.Equal(t, result, int64(179118))
+//			}},
+//		{
+//			fstest.MapFS{
+//				"hello.txt": {
+//					Data: []byte("hello, world"),
+//				},
+//			},
+//			func(result int64, err error) {
+//				assert.Error(t, err)
+//			}},
+//	}
+//
+//	for _, testCase := range testCases {
+//		result, err := ReadUptimeFS(testCase.fstest)
+//		testCase.assert(result, err)
+//	}
+//}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/uptime_test.go
@@ -2,38 +2,47 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !windows
+// +build !windows
+
 package proc
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"testing/fstest"
+)
 
 var uptime = "179118.54 1008710.15"
 
-//func TestReadUpTimeFS(t *testing.T) {
-//	testCases := []struct {
-//		fstest fstest.MapFS
-//		assert func(int64, error)
-//	}{
-//		{
-//			fstest.MapFS{
-//				"proc/uptime": {
-//					Data: []byte(uptime),
-//				},
-//			},
-//			func(result int64, err error) {
-//				assert.Nil(t, err)
-//				assert.Equal(t, result, int64(179118))
-//			}},
-//		{
-//			fstest.MapFS{
-//				"hello.txt": {
-//					Data: []byte("hello, world"),
-//				},
-//			},
-//			func(result int64, err error) {
-//				assert.Error(t, err)
-//			}},
-//	}
-//
-//	for _, testCase := range testCases {
-//		result, err := ReadUptimeFS(testCase.fstest)
-//		testCase.assert(result, err)
-//	}
-//}
+func TestReadUpTimeFS(t *testing.T) {
+	testCases := []struct {
+		fstest fstest.MapFS
+		assert func(int64, error)
+	}{
+		{
+			fstest.MapFS{
+				"proc/uptime": {
+					Data: []byte(uptime),
+				},
+			},
+			func(result int64, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result, int64(179118))
+			}},
+		{
+			fstest.MapFS{
+				"hello.txt": {
+					Data: []byte("hello, world"),
+				},
+			},
+			func(result int64, err error) {
+				assert.Error(t, err)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := ReadUptimeFS(testCase.fstest)
+		testCase.assert(result, err)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

This PR enhance the functionality of the `procfs` so it can also support file system injection. 

## Why is it important?
This change is important for two reasons:
1. It let the user expose only a part of his file system/give a relative path.
2. It enhances the functionality such that a developer can use an in-memory file system such as [`fstest`](https://pkg.go.dev/testing/fstest)

This change is required by the @elastic/cloud-posture-security, since we are using this extension and would like to write test using `fstest`.
## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues
- Relates [#3263](https://github.com/elastic/security-team/issues/3263)


- Closes: https://github.com/elastic/security-team/issues/3320