### PR TITLE
add ServiceAccount kube type support

### DIFF
--- a/libbeat/common/kubernetes/informer.go
+++ b/libbeat/common/kubernetes/informer.go
@@ -149,6 +149,18 @@ func NewInformer(client kubernetes.Interface, resource Resource, opts WatchOptio
 		}
 
 		objType = "service"
+	case *ServiceAccount:
+		sa := client.CoreV1().ServiceAccounts(opts.Namespace)
+		listwatch = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return sa.List(ctx, options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return sa.Watch(ctx, options)
+			},
+		}
+
+		objType = "service"
 	case *CronJob:
 		cronjob := client.BatchV1().CronJobs(opts.Namespace)
 		listwatch = &cache.ListWatch{

--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -76,6 +76,9 @@ type StatefulSet = appsv1.StatefulSet
 // Service data
 type Service = v1.Service
 
+// ServiceAccount data
+type ServiceAccount = v1.ServiceAccount
+
 // Job data
 type Job = batchv1.Job
 


### PR DESCRIPTION
## What does this PR do?
Adds a new Kubernetes type

## Why is it important?
Cloudbeat's kube fetcher will need to have this type supported.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Notes:
- Should I also add this change into [elastic-agent-autodiscover](https://github.com/elastic/elastic-agent-autodiscover)?
