### PR TITLE
Fix export dashboards

### DIFF
--- a/libbeat/kibana/client_test.go
+++ b/libbeat/kibana/client_test.go
@@ -43,6 +43,7 @@ func TestErrorJson(t *testing.T) {
 }
 
 func assertConnection(t *testing.T, URL string, expectedStatusCode int) {
+	t.Helper()
 	conn := Connection{
 		URL:  URL,
 		HTTP: http.DefaultClient,

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -75,44 +75,6 @@ class Test(BaseTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @pytest.mark.tag('integration')
-    def test_load_dashboard_into_space(self, create_space=True):
-        """
-        Test loading dashboards into Kibana space
-        """
-        version = self.get_version()
-        if semver.compare(version, "6.5.0") == -1:
-            # Skip for Kibana versions < 6.5.0 as Kibana Spaces not available
-            raise unittest.SkipTest
-
-        self.render_config_template()
-        if create_space:
-            self.create_kibana_space()
-
-        beat = self.start_beat(
-            logging_args=["-e", "-d", "*"],
-            extra_args=["setup",
-                        "--dashboards",
-                        "-E", "setup.dashboards.file=" +
-                        os.path.join(self.beat_path, "tests", "files", "testbeat-dashboards.zip"),
-                        "-E", "setup.dashboards.beat=testbeat",
-                        "-E", "setup.kibana.protocol=http",
-                        "-E", "setup.kibana.host=" + self.get_kibana_host(),
-                        "-E", "setup.kibana.port=" + self.get_kibana_port(),
-                        "-E", "setup.kibana.username=beats",
-                        "-E", "setup.kibana.password=testing",
-                        "-E", "setup.kibana.space.id=foo-bar",
-                        "-E", "output.elasticsearch.hosts=['" + self.get_host() + "']",
-                        "-E", "output.elasticsearch.username=admin",
-                        "-E", "output.elasticsearch.password=testing",
-                        "-E", "output.file.enabled=false"]
-        )
-
-        beat.check_wait(exit_code=0)
-
-        assert self.log_contains("Kibana dashboards successfully loaded") is True
-
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @pytest.mark.tag('integration')
     def test_load_only_index_patterns(self):
         """
         Test loading dashboards
@@ -226,33 +188,6 @@ class Test(BaseTest):
 
         assert p.returncode != 0
 
-    @unittest.skip("Failing test: https://github.com/elastic/beats/issues/29327")
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @pytest.mark.tag('integration')
-    def test_dev_tool_export_dashboard_by_id_from_space(self):
-        """
-        Test dev-tools/cmd/dashboards exports dashboard from Kibana space
-        and removes unsupported characters
-        """
-        version = self.get_version()
-        if semver.compare(version, "6.5.0") == -1:
-            # Skip for Kibana versions < 6.5.0 as Kibana Spaces not available
-            raise unittest.SkipTest
-
-        self.test_load_dashboard_into_space(False)
-
-        folder_name = "system-overview"
-        path = os.path.normpath(self.beat_path + "/../dev-tools/cmd/dashboards/export_dashboards.go")
-        command = path + " -kibana http://" + self.get_kibana_host() + ":" + self.get_kibana_port()
-        command = "go run " + command + " -dashboard Metricbeat-system-overview -space-id foo-bar -folder " + folder_name
-
-        p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        content, err = p.communicate()
-
-        assert p.returncode == 0
-
-        self._check_if_dashboard_exported(folder_name)
-
     def _check_if_dashboard_exported(self, folder_name):
         kibana_semver = semver.VersionInfo.parse(self.get_version())
         dashboard_folder = os.path.join(folder_name, "_meta", "kibana", str(kibana_semver.major), "dashboard")
@@ -272,22 +207,6 @@ class Test(BaseTest):
 
     def get_kibana_port(self):
         return os.getenv('KIBANA_PORT', '5601')
-
-    def create_kibana_space(self):
-        url = "http://" + self.get_kibana_host() + ":" + self.get_kibana_port() + \
-            "/api/spaces/space"
-        data = {
-            "id": "libbeat-system-tests",
-            "name": "Libbeat System Tests"
-        }
-
-        headers = {
-            "kbn-xsrf": "1"
-        }
-
-        r = requests.post(url, json=data, headers=headers, auth=("beats", "testing"))
-        if r.status_code != 200 and r.status_code != 409:
-            self.fail('Bad Kibana status code when creating space: {}'.format(r.status_code))
 
     def get_version(self):
         url = "http://" + self.get_kibana_host() + ":" + self.get_kibana_port() + \

--- a/libbeat/tests/system/test_dashboard.py
+++ b/libbeat/tests/system/test_dashboard.py
@@ -167,8 +167,8 @@ class Test(BaseTest):
         command = "go run " + command + " -dashboard Metricbeat-system-overview -folder " + folder_name
 
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        content, err = p.communicate()
-        assert p.returncode == 0
+        _, stderr = p.communicate()
+        assert p.returncode == 0, stderr
 
         self._check_if_dashboard_exported(folder_name)
 
@@ -184,9 +184,9 @@ class Test(BaseTest):
         command = "go run " + command + " -dashboard No-such-dashboard"
 
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        content, err = p.communicate()
+        _, stderr = p.communicate()
 
-        assert p.returncode != 0
+        assert p.returncode != 0, stderr
 
     def _check_if_dashboard_exported(self, folder_name):
         kibana_semver = semver.VersionInfo.parse(self.get_version())


### PR DESCRIPTION

## What does this PR do?

Cleans up the dashboard system tests by removing a broken test, and related tests that do not provide any valuable test coverage.

At some point in the past (during 8.0) the `test_dev_tool_export_dashboard_by_id_from_space` broke. The reason it broke is that we upload the same dashboards multiple times as part of the test, and there must have been a change in Kibana to ensure that all dashboards have unique `id` fields by generating a UUID on conflict. This made it so that we could not export the dashboard using the original ID anymore, breaking the test.

Previously the affected dashboard would always have root attributes like this:

```json
      "type": "dashboard",
      "id": "Metricbeat-system-overview",
      "namespaces": [
        "foo-bar"
      ],
```

At some point it changed so that uploading a dashboard with the same ID a second time in a different space would give you this instead:

```json
      "type": "dashboard",
      "id": "a094b66b-7cb0-4d7c-8a22-c414e510a343",
      "namespaces": [
        "foo-bar"
      ],
      "originId": "Metricbeat-system-overview",
```

When the ID is changed the response to the import API gives you the new ID back, but in these tests we the import is done by running a beat as a process and we don't have access to the import API response to save it for use during export. You also can't use the `originId` attribute in the spaces API from what I could tell.

Rather than write a bunch of code to work around this I just removed all the tests to do with Kibana spaces. The only change from the client side when interacting with a space is the addition of the `/s/<space-id>/` prefix to the path in the URL. I just updated a unit test to confirm we add this prefix when interacting with a space rather than re-testing all the API interactions a second time with a prefix added.

## Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Related issues

- Closes #29327
