### PR TITLE
Azure: add storage_account_container config option

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -125,6 +125,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add support in httpjson input for chain calls. {pull}29816[29816]
 - checkpoint module: Add `network.transport` derived from IANA number. {pull}31076[31076]
 - Add URL Encode template function for httpjson input. {pull}30962[30962]
+- Add `storage_account_container` configuration option to Azure logs. {pull}31279[31279]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -550,6 +550,8 @@ filebeat.modules:
       connection_string: ""
       # the name of the storage account the state/offsets will be stored and updated
       storage_account: ""
+      # the name of the storage account container you would like to store the offset information in.
+      storage_account_container: ""
       # the storage account key, this key will be used to authorize access to data in your storage account
       storage_account_key: ""
 

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -49,7 +49,12 @@ func (conf *azureInputConfig) Validate() error {
 	return nil
 }
 
+// storageContainerValidate validated the storage_account_container to make sure it is conforming to all the Azure
+// naming rules.
+// To learn more, please check the Azure documentation visiting:
+// https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
 func storageContainerValidate(name string) error {
+	var previousRune rune
 	runes := []rune(name)
 	length := len(runes)
 	if length < 3 {
@@ -61,10 +66,17 @@ func storageContainerValidate(name string) error {
 	if !unicode.IsLower(runes[0]) && !unicode.IsNumber(runes[0]) {
 		return fmt.Errorf("storage_account_container (%s) must start with a lowercase letter or number", name)
 	}
+	if !unicode.IsLower(runes[length-1]) && !unicode.IsNumber(runes[length-1]) {
+		return fmt.Errorf("storage_account_container (%s) must end with a lowercase letter or number", name)
+	}
 	for i := 0; i < length; i++ {
-		if !unicode.IsLower(runes[i]) && !unicode.IsNumber(runes[i]) && !('-' == runes[i]) {
+		if !unicode.IsLower(runes[i]) && !unicode.IsNumber(runes[i]) && !(runes[i] == '-') {
 			return fmt.Errorf("rune %d of storage_account_container (%s) is not a lowercase letter, number or dash", i, name)
 		}
+		if runes[i] == '-' && previousRune == runes[i] {
+			return fmt.Errorf("consecutive dashes ('-') are not permitted in storage_account_container (%s)", name)
+		}
+		previousRune = runes[i]
 	}
 	return nil
 }

--- a/x-pack/filebeat/module/azure/_meta/config.yml
+++ b/x-pack/filebeat/module/azure/_meta/config.yml
@@ -11,6 +11,8 @@
       connection_string: ""
       # the name of the storage account the state/offsets will be stored and updated
       storage_account: ""
+      # the name of the storage account container you would like to store the offset information in.
+      storage_account_container: ""
       # the storage account key, this key will be used to authorize access to data in your storage account
       storage_account_key: ""
 

--- a/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/config/azure-eventhub.yml
@@ -1,7 +1,6 @@
 type: azure-eventhub
 {{ if .eventhub }}
 eventhub: {{ .eventhub }}
-storage_account_container: filebeat-activitylogs-{{ .eventhub }}
 {{ end }}
 
 {{ if .connection_string }}
@@ -18,6 +17,14 @@ storage_account: {{ .storage_account }}
 
 {{ if .storage_account_key }}
 storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .storage_account_container }}
+storage_account_container: {{ .storage_account_container }}
+{{ else }}
+{{ if .eventhub }}
+storage_account_container: filebeat-activitylogs-{{ .eventhub }}
+{{ end }}
 {{ end }}
 
 {{ if .resource_manager_endpoint }}

--- a/x-pack/filebeat/module/azure/activitylogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/manifest.yml
@@ -10,6 +10,7 @@ var:
   - name: connection_string
   - name: storage_account
   - name: storage_account_key
+  - name: storage_account_container
   - name: resource_manager_endpoint
   - name: tags
     default: [forwarded]

--- a/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/config/azure-eventhub.yml
@@ -1,7 +1,6 @@
 type: azure-eventhub
 {{ if .eventhub }}
 eventhub: {{ .eventhub }}
-storage_account_container: filebeat-auditlogs-{{ .eventhub }}
 {{ end }}
 
 {{ if .connection_string }}
@@ -18,6 +17,14 @@ storage_account: {{ .storage_account }}
 
 {{ if .storage_account_key }}
 storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .storage_account_container }}
+storage_account_container: {{ .storage_account_container }}
+{{ else }}
+{{ if .eventhub }}
+storage_account_container: filebeat-auditlogs-{{ .eventhub }}
+{{ end }}
 {{ end }}
 
 {{ if .resource_manager_endpoint }}

--- a/x-pack/filebeat/module/azure/auditlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/manifest.yml
@@ -10,6 +10,7 @@ var:
   - name: connection_string
   - name: storage_account
   - name: storage_account_key
+  - name: storage_account_container
   - name: resource_manager_endpoint
   - name: tags
     default: [forwarded]

--- a/x-pack/filebeat/module/azure/platformlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/platformlogs/config/azure-eventhub.yml
@@ -1,7 +1,6 @@
 type: azure-eventhub
 {{ if .eventhub }}
 eventhub: {{ .eventhub }}
-storage_account_container: filebeat-platformlogs-{{ .eventhub }}
 {{ end }}
 
 {{ if .connection_string }}
@@ -18,6 +17,14 @@ storage_account: {{ .storage_account }}
 
 {{ if .storage_account_key }}
 storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .storage_account_container }}
+storage_account_container: {{ .storage_account_container }}
+{{ else }}
+{{ if .eventhub }}
+storage_account_container: filebeat-platformlogs-{{ .eventhub }}
+{{ end }}
 {{ end }}
 
 {{ if .resource_manager_endpoint }}

--- a/x-pack/filebeat/module/azure/platformlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/platformlogs/manifest.yml
@@ -9,6 +9,7 @@ var:
   - name: connection_string
   - name: storage_account
   - name: storage_account_key
+  - name: storage_account_container
   - name: resource_manager_endpoint
   - name: tags
     default: [forwarded]

--- a/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/config/azure-eventhub.yml
@@ -1,7 +1,6 @@
 type: azure-eventhub
 {{ if .eventhub }}
 eventhub: {{ .eventhub }}
-storage_account_container: filebeat-signinlogs-{{ .eventhub }}
 {{ end }}
 
 {{ if .connection_string }}
@@ -18,6 +17,14 @@ storage_account: {{ .storage_account }}
 
 {{ if .storage_account_key }}
 storage_account_key: {{ .storage_account_key }}
+{{ end }}
+
+{{ if .storage_account_container }}
+storage_account_container: {{ .storage_account_container }}
+{{ else }}
+{{ if .eventhub }}
+storage_account_container: filebeat-signinlogs-{{ .eventhub }}
+{{ end }}
 {{ end }}
 
 {{ if .resource_manager_endpoint }}

--- a/x-pack/filebeat/module/azure/signinlogs/manifest.yml
+++ b/x-pack/filebeat/module/azure/signinlogs/manifest.yml
@@ -10,6 +10,7 @@ var:
   - name: connection_string
   - name: storage_account
   - name: storage_account_key
+  - name: storage_account_container
   - name: resource_manager_endpoint
   - name: tags
     default: [forwarded]

--- a/x-pack/filebeat/modules.d/azure.yml.disabled
+++ b/x-pack/filebeat/modules.d/azure.yml.disabled
@@ -14,6 +14,8 @@
       connection_string: ""
       # the name of the storage account the state/offsets will be stored and updated
       storage_account: ""
+      # the name of the storage account container you would like to store the offset information in.
+      storage_account_container: ""
       # the storage account key, this key will be used to authorize access to data in your storage account
       storage_account_key: ""
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Add a new `storage_account_container` configuration option for Azure logs. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

End users can now customize the storage account container name to support edge cases not covered by the default naming convention.

For example, SA container name for activity logs is built using `filebeat-activitylogs-{{ .eventhub }}`: event hub name allows `_` (underscore) character, but unfortunately the storage account container [does not](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run Filebeat with the following command line:

```text
-e
-v
-d
*
--strict.perms=false
--path.home
/Users/zmoog/code/projects/zmoog/beats/x-pack/filebeat
-E
cloud.id=<redacted>
-E
cloud.auth=<redacted>
-E
gc_percent=100
-E
setup.ilm.enabled=false
-E
setup.template.enabled=false
-E
output.elasticsearch.allow_older_versions=true
--modules
azure
-M
azure.activitylogs.enabled=true
-M
azure.activitylogs.var.connection_string=<redacted>
-M
azure.activitylogs.var.storage_account=mbrancastorageaccount
-M
azure.activitylogs.var.storage_account_key=<redacted>
-M
azure.activitylogs.var.storage_account_container=mystoragecontainer
```

A storage account container named `mystoragecontainer` will be created and used to keep track if the Azure logs fetched from the Event Hub.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates o elastic/integrations#3006

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
