### PR TITLE
ci: cancel after gitCheckout to avoid DoS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,11 +53,11 @@ pipeline {
     stage('Checkout') {
       options { skipDefaultCheckout() }
       steps {
-        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         // Here we do a checkout into a temporary directory in order to have the
         // side-effect of setting up the git environment correctly.
         gitCheckout(basedir: "${pwd(tmp: true)}", githubNotifyFirstTimeContributor: true)
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         dir("${BASE_DIR}") {
             // We use a raw checkout to avoid the many extra objects which are brought in
             // with a `git fetch` as would happen if we used the `gitCheckout` step.


### PR DESCRIPTION
### What

Who can run in the CI is done implicitly in the `gitcheckout` step therefore, the cancelPreviousBuild should happen afterwards.

### Why

Avoid killing valid builds in the CI if the comment is not coming from the right set of users

Otherwise

<img width="340" alt="image" src="https://user-images.githubusercontent.com/2871786/162728863-ab264dab-96b8-493b-8d44-eea4ed505994.png">
