### PR TITLE
Add orchestrator cluster ECS fields in k8s events

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -155,7 +155,6 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Enhance Oracle Module: Change tablespace metricset collection period {issue}30948[30948] {pull}31259[#31259]
 - Add orchestrator cluster ECS fields in kubernetes events {pull}31341[31341]
 
-
 *Packetbeat*
 
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -153,6 +153,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Populate new container ECS fields in Kubernetes module. {pull}30181[30181]
 - Populate ecs container fields in Containerd module. {pull}31025[31025]
 - Enhance Oracle Module: Change tablespace metricset collection period {issue}30948[30948] {pull}31259[#31259]
+- Add orchestrator cluster ECS fields in kubernetes events {pull}31341[31341]
+
 
 *Packetbeat*
 

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -19,8 +19,9 @@ package event
 
 import (
 	"fmt"
-	k8sclient "k8s.io/client-go/kubernetes"
 	"time"
+
+	k8sclient "k8s.io/client-go/kubernetes"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
@@ -87,7 +88,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		LabelsDedot:      config.LabelsDedot,
 		AnnotationsDedot: config.AnnotationsDedot,
 	}
-
 
 	ms := &MetricSet{
 		BaseMetricSet: base,

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -99,7 +99,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	// add ECS orchestrator fields
 	cfg, _ := common.NewConfigFrom(&config)
-	ecsClusterMeta, err := getClusterECSMeta(cfg, client)
+	ecsClusterMeta, err := getClusterECSMeta(cfg, client, ms.Logger())
 	if err != nil {
 		ms.Logger().Debugf("could not retrieve cluster metadata: %w", err)
 	}
@@ -110,17 +110,17 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return ms, nil
 }
 
-func getClusterECSMeta(cfg *common.Config, client k8sclient.Interface) (common.MapStr, error) {
+func getClusterECSMeta(cfg *common.Config, client k8sclient.Interface, logger *logp.Logger) (common.MapStr, error) {
 	clusterInfo, err := metadata.GetKubernetesClusterIdentifier(cfg, client)
 	if err != nil {
 		return nil, fmt.Errorf("fail to get kubernetes cluster metadata: %w", err)
 	}
 	ecsClusterMeta := common.MapStr{}
 	if clusterInfo.Url != "" {
-		ecsClusterMeta.Put("orchestrator.cluster.url", clusterInfo.Url)
+		util.ShouldPut(ecsClusterMeta, "orchestrator.cluster.url", clusterInfo.Url, logger)
 	}
 	if clusterInfo.Name != "" {
-		ecsClusterMeta.Put("orchestrator.cluster.name", clusterInfo.Name)
+		util.ShouldPut(ecsClusterMeta, "orchestrator.cluster.name", clusterInfo.Name, logger)
 	}
 	return ecsClusterMeta, nil
 }


### PR DESCRIPTION
## What does this PR do?
This PR adds ECS orchestrator fields for k8s events. This is not happening at the moment because events are being collected through "watchers" and the metadata generators are not applicable due to the nature of these objects. However we can directly add orchestrator metadata about the cluster.

## Why is it important?
In order to be able to filter out events per cluster on Dashboards.

Closes https://github.com/elastic/integrations/issues/3114


Sample ES event:
```json
{
  "@timestamp": "2022-04-19T08:40:34.347Z",
  "@metadata": {
    "beat": "metricbeat",
    "type": "_doc",
    "version": "8.3.0"
  },
  "ecs": {
    "version": "8.0.0"
  },
  "host": {
    "name": "kind-control-plane"
  },
  "agent": {
    "type": "metricbeat",
    "version": "8.3.0",
    "ephemeral_id": "118c830a-fc6a-46f2-b99a-b7cd29d53350",
    "id": "b210221a-9944-4f3d-8920-6fa617f66a24",
    "name": "kind-control-plane"
  },
  "kubernetes": {
    "event": {
      "reason": "Pulling",
      "type": "Normal",
      "count": 1,
      "source": {
        "component": "kubelet",
        "host": "kind-control-plane"
      },
      "involved_object": {
        "uid": "46c9d822-5415-49e5-8c1f-cfcb8e110ec2",
        "api_version": "v1",
        "resource_version": "353488",
        "name": "busybox",
        "kind": "Pod"
      },
      "metadata": {
        "resource_version": "353495",
        "timestamp": {
          "created": "2022-04-19T08:40:34.000Z"
        },
        "name": "busybox.16e73f86433fba9c",
        "namespace": "default",
        "self_link": "",
        "generate_name": "",
        "uid": "ea38e90c-c262-4e74-ac72-af6b6844605f"
      },
      "timestamp": {
        "first_occurrence": "2022-04-19T08:40:34.000Z",
        "last_occurrence": "2022-04-19T08:40:34.000Z"
      },
      "message": "Pulling image \"busybox:1.28\""
    }
  },
  "orchestrator": {
    "cluster": {
      "url": "kind-control-plane:6443",
      "name": "kind"
    }
  },
  "metricset": {
    "name": "event"
  },
  "event": {
    "dataset": "kubernetes.event",
    "module": "kubernetes"
  },
  "service": {
    "type": "kubernetes"
  }
}
```