### PR TITLE
doc: fix multiline examples in documentation

### DIFF
--- a/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
@@ -168,8 +168,8 @@ The multiline message is stored under the key `msg`.
         keys_under_root: true
         message_key: msg
     - multiline:
-        type: counter
-        lines_count: 3
+        type: count
+        count_lines: 3
 ----
 
 See the available parser settings in detail below.


### PR DESCRIPTION
## What does this PR do?

Fixes a documentation example

## Why is it important?

It fixes a documentation example

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
