### PR TITLE
[Auditbeat] Mount /etc/machine-id in auditbeat test container

### DIFF
--- a/x-pack/auditbeat/docker-compose.yml
+++ b/x-pack/auditbeat/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ${PWD}/../..:/go/src/github.com/elastic/beats/
       - /sys:/sys
+      - /etc/machine-id:/etc/machine-id:ro
     command: make
     privileged: true
     pid: host


### PR DESCRIPTION
_This is a test to see if it fixes CI._

## What does this PR do?

Make sure /etc/machine-id is present in containers that are
running system tests to ensure that the host ID is available for
computing entity_id values for events.

## Why is it important?

Fixes tests that are failing on CI due to a change to the debian:bullseye base image to remove /etc/machine-id.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
 this PR will be tested by the reviewer: commands, dependencies, steps, etc.


## Logs

There were warnings in the Auditbeat output. And you can see that the the `host.id` is missing from the "Host info" log message.

```
{
  "log.level": "info",
  "@timestamp": "2022-03-30T23:53:33.670Z",
  "log.logger": "beat",
  "log.origin": {
    "file.name": "instance/beat.go",
    "file.line": 1079
  },
  "message": "Host info",
  "service.name": "auditbeat",
  "system_info": {
    "host": {
      "architecture": "x86_64",
      "boot_time": "2022-03-30T23:24:00Z",
      "containerized": false,
      "name": "b9c23c005ad3",
      "ip": [
        "127.0.0.1/8",
        "172.18.0.2/16"
      ],
      "kernel_version": "5.4.0-1068-gcp",
      "mac": [
        "02:42:ac:12:00:02"
      ],
      "os": {
        "type": "linux",
        "family": "debian",
        "platform": "debian",
        "name": "Debian GNU/Linux",
        "version": "11 (bullseye)",
        "major": 11,
        "minor": 0,
        "patch": 0,
        "codename": "bullseye"
      },
      "timezone": "UTC",
      "timezone_offset_sec": 0
    },
    "ecs.version": "1.6.0"
  }
}
{
  "log.level": "warn",
  "@timestamp": "2022-03-30T23:53:33.672Z",
  "log.logger": "system",
  "log.origin": {
    "file.name": "system/system.go",
    "file.line": 65
  },
  "message": "Could not get host ID, will not fill entity_id fields.",
  "service.name": "auditbeat",
  "ecs.version": "1.6.0"
}
```

When we upgraded Go the underlying container image used to run the integ tests changed. That might be related.

```
akroh@akroh-ubuntu1804-beats-ci:~$ sudo docker run -it --rm golang:1.17.8 cat /etc/machine-id
cat: /etc/machine-id: No such file or directory
akroh@akroh-ubuntu1804-beats-ci:~$ sudo docker run -it --rm golang:1.17.6 cat /etc/machine-id
88544b92092430bc5d3fbbffc12a2f04
akroh@akroh-ubuntu1804-beats-ci:~$ cat /etc/machine-id
bd0cf943b8f2153dd5b55fd690fddf9a
```

The upstream debian bullseye image changed to exclude /etc/machine-id. See: The upstream debian:bullseye image changed to remove /etc/machine-id. https://github.com/debuerreotype/debuerreotype/commit/2db5216500436ea642118acc5c1209986d07898c#diff-37cb13223711ddf6e91e896aaaca349bae294c7f7f44f74c3e0f6791c9155652R261
