### PR TITLE
[Filebeat] Updating Fields to Match ECS Format

### DIFF
--- a/filebeat/docs/modules/panw.asciidoc
+++ b/filebeat/docs/modules/panw.asciidoc
@@ -89,8 +89,8 @@ in ECS that are added under the `panw.panos` prefix:
 | Generated Time | `@timestamp` |
 | Source IP | client.ip source.ip |
 | Destination IP | server.ip destination.ip |
-| NAT Source IP |  | panw.panos.source.nat.ip
-| NAT Destination IP |  | panw.panos.destination.nat.ip
+| NAT Source IP | source.nat.ip |
+| NAT Destination IP | destination.nat.ip |
 | Rule Name |  | panw.panos.ruleset
 | Source User | client.user.name source.user.name |
 | Destination User | server.user.name destination.user.name |
@@ -102,8 +102,8 @@ in ECS that are added under the `panw.panos` prefix:
 | Session ID |  | panw.panos.flow_id
 | Source Port | client.port source.port |
 | Destination Port | destination.port server.port |
-| NAT Source Port |  | panw.panos.source.nat.port
-| NAT Destination Port |  | panw.panos.destination.nat.port
+| NAT Source Port | source.nat.port |
+| NAT Destination Port | destination.nat.port |
 | Flags | labels |
 | Protocol | network.transport |
 | Action | event.outcome |
@@ -131,8 +131,8 @@ in ECS that are added under the `panw.panos` prefix:
 | Generated Time | `@timestamp` |
 | Source IP | client.ip source.ip |
 | Destination IP | server.ip destination.ip |
-| NAT Source IP |  | panw.panos.source.nat.ip
-| NAT Destination IP |  | panw.panos.destination.nat.ip
+| NAT Source IP | source.nat.ip |
+| NAT Destination IP | destination.nat.ip |
 | Rule Name |  | panw.panos.ruleset
 | Source User | client.user.name source.user.name |
 | Destination User | server.user.name destination.user.name |
@@ -144,8 +144,8 @@ in ECS that are added under the `panw.panos` prefix:
 | Session ID |  | panw.panos.flow_id
 | Source Port | client.port source.port |
 | Destination Port | destination.port server.port |
-| NAT Source Port |  | panw.panos.source.nat.port
-| NAT Destination Port |  | panw.panos.destination.nat.port
+| NAT Source Port | source.nat.port |
+| NAT Destination Port | destination.nat.port |
 | Flags | labels |
 | Protocol | network.transport |
 | Action | event.outcome |


### PR DESCRIPTION
removing from the *.nat.* fields to match ECS when panw.panos. exists in the beginning

Type of change
-DOCS

## What does this PR do?
It aligns the panos fields to ECS


## Why is it important?
It aligns and corrects the panos fields to ECS


## Checklist

- [x] My code follows the style guidelines of this project
- [ ~~] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [~~] I have made corresponding change to the default configuration files
- [~~] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist
- [] verify fields align with ECS base fields