### PR TITLE
packetbeat/sniffer: update error check to match github.com/google/gopacket/afpacket API

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -77,7 +77,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 *Packetbeat*
 
 - Prevent panic when querying Npcap version on Windows. {issue}30820[30820] {pull}30821[30821] {pull}30837[30837]
-- packetbeat/sniffer: update error check to match github.com/google/gopacket/afpacket. {issue}30731[30731] {issue}30822[30822] {pull}[30882]
+- packetbeat: Fix timeout error in af_packet capture mode. {issue}30731[30731] {issue}30822[30822] {pull}30882[30882]
 
 *Winlogbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -77,6 +77,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 *Packetbeat*
 
 - Prevent panic when querying Npcap version on Windows. {issue}30820[30820] {pull}30821[30821] {pull}30837[30837]
+- packetbeat/sniffer: update error check to match github.com/google/gopacket/afpacket. {issue}30731[30731] {issue}30822[30822] {pull}[30882]
 
 *Winlogbeat*
 

--- a/packetbeat/sniffer/afpacket_linux.go
+++ b/packetbeat/sniffer/afpacket_linux.go
@@ -162,3 +162,8 @@ func setPromiscMode(device string, enabled bool) error {
 	// TODO: replace with x/net/bpf or pcap
 	return syscall.SetLsfPromisc(device, enabled)
 }
+
+// isAfpacketErrTimeout returns whether err is afpacket.ErrTimeout.
+func isAfpacketErrTimeout(err error) bool {
+	return err == afpacket.ErrTimeout
+}

--- a/packetbeat/sniffer/afpacket_nonlinux.go
+++ b/packetbeat/sniffer/afpacket_nonlinux.go
@@ -50,3 +50,9 @@ func (h *afpacketHandle) LinkType() layers.LinkType {
 
 func (h *afpacketHandle) Close() {
 }
+
+// isAfpacketErrTimeout returns whether the error is afpacket.ErrTimeout, always false on
+// non-linux systems.
+func isAfpacketErrTimeout(error) bool {
+	return false
+}

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"runtime"
-	"syscall"
 	"time"
 
 	"github.com/google/gopacket"
@@ -179,8 +178,8 @@ func (s *Sniffer) Run() error {
 		}
 
 		data, ci, err := handle.ReadPacketData()
-		if err == pcap.NextErrorTimeoutExpired || err == syscall.EINTR {
-			logp.Debug("sniffer", "Interrupted")
+		if err == pcap.NextErrorTimeoutExpired || isAfpacketErrTimeout(err) {
+			logp.Debug("sniffer", "timedout")
 			continue
 		}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
Previously we were using github.com/tsg/gopacket, an older fork of github.com/google/gopacket
with additions that were necessary to support functionality that we needed. In 274ccac we
changed over to a more recent fork of github.com/google/gopacket porting forward some of the
changes that we had made to a collection of forks. A significant difference between the tsg
fork and the google package, not found until now was in how poll calls are handled in the
afpacket package; in the tsg fork, a zero poll event count was returned as EINTR

	func (h *TPacket) pollForFirstPacket(hdr header) error {
		for hdr.getStatus()&C.TP_STATUS_USER == 0 {
			h.pollset.fd = h.fd
			h.pollset.events = C.POLLIN
			h.pollset.revents = 0
			timeout := C.int(h.opts.timeout / time.Millisecond)
			n, err := C.poll(&h.pollset, 1, timeout)
			if n == 0 {
				/* propagate timeout when no packets are available
				   otherwise it will loop forever until a packet
				  is received. */
				return syscall.EINTR
			}
			h.stats.Polls++
			if err != nil {
				return err
			}
		}

		h.shouldReleasePacket = true
		return nil
	}

while in the google package an afpacket error, ErrTimeout is returned in the
same context.

	func (h *TPacket) pollForFirstPacket(hdr header) error {
		tm := int(h.opts.pollTimeout / time.Millisecond)
		for hdr.getStatus()&unix.TP_STATUS_USER == 0 {
			pollset := [1]unix.PollFd{
				{
					Fd:     int32(h.fd),
					Events: unix.POLLIN,
				},
			}
			n, err := unix.Poll(pollset[:], tm)
			if n == 0 {
				return ErrTimeout
			}

			atomic.AddInt64(&h.stats.Polls, 1)
			if pollset[0].Revents&unix.POLLERR > 0 {
				return ErrPoll
			}
			if err == syscall.EINTR {
				continue
			}
			if err != nil {
				return err
			}
		}

		h.shouldReleasePacket = true
		return nil
	}

This change brings the calling code into agreement with the afpacket package and
updates the logging message.
 
## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Without this change the af_packet capture mode is not functional.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This can be tested locally on a linux host using the following config by running `packetbeat -e -d flows,sniffer` as root.
```
output:
  console:
    enabled: true
    pretty: true
packetbeat:
  flows:
    period: 10s
    timeout: 30s
  interfaces:
    device: any
    internal_networks:
    - private
    type: af_packet
  protocols:
  - enabled: false
    type: icmp
  - ports:
    - 80
    - 8082
    - 8000
    - 5000
    - 8002
    type: http
path:
  config: ./packetbeat8
  data: ./packetbeat8/data
  home: ./packetbeat8
  logs: ./packetbeat8/logs
processors:
- else:
  - add_host_metadata: null
  if:
    contains:
      tags: forwarded
  then:
  - drop_fields:
      fields:
      - host
- add_cloud_metadata: null
- add_docker_metadata: null
- detect_mime_type:
    field: http.request.body.content
    target: http.request.mime_type
- detect_mime_type:
    field: http.response.body.content
    target: http.response.mime_type
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #30731.
- Closes #30822.

Also see https://discuss.elastic.co/t/packetbeat8-0-af-packet-report-errors/298180.

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
