### PR TITLE
filestream: use try lock instead of lock when migrating identifiers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - elasticsearch: fix duplicate ingest when using a common appender configuration {issue}30428[30428] {pull}30440[30440]
 - Prevent logic race on clearing data during request in httpjson. {pull}30730[30730]
 - Do not emit error log when filestream reader reaches EOF and `close.reader.on_eof` is enabled. {pull}31109[31109]
+- Prevents filestream inputs from being stuck while being created. {pull}31240[31240]
 
 *Filebeat*
 

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -222,7 +222,10 @@ func (s *sourceStore) FixUpIdentifiers(getNewID func(v Value) (string, interface
 			continue
 		}
 
-		res.lock.Lock()
+		if !res.lock.TryLock() {
+			s.store.log.Infof("cannot lock '%s', will not update registry for it", key)
+			continue
+		}
 
 		newKey, updatedMeta := getNewID(res)
 		if len(newKey) > 0 && res.internalState.TTL > 0 {


### PR DESCRIPTION
## What does this PR do?

When new filestream inputs are created, we try to migrate registry
entries from inputs that did not have an ID set to their newly set
ID. Using a normal mutex lock can create a situation where the
registry entry is locked and the input will never finish being
created.

This PR fixes this by using a TryLock and just skipping entries that
are already locked.
## Why is it important?
It fixes filestream inputs being stuck while being created.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
~~## How to test this PR locally~~

## Related issues
- Closes https://github.com/elastic/elastic-agent/issues/281

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
