### PR TITLE
Remove backport notification

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -141,24 +141,6 @@ pull_request_rules:
       comment:
         message: |
           This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
-  - name: notify the backport policy
-    conditions:
-      - -label~=^backport
-      - base=main
-      - -merged
-      - -closed
-    actions:
-      comment:
-        message: |
-          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
-          To fixup this pull request, you need to add the backport labels for the needed
-          branches, such as:
-          * `backport-v./d./d./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
-
-          **NOTE**: `backport-skip` has been added to this pull request.
-      label:
-        add:
-          - backport-skip
   - name: remove-backport label
     conditions:
       - label~=backport-v


### PR DESCRIPTION
When we had the 8.0 and 7.x branch, it was frequent that backports were missing so we added a notification to remind everyone to do backports. But now we 8 out the doors and main being the branch from which minors are branched of, by default no backports are needed anymore except for bugfixes / security fixes. Because of this, the automation to notify contributors around backports is not needed anymore and can even be confusing.

The backport-skip label is from my perspective not needed anymore.
