### PR TITLE
[heartbeat][docs] Add note about ensuring correct index settings for uptime

### DIFF
--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -37,9 +37,8 @@ We recommend that you fully upgrade {es} and {kib} to version 8.0
 before upgrading {beats}. The {beats} version must be lower than or equal to the
 {es} version. {beats} cannot send data to older versions of {es}.
 
-Users of the Uptime app should make sure to add `synthetics-*` to their "Index Pattern"
-in the Uptime Kibana app's settings page. Heartbeat 8.0 will prefer the synthetics datastream
-by default, rather than the old `heartbeat-*` indices.
+Users of the Uptime app should make sure to add `heartbeat-8*` and `synthetics-*` to their "Index Patterns"
+in the Uptime Kibana app's settings page. The first index is used by newer versions of Heartbeat, while the latter is used by Fleet.
 
 If you're on {beats} 7.0 through 7.16, upgrade the {stack} and {beats} to
 version 7.17 *before* proceeding with the 8.0 upgrade.

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -37,8 +37,8 @@ We recommend that you fully upgrade {es} and {kib} to version 8.0
 before upgrading {beats}. The {beats} version must be lower than or equal to the
 {es} version. {beats} cannot send data to older versions of {es}.
 
-Users of the Uptime app should make sure to add `heartbeat-8*` and `synthetics-*` to their "Index Patterns"
-in the Uptime Kibana app's settings page. The first index is used by newer versions of Heartbeat, while the latter is used by Fleet.
+If you use the Uptime app in {kib}, make sure you add `heartbeat-8*` and `synthetics-*` to *Uptime indices*
+on the {observability-guide}/configure-uptime-settings.html[Settings page]. The first index is used by newer versions of {beatname_uc}, while the latter is used by {fleet}.
 
 If you're on {beats} 7.0 through 7.16, upgrade the {stack} and {beats} to
 version 7.17 *before* proceeding with the 8.0 upgrade.

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -37,6 +37,9 @@ We recommend that you fully upgrade {es} and {kib} to version 8.0
 before upgrading {beats}. The {beats} version must be lower than or equal to the
 {es} version. {beats} cannot send data to older versions of {es}.
 
+Users of the Uptime app should make sure to add `synthetics-*` to their "Index Pattern"
+in the Uptime Kibana app's settings page.
+
 If you're on {beats} 7.0 through 7.16, upgrade the {stack} and {beats} to
 version 7.17 *before* proceeding with the 8.0 upgrade.
 

--- a/libbeat/docs/upgrading.asciidoc
+++ b/libbeat/docs/upgrading.asciidoc
@@ -38,7 +38,8 @@ before upgrading {beats}. The {beats} version must be lower than or equal to the
 {es} version. {beats} cannot send data to older versions of {es}.
 
 Users of the Uptime app should make sure to add `synthetics-*` to their "Index Pattern"
-in the Uptime Kibana app's settings page.
+in the Uptime Kibana app's settings page. Heartbeat 8.0 will prefer the synthetics datastream
+by default, rather than the old `heartbeat-*` indices.
 
 If you're on {beats} 7.0 through 7.16, upgrade the {stack} and {beats} to
 version 7.17 *before* proceeding with the 8.0 upgrade.


### PR DESCRIPTION
Goes hand in hand with https://github.com/elastic/kibana/pull/129312 . 

Currently, when upgrading the stack, users who have a settings saved object will not see new heartbeat data in typical situations due to their index pattern being stuck on `heartbeat-7*`.
