### PR TITLE
[Filebeat] http_endpoint: add gzip content-encoding support

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -125,6 +125,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Filebeat*
 
+- http_endpoint input: Add support for requests with `Content-Encoding: gzip`. {issue}31005[31005]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -11,9 +11,31 @@
 
 beta[]
 
-Use the `http_endpoint` input to create a HTTP listener that can receive incoming HTTP POST requests.
+The HTTP Endpoint input initializes a listening HTTP server that collects
+incoming HTTP POST requests containing a JSON body. The body must be either an
+object or an array of objects. Any other data types will result in an HTTP 400
+(Bad Request) response. For arrays, one document is created for each object in
+the array.
 
-This input can for example be used to receive incoming webhooks from a third-party application or service.
+gzip encoded request bodies are supported if a `Content-Encoding: gzip` header
+is sent with the request.
+
+This input can for example be used to receive incoming webhooks from a
+third-party application or service.
+
+These are the possible response codes from the server.
+
+[options="header"]
+|=========================================================================================================================================================
+| HTTP Response Code  | Name                    | Reason
+| 200                 | OK                      | Returned on success.
+| 400                 | Bad Request             | Returned if JSON body decoding fails.
+| 401                 | Unauthorized            | Returned when basic auth, secret header, or HMAC validation fails.
+| 405                 | Method Not Allowed      | Returned if methods other than POST are used.
+| 406                 | Not Acceptable          | Returned if the POST request does not contain a body.
+| 415                 | Unsupported Media Type  | Returned if the Content-Type is not application/json. Or if Content-Encoding is present and is not gzip.
+| 500                 | Internal Server Error   | Returned if an I/O error occurs reading the request.
+|=========================================================================================================================================================
 
 Example configurations:
 


### PR DESCRIPTION
## What does this PR do?

Accept requests with `Content-Encoding: gzip`.

Closes #31005

## Why is it important?

Some applications use gzip request encoding when pushing logs.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #31005
