### PR TITLE
[azureeventhub] SA container: replace underscores(_) with hyphens(-)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -119,6 +119,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add URL Encode template function for httpjson input. {pull}30962[30962]
 - Add `storage_account_container` configuration option to Azure logs. {pull}31279[31279]
 - Add `application/zip` decoder to the `httpsjon` input. {issue}31282[31282] {pull}31304[31304]
+- Sanitize the Azure storage account container names with underscores (_). {pull}31384[31384]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -10,7 +10,10 @@ package azureeventhub
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"unicode"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 type azureInputConfig struct {
@@ -29,6 +32,7 @@ const ephContainerName = "filebeat"
 
 // Validate validates the config.
 func (conf *azureInputConfig) Validate() error {
+	logger := logp.NewLogger("azureInputConfig.validate")
 	if conf.ConnectionString == "" {
 		return errors.New("no connection string configured")
 	}
@@ -40,6 +44,20 @@ func (conf *azureInputConfig) Validate() error {
 	}
 	if conf.SAContainer == "" {
 		conf.SAContainer = fmt.Sprintf("%s-%s", ephContainerName, conf.EventHubName)
+	}
+	if strings.Contains(conf.SAContainer, "_") {
+		originalValue := conf.SAContainer
+		// When a user specifies an event hub name in the input settings,
+		// the configuration uses it to compose the storage account (SA) container
+		// name (for example, `filebeat-<LOGTYPE>-<EVENTHUB>`).
+		//
+		// The event hub allows names with underscores (_) characters, but unfortunately,
+		// the SA container does not permit them.
+		//
+		// So instead of throwing an error to the user we decided try to replace (_)
+		// characters with hyphens (-).
+		conf.SAContainer = strings.ReplaceAll(conf.SAContainer, "_", "-")
+		logger.Warnf("removed underscores (_) from the storage account container name (before: %s, now: %s", originalValue, conf.SAContainer)
 	}
 	err := storageContainerValidate(conf.SAContainer)
 	if err != nil {

--- a/x-pack/filebeat/input/azureeventhub/config.go
+++ b/x-pack/filebeat/input/azureeventhub/config.go
@@ -32,7 +32,7 @@ const ephContainerName = "filebeat"
 
 // Validate validates the config.
 func (conf *azureInputConfig) Validate() error {
-	logger := logp.NewLogger("azureInputConfig.validate")
+	logger := logp.NewLogger("azureeventhub.config")
 	if conf.ConnectionString == "" {
 		return errors.New("no connection string configured")
 	}
@@ -49,15 +49,15 @@ func (conf *azureInputConfig) Validate() error {
 		originalValue := conf.SAContainer
 		// When a user specifies an event hub name in the input settings,
 		// the configuration uses it to compose the storage account (SA) container
-		// name (for example, `filebeat-<LOGTYPE>-<EVENTHUB>`).
+		// name (for example, `filebeat-<DATA-STREAM>-<EVENTHUB>`).
 		//
 		// The event hub allows names with underscores (_) characters, but unfortunately,
 		// the SA container does not permit them.
 		//
-		// So instead of throwing an error to the user we decided try to replace (_)
-		// characters with hyphens (-).
+		// So instead of throwing an error to the user, we decided to replace
+		// underscores (_) characters with hyphens (-).
 		conf.SAContainer = strings.ReplaceAll(conf.SAContainer, "_", "-")
-		logger.Warnf("removed underscores (_) from the storage account container name (before: %s, now: %s", originalValue, conf.SAContainer)
+		logger.Warnf("replaced underscores (_) with hyphens (-) in the storage account container name (before: %s, now: %s", originalValue, conf.SAContainer)
 	}
 	err := storageContainerValidate(conf.SAContainer)
 	if err != nil {

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -8,6 +8,7 @@
 package azureeventhub
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -34,21 +35,24 @@ func TestStorageContainerValidate(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	t.Run("Check event hub names containing underscores", func(t *testing.T) {
+	t.Run("Sanitize storage account containers with underscores", func(t *testing.T) {
 		config := azureInputConfig{
 			ConnectionString: "sb://test-ns.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SECRET",
-			EventHubName:     "eventhub_00",
+			EventHubName:     "event_hub_00",
 			SAName:           "teststorageaccount",
 			SAKey:            "secret",
-			SAContainer:      "filebeat-activitylogs-eventhub_00",
+			SAContainer:      "filebeat-activitylogs-event_hub_00",
 		}
 
 		if err := config.Validate(); err != nil {
-			t.Fatal(err)
+			t.Fatalf("unexpected validation error: %v", err)
 		}
 
-		if config.SAContainer != "filebeat-activitylogs-eventhub-00" {
-			t.Errorf("underscores (_) not replaced with hyphens (-): %s", config.SAContainer)
-		}
+		assert.Equal(
+			t,
+			"filebeat-activitylogs-event-hub-00",
+			config.SAContainer,
+			"underscores (_) not replaced with hyphens (-)",
+		)
 	})
 }

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -8,8 +8,9 @@
 package azureeventhub
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStorageContainerValidate(t *testing.T) {

--- a/x-pack/filebeat/input/azureeventhub/config_test.go
+++ b/x-pack/filebeat/input/azureeventhub/config_test.go
@@ -20,6 +20,8 @@ func TestStorageContainerValidate(t *testing.T) {
 		{"a", false},
 		{"a-name-that-is-really-too-long-to-be-valid-and-should-never-be-used-no-matter-what", false},
 		{"-not-valid", false},
+		{"not-valid-", false},
+		{"not--valid", false},
 		{"capital-A-not-valid", false},
 		{"no_underscores_either", false},
 	}
@@ -29,4 +31,24 @@ func TestStorageContainerValidate(t *testing.T) {
 			t.Errorf("storageContainerValidate(%s) = %v", test.input, err)
 		}
 	}
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("Check event hub names containing underscores", func(t *testing.T) {
+		config := azureInputConfig{
+			ConnectionString: "sb://test-ns.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SECRET",
+			EventHubName:     "eventhub_00",
+			SAName:           "teststorageaccount",
+			SAKey:            "secret",
+			SAContainer:      "filebeat-activitylogs-eventhub_00",
+		}
+
+		if err := config.Validate(); err != nil {
+			t.Fatal(err)
+		}
+
+		if config.SAContainer != "filebeat-activitylogs-eventhub-00" {
+			t.Errorf("underscores (_) not replaced with hyphens (-): %s", config.SAContainer)
+		}
+	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Sanitize the SA container name when users configure the `azureeventhub` input using an Event Hub name with underscores (_).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

When a user specifies an event hub name in the input settings, the configuration uses it to compose the storage account (SA) container name. For example, with an event hub name of `<EVENT-HUB-NAME>`, the used SA container name becomes `filebeat-<DATA-STREAM>-<EVENT-HUB-NAME>` (e.g., `filebeat-auditlogs-eventhub00`).

The event hub allows names with underscores (_) characters, but unfortunately, the SA container does not permit them.

So instead of throwing an error to the user, we [decided](https://github.com/elastic/integrations/issues/3006#issuecomment-1102753497) to replace the (_) characters with hyphens (-).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related elastic/integrations#3006

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
