### PR TITLE
Update repositories.asciidoc

### DIFF
--- a/libbeat/docs/repositories.asciidoc
+++ b/libbeat/docs/repositories.asciidoc
@@ -122,6 +122,7 @@ sudo apt-get update && sudo apt-get install {beatname_pkg}
 --------------------------------------------------
 sudo systemctl enable {beatname_pkg}
 --------------------------------------------------
+ifndef::apm-server[]
 +
 If your system does not use `systemd` then run:
 +
@@ -129,6 +130,7 @@ If your system does not use `systemd` then run:
 --------------------------------------------------
 sudo update-rc.d {beatname_pkg} defaults 95 10
 --------------------------------------------------
+endif::[]
 
 endif::[]
 
@@ -224,6 +226,7 @@ sudo yum install {beatname_pkg}
 --------------------------------------------------
 sudo systemctl enable {beatname_pkg}
 --------------------------------------------------
+ifndef::apm-server[]
 +
 If your system does not use `systemd` then run:
 +
@@ -231,5 +234,6 @@ If your system does not use `systemd` then run:
 --------------------------------------------------
 sudo chkconfig --add {beatname_pkg}
 --------------------------------------------------
+endif::[]
 
 endif::[]


### PR DESCRIPTION
### Summary

> As of 8.1, all Linux distros supported by APM Server support systemd.

This PR persists the documentation change made in https://github.com/elastic/apm-server/pull/7576 to the Beats repository.

Closes https://github.com/elastic/apm-server/issues/7577.