### PR TITLE
packetbeat/{beater,npcap}: prevent panic when querying Npcap version and perform install before all other work

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Packetbeat*
 
+- Prevent panic when querying Npcap version on Windows. {issue}30820[30820] {pull}30821[30821]
 
 *Winlogbeat*
 

--- a/packetbeat/beater/install_npcap.go
+++ b/packetbeat/beater/install_npcap.go
@@ -25,8 +25,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/google/gopacket/pcap"
-
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/packetbeat/npcap"
@@ -44,7 +42,7 @@ func installNpcap(b *beat.Beat) error {
 
 	defer func() {
 		log := logp.NewLogger("npcap")
-		npcapVersion := pcap.Version()
+		npcapVersion := npcap.Version()
 		if npcapVersion == "" {
 			log.Warn("no version available for npcap")
 		} else {

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -90,14 +90,16 @@ func New(b *beat.Beat, rawConfig *common.Config) (beat.Beater, error) {
 		configurator = initialConfig().FromStatic
 	}
 
-	factory := newProcessorFactory(b.Info.Name, make(chan error, maxSniffers), b, configurator)
-	if err := factory.CheckConfig(rawConfig); err != nil {
+	// Install Npcap if needed. This need to happen before any other
+	// work on Windows, including config checking, because that involves
+	// probing interfaces.
+	err := installNpcap(b)
+	if err != nil {
 		return nil, err
 	}
 
-	// Install Npcap if needed.
-	err := installNpcap(b)
-	if err != nil {
+	factory := newProcessorFactory(b.Info.Name, make(chan error, maxSniffers), b, configurator)
+	if err := factory.CheckConfig(rawConfig); err != nil {
 		return nil, err
 	}
 

--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -154,6 +154,9 @@ func (p *processorFactory) Create(pipeline beat.PipelineConnector, cfg *common.C
 	return newProcessor(config.ShutdownTimeout, publisher, flows, sniffer, p.err), nil
 }
 
+// CheckConfig performs a dry-run creation of a Packetbeat pipeline based
+// on the provided configuration. This will involve setting up some dummy
+// sniffers and so will need libpcap to be loaded.
 func (p *processorFactory) CheckConfig(config *common.Config) error {
 	runner, err := p.Create(pipeline.NewNilPipeline(), config)
 	if err != nil {

--- a/packetbeat/npcap/npcap.go
+++ b/packetbeat/npcap/npcap.go
@@ -56,7 +56,7 @@ func Install(ctx context.Context, log *logp.Logger, path, dst string, compat boo
 }
 
 func install(ctx context.Context, log *logp.Logger, path, dst string, compat bool) error {
-	if pcap.Version() != "" {
+	if Version() != "" {
 		// If we are here there is a runtime Npcap DLL loaded. We need to
 		// unload this to prevent the application being killed during the
 		// install.
@@ -99,6 +99,19 @@ func install(ctx context.Context, log *logp.Logger, path, dst string, compat boo
 	return loadWinPCAP()
 }
 
+// Version returns the installed version of pcap or the empty string if no
+// installation is present.
+func Version() string {
+	defer func() {
+		// recover purely to suppress the panic which will
+		// have happened due to Npcap not being installed.
+		// The empty string signifies that no installation
+		// exists.
+		recover()
+	}()
+	return pcap.Version()
+}
+
 func Upgradeable() bool {
 	// This is only set when a real installer is placed in
 	// x-pack/packetbeat/npcap/installer.
@@ -111,7 +124,7 @@ func Upgradeable() bool {
 	//  Npcap version 1.55, based on libpcap version 1.10.2-PRE-GIT
 	//
 	// if an Npcap version is installed. See https://nmap.org/npcap/guide/npcap-devguide.html#npcap-detect
-	installed := pcap.Version()
+	installed := Version()
 	if !strings.HasPrefix(installed, "Npcap version") {
 		return true
 	}
@@ -133,7 +146,7 @@ func Uninstall(ctx context.Context, log *logp.Logger, path string) error {
 	if runtime.GOOS != "windows" {
 		return errors.New("npcap: called Uninstall on non-Windows platform")
 	}
-	if pcap.Version() == "" {
+	if Version() == "" {
 		return nil
 	}
 	return uninstall(ctx, log, path)

--- a/x-pack/packetbeat/magefile.go
+++ b/x-pack/packetbeat/magefile.go
@@ -8,6 +8,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -19,14 +20,14 @@ import (
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 	packetbeat "github.com/elastic/beats/v7/packetbeat/scripts/mage"
 
-	// mage:import
+	//mage:import
 	"github.com/elastic/beats/v7/dev-tools/mage/target/common"
-	// mage:import
+	//mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/compose"
-	// mage:import
+	//mage:import
 	_ "github.com/elastic/beats/v7/dev-tools/mage/target/unittest"
-	// mage:import
-	_ "github.com/elastic/beats/v7/dev-tools/mage/target/test"
+	//mage:import
+	"github.com/elastic/beats/v7/dev-tools/mage/target/test"
 )
 
 // NpcapVersion specifies the version of the OEM Npcap installer to bundle with
@@ -36,6 +37,8 @@ const NpcapVersion = "1.60"
 
 func init() {
 	common.RegisterCheckDeps(Update)
+
+	test.RegisterDeps(TestSystem)
 
 	devtools.BeatDescription = "Packetbeat analyzes network traffic and sends the data to Elasticsearch."
 	devtools.BeatLicense = "Elastic License"
@@ -138,4 +141,12 @@ func Package() {
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
 	return devtools.TestPackages()
+}
+
+func TestSystem(ctx context.Context) error {
+	mg.Deps(devtools.BuildSystemTestBinary)
+
+	args := devtools.DefaultGoTestIntegrationArgs()
+	args.Packages = []string{"./tests/system/..."}
+	return devtools.GoTest(ctx, args)
 }

--- a/x-pack/packetbeat/tests/system/app_test.go
+++ b/x-pack/packetbeat/tests/system/app_test.go
@@ -1,0 +1,94 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build integration
+// +build integration
+
+package system
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/packetbeat/npcap"
+)
+
+func TestWindowsNpcapInstaller(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skipf("skipping non-Windows GOOS: %s", runtime.GOOS)
+	}
+
+	stdout, stderr, err := runPacketbeat(t, "devices")
+	require.NoError(t, err, stderr)
+	t.Log("Output:\n", stdout)
+
+	b, err := os.ReadFile(`C:\Program Files\Npcap\install.log`)
+	if err != nil {
+		return fmt.Errorf("could not read install.log: %w", err)
+	}
+	// From inspection we expect a line "DetailPrint: Starting the npcap driver".
+	if !bytes.Contains(b, []byte("Starting the npcap driver")) {
+		return errors.New("install log does not include npcap drives start line")
+	}
+
+	installedNpcapVersion := npcap.Version()
+	if !strings.Contains(installedNpcapVersion, NpcapVersion) {
+		return fmt.Errorf("unexpected npcap version installed: want:%s have:%s", NpcapVersion, installedNpcapVersion)
+	}
+}
+
+func TestDevices(t *testing.T) {
+	stdout, stderr, err := runPacketbeat(t, "devices")
+	require.NoError(t, err, stderr)
+	t.Log("Output:\n", stdout)
+
+	ifcs, err := net.Interfaces()
+	require.NoError(t, err)
+
+	for _, ifc := range ifcs {
+		assert.Contains(t, stdout, ifc.Name)
+	}
+}
+
+func runPacketbeat(t testing.TB, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	packetbeatPath, err := filepath.Abs(exe("../../packetbeat.test"))
+	require.NoError(t, err)
+
+	if _, err := os.Stat(packetbeatPath); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			t.Skipf("%v binary not found", filepath.Base(packetbeatPath))
+		}
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(packetbeatPath, append([]string{"-systemTest"}, args...)...)
+	cmd.Dir = t.TempDir()
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	err = cmd.Run()
+
+	return strings.TrimSpace(stdoutBuf.String()), strings.TrimSpace(stderrBuf.String()), err
+}
+
+func exe(path string) string {
+	if runtime.GOOS == "windows" {
+		return path + ".exe"
+	}
+	return path
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This fixes a crash on Windows 10 when running Packetbeat.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The bug block all functionality on that platform.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This needs to be tested on a Windows 10 machine. I used StefanScherer/windows_10 with the beats Vagrantfile. Build x-pack/packetbeat with `go build` and run with `.\packetbeat -e -d *`. Check `C:\Program Files` for the presence of the Npcap installation directory. Without this fix, no install will result; after this fix a new installation will be present on exit (packetbeat will still exit with an error unless a network interface is setup on the VM).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #30820.

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
