### PR TITLE
Update Jinja2 version used in tests to 2.11.3.

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -16,7 +16,7 @@ idna==2.6
 importlib-metadata==1.7.0
 iniconfig==1.0.1
 ipaddress==1.0.19
-Jinja2==2.11.2
+Jinja2==2.11.3
 jsondiff==1.1.2
 jsonschema==3.2.0
 kafka-python==1.4.3


### PR DESCRIPTION
Update to the latest 2.11.x release. Matches what is used on AIX.