### PR TITLE
Enable k8s scheduler test

### DIFF
--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: lint
     k8sTest:
-        k8sTest: "v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17"
+        k8sTest: "v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
         stage: mandatory

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: lint
     k8sTest:
-        k8sTest: "v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17,v1.14.10"
+        k8sTest: "v1.21.1,v1.20.7,v1.19.11,v1.18.19,v1.17.17"
         stage: mandatory

--- a/metricbeat/module/kubernetes/scheduler/scheduler_integration_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_integration_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestFetchMetricset(t *testing.T) {
-	t.Skip("Failing/flaky test: https://github.com/elastic/beats/issues/30973")
 	config := test.GetSchedulerConfig(t, "scheduler")
 	metricSet := mbtest.NewFetcher(t, config)
 	events, errs := metricSet.FetchEvents()

--- a/metricbeat/module/kubernetes/test/integration.go
+++ b/metricbeat/module/kubernetes/test/integration.go
@@ -79,10 +79,10 @@ func GetKubeProxyConfig(t *testing.T, metricSetName string) map[string]interface
 func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface{} {
 	t.Helper()
 	return map[string]interface{}{
-		"module":            "kubernetes",
-		"metricsets":        []string{metricSetName},
-		"host":              "${NODE_NAME}",
-		"hosts":             []string{"http://0.0.0.0:10251"},
+		"module":     "kubernetes",
+		"metricsets": []string{metricSetName},
+		"host":       "${NODE_NAME}",
+		"hosts":      []string{"http://0.0.0.0:10251"},
 	}
 }
 

--- a/metricbeat/module/kubernetes/test/integration.go
+++ b/metricbeat/module/kubernetes/test/integration.go
@@ -82,11 +82,7 @@ func GetSchedulerConfig(t *testing.T, metricSetName string) map[string]interface
 		"module":            "kubernetes",
 		"metricsets":        []string{metricSetName},
 		"host":              "${NODE_NAME}",
-		"hosts":             []string{"https://0.0.0.0:10259"},
-		"bearer_token_file": "/var/run/secrets/kubernetes.io/serviceaccount/token",
-		"ssl": map[string]interface{}{
-			"verification_mode": "none",
-		},
+		"hosts":             []string{"http://0.0.0.0:10251"},
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Enable back k8s scheduler integration test.

Closes https://github.com/elastic/beats/issues/30973