### PR TITLE
ci: e2e-testing should fail the build

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -427,23 +427,21 @@ def runE2ETests(){
 
   def suites = '' // empty value represents all suites in the E2E tests
 
-  catchError(buildResult: 'UNSTABLE', message: 'Unable to run e2e tests', stageResult: 'FAILURE') {
-    def suitesSet = e2eTestSuites.toSet()
+  def suitesSet = e2eTestSuites.toSet()
 
-    if (!suitesSet.contains('ALL')) {
-      suitesSet.each { suite ->
-        suites += "${suite},"
-      };
-    }
-    echo 'runE2E will run now in a sync mode to validate packages can be published.'
-    runE2E(runTestsSuites: suites,
-           beatVersion: "${env.BEAT_VERSION}-SNAPSHOT",
-           gitHubCheckName: env.GITHUB_CHECK_E2E_TESTS_NAME,
-           gitHubCheckRepo: env.REPO,
-           gitHubCheckSha1: env.GIT_BASE_COMMIT,
-           propagate: true,
-           wait: true)
+  if (!suitesSet.contains('ALL')) {
+    suitesSet.each { suite ->
+      suites += "${suite},"
+    };
   }
+  echo 'runE2E will run now in a sync mode to validate packages can be published.'
+  runE2E(runTestsSuites: suites,
+         beatVersion: "${env.BEAT_VERSION}-SNAPSHOT",
+         gitHubCheckName: env.GITHUB_CHECK_E2E_TESTS_NAME,
+         gitHubCheckRepo: env.REPO,
+         gitHubCheckSha1: env.GIT_BASE_COMMIT,
+         propagate: true,
+         wait: true)
 }
 
 /**


### PR DESCRIPTION
### What

Fail the build if the e2e-testing failed

### Why

Otherwise the `DRA` stages are triggered regardless and therefore the staging or snapshot artifacts are uploaded. While the `e2e-testing` is the quality gate keeper

![image](https://user-images.githubusercontent.com/2871786/161602089-e2092889-f12b-408c-b44a-8f53a64c869b.png)
