### PR TITLE
Disable the failing k8s scheduler integration test.

### DIFF
--- a/metricbeat/module/kubernetes/scheduler/scheduler_integration_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_integration_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
+	t.Skip("Failing/flaky test: https://github.com/elastic/beats/issues/30973")
 	config := test.GetSchedulerConfig(t, "scheduler")
 	metricSet := mbtest.NewFetcher(t, config)
 	events, errs := metricSet.FetchEvents()

--- a/metricbeat/module/kubernetes/scheduler/scheduler_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_test.go
@@ -30,7 +30,6 @@ import (
 const testFile = "_meta/test/metrics"
 
 func TestEventMapping(t *testing.T) {
-	t.Skip("Failing/flaky test: https://github.com/elastic/beats/issues/30973")
 	ptest.TestMetricSet(t, "kubernetes", "scheduler",
 		ptest.TestCases{
 			{


### PR DESCRIPTION
https://github.com/elastic/beats/issues/30973

https://github.com/elastic/beats/pull/30990 skipped the wrong test in the affected package.

