### PR TITLE
Add data stream loading step to manual index loading guide

### DIFF
--- a/libbeat/docs/howto/load-index-templates.asciidoc
+++ b/libbeat/docs/howto/load-index-templates.asciidoc
@@ -313,7 +313,9 @@ PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile {beat
 ----
 endif::win_os[]
 
-Once you loaded the index template, load the data stream as well.
+Once you have loaded the index template, load the data stream as well. If you
+do not load it, you have to give the publisher user `manage` permission on
+{beatname_lc}-{version} index.
 
 ifdef::deb_os,rpm_os[]
 *deb and rpm:*

--- a/libbeat/docs/howto/load-index-templates.asciidoc
+++ b/libbeat/docs/howto/load-index-templates.asciidoc
@@ -312,3 +312,44 @@ endif::win_only[]
 PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_index_template/{beatname_lc}-{version}
 ----
 endif::win_os[]
+
+Once you loaded the index template, load the data stream as well.
+
+ifdef::deb_os,rpm_os[]
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+curl -XPUT http://localhost:9200/_data_stream/{beatname_lc}-{version}
+----
+endif::deb_os,rpm_os[]
+
+ifdef::mac_os[]
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+curl -XPUT http://localhost:9200/_data_stream/{beatname_lc}-{version}
+----
+endif::mac_os[]
+
+ifdef::linux_os[]
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+curl -XPUT http://localhost:9200/_data_stream/{beatname_lc}-{version}
+----
+endif::linux_os[]
+
+ifdef::win_os[]
+ifndef::win_only[]
+*win:*
+endif::win_only[]
+
+["source","sh",subs="attributes"]
+----
+PS > Invoke-RestMethod -Method Put -Uri http://localhost:9200/_data_stream/{beatname_lc}-{version}
+----
+endif::win_os[]
+


### PR DESCRIPTION
## What does this PR do?

This PR adds the one more extra step required for template loading since 8.0. As we are using data streams, it has to be created in advance, so publisher users do not need extra permissions.

## Why is it important?

Without loading the data stream, the publisher user needs unnecessary permissions. It is better to add the data stream in advance, after loading the index template.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
