### PR TITLE
Rename `lint` stage to `checks` on the CI

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C auditbeat check;
           make -C auditbeat update;
           make -C x-pack/auditbeat check;
           make -C x-pack/auditbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -12,11 +12,11 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
             make -C deploy/kubernetes all;
             make check-no-changes;
-        stage: lint
+        stage: checks
     k8sTest:
         k8sTest: "v1.23.4,v1.22.7,v1.21.10"
         stage: mandatory

--- a/dev-tools/Jenkinsfile.yml
+++ b/dev-tools/Jenkinsfile.yml
@@ -12,6 +12,6 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: "make -C dev-tools check"
-        stage: lint
+        stage: checks

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C filebeat check;
           make -C filebeat update;
           make -C x-pack/filebeat check;
           make -C x-pack/filebeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C heartbeat check;
           make -C heartbeat update;
           make -C x-pack/heartbeat check;
           make -C x-pack/heartbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -12,14 +12,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C libbeat check;
           make -C libbeat update;
           make -C x-pack/libbeat check;
           make -C x-pack/libbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C metricbeat check;
           make -C metricbeat update;
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -13,7 +13,7 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C packetbeat check;
           make -C packetbeat update;
@@ -21,7 +21,7 @@ stages:
           cd x-pack/packetbeat;
           mage check;
           mage update;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C winlogbeat check;
           make -C winlogbeat update;
           make -C x-pack/winlogbeat check;
           make -C x-pack/winlogbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     crosscompile:
         make: "make -C winlogbeat crosscompile"
         stage: mandatory

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/auditbeat check;
           make -C x-pack/auditbeat update;
           make -C auditbeat check;
           make -C auditbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/dockerlogbeat/Jenkinsfile.yml
+++ b/x-pack/dockerlogbeat/Jenkinsfile.yml
@@ -13,12 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/dockerlogbeat check;
           make -C x-pack/dockerlogbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/filebeat check;
           make -C x-pack/filebeat update;
           make -C filebeat check;
           make -C filebeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -13,12 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/functionbeat check;
           make -C x-pack/functionbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/heartbeat check;
           make -C x-pack/heartbeat update;
           make -C heartbeat check;
           make -C heartbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/libbeat/Jenkinsfile.yml
+++ b/x-pack/libbeat/Jenkinsfile.yml
@@ -13,12 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/libbeat check;
           make -C x-pack/libbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -13,14 +13,14 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/metricbeat check;
           make -C x-pack/metricbeat update;
           make -C metricbeat check;
           make -C metricbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -13,12 +13,12 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/osquerybeat check;
           make -C x-pack/osquerybeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     unitTest:
         mage: "mage build unitTest"
         stage: mandatory

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -13,7 +13,7 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    lint:
+    checks:
         mage: |
           mage check;
           mage update;
@@ -21,7 +21,7 @@ stages:
           make -C packetbeat check;
           make -C packetbeat update;
           make check-no-changes;
-        stage: lint
+        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -13,7 +13,7 @@ when:
     tags: true                 ## for all the tags
 platform: "windows-2022"       ## default label for all the stages
 stages:
-    lint:
+    checks:
         make: |
           make -C x-pack/winlogbeat check;
           make -C x-pack/winlogbeat update;
@@ -22,7 +22,7 @@ stages:
           make check-no-changes;
         platforms:             ## override default labels in this specific stage.
             - "immutable && ubuntu-18"
-        stage: lint
+        stage: checks
     build:
         mage: "mage build unitTest"
         withModule: true


### PR DESCRIPTION
## What does this PR do?

Since we introduced the linter and the Github action this naming started
causing some confusion. Now it's more obvious where the actual linting
takes place and where we have just additional checks.

## Why is it important?

We already had a discussion regarding this confusion with @ruflin in https://github.com/elastic/beats/pull/31098
