### PR TITLE
Bugs metricbeat jolokia debug print uri

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add back missing metrics to system/linux. {pull}30774[30774]
 - GCP metrics query instances with aggregatedList API to improve efficiency. {pull}30154[#30153]
 - Fix delay in perfmon counters collection {issue}30686[30686] {pull}30861[#30861]
+- Fix Jolokia module to print URI for one of the debug logs. {pull}TBD[TBD]
 
 *Packetbeat*
 

--- a/metricbeat/module/jolokia/jmx/config.go
+++ b/metricbeat/module/jolokia/jmx/config.go
@@ -482,7 +482,7 @@ func (pc *JolokiaHTTPPostFetcher) Fetch(m *MetricSet) ([]common.MapStr, error) {
 	if logp.IsDebug(metricsetName) {
 		for _, r := range httpReqs {
 			m.log.Debugw("Jolokia request URI and body",
-				"httpMethod", r.HTTPMethod, "URI", r.URI, "body", string(r.Body), "type", "request")
+				"httpMethod", r.HTTPMethod, "URI", m.BaseMetricSet.HostData().SanitizedURI+r.URI, "body", string(r.Body), "type", "request")
 		}
 	}
 


### PR DESCRIPTION


## What does this PR do?

One of the debug logs was not printing the URI for POST call.
Fix the code to print Sanitized URI, same used for GET calls.


## Why is it important?

Fixes issue filed #28591

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist



## How to test this PR locally



## Related issues

Closes #28591
- 

## Use cases



## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs
Log after fix:
{"log.level":"debug","@timestamp":"2022-03-22T12:14:08.343+0530","log.logger":"jolokia.jmx","log.origin":{"file.name":"jmx/config.go","file.line":484},"message":"Jolokia request URI and body","service.name":"metricbeat","host":"localhost:8779","httpMethod":"POST","URI":"http://localhost:8779/jolokia/%3FignoreErrors=true&canonicalNaming=false","body":"[{\"type\":\"read\",\"mbean\":\"java.lang:type=Memory\",\"attribute\":[\"HeapMemoryUsage\",\"NonHeapMemoryUsage\"],\"config\":{\"canonicalNaming\":true,\"ignoreErrors\":true}}]","type":"request","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-03-22T12:14:08.343+0530","log.origin":{"file.name":"cfgfile/reload.go","file.line":224},"message":"Loading of config files completed.","service.name":"metricbeat","ecs.version":"1.6.0"}
