### PR TITLE
Remove the unused "fmt" import.

### DIFF
--- a/x-pack/functionbeat/manager/cmd/root.go
+++ b/x-pack/functionbeat/manager/cmd/root.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Missed in a previous commit removing a log message: https://github.com/elastic/beats/pull/31133

Causing CI to fail for main on the `mage check` target.


