### PR TITLE
wrap all optional mapStr.Put in kuberntes module with debug logs

### DIFF
--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -72,7 +72,7 @@ func (m *MetricSet) Fetch(ctx context.Context, r mb.ReporterV2) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get docker containers list")
 	}
-	eventsMapping(r, containers, m.dedot)
+	eventsMapping(r, containers, m.dedot, m.Logger())
 
 	return nil
 }

--- a/metricbeat/module/docker/container/container.go
+++ b/metricbeat/module/docker/container/container.go
@@ -22,10 +22,10 @@ package container
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/docker"
@@ -70,7 +70,7 @@ func (m *MetricSet) Fetch(ctx context.Context, r mb.ReporterV2) error {
 	// Fetch a list of all containers.
 	containers, err := m.dockerClient.ContainerList(ctx, types.ContainerListOptions{})
 	if err != nil {
-		return errors.Wrap(err, "failed to get docker containers list")
+		return fmt.Errorf("failed to get docker containers list: %w", err)
 	}
 	eventsMapping(r, containers, m.dedot, m.Logger())
 

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -24,16 +24,18 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/docker"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
-func eventsMapping(r mb.ReporterV2, containersList []types.Container, dedot bool) {
+func eventsMapping(r mb.ReporterV2, containersList []types.Container, dedot bool, logger *logp.Logger) {
 	for _, container := range containersList {
-		eventMapping(r, &container, dedot)
+		eventMapping(r, &container, dedot, logger)
 	}
 }
 
-func eventMapping(r mb.ReporterV2, cont *types.Container, dedot bool) {
+func eventMapping(r mb.ReporterV2, cont *types.Container, dedot bool, logger *logp.Logger) {
 	event := common.MapStr{
 		"container": common.MapStr{
 			"id": cont.ID,
@@ -60,7 +62,7 @@ func eventMapping(r mb.ReporterV2, cont *types.Container, dedot bool) {
 	labels := docker.DeDotLabels(cont.Labels, dedot)
 
 	if len(labels) > 0 {
-		event.Put("docker.container.labels", labels)
+		util.ShouldPut(event, "docker.container.labels", labels, logger)
 	}
 
 	r.Event(mb.Event{

--- a/metricbeat/module/docker/container/data.go
+++ b/metricbeat/module/docker/container/data.go
@@ -30,8 +30,8 @@ import (
 )
 
 func eventsMapping(r mb.ReporterV2, containersList []types.Container, dedot bool, logger *logp.Logger) {
-	for _, container := range containersList {
-		eventMapping(r, &container, dedot, logger)
+	for i := range containersList {
+		eventMapping(r, &containersList[i], dedot, logger)
 	}
 }
 

--- a/metricbeat/module/kubernetes/apiserver/metricset.go
+++ b/metricbeat/module/kubernetes/apiserver/metricset.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
 // Metricset for apiserver is a prometheus based metricset
@@ -79,7 +80,7 @@ func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 					reporter.Error(err)
 					continue
 				}
-				event.Put("request.count", v)
+				util.ShouldPut(event, "request.count", v, m.Logger())
 				event.Delete("request.beforev14")
 			}
 		}

--- a/metricbeat/module/kubernetes/apiserver/metricset.go
+++ b/metricbeat/module/kubernetes/apiserver/metricset.go
@@ -18,7 +18,7 @@
 package apiserver
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -53,7 +53,7 @@ func getMetricsetFactory(prometheusMappings *prometheus.MetricsMapping) mb.Metri
 func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 	events, err := m.prometheusClient.GetProcessedMetrics(m.prometheusMappings)
 	if err != nil {
-		return errors.Wrap(err, "error getting metrics")
+		return fmt.Errorf("error getting metrics: %w", err)
 	}
 
 	rcPost14 := false
@@ -73,7 +73,7 @@ func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 				if bothInformed, _ := event.HasKey("request.count"); !bothInformed {
 					continue
 				}
-				event.Delete("request.beforev14")
+				util.ShouldDelete(event, "request.beforev14", m.Logger())
 			} else {
 				v, err := event.GetValue("request.beforev14.count")
 				if err != nil {
@@ -81,7 +81,7 @@ func (m *metricset) Fetch(reporter mb.ReporterV2) error {
 					continue
 				}
 				util.ShouldPut(event, "request.count", v, m.Logger())
-				event.Delete("request.beforev14")
+				util.ShouldDelete(event, "request.beforev14", m.Logger())
 			}
 		}
 

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -93,7 +93,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		return
 	}
 
-	events, err := eventMapping(body, util.PerfMetrics)
+	events, err := eventMapping(body, util.PerfMetrics, m.Logger())
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)
@@ -109,7 +109,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 			m.Logger().Error(err)
 		}
 		// Enrich event with container ECS fields
-		containerEcsFields := ecsfields(event)
+		containerEcsFields := ecsfields(event, m.Logger())
 		if len(containerEcsFields) != 0 {
 			if e.RootFields != nil {
 				e.RootFields.DeepUpdate(common.MapStr{

--- a/metricbeat/module/kubernetes/container/container_test.go
+++ b/metricbeat/module/kubernetes/container/container_test.go
@@ -28,12 +28,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
+	logger := logp.NewLogger("kubernetes.container")
+
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
@@ -45,7 +48,7 @@ func TestEventMapping(t *testing.T) {
 	cache.NodeMemAllocatable.Set("gke-beats-default-pool-a5b33e2e-hdww", 146227200)
 	cache.ContainerMemLimit.Set(util.ContainerUID("default", "nginx-deployment-2303442956-pcqfc", "nginx"), 14622720)
 
-	events, err := eventMapping(body, cache)
+	events, err := eventMapping(body, cache, logger)
 	assert.NoError(t, err, "error mapping "+testFile)
 
 	assert.Len(t, events, 1, "got wrong number of events")
@@ -87,7 +90,7 @@ func TestEventMapping(t *testing.T) {
 		testValue(t, events[0], k, v)
 	}
 
-	containerEcsFields := ecsfields(events[0])
+	containerEcsFields := ecsfields(events[0], logger)
 	testEcs := map[string]interface{}{
 		"cpu.usage":    0.005631997,
 		"memory.usage": 0.01,

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -24,7 +24,9 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
 	"github.com/elastic/beats/v7/libbeat/common/safemapstr"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
 // init registers the MetricSet with the central registry.
@@ -60,12 +62,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	err := base.Module().UnpackConfig(&config)
 	if err != nil {
-		return nil, fmt.Errorf("fail to unpack the kubernetes event configuration: %s", err)
+		return nil, fmt.Errorf("fail to unpack the kubernetes event configuration: %w", err)
 	}
 
 	client, err := kubernetes.GetKubernetesClient(config.KubeConfig, config.KubeClientOptions)
 	if err != nil {
-		return nil, fmt.Errorf("fail to get kubernetes client: %s", err.Error())
+		return nil, fmt.Errorf("fail to get kubernetes client: %w", err)
 	}
 
 	watchOptions := kubernetes.WatchOptions{
@@ -75,7 +77,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	watcher, err := kubernetes.NewNamedWatcher("event", client, &kubernetes.Event{}, watchOptions, nil)
 	if err != nil {
-		return nil, fmt.Errorf("fail to init kubernetes watcher: %s", err.Error())
+		return nil, fmt.Errorf("fail to init kubernetes watcher: %w", err)
 	}
 
 	dedotConfig := dedotConfig{
@@ -97,17 +99,20 @@ func (m *MetricSet) Run(reporter mb.PushReporter) {
 	now := time.Now()
 	handler := kubernetes.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			reporter.Event(generateMapStrFromEvent(obj.(*kubernetes.Event), m.dedotConfig))
+			reporter.Event(generateMapStrFromEvent(obj.(*kubernetes.Event), m.dedotConfig, m.Logger()))
 		},
 		UpdateFunc: func(obj interface{}) {
-			reporter.Event(generateMapStrFromEvent(obj.(*kubernetes.Event), m.dedotConfig))
+			reporter.Event(generateMapStrFromEvent(obj.(*kubernetes.Event), m.dedotConfig, m.Logger()))
 		},
 		// ignore events that are deleted
 		DeleteFunc: nil,
 	}
 	m.watcher.AddEventHandler(kubernetes.FilteringResourceEventHandler{
 		FilterFunc: func(obj interface{}) bool {
-			eve := obj.(*kubernetes.Event)
+			eve, ok := obj.(*kubernetes.Event)
+			if !ok {
+				m.Logger().Debugf("Error while casting event: %s", ok)
+			}
 			// if fields are null they are decoded to `0001-01-01 00:00:00 +0000 UTC`
 			// so we need to check if they are valid first
 			lastTimestampValid := !kubernetes.Time(&eve.LastTimestamp).IsZero()
@@ -128,10 +133,9 @@ func (m *MetricSet) Run(reporter mb.PushReporter) {
 	m.watcher.Start()
 	<-reporter.Done()
 	m.watcher.Stop()
-	return
 }
 
-func generateMapStrFromEvent(eve *kubernetes.Event, dedotConfig dedotConfig) common.MapStr {
+func generateMapStrFromEvent(eve *kubernetes.Event, dedotConfig dedotConfig, logger *logp.Logger) common.MapStr {
 	eventMeta := common.MapStr{
 		"timestamp": common.MapStr{
 			"created": kubernetes.Time(&eve.ObjectMeta.CreationTimestamp).UTC(),
@@ -149,9 +153,13 @@ func generateMapStrFromEvent(eve *kubernetes.Event, dedotConfig dedotConfig) com
 		for k, v := range eve.ObjectMeta.Labels {
 			if dedotConfig.LabelsDedot {
 				label := common.DeDot(k)
-				labels.Put(label, v)
+				util.ShouldPut(labels, label, v, logger)
+
 			} else {
-				safemapstr.Put(labels, k, v)
+				err := safemapstr.Put(labels, k, v)
+				if err != nil {
+					logger.Debugf("Failed to put field '%s' with value '%s': %s", k, v, err)
+				}
 			}
 		}
 
@@ -163,9 +171,12 @@ func generateMapStrFromEvent(eve *kubernetes.Event, dedotConfig dedotConfig) com
 		for k, v := range eve.ObjectMeta.Annotations {
 			if dedotConfig.AnnotationsDedot {
 				annotation := common.DeDot(k)
-				annotations.Put(annotation, v)
+				util.ShouldPut(annotations, annotation, v, logger)
 			} else {
-				safemapstr.Put(annotations, k, v)
+				err := safemapstr.Put(annotations, k, v)
+				if err != nil {
+					logger.Debugf("Failed to put field '%s' with value '%s': %s", k, v, err)
+				}
 			}
 		}
 

--- a/metricbeat/module/kubernetes/event/event_test.go
+++ b/metricbeat/module/kubernetes/event/event_test.go
@@ -25,9 +25,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 func TestGenerateMapStrFromEvent(t *testing.T) {
+	logger := logp.NewLogger("kubernetes.event")
+
 	labels := map[string]string{
 		"app.kubernetes.io/name":      "mysql",
 		"app.kubernetes.io/version":   "5.7.21",
@@ -155,7 +158,7 @@ func TestGenerateMapStrFromEvent(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			mapStrOutput := generateMapStrFromEvent(&test.mockEvent, test.dedotConfig)
+			mapStrOutput := generateMapStrFromEvent(&test.mockEvent, test.dedotConfig, logger)
 			assert.Equal(t, test.expectedMetadata["labels"], mapStrOutput["metadata"].(common.MapStr)["labels"])
 			assert.Equal(t, test.expectedMetadata["annotations"], mapStrOutput["metadata"].(common.MapStr)["annotations"])
 			assert.Equal(t, source.Host, mapStrOutput["source"].(common.MapStr)["host"])

--- a/metricbeat/module/kubernetes/kubernetes.go
+++ b/metricbeat/module/kubernetes/kubernetes.go
@@ -18,11 +18,11 @@
 package kubernetes
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/mitchellh/hashstructure"
-	"github.com/pkg/errors"
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/elastic/beats/v7/metricbeat/helper"
@@ -97,7 +97,7 @@ func ModuleBuilder() func(base mb.BaseModule) (mb.Module, error) {
 	return func(base mb.BaseModule) (mb.Module, error) {
 		hash, err := generateCacheHash(base.Config().Hosts)
 		if err != nil {
-			return nil, errors.Wrap(err, "error generating cache hash for kubeStateMetricsCache")
+			return nil, fmt.Errorf("error generating cache hash for kubeStateMetricsCache: %w", err)
 		}
 		m := module{
 			BaseModule:            base,

--- a/metricbeat/module/kubernetes/node/data.go
+++ b/metricbeat/module/kubernetes/node/data.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
-func eventMapping(content []byte) (common.MapStr, error) {
+func eventMapping(content []byte, logger *logp.Logger) (common.MapStr, error) {
 	var summary kubernetes.Summary
 	err := json.Unmarshal(content, &summary)
 	if err != nil {
@@ -106,7 +108,7 @@ func eventMapping(content []byte) (common.MapStr, error) {
 	}
 
 	if node.StartTime != "" {
-		nodeEvent.Put("start_time", node.StartTime)
+		util.ShouldPut(nodeEvent, "start_time", node.StartTime, logger)
 	}
 
 	return nodeEvent, nil

--- a/metricbeat/module/kubernetes/node/data.go
+++ b/metricbeat/module/kubernetes/node/data.go
@@ -31,7 +31,7 @@ func eventMapping(content []byte, logger *logp.Logger) (common.MapStr, error) {
 	var summary kubernetes.Summary
 	err := json.Unmarshal(content, &summary)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot unmarshal json response: %s", err)
+		return nil, fmt.Errorf("cannot unmarshal json response: %w", err)
 	}
 
 	node := summary.Node

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -40,8 +39,6 @@ var (
 		DefaultScheme: defaultScheme,
 		DefaultPath:   defaultPath,
 	}.Build()
-
-	logger = logp.NewLogger("kubernetes.node")
 )
 
 // init registers the MetricSet with the central registry.
@@ -115,8 +112,6 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		m.Logger().Debug("error trying to emit event")
 		return
 	}
-
-	return
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/node/node.go
+++ b/metricbeat/module/kubernetes/node/node.go
@@ -97,7 +97,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		return
 	}
 
-	event, err := eventMapping(body)
+	event, err := eventMapping(body, m.Logger())
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)

--- a/metricbeat/module/kubernetes/node/node_test.go
+++ b/metricbeat/module/kubernetes/node/node_test.go
@@ -28,18 +28,21 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
+	logger := logp.NewLogger("kubernetes.node")
+
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
 	body, err := ioutil.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
-	event, err := eventMapping(body)
+	event, err := eventMapping(body, logger)
 	assert.NoError(t, err, "error mapping "+testFile)
 
 	testCases := map[string]interface{}{

--- a/metricbeat/module/kubernetes/pod/data.go
+++ b/metricbeat/module/kubernetes/pod/data.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
-func eventMapping(content []byte, perfMetrics *util.PerfMetricsCache) ([]common.MapStr, error) {
+func eventMapping(content []byte, perfMetrics *util.PerfMetricsCache, logger *logp.Logger) ([]common.MapStr, error) {
 	events := []common.MapStr{}
 
 	var summary kubernetes.Summary
@@ -103,7 +104,7 @@ func eventMapping(content []byte, perfMetrics *util.PerfMetricsCache) ([]common.
 		}
 
 		if pod.StartTime != "" {
-			_, _ = podEvent.Put("start_time", pod.StartTime)
+			util.ShouldPut(podEvent, "start_time", pod.StartTime, logger)
 		}
 
 		if coresLimit > nodeCores {
@@ -115,31 +116,31 @@ func eventMapping(content []byte, perfMetrics *util.PerfMetricsCache) ([]common.
 		}
 
 		if nodeCores > 0 {
-			_, _ = podEvent.Put("cpu.usage.node.pct", float64(usageNanoCores)/1e9/nodeCores)
+			util.ShouldPut(podEvent, "cpu.usage.node.pct", float64(usageNanoCores)/1e9/nodeCores, logger)
 		}
 
 		if coresLimit > 0 {
-			_, _ = podEvent.Put("cpu.usage.limit.pct", float64(usageNanoCores)/1e9/coresLimit)
+			util.ShouldPut(podEvent, "cpu.usage.limit.pct", float64(usageNanoCores)/1e9/coresLimit, logger)
 		}
 
 		if usageMem > 0 {
 			if nodeMem > 0 {
-				_, _ = podEvent.Put("memory.usage.node.pct", float64(usageMem)/nodeMem)
+				util.ShouldPut(podEvent, "memory.usage.node.pct", float64(usageMem)/nodeMem, logger)
 			}
 			if memLimit > 0 {
-				_, _ = podEvent.Put("memory.usage.limit.pct", float64(usageMem)/memLimit)
-				_, _ = podEvent.Put("memory.working_set.limit.pct", float64(workingSet)/memLimit)
-
+				util.ShouldPut(podEvent, "memory.usage.limit.pct", float64(usageMem)/memLimit, logger)
+				util.ShouldPut(podEvent, "memory.working_set.limit.pct", float64(workingSet)/memLimit, logger)
 			}
 		}
 
 		if workingSet > 0 && usageMem == 0 {
 			if nodeMem > 0 {
-				_, _ = podEvent.Put("memory.usage.node.pct", float64(workingSet)/nodeMem)
+				util.ShouldPut(podEvent, "memory.usage.node.pct", float64(workingSet)/nodeMem, logger)
 			}
 			if memLimit > 0 {
-				_, _ = podEvent.Put("memory.usage.limit.pct", float64(workingSet)/memLimit)
-				_, _ = podEvent.Put("memory.working_set.limit.pct", float64(workingSet)/memLimit)
+				util.ShouldPut(podEvent, "memory.usage.limit.pct", float64(workingSet)/memLimit, logger)
+
+				util.ShouldPut(podEvent, "memory.working_set.limit.pct", float64(workingSet)/memLimit, logger)
 			}
 		}
 
@@ -149,19 +150,17 @@ func eventMapping(content []byte, perfMetrics *util.PerfMetricsCache) ([]common.
 }
 
 // ecsfields maps pod events fields to container ecs fields
-func ecsfields(podEvent common.MapStr) common.MapStr {
+func ecsfields(podEvent common.MapStr, logger *logp.Logger) common.MapStr {
 	ecsfields := common.MapStr{}
 
 	egressBytes, err := podEvent.GetValue("network.tx.bytes")
 	if err == nil {
-		_, _ = ecsfields.Put("network.egress.bytes", egressBytes)
-
+		util.ShouldPut(ecsfields, "network.egress.bytes", egressBytes, logger)
 	}
 
 	ingressBytes, err := podEvent.GetValue("network.rx.bytes")
 	if err == nil {
-		_, _ = ecsfields.Put("network.ingress.bytes", ingressBytes)
-
+		util.ShouldPut(ecsfields, "network.ingress.bytes", ingressBytes, logger)
 	}
 
 	return ecsfields

--- a/metricbeat/module/kubernetes/pod/pod.go
+++ b/metricbeat/module/kubernetes/pod/pod.go
@@ -73,6 +73,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if !ok {
 		return nil, fmt.Errorf("must be child of kubernetes module")
 	}
+
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,
@@ -94,7 +95,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		return
 	}
 
-	events, err := eventMapping(body, util.PerfMetrics)
+	events, err := eventMapping(body, util.PerfMetrics, m.Logger())
 	if err != nil {
 		m.Logger().Error(err)
 		reporter.Error(err)
@@ -111,7 +112,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		}
 
 		// Enrich event with container ECS fields
-		containerEcsFields := ecsfields(event)
+		containerEcsFields := ecsfields(event, m.Logger())
 		if len(containerEcsFields) != 0 {
 			if e.RootFields != nil {
 				e.RootFields.DeepUpdate(common.MapStr{

--- a/metricbeat/module/kubernetes/pod/pod_test.go
+++ b/metricbeat/module/kubernetes/pod/pod_test.go
@@ -28,12 +28,15 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
+	logger := logp.NewLogger("kubernetes.pod")
+
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
@@ -45,7 +48,7 @@ func TestEventMapping(t *testing.T) {
 	cache.NodeMemAllocatable.Set("gke-beats-default-pool-a5b33e2e-hdww", 146227200)
 	cache.ContainerMemLimit.Set(util.ContainerUID("default", "nginx-deployment-2303442956-pcqfc", "nginx"), 14622720)
 
-	events, err := eventMapping(body, cache)
+	events, err := eventMapping(body, cache, logger)
 	assert.NoError(t, err, "error mapping "+testFile)
 
 	assert.Len(t, events, 1, "got wrong number of events")

--- a/metricbeat/module/kubernetes/state_container/state_container.go
+++ b/metricbeat/module/kubernetes/state_container/state_container.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -34,8 +32,6 @@ import (
 const (
 	defaultScheme = "http"
 	defaultPath   = "/metrics"
-	// Nanocores conversion 10^9
-	nanocores = 1000000000
 )
 
 var (
@@ -135,11 +131,11 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 
 	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
-		return errors.Wrap(err, "error getting families")
+		return fmt.Errorf("error getting families: %w", err)
 	}
 	events, err := m.prometheus.ProcessMetrics(families, mapping)
 	if err != nil {
-		return errors.Wrap(err, "error getting event")
+		return fmt.Errorf("error getting event: %w", err)
 	}
 
 	m.enricher.Enrich(events)
@@ -151,18 +147,26 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		if containerID, ok := event["id"]; ok {
 			// we don't expect errors here, but if any we would obtain an
 			// empty string
-			cID := (containerID).(string)
+			cID, ok := (containerID).(string)
+			if !ok {
+				m.Logger().Debugf("Error while casting containerID: %s", ok)
+			}
 			split := strings.Index(cID, "://")
 			if split != -1 {
-				containerFields.Put("runtime", cID[:split])
-				containerFields.Put("id", cID[split+3:])
+				util.ShouldPut(containerFields, "runtime", cID[:split], m.Logger())
+
+				util.ShouldPut(containerFields, "id", cID[split+3:], m.Logger())
 			}
 		}
 		if containerImage, ok := event["image"]; ok {
-			cImage := (containerImage).(string)
-			containerFields.Put("image.name", cImage)
+			cImage, ok := (containerImage).(string)
+			if !ok {
+				m.Logger().Debugf("Error while casting containerImage: %s", ok)
+			}
+
+			util.ShouldPut(containerFields, "image.name", cImage, m.Logger())
 			// remove kubernetes.container.image field as value is the same as ECS container.image.name field
-			event.Delete("image")
+			util.ShouldDelete(event, "image", m.Logger())
 		}
 
 		e, err := util.CreateEvent(event, "kubernetes.container")

--- a/metricbeat/module/kubernetes/system/data.go
+++ b/metricbeat/module/kubernetes/system/data.go
@@ -34,7 +34,7 @@ func eventMapping(content []byte, logger *logp.Logger) ([]common.MapStr, error) 
 	var summary kubernetes.Summary
 	err := json.Unmarshal(content, &summary)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot unmarshal json response: %s", err)
+		return nil, fmt.Errorf("cannot unmarshal json response: %w", err)
 	}
 
 	node := summary.Node

--- a/metricbeat/module/kubernetes/system/data.go
+++ b/metricbeat/module/kubernetes/system/data.go
@@ -22,11 +22,13 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
-func eventMapping(content []byte) ([]common.MapStr, error) {
+func eventMapping(content []byte, logger *logp.Logger) ([]common.MapStr, error) {
 	events := []common.MapStr{}
 
 	var summary kubernetes.Summary
@@ -69,7 +71,7 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 		}
 
 		if syscontainer.StartTime != "" {
-			containerEvent.Put("start_time", syscontainer.StartTime)
+			util.ShouldPut(containerEvent, "start_time", syscontainer.StartTime, logger)
 		}
 
 		events = append(events, containerEvent)

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -90,7 +90,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'system' Metricset data")
 	}
 
-	events, err := eventMapping(body)
+	events, err := eventMapping(body, m.Logger())
 	if err != nil {
 		return errors.Wrap(err, "error in mapping")
 	}

--- a/metricbeat/module/kubernetes/system/system.go
+++ b/metricbeat/module/kubernetes/system/system.go
@@ -20,9 +20,6 @@ package system
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -39,8 +36,6 @@ var (
 		DefaultScheme: defaultScheme,
 		DefaultPath:   defaultPath,
 	}.Build()
-
-	logger = logp.NewLogger("kubernetes.system")
 )
 
 // init registers the MetricSet with the central registry.
@@ -87,12 +82,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
-		return errors.Wrap(err, "error doing HTTP request to fetch 'system' Metricset data")
+		return fmt.Errorf("error doing HTTP request to fetch 'system' Metricset data: %w", err)
 	}
 
 	events, err := eventMapping(body, m.Logger())
 	if err != nil {
-		return errors.Wrap(err, "error in mapping")
+		return fmt.Errorf("error in mapping: %w", err)
 	}
 
 	for _, e := range events {

--- a/metricbeat/module/kubernetes/system/system_test.go
+++ b/metricbeat/module/kubernetes/system/system_test.go
@@ -28,18 +28,21 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
+	logger := logp.NewLogger("kubernetes.system")
+
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
 	body, err := ioutil.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
-	events, err := eventMapping(body)
+	events, err := eventMapping(body, logger)
 	assert.NoError(t, err, "error mapping "+testFile)
 
 	assert.Len(t, events, 1, "got wrong number of events")

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -456,7 +456,11 @@ func (m *enricher) Enrich(events []common.MapStr) {
 				delete(k8sMeta, "pod")
 			}
 			ecsMeta := meta.Clone()
-			ecsMeta.Delete("kubernetes")
+			err = ecsMeta.Delete("kubernetes")
+			if err != nil {
+				logp.Debug("kubernetes", "Failed to delete field '%s': %s", "kubernetes", err)
+			}
+
 			event.DeepUpdate(common.MapStr{
 				mb.ModuleDataKey: k8sMeta,
 				"meta":           ecsMeta,

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -497,3 +497,10 @@ func CreateEvent(event common.MapStr, namespace string) (mb.Event, error) {
 	}
 	return e, err
 }
+
+func ShouldPut(event common.MapStr, field string, value interface{}, logger *logp.Logger) {
+	_, err := event.Put(field, value)
+	if err != nil {
+		logger.Debugf("Failed to put field %v with value %v: %v", field, value, err)
+	}
+}

--- a/metricbeat/module/kubernetes/util/kubernetes_test.go
+++ b/metricbeat/module/kubernetes/util/kubernetes_test.go
@@ -32,6 +32,11 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+var (
+	logger = logp.NewLogger("kubernetes")
 )
 
 func TestBuildMetadataEnricher(t *testing.T) {
@@ -128,9 +133,9 @@ func (f *mockFuncs) update(m map[string]common.MapStr, obj kubernetes.Resource) 
 		},
 	}
 	for k, v := range accessor.GetLabels() {
-		meta.Put(fmt.Sprintf("kubernetes.%v", k), v)
+		ShouldPut(meta, fmt.Sprintf("kubernetes.%v", k), v, logger)
 	}
-	meta.Put("orchestrator.cluster.name", "gke-4242")
+	ShouldPut(meta, "orchestrator.cluster.name", "gke-4242", logger)
 	m[accessor.GetName()] = meta
 }
 

--- a/metricbeat/module/kubernetes/volume/data.go
+++ b/metricbeat/module/kubernetes/volume/data.go
@@ -22,17 +22,19 @@ import (
 	"fmt"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
-func eventMapping(content []byte) ([]common.MapStr, error) {
+func eventMapping(content []byte, logger *logp.Logger) ([]common.MapStr, error) {
 	events := []common.MapStr{}
 
 	var summary kubernetes.Summary
 	err := json.Unmarshal(content, &summary)
 	if err != nil {
-		return nil, fmt.Errorf("Cannot unmarshal json response: %s", err)
+		return nil, fmt.Errorf("cannot unmarshal json response: %w", err)
 	}
 
 	node := summary.Node
@@ -68,10 +70,10 @@ func eventMapping(content []byte) ([]common.MapStr, error) {
 				},
 			}
 			if volume.CapacityBytes > 0 {
-				volumeEvent.Put("fs.used.pct", float64(volume.UsedBytes)/float64(volume.CapacityBytes))
+				util.ShouldPut(volumeEvent, "fs.used.pct", float64(volume.UsedBytes)/float64(volume.CapacityBytes), logger)
 			}
 			if volume.Inodes > 0 {
-				volumeEvent.Put("fs.inodes.pct", float64(volume.InodesUsed)/float64(volume.Inodes))
+				util.ShouldPut(volumeEvent, "fs.inodes.pct", float64(volume.InodesUsed)/float64(volume.Inodes), logger)
 			}
 			events = append(events, volumeEvent)
 		}

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -20,8 +20,6 @@ package volume
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -87,7 +85,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	body, err := m.mod.GetKubeletStats(m.http)
 	if err != nil {
-		return errors.Wrap(err, "error doing HTTP request to fetch 'volume' Metricset data")
+		return fmt.Errorf("error doing HTTP request to fetch 'volume' Metricset data: %w", err)
 	}
 
 	events, err := eventMapping(body, logger)

--- a/metricbeat/module/kubernetes/volume/volume.go
+++ b/metricbeat/module/kubernetes/volume/volume.go
@@ -90,7 +90,10 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		return errors.Wrap(err, "error doing HTTP request to fetch 'volume' Metricset data")
 	}
 
-	events, err := eventMapping(body)
+	events, err := eventMapping(body, logger)
+	if err != nil {
+		return err
+	}
 	for _, e := range events {
 		isOpen := reporter.Event(mb.TransformMapStrToEvent("kubernetes", e, nil))
 		if !isOpen {

--- a/metricbeat/module/kubernetes/volume/volume_test.go
+++ b/metricbeat/module/kubernetes/volume/volume_test.go
@@ -28,18 +28,21 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 const testFile = "../_meta/test/stats_summary.json"
 
 func TestEventMapping(t *testing.T) {
+	logger := logp.NewLogger("kubernetes.volume")
+
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
 	body, err := ioutil.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
-	events, err := eventMapping(body)
+	events, err := eventMapping(body, logger)
 	assert.NoError(t, err, "error mapping "+testFile)
 
 	assert.Len(t, events, 1, "got wrong number of events")


### PR DESCRIPTION
## What does this PR do?

Improve error handling in the Kubernetes module. This PR introduces error handling for optional fields in MapStr structs by logging the error with Debug level. Thus removing linter errors.

## Why is it important?

We want to improve the quality of our code and make it compliant with golang-ci linter

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [x] nothing really. The code changes cannot be easily tested

## How to test this PR locally

cd metricbeat
mage unitTest

## Related issues

- Closes [#31067](https://github.com/elastic/beats/issues/31067)
