### PR TITLE
Add workaround to cgroups self-monitoring error messages in 7.17 releases

### DIFF
--- a/libbeat/cmd/instance/metrics/metrics.go
+++ b/libbeat/cmd/instance/metrics/metrics.go
@@ -280,11 +280,7 @@ func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
 	V.OnRegistryStart()
 	defer V.OnRegistryFinished()
 
-	pid, err := process.GetSelfPid()
-	if err != nil {
-		logp.Err("error getting PID for self process: %v", err)
-		return
-	}
+	pid := os.Getpid()
 
 	cgroups, err := cgroup.NewReaderOptions(cgroup.ReaderOptions{
 		IgnoreRootCgroups:        true,
@@ -301,7 +297,7 @@ func reportBeatCgroups(_ monitoring.Mode, V monitoring.Visitor) {
 
 	cgv, err := cgroups.CgroupsVersion(pid)
 	if err != nil {
-		logp.Err("error determining cgroups version: %v", err)
+		logp.L().Debugf("error determining cgroups version: %v", err)
 		return
 	}
 


### PR DESCRIPTION
## What does this PR do?

This is a continuation of https://github.com/elastic/beats/pull/30228

Although as @jlind23 mentioned, we initially didn't want to backport this as we don't have much testing in this area, however it's still filling up log files for people, so this is a conservative "backport" that just gives us the change that should eliminate the error when running under certain container schemes.

## Why is it important?

This fixes a source of log spam for user running certain container setups.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

