### PR TITLE
metricbeat/module/linux/memory: fix dropped error

### DIFF
--- a/metricbeat/module/linux/memory/data.go
+++ b/metricbeat/module/linux/memory/data.go
@@ -74,6 +74,9 @@ func FetchLinuxMemStats(baseMap common.MapStr, hostfs resolve.Resolver) error {
 	}
 	swap := common.MapStr{}
 	err = typeconv.Convert(&swap, &eventRaw.Swap)
+	if err != nil {
+		return errors.Wrap(err, "error converting raw event")
+	}
 
 	baseMap["swap"] = swap
 


### PR DESCRIPTION
This fixes a dropped `err` variable in `metricbeat/module/linux/memory`.