### PR TITLE
libbeat: log debug for `proxy_url` and fixed docs

### DIFF
--- a/libbeat/common/transport/proxy.go
+++ b/libbeat/common/transport/proxy.go
@@ -67,6 +67,7 @@ func ProxyDialer(log *logp.Logger, config *ProxyConfig, forward Dialer) (Dialer,
 		return nil, err
 	}
 
+	log.Debugf("breaking down proxy URL. Scheme: '%s', host[:port]: '%s', path: '%s'", url.Scheme, url.Host, url.Path)
 	log.Infof("proxy host: '%s'", url.Host)
 	return DialerFunc(func(network, address string) (net.Conn, error) {
 		var err error

--- a/libbeat/esleg/eslegclient/connection.go
+++ b/libbeat/esleg/eslegclient/connection.go
@@ -177,6 +177,7 @@ func NewClients(cfg *common.Config, beatname string) ([]Connection, error) {
 	}
 
 	if proxyURL := config.Transport.Proxy.URL; proxyURL != nil {
+		logp.Debug("breaking down proxy URL. Scheme: '%s', host[:port]: '%s', path: '%s'", proxyURL.Scheme, proxyURL.Host, proxyURL.Path)
 		logp.Info("using proxy URL: %s", proxyURL.URI().String())
 	}
 

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -183,8 +183,7 @@ variables are ignored.
 ===== `proxy_url`
 
 The URL of the proxy to use when connecting to the Elasticsearch servers. The
-value may be either a complete URL or a "host[:port]", in which case the "http"
-scheme is assumed. If a value is not specified through the configuration file
+value must be a complete URL. If a value is not specified through the configuration file
 then proxy environment variables are used. See the
 https://golang.org/pkg/net/http/#ProxyFromEnvironment[Go documentation]
 for more information about the environment variables.

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -65,6 +65,7 @@ func makeES(
 	}
 
 	if proxyURL := config.Transport.Proxy.URL; proxyURL != nil && !config.Transport.Proxy.Disable {
+		log.Debugf("breaking down proxy URL. Scheme: '%s', host[:port]: '%s', path: '%s'", proxyURL.Scheme, proxyURL.Host, proxyURL.Path)
 		log.Infof("Using proxy URL: %s", proxyURL)
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fixes the documentation regarding Elasticsearch output `proxy_url`
configuration format.

Debug logs are added with the breakdown of `proxy_url`.

## Why is it important?

Our documentation did not mach the way `proxy_url` is parsed for Elasticsearch output.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~

## How to test this PR locally

Add the `proxy_url` setting to any output that supports it, start a Beat with log debug, look for the log message breaking down the proxy URL that look like this:
```
{"log.level":"debug","@timestamp":"2022-04-04T18:05:42.644+0200","log.logger":"elasticsearch","log.origin":{"file.name":"elasticsearch/elasticsearch.go","file.line":68},"message":"breaking down proxy URL. Scheme: 'https', host[:port]: 'my-proxy.proxy:8888', path: '/proxy/path'","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-04T18:05:42.644+0200","log.logger":"elasticsearch","log.origin":{"file.name":"elasticsearch/elasticsearch.go","file.line":69},"message":"Using proxy URL: https://my-proxy.proxy:8888/proxy/path","service.name":"filebeat","ecs.version":"1.6.0"}
```

Configuration example:
```yaml
output.elasticsearch:
  enabled: true
  hosts: ["localhost:9200"]
  proxy_url: "https://my-proxy.proxy:8888/proxy/path"
```

## Related issues

- Closes #29249

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
