### PR TITLE
Upgrade osquery to 5.2.2

### DIFF
--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -30,14 +30,14 @@ const (
 	osqueryDarwinPath      = "opt/osquery/lib/" + osqueryDarwinApp
 
 	osqueryLinuxPath = "opt/osquery/bin"
-	osqueryVersion   = "5.0.1"
+	osqueryVersion   = "5.2.2"
 	osqueryMSIExt    = ".msi"
 	osqueryPkgExt    = ".pkg"
 
-	osqueryDistroDarwinSHA256   = "ec58996e64637d861ccead8dc6bc8865662728f6e5bc2694a3c92f0f4a371095"
-	osqueryDistroLinuxSHA256    = "acac95714d388f02d5f417b0aaf86de7dbb8f6b3788340a6f8517ee2cd314235"
-	osqueryDistroLinuxARMSHA256 = "712b704036929df14cbe5d3e41bd4e0ae325e698296691763af46dc0d6e77394"
-	osqueryDistroWindowsSHA256  = "e0d01f56e0739a0ce2b3beb03ecea277ed146754884e225cba45083043442acc"
+	osqueryDistroDarwinSHA256   = "c1db00554f65a1f240e9c827c73e0a768fbda66475b18bd68786b3a12e04200f"
+	osqueryDistroLinuxSHA256    = "e86e4cec2f941782a6223a09c2e9d7bdc6cfea0e30ba9792056749b0e79f4576"
+	osqueryDistroLinuxARMSHA256 = "799f4851adeafd251aa57a91e20a9180c5b0c5e0d06cfc12815a1eaf631aaaa1"
+	osqueryDistroWindowsSHA256  = "d784b9c114ae2f5216dc5aa6bf311863c2db8fdaca31085e38a51b35eefa6c50"
 )
 
 type OSArch struct {


### PR DESCRIPTION
## What does this PR do?

Upgrades osquery to 5.2.2. 

## Why is it important?

* Updates to the latest release of osquery.
* Picks up our contribution to osquery that was included in this release of osquery:
```
Add windows_firewall_rules table for windows
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## How to test this PR locally

* Install the agent with osquery manager added to the policy, issue ```select * from windows_firewall_rules``` live query, observe result from this new table.

## Related issues

- Relates https://github.com/elastic/security-team/issues/3302


## Screenshots
<img width="1250" alt="Screen Shot 2022-03-16 at 2 27 27 PM" src="https://user-images.githubusercontent.com/872351/158663336-b32a7e0e-1977-4516-a8ff-e6d0eeb3dacc.png">


<img width="1125" alt="Screen Shot 2022-03-16 at 2 28 34 PM" src="https://user-images.githubusercontent.com/872351/158663304-9d89f459-3f3c-4f31-8c6a-5f55b9f4b3ff.png">

