### PR TITLE
[DOC] Highlight limitation of File Integrity Module

### DIFF
--- a/auditbeat/docs/modules/file_integrity.asciidoc
+++ b/auditbeat/docs/modules/file_integrity.asciidoc
@@ -40,6 +40,9 @@ actually happened.
 The file integrity module should not be used to monitor paths on network file
 systems.
 
+NOTE: On Linux, this module only monitors traditional UNIX permissions. It doesn't
+report changes to a file's extended ACL permissions.
+
 [float]
 === Configuration options
 


### PR DESCRIPTION
## What does this PR do?

File integrity module can only monitor traditional UNIX permissions.
Changes done via `setfacl` for example are only reported if they affect also traditional UNIX permissions.

## Why is it important?

Set expectations for users
