### PR TITLE
Update the list of required priviledges during setup and publishing

### DIFF
--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -61,10 +61,9 @@ ifndef::no_ilm[]
 |Set up and manage index lifecycle management (ILM) policy
 endif::no_ilm[]
 
-
 |Index
 |`manage` on +{beat_default_index_prefix}-*+ indices
-|Set up aliases used by ILM
+|Load data stream
 
 |====
 +
@@ -263,18 +262,6 @@ endif::[]
 |Index
 |`create_doc` on +{beat_default_index_prefix}-*+ indices
 |Write events into {es}
-
-ifndef::no_ilm[]
-|Index
-|`view_index_metadata` on +{beat_default_index_prefix}-*+ indices
-|Check for alias when connecting to clusters that support ILM.
-Not needed when `setup.ilm.check_exists` is `false`.
-endif::no_ilm[]
-
-|Index
-|`create_index` on +{beat_default_index_prefix}-*+ indices
-|Create daily indices when connecting to clusters that do not support ILM.
-Not needed when using ILM.
 |====
 ifndef::apm-server[]
 +

--- a/libbeat/docs/security/users.asciidoc
+++ b/libbeat/docs/security/users.asciidoc
@@ -61,21 +61,11 @@ ifndef::no_ilm[]
 |Set up and manage index lifecycle management (ILM) policy
 endif::no_ilm[]
 
-ifdef::has_ml_jobs[]
-|Cluster
-|`manage_ml`
-|Set up Machine Learning job configurations
-endif::has_ml_jobs[]
 
 |Index
 |`manage` on +{beat_default_index_prefix}-*+ indices
 |Set up aliases used by ILM
 
-ifdef::has_ml_jobs[]
-|Index
-|`read` on +{beat_default_index_prefix}-*+ indices
-|Read {beatname_uc} indices in order to set up Machine Learning jobs
-endif::has_ml_jobs[]
 |====
 +
 Omit any privileges that aren't relevant in your environment.


### PR DESCRIPTION
## What does this PR do?

This PR updates the required priviledges of Beats during setup and publishing phase.

## Why is it important?

Beats do not load ML jobs since 8.0, so ML priviledges are unnecessary. Also, Beats do not use aliases, so there is no need for access to them. Instead we load a data stream, so the reason for `manage` priviledge is updated.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
