### PR TITLE
[libbeat][aws] Fix AWS config initialization issue when using a role

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Fix dissect trim panics from DELETE (127)(\u007f) character {issue}30657[30657] {pull}30658[30658]
 - Add ecs container fields {pull}31020[31020]
 - Fix docs reference for syslog processor {pull}31087[31087]
+- Fix AWS config initialization issue when using a role {issue}30999[30999] {pull}31014[31014]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -6,6 +6,7 @@ package aws
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/external"
 	"github.com/aws/aws-sdk-go-v2/aws/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
@@ -98,7 +98,6 @@ func GetAWSCredentials(config ConfigAWS) (awssdk.Config, error) {
 }
 
 func getAccessKeys(config ConfigAWS) awssdk.Config {
-	//logger := logp.NewLogger("getAccessKeys")
 	awsConfig := defaults.Config()
 	awsCredentials := awssdk.Credentials{
 		AccessKeyID:     config.AccessKeyID,
@@ -137,7 +136,7 @@ func getSharedCredentialProfile(config ConfigAWS) (awssdk.Config, error) {
 
 	awsConfig, err := external.LoadDefaultAWSConfig(options...)
 	if err != nil {
-		return awsConfig, errors.Wrap(err, "external.LoadDefaultAWSConfig failed with shared credential profile given")
+		return awsConfig, fmt.Errorf("external.LoadDefaultAWSConfig failed with shared credential profile given: %w", err)
 	}
 
 	logger.Debug("Using shared credential profile for AWS credential")

--- a/x-pack/libbeat/common/aws/credentials.go
+++ b/x-pack/libbeat/common/aws/credentials.go
@@ -45,7 +45,6 @@ type ConfigAWS struct {
 
 // InitializeAWSConfig function creates the awssdk.Config object from the provided config
 func InitializeAWSConfig(config ConfigAWS) (awssdk.Config, error) {
-	logger := logp.NewLogger("InitializeAWSConfig")
 	AWSConfig, _ := GetAWSCredentials(config)
 	if AWSConfig.Region == "" {
 		if config.DefaultRegion != "" {
@@ -57,7 +56,6 @@ func InitializeAWSConfig(config ConfigAWS) (awssdk.Config, error) {
 
 	// Assume IAM role if iam_role config parameter is given
 	if config.RoleArn != "" {
-		logger.Debug("Switching credentials provider to AssumeRoleProvider")
 		AWSConfig = switchToAssumeRoleProvider(config, AWSConfig)
 	}
 
@@ -145,6 +143,8 @@ func getSharedCredentialProfile(config ConfigAWS) (awssdk.Config, error) {
 
 // switchToAssumeRoleProvider switches the credentials provider in the awsConfig to the `AssumeRoleProvider`.
 func switchToAssumeRoleProvider(config ConfigAWS, awsConfig awssdk.Config) awssdk.Config {
+	logger := logp.NewLogger("switchToAssumeRoleProvider")
+	logger.Debug("Switching credentials provider to AssumeRoleProvider")
 	stsSvc := sts.New(awsConfig)
 	stsCredProvider := stscreds.NewAssumeRoleProvider(stsSvc, config.RoleArn)
 	awsConfig.Credentials = stsCredProvider


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Set up the `AssumeRoleProvider` after the AWS region value from Filebeat settings is applied to the AWS SDK configuration.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When Filebeat uses a role ARN, it sets up `AssumeRoleProvider` before evaluating the region value from its settings.

If the AWS SDK configuration loaded from `~/.aws/config` does not contain a region, the error described in #30999 happens.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Requirements:

- A SQS queue (in this example, `https://sqs.eu-west-1.amazonaws.com/000123456789/elastic-cloudtrail-logs`),
- an IAM role ARN (in this example, `arn:aws:iam::000123456789:role/elastic-agent-role`)

Configure the IAM Role as EC2 instance role with the following trust relationship:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Service": "ec2.amazonaws.com"
            },
            "Action": "sts:AssumeRole"
        }
    ]
}
```

Also add some permission to the role to access SQS and S3 ("Amazon SQS Full Access" and "SQS Read only Access" are probably fine for a quick test).

Here's an example command line arguments for Filebeat:

```text
-e
-v
-d
*
--strict.perms=false
--path.home
/Users/zmoog/code/projects/zmoog/beats/x-pack/filebeat
-E
cloud.id=<CLOUD_ID>
-E
cloud.api_key=<CLOUD_API_KEY>
-E
gc_percent=100
-E
setup.ilm.enabled=false
-E
setup.template.enabled=false
--modules
aws
-M
aws.s3access.enabled=true
-M
aws.s3access.input.default_region=eu-west-1
-M
aws.s3access.input.queue_url=https://sqs.eu-west-1.amazonaws.com/000123456789/elastic-cloudtrail-logs
-M
aws.s3access.input.role_arn=arn:aws:iam::000123456789:role/elastic-agent-role
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #30999 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
