### PR TITLE
Disable failing k8s scheduler test.

### DIFF
--- a/metricbeat/module/kubernetes/scheduler/scheduler_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_test.go
@@ -30,6 +30,7 @@ import (
 const testFile = "_meta/test/metrics"
 
 func TestEventMapping(t *testing.T) {
+	t.Skip("Failing/flaky test: https://github.com/elastic/beats/issues/30973")
 	ptest.TestMetricSet(t, "kubernetes", "scheduler",
 		ptest.TestCases{
 			{


### PR DESCRIPTION
Disable a failing test in 7.17 that has been failing for several days.

Documented at https://github.com/elastic/beats/issues/30973

