### PR TITLE
Fix export dashboards scripts

### DIFF
--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -134,6 +134,6 @@ func exportSingleDashboard(client *kibana.Client, dashboard, folder string) erro
 	if err != nil {
 		return fmt.Errorf("failed to export the dashboard: %+v", err)
 	}
-
+	result = dashboards.DecodeExported(result)
 	return dashboards.SaveToFolder(result, folder, client.GetVersion())
 }

--- a/dev-tools/cmd/dashboards/export_dashboards.go
+++ b/dev-tools/cmd/dashboards/export_dashboards.go
@@ -62,12 +62,12 @@ func main() {
 	}
 
 	var user, pass string
+	user = "beats"
+	pass = "testing"
 	if u.User != nil {
 		user = u.User.Username()
 		pass, _ = u.User.Password()
 	}
-	user = "beats"
-	pass = "testing"
 	transport := httpcommon.DefaultHTTPTransportSettings()
 	transport.Timeout = kibanaTimeout
 

--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -182,6 +182,15 @@ func CollectDocs() error {
 	return metricbeat.CollectDocs()
 }
 
+// ExportDashboard exports a dashboard and writes it into the correct directory.
+//
+// Required environment variables:
+// - MODULE: Name of the module
+// - ID:     Dashboard id
+func ExportDashboard() error {
+	return devtools.ExportDashboard()
+}
+
 // IntegTest executes integration tests (it uses Docker to run the tests).
 func IntegTest() {
 	mg.SerialDeps(GoIntegTest, PythonIntegTest)


### PR DESCRIPTION
## What does this PR do?
This PR adds `ExportDashboard` target in magefile of Metricbeat and fixes username+password defaults order in `dev-tools/cmd/dashboards/export_dashboards.go`

## Why is it important?
So as to make it possible to export Metricbeat dashboards with a command like `KIBANA_URL=http://elastic:changeme@0.0.0.0:5601 MODULE=kubernetes ID=e0381d10-e4a6-11eb-9d53-3b3d1d47c519 mage ExportDashboard`

Related to https://github.com/elastic/beats/pull/30913