### PR TITLE
Fix the name `close.reader.on_eof` in reference configuration and documentation

### DIFF
--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -487,7 +487,7 @@ filebeat.inputs:
   # Closes the file handler as soon as the harvesters reaches the end of the file.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close.reader.eof: false
+  #close.reader.on_eof: false
 
   # Close timeout closes the harvester after the predefined time.
   # This is independent if the harvester did finish reading the file or not.

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -308,7 +308,7 @@ rotate files, make sure this option is enabled.
 
 [float]
 [id="{beatname_lc}-input-{type}-close-eof"]
-===== `close.reader.eof`
+===== `close.reader.on_eof`
 
 WARNING: Only use this option if you understand that data loss is a potential
 side effect.

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -894,7 +894,7 @@ filebeat.inputs:
   # Closes the file handler as soon as the harvesters reaches the end of the file.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close.reader.eof: false
+  #close.reader.on_eof: false
 
   # Close timeout closes the harvester after the predefined time.
   # This is independent if the harvester did finish reading the file or not.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2927,7 +2927,7 @@ filebeat.inputs:
   # Closes the file handler as soon as the harvesters reaches the end of the file.
   # By default this option is disabled.
   # Note: Potential data loss. Make sure to read and understand the docs for this option.
-  #close.reader.eof: false
+  #close.reader.on_eof: false
 
   # Close timeout closes the harvester after the predefined time.
   # This is independent if the harvester did finish reading the file or not.


### PR DESCRIPTION
## What does this PR do?

This PR fixes the name of the option that tells filestream input to close files after reaching EOF. The incorrect name was `close.reader.eof`. Now the correct name `close.reader.on_eof` is used in documentation and reference configuration.

## Why is it important?

Misleading information is removed from docs.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
