### PR TITLE
libbeat/reader/syslog: relax timestamp parsing to allow leading zero

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,6 +106,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add cronjob metadata by default {pull}30637[30637]
 - New option `setup.template.json.data_stream` is added to indicate if the JSON index template is a data stream. {pull}31048[31048]
 - Add support for port mapping in docker hints. {pull}31243[31243]
+- Relax timestamp syntax for RFC3164 syslog to allow leading zero on day. {issue}16824[16824] {pull}31254[31254]
 
 *Auditbeat*
 

--- a/libbeat/reader/syslog/docs/syslog.asciidoc
+++ b/libbeat/reader/syslog/docs/syslog.asciidoc
@@ -40,12 +40,17 @@ filebeat.inputs:
 The RFC 3164 format accepts the following forms of timestamps:
 
 * Local timestamp (`Mmm dd hh:mm:ss`):
+  ** `Jan  3 14:09:01`
+  ** `Jan 03 14:09:01`
   ** `Jan 23 14:09:01`
 * RFC-3339*:
   ** `2003-10-11T22:14:15Z`
   ** `2003-10-11T22:14:15.123456Z`
   ** `2003-10-11T22:14:15-06:00`
   ** `2003-10-11T22:14:15.123456-06:00`
+
+As an extension to RFC 3164, dates with a day that has a leading zero are allowed. For
+example, `Feb 08 08:59:59` is accepted as well as the RFC-compliant `Feb  8 08:59:59`.
 
 *Note*: The local timestamp (for example, `Jan 23 14:09:01`) that accompanies an
 RFC 3164 message lacks year and time zone information. The time zone will be enriched

--- a/libbeat/reader/syslog/parser/common.rl
+++ b/libbeat/reader/syslog/parser/common.rl
@@ -71,7 +71,7 @@
 
     # Timestamp
     timestamp_rfc3339 = (ts_yyyymmdd 'T' ts_hhmmss ('.' digit{1,6})? ts_offset) >tok %set_timestamp_rfc3339 $err(err_timestamp);
-    timestamp_bsd     = (month_str . sp . day_nopad . sp . ts_hhmmss) >tok %set_timestamp_bsd $err(err_timestamp);
+    timestamp_bsd     = (month_str . sp . (day_nopad|day) . sp . ts_hhmmss) >tok %set_timestamp_bsd $err(err_timestamp);
 
     # Hostname
     hostname_range    = graph{1,255};

--- a/libbeat/reader/syslog/rfc3164_gen.go
+++ b/libbeat/reader/syslog/rfc3164_gen.go
@@ -5079,6 +5079,8 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 		switch data[p] {
 		case 32:
 			goto st303
+		case 48:
+			goto st303
 		case 51:
 			goto st316
 		}
@@ -5235,7 +5237,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof318
 		}
 	st_case_318:
-//line rfc3164_gen.go:5230
+//line rfc3164_gen.go:5232
 		if data[p] == 101 {
 			goto st319
 		}
@@ -5260,7 +5262,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof320
 		}
 	st_case_320:
-//line rfc3164_gen.go:5255
+//line rfc3164_gen.go:5257
 		if data[p] == 101 {
 			goto st321
 		}
@@ -5285,7 +5287,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof322
 		}
 	st_case_322:
-//line rfc3164_gen.go:5280
+//line rfc3164_gen.go:5282
 		switch data[p] {
 		case 97:
 			goto st323
@@ -5325,7 +5327,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof325
 		}
 	st_case_325:
-//line rfc3164_gen.go:5320
+//line rfc3164_gen.go:5322
 		if data[p] == 97 {
 			goto st326
 		}
@@ -5353,7 +5355,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof327
 		}
 	st_case_327:
-//line rfc3164_gen.go:5348
+//line rfc3164_gen.go:5350
 		if data[p] == 111 {
 			goto st328
 		}
@@ -5378,7 +5380,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof329
 		}
 	st_case_329:
-//line rfc3164_gen.go:5373
+//line rfc3164_gen.go:5375
 		if data[p] == 99 {
 			goto st330
 		}
@@ -5403,7 +5405,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof331
 		}
 	st_case_331:
-//line rfc3164_gen.go:5398
+//line rfc3164_gen.go:5400
 		if data[p] == 101 {
 			goto st332
 		}
@@ -5428,7 +5430,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof333
 		}
 	st_case_333:
-//line rfc3164_gen.go:5423
+//line rfc3164_gen.go:5425
 		switch data[p] {
 		case 57:
 			goto st335
@@ -5450,7 +5452,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 			goto _test_eof334
 		}
 	st_case_334:
-//line rfc3164_gen.go:5445
+//line rfc3164_gen.go:5447
 		if data[p] == 62 {
 			goto tr5
 		}
@@ -6622,7 +6624,7 @@ func parseRFC3164(data string, loc *time.Location) (message, error) {
 				err = ErrHostname
 				p--
 
-//line rfc3164_gen.go:5870
+//line rfc3164_gen.go:5872
 			}
 		}
 

--- a/libbeat/reader/syslog/rfc3164_test.go
+++ b/libbeat/reader/syslog/rfc3164_test.go
@@ -76,6 +76,17 @@ var parseRFC3164Cases = map[string]struct {
 			msg:       "this is the message",
 		},
 	},
+	"non-standard-date": {
+		In: "<123>Sep 01 02:03:04 hostname message",
+		Want: message{
+			timestamp: mustParseTimeLoc(time.Stamp, "Sep 1 02:03:04", time.Local),
+			priority:  123,
+			facility:  15,
+			severity:  3,
+			hostname:  "hostname",
+			msg:       "message",
+		},
+	},
 	"err-pri-not-a-number": {
 		In:      "<abc>Oct 11 22:14:15 test-host this is the message",
 		WantErr: ErrPriority,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This change relaxes the RFC3164 timestamp grammar to allow dates with a leading
zero to be parsed as valid syslog timestamps, bringing the parser's behaviour into
line with the parser in filebeat/input/syslog.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

There are non-standard syslog generating implementations that we were previously unable to consume. With this change we also gain the possibility of reducing the number of syslog parser implementations that we have.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Confirm that the equivalent [test in filebeat/input/syslog](https://github.com/elastic/beats/blob/60fcf9d6f210258ab8a1b56039fa4eb65f1aeb54/filebeat/input/syslog/rfc3164_test.go#L666-L681) matches (there is one difference in that the hostname in that package's test does not conform to the RFC).
- [ ] This is arguably a bug fix even though it is a break from the strict definition in the RFC. Opinions on this are welcome.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

`go test github.com/elastic/beats/v7/libbeat/reader/syslog`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #16824
- Relates #31246

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
