### PR TITLE
Fix scheduler and controllermanager k8s tests

### DIFF
--- a/metricbeat/module/kubernetes/test/integration.go
+++ b/metricbeat/module/kubernetes/test/integration.go
@@ -79,10 +79,14 @@ func GetKubeProxyConfig(t *testing.T, metricSetName string) map[string]interface
 func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface{} {
 	t.Helper()
 	return map[string]interface{}{
-		"module":     "kubernetes",
-		"metricsets": []string{metricSetName},
-		"host":       "${NODE_NAME}",
-		"hosts":      []string{"localhost:10251"},
+		"module":            "kubernetes",
+		"metricsets":        []string{metricSetName},
+		"host":              "${NODE_NAME}",
+		"hosts":             []string{"https://0.0.0.0:10259"},
+		"bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		"ssl": map[string]interface{}{
+			"verification_mode": "none",
+		},
 	}
 }
 
@@ -90,9 +94,13 @@ func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface
 func GetControllerManagerConfig(t *testing.T, metricSetName string) map[string]interface{} {
 	t.Helper()
 	return map[string]interface{}{
-		"module":     "kubernetes",
-		"metricsets": []string{metricSetName},
-		"host":       "${NODE_NAME}",
-		"hosts":      []string{"localhost:10252"},
+		"module":            "kubernetes",
+		"metricsets":        []string{metricSetName},
+		"host":              "${NODE_NAME}",
+		"hosts":             []string{"https://0.0.0.0:10257"},
+		"bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
+		"ssl": map[string]interface{}{
+			"verification_mode": "none",
+		},
 	}
 }


### PR DESCRIPTION
## What does this PR do?
Align testing with https://github.com/elastic/beats/pull/26729 after default k8s version for integration test was updated at https://github.com/elastic/beats/pull/30747. 

Actually this is due to https://github.com/elastic/infra/pull/35111, because for `goInteg` tests `kind` is a requirement and is actually installed by default on the workers by https://github.com/elastic/infra/pull/35111.


Related to https://github.com/elastic/beats/pull/30870.