### PR TITLE
ci: extended meta-stage for ARM and extended_win for Windows-2019

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -34,7 +34,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -34,7 +34,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -34,7 +34,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -31,6 +31,7 @@ stages:
                 - "arm"
             parameters:
                 - "armTest"
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -58,7 +58,7 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-        stage: extended
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -35,7 +35,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -34,7 +34,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     build:
         mage: "mage update build test"
         withModule: true       ## run the ITs only if the changeset affects a specific module.

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -32,7 +32,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -34,7 +34,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -30,6 +30,7 @@ stages:
                 - "arm"
             parameters:
                 - "armTest"
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -35,7 +35,7 @@ stages:
                 - "armTest"
             branches: true     ## for all the branches
             tags: true         ## for all the tags
-        stage: mandatory
+        stage: extended
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -11,7 +11,7 @@ when:
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-winlogbeat"
     tags: true                 ## for all the tags
-platform: "windows-2019"       ## default label for all the stages
+platform: "windows-2022"       ## default label for all the stages
 stages:
     lint:
         make: |
@@ -28,12 +28,12 @@ stages:
         withModule: true
         platforms:             ## override default labels in this specific stage.
             - "windows-2019"
-        stage: extended
-    windows-2022:
+        stage: mandatory
+    windows-2019:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
-            - "windows-2022"
-        stage: mandatory
+            - "windows-2019"
+        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

Use the right meta-stages for the ARM and windows workers

## Why is it important?

Ensure we can cope with the build capacities by reducing what we run in parallel:

1) Mandatory is linux and windows-2022/windows-2016
2) Extended is ARM
3) Extended-Win is the one for all the remaining windows versions.


Used to be:

<img width="725" alt="image" src="https://user-images.githubusercontent.com/2871786/158581169-1a333cba-be26-4a82-8e5d-aa4348463d14.png">


And 