### PR TITLE
metricbeat/module/system/memory: fix dropped error

### DIFF
--- a/metricbeat/module/system/memory/memory.go
+++ b/metricbeat/module/system/memory/memory.go
@@ -60,7 +60,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 	memory := common.MapStr{}
 	err = typeconv.Convert(&memory, &eventRaw)
-
+	if err != nil {
+		return err
+	}
 	r.Event(mb.Event{
 		MetricSetFields: memory,
 	})


### PR DESCRIPTION
- Bug
 
This fixes a dropped `err` variable in `metricbeat/module/system/memory`.