### PR TITLE
Filebeat: renamed data.kubernetes.container.id to data.container.id

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -24,8 +24,8 @@ data:
     #      - config:
     #        - module: 'file_integrity'
     #          paths:
-    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/bin'
-    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/etc'
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.container.id}/rootfs/bin'
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.container.id}/rootfs/etc'
     #          scan_at_start: false
     #          recursive: true
 

--- a/deploy/kubernetes/auditbeat/auditbeat-configmap.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-configmap.yaml
@@ -24,8 +24,8 @@ data:
     #      - config:
     #        - module: 'file_integrity'
     #          paths:
-    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/bin'
-    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.kubernetes.container.id}/rootfs/etc'
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.container.id}/rootfs/bin'
+    #            - '/run/containerd/io.containerd.runtime.v1.linux/k8s.io/${data.container.id}/rootfs/etc'
     #          scan_at_start: false
     #          recursive: true
 

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -28,7 +28,7 @@ data:
     #      hints.default_config:
     #        type: container
     #        paths:
-    #          - /var/log/containers/*${data.kubernetes.container.id}.log
+    #          - /var/log/containers/*${data.container.id}.log
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -28,7 +28,7 @@ data:
     #      hints.default_config:
     #        type: container
     #        paths:
-    #          - /var/log/containers/*${data.kubernetes.container.id}.log
+    #          - /var/log/containers/*${data.container.id}.log
 
     processors:
       - add_cloud_metadata:

--- a/filebeat/_meta/test/docs/01_playground/filebeat.yaml
+++ b/filebeat/_meta/test/docs/01_playground/filebeat.yaml
@@ -28,7 +28,7 @@ data:
     #      hints.default_config:
     #        type: container
     #        paths:
-    #          - /var/log/containers/*${data.kubernetes.container.id}.log
+    #          - /var/log/containers/*${data.container.id}.log
 
     processors:
       - add_cloud_metadata:

--- a/filebeat/autodiscover/builder/hints/config_test.go
+++ b/filebeat/autodiscover/builder/hints/config_test.go
@@ -30,7 +30,7 @@ func TestUnpackCopiesDefault(t *testing.T) {
 		"default_config": common.MapStr{
 			"type": "container",
 			"paths": []string{
-				"/var/log/containers/*${data.kubernetes.container.id}.log",
+				"/var/log/containers/*${data.container.id}.log",
 			},
 		},
 	})

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -756,6 +756,35 @@ func TestGenerateHintsWithPaths(t *testing.T) {
 			},
 		},
 		{
+			msg: "Empty event hints should return default config. Check for data.kubernetes.container.id instead",
+			event: bus.Event{
+				"host": "1.2.3.4",
+				"kubernetes": common.MapStr{
+					"container": common.MapStr{
+						"name": "foobar",
+						"id":   "abc-k8s",
+					},
+					"pod": common.MapStr{
+						"name": "pod",
+						"uid":  "12345",
+					},
+				},
+				"container": common.MapStr{
+					"name": "foobar",
+					"id":   "abc",
+				},
+			},
+			path: "/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
+			len:  1,
+			result: common.MapStr{
+				"type": "docker",
+				"containers": map[string]interface{}{
+					"paths": []interface{}{"/var/lib/docker/containers/abc-k8s/*-json.log"},
+				},
+				"close_timeout": "true",
+			},
+		},
+		{
 			msg: "Hint with processors config must have a processors in the input config",
 			event: bus.Event{
 				"host": "1.2.3.4",

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -745,7 +745,7 @@ func TestGenerateHintsWithPaths(t *testing.T) {
 					"id":   "abc",
 				},
 			},
-			path: "/var/lib/docker/containers/${data.kubernetes.container.id}/*-json.log",
+			path: "/var/lib/docker/containers/${data.container.id}/*-json.log",
 			len:  1,
 			result: common.MapStr{
 				"type": "docker",

--- a/filebeat/docs/autodiscover-kubernetes-config.asciidoc
+++ b/filebeat/docs/autodiscover-kubernetes-config.asciidoc
@@ -12,7 +12,7 @@ filebeat.autodiscover:
           config:
             - type: container
               paths:
-                - /var/log/containers/*-${data.kubernetes.container.id}.log
+                - /var/log/containers/*-${data.container.id}.log
               exclude_lines: ["^\\s+[\\-`('.|_]"]  # drop asciiart lines
 -------------------------------------------------------------------------------------
 
@@ -36,5 +36,5 @@ filebeat.autodiscover:
                 input:
                   type: container
                   paths:
-                    - /var/log/containers/*-${data.kubernetes.container.id}.log
+                    - /var/log/containers/*-${data.container.id}.log
 -------------------------------------------------------------------------------------

--- a/filebeat/docs/running-on-kubernetes.asciidoc
+++ b/filebeat/docs/running-on-kubernetes.asciidoc
@@ -189,14 +189,14 @@ filebeat.autodiscover:
             config:
               - type: container
                 paths:
-                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+                  - "/var/log/containers/*-${data.container.id}.log"
           - condition:
               contains:
                 kubernetes.container.name: "json-logging"
             config:
               - type: container
                 paths:
-                  - "/var/log/containers/*-${data.kubernetes.container.id}.log"
+                  - "/var/log/containers/*-${data.container.id}.log"
                 json.keys_under_root: true
                 json.add_error_key: true
                 json.message_key: message
@@ -221,7 +221,7 @@ filebeat.autodiscover:
       hints.default_config:
         type: container
         paths:
-          - /var/log/containers/*${data.kubernetes.container.id}.log
+          - /var/log/containers/*${data.container.id}.log
 ------------------------------------------------
 +
 Then annotate the pod properly:

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -218,6 +218,7 @@ These are the fields available within config templating. The `kubernetes.*` fiel
 [float]
 ====== Pod specific:
   * container.id
+  * container.image.name
   * kubernetes.container.id
   * kubernetes.container.image
   * kubernetes.container.name

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -217,6 +217,7 @@ These are the fields available within config templating. The `kubernetes.*` fiel
 
 [float]
 ====== Pod specific:
+  * container.id
   * kubernetes.container.id
   * kubernetes.container.image
   * kubernetes.container.name


### PR DESCRIPTION
## What does this PR do?

Renamed data.kubernetes.container.id to data.container.id in docs and test in the Filebeat module. The field data.container.id is already a copy of data.kubernetes.container.id, it is a ECS field and it is supposed to replace the latter one in the future.

## Why is it important?

More consistent docs.

## Checklist

- [x] I have made corresponding changes to the documentation

## Related issues

- Closes https://github.com/elastic/beats/issues/31261
