### PR TITLE
[Heartbeat] Enable Heartbeat to run when elastic-agent container is executed as root

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -19,7 +19,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 *Filebeat*
 
 *Heartbeat*
-
+- Restrict setuid to containerized environments. {pull}30869[30869]
 
 *Metricbeat*
 
@@ -42,6 +42,11 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Fix the ability for subcommands to be ran properly from the beats containers. {pull}30452[30452]
 - Update docker/distribution dependency library to fix a security issues concerning OCI Manifest Type Confusion Issue. {pull}30462[30462]
 - Fix dissect trim panics from DELETE (127)(\u007f) character {issue}30657[30657] {pull}30658[30658]
+- Load data stream during setup, so users do not need extra permissions during publishing. {issue}30647[30647] {pull}31048[31048]
+- Add ecs container fields {pull}31020[31020]
+- Fix docs reference for syslog processor {pull}31087[31087]
+- Fix AWS config initialization issue when using a role {issue}30999[30999] {pull}31014[31014]
+- Fix group write permissions on runtime directories. {pull}30869[30869]
 
 *Auditbeat*
 

--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -2,6 +2,9 @@
 
 set -eo pipefail
 
+# Update umask to retain group write permissions on runtime directories: $root/tmp/default, $root/logs/default and $root/run/default
+umask 0007
+
 # For information on the possible environment variables that can be passed into the container. Run the following
 # command for information on the options that are available.
 #

--- a/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
+++ b/dev-tools/packaging/templates/docker/docker-entrypoint.elastic-agent.tmpl
@@ -2,9 +2,6 @@
 
 set -eo pipefail
 
-# Update umask to retain group write permissions on runtime directories: $root/tmp/default, $root/logs/default and $root/run/default
-umask 0007
-
 # For information on the possible environment variables that can be passed into the container. Run the following
 # command for information on the options that are available.
 #

--- a/heartbeat/security/security.go
+++ b/heartbeat/security/security.go
@@ -28,6 +28,8 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/elastic/go-sysinfo"
+
 	"kernel.org/pub/linux/libs/security/libcap/cap"
 
 	"github.com/elastic/beats/v7/libbeat/common/seccomp"
@@ -39,7 +41,13 @@ func init() {
 	// In the context of a container, where users frequently run as root, we follow BEAT_SETUID_AS to setuid/gid
 	// and add capabilities to make this actually run as a regular user. This also helps Node.js in synthetics, which
 	// does not want to run as root. It's also just generally more secure.
-	if localUserName := os.Getenv("BEAT_SETUID_AS"); localUserName != "" && syscall.Geteuid() == 0 {
+	sysInfo, err := sysinfo.Host()
+	isContainer := false
+	if err == nil && sysInfo.Info().Containerized != nil {
+		isContainer = *sysInfo.Info().Containerized
+	}
+
+	if localUserName := os.Getenv("BEAT_SETUID_AS"); isContainer && localUserName != "" && syscall.Geteuid() == 0 {
 		err := changeUser(localUserName)
 		if err != nil {
 			panic(err)

--- a/heartbeat/security/security.go
+++ b/heartbeat/security/security.go
@@ -60,7 +60,7 @@ func init() {
 	// rather than relying on errors from `setcap`
 	_ = setCapabilities()
 
-	err := setSeccompRules()
+	err = setSeccompRules()
 	if err != nil {
 		panic(err)
 	}
@@ -71,33 +71,33 @@ func changeUser(localUserName string) error {
 	if err != nil {
 		return fmt.Errorf("could not lookup '%s': %w", localUser, err)
 	}
-	localUserUid, err := strconv.Atoi(localUser.Uid)
+	localUserUID, err := strconv.Atoi(localUser.Uid)
 	if err != nil {
 		return fmt.Errorf("could not parse UID '%s' as int: %w", localUser.Uid, err)
 	}
-	localUserGid, err := strconv.Atoi(localUser.Gid)
+	localUserGID, err := strconv.Atoi(localUser.Gid)
 	if err != nil {
 		return fmt.Errorf("could not parse GID '%s' as int: %w", localUser.Uid, err)
 	}
 	// We include the root group because the docker image contains many directories (data,logs)
 	// that are owned by root:root with 0775 perms. The heartbeat user is in both groups
 	// in the container, but we need to repeat that here.
-	err = syscall.Setgroups([]int{localUserGid, 0})
+	err = syscall.Setgroups([]int{localUserGID, 0})
 	if err != nil {
 		return fmt.Errorf("could not set groups: %w", err)
 	}
 
 	// Set the main group as localUserUid so new files created are owned by the user's group
-	err = syscall.Setgid(localUserGid)
+	err = syscall.Setgid(localUserGID)
 	if err != nil {
-		return fmt.Errorf("could not set gid to %d: %w", localUserGid, err)
+		return fmt.Errorf("could not set gid to %d: %w", localUserGID, err)
 	}
 
 	// Note this is not the regular SetUID! Look at the 'cap' package docs for it, it preserves
 	// capabilities post-SetUID, which we use to lock things down immediately
-	err = cap.SetUID(localUserUid)
+	err = cap.SetUID(localUserUID)
 	if err != nil {
-		return fmt.Errorf("could not setuid to %d: %w", localUserUid, err)
+		return fmt.Errorf("could not setuid to %d: %w", localUserUID, err)
 	}
 
 	// This may not be necessary, but is good hygiene, we do some shelling out to node/npm etc.

--- a/libbeat/paths/paths.go
+++ b/libbeat/paths/paths.go
@@ -87,7 +87,7 @@ func (paths *Path) InitPaths(cfg *Path) error {
 	// make sure the data path exists
 	err = os.MkdirAll(paths.Data, 0770)
 	if err != nil {
-		return fmt.Errorf("Failed to create data path %s: %v", paths.Data, err)
+		return fmt.Errorf("failed to create data path %s: %w", paths.Data, err)
 	}
 
 	return nil

--- a/libbeat/paths/paths.go
+++ b/libbeat/paths/paths.go
@@ -85,7 +85,7 @@ func (paths *Path) InitPaths(cfg *Path) error {
 	}
 
 	// make sure the data path exists
-	err = os.MkdirAll(paths.Data, 0750)
+	err = os.MkdirAll(paths.Data, 0770)
 	if err != nil {
 		return fmt.Errorf("Failed to create data path %s: %v", paths.Data, err)
 	}


### PR DESCRIPTION
Since it's a bugfix, I'm including `elastic-agent` changes to be backported to `8.2` and I will create a separate PR on `elastic-agent` repo for `8.3`.

## What does this PR do?

This PR:
- Includes group write permission in runtime directories, 
- adapts `umask` on docker containers,
- restricts heartbeat `setuid` to containerized instances.

This PR works in tandem with elastic/elastic-agent#202.

## Why is it important?

Heartbeat comes with `setuid` functionality to be able to run `npm` as a non-root user during synthetics checks inside an `elastic-agent` container. Without it, `npm` would complain when executed as root.

When `elastic-agent` is executed as root, all beats (filebeat, metricbeat, ...) run as `root` and `heartbeat` will run as user specified on `BEAT_SETUID_AS` env variable, `elastic-agent` by default. This user needs permissions to write to local directories and we enable that by making the user belong to `root` group. But some of the directories that the user need access to, that are created during runtime, do not allow for group write permission, meaning `heartbeat` won't be able to start and it will eventually report as degraded:

````
2022-02-02T22:14:03.608Z        INFO    log/reporter.go:40      2022-02-02T22:14:03Z - message: Application: heartbeat--7.16.3[34930eab-508d-45c6-b839-5787ec1ca7eb]: State changed to DEGRADED: Missed last check-in - type: 'STATE' - sub_type: 'RUNNING'
2022-02-02T22:14:03.608Z        WARN    status/reporter.go:236  Elastic Agent status changed to: 'degraded'
````

These are the directories:

````
$ ls -al state/data/{logs,tmp,run} | grep default
drwxr-xr-x 2 root root   4096 Mar 10 18:00 default
drwxr-x--- 5 root root 4096 Mar 10 13:29 default
drwxr-xr-x 3 root root 4096 Mar 10 13:28 default
````


Most of our own documented examples to run `heartbeat` and `elastic-agent` in k8s are configured to run as `root`, check [here](https://raw.githubusercontent.com/elastic/cloud-on-k8s/2.1/config/recipes/beats/heartbeat_es_kb_health.yaml) and [here](https://raw.githubusercontent.com/elastic/cloud-on-k8s/2.1/config/recipes/elastic-agent/kubernetes-integration.yaml) for reference.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Build beats and elastic-agent locally:
````bash
x-pack/heartbeat $  env PLATFORMS="+all linux/amd64" mage package
...
x-pack/filebeat $  env PLATFORMS="+all linux/amd64" mage package
...
x-pack/metricbeat $  env PLATFORMS="+all linux/amd64" mage package
...
x-pack/elastic-agent $  env PLATFORMS="+all linux/amd64" mage dev:package
...
````
- Run the container locally as `root`:
```bash
docker run -u root --rm --name agent --env FLEET_ENROLL=1 --env FLEET_URL=<fleet url> --env FLEET_ENROLLMENT_TOKEN=<token> -it docker.elastic.co/beats/elastic-agent:8.2.0
````
- Attach to the container separately and verify that required directories have group write permissions:
````bash
$ docker exec -u root -it agent /bin/bash
root@f9a201aef696:/usr/share/elastic-agent# ls -al state/data/{tmp,logs,run} | grep default
drwxrwx--- 2 root root 4096 Mar 16 15:02 default
drwxrwx--- 6 root root 4096 Mar 16 15:02 default
drwxrwx--- 5 root root 4096 Mar 16 15:02 default
````

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates to #30171.

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->
![image](https://user-images.githubusercontent.com/95703246/158636687-35ef6ec0-3212-47ae-9f82-67379dba759d.png)
