### PR TITLE
Osquerybeat: Add darwin/arm64 packaging support

### DIFF
--- a/x-pack/osquerybeat/dev-tools/packaging/packages.yml
+++ b/x-pack/osquerybeat/dev-tools/packaging/packages.yml
@@ -91,6 +91,14 @@ specs:
             source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}
 
     - os: darwin
+      arch: amd64
+      types: [tgz]
+      spec:
+        <<: *unix_binary_spec
+        <<: *elastic_license_for_binaries
+
+    - os: darwin
+      arch: arm64
       types: [tgz]
       spec:
         <<: *unix_binary_spec

--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -138,6 +138,7 @@ var specs = map[OSArch]Spec{
 	{"linux", "amd64"}:   {"_1.linux_x86_64.tar.gz", osqueryDistroLinuxSHA256, true},
 	{"linux", "arm64"}:   {"_1.linux_aarch64.tar.gz", osqueryDistroLinuxARMSHA256, true},
 	{"darwin", "amd64"}:  {osqueryPkgExt, osqueryDistroDarwinSHA256, false},
+	{"darwin", "arm64"}:  {osqueryPkgExt, osqueryDistroDarwinSHA256, false},
 	{"windows", "amd64"}: {osqueryMSIExt, osqueryDistroWindowsSHA256, false},
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds support for osquerybeat darwin/arm64 packaging

## Why is it important?

Fixes the issue with Apple M1 build https://github.com/elastic/elastic-agent/pull/203

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas


## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/203


