### PR TITLE
Add automation for project board

### DIFF
--- a/.github/workflows/elastic-agent-project-board.yml
+++ b/.github/workflows/elastic-agent-project-board.yml
@@ -1,0 +1,42 @@
+name: Add to Elastic Agent Data Plane or Control Plane Board
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add_to_data_plane-project:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.label.name == 'Team:Elastic-Agent-Data-Plane'
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:String!,$contentid:String!) {
+               updateIssue(input: {id:$contentid, projectIds:$projectid}) {
+                clientMutationId
+              }
+             }
+          projectid: "PRO_kwDOAGc3Zs4AzG8z"
+          contentid: ${{ github.event.issue.node_id }}
+          GITHUB_TOKEN: ${{ secrets.ELASTIC_AGENT_PROJECT_BOARD_TOKEN }}
+  add_to_control_plane-project:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.label.name == 'Team:Elastic-Agent-Control-Plane'
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:[ID!]!,$contentid:ID!) {
+              updateIssue(input: {id:$contentid, projectIds:$projectid}) {
+               clientMutationId
+             }
+            }
+          projectid: "PRO_kwDOAGc3Zs4AzG9E"
+          contentid: ${{ github.event.issue.node_id }}
+          GITHUB_TOKEN: ${{ secrets.ELASTIC_AGENT_PROJECT_BOARD_TOKEN }}


### PR DESCRIPTION
Automation was removed when we move Elastic Agent out of Beats. The aim of this PR is to create it again.
