### PR TITLE
Emit summaries when synthetics exits without emitting journey/end [#30729]

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -122,7 +122,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Heartbeat*
 
-
+- Generate summary documents for journeys which exit successfully, but do not emit `journey/end` events {pull}30825[30825]
 
 *Metricbeat*
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -241,7 +241,7 @@ func TestEnrichSynthEvent(t *testing.T) {
 		check   func(t *testing.T, e *beat.Event, je *journeyEnricher)
 	}{
 		{
-			"cmd/status",
+			"cmd/status - with error",
 			&journeyEnricher{},
 			&SynthEvent{
 				Type:  "cmd/status",
@@ -253,6 +253,26 @@ func TestEnrichSynthEvent(t *testing.T) {
 					"summary": map[string]int{
 						"up":   0,
 						"down": 1,
+					},
+				})
+				testslike.Test(t, v, e.Fields)
+			},
+		},
+		{
+			// If a journey did not emit `journey/end` but exited without
+			// errors, we consider the journey to be up.
+			"cmd/status - without error",
+			&journeyEnricher{},
+			&SynthEvent{
+				Type:  "cmd/status",
+				Error: nil,
+			},
+			true,
+			func(t *testing.T, e *beat.Event, je *journeyEnricher) {
+				v := lookslike.MustCompile(common.MapStr{
+					"summary": map[string]int{
+						"up":   1,
+						"down": 0,
 					},
 				})
 				testslike.Test(t, v, e.Fields)
@@ -325,7 +345,7 @@ func TestEnrichSynthEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &beat.Event{}
-			if err := tt.je.enrichSynthEvent(e, tt.se); (err != nil) != tt.wantErr {
+			if err := tt.je.enrichSynthEvent(e, tt.se); (err == nil && tt.wantErr) || (err != nil && !tt.wantErr) {
 				t.Errorf("journeyEnricher.enrichSynthEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			tt.check(t, e, tt.je)
@@ -404,6 +424,62 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSummaryWithoutJourneyEnd(t *testing.T) {
+	journey := &Journey{
+		Name: "A journey that never emits journey/end but exits successfully",
+		Id:   "no-journey-end-but-success",
+	}
+	journeyStart := &SynthEvent{
+		Type:                 "journey/start",
+		TimestampEpochMicros: 1000,
+		PackageVersion:       "1.0.0",
+		Journey:              journey,
+		Payload:              common.MapStr{},
+	}
+
+	cmdStatus := &SynthEvent{
+		Type:                 "cmd/status",
+		Error:                nil,
+		TimestampEpochMicros: 3000,
+	}
+
+	url1 := "http://example.net/url1"
+	synthEvents := []*SynthEvent{
+		journeyStart,
+		makeStepEvent("step/end", 20, "Step1", 1, "", url1, nil),
+		cmdStatus,
+	}
+
+	je := &journeyEnricher{}
+
+	hasCmdStatus := false
+
+	for idx, se := range synthEvents {
+		e := &beat.Event{}
+		stdFields := StdSuiteFields{IsInline: false}
+		t.Run(fmt.Sprintf("event %d", idx), func(t *testing.T) {
+			enrichErr := je.enrich(e, se, stdFields)
+
+			if se != nil && se.Type == "cmd/status" {
+				hasCmdStatus = true
+				require.Error(t, enrichErr, "journey did not finish executing, 1 steps ran")
+
+				u, _ := url.Parse(url1)
+
+				v := lookslike.MustCompile(common.MapStr{
+					"synthetics.type":     "heartbeat/summary",
+					"url":                 wrappers.URLFields(u),
+					"monitor.duration.us": int64(cmdStatus.Timestamp().Sub(journeyStart.Timestamp()) / time.Microsecond),
+				})
+
+				testslike.Test(t, v, e.Fields)
+			}
+		})
+	}
+
+	require.True(t, hasCmdStatus)
 }
 
 func TestCreateSummaryEvent(t *testing.T) {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
@@ -141,8 +141,8 @@ Loop:
 		require.Equal(t, "Stderr 2", stdoutEvents[1].Payload["message"])
 	})
 	t.Run("should have one event per line in sampleinput", func(t *testing.T) {
-		// 27 lines are in sample.ndjson + 2 from stderr + 1 from stdout
-		expected := 27 + 2 + 1
+		// 27 lines are in sample.ndjson + 2 from stderr + 1 from stdout + 1 from the command exit
+		expected := 28 + 2 + 1
 		require.Len(t, synthEvents, expected)
 	})
 
@@ -150,6 +150,7 @@ Loop:
 		"journey/start",
 		"step/end",
 		"journey/end",
+		"cmd/status",
 	}
 	for _, typ := range expectedEventTypes {
 		t.Run(fmt.Sprintf("Should have at least one event of type %s", typ), func(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

This PR fixes #30729 by always emitting `heartbeat/summary` documents when a command exits without `journey/end`.

These documents have the following message:

> journey did not finish executing, X steps ran


## Why is it important?

Such a change will cause the Uptime UI to be able to display correct results even if a journey execution exits successfully but doesn't manage to write a `journey/end` event to the desired descriptor. Such a situation could happen when the synthetics runner buffer was full and wasn't emptied on time before the command's exit, as described in https://github.com/elastic/synthetics/issues/446 and fixed in https://github.com/elastic/synthetics/pull/465


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (Does not apply)
- [x] I have made corresponding change to the default configuration files  (Does not apply)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Author's Checklist

I've done so myself, but would like reviewers to verify the following:

- [x] Running journeys on the latest version of the synthetics runner works fine for journeys which emit `journey/end`
- [x] Running journeys on the latest version of the synthetics runner works fine for journeys which exit with `status code > 0` and do not emit `journey/end`
- [x] Running journeys on the latest version of the synthetics runner works fine for journeys which exit with `status code == 0` _and_ emit `journey/end`


## How to test this PR locally

To test this PR locally you must have a version of the `synthetics` runner which _does not_ emit `journey/end` events once its finished. Then, you'll use that version to run a browser monitor and verify that the documents in Kibana do contain summaries with the following error message:

> journey did not finish executing, X steps ran

1. Update your local version of the `synthetics` package by removing these lines which are responsible for emitting `journey/end` events: https://github.com/elastic/synthetics/blob/e594196f4b083917fb7e44d67e208e1a87ea29a5/src/reporters/json.ts#L474-L484 (just comment them).
2. Copy the journey below and run it locally using `pbpaste | elastic-synthetics --screenshots off --inline --rich-events | jq .type`
    ```js
    step("no journey end", async () => { await page.goto("https://bbc.co.uk") });
    ```
    **You should ensure that no `journey/end` is emitted when running this journey. You must verify that because when running `heartbeat` you want to simulate what would happen when journeys exit without emitting `journey/end`.**
3. Checkout this branch and build `heartbeat`.
4. Run the `heartbeat` executable you just compiled with the following monitor:
    ```yml
    heartbeat.monitors:
    - type: browser
      id: test-no-end-emitted
      name: test-no-end-emitted
      schedule: '@every 1m'
      source:
        inline:
          script: |-
            step("no journey end", async () => {
              await page.goto('https://www.bbc.co.uk');
            });
    ```
    You can use `ELASTIC_SYNTHETICS_CAPABLE=true ./heartbeat -c /tmp/heartbeat.yml -e -d "*"` for that.
5. Go to Kibana and ensure that there is a summary for this monitor which mentions it didn't run to completion.


## Related issues

- Closes #30729


## Screenshots

![Screenshot 2022-03-15 at 12 17 35](https://user-images.githubusercontent.com/6868147/158376038-f2116b05-22ae-402a-bb96-e2aa0558e1d9.png)

