### PR TITLE
Do not emit error when EOF is reached and `close.reader.on_eof` is enabled

### DIFF
--- a/filebeat/input/filestream/input.go
+++ b/filebeat/input/filestream/input.go
@@ -19,6 +19,7 @@ package filestream
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"golang.org/x/text/transform"
@@ -318,6 +319,8 @@ func (inp *filestream) readFromSource(
 				log.Infof("File was truncated. Begin reading file from offset 0. Path=%s", path)
 			case ErrClosed:
 				log.Info("Reader was closed. Closing.")
+			case io.EOF:
+				log.Debugf("EOF has been reached. Closing.")
 			default:
 				log.Errorf("Read line error: %v", err)
 			}


### PR DESCRIPTION
## What does this PR do?

This PR downgrades the log level of the following log message to debug:
```
Read line error: EOF
```

## Why is it important?

The message above is not an error. Filestream emits this when the file reader reaches EOF and `close.reader.on_eof` is enabled. However, the message can be useful during debugging issues, so I am keeping the logging of this event.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
