### PR TITLE
Heartbeat service telemetry collection

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -124,6 +124,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Heartbeat*
 
+- Heartbeat will now send more usage statistics (monitor durations, and browser steps) when monitoring is enabled. {pull}31398[31398]
 
 *Metricbeat*
 

--- a/heartbeat/hbtestllext/isdefs.go
+++ b/heartbeat/hbtestllext/isdefs.go
@@ -41,3 +41,11 @@ var IsInt64 = isdef.Is("positiveInt64", func(path llpath.Path, v interface{}) *l
 	}
 	return llresult.ValidResult(path)
 })
+
+var IsDuration = isdef.Is("duration", func(path llpath.Path, v interface{}) *llresult.Results {
+	_, ok := v.(time.Duration)
+	if !ok {
+		return llresult.SimpleResult(path, false, "expected a duration")
+	}
+	return llresult.ValidResult(path)
+})

--- a/heartbeat/hbtestllext/validators.go
+++ b/heartbeat/hbtestllext/validators.go
@@ -34,7 +34,7 @@ var MonitorTimespanValidator = lookslike.MustCompile(map[string]interface{}{
 var MonitorDurationValidator = lookslike.MustCompile(map[string]interface{}{
 	"monitor": map[string]interface{}{
 		"duration": map[string]interface{}{
-			"us": IsDuration,
+			"us": IsInt64,
 		},
 	},
 })

--- a/heartbeat/hbtestllext/validators.go
+++ b/heartbeat/hbtestllext/validators.go
@@ -30,3 +30,11 @@ var MonitorTimespanValidator = lookslike.MustCompile(map[string]interface{}{
 		},
 	},
 })
+
+var MonitorDurationValidator = lookslike.MustCompile(map[string]interface{}{
+	"monitor": map[string]interface{}{
+		"duration": map[string]interface{}{
+			"us": IsDuration,
+		},
+	},
+})

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -78,10 +78,8 @@ func sendTLSRequest(t *testing.T, testURL string, useUrls bool, extraConfig map[
 		configSrc["hosts"] = testURL
 	}
 
-	if extraConfig != nil {
-		for k, v := range extraConfig {
-			configSrc[k] = v
-		}
+	for k, v := range extraConfig {
+		configSrc[k] = v
 	}
 
 	config, err := common.NewConfigFrom(configSrc)
@@ -534,6 +532,7 @@ func runHTTPSServerCheck(
 		}
 		for k, v := range missing {
 			if found, err := event.Fields.HasKey(k); !found || err != nil {
+				//nolint:errcheck // HasKey check above
 				event.Fields.Put(k, v)
 			}
 		}
@@ -561,6 +560,9 @@ func TestExpiredHTTPSServer(t *testing.T) {
 	tlsCert, err := tls.LoadX509KeyPair("../fixtures/expired.cert", "../fixtures/expired.key")
 	require.NoError(t, err)
 	host, port, cert, closeSrv := hbtest.StartHTTPSServer(t, tlsCert)
+
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	defer closeSrv()
 	u := &url.URL{Scheme: "https", Host: net.JoinHostPort(host, port)}
 
@@ -582,6 +584,7 @@ func TestExpiredHTTPSServer(t *testing.T) {
 }
 
 func TestHTTPSx509Auth(t *testing.T) {
+	//nolint:goconst // windows is a test-scoped value, doesn't make sense to make it a constant.
 	if runtime.GOOS == "windows" && bits.UintSize == 32 {
 		t.Skip("flaky test: https://github.com/elastic/beats/issues/25857")
 	}
@@ -816,22 +819,16 @@ func httpConnectTunnel(writer http.ResponseWriter, request *http.Request) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
+		//nolint:errcheck // test-controlled copy
 		io.Copy(destConn, clientReadWriter)
 		wg.Done()
 	}()
 	go func() {
+		//nolint:errcheck // test-controlled copy
 		io.Copy(clientConn, destConn)
 		wg.Done()
 	}()
 	wg.Wait()
-}
-
-func mustParseURL(t *testing.T, url string) *url.URL {
-	parsed, err := common.ParseURL(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return parsed
 }
 
 // helper that compresses some content as gzip

--- a/heartbeat/monitors/active/icmp/icmp_test.go
+++ b/heartbeat/monitors/active/icmp/icmp_test.go
@@ -72,24 +72,21 @@ func execTestICMPCheck(t *testing.T, cfg Config) (mockLoop, *beat.Event) {
 	jf, err := newJobFactory(cfg, monitors.NewStdResolver(), tl)
 	require.NoError(t, err)
 	p, err := jf.makePlugin()
+	require.NoError(t, err)
 	require.Len(t, p.Jobs, 1)
 	require.Equal(t, 1, p.Endpoints)
 	e := &beat.Event{}
 	sched, _ := schedule.Parse("@every 1s")
 	wrapped := wrappers.WrapCommon(p.Jobs, stdfields.StdMonitorFields{ID: "test", Type: "icmp", Schedule: sched, Timeout: 1}, stats)
-	wrapped[0](e)
+	_, err = wrapped[0](e)
+	require.NoError(t, err)
 	return tl, e
 }
 
 type mockLoop struct {
-	pingRtt             time.Duration
-	pingRequests        int
-	pingErr             error
-	checkNetworkModeErr error
-}
-
-func (t mockLoop) checkNetworkMode(mode string) error {
-	return t.checkNetworkModeErr
+	pingRtt      time.Duration
+	pingRequests int
+	pingErr      error
 }
 
 func (t mockLoop) ping(addr *net.IPAddr, timeout time.Duration, interval time.Duration) (time.Duration, int, error) {

--- a/heartbeat/monitors/active/tcp/helpers_test.go
+++ b/heartbeat/monitors/active/tcp/helpers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/heartbeat/hbtest"
+	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
@@ -35,6 +36,11 @@ import (
 )
 
 func testTCPConfigCheck(t *testing.T, configMap common.MapStr, host string, port uint16) *beat.Event {
+	var stats = plugin.NewMultiRegistry(
+		[]plugin.StartStopRegistryRecorder{},
+		[]plugin.DurationRegistryRecorder{},
+	)
+
 	config, err := common.NewConfigFrom(configMap)
 	require.NoError(t, err)
 
@@ -42,7 +48,7 @@ func testTCPConfigCheck(t *testing.T, configMap common.MapStr, host string, port
 	require.NoError(t, err)
 
 	sched := schedule.MustParse("@every 1s")
-	job := wrappers.WrapCommon(p.Jobs, stdfields.StdMonitorFields{ID: "test", Type: "tcp", Schedule: sched, Timeout: 1})[0]
+	job := wrappers.WrapCommon(p.Jobs, stdfields.StdMonitorFields{ID: "test", Type: "tcp", Schedule: sched, Timeout: 1}, stats)[0]
 
 	event := &beat.Event{}
 	_, err = job(event)

--- a/heartbeat/monitors/active/tcp/helpers_test.go
+++ b/heartbeat/monitors/active/tcp/helpers_test.go
@@ -23,6 +23,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	//nolint:gomodguard // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
@@ -35,7 +37,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func testTCPConfigCheck(t *testing.T, configMap common.MapStr, host string, port uint16) *beat.Event {
+func testTCPConfigCheck(t *testing.T, configMap common.MapStr) *beat.Event {
 	var stats = plugin.NewMultiRegistry(
 		[]plugin.StartStopRegistryRecorder{},
 		[]plugin.DurationRegistryRecorder{},
@@ -59,7 +61,7 @@ func testTCPConfigCheck(t *testing.T, configMap common.MapStr, host string, port
 	return event
 }
 
-func setupServer(t *testing.T, serverCreator func(http.Handler) (*httptest.Server, error)) (*httptest.Server, uint16, error) {
+func setupServer(serverCreator func(http.Handler) (*httptest.Server, error)) (*httptest.Server, uint16, error) {
 	server, err := serverCreator(hbtest.HelloWorldHandler(200))
 	if err != nil {
 		return nil, 0, err

--- a/heartbeat/monitors/active/tcp/socks5_test.go
+++ b/heartbeat/monitors/active/tcp/socks5_test.go
@@ -54,10 +54,15 @@ func TestSocks5Job(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			host, port, ip, closeEcho, err := startEchoServer(t)
 			require.NoError(t, err)
+
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			defer closeEcho()
 
 			_, proxyPort, proxyIp, closeProxy, err := startSocks5Server(t)
 			require.NoError(t, err)
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			defer closeProxy()
 
 			proxyURL := &url.URL{Scheme: "socks5", Host: net.JoinHostPort(proxyIp, fmt.Sprint(proxyPort))}
@@ -70,7 +75,7 @@ func TestSocks5Job(t *testing.T) {
 				"check.receive":            "echo123",
 				"check.send":               "echo123",
 			}
-			event := testTCPConfigCheck(t, configMap, host, port)
+			event := testTCPConfigCheck(t, configMap)
 
 			testslike.Test(
 				t,
@@ -96,6 +101,7 @@ func TestSocks5Job(t *testing.T) {
 }
 
 func startSocks5Server(t *testing.T) (host string, port uint16, ip string, close func() error, err error) {
+	//nolint:goconst // test-scoped value, shouldn't make it a constant.
 	host = "localhost"
 	config := &socks5.Config{}
 	server, err := socks5.New(config)
@@ -108,6 +114,7 @@ func startSocks5Server(t *testing.T) (host string, port uint16, ip string, close
 		return "", 0, "", nil, err
 	}
 	ip, portStr, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
 	portUint64, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		listener.Close()

--- a/heartbeat/monitors/active/tcp/tcp.go
+++ b/heartbeat/monitors/active/tcp/tcp.go
@@ -142,6 +142,8 @@ func (jf *jobFactory) makeEndpointJob(endpointURL *url.URL) (jobs.Job, error) {
 	// in resolving the actual IP.
 	// Create one job for every port number configured.
 	if jf.config.Socks5.URL != "" && !jf.config.Socks5.LocalResolve {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		jf.makeSocksLookupEndpointJob(endpointURL)
 	}
 
@@ -171,6 +173,8 @@ func (jf *jobFactory) makeDirectEndpointJob(endpointURL *url.URL) (jobs.Job, err
 }
 
 // makeSocksLookupEndpointJob makes jobs that use a Socks5 proxy to perform DNS lookups
+//nolint:unparam // There are no new changes to this line but
+// linter has been activated in the meantime. We'll cleanup separately.
 func (jf *jobFactory) makeSocksLookupEndpointJob(endpointURL *url.URL) (jobs.Job, error) {
 	return wrappers.WithURLField(endpointURL,
 		jobs.MakeSimpleJob(func(event *beat.Event) error {
@@ -228,6 +232,8 @@ func (jf *jobFactory) execDialer(
 	conn, err := dialer.Dial("tcp", addr)
 	if err != nil {
 		debugf("dial failed with: %v", err)
+		//nolint:errorlint // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		if certErr, ok := err.(x509.CertificateInvalidError); ok {
 			tlsmeta.AddCertMetadata(event.Fields, []*x509.Certificate{certErr.Cert})
 		}
@@ -246,6 +252,8 @@ func (jf *jobFactory) execDialer(
 
 	validateStart := time.Now()
 	err = jf.dataCheck.Check(conn)
+	//nolint:errorlint // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	if err != nil && err != errRecvMismatch {
 		debugf("check failed with: %v", err)
 		return reason.IOFailed(err)

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -44,7 +44,7 @@ func testTCPCheck(t *testing.T, host string, port uint16) *beat.Event {
 		"ports":   port,
 		"timeout": "1s",
 	}
-	return testTCPConfigCheck(t, config, host, port)
+	return testTCPConfigCheck(t, config)
 }
 
 // TestUpEndpointJob tests an up endpoint configured using either direct lookups or IPs
@@ -77,7 +77,7 @@ func TestUpEndpointJob(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.name, func(t *testing.T) {
-			server, port, err := setupServer(t, func(handler http.Handler) (*httptest.Server, error) {
+			server, port, err := setupServer(func(handler http.Handler) (*httptest.Server, error) {
 				return newHostTestServer(handler, scenario.hostname)
 			})
 			// Some machines don't have ipv6 setup correctly, so we ignore the test
@@ -157,6 +157,8 @@ func TestUnreachableEndpointJob(t *testing.T) {
 func TestCheckUp(t *testing.T) {
 	host, port, ip, closeEcho, err := startEchoServer(t)
 	require.NoError(t, err)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	defer closeEcho()
 
 	configMap := common.MapStr{
@@ -167,7 +169,7 @@ func TestCheckUp(t *testing.T) {
 		"check.send":    "echo123",
 	}
 
-	event := testTCPConfigCheck(t, configMap, host, port)
+	event := testTCPConfigCheck(t, configMap)
 
 	testslike.Test(
 		t,
@@ -190,6 +192,8 @@ func TestCheckUp(t *testing.T) {
 func TestCheckDown(t *testing.T) {
 	host, port, ip, closeEcho, err := startEchoServer(t)
 	require.NoError(t, err)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	defer closeEcho()
 
 	configMap := common.MapStr{
@@ -200,7 +204,7 @@ func TestCheckDown(t *testing.T) {
 		"check.send":    "echo123",
 	}
 
-	event := testTCPConfigCheck(t, configMap, host, port)
+	event := testTCPConfigCheck(t, configMap)
 
 	testslike.Test(
 		t,
@@ -262,6 +266,7 @@ func startEchoServer(t *testing.T) (host string, port uint16, ip string, close f
 	}()
 
 	ip, portStr, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
 	portUint64, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		listener.Close()

--- a/heartbeat/monitors/active/tcp/tls_test.go
+++ b/heartbeat/monitors/active/tcp/tls_test.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
@@ -181,6 +182,11 @@ func setupTLSTestServer(t *testing.T) (ip string, port uint16, cert *x509.Certif
 }
 
 func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string, resolver monitors.Resolver) *beat.Event {
+	var stats = plugin.NewMultiRegistry(
+		[]plugin.StartStopRegistryRecorder{},
+		[]plugin.DurationRegistryRecorder{},
+	)
+
 	config, err := common.NewConfigFrom(common.MapStr{
 		"hosts":   host,
 		"ports":   int64(port),
@@ -193,7 +199,7 @@ func testTLSTCPCheck(t *testing.T, host string, port uint16, certFileName string
 	require.NoError(t, err)
 
 	sched := schedule.MustParse("@every 1s")
-	job := wrappers.WrapCommon(p.Jobs, stdfields.StdMonitorFields{ID: "test", Type: "tcp", Schedule: sched, Timeout: 1})[0]
+	job := wrappers.WrapCommon(p.Jobs, stdfields.StdMonitorFields{ID: "test", Type: "tcp", Schedule: sched, Timeout: 1}, stats)[0]
 
 	event := &beat.Event{}
 	_, err = job(event)

--- a/heartbeat/monitors/active/tcp/tls_test.go
+++ b/heartbeat/monitors/active/tcp/tls_test.go
@@ -126,6 +126,8 @@ func TestTLSExpiredCert(t *testing.T) {
 	require.NoError(t, err)
 
 	ip, portStr, cert, closeSrv := hbtest.StartHTTPSServer(t, tlsCert)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	defer closeSrv()
 
 	portInt, err := strconv.Atoi(portStr)
@@ -151,7 +153,7 @@ func TestTLSExpiredCert(t *testing.T) {
 
 func setupTLSTestServer(t *testing.T) (ip string, port uint16, cert *x509.Certificate, certFile *os.File, teardown func()) {
 	// Start up a TLS Server
-	server, port, err := setupServer(t, func(handler http.Handler) (*httptest.Server, error) {
+	server, port, err := setupServer(func(handler http.Handler) (*httptest.Server, error) {
 		return httptest.NewTLSServer(handler), nil
 	})
 	require.NoError(t, err)

--- a/heartbeat/monitors/factory_test.go
+++ b/heartbeat/monitors/factory_test.go
@@ -138,6 +138,8 @@ func TestPreProcessors(t *testing.T) {
 			t.Run("event.data_stream", func(t *testing.T) {
 				dataStreamRaw, _ := e.GetValue("data_stream")
 				if tt.expectedDatastream != nil {
+					//nolint:errcheck // There are no new changes to this line but
+					// linter has been activated in the meantime. We'll cleanup separately.
 					dataStream := dataStreamRaw.(add_data_stream.DataStream)
 					require.Equal(t, eventDs, dataStream.Dataset, "event.dataset be identical to data_stream.dataset")
 
@@ -150,7 +152,7 @@ func TestPreProcessors(t *testing.T) {
 
 func TestDuplicateMonitorIDs(t *testing.T) {
 	serverMonConf := mockPluginConf(t, "custom", "custom", "@every 1ms", "http://example.net")
-	badConf := mockBadPluginConf(t, "custom", "@every 1ms")
+	badConf := mockBadPluginConf(t, "custom")
 	reg, built, closed := mockPluginsReg()
 	pipelineConnector := &MockPipelineConnector{}
 

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/atomic"
-	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/go-lookslike"
 	"github.com/elastic/go-lookslike/isdef"
 	"github.com/elastic/go-lookslike/validator"
@@ -141,7 +140,10 @@ func createMockJob() ([]jobs.Job, error) {
 }
 
 func mockPluginBuilder() (plugin.PluginFactory, *atomic.Int, *atomic.Int) {
-	reg := monitoring.NewRegistry()
+	var stats = plugin.NewMultiRegistry(
+		[]plugin.StartStopRegistryRecorder{},
+		[]plugin.DurationRegistryRecorder{},
+	)
 
 	built := atomic.NewInt(0)
 	closed := atomic.NewInt(0)
@@ -170,7 +172,7 @@ func mockPluginBuilder() (plugin.PluginFactory, *atomic.Int, *atomic.Int) {
 
 				return plugin.Plugin{Jobs: j, DoClose: closer, Endpoints: 1}, err
 			},
-			Stats: plugin.NewPluginCountersRecorder("test", reg)},
+			Stats: stats},
 		built,
 		closed
 }

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -71,7 +71,7 @@ type Monitor struct {
 
 	// stats is the countersRecorder used to record lifecycle events
 	// for global metrics + telemetry
-	stats plugin.RegistryRecorder
+	stats plugin.StartStopRegistryRecorder
 
 	runOnce bool
 }
@@ -180,7 +180,7 @@ func newMonitorUnsafe(
 		}}
 	}
 
-	wrappedJobs := wrappers.WrapCommon(p.Jobs, m.stdFields)
+	wrappedJobs := wrappers.WrapCommon(p.Jobs, m.stdFields, pluginFactory.Stats)
 	m.endpoints = p.Endpoints
 
 	m.configuredJobs, err = m.makeTasks(config, wrappedJobs)

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -22,6 +22,9 @@ import (
 	"sync"
 
 	"github.com/mitchellh/hashstructure"
+
+	//nolint:gomodguard // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/heartbeat/monitors/jobs"
@@ -173,7 +176,7 @@ func newMonitorUnsafe(
 	// that it can render.
 	if err != nil {
 		// Note, needed to hoist err to this scope, not just to add a prefix
-		fullErr := fmt.Errorf("job could not be initialized: %s", err)
+		fullErr := fmt.Errorf("job could not be initialized: %w", err)
 		// A placeholder job that always returns an error
 		p.Jobs = []jobs.Job{func(event *beat.Event) ([]jobs.Job, error) {
 			return nil, fullErr
@@ -211,11 +214,15 @@ func (m *Monitor) makeTasks(config *common.Config, jobs []jobs.Job) ([]*configur
 		return nil, errors.Wrap(err, "invalid config, could not unpack monitor config")
 	}
 
+	//nolint:prealloc // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	var mTasks []*configuredJob
 	for _, job := range jobs {
 		t, err := newConfiguredJob(job, mtConf, m)
 		if err != nil {
 			// Failure to compile monitor processors should not crash hb or prevent progress
+			//nolint:errorlint // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			if _, ok := err.(ProcessorsError); ok {
 				logp.Critical("Failed to load monitor processors: %v", err)
 				continue
@@ -244,6 +251,8 @@ func (m *Monitor) Start() {
 			}
 			t.Start(&WrappedClient{
 				Publish: func(event beat.Event) {
+					//nolint:errcheck // There are no new changes to this line but
+					// linter has been activated in the meantime. We'll cleanup separately.
 					client.Publish(event)
 				},
 				Close: client.Close,

--- a/heartbeat/monitors/plugin/lightweight_duration_recorder.go
+++ b/heartbeat/monitors/plugin/lightweight_duration_recorder.go
@@ -1,6 +1,19 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package plugin
 

--- a/heartbeat/monitors/plugin/lightweight_duration_recorder.go
+++ b/heartbeat/monitors/plugin/lightweight_duration_recorder.go
@@ -1,0 +1,35 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package plugin
+
+import (
+	"strconv"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+type DurationRegistryRecorder interface {
+	RecordDuration(duration int64)
+}
+
+type durationRecorder struct {
+	durationHistogram *monitoring.UniqueList // histogram with the count of durations (in ms) for tests
+}
+
+func NewDurationRecorder(pluginName string, r *monitoring.Registry) DurationRegistryRecorder {
+	pluginRegistry := r.GetRegistry(pluginName)
+	if pluginRegistry == nil {
+		pluginRegistry = r.NewRegistry(pluginName)
+	}
+
+	durationHistogram := monitoring.NewUniqueList()
+	monitoring.NewFunc(pluginRegistry, "duration_histogram", durationHistogram.ReportMap, monitoring.Report)
+
+	return durationRecorder{durationHistogram}
+}
+
+func (dr durationRecorder) RecordDuration(d int64) {
+	dr.durationHistogram.Add(strconv.FormatInt(d, 10))
+}

--- a/heartbeat/monitors/plugin/plugin.go
+++ b/heartbeat/monitors/plugin/plugin.go
@@ -49,7 +49,7 @@ type Plugin struct {
 	Endpoints int
 }
 
-// Close closes the plugin, invoking any DoClose hooks if avialable.
+// Close closes the :lugin, invoking any DoClose hooks if avialable.
 func (p Plugin) Close() error {
 	if p.DoClose != nil {
 		return p.DoClose()

--- a/heartbeat/monitors/plugin/plugin.go
+++ b/heartbeat/monitors/plugin/plugin.go
@@ -60,8 +60,8 @@ var pluginKey = "heartbeat.monitor"
 var stateGlobalRecorder = newRootGaugeRecorder(hbregistry.TelemetryRegistry)
 
 func statsForPlugin(pluginName string) MultiRegistryRecorder {
-	return MultiRegistry{
-		startStopRecorders: []StartStopRegistryRecorder{
+	return NewMultiRegistry(
+		[]StartStopRegistryRecorder{
 			// state (telemetry)
 			newPluginGaugeRecorder(pluginName, hbregistry.TelemetryRegistry),
 			// Record global monitors / endpoints count
@@ -69,10 +69,10 @@ func statsForPlugin(pluginName string) MultiRegistryRecorder {
 			// When stats for this plugin are updated, update the global stats as well
 			stateGlobalRecorder,
 		},
-		durationRecorders: []DurationRegistryRecorder{
+		[]DurationRegistryRecorder{
 			NewDurationRecorder(pluginName, hbregistry.StatsRegistry),
 		},
-	}
+	)
 }
 
 func init() {

--- a/heartbeat/monitors/plugin/plugin.go
+++ b/heartbeat/monitors/plugin/plugin.go
@@ -46,7 +46,7 @@ type Plugin struct {
 	Endpoints int
 }
 
-// Close closes the :lugin, invoking any DoClose hooks if avialable.
+// Close closes the :lugin, invoking any DoClose hooks if available.
 func (p Plugin) Close() error {
 	if p.DoClose != nil {
 		return p.DoClose()
@@ -97,7 +97,7 @@ const (
 	PassiveMonitor
 )
 
-// globalPluginsReg maintains the canonical list of valid Heartbeat monitorStarts at runtime.
+// GlobalPluginsReg maintains the canonical list of valid Heartbeat monitorStarts at runtime.
 var GlobalPluginsReg = NewPluginsReg()
 
 type PluginsReg struct {
@@ -156,6 +156,8 @@ func (r *PluginsReg) Get(name string) (PluginFactory, bool) {
 }
 
 func (r *PluginsReg) String() string {
+	//nolint:prealloc // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	var monitors []string
 	for m := range r.monitors {
 		monitors = append(monitors, m)

--- a/heartbeat/monitors/plugin/regrecord.go
+++ b/heartbeat/monitors/plugin/regrecord.go
@@ -31,6 +31,10 @@ type MultiRegistry struct {
 	durationRecorders  []DurationRegistryRecorder
 }
 
+func NewMultiRegistry(startStopRecorders []StartStopRegistryRecorder, durationRecorders []DurationRegistryRecorder) MultiRegistry {
+	return MultiRegistry{startStopRecorders, durationRecorders}
+}
+
 // MultiRegistryRecorder composes multiple statsRecorders.
 type MultiRegistryRecorder interface {
 	StartMonitor(endpoints int64)

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -220,8 +220,10 @@ func addBrowserMonitorDuration(stats plugin.MultiRegistryRecorder) jobs.JobWrapp
 			if hasSummary && hasDuration {
 				durationUs, _ := event.Fields.GetValue("monitor.duration.us")
 
-				durationMs := durationUs.(time.Duration).Milliseconds()
+				durationMs := time.Duration(durationUs.(int64)) * time.Microsecond
 				stats.RecordDuration(int64(durationMs))
+
+				logp.Info("Browser monitor completed in %dms", durationMs)
 			}
 
 			return cont, nil

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -209,6 +209,11 @@ func addLightweightMonitorDuration(stats plugin.MultiRegistryRecorder) jobs.JobW
 
 			// stats.RecordDuration(duration.Milliseconds())
 
+			logp.L().Infow(
+				"Lightweight monitor completed",
+				logp.Int64("durationMs", duration.Milliseconds()),
+			)
+
 			return cont, err
 		}
 	}
@@ -228,7 +233,10 @@ func addBrowserMonitorDuration(stats plugin.MultiRegistryRecorder) jobs.JobWrapp
 				durationMs := durationUs.(int64) * int64(time.Microsecond)
 				stats.RecordDuration(durationMs)
 
-				logp.Info("Browser monitor completed in %dms", durationMs)
+				logp.L().Infow(
+					"Browser monitor completed",
+					logp.Int64("durationMs", durationMs),
+				)
 			}
 
 			return cont, nil

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -219,7 +219,8 @@ func addBrowserMonitorDuration(stats plugin.MultiRegistryRecorder) jobs.JobWrapp
 
 			if hasSummary && hasDuration {
 				durationUs, _ := event.Fields.GetValue("monitor.duration.us")
-				durationMs := (time.Duration(durationUs.(int64)) * time.Microsecond).Milliseconds()
+
+				durationMs := durationUs.(time.Duration).Milliseconds()
 				stats.RecordDuration(int64(durationMs))
 			}
 

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/heartbeat/eventext"
 	"github.com/elastic/beats/v7/heartbeat/hbtestllext"
 	"github.com/elastic/beats/v7/heartbeat/monitors/jobs"
+	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -63,8 +64,13 @@ var testBrowserMonFields = stdfields.StdMonitorFields{
 }
 
 func testCommonWrap(t *testing.T, tt testDef) {
+	var stats = plugin.NewMultiRegistry(
+		[]plugin.StartStopRegistryRecorder{},
+		[]plugin.DurationRegistryRecorder{},
+	)
+
 	t.Run(tt.name, func(t *testing.T) {
-		wrapped := WrapCommon(tt.jobs, tt.stdFields)
+		wrapped := WrapCommon(tt.jobs, tt.stdFields, stats)
 
 		results, err := jobs.ExecJobsAndConts(t, wrapped)
 		assert.NoError(t, err)

--- a/heartbeat/scheduler/timerqueue/queue_test.go
+++ b/heartbeat/scheduler/timerqueue/queue_test.go
@@ -50,6 +50,8 @@ func TestStress(t *testing.T) {
 
 		select {
 		case <-failed:
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
 			require.FailNow(t, "Scheduler test iteration timed out, deadlock issue?")
 		case <-succeeded:
@@ -98,6 +100,8 @@ func testQueueRunsInOrderOnce(t *testing.T) {
 
 	var taskResults []int
 Reader:
+	//nolint:gosimple // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	for {
 		select {
 		case res := <-taskResCh:
@@ -124,6 +128,8 @@ func TestQueueRunsTasksAddedAfterStart(t *testing.T) {
 		resCh <- 1
 	})
 
+	//nolint:gosimple // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	select {
 	case r := <-resCh:
 		require.Equal(t, 1, r)

--- a/libbeat/monitoring/list.go
+++ b/libbeat/monitoring/list.go
@@ -70,3 +70,15 @@ func (l *UniqueList) Report(m Mode, V Visitor) {
 	ReportInt(V, "count", count)
 	ReportStringSlice(V, "names", items)
 }
+
+func (l *UniqueList) ReportMap(m Mode, V Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	l.Lock()
+	defer l.Unlock()
+
+	for key, val := range l.list {
+		ReportInt(V, key, int64(val))
+	}
+}

--- a/x-pack/heartbeat/monitors/browser/browser.go
+++ b/x-pack/heartbeat/monitors/browser/browser.go
@@ -13,10 +13,12 @@ import (
 	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/x-pack/heartbeat/stats"
 )
 
 func init() {
 	plugin.Register("browser", create, "synthetic", "synthetics/synthetic")
+	stats.GetBrowserStats()
 }
 
 var showExperimentalOnce = sync.Once{}
@@ -40,7 +42,7 @@ func create(name string, cfg *common.Config) (p plugin.Plugin, err error) {
 		return plugin.Plugin{}, fmt.Errorf("script monitors cannot be run as root!")
 	}
 
-	s, err := NewSuite(cfg)
+	s, err := NewSuite(cfg, stats.GetBrowserStats())
 	if err != nil {
 		return plugin.Plugin{}, err
 	}

--- a/x-pack/heartbeat/monitors/browser/browser.go
+++ b/x-pack/heartbeat/monitors/browser/browser.go
@@ -39,7 +39,7 @@ func create(name string, cfg *common.Config) (p plugin.Plugin, err error) {
 
 	// We do not use user.Current() which does not reflect setuid changes!
 	if syscall.Geteuid() == 0 {
-		return plugin.Plugin{}, fmt.Errorf("script monitors cannot be run as root!")
+		return plugin.Plugin{}, fmt.Errorf("script monitors cannot be run as root")
 	}
 
 	s, err := NewSuite(cfg, stats.GetBrowserStats())

--- a/x-pack/heartbeat/monitors/browser/source/inline.go
+++ b/x-pack/heartbeat/monitors/browser/source/inline.go
@@ -17,7 +17,7 @@ type InlineSource struct {
 var ErrNoInlineScript = fmt.Errorf("no 'script' value specified for inline source")
 
 func (s *InlineSource) Validate() error {
-	if !regexp.MustCompile("\\S").MatchString(s.Script) {
+	if !regexp.MustCompile(`\S`).MatchString(s.Script) {
 		return ErrNoInlineScript
 	}
 

--- a/x-pack/heartbeat/monitors/browser/source/local.go
+++ b/x-pack/heartbeat/monitors/browser/source/local.go
@@ -41,7 +41,7 @@ func (l *LocalSource) Validate() error {
 		return fmt.Errorf("%s: %w", base, err)
 	}
 	if !s.IsDir() {
-		return fmt.Errorf("%s: path points to a non-directory", base)
+		return fmt.Errorf("%w: path points to a non-directory", base)
 	}
 	// ensure the used synthetics version dep used in suite does not
 	// exceed our supported range

--- a/x-pack/heartbeat/monitors/browser/source/source.go
+++ b/x-pack/heartbeat/monitors/browser/source/source.go
@@ -31,7 +31,7 @@ func (s *Source) Active() ISource {
 	return s.ActiveMemo
 }
 
-var ErrInvalidSource = fmt.Errorf("no or unknown source type specified for synthetic monitor.")
+var ErrInvalidSource = fmt.Errorf("no or unknown source type specified for synthetic monitor")
 
 func (s *Source) Validate() error {
 	if s.Active() == nil {

--- a/x-pack/heartbeat/monitors/browser/source/validatepackage.go
+++ b/x-pack/heartbeat/monitors/browser/source/validatepackage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-// ensure compatability of synthetics by enforcing the installed
+// ensure compatibility of synthetics by enforcing the installed
 // version never goes beyond this range
 const ExpectedSynthVersion = "<2.0.0"
 
@@ -27,7 +27,7 @@ type packageJson struct {
 	} `json:"devDependencies"`
 }
 
-var nonNumberRegex = regexp.MustCompile("\\D")
+var nonNumberRegex = regexp.MustCompile(`\D`)
 
 // parsed a given dep version by ignoring all range tags (^, = , >, <)
 func parseVersion(version string) string {

--- a/x-pack/heartbeat/monitors/browser/suite_test.go
+++ b/x-pack/heartbeat/monitors/browser/suite_test.go
@@ -16,7 +16,10 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/x-pack/heartbeat/monitors/browser/source"
 	"github.com/elastic/beats/v7/x-pack/heartbeat/monitors/browser/synthexec"
+	"github.com/elastic/beats/v7/x-pack/heartbeat/stats"
 )
+
+var browserStats = stats.GetBrowserStats()
 
 func TestValidLocal(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
@@ -39,7 +42,7 @@ func TestValidLocal(t *testing.T) {
 			},
 		},
 	})
-	s, e := NewSuite(cfg)
+	s, e := NewSuite(cfg, browserStats)
 	require.NoError(t, e)
 	require.NotNil(t, s)
 	_, ok := s.InlineSource()
@@ -72,7 +75,7 @@ func TestValidInline(t *testing.T) {
 			},
 		},
 	})
-	s, e := NewSuite(cfg)
+	s, e := NewSuite(cfg, browserStats)
 	require.NoError(t, e)
 	require.NotNil(t, s)
 	sSrc, ok := s.InlineSource()
@@ -94,7 +97,7 @@ func TestNameRequired(t *testing.T) {
 			},
 		},
 	})
-	_, e := NewSuite(cfg)
+	_, e := NewSuite(cfg, browserStats)
 	require.Regexp(t, ErrNameRequired, e)
 }
 
@@ -107,7 +110,7 @@ func TestIDRequired(t *testing.T) {
 			},
 		},
 	})
-	_, e := NewSuite(cfg)
+	_, e := NewSuite(cfg, browserStats)
 	require.Regexp(t, ErrIdRequired, e)
 }
 
@@ -115,7 +118,7 @@ func TestEmptySource(t *testing.T) {
 	cfg := common.MustNewConfigFrom(common.MapStr{
 		"source": common.MapStr{},
 	})
-	s, e := NewSuite(cfg)
+	s, e := NewSuite(cfg, browserStats)
 
 	require.Regexp(t, ErrBadConfig(source.ErrInvalidSource), e)
 	require.Nil(t, s)

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -23,10 +23,10 @@ type enricher func(event *beat.Event, se *SynthEvent, fields StdSuiteFields) err
 
 type streamEnricher struct {
 	je *journeyEnricher
-	s  *stats.BrowserStats
+	s  stats.BrowserStatsRecorder
 }
 
-func newStreamEnricher(s *stats.BrowserStats) streamEnricher {
+func newStreamEnricher(s stats.BrowserStatsRecorder) streamEnricher {
 	return streamEnricher{s: s}
 }
 
@@ -68,7 +68,7 @@ func makeUuid() string {
 	return u.String()
 }
 
-func (je *journeyEnricher) enrich(event *beat.Event, se *SynthEvent, fields StdSuiteFields, s *stats.BrowserStats) error {
+func (je *journeyEnricher) enrich(event *beat.Event, se *SynthEvent, fields StdSuiteFields, s stats.BrowserStatsRecorder) error {
 	if se == nil {
 		return nil
 	}
@@ -124,7 +124,7 @@ func (je *journeyEnricher) enrich(event *beat.Event, se *SynthEvent, fields StdS
 	return je.enrichSynthEvent(event, se, s)
 }
 
-func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent, s *stats.BrowserStats) error {
+func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent, s stats.BrowserStatsRecorder) error {
 	var jobErr error
 	if se.Error != nil {
 		jobErr = stepError(se.Error)
@@ -176,7 +176,7 @@ func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent, s
 	return jobErr
 }
 
-func (je *journeyEnricher) createSummary(event *beat.Event, s *stats.BrowserStats) error {
+func (je *journeyEnricher) createSummary(event *beat.Event, s stats.BrowserStatsRecorder) error {
 	var up, down int
 	if je.errorCount > 0 {
 		up = 0

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -32,7 +32,7 @@ func newStreamEnricher(s stats.BrowserStatsRecorder) streamEnricher {
 }
 
 func (e *streamEnricher) enrich(event *beat.Event, se *SynthEvent, fields StdSuiteFields) error {
-	if e.je == nil || (se != nil && se.Type == "journey/start") {
+	if e.je == nil || (se != nil && se.Type == JourneyStart) {
 		e.je = newJourneyEnricher()
 	}
 
@@ -78,12 +78,12 @@ func (je *journeyEnricher) enrich(event *beat.Event, se *SynthEvent, fields StdS
 		event.Timestamp = se.Timestamp()
 		// Record start and end so we can calculate journey duration accurately later
 		switch se.Type {
-		case "journey/start":
+		case JourneyStart:
 			je.firstError = nil
 			je.checkGroup = makeUuid()
 			je.journey = se.Journey
 			je.start = event.Timestamp
-		case "journey/end", "cmd/status":
+		case JourneyEnd, CmdStatus:
 			je.end = event.Timestamp
 		}
 	} else {
@@ -136,14 +136,14 @@ func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent, s
 	}
 
 	switch se.Type {
-	case "cmd/status":
+	case CmdStatus:
 		// If a command failed _after_ the journey was complete, as it happens
 		// when an `afterAll` hook fails, for example, we don't wan't to include
 		// a summary in the cmd/status event.
 		if !je.journeyComplete {
 			return je.createSummary(event, s)
 		}
-	case "journey/end":
+	case JourneyEnd:
 		je.journeyComplete = true
 		return je.createSummary(event, s)
 	case "step/end":
@@ -162,6 +162,8 @@ func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent, s
 		event.SetID(se.Id)
 		// This is only relevant for screenshots, which have a specific ID
 		// In that case we always want to issue an update op
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		event.Meta.Put(events.FieldMetaOpType, events.OpTypeCreate)
 	}
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat/events"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors/add_data_stream"
 	"github.com/elastic/beats/v7/x-pack/heartbeat/stats"
 
@@ -216,6 +217,8 @@ func (je *journeyEnricher) createSummary(event *beat.Event, s stats.BrowserStats
 	// In case we want to add the stepcount to the summary document in the future
 	// we can then move this call to the recorder to the job wrapper functions
 	s.RegisterStepCount(je.stepCount)
+
+	logp.Info("Browser monitor completed with %d steps", je.stepCount)
 
 	if je.journeyComplete {
 		return je.firstError

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -220,7 +220,10 @@ func (je *journeyEnricher) createSummary(event *beat.Event, s stats.BrowserStats
 	// we can then move this call to the recorder to the job wrapper functions
 	s.RegisterStepCount(je.stepCount)
 
-	logp.Info("Browser monitor completed with %d steps", je.stepCount)
+	logp.L().Infow(
+		"Browser monitor summary ready",
+		logp.Int("stepCount", je.stepCount),
+	)
 
 	if je.journeyComplete {
 		return je.firstError

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -214,7 +214,6 @@ func (je *journeyEnricher) createSummary(event *beat.Event, s *stats.BrowserStat
 	})
 
 	s.RegisterStepCount(je.stepCount)
-	s.RegisterDuration(int64(je.end.Sub(je.start) / time.Microsecond))
 
 	if je.journeyComplete {
 		return je.firstError

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -213,6 +213,8 @@ func (je *journeyEnricher) createSummary(event *beat.Event, s *stats.BrowserStat
 		},
 	})
 
+	// In case we want to add the stepcount to the summary document in the future
+	// we can then move this call to the recorder to the job wrapper functions
 	s.RegisterStepCount(je.stepCount)
 
 	if je.journeyComplete {

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -64,19 +64,22 @@ func TestJourneyEnricher(t *testing.T) {
 		Stack:   "last\nerr\nstack",
 	}
 	journeyStart := &SynthEvent{
-		Type:                 "journey/start",
+		Type:                 JourneyStart,
 		TimestampEpochMicros: 1000,
 		PackageVersion:       "1.0.0",
 		Journey:              journey,
 		Payload:              common.MapStr{},
 	}
 	journeyEnd := &SynthEvent{
-		Type:                 "journey/end",
+		Type:                 JourneyEnd,
 		TimestampEpochMicros: 2000,
 		PackageVersion:       "1.0.0",
 		Journey:              journey,
 		Payload:              common.MapStr{},
 	}
+
+	//nolint:goconst // it doesn't make sense to make a testing
+	// variable a constant in this context for so few uses
 	url1 := "http://example.net/url1"
 	url2 := "http://example.net/url2"
 	url3 := "http://example.net/url3"
@@ -85,10 +88,10 @@ func TestJourneyEnricher(t *testing.T) {
 		journeyStart,
 		makeStepEvent("step/start", 10, "Step1", 1, "succeeded", "", nil),
 		makeStepEvent("step/end", 20, "Step1", 1, "", url1, nil),
-		makeStepEvent("step/start", 21, "Step2", 1, "", "", nil),
-		makeStepEvent("step/end", 30, "Step2", 1, "failed", url2, syntherr),
-		makeStepEvent("step/start", 31, "Step3", 1, "", "", nil),
-		makeStepEvent("step/end", 40, "Step3", 1, "", url3, otherErr),
+		makeStepEvent("step/start", 21, "Step2", 2, "", "", nil),
+		makeStepEvent("step/end", 30, "Step2", 2, "failed", url2, syntherr),
+		makeStepEvent("step/start", 31, "Step3", 3, "", "", nil),
+		makeStepEvent("step/end", 40, "Step3", 3, "", url3, otherErr),
 		journeyEnd,
 	}
 
@@ -113,7 +116,7 @@ func TestJourneyEnricher(t *testing.T) {
 
 		// We need an expectation for each input plus a final
 		// expectation for the summary which comes on the nil data.
-		if se.Type != "journey/end" {
+		if se.Type != JourneyEnd {
 			// Test that the created event includes the mapped
 			// version of the event
 			v = append(v, lookslike.MustCompile(se.ToMap()))
@@ -236,7 +239,8 @@ func TestEnrichConsoleSynthEvents(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			browserStats := testBrowserStats{}
 			e := &beat.Event{}
-			tt.je.enrichSynthEvent(e, tt.se, &browserStats)
+			err := tt.je.enrichSynthEvent(e, tt.se, &browserStats)
+			require.NoError(t, err)
 			tt.check(t, e, tt.je)
 		})
 	}
@@ -254,7 +258,7 @@ func TestEnrichSynthEvent(t *testing.T) {
 			"cmd/status - with error",
 			&journeyEnricher{},
 			&SynthEvent{
-				Type:  "cmd/status",
+				Type:  CmdStatus,
 				Error: &SynthError{Name: "cmdexit", Message: "cmd err msg"},
 			},
 			true,
@@ -274,7 +278,7 @@ func TestEnrichSynthEvent(t *testing.T) {
 			"cmd/status - without error",
 			&journeyEnricher{},
 			&SynthEvent{
-				Type:  "cmd/status",
+				Type:  CmdStatus,
 				Error: nil,
 			},
 			true,
@@ -289,9 +293,9 @@ func TestEnrichSynthEvent(t *testing.T) {
 			},
 		},
 		{
-			"journey/end",
+			JourneyEnd,
 			&journeyEnricher{},
-			&SynthEvent{Type: "journey/end"},
+			&SynthEvent{Type: JourneyEnd},
 			false,
 			func(t *testing.T, e *beat.Event, je *journeyEnricher) {
 				v := lookslike.MustCompile(common.MapStr{
@@ -370,7 +374,7 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 		Id:   "my-bad-after-all-hook",
 	}
 	journeyStart := &SynthEvent{
-		Type:                 "journey/start",
+		Type:                 JourneyStart,
 		TimestampEpochMicros: 1000,
 		PackageVersion:       "1.0.0",
 		Journey:              journey,
@@ -382,14 +386,14 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 		Stack:   "my\nerr\nstack",
 	}
 	journeyEnd := &SynthEvent{
-		Type:                 "journey/end",
+		Type:                 JourneyEnd,
 		TimestampEpochMicros: 2000,
 		PackageVersion:       "1.0.0",
 		Journey:              journey,
 		Payload:              common.MapStr{},
 	}
 	cmdStatus := &SynthEvent{
-		Type:                 "cmd/status",
+		Type:                 CmdStatus,
 		Error:                &SynthError{Name: "cmdexit", Message: "cmd err msg"},
 		TimestampEpochMicros: 3000,
 	}
@@ -412,7 +416,7 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 			browserStats := testBrowserStats{}
 			enrichErr := je.enrich(e, se, stdFields, &browserStats)
 
-			if se != nil && se.Type == "cmd/status" {
+			if se != nil && se.Type == CmdStatus {
 				t.Run("no summary in cmd/status", func(t *testing.T) {
 					require.NotContains(t, e.Fields, "summary")
 				})
@@ -420,7 +424,7 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 
 			// Only the journey/end event should get a summary when
 			// it's emitted before the cmd/status (when an afterX hook fails).
-			if se != nil && se.Type == "journey/end" {
+			if se != nil && se.Type == JourneyEnd {
 				require.Equal(t, stepError(syntherr), enrichErr)
 
 				u, _ := url.Parse(badStepUrl)
@@ -444,7 +448,7 @@ func TestSummaryWithoutJourneyEnd(t *testing.T) {
 		Id:   "no-journey-end-but-success",
 	}
 	journeyStart := &SynthEvent{
-		Type:                 "journey/start",
+		Type:                 JourneyStart,
 		TimestampEpochMicros: 1000,
 		PackageVersion:       "1.0.0",
 		Journey:              journey,
@@ -452,7 +456,7 @@ func TestSummaryWithoutJourneyEnd(t *testing.T) {
 	}
 
 	cmdStatus := &SynthEvent{
-		Type:                 "cmd/status",
+		Type:                 CmdStatus,
 		Error:                nil,
 		TimestampEpochMicros: 3000,
 	}
@@ -475,7 +479,7 @@ func TestSummaryWithoutJourneyEnd(t *testing.T) {
 			browserStats := testBrowserStats{}
 			enrichErr := je.enrich(e, se, stdFields, &browserStats)
 
-			if se != nil && se.Type == "cmd/status" {
+			if se != nil && se.Type == CmdStatus {
 				hasCmdStatus = true
 				require.Error(t, enrichErr, "journey did not finish executing, 1 steps ran")
 
@@ -583,12 +587,13 @@ func TestCreateSummaryEvent(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-			common.MergeFields(tt.expected, common.MapStr{
+			err = common.MergeFields(tt.expected, common.MapStr{
 				"url":                common.MapStr{},
 				"event.type":         "heartbeat/summary",
 				"synthetics.type":    "heartbeat/summary",
 				"synthetics.journey": Journey{},
 			}, true)
+			require.NoError(t, err)
 			testslike.Test(t, lookslike.Strict(lookslike.MustCompile(tt.expected)), e.Fields)
 			require.Equal(t, tt.je.stepCount, browserStats.stepCount)
 		})

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat/events"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/processors/add_data_stream"
-	"github.com/elastic/beats/v7/x-pack/heartbeat/stats"
 	"github.com/elastic/go-lookslike"
 	"github.com/elastic/go-lookslike/testslike"
 	"github.com/elastic/go-lookslike/validator"
@@ -35,10 +34,15 @@ func makeStepEvent(typ string, ts float64, name string, index int, status string
 	}
 }
 
-var browserStats = stats.GetBrowserStats()
+type testBrowserStats struct {
+	stepCount int
+}
+
+func (tbs *testBrowserStats) RegisterStepCount(c int) {
+	tbs.stepCount = c
+}
 
 func TestJourneyEnricher(t *testing.T) {
-
 	var stdFields = StdSuiteFields{
 		Id:       "mysuite",
 		Name:     "mysuite",
@@ -129,7 +133,8 @@ func TestJourneyEnricher(t *testing.T) {
 	check := func(t *testing.T, se *SynthEvent, ssf StdSuiteFields) {
 		e := &beat.Event{}
 		t.Run(fmt.Sprintf("event: %s", se.Type), func(t *testing.T) {
-			enrichErr := je.enrich(e, se, ssf, browserStats)
+			browserStats := testBrowserStats{}
+			enrichErr := je.enrich(e, se, ssf, &browserStats)
 			if se.Error != nil {
 				require.Equal(t, stepError(se.Error), enrichErr)
 			}
@@ -229,8 +234,9 @@ func TestEnrichConsoleSynthEvents(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			browserStats := testBrowserStats{}
 			e := &beat.Event{}
-			tt.je.enrichSynthEvent(e, tt.se, browserStats)
+			tt.je.enrichSynthEvent(e, tt.se, &browserStats)
 			tt.check(t, e, tt.je)
 		})
 	}
@@ -348,8 +354,9 @@ func TestEnrichSynthEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			browserStats := testBrowserStats{}
 			e := &beat.Event{}
-			if err := tt.je.enrichSynthEvent(e, tt.se, browserStats); (err == nil && tt.wantErr) || (err != nil && !tt.wantErr) {
+			if err := tt.je.enrichSynthEvent(e, tt.se, &browserStats); (err == nil && tt.wantErr) || (err != nil && !tt.wantErr) {
 				t.Errorf("journeyEnricher.enrichSynthEvent() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			tt.check(t, e, tt.je)
@@ -402,7 +409,8 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 		e := &beat.Event{}
 		stdFields := StdSuiteFields{IsInline: false}
 		t.Run(fmt.Sprintf("event %d", idx), func(t *testing.T) {
-			enrichErr := je.enrich(e, se, stdFields, browserStats)
+			browserStats := testBrowserStats{}
+			enrichErr := je.enrich(e, se, stdFields, &browserStats)
 
 			if se != nil && se.Type == "cmd/status" {
 				t.Run("no summary in cmd/status", func(t *testing.T) {
@@ -464,7 +472,8 @@ func TestSummaryWithoutJourneyEnd(t *testing.T) {
 		e := &beat.Event{}
 		stdFields := StdSuiteFields{IsInline: false}
 		t.Run(fmt.Sprintf("event %d", idx), func(t *testing.T) {
-			enrichErr := je.enrich(e, se, stdFields, browserStats)
+			browserStats := testBrowserStats{}
+			enrichErr := je.enrich(e, se, stdFields, &browserStats)
 
 			if se != nil && se.Type == "cmd/status" {
 				hasCmdStatus = true
@@ -499,6 +508,7 @@ func TestCreateSummaryEvent(t *testing.T) {
 			start:           time.Now(),
 			end:             time.Now().Add(10 * time.Microsecond),
 			journeyComplete: true,
+			stepCount:       1334,
 		},
 		expected: common.MapStr{
 			"monitor.duration.us": int64(10),
@@ -517,6 +527,7 @@ func TestCreateSummaryEvent(t *testing.T) {
 			journeyComplete: true,
 			errorCount:      1,
 			firstError:      fmt.Errorf("journey errored"),
+			stepCount:       1335,
 		},
 		expected: common.MapStr{
 			"monitor.duration.us": int64(10),
@@ -533,6 +544,7 @@ func TestCreateSummaryEvent(t *testing.T) {
 			start:           time.Now(),
 			end:             time.Now().Add(10 * time.Microsecond),
 			journeyComplete: false,
+			stepCount:       1336,
 		},
 		expected: common.MapStr{
 			"monitor.duration.us": int64(10),
@@ -548,6 +560,7 @@ func TestCreateSummaryEvent(t *testing.T) {
 			journey:         &Journey{},
 			end:             time.Now().Add(10 * time.Microsecond),
 			journeyComplete: false,
+			stepCount:       1337,
 			errorCount:      1,
 		},
 		expected: common.MapStr{
@@ -561,8 +574,10 @@ func TestCreateSummaryEvent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			browserStats := testBrowserStats{}
+
 			e := &beat.Event{}
-			err := tt.je.createSummary(e, browserStats)
+			err := tt.je.createSummary(e, &browserStats)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
@@ -575,6 +590,7 @@ func TestCreateSummaryEvent(t *testing.T) {
 				"synthetics.journey": Journey{},
 			}, true)
 			testslike.Test(t, lookslike.Strict(lookslike.MustCompile(tt.expected)), e.Fields)
+			require.Equal(t, tt.je.stepCount, browserStats.stepCount)
 		})
 	}
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/execmultiplexer_test.go
@@ -15,7 +15,6 @@ func TestExecMultiplexer(t *testing.T) {
 	em := NewExecMultiplexer()
 
 	// Generate three fake journeys with three fake steps
-	var testJourneys []*Journey
 	var testEvents []*SynthEvent
 	time := float64(0)
 	for jIdx := 0; jIdx < 3; jIdx++ {
@@ -24,7 +23,6 @@ func TestExecMultiplexer(t *testing.T) {
 			Name: fmt.Sprintf("J%d", jIdx),
 			Id:   fmt.Sprintf("j-%d", jIdx),
 		}
-		testJourneys = append(testJourneys, journey)
 		testEvents = append(testEvents, &SynthEvent{
 			Journey:              journey,
 			Type:                 "journey/start",
@@ -62,6 +60,8 @@ func TestExecMultiplexer(t *testing.T) {
 
 	// Wait for all results
 Loop:
+	//nolint:gosimple // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	for {
 		select {
 		case result := <-em.synthEvents:

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -74,6 +74,8 @@ func suiteCommandFactory(suitePath string, args ...string) (func() *exec.Cmd, er
 // InlineJourneyJob returns a job that runs the given source as a single journey.
 func InlineJourneyJob(ctx context.Context, script string, params common.MapStr, fields StdSuiteFields, s stats.BrowserStatsRecorder, extraArgs ...string) jobs.Job {
 	newCmd := func() *exec.Cmd {
+		//nolint:gosec // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		return exec.Command("elastic-synthetics", append(extraArgs, "--inline")...)
 	}
 
@@ -137,6 +139,8 @@ func runCmd(
 	}
 
 	// Variant of the command with no params, which could contain sensitive stuff
+	//nolint:gosec // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	loggableCmd := exec.Command(cmd.Path, cmd.Args...)
 	if len(params) > 0 {
 		paramsBytes, _ := json.Marshal(params)
@@ -167,6 +171,8 @@ func runCmd(
 	}
 	wg.Add(1)
 	go func() {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		scanToSynthEvents(stdoutPipe, stdoutToSynthEvent, mpx.writeSynthEvent)
 		wg.Done()
 	}()
@@ -177,6 +183,8 @@ func runCmd(
 	}
 	wg.Add(1)
 	go func() {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		scanToSynthEvents(stderrPipe, stderrToSynthEvent, mpx.writeSynthEvent)
 		wg.Done()
 	}()
@@ -184,6 +192,8 @@ func runCmd(
 	// Send the test results into the output
 	wg.Add(1)
 	go func() {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		scanToSynthEvents(jsonReader, jsonToSynthEvent, mpx.writeSynthEvent)
 		wg.Done()
 	}()
@@ -196,6 +206,8 @@ func runCmd(
 	// Kill the process if the context ends
 	go func() {
 		<-ctx.Done()
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		cmd.Process.Kill()
 	}()
 
@@ -289,7 +301,8 @@ func jsonToSynthEvent(bytes []byte, text string) (res *SynthEvent, err error) {
 	if res.Type == "" {
 		return nil, fmt.Errorf("unmarshal succeeded, but no type found for: %s", text)
 	}
-	return
+
+	return res, err
 }
 
 // getNpmRoot gets the closest ancestor path that contains package.json.

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -40,7 +40,7 @@ type FilterJourneyConfig struct {
 }
 
 // SuiteJob will run a single journey by name from the given suite.
-func SuiteJob(ctx context.Context, suitePath string, params common.MapStr, filterJourneys FilterJourneyConfig, fields StdSuiteFields, s *stats.BrowserStats, extraArgs ...string) (jobs.Job, error) {
+func SuiteJob(ctx context.Context, suitePath string, params common.MapStr, filterJourneys FilterJourneyConfig, fields StdSuiteFields, s stats.BrowserStatsRecorder, extraArgs ...string) (jobs.Job, error) {
 	// Run the command in the given suitePath, use '.' as the first arg since the command runs
 	// in the correct dir
 	cmdFactory, err := suiteCommandFactory(suitePath, extraArgs...)
@@ -72,7 +72,7 @@ func suiteCommandFactory(suitePath string, args ...string) (func() *exec.Cmd, er
 }
 
 // InlineJourneyJob returns a job that runs the given source as a single journey.
-func InlineJourneyJob(ctx context.Context, script string, params common.MapStr, fields StdSuiteFields, s *stats.BrowserStats, extraArgs ...string) jobs.Job {
+func InlineJourneyJob(ctx context.Context, script string, params common.MapStr, fields StdSuiteFields, s stats.BrowserStatsRecorder, extraArgs ...string) jobs.Job {
 	newCmd := func() *exec.Cmd {
 		return exec.Command("elastic-synthetics", append(extraArgs, "--inline")...)
 	}
@@ -83,7 +83,7 @@ func InlineJourneyJob(ctx context.Context, script string, params common.MapStr, 
 // startCmdJob adapts commands into a heartbeat job. This is a little awkward given that the command's output is
 // available via a sequence of events in the multiplexer, while heartbeat jobs are tail recursive continuations.
 // Here, we adapt one to the other, where each recursive job pulls another item off the chan until none are left.
-func startCmdJob(ctx context.Context, newCmd func() *exec.Cmd, stdinStr *string, params common.MapStr, filterJourneys FilterJourneyConfig, fields StdSuiteFields, s *stats.BrowserStats) jobs.Job {
+func startCmdJob(ctx context.Context, newCmd func() *exec.Cmd, stdinStr *string, params common.MapStr, filterJourneys FilterJourneyConfig, fields StdSuiteFields, s stats.BrowserStatsRecorder) jobs.Job {
 	return func(event *beat.Event) ([]jobs.Job, error) {
 		mpx, err := runCmd(ctx, newCmd(), stdinStr, params, filterJourneys)
 		if err != nil {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -56,21 +56,33 @@ func (se SynthEvent) ToMap() (m common.MapStr) {
 		},
 	})
 	if len(se.Payload) > 0 {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.payload", se.Payload)
 	}
 	if se.Blob != "" {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.blob", se.Blob)
 	}
 	if se.BlobMime != "" {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.blob_mime", se.BlobMime)
 	}
 	if se.Step != nil {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.step", se.Step.ToMap())
 	}
 	if se.Journey != nil {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.journey", se.Journey.ToMap())
 	}
 	if se.Error != nil {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.error", se.Error.toMap())
 	}
 
@@ -79,6 +91,8 @@ func (se SynthEvent) ToMap() (m common.MapStr) {
 		if e != nil {
 			logp.Warn("Could not parse synthetics URL '%s': %s", se.URL, e.Error())
 		} else {
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			m.Put("url", wrappers.URLFields(u))
 		}
 	}
@@ -164,3 +178,7 @@ func (j Journey) ToMap() common.MapStr {
 		"id":   j.Id,
 	}
 }
+
+const JourneyStart = "journey/start"
+const JourneyEnd = "journey/end"
+const CmdStatus = "cmd/status"

--- a/x-pack/heartbeat/monitors/browser/synthexec/testcmd/main.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/testcmd/main.go
@@ -42,11 +42,18 @@ func main() {
 			os.Stderr.WriteString("Stderr 2\n")
 			time.Sleep(time.Millisecond * 100)
 		}
+
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		pipe.WriteString(scanner.Text())
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		pipe.WriteString("\n")
 		i++
 	}
 	if scanner.Err() != nil {
+		//nolint:forbidigo // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		fmt.Printf("Scanner error %s", scanner.Err())
 		os.Exit(1)
 	}

--- a/x-pack/heartbeat/stats/browser_stats.go
+++ b/x-pack/heartbeat/stats/browser_stats.go
@@ -17,6 +17,10 @@ type BrowserStats struct {
 	stepsHistogram *monitoring.UniqueList // histogram with the count for monitors with each number of steps
 }
 
+type BrowserStatsRecorder interface {
+	RegisterStepCount(int)
+}
+
 func GetBrowserStats() *BrowserStats {
 	if globalBrowserRecorder != nil {
 		return globalBrowserRecorder

--- a/x-pack/heartbeat/stats/browser_stats.go
+++ b/x-pack/heartbeat/stats/browser_stats.go
@@ -1,0 +1,48 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package stats
+
+import (
+	"strconv"
+
+	"github.com/elastic/beats/v7/heartbeat/hbregistry"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+var globalBrowserRecorder *BrowserStats = nil
+
+type BrowserStats struct {
+	stepsHistogram    *monitoring.UniqueList // histogram with the count for monitors with each number of steps
+	durationHistogram *monitoring.UniqueList // histogram with the count of durations (in ms) for tests
+}
+
+func GetBrowserStats() *BrowserStats {
+	if globalBrowserRecorder != nil {
+		return globalBrowserRecorder
+	}
+
+	tr := hbregistry.StatsRegistry
+	r := tr.GetRegistry("browser")
+
+	stepsHistogram := monitoring.NewUniqueList()
+	monitoring.NewFunc(r, "steps_histogram", stepsHistogram.ReportMap, monitoring.Report)
+
+	durationHistogram := monitoring.NewUniqueList()
+	monitoring.NewFunc(r, "duration_histogram", durationHistogram.ReportMap, monitoring.Report)
+
+	s := BrowserStats{stepsHistogram, durationHistogram}
+
+	globalBrowserRecorder = &s
+
+	return globalBrowserRecorder
+}
+
+func (b BrowserStats) RegisterDuration(d int64) {
+	b.durationHistogram.Add(strconv.FormatInt(d, 10))
+}
+
+func (b BrowserStats) RegisterStepCount(c int) {
+	b.stepsHistogram.Add(strconv.Itoa(c))
+}

--- a/x-pack/heartbeat/stats/browser_stats.go
+++ b/x-pack/heartbeat/stats/browser_stats.go
@@ -14,8 +14,7 @@ import (
 var globalBrowserRecorder *BrowserStats = nil
 
 type BrowserStats struct {
-	stepsHistogram    *monitoring.UniqueList // histogram with the count for monitors with each number of steps
-	durationHistogram *monitoring.UniqueList // histogram with the count of durations (in ms) for tests
+	stepsHistogram *monitoring.UniqueList // histogram with the count for monitors with each number of steps
 }
 
 func GetBrowserStats() *BrowserStats {
@@ -29,18 +28,11 @@ func GetBrowserStats() *BrowserStats {
 	stepsHistogram := monitoring.NewUniqueList()
 	monitoring.NewFunc(r, "steps_histogram", stepsHistogram.ReportMap, monitoring.Report)
 
-	durationHistogram := monitoring.NewUniqueList()
-	monitoring.NewFunc(r, "duration_histogram", durationHistogram.ReportMap, monitoring.Report)
-
-	s := BrowserStats{stepsHistogram, durationHistogram}
+	s := BrowserStats{stepsHistogram}
 
 	globalBrowserRecorder = &s
 
 	return globalBrowserRecorder
-}
-
-func (b BrowserStats) RegisterDuration(d int64) {
-	b.durationHistogram.Add(strconv.FormatInt(d, 10))
 }
 
 func (b BrowserStats) RegisterStepCount(c int) {


### PR DESCRIPTION
> ⚠️ I'm moving this back to a draft state as I've recently spoken to @vigneshshanmugam and we'd like to keep changes as small as possible for the time being given: (1) we would like @andrewvc to review this once he's back and (2) we deemed these changes could be useful to improve Heartbeat's monitoring capabilities, especially considering how thorough they are.
> We decided to merge https://github.com/elastic/beats/pull/31405 just so that we can immediately have the metrics we need and then we'll look deeper into this PR.

## What does this PR do?

This PR adds the necessary metric collection mechanisms for https://github.com/elastic/beats/issues/30433.


## Why is it important?

It's necessary so that we have relevant stats in the telemetry cluster to analyse the service's behaviour.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] It's extremely important that we **test this PR E2E** as it deeply interferes with Heartbeat's capability of sending any stats to any ES instances.
- [ ] Please verify the output type of the data we're sending to our cluster to see if you agree with the way we're reporting data.
- [ ] Please ensure these are all the stats we need to perform the analysis we'll do for the service.
- [ ] As far as I understand, bytes written is already covered by https://github.com/elastic/beats/blob/main/libbeat/outputs/metrics.go#L41. I'd appreciate if someone could double-check I haven't missed anything here and advise on whether we need further changes to this.

### Open question

If we'll report all of the durations and steps the monitors ran, the monitoring output size will grow larger with time as we must register all of the duration buckets.

* Should we do something to prevent this from happening like more aggressive bucketing of possible durations and steps?
* Should we clear lists once they're reported once?


## How to test this PR locally

1. Run an ES instance, either locally or in the cloud
2. Create a `heartbeat.yml` configuration file and enable monitoring reporting
    ```yml
    monitoring:
      enabled: true
      elasticsearch:
        username: your_username
        password: your_password
    ```
3. Create a few monitors: both lightweight and heavyweight (both HTTP, and browser monitors, for example)
4. Build Heartbeat from this branch and start it
5. Query your cluster's `.monitoring-beats*` indices for this monitoring data and verify it contains the new fields for the step and durations of monitors.
  ```
  GET .monitoring-beats*/_search
  {
    "sort": { "timestamp": { "order":  "desc" }}
  }
  ```


## Related issues

Fixes #30433.


## Screenshots

![Screenshot 2022-04-24 at 14 31 40](https://user-images.githubusercontent.com/6868147/164978954-48609342-e976-4a2c-bc91-9c5c743263e5.png)



## Logs

A debug log indicating the fields have been sent:

```
{"log.level":"debug","@timestamp":"2022-04-23T18:23:49.848+0100","log.logger":"monitoring","log.origin":{"file.name":"processing/processors.go","file.line":209},"message":"Publish event: {\n  \"@timestamp\": \"2022-04-23T17:23:49.846Z\",\n  \"@metadata\": {\n    \"beat\": \"heartbeat\",\n    \"type\": \"_doc\",\n    \"version\": \"8.3.0\",\n    \"cluster_uuid\":
\"LI2Mb7skRcmzu4nuvKPiUQ\",\n    \"type\": \"beats_stats\",\n    \"interval_ms\": 10000,\n    \"params\": {\n      \"interval\": \"10s\"\n    }\n  },\n  \"metrics\": {\n    \"beat\": {\n      \"info\": {\n        \"uptime\": {\n          \"ms\": 40049\n        },\n        \"ephemeral_id\": \"121f5605-edaa-4d9c-b259-386f17b6e7ad\",\n        \"version\": \"8.3.0\"\
n      },\n      \"memstats\": {\n        \"memory_total\": 113862152,\n        \"memory_alloc\": 40542512,\n        \"memory_sys\": 70534152,\n        \"gc_next\": 43425440,\n        \"rss\": 88915968\n      },\n      \"cpu\": {\n        \"user\": {\n          \"ticks\": 983,\n          \"time\": {\n            \"ms\": 983\n          }\n        },\n        \"sys
tem\": {\n          \"ticks\": 186,\n          \"time\": {\n            \"ms\": 186\n          }\n        },\n        \"total\": {\n          \"time\": {\n            \"ms\": 1169\n          },\n          \"value\": 0,\n          \"ticks\": 1169\n        }\n      },\n      \"runtime\": {\n        \"goroutines\": 44\n      }\n    },\n    \"libbeat\": {\n      \"co
nfig\": {\n        \"scans\": 0,\n        \"reloads\": 0,\n        \"module\": {\n          \"stops\": 0,\n          \"running\": 0,\n          \"starts\": 0\n        }\n      },\n      \"output\": {\n        \"write\": {\n          \"errors\": 0,\n          \"bytes\": 2582611\n        },\n        \"read\": {\n          \"errors\": 0,\n          \"bytes\": 23497\
n        },\n        \"type\": \"elasticsearch\",\n        \"events\": {\n          \"duplicates\": 383,\n          \"active\": 0,\n          \"toomany\": 0,\n          \"batches\": 16,\n          \"total\": 715,\n          \"acked\": 332,\n          \"failed\": 0,\n          \"dropped\": 0\n        }\n      },\n      \"pipeline\": {\n        \"queue\": {\n
    \"max_events\": 4096,\n          \"acked\": 715\n        },\n        \"clients\": 4,\n        \"events\": {\n          \"active\": 0,\n          \"total\": 715,\n          \"filtered\": 0,\n          \"published\": 715,\n          \"failed\": 0,\n          \"dropped\": 0,\n          \"retry\": 3\n        }\n      }\n    },\n    \"heartbeat\": {\n      \"http\
": {\n        \"monitor_stops\": 0,\n        \"endpoint_starts\": 1,\n        \"endpoint_stops\": 0,\n        \"duration_histogram\": {\n          \"258\": 1\n        },\n        \"monitor_starts\": 1\n      },\n      \"icmp\": {\n        \"endpoint_starts\": 0,\n        \"endpoint_stops\": 0,\n        \"monitor_starts\": 0,\n        \"monitor_stops\": 0\n      }
,\n      \"tcp\": {\n        \"endpoint_stops\": 0,\n        \"monitor_starts\": 0,\n        \"monitor_stops\": 0,\n        \"endpoint_starts\": 0\n      },\n      \"browser\": {\n        \"monitor_starts\": 3,\n        \"monitor_stops\": 0,\n        \"endpoint_starts\": 3,\n        \"endpoint_stops\": 0,\n        \"duration_histogram\": {\n          \"10023\": 1
,\n          \"1164\": 1,\n          \"4768\": 1\n        },\n        \"steps_histogram\": {\n          \"1\": 1,\n          \"2\": 1,\n          \"3\": 1\n        }\n      },\n      \"scheduler\": {\n        \"tasks\": {\n          \"active\": 0,\n          \"waiting\": 0\n        },\n        \"jobs\": {\n          \"missed_deadline\": 0,\n          \"active\":
0\n        }\n      }\n    },\n    \"system\": {\n      \"load\": {\n        \"15\": 5.1177,\n        \"norm\": {\n          \"1\": 0.2659,\n          \"5\": 0.3255,\n          \"15\": 0.3199\n        },\n        \"1\": 4.2539,\n        \"5\": 5.2075\n      },\n      \"cpu\": {\n        \"cores\": 16\n      }\n    }\n  },\n  \"beat\": {\n    \"name\": \"Lucass-Ma
cBook-Pro.local\",\n    \"host\": \"Lucass-MacBook-Pro.local\",\n    \"uuid\": \"e585215b-0595-4ed2-9031-6f91a39aa294\",\n    \"type\": \"heartbeat\",\n    \"version\": \"8.3.0\"\n  }\n}","service.name":"heartbeat","ecs.version":"1.6.0"}
```