### PR TITLE
Improve k8s dashboard

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -138,6 +138,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add `commandstats` field to Redis module {pull}29662[29662]
 - Extend documentation about `kubernetes.node.network.*` fields {pull}30826[30826]
 - Add `kubernetes.volume.fs.inodes.pct` field. {pull}30785[30785]
+- Improve Kubernetes dashboard. {pull}30913[30913]
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/e0381d10-e4a6-11eb-9d53-3b3d1d47c519.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/e0381d10-e4a6-11eb-9d53-3b3d1d47c519.json
@@ -32,7 +32,7 @@
                 "panelIndex": "1",
                 "panelRefName": "panel_1",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -48,7 +48,7 @@
                 "panelIndex": "2",
                 "panelRefName": "panel_2",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -64,7 +64,7 @@
                 "panelIndex": "5",
                 "panelRefName": "panel_5",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -80,7 +80,7 @@
                 "panelIndex": "6",
                 "panelRefName": "panel_6",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -96,7 +96,7 @@
                 "panelIndex": "7",
                 "panelRefName": "panel_7",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -112,7 +112,7 @@
                 "panelIndex": "8",
                 "panelRefName": "panel_8",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -128,7 +128,7 @@
                 "panelIndex": "9",
                 "panelRefName": "panel_9",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -144,7 +144,7 @@
                 "panelIndex": "10",
                 "panelRefName": "panel_10",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -160,7 +160,7 @@
                 "panelIndex": "11",
                 "panelRefName": "panel_11",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -176,7 +176,7 @@
                 "panelIndex": "12",
                 "panelRefName": "panel_12",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -192,7 +192,7 @@
                 "panelIndex": "13",
                 "panelRefName": "panel_13",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -208,7 +208,7 @@
                 "panelIndex": "14",
                 "panelRefName": "panel_14",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -224,7 +224,7 @@
                 "panelIndex": "15",
                 "panelRefName": "panel_15",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             },
             {
                 "embeddableConfig": {
@@ -240,17 +240,17 @@
                 "panelIndex": "43e2c937-a06e-4f6c-9e01-e2669110f160",
                 "panelRefName": "panel_43e2c937-a06e-4f6c-9e01-e2669110f160",
                 "type": "visualization",
-                "version": "7.11.0"
+                "version": "8.2.0-SNAPSHOT"
             }
         ],
         "timeRestore": false,
         "title": "[Metricbeat Kubernetes] Overview ECS",
         "version": 1
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "e0381d10-e4a6-11eb-9d53-3b3d1d47c519",
     "migrationVersion": {
-        "dashboard": "7.14.0"
+        "dashboard": "8.2.0"
     },
     "references": [
         {
@@ -325,6 +325,6 @@
         }
     ],
     "type": "dashboard",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTIsMV0="
+    "updated_at": "2022-03-21T09:56:20.439Z",
+    "version": "WzI5MTEsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/e0381d10-e4a6-11eb-9d53-3b3d1d47c519.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/e0381d10-e4a6-11eb-9d53-3b3d1d47c519.json
@@ -32,7 +32,7 @@
                 "panelIndex": "1",
                 "panelRefName": "panel_1",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -48,7 +48,7 @@
                 "panelIndex": "2",
                 "panelRefName": "panel_2",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -64,7 +64,7 @@
                 "panelIndex": "5",
                 "panelRefName": "panel_5",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -80,7 +80,7 @@
                 "panelIndex": "6",
                 "panelRefName": "panel_6",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -96,7 +96,7 @@
                 "panelIndex": "7",
                 "panelRefName": "panel_7",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -112,7 +112,7 @@
                 "panelIndex": "8",
                 "panelRefName": "panel_8",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -128,7 +128,7 @@
                 "panelIndex": "9",
                 "panelRefName": "panel_9",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -144,7 +144,7 @@
                 "panelIndex": "10",
                 "panelRefName": "panel_10",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -160,7 +160,7 @@
                 "panelIndex": "11",
                 "panelRefName": "panel_11",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -176,7 +176,7 @@
                 "panelIndex": "12",
                 "panelRefName": "panel_12",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -192,7 +192,7 @@
                 "panelIndex": "13",
                 "panelRefName": "panel_13",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -208,7 +208,7 @@
                 "panelIndex": "14",
                 "panelRefName": "panel_14",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -224,7 +224,7 @@
                 "panelIndex": "15",
                 "panelRefName": "panel_15",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             },
             {
                 "embeddableConfig": {
@@ -240,7 +240,7 @@
                 "panelIndex": "43e2c937-a06e-4f6c-9e01-e2669110f160",
                 "panelRefName": "panel_43e2c937-a06e-4f6c-9e01-e2669110f160",
                 "type": "visualization",
-                "version": "8.2.0-SNAPSHOT"
+                "version": "8.2.0"
             }
         ],
         "timeRestore": false,

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/022a54c0-2bf5-11e7-859b-f78b612cde28-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/022a54c0-2bf5-11e7-859b-f78b612cde28-ecs.json
@@ -12,6 +12,7 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:state_deployment"
@@ -61,13 +62,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "022a54c0-2bf5-11e7-859b-f78b612cde28-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTMsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MDUsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/16fa4470-2bfd-11e7-859b-f78b612cde28-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/16fa4470-2bfd-11e7-859b-f78b612cde28-ecs.json
@@ -23,6 +23,7 @@
                         "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:pod"
@@ -86,13 +87,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "16fa4470-2bfd-11e7-859b-f78b612cde28-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTgsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MDksMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/174a6ad0-30e0-11e7-8df8-6d3604a72912-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/174a6ad0-30e0-11e7-8df8-6d3604a72912-ecs.json
@@ -2,17 +2,23 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Unavailable pods [Metricbeat Kubernetes] ECS",
         "uiStateJSON": {},
         "version": 1,
         "visState": {
             "aggs": [],
-            "listeners": {},
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "background_color_rules": [
                     {
                         "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
@@ -23,6 +29,7 @@
                         "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:state_deployment"
@@ -40,33 +47,53 @@
                 "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
                 "index_pattern": "metricbeat-*",
                 "interval": "auto",
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
                         "chart_type": "line",
                         "color": "#68BC00",
                         "fill": 0.5,
-                        "formatter": "number",
+                        "formatter": "",
                         "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912",
                         "label": "Unavailable Pods",
                         "line_width": 1,
                         "metrics": [
                             {
+                                "agg_with": "avg",
                                 "field": "kubernetes.deployment.replicas.unavailable",
                                 "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912",
-                                "type": "sum"
+                                "order": "desc",
+                                "order_by": "@timestamp",
+                                "size": 1,
+                                "type": "top_hit"
+                            },
+                            {
+                                "function": "sum",
+                                "id": "5cffb9f0-a6b4-11ec-ad4d-1dee3ca0438a",
+                                "type": "series_agg"
                             }
                         ],
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",
                         "split_color_mode": "gradient",
-                        "split_mode": "everything",
-                        "stacked": "none"
+                        "split_mode": "terms",
+                        "stacked": "none",
+                        "terms_field": [
+                            "kubernetes.deployment.name",
+                            "kubernetes.namespace"
+                        ],
+                        "terms_size": "10001",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
+                "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
+                "time_range_mode": "last_value",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "metric",
                 "use_kibana_indexes": false
             },
@@ -74,13 +101,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "174a6ad0-30e0-11e7-8df8-6d3604a72912-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMjMsMV0="
+    "updated_at": "2022-03-18T12:10:56.522Z",
+    "version": "WzI3ODksMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/294546b0-30d6-11e7-8df8-6d3604a72912-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/294546b0-30d6-11e7-8df8-6d3604a72912-ecs.json
@@ -23,6 +23,7 @@
                         "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:pod"
@@ -86,13 +87,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "294546b0-30d6-11e7-8df8-6d3604a72912-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTksMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MTAsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/408fccf0-30d6-11e7-8df8-6d3604a72912-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/408fccf0-30d6-11e7-8df8-6d3604a72912-ecs.json
@@ -23,6 +23,7 @@
                         "id": "68cdba10-30e0-11e7-8df8-6d3604a72912"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:state_node"
@@ -73,13 +74,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "408fccf0-30d6-11e7-8df8-6d3604a72912-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMjAsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MTEsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/44f12b40-2bf4-11e7-859b-f78b612cde28-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/44f12b40-2bf4-11e7-859b-f78b612cde28-ecs.json
@@ -23,6 +23,7 @@
                         "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)"
@@ -141,13 +142,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "44f12b40-2bf4-11e7-859b-f78b612cde28-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTQsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MDYsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/58e644f0-30d6-11e7-8df8-6d3604a72912-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/58e644f0-30d6-11e7-8df8-6d3604a72912-ecs.json
@@ -18,6 +18,7 @@
                         "id": "802104d0-2bfc-11e7-859b-f78b612cde28"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:container"
@@ -75,13 +76,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "58e644f0-30d6-11e7-8df8-6d3604a72912-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMjEsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MTIsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/7aac4fd0-30e0-11e7-8df8-6d3604a72912-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/7aac4fd0-30e0-11e7-8df8-6d3604a72912-ecs.json
@@ -12,6 +12,7 @@
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:state_deployment"
@@ -61,13 +62,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "7aac4fd0-30e0-11e7-8df8-6d3604a72912-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMjQsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MTQsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/a4c9d360-30df-11e7-8df8-6d3604a72912-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/a4c9d360-30df-11e7-8df8-6d3604a72912-ecs.json
@@ -17,6 +17,7 @@
                         "id": "802104d0-2bfc-11e7-859b-f78b612cde28"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:container"
@@ -75,13 +76,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "a4c9d360-30df-11e7-8df8-6d3604a72912-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMjIsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MTMsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/cd059410-2bfb-11e7-859b-f78b612cde28-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/cd059410-2bfb-11e7-859b-f78b612cde28-ecs.json
@@ -23,6 +23,7 @@
                         "id": "68cdba10-30e0-11e7-8df8-6d3604a72912"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:state_deployment"
@@ -73,13 +74,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "cd059410-2bfb-11e7-859b-f78b612cde28-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTUsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MDcsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/d54c65f0-e4a6-11eb-9d53-3b3d1d47c519.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/d54c65f0-e4a6-11eb-9d53-3b3d1d47c519.json
@@ -41,10 +41,10 @@
             "type": "input_control_vis"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "d54c65f0-e4a6-11eb-9d53-3b3d1d47c519",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [
         {
@@ -54,6 +54,6 @@
         }
     ],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMjYsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MTUsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/d6564360-2bfc-11e7-859b-f78b612cde28-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/d6564360-2bfc-11e7-859b-f78b612cde28-ecs.json
@@ -22,6 +22,7 @@
                         "id": "1373ddd0-2bf2-11e7-859b-f78b612cde28"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND (metricset.name:container OR metricset.name:state_node)"
@@ -121,13 +122,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "d6564360-2bfc-11e7-859b-f78b612cde28-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTcsMV0="
+    "updated_at": "2022-03-18T11:52:30.304Z",
+    "version": "WzI3MDgsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3-ecs.json
@@ -2,17 +2,23 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Available pods [Metricbeat Kubernetes] ECS",
         "uiStateJSON": {},
         "version": 1,
         "visState": {
             "aggs": [],
-            "listeners": {},
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "background_color_rules": [
                     {
                         "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
@@ -23,6 +29,7 @@
                         "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:state_deployment"
@@ -40,33 +47,54 @@
                 "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
                 "index_pattern": "metricbeat-*",
                 "interval": "auto",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
                         "chart_type": "line",
                         "color": "#68BC00",
                         "fill": 0.5,
-                        "formatter": "number",
+                        "formatter": "",
                         "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912",
                         "label": "Available Pods",
                         "line_width": 1,
                         "metrics": [
                             {
+                                "agg_with": "avg",
                                 "field": "kubernetes.deployment.replicas.available",
                                 "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912",
-                                "type": "sum"
+                                "order": "desc",
+                                "order_by": "@timestamp",
+                                "size": 1,
+                                "type": "top_hit"
+                            },
+                            {
+                                "function": "sum",
+                                "id": "ca293350-a6b2-11ec-806f-0d8163a9ab5c",
+                                "type": "series_agg"
                             }
                         ],
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",
                         "split_color_mode": "gradient",
-                        "split_mode": "everything",
-                        "stacked": "none"
+                        "split_mode": "terms",
+                        "stacked": "none",
+                        "terms_field": [
+                            "kubernetes.deployment.name",
+                            "kubernetes.namespace"
+                        ],
+                        "terms_size": "10000",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
+                "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "metric",
                 "use_kibana_indexes": false
             },
@@ -74,13 +102,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "da1ff7c0-30ed-11e7-b9e5-2b5b07213ab3-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMjUsMV0="
+    "updated_at": "2022-03-18T12:11:07.122Z",
+    "version": "WzI3OTAsMl0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/visualization/e1018b90-2bfb-11e7-859b-f78b612cde28-ecs.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/visualization/e1018b90-2bfb-11e7-859b-f78b612cde28-ecs.json
@@ -2,17 +2,23 @@
     "attributes": {
         "description": "",
         "kibanaSavedObjectMeta": {
-            "searchSourceJSON": {}
+            "searchSourceJSON": {
+                "filter": [],
+                "query": {
+                    "language": "kuery",
+                    "query": ""
+                }
+            }
         },
         "title": "Desired pods [Metricbeat Kubernetes] ECS",
         "uiStateJSON": {},
         "version": 1,
         "visState": {
             "aggs": [],
-            "listeners": {},
             "params": {
                 "axis_formatter": "number",
                 "axis_position": "left",
+                "axis_scale": "normal",
                 "background_color_rules": [
                     {
                         "id": "508ffb30-30d5-11e7-8df8-6d3604a72912"
@@ -23,6 +29,7 @@
                         "id": "674d83b0-30d5-11e7-8df8-6d3604a72912"
                     }
                 ],
+                "drop_last_bucket": 1,
                 "filter": {
                     "language": "lucene",
                     "query": "event.module:kubernetes AND metricset.name:state_deployment"
@@ -40,33 +47,54 @@
                 "id": "2fe9d3b0-30d5-11e7-8df8-6d3604a72912",
                 "index_pattern": "metricbeat-*",
                 "interval": "auto",
+                "isModelInvalid": false,
+                "max_lines_legend": 1,
                 "series": [
                     {
                         "axis_position": "right",
                         "chart_type": "line",
                         "color": "#68BC00",
                         "fill": 0.5,
-                        "formatter": "number",
+                        "formatter": "",
                         "id": "2fe9d3b1-30d5-11e7-8df8-6d3604a72912",
                         "label": "Desired Pods",
                         "line_width": 1,
                         "metrics": [
                             {
+                                "agg_with": "avg",
                                 "field": "kubernetes.deployment.replicas.desired",
                                 "id": "54cf79a0-30d5-11e7-8df8-6d3604a72912",
-                                "type": "sum"
+                                "order": "desc",
+                                "order_by": "@timestamp",
+                                "size": 1,
+                                "type": "top_hit"
+                            },
+                            {
+                                "function": "sum",
+                                "id": "fcfb7ee0-a6b3-11ec-b4d0-9b3b6517e9b9",
+                                "type": "series_agg"
                             }
                         ],
                         "point_size": 1,
                         "seperate_axis": 0,
                         "series_interval": "10s",
                         "split_color_mode": "gradient",
-                        "split_mode": "everything",
-                        "stacked": "none"
+                        "split_mode": "terms",
+                        "stacked": "none",
+                        "terms_field": [
+                            "kubernetes.deployment.name",
+                            "kubernetes.namespace"
+                        ],
+                        "terms_size": "10000",
+                        "time_range_mode": "entire_time_range"
                     }
                 ],
+                "show_grid": 1,
                 "show_legend": 1,
                 "time_field": "@timestamp",
+                "time_range_mode": "entire_time_range",
+                "tooltip_mode": "show_all",
+                "truncate_legend": 1,
                 "type": "metric",
                 "use_kibana_indexes": false
             },
@@ -74,13 +102,13 @@
             "type": "metrics"
         }
     },
-    "coreMigrationVersion": "8.0.0",
+    "coreMigrationVersion": "8.2.0",
     "id": "e1018b90-2bfb-11e7-859b-f78b612cde28-ecs",
     "migrationVersion": {
-        "visualization": "7.14.0"
+        "visualization": "8.1.0"
     },
     "references": [],
     "type": "visualization",
-    "updated_at": "2021-08-04T16:31:37.319Z",
-    "version": "WzQwMTYsMV0="
+    "updated_at": "2022-03-18T12:12:36.940Z",
+    "version": "WzI3OTQsMl0="
 }


### PR DESCRIPTION
## What does this PR do?
This PR leverages https://github.com/elastic/kibana/pull/126015 in order to solve https://github.com/elastic/integrations/issues/2159


## Why is it important?
At the moment the k8s Dashboard can be showing inconsistent values in the views for the "Desired", "Available" and "Unavailable" Pods. The reason is described at https://github.com/elastic/integrations/issues/2159. With this chance we aim to improve the situation so as the views to be showing correct values by using the proper aggregations.

## Related issues

- Relates https://github.com/elastic/integrations/issues/2159

## Screenshots

Changing the time range of the dashboard was giving inconsistent values in the views. Below find attached the consistent views with different time ranges:
<img width="1674" alt="Screenshot 2022-03-18 at 12 13 17 PM" src="https://user-images.githubusercontent.com/11754898/159004823-0ef25fb0-fc76-4ed7-aad3-c1b868ac0592.png">
<img width="1674" alt="Screenshot 2022-03-18 at 12 13 13 PM" src="https://user-images.githubusercontent.com/11754898/159004842-8943098e-0fc1-40e8-a3fd-b08be0d55bdd.png">
<img width="1674" alt="Screenshot 2022-03-18 at 12 13 07 PM" src="https://user-images.githubusercontent.com/11754898/159004850-a90427b0-fb8d-47c0-969e-5694adc8e9e8.png">

<img width="1660" alt="Screenshot 2022-03-18 at 12 09 41 PM" src="https://user-images.githubusercontent.com/11754898/159008693-83d95f59-22c9-4030-b5d5-fef65fa35d6f.png">


