### PR TITLE
DRA: support for staging

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -48,8 +48,6 @@ pipeline {
         anyOf {
           triggeredBy cause: "IssueCommentCause"
           expression {
-            // TODO
-            return true
             def ret = isUserTrigger() || isUpstreamTrigger()
             if(!ret){
               currentBuild.result = 'NOT_BUILT'
@@ -92,27 +90,17 @@ pipeline {
             dir("${BASE_DIR}"){
               setEnvVar('BEAT_VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
             }
-            // TODO
-            //setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
-            setEnvVar('IS_BRANCH_AVAILABLE', true)
+            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
           }
         }
         stage('Build Packages'){
           options { skipDefaultCheckout() }
-          // TODO
-          when {
-            expression { return false }
-          }
           steps {
             generateSteps()
           }
         }
         stage('Run E2E Tests for Packages'){
           options { skipDefaultCheckout() }
-          // TODO
-          when {
-            expression { return false }
-          }
           steps {
             runE2ETests()
           }
@@ -176,10 +164,7 @@ def getBucketUri(type) {
   // commit for the normal workflow, snapshots (aka SNAPSHOT=true)
   // staging for the staging workflow, SNAPSHOT=false
   def folder = type.equals('staging') ? 'staging' : 'commits'
-  // TODO: test
-  withEnv(["GIT_BASE_COMMIT=524cda1a27b445a341a145a72931f66395267d8a"]) {
   return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
-  }
 }
 
 def runReleaseManager(def args = [:]) {
@@ -192,23 +177,16 @@ def runReleaseManager(def args = [:]) {
     // TODO: as long as googleStorageDownload does not support recursive copy with **/*
     dir("build/distributions") {
       gsutil(command: "-m -q cp -r ${bucketUri} .", credentialsId: env.JOB_GCS_EXT_CREDENTIALS)
-      // TODO: test
-      withEnv(["GIT_BASE_COMMIT=524cda1a27b445a341a145a72931f66395267d8a"]) {
       sh(label: 'move one level up', script: "mv ${env.GIT_BASE_COMMIT}/** .")
-      }
     }
     sh(label: "debug package", script: 'find build/distributions -type f -ls || true')
     sh(label: 'prepare-release-manager-artifacts', script: ".ci/scripts/prepare-release-manager.sh")
     dockerLogin(secret: env.DOCKERELASTIC_SECRET, registry: env.DOCKER_REGISTRY)
-    // TODO: test
-    withEnv(["BRANCH_NAME=main"]) {
     releaseManager(project: 'beats',
                    version: env.BEAT_VERSION,
                    type: type,
                    artifactsFolder: 'build/distributions',
                    outputFile: args.outputFile)
-    // TODO: test
-    }
   }
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -263,7 +263,7 @@ def generateArmStep(beat) {
           }
         }
         deleteDir()
-        release('snapshot')
+        release('staging')
       }
     }
   }
@@ -403,7 +403,7 @@ def release(type){
                                    sharedPublicly: true)
           }
         } else {
-          log(level: 'INFO', text: "${env.BEATS_FOLDER} for ${type} does not require to upload the artifacts.")
+          log(level: 'INFO', text: "${env.BEATS_FOLDER} for ${type} does not require to upload the staging artifacts.")
         }
       }
     }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -48,6 +48,8 @@ pipeline {
         anyOf {
           triggeredBy cause: "IssueCommentCause"
           expression {
+            // TODO
+            return true
             def ret = isUserTrigger() || isUpstreamTrigger()
             if(!ret){
               currentBuild.result = 'NOT_BUILT'
@@ -90,7 +92,9 @@ pipeline {
             dir("${BASE_DIR}"){
               setEnvVar('BEAT_VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
             }
-            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            // TODO
+            //setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            setEnvVar('IS_BRANCH_AVAILABLE', true)
           }
         }
         stage('Build Packages'){
@@ -101,6 +105,10 @@ pipeline {
         }
         stage('Run E2E Tests for Packages'){
           options { skipDefaultCheckout() }
+          // TODO
+          when {
+            expression { return false }
+          }
           steps {
             runE2ETests()
           }
@@ -118,7 +126,9 @@ pipeline {
           }
           steps {
             runReleaseManager(type: 'snapshot', outputFile: env.DRA_OUTPUT)
-            whenFalse(env.BRANCH_NAME.equals('main')) {
+            //TODO
+            //whenFalse(env.BRANCH_NAME.equals('main')) {
+            whenTrue(env.BRANCH_NAME.equals('main')) {
               runReleaseManager(type: 'staging', outputFile: env.DRA_OUTPUT)
             }
           }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -99,6 +99,10 @@ pipeline {
         }
         stage('Build Packages'){
           options { skipDefaultCheckout() }
+          // TODO
+          when {
+            expression { return false }
+          }
           steps {
             generateSteps()
           }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -157,12 +157,16 @@ pipeline {
   }
 }
 
-def runReleaseManager(def args = [:]) {
+def getBucketUri(type) {
   // It uses the folder structure done in uploadPackagesToGoogleBucket
-  def bucketUri = "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/commits/${env.GIT_BASE_COMMIT}"
-  if (type.equals('staging')) {
-    bucketUri = "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/staging/commits/${env.GIT_BASE_COMMIT}"
-  }
+  // commit for the normal workflow, snapshots (aka SNAPSHOT=true)
+  // staging for the staging workflow, SNAPSHOT=false
+  def folder = type.equals('staging') ? 'staging' : 'commit'
+  return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
+}
+
+def runReleaseManager(def args = [:]) {
+  def bucketUri = getBucketUri(args.get('type', 'snapshot'))
   deleteDir()
   unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
   dir("${BASE_DIR}") {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -278,8 +278,17 @@ def generateLinuxStep(beat) {
           }
         }
         prepareE2ETestForPackage("${beat}")
-        deleteDir()
-        release('staging')
+        // As long as we reuse the same worker to package more than
+        // once, the workspace gets corrupted with some permissions
+        // therefore let's reset the workspace to a new location
+        // in order to reuse the worker and successfully run the package
+        def work = "workspace/${env.JOB_BASE_NAME}-${env.BUILD_NUMBER}-staging"
+        ws(work) {
+          withEnv(["HOME=${env.WORKSPACE}"]) {
+            deleteDir()
+            release('staging')
+          }
+        }
       }
     }
   }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -198,7 +198,7 @@ def runReleaseManager(def args = [:]) {
       }
     }
     sh(label: "debug package", script: 'find build/distributions -type f -ls || true')
-    sh(label: 'prepare-release-manager-artifacts', script: ".ci/scripts/prepare-release-manager.sh")
+    sh(label: 'prepare-release-manager-artifacts', script: ".ci/scripts/prepare-release-manager.sh ${type}")
     dockerLogin(secret: env.DOCKERELASTIC_SECRET, registry: env.DOCKER_REGISTRY)
     // TODO: test
     withEnv(["BRANCH_NAME=main"]) {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -476,9 +476,6 @@ def notifyStatus(def args = [:]) {
   def analyse = args.get('analyse', false)
   def subject = args.get('subject', '')
   def body = args.get('body', '')
-  // TODO: test begin
-  archiveArtifacts(allowEmptyArchive: true, artifacts: releaseManagerFile)
-  // TODO: test end
   releaseManagerNotification(file: releaseManagerFile,
                              analyse: analyse,
                              slackChannel: "${env.SLACK_CHANNEL}",

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -22,8 +22,8 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     GITHUB_CHECK_E2E_TESTS_NAME = 'E2E Tests'
     PIPELINE_LOG_LEVEL = "INFO"
-    SLACK_CHANNEL = '#beats'
-    NOTIFY_TO = 'beats-contrib+package-beats@elastic.co'
+    SLACK_CHANNEL = 'UJ2J1AZV2'
+    NOTIFY_TO = 'victor.martinez+package-beats@elastic.co'
   }
   options {
     timeout(time: 4, unit: 'HOURS')

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -166,7 +166,8 @@ def getBucketUri(type) {
 }
 
 def runReleaseManager(def args = [:]) {
-  def bucketUri = getBucketUri(args.get('type', 'snapshot'))
+  def type = args.get('type', 'snapshot')
+  def bucketUri = getBucketUri(type)
   deleteDir()
   unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
   dir("${BASE_DIR}") {
@@ -181,7 +182,7 @@ def runReleaseManager(def args = [:]) {
     dockerLogin(secret: env.DOCKERELASTIC_SECRET, registry: env.DOCKER_REGISTRY)
     releaseManager(project: 'beats',
                    version: env.BEAT_VERSION,
-                   type: args.type,
+                   type: type,
                    artifactsFolder: 'build/distributions',
                    outputFile: args.outputFile)
   }
@@ -393,6 +394,7 @@ def release(type){
         if (type.equals('staging')) {
           dir("build/distributions") {
             def bucketUri = getBucketUri(type)
+            echo "Copy files to ${bucketUri} if staging"
             googleStorageUploadExt(bucket: "${bucketUri}/${folder}",
                                    credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
                                    pattern: "*",

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -262,8 +262,11 @@ def generateArmStep(beat) {
             pushCIDockerImages(arch: 'arm64')
           }
         }
-        deleteDir()
-        release('staging')
+        // Staging is only needed from branches (main or release branches)
+        if (isBranch()) {
+          deleteDir()
+          release('staging')
+        }
       }
     }
   }
@@ -281,15 +284,19 @@ def generateLinuxStep(beat) {
           }
         }
         prepareE2ETestForPackage("${beat}")
-        // As long as we reuse the same worker to package more than
-        // once, the workspace gets corrupted with some permissions
-        // therefore let's reset the workspace to a new location
-        // in order to reuse the worker and successfully run the package
-        def work = "workspace/${env.JOB_BASE_NAME}-${env.BUILD_NUMBER}-staging"
-        ws(work) {
-          withEnv(["HOME=${env.WORKSPACE}"]) {
-            deleteDir()
-            release('staging')
+
+        // Staging is only needed from branches (main or release branches)
+        if (isBranch()) {
+          // As long as we reuse the same worker to package more than
+          // once, the workspace gets corrupted with some permissions
+          // therefore let's reset the workspace to a new location
+          // in order to reuse the worker and successfully run the package
+          def work = "workspace/${env.JOB_BASE_NAME}-${env.BUILD_NUMBER}-staging"
+          ws(work) {
+            withEnv(["HOME=${env.WORKSPACE}"]) {
+              deleteDir()
+              release('staging')
+            }
           }
         }
       }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -99,10 +99,6 @@ pipeline {
         }
         stage('Build Packages'){
           options { skipDefaultCheckout() }
-          // TODO
-          when {
-            expression { return false }
-          }
           steps {
             generateSteps()
           }
@@ -166,8 +162,7 @@ def getBucketUri(type) {
   // commit for the normal workflow, snapshots (aka SNAPSHOT=true)
   // staging for the staging workflow, SNAPSHOT=false
   def folder = type.equals('staging') ? 'staging' : 'commit'
-  //return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
-  return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/e2418ef4de3548f535a12ffd8ca9f65aefe4d798"
+  return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
 }
 
 def runReleaseManager(def args = [:]) {
@@ -180,8 +175,7 @@ def runReleaseManager(def args = [:]) {
     // TODO: as long as googleStorageDownload does not support recursive copy with **/*
     dir("build/distributions") {
       gsutil(command: "-m -q cp -r ${bucketUri} .", credentialsId: env.JOB_GCS_EXT_CREDENTIALS)
-      //sh(label: 'move one level up', script: "mv ${env.GIT_BASE_COMMIT}/** .")
-      sh(label: 'move one level up', script: "mv e2418ef4de3548f535a12ffd8ca9f65aefe4d798/** .")
+      sh(label: 'move one level up', script: "mv ${env.GIT_BASE_COMMIT}/** .")
     }
     sh(label: "debug package", script: 'find build/distributions -type f -ls || true')
     sh(label: 'prepare-release-manager-artifacts', script: ".ci/scripts/prepare-release-manager.sh")

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -224,11 +224,12 @@ def generateSteps() {
   }
 
   // enable beats-dashboards within the existing worker
-  ['snapshot', 'staging'].each { type ->
-    parallelTasks["beats-dashboards-${type}"] = {
-      withGithubNotify(context: "beats-dashboards-${type}") {
-        deleteDir()
-        withEnv(["HOME=${env.WORKSPACE}"]) {
+
+  parallelTasks["beats-dashboards"] = {
+    withGithubNotify(context: "beats-dashboards") {
+      withEnv(["HOME=${env.WORKSPACE}"]) {
+        ['snapshot', 'staging'].each { type ->
+          deleteDir()
           withBeatsEnv(type) {
             sh(label: 'make dependencies.csv', script: 'make build/distributions/dependencies.csv')
             sh(label: 'make beats-dashboards', script: 'make beats-dashboards')
@@ -376,7 +377,7 @@ def release(type){
           folder: folder,
           pattern: "build/distributions/*"
         )
-        if (type.equals('stating')) {
+        if (type.equals('staging')) {
           echo 'TBD: Upload to a different bucket location'
         }
       }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -162,7 +162,8 @@ def getBucketUri(type) {
   // commit for the normal workflow, snapshots (aka SNAPSHOT=true)
   // staging for the staging workflow, SNAPSHOT=false
   def folder = type.equals('staging') ? 'staging' : 'commit'
-  return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
+  //return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
+  return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/e2418ef4de3548f535a12ffd8ca9f65aefe4d798"
 }
 
 def runReleaseManager(def args = [:]) {
@@ -175,7 +176,8 @@ def runReleaseManager(def args = [:]) {
     // TODO: as long as googleStorageDownload does not support recursive copy with **/*
     dir("build/distributions") {
       gsutil(command: "-m -q cp -r ${bucketUri} .", credentialsId: env.JOB_GCS_EXT_CREDENTIALS)
-      sh(label: 'move one level up', script: "mv ${env.GIT_BASE_COMMIT}/** .")
+      //sh(label: 'move one level up', script: "mv ${env.GIT_BASE_COMMIT}/** .")
+      sh(label: 'move one level up', script: "mv e2418ef4de3548f535a12ffd8ca9f65aefe4d798/** .")
     }
     sh(label: "debug package", script: 'find build/distributions -type f -ls || true')
     sh(label: 'prepare-release-manager-artifacts', script: ".ci/scripts/prepare-release-manager.sh")

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -161,7 +161,7 @@ def getBucketUri(type) {
   // It uses the folder structure done in uploadPackagesToGoogleBucket
   // commit for the normal workflow, snapshots (aka SNAPSHOT=true)
   // staging for the staging workflow, SNAPSHOT=false
-  def folder = type.equals('staging') ? 'staging' : 'commit'
+  def folder = type.equals('staging') ? 'staging' : 'commits'
   return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -48,6 +48,8 @@ pipeline {
         anyOf {
           triggeredBy cause: "IssueCommentCause"
           expression {
+            // TODO
+            return true
             def ret = isUserTrigger() || isUpstreamTrigger()
             if(!ret){
               currentBuild.result = 'NOT_BUILT'
@@ -90,17 +92,27 @@ pipeline {
             dir("${BASE_DIR}"){
               setEnvVar('BEAT_VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
             }
-            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            // TODO
+            //setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
+            setEnvVar('IS_BRANCH_AVAILABLE', true)
           }
         }
         stage('Build Packages'){
           options { skipDefaultCheckout() }
+          // TODO
+          when {
+            expression { return false }
+          }
           steps {
             generateSteps()
           }
         }
         stage('Run E2E Tests for Packages'){
           options { skipDefaultCheckout() }
+          // TODO
+          when {
+            expression { return false }
+          }
           steps {
             runE2ETests()
           }
@@ -164,7 +176,10 @@ def getBucketUri(type) {
   // commit for the normal workflow, snapshots (aka SNAPSHOT=true)
   // staging for the staging workflow, SNAPSHOT=false
   def folder = type.equals('staging') ? 'staging' : 'commits'
+  // TODO: test
+  withEnv(["GIT_BASE_COMMIT=524cda1a27b445a341a145a72931f66395267d8a"]) {
   return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
+  }
 }
 
 def runReleaseManager(def args = [:]) {
@@ -177,16 +192,23 @@ def runReleaseManager(def args = [:]) {
     // TODO: as long as googleStorageDownload does not support recursive copy with **/*
     dir("build/distributions") {
       gsutil(command: "-m -q cp -r ${bucketUri} .", credentialsId: env.JOB_GCS_EXT_CREDENTIALS)
+      // TODO: test
+      withEnv(["GIT_BASE_COMMIT=524cda1a27b445a341a145a72931f66395267d8a"]) {
       sh(label: 'move one level up', script: "mv ${env.GIT_BASE_COMMIT}/** .")
+      }
     }
     sh(label: "debug package", script: 'find build/distributions -type f -ls || true')
     sh(label: 'prepare-release-manager-artifacts', script: ".ci/scripts/prepare-release-manager.sh")
     dockerLogin(secret: env.DOCKERELASTIC_SECRET, registry: env.DOCKER_REGISTRY)
+    // TODO: test
+    withEnv(["BRANCH_NAME=main"]) {
     releaseManager(project: 'beats',
                    version: env.BEAT_VERSION,
                    type: type,
                    artifactsFolder: 'build/distributions',
                    outputFile: args.outputFile)
+    // TODO: test
+    }
   }
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -176,7 +176,10 @@ def getBucketUri(type) {
   // commit for the normal workflow, snapshots (aka SNAPSHOT=true)
   // staging for the staging workflow, SNAPSHOT=false
   def folder = type.equals('staging') ? 'staging' : 'commits'
+  // TODO: test
+  withEnv(["GIT_BASE_COMMIT=524cda1a27b445a341a145a72931f66395267d8a"]) {
   return "gs://${env.JOB_GCS_BUCKET}/${env.REPO}/${folder}/${env.GIT_BASE_COMMIT}"
+  }
 }
 
 def runReleaseManager(def args = [:]) {
@@ -189,7 +192,10 @@ def runReleaseManager(def args = [:]) {
     // TODO: as long as googleStorageDownload does not support recursive copy with **/*
     dir("build/distributions") {
       gsutil(command: "-m -q cp -r ${bucketUri} .", credentialsId: env.JOB_GCS_EXT_CREDENTIALS)
+      // TODO: test
+      withEnv(["GIT_BASE_COMMIT=524cda1a27b445a341a145a72931f66395267d8a"]) {
       sh(label: 'move one level up', script: "mv ${env.GIT_BASE_COMMIT}/** .")
+      }
     }
     sh(label: "debug package", script: 'find build/distributions -type f -ls || true')
     sh(label: 'prepare-release-manager-artifacts', script: ".ci/scripts/prepare-release-manager.sh")

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -467,6 +467,9 @@ def notifyStatus(def args = [:]) {
   def analyse = args.get('analyse', false)
   def subject = args.get('subject', '')
   def body = args.get('body', '')
+  // TODO: test begin
+  archiveArtifacts(allowEmptyArchive: true, artifacts: releaseManagerFile)
+  // TODO: test end
   releaseManagerNotification(file: releaseManagerFile,
                              analyse: analyse,
                              slackChannel: "${env.SLACK_CHANNEL}",

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -22,8 +22,8 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     GITHUB_CHECK_E2E_TESTS_NAME = 'E2E Tests'
     PIPELINE_LOG_LEVEL = "INFO"
-    SLACK_CHANNEL = 'UJ2J1AZV2'
-    NOTIFY_TO = 'victor.martinez+package-beats@elastic.co'
+    SLACK_CHANNEL = '#beats'
+    NOTIFY_TO = 'beats-contrib+package-beats@elastic.co'
     DRA_OUTPUT = 'release-manager.out'
   }
   options {
@@ -236,7 +236,6 @@ def generateSteps() {
   }
 
   // enable beats-dashboards within the existing worker
-
   parallelTasks["beats-dashboards"] = {
     withGithubNotify(context: "beats-dashboards") {
       withEnv(["HOME=${env.WORKSPACE}"]) {
@@ -251,8 +250,6 @@ def generateSteps() {
       }
     }
   }
-
-
   parallel(parallelTasks)
 }
 

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -384,7 +384,7 @@ def release(type){
     ]) {
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       dir("${env.BEATS_FOLDER}") {
-        sh(label: "Release ${env.BEATS_FOLDER} ${env.PLATFORMS}", script: 'mage package')
+        sh(label: "mage package ${type} ${env.BEATS_FOLDER} ${env.PLATFORMS}", script: 'mage package')
         def folder = getBeatsName(env.BEATS_FOLDER)
         uploadPackagesToGoogleBucket(
           credentialsId: env.JOB_GCS_EXT_CREDENTIALS,
@@ -396,12 +396,14 @@ def release(type){
         if (type.equals('staging')) {
           dir("build/distributions") {
             def bucketUri = getBucketUri(type)
-            echo "Copy files to ${bucketUri} if staging"
+            log(level: 'INFO', text: "${env.BEATS_FOLDER} for ${type} requires to upload the artifacts to ${bucketUri}.")
             googleStorageUploadExt(bucket: "${bucketUri}/${folder}",
                                    credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
                                    pattern: "*",
                                    sharedPublicly: true)
           }
+        } else {
+          log(level: 'INFO', text: "${env.BEATS_FOLDER} for ${type} does not require to upload the artifacts.")
         }
       }
     }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -382,7 +382,13 @@ def release(type){
           pattern: "build/distributions/*"
         )
         if (type.equals('staging')) {
-          echo 'TBD: Upload to a different bucket location'
+          dir("build/distributions") {
+            def bucketUri = getBucketUri(type)
+            googleStorageUploadExt(bucket: "${bucketUri}/${folder}",
+                                   credentialsId: "${JOB_GCS_EXT_CREDENTIALS}",
+                                   pattern: "*",
+                                   sharedPublicly: true)
+          }
         }
       }
     }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -166,6 +166,7 @@ def runReleaseManager(def args = [:]) {
   deleteDir()
   unstashV2(name: 'source', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
   dir("${BASE_DIR}") {
+    unstash "dependencies-${type}"
     // TODO: as long as googleStorageDownload does not support recursive copy with **/*
     dir("build/distributions") {
       gsutil(command: "-m -q cp -r ${bucketUri} .", credentialsId: env.JOB_GCS_EXT_CREDENTIALS)

--- a/.ci/scripts/prepare-release-manager.sh
+++ b/.ci/scripts/prepare-release-manager.sh
@@ -36,3 +36,6 @@ find build/distributions -name '*linux-amd64.docker.tar.gz*' -print0 |
     echo "Rename file $file"
     mv "$file" "${file/linux-amd64.docker.tar.gz/docker-image-linux-amd64.tar.gz}"
   done
+
+echo 'List all the files'
+find build/distributions -type f -ls || true

--- a/.ci/scripts/prepare-release-manager.sh
+++ b/.ci/scripts/prepare-release-manager.sh
@@ -15,7 +15,7 @@ FINAL_VERSION=$VERSION-SNAPSHOT
 if [ "$TYPE" != "snapshot" ] ; then
   FINAL_VERSION=$VERSION
 fi
-VERSION=$(make get-version)
+echo "Rename dependencies to $FINAL_VERSION"
 mv build/distributions/dependencies.csv \
    build/distributions/dependencies-"$FINAL_VERSION".csv
 


### PR DESCRIPTION
### What

- Enable `snapshot` workflow for `main` and release branches. Stage `DRA Snapshot`
- Enable `staging` workflow for release branches. Stage `DRA Staging`
- Use the same node where the specific packages are generated for each beat, and run first the `snapshot` and then `staging` (aka SNAPSHOT=false)
- `staging` artifacts are uploaded to the `staginig` subfolder in the Google Bucket while `snapshot` artifacts are uploaded to the `commits` folder (this is the default behaviour we had in place)


### Test

See [job](https://beats-ci.elastic.co/job/Beats/job/packaging/view/change-requests/job/PR-31092/)

Produced:

- snapshot -> https://artifacts-snapshot.elastic.co/beats/8.3.0-c1154f51/summary-8.3.0-SNAPSHOT.html
- staging -> https://artifacts-staging.elastic.co/beats/8.3.0-7fb50dba/summary-8.3.0.html