### PR TITLE
Fix panic in the filestream harvester

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -61,7 +61,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
   inputs will fix the problem without generating any data duplication{issue}30061[30061]
 
 - Recover CEF extensions from messages with invalid/incomplete headers. {issue}30757[30757] {pull}30938[30938]
-- Fix panic in the filestream harvester {issue}29024[29024] {pull}31041[31041]
+- Fix panic in filestream input when `copy_truncate` log rotation strategy is used {issue}29024[29024] {pull}31041[31041]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -61,6 +61,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
   inputs will fix the problem without generating any data duplication{issue}30061[30061]
 
 - Recover CEF extensions from messages with invalid/incomplete headers. {issue}30757[30757] {pull}30938[30938]
+- Fix panic in the filestream harvester {issue}29024[29024] {pull}31041[31041]
 
 *Heartbeat*
 

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -508,7 +508,8 @@ func (r *resource) copyInto(dst *resource) {
 	dst.pendingCursorValue = nil
 	dst.pendingUpdate = nil
 	dst.cursorMeta = r.cursorMeta
-	dst.lock = unison.MakeMutex()
+	// dst.lock should not be overwritten here because it's supposed to be locked
+	// before this function call and it's important to preserve the previous value.
 }
 
 func (r *resource) copyWithNewKey(key string) *resource {

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -31,11 +31,26 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+	"github.com/elastic/go-concert/unison"
 )
 
 type testStateStore struct {
 	Store    *statestore.Store
 	GCPeriod time.Duration
+}
+
+func TestResource_CopyInto(t *testing.T) {
+	src := resource{lock: unison.MakeMutex()}
+	dst := resource{lock: unison.MakeMutex()}
+	src.lock.Lock()
+	dst.lock.Lock()
+
+	src.copyInto(&dst)
+
+	require.NotPanics(t, func() {
+		src.lock.Unlock()
+		dst.lock.Unlock()
+	}, "perhaps `lock` field was replaced during the copy")
 }
 
 func TestStore_OpenClose(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

The mutex of the resource was mistakenly overwritten with a new one
and then unlocking this new mutex caused it to panic.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Our customers faced this issue and it crashes filebeat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Create a folder, e.g. `/home/user/input`
2. Create this configuration file e.g. `/home/filebeat_lock_panic.yml`:

```yaml
logging:
  level: debug

output.console:
  enabled: true

filebeat.inputs:
  - type: filestream
    paths:
      - "/home/user/input/input/pattern1.log*"
    rotation.external.strategy.copytruncate:
      suffix_regex: '\.\d+$'

  - type: filestream
    paths:
      - "/home/user/input/pattern2.log*"
    rotation.external.strategy.copytruncate:
      suffix_regex: '\.\d+$'

  - type: filestream
    paths:
      - "/home/user/input/pattern3.log*"
    rotation.external.strategy.copytruncate:
      suffix_regex: '\.\d+$'

  - type: filestream
    paths:
      - "/home/user/input/pattern4.log*"
    rotation.external.strategy.copytruncate:
      suffix_regex: '\.\d+$'

  - type: filestream
    paths:
      - "/home/user/input/pattern5.log*"
    rotation.external.strategy.copytruncate:
      suffix_regex: '\.\d+$'
```
3. Run filebeat with this command with the configuration from step 2:

```sh
./filebeat -e -c /home/user/filebeat_lock_panic.yml
```

4. Copy files from this archive into the directory from step 1: 
[repro.zip](https://github.com/elastic/beats/files/8371201/repro.zip)

5. Before this change after ~10 seconds you would see this error on the console:

```
panic: unlock on unlocked mutex

goroutine 124 [running]:
github.com/elastic/go-concert/unison.Mutex.Unlock({0x140007e4060})
        /Users/rdner/go/pkg/mod/github.com/elastic/go-concert@v0.2.0/unison/mutex.go:132 +0x60
github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.releaseResource(0x1400016e000)
        /Users/rdner/Projects/beats/filebeat/input/filestream/internal/input-logfile/harvester.go:296 +0x2c
github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile.(*defaultHarvesterGroup).Continue.func1({0x102dafef8, 0x140006cab40})
        /Users/rdner/Projects/beats/filebeat/input/filestream/internal/input-logfile/harvester.go:246 +0x228
github.com/elastic/go-concert/unison.(*TaskGroup).Go.func1(0x1400087c048, 0x14000952050)
        /Users/rdner/go/pkg/mod/github.com/elastic/go-concert@v0.2.0/unison/taskgroup.go:163 +0x90
created by github.com/elastic/go-concert/unison.(*TaskGroup).Go
        /Users/rdner/go/pkg/mod/github.com/elastic/go-concert@v0.2.0/unison/taskgroup.go:159 +0xcc
```

After this change filebeat is running normally for the next few minutes.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes [#29024](https://github.com/elastic/beats/issues/29024)