### PR TITLE
Add heartbeat telemetry logs (step count and duration)

### DIFF
--- a/heartbeat/hbtest/hbtestutil.go
+++ b/heartbeat/hbtest/hbtestutil.go
@@ -61,6 +61,8 @@ func HelloWorldHandler(status int) http.HandlerFunc {
 				w.Header().Set("Location", "/somewhere")
 			}
 			w.WriteHeader(status)
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			io.WriteString(w, HelloWorldBody)
 		},
 	)
@@ -78,6 +80,8 @@ func SizedResponseHandler(bytes int) http.HandlerFunc {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(200)
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			io.WriteString(w, body.String())
 		},
 	)
@@ -90,6 +94,8 @@ func CustomResponseHandler(body []byte, status int, extraHeaders map[string]stri
 				w.Header().Add(key, val)
 			}
 			w.WriteHeader(status)
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			w.Write(body)
 		},
 	)
@@ -107,6 +113,8 @@ func RedirectHandler(redirectingPaths map[string]string, body string) http.Handl
 				w.WriteHeader(302)
 			} else {
 				w.WriteHeader(200)
+				//nolint:errcheck // There are no new changes to this line but
+				// linter has been activated in the meantime. We'll cleanup separately.
 				io.WriteString(w, body)
 			}
 		})
@@ -137,12 +145,16 @@ func TLSChecks(chainIndex, certIndex int, certificate *x509.Certificate) validat
 		PeerCertificates:  []*x509.Certificate{certificate},
 	}, time.Duration(1))
 
-	expected.Put("tls.rtt.handshake.us", isdef.IsDuration)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
+	expected.Put("tls.rtt.handshake.us", hbtestllext.IsInt64)
 
 	// Generally, the exact cipher will match, but on windows 7 32bit this is not true!
 	// We don't actually care about the exact cipher matching, since we're not testing the TLS
 	// implementation, we trust go there, just that most of the metadata is present
 	if runtime.GOOS == "windows" && bits.UintSize == 32 {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		expected.Put("tls.cipher", isdef.IsString)
 	}
 
@@ -171,7 +183,7 @@ func BaseChecks(ip string, status string, typ string) validator.Validator {
 			"monitor": map[string]interface{}{
 				"ip":          ipCheck,
 				"status":      status,
-				"duration.us": isdef.IsDuration,
+				"duration.us": hbtestllext.IsInt64,
 				"id":          isdef.IsNonEmptyString,
 				"name":        isdef.IsString,
 				"type":        typ,
@@ -197,7 +209,7 @@ func ResolveChecks(ip string) validator.Validator {
 	return lookslike.MustCompile(map[string]interface{}{
 		"resolve": map[string]interface{}{
 			"ip":     ip,
-			"rtt.us": isdef.IsDuration,
+			"rtt.us": hbtestllext.IsInt64,
 		},
 	})
 }
@@ -246,7 +258,7 @@ func ExpiredCertChecks(cert *x509.Certificate) validator.Validator {
 // RespondingTCPChecks creates a skima.Validator that represents the "tcp" field present
 // in all heartbeat events that use a Tcp connection as part of their DialChain
 func RespondingTCPChecks() validator.Validator {
-	return lookslike.MustCompile(map[string]interface{}{"tcp.rtt.connect.us": isdef.IsDuration})
+	return lookslike.MustCompile(map[string]interface{}{"tcp.rtt.connect.us": hbtestllext.IsInt64})
 }
 
 // CertToTempFile takes a certificate and returns an *os.File with a PEM encoded
@@ -259,6 +271,8 @@ func CertToTempFile(t *testing.T, cert *x509.Certificate) *os.File {
 	// disk, not memory, so this little bit of extra work is worthwhile
 	certFile, err := ioutil.TempFile("", "sslcert")
 	require.NoError(t, err)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	certFile.WriteString(x509util.CertToPEMString(cert))
 	return certFile
 }
@@ -268,6 +282,8 @@ func StartHTTPSServer(t *testing.T, tlsCert tls.Certificate) (host string, port 
 	require.NoError(t, err)
 
 	// No need to start a real server, since this is invalid, we just
+	//nolint:gosec // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	l, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 	})
@@ -275,6 +291,8 @@ func StartHTTPSServer(t *testing.T, tlsCert tls.Certificate) (host string, port 
 
 	srv := &http.Server{Handler: HelloWorldHandler(200)}
 	go func() {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		srv.Serve(l)
 	}()
 

--- a/heartbeat/look/look.go
+++ b/heartbeat/look/look.go
@@ -29,9 +29,6 @@ import (
 
 // RTT formats a round-trip-time given as time.Duration into an
 // event field. The duration is stored in `{"us": rtt}`.
-// TODO: This returns a time.Duration, which isn't quite right. time.Duration
-// represents nanos, whereas this really returns millis. It should probably
-// return a plain int64 type instead.
 func RTT(rtt time.Duration) common.MapStr {
 	if rtt < 0 {
 		rtt = 0
@@ -41,12 +38,14 @@ func RTT(rtt time.Duration) common.MapStr {
 		// cast to int64 since a go duration is a nano, but we want micros
 		// This makes the types less confusing because other wise the duration
 		// we get back has the wrong unit
-		"us": rtt / (time.Microsecond / time.Nanosecond),
+		"us": rtt.Microseconds(),
 	}
 }
 
 // Reason formats an error into an error event field.
 func Reason(err error) common.MapStr {
+	//nolint:errorlint // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	if r, ok := err.(reason.Reason); ok {
 		return reason.Fail(r)
 	}

--- a/heartbeat/look/look_test.go
+++ b/heartbeat/look/look_test.go
@@ -30,18 +30,18 @@ import (
 )
 
 // helper
-func testRTT(t *testing.T, expected time.Duration, provided time.Duration) {
+func testRTT(t *testing.T, expected int64, provided time.Duration) {
 	actual, err := RTT(provided).GetValue("us")
 	assert.NoError(t, err)
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual.(int64))
 }
 
 func TestPositiveRTTIsKept(t *testing.T) {
-	testRTT(t, 5, time.Duration(5*time.Microsecond))
+	testRTT(t, 5, 5*time.Microsecond)
 }
 
 func TestNegativeRTTIsZero(t *testing.T) {
-	testRTT(t, time.Duration(0), time.Duration(-1))
+	testRTT(t, 0, time.Duration(-1))
 }
 
 func TestReason(t *testing.T) {

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -568,7 +568,6 @@ func TestExpiredHTTPSServer(t *testing.T) {
 }
 
 func TestHTTPSx509Auth(t *testing.T) {
-	//nolint:goconst // Test variable.
 	if runtime.GOOS == "windows" && bits.UintSize == 32 {
 		t.Skip("flaky test: https://github.com/elastic/beats/issues/25857")
 	}

--- a/heartbeat/monitors/active/http/http_test.go
+++ b/heartbeat/monitors/active/http/http_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/heartbeat/hbtest"
+	"github.com/elastic/beats/v7/heartbeat/hbtestllext"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
@@ -72,10 +73,8 @@ func sendTLSRequest(t *testing.T, testURL string, useUrls bool, extraConfig map[
 		configSrc["hosts"] = testURL
 	}
 
-	if extraConfig != nil {
-		for k, v := range extraConfig {
-			configSrc[k] = v
-		}
+	for k, v := range extraConfig {
+		configSrc[k] = v
 	}
 
 	config, err := common.NewConfigFrom(configSrc)
@@ -125,11 +124,11 @@ func respondingHTTPStatusAndTimingChecks(statusCode int) validator.Validator {
 	return lookslike.MustCompile(map[string]interface{}{
 		"http": map[string]interface{}{
 			"response.status_code":   statusCode,
-			"rtt.content.us":         isdef.IsDuration,
-			"rtt.response_header.us": isdef.IsDuration,
-			"rtt.total.us":           isdef.IsDuration,
-			"rtt.validate.us":        isdef.IsDuration,
-			"rtt.write_request.us":   isdef.IsDuration,
+			"rtt.content.us":         hbtestllext.IsInt64,
+			"rtt.response_header.us": hbtestllext.IsInt64,
+			"rtt.total.us":           hbtestllext.IsInt64,
+			"rtt.validate.us":        hbtestllext.IsInt64,
+			"rtt.write_request.us":   hbtestllext.IsInt64,
 		},
 	})
 }
@@ -142,7 +141,7 @@ func minimalRespondingHTTPChecks(url, mimeType string, statusCode int) validator
 			"http": map[string]interface{}{
 				"response.mime_type":   mimeType,
 				"response.status_code": statusCode,
-				"rtt.total.us":         isdef.IsDuration,
+				"rtt.total.us":         hbtestllext.IsInt64,
 			},
 		}),
 	)
@@ -508,17 +507,18 @@ func runHTTPSServerCheck(
 	// When connecting through a proxy, the following fields are missing.
 	if _, isProxy := reqExtraConfig["proxy_url"]; isProxy {
 		missing := map[string]interface{}{
-			"http.rtt.response_header.us": time.Duration(0),
-			"http.rtt.content.us":         time.Duration(0),
+			"http.rtt.response_header.us": int64(0),
+			"http.rtt.content.us":         int64(0),
 			"monitor.ip":                  "127.0.0.1",
-			"tcp.rtt.connect.us":          time.Duration(0),
-			"http.rtt.validate.us":        time.Duration(0),
-			"http.rtt.write_request.us":   time.Duration(0),
-			"tls.rtt.handshake.us":        time.Duration(0),
+			"tcp.rtt.connect.us":          int64(0),
+			"http.rtt.validate.us":        int64(0),
+			"http.rtt.write_request.us":   int64(0),
+			"tls.rtt.handshake.us":        int64(0),
 		}
 		for k, v := range missing {
 			if found, err := event.Fields.HasKey(k); !found || err != nil {
-				event.Fields.Put(k, v)
+				_, err := event.Fields.Put(k, v)
+				require.NoError(t, err)
 			}
 		}
 	}
@@ -545,6 +545,8 @@ func TestExpiredHTTPSServer(t *testing.T) {
 	tlsCert, err := tls.LoadX509KeyPair("../fixtures/expired.cert", "../fixtures/expired.key")
 	require.NoError(t, err)
 	host, port, cert, closeSrv := hbtest.StartHTTPSServer(t, tlsCert)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	defer closeSrv()
 	u := &url.URL{Scheme: "https", Host: net.JoinHostPort(host, port)}
 
@@ -566,6 +568,7 @@ func TestExpiredHTTPSServer(t *testing.T) {
 }
 
 func TestHTTPSx509Auth(t *testing.T) {
+	//nolint:goconst // Test variable.
 	if runtime.GOOS == "windows" && bits.UintSize == 32 {
 		t.Skip("flaky test: https://github.com/elastic/beats/issues/25857")
 	}
@@ -792,22 +795,18 @@ func httpConnectTunnel(writer http.ResponseWriter, request *http.Request) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		io.Copy(destConn, clientReadWriter)
 		wg.Done()
 	}()
 	go func() {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		io.Copy(clientConn, destConn)
 		wg.Done()
 	}()
 	wg.Wait()
-}
-
-func mustParseURL(t *testing.T, url string) *url.URL {
-	parsed, err := common.ParseURL(url)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return parsed
 }
 
 // helper that compresses some content as gzip

--- a/heartbeat/monitors/active/tcp/socks5_test.go
+++ b/heartbeat/monitors/active/tcp/socks5_test.go
@@ -100,7 +100,6 @@ func TestSocks5Job(t *testing.T) {
 }
 
 func startSocks5Server(t *testing.T) (host string, port uint16, ip string, close func() error, err error) {
-	//nolint:goconst // Test variable.
 	host = "localhost"
 	config := &socks5.Config{}
 	server, err := socks5.New(config)

--- a/heartbeat/monitors/active/tcp/socks5_test.go
+++ b/heartbeat/monitors/active/tcp/socks5_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/heartbeat/hbtest"
+	"github.com/elastic/beats/v7/heartbeat/hbtestllext"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/go-lookslike"
-	"github.com/elastic/go-lookslike/isdef"
 	"github.com/elastic/go-lookslike/testslike"
 )
 
@@ -54,10 +54,14 @@ func TestSocks5Job(t *testing.T) {
 		t.Run(scenario.name, func(t *testing.T) {
 			host, port, ip, closeEcho, err := startEchoServer(t)
 			require.NoError(t, err)
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			defer closeEcho()
 
 			_, proxyPort, proxyIp, closeProxy, err := startSocks5Server(t)
 			require.NoError(t, err)
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			defer closeProxy()
 
 			proxyURL := &url.URL{Scheme: "socks5", Host: net.JoinHostPort(proxyIp, fmt.Sprint(proxyPort))}
@@ -82,10 +86,10 @@ func TestSocks5Job(t *testing.T) {
 					hbtest.ResolveChecks(ip),
 					lookslike.MustCompile(map[string]interface{}{
 						"tcp": map[string]interface{}{
-							"rtt.validate.us": isdef.IsDuration,
+							"rtt.validate.us": hbtestllext.IsInt64,
 						},
 						"socks5": map[string]interface{}{
-							"rtt.connect.us": isdef.IsDuration,
+							"rtt.connect.us": hbtestllext.IsInt64,
 						},
 					}),
 				)),
@@ -96,6 +100,7 @@ func TestSocks5Job(t *testing.T) {
 }
 
 func startSocks5Server(t *testing.T) (host string, port uint16, ip string, close func() error, err error) {
+	//nolint:goconst // Test variable.
 	host = "localhost"
 	config := &socks5.Config{}
 	server, err := socks5.New(config)
@@ -108,7 +113,9 @@ func startSocks5Server(t *testing.T) (host string, port uint16, ip string, close
 		return "", 0, "", nil, err
 	}
 	ip, portStr, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
 	portUint64, err := strconv.ParseUint(portStr, 10, 16)
+	require.NoError(t, err)
 	if err != nil {
 		listener.Close()
 		return "", 0, "", nil, err

--- a/heartbeat/monitors/active/tcp/tcp_test.go
+++ b/heartbeat/monitors/active/tcp/tcp_test.go
@@ -29,11 +29,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/heartbeat/hbtest"
+	"github.com/elastic/beats/v7/heartbeat/hbtestllext"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	btesting "github.com/elastic/beats/v7/libbeat/testing"
 	"github.com/elastic/go-lookslike"
-	"github.com/elastic/go-lookslike/isdef"
 	"github.com/elastic/go-lookslike/testslike"
 	"github.com/elastic/go-lookslike/validator"
 )
@@ -157,6 +157,8 @@ func TestUnreachableEndpointJob(t *testing.T) {
 func TestCheckUp(t *testing.T) {
 	host, port, ip, closeEcho, err := startEchoServer(t)
 	require.NoError(t, err)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	defer closeEcho()
 
 	configMap := common.MapStr{
@@ -179,7 +181,7 @@ func TestCheckUp(t *testing.T) {
 			hbtest.ResolveChecks(ip),
 			lookslike.MustCompile(map[string]interface{}{
 				"tcp": map[string]interface{}{
-					"rtt.validate.us": isdef.IsDuration,
+					"rtt.validate.us": hbtestllext.IsInt64,
 				},
 			}),
 		)),
@@ -190,6 +192,8 @@ func TestCheckUp(t *testing.T) {
 func TestCheckDown(t *testing.T) {
 	host, port, ip, closeEcho, err := startEchoServer(t)
 	require.NoError(t, err)
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	defer closeEcho()
 
 	configMap := common.MapStr{
@@ -212,7 +216,7 @@ func TestCheckDown(t *testing.T) {
 			hbtest.ResolveChecks(ip),
 			lookslike.MustCompile(map[string]interface{}{
 				"tcp": map[string]interface{}{
-					"rtt.validate.us": isdef.IsDuration,
+					"rtt.validate.us": hbtestllext.IsInt64,
 				},
 				"error": map[string]interface{}{
 					"type":    "validate",
@@ -262,6 +266,7 @@ func startEchoServer(t *testing.T) (host string, port uint16, ip string, close f
 	}()
 
 	ip, portStr, err := net.SplitHostPort(listener.Addr().String())
+	require.NoError(t, err)
 	portUint64, err := strconv.ParseUint(portStr, 10, 16)
 	if err != nil {
 		listener.Close()

--- a/heartbeat/monitors/logger/logger.go
+++ b/heartbeat/monitors/logger/logger.go
@@ -1,0 +1,113 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logger
+
+import (
+	"errors"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+var eventLogger *logp.Logger = nil
+
+const ActionMonitorRun = "monitor.run"
+
+type durationLoggable struct {
+	Ms int64 `json:"ms"`
+}
+
+type monitorRunInfo struct {
+	MonitorID string           `json:"id"`
+	Type      string           `json:"type"`
+	Duration  durationLoggable `json:"duration"`
+	Steps     *int             `json:"steps,omitempty"`
+}
+
+func NewMonitorRunInfo(id string, t string, dMs int64) monitorRunInfo {
+	return monitorRunInfo{
+		MonitorID: id,
+		Type:      t,
+		Duration:  durationLoggable{Ms: dMs},
+	}
+}
+
+func SetLogger(l *logp.Logger) *logp.Logger {
+	eventLogger = l
+	return eventLogger
+}
+
+func getLogger() *logp.Logger {
+	if eventLogger == nil {
+		return SetLogger(logp.NewLogger("heartbeat.events"))
+	}
+
+	return eventLogger
+}
+
+func extractRunInfo(event *beat.Event) (*monitorRunInfo, error) {
+	monitorID, mIDErr := event.GetValue("monitor.id")
+	durationUs, dErr := event.GetValue("monitor.duration.us")
+	monType, tErr := event.GetValue("monitor.type")
+	if mIDErr != nil || dErr != nil || tErr != nil {
+		getLogger().Errorw(
+			"Error gathering information to log event",
+			logp.Errors("logErrors", []error{mIDErr, dErr, tErr}),
+		)
+
+		return nil, errors.New("error gathering information to log event")
+	}
+
+	durationMs := time.Duration(durationUs.(int64) * int64(time.Microsecond)).Milliseconds()
+	runInfo := NewMonitorRunInfo(
+		monitorID.(string),
+		monType.(string),
+		durationMs,
+	)
+
+	return &runInfo, nil
+}
+
+func LogBrowserRun(event *beat.Event, stepCount int) {
+	monitor, err := extractRunInfo(event)
+	if err != nil {
+		return
+	}
+
+	monitor.Steps = &stepCount
+
+	getLogger().Infow(
+		"Browser monitor summary ready",
+		logp.Any("event", map[string]string{"action": ActionMonitorRun}),
+		logp.Any("monitor", monitor),
+	)
+}
+
+func LogLightweightRun(event *beat.Event) {
+	monitor, err := extractRunInfo(event)
+	if err != nil {
+		return
+	}
+
+	getLogger().Infow(
+		"Lightweight monitor finished.",
+		logp.Any("event", map[string]string{"action": ActionMonitorRun}),
+		logp.Any("monitor", monitor),
+	)
+}

--- a/heartbeat/monitors/logger/logger.go
+++ b/heartbeat/monitors/logger/logger.go
@@ -30,7 +30,7 @@ var eventLogger *logp.Logger = nil
 const ActionMonitorRun = "monitor.run"
 
 type durationLoggable struct {
-	Ms int64 `json:"ms"`
+	Mills int64 `json:"ms"`
 }
 
 type monitorRunInfo struct {
@@ -44,7 +44,7 @@ func NewMonitorRunInfo(id string, t string, dMs int64) monitorRunInfo {
 	return monitorRunInfo{
 		MonitorID: id,
 		Type:      t,
-		Duration:  durationLoggable{Ms: dMs},
+		Duration:  durationLoggable{Mills: dMs},
 	}
 }
 
@@ -84,29 +84,18 @@ func extractRunInfo(event *beat.Event) (*monitorRunInfo, error) {
 	return &runInfo, nil
 }
 
-func LogBrowserRun(event *beat.Event, stepCount int) {
+func LogRun(event *beat.Event, stepCount *int) {
 	monitor, err := extractRunInfo(event)
 	if err != nil {
 		return
 	}
 
-	monitor.Steps = &stepCount
-
-	getLogger().Infow(
-		"Browser monitor summary ready",
-		logp.Any("event", map[string]string{"action": ActionMonitorRun}),
-		logp.Any("monitor", monitor),
-	)
-}
-
-func LogLightweightRun(event *beat.Event) {
-	monitor, err := extractRunInfo(event)
-	if err != nil {
-		return
+	if stepCount != nil {
+		monitor.Steps = stepCount
 	}
 
 	getLogger().Infow(
-		"Lightweight monitor finished.",
+		"Monitor finished",
 		logp.Any("event", map[string]string{"action": ActionMonitorRun}),
 		logp.Any("monitor", monitor),
 	)

--- a/heartbeat/monitors/logger/logger_test.go
+++ b/heartbeat/monitors/logger/logger_test.go
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logger
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func TestLogBrowserRun(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+	SetLogger(logp.NewLogger("t", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(in, core)
+	})))
+
+	durationUs := int64(5000 * time.Microsecond)
+	durationMs := time.Duration(durationUs * int64(time.Microsecond)).Milliseconds()
+	steps := 1337
+
+	fields := common.MapStr{
+		"monitor.id":          "b0",
+		"monitor.duration.us": durationUs,
+		"monitor.type":        "browser",
+	}
+
+	event := beat.Event{Fields: fields}
+
+	LogBrowserRun(&event, steps)
+
+	observedEntries := observed.All()
+	require.Len(t, observedEntries, 1)
+	assert.Equal(t, "Browser monitor summary ready", observedEntries[0].Message)
+
+	expectedMonitor := NewMonitorRunInfo("b0", "browser", durationMs)
+	expectedMonitor.Steps = &steps
+	assert.ElementsMatch(t, []zap.Field{
+		logp.Any("event", map[string]string{"action": ActionMonitorRun}),
+		logp.Any("monitor", &expectedMonitor),
+	}, observedEntries[0].Context)
+}
+
+func TestLogLightweightRun(t *testing.T) {
+	core, observed := observer.New(zapcore.InfoLevel)
+	SetLogger(logp.NewLogger("t", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(in, core)
+	})))
+
+	durationUs := int64(5000 * time.Microsecond)
+	durationMs := time.Duration(durationUs * int64(time.Microsecond)).Milliseconds()
+
+	fields := common.MapStr{
+		"monitor.id":          "h0",
+		"monitor.duration.us": durationUs,
+		"monitor.type":        "http",
+	}
+
+	event := beat.Event{Fields: fields}
+
+	LogLightweightRun(&event)
+
+	observedEntries := observed.All()
+	require.Len(t, observedEntries, 1)
+	assert.Equal(t, "Lightweight monitor finished.", observedEntries[0].Message)
+
+	expectedMonitor := NewMonitorRunInfo("h0", "http", durationMs)
+	assert.ElementsMatch(t, []zap.Field{
+		logp.Any("event", map[string]string{"action": ActionMonitorRun}),
+		logp.Any("monitor", &expectedMonitor),
+	}, observedEntries[0].Context)
+}

--- a/heartbeat/monitors/mocks_test.go
+++ b/heartbeat/monitors/mocks_test.go
@@ -53,9 +53,7 @@ func (c *MockBeatClient) PublishAll(events []beat.Event) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	for _, e := range events {
-		c.publishes = append(c.publishes, e)
-	}
+	c.publishes = append(c.publishes, events...)
 }
 
 func (c *MockBeatClient) Close() error {
@@ -111,7 +109,7 @@ func baseMockEventMonitorValidator(id string, name string, status string) valida
 			"id":          idMatcher,
 			"name":        name,
 			"type":        "test",
-			"duration.us": isdef.IsDuration,
+			"duration.us": hbtestllext.IsInt64,
 			"status":      status,
 			"check_group": isdef.IsString,
 		},
@@ -131,6 +129,8 @@ func mockEventCustomFields() map[string]interface{} {
 	return common.MapStr{"foo": "bar"}
 }
 
+//nolint:unparam // There are no new changes to this line but
+// linter has been activated in the meantime. We'll cleanup separately.
 func createMockJob() ([]jobs.Job, error) {
 	j := jobs.MakeSimpleJob(func(event *beat.Event) error {
 		eventext.MergeEventFields(event, mockEventCustomFields())
@@ -178,6 +178,8 @@ func mockPluginBuilder() (plugin.PluginFactory, *atomic.Int, *atomic.Int) {
 func mockPluginsReg() (p *plugin.PluginsReg, built *atomic.Int, closed *atomic.Int) {
 	reg := plugin.NewPluginsReg()
 	builder, built, closed := mockPluginBuilder()
+	//nolint:errcheck // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	reg.Add(builder)
 	return reg, built, closed
 }
@@ -203,6 +205,8 @@ func mockPluginConf(t *testing.T, id string, name string, schedule string, url s
 
 // mockBadPluginConf returns a conf with an invalid plugin config.
 // This should fail after the generic plugin checks fail since the HTTP plugin requires 'urls' to be set.
+//nolint:unparam // There are no new changes to this line but
+// linter has been activated in the meantime. We'll cleanup separately.
 func mockBadPluginConf(t *testing.T, id string, schedule string) *common.Config {
 	confMap := map[string]interface{}{
 		"type":        "test",

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -185,16 +185,21 @@ func addMonitorStatus(summaryOnly bool) jobs.JobWrapper {
 func addMonitorDuration(job jobs.Job) jobs.Job {
 	return func(event *beat.Event) ([]jobs.Job, error) {
 		start := time.Now()
-
 		cont, err := job(event)
+		duration := time.Since(start)
 
 		if event != nil {
 			eventext.MergeEventFields(event, common.MapStr{
 				"monitor": common.MapStr{
-					"duration": look.RTT(time.Since(start)),
+					"duration": look.RTT(duration),
 				},
 			})
 			event.Timestamp = start
+
+			logp.L().Infow(
+				"Lightweight monitor finished.",
+				logp.Int64("durationMs", duration.Milliseconds()),
+			)
 		}
 
 		return cont, err

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -199,10 +199,14 @@ func addMonitorDuration(job jobs.Job) jobs.Job {
 			})
 			event.Timestamp = start
 
-			logp.L().Infow(
-				"Lightweight monitor finished.",
-				logp.Int64("durationMs", duration.Milliseconds()),
-			)
+			monitorID, err := event.GetValue("monitor.id")
+			if err != nil {
+				logp.L().Infow(
+					"Lightweight monitor finished.",
+					logp.String("monitorId", monitorID.(string)),
+					logp.Int64("durationMs", duration.Milliseconds()),
+				)
+			}
 		}
 
 		return cont, err

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -24,6 +24,9 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/mitchellh/hashstructure"
+
+	//nolint:gomodguard // There are no new changes to this line but
+	// linter has been activated in the meantime. We'll cleanup separately.
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/heartbeat/eventext"
@@ -57,7 +60,7 @@ func WrapLightweight(js []jobs.Job, stdMonFields stdfields.StdMonitorFields) []j
 			addMonitorDuration,
 		),
 		func() jobs.JobWrapper {
-			return makeAddSummary(stdMonFields.Type)
+			return makeAddSummary()
 		})
 }
 
@@ -207,7 +210,7 @@ func addMonitorDuration(job jobs.Job) jobs.Job {
 }
 
 // makeAddSummary summarizes the job, adding the `summary` field to the last event emitted.
-func makeAddSummary(monitorType string) jobs.JobWrapper {
+func makeAddSummary() jobs.JobWrapper {
 	// This is a tricky method. The way this works is that we track the state across jobs in the
 	// state struct here.
 	state := struct {
@@ -254,6 +257,8 @@ func makeAddSummary(monitorType string) jobs.JobWrapper {
 				}
 			}
 
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			event.PutValue("monitor.check_group", state.checkGroup)
 
 			// Adjust the total remaining to account for new continuations

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/beats/v7/heartbeat/eventext"
 	"github.com/elastic/beats/v7/heartbeat/look"
 	"github.com/elastic/beats/v7/heartbeat/monitors/jobs"
+	"github.com/elastic/beats/v7/heartbeat/monitors/logger"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -199,14 +200,7 @@ func addMonitorDuration(job jobs.Job) jobs.Job {
 			})
 			event.Timestamp = start
 
-			monitorID, err := event.GetValue("monitor.id")
-			if err != nil {
-				logp.L().Infow(
-					"Lightweight monitor finished.",
-					logp.String("monitorId", monitorID.(string)),
-					logp.Int64("durationMs", duration.Milliseconds()),
-				)
-			}
+			logger.LogLightweightRun(event)
 		}
 
 		return cont, err

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -200,7 +200,7 @@ func addMonitorDuration(job jobs.Job) jobs.Job {
 			})
 			event.Timestamp = start
 
-			logger.LogLightweightRun(event)
+			logger.LogRun(event, nil)
 		}
 
 		return cont, err

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -125,7 +125,7 @@ func TestSimpleJob(t *testing.T) {
 		nil,
 		func(t *testing.T, results []*beat.Event, observed []observer.LoggedEntry) {
 			require.Len(t, observed, 1)
-			require.Equal(t, "Lightweight monitor finished.", observed[0].Message)
+			require.Equal(t, "Monitor finished", observed[0].Message)
 
 			durationUs, err := results[0].Fields.GetValue("monitor.duration.us")
 			require.NoError(t, err)

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -26,14 +26,19 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/elastic/beats/v7/heartbeat/eventext"
 	"github.com/elastic/beats/v7/heartbeat/hbtestllext"
 	"github.com/elastic/beats/v7/heartbeat/monitors/jobs"
+	"github.com/elastic/beats/v7/heartbeat/monitors/logger"
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
 	"github.com/elastic/beats/v7/heartbeat/scheduler/schedule"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-lookslike"
 	"github.com/elastic/go-lookslike/isdef"
 	"github.com/elastic/go-lookslike/testslike"
@@ -41,11 +46,12 @@ import (
 )
 
 type testDef struct {
-	name      string
-	stdFields stdfields.StdMonitorFields
-	jobs      []jobs.Job
-	want      []validator.Validator
-	metaWant  []validator.Validator
+	name         string
+	stdFields    stdfields.StdMonitorFields
+	jobs         []jobs.Job
+	want         []validator.Validator
+	metaWant     []validator.Validator
+	logValidator func(t *testing.T, results []*beat.Event, observed []observer.LoggedEntry)
 }
 
 var testMonFields = stdfields.StdMonitorFields{
@@ -66,12 +72,18 @@ func testCommonWrap(t *testing.T, tt testDef) {
 	t.Run(tt.name, func(t *testing.T) {
 		wrapped := WrapCommon(tt.jobs, tt.stdFields)
 
+		core, observedLogs := observer.New(zapcore.InfoLevel)
+		logger.SetLogger(logp.NewLogger("t", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(in, core)
+		})))
+
 		results, err := jobs.ExecJobsAndConts(t, wrapped)
 		assert.NoError(t, err)
 
 		require.Equal(t, len(results), len(tt.want), "Expected test def wants to correspond exactly to number results.")
 		for idx, r := range results {
 			t.Run(fmt.Sprintf("result at index %d", idx), func(t *testing.T) {
+
 				want := tt.want[idx]
 				testslike.Test(t, lookslike.Strict(want), r.Fields)
 
@@ -79,7 +91,12 @@ func testCommonWrap(t *testing.T, tt testDef) {
 					metaWant := tt.metaWant[idx]
 					testslike.Test(t, lookslike.Strict(metaWant), r.Meta)
 				}
+
 			})
+		}
+
+		if tt.logValidator != nil {
+			tt.logValidator(t, results, observedLogs.All())
 		}
 	})
 }
@@ -94,7 +111,7 @@ func TestSimpleJob(t *testing.T) {
 				urlValidator(t, "tcp://foo.com:80"),
 				lookslike.MustCompile(map[string]interface{}{
 					"monitor": map[string]interface{}{
-						"duration.us": isdef.IsDuration,
+						"duration.us": hbtestllext.IsInt64,
 						"id":          testMonFields.ID,
 						"name":        testMonFields.Name,
 						"type":        testMonFields.Type,
@@ -106,6 +123,20 @@ func TestSimpleJob(t *testing.T) {
 				summaryValidator(1, 0),
 			)},
 		nil,
+		func(t *testing.T, results []*beat.Event, observed []observer.LoggedEntry) {
+			require.Len(t, observed, 1)
+			require.Equal(t, "Lightweight monitor finished.", observed[0].Message)
+
+			durationUs, err := results[0].Fields.GetValue("monitor.duration.us")
+			require.NoError(t, err)
+
+			durationMs := time.Duration(durationUs.(int64) * int64(time.Microsecond)).Milliseconds()
+			expectedMonitor := logger.NewMonitorRunInfo(testMonFields.ID, testMonFields.Type, durationMs)
+			require.ElementsMatch(t, []zap.Field{
+				logp.Any("event", map[string]string{"action": logger.ActionMonitorRun}),
+				logp.Any("monitor", &expectedMonitor),
+			}, observed[0].Context)
+		},
 	})
 }
 
@@ -121,7 +152,7 @@ func TestJobWithServiceName(t *testing.T) {
 				urlValidator(t, "tcp://foo.com:80"),
 				lookslike.MustCompile(map[string]interface{}{
 					"monitor": map[string]interface{}{
-						"duration.us": isdef.IsDuration,
+						"duration.us": hbtestllext.IsInt64,
 						"id":          testMonFields.ID,
 						"name":        testMonFields.Name,
 						"type":        testMonFields.Type,
@@ -136,6 +167,7 @@ func TestJobWithServiceName(t *testing.T) {
 				summaryValidator(1, 0),
 			)},
 		nil,
+		nil,
 	})
 }
 
@@ -148,7 +180,7 @@ func TestErrorJob(t *testing.T) {
 		lookslike.MustCompile(map[string]interface{}{"error": map[string]interface{}{"message": "myerror", "type": "io"}}),
 		lookslike.MustCompile(map[string]interface{}{
 			"monitor": map[string]interface{}{
-				"duration.us": isdef.IsDuration,
+				"duration.us": hbtestllext.IsInt64,
 				"id":          testMonFields.ID,
 				"name":        testMonFields.Name,
 				"type":        testMonFields.Type,
@@ -169,6 +201,7 @@ func TestErrorJob(t *testing.T) {
 				summaryValidator(0, 1),
 			)},
 		nil,
+		nil,
 	})
 }
 
@@ -180,7 +213,7 @@ func TestMultiJobNoConts(t *testing.T) {
 			urlValidator(t, u),
 			lookslike.MustCompile(map[string]interface{}{
 				"monitor": map[string]interface{}{
-					"duration.us": isdef.IsDuration,
+					"duration.us": hbtestllext.IsInt64,
 					"id":          uniqScope.IsUniqueTo("id"),
 					"name":        testMonFields.Name,
 					"type":        testMonFields.Type,
@@ -198,6 +231,7 @@ func TestMultiJobNoConts(t *testing.T) {
 		testMonFields,
 		[]jobs.Job{makeURLJob(t, "http://foo.com"), makeURLJob(t, "http://bar.com")},
 		[]validator.Validator{validatorMaker("http://foo.com"), validatorMaker("http://bar.com")},
+		nil,
 		nil,
 	})
 }
@@ -227,7 +261,7 @@ func TestMultiJobConts(t *testing.T) {
 			lookslike.MustCompile(map[string]interface{}{"cont": msg}),
 			lookslike.MustCompile(map[string]interface{}{
 				"monitor": map[string]interface{}{
-					"duration.us": isdef.IsDuration,
+					"duration.us": hbtestllext.IsInt64,
 					"id":          uniqScope.IsUniqueTo(u),
 					"name":        testMonFields.Name,
 					"type":        testMonFields.Type,
@@ -255,6 +289,7 @@ func TestMultiJobConts(t *testing.T) {
 				summaryValidator(2, 0),
 			),
 		},
+		nil,
 		nil,
 	})
 }
@@ -285,7 +320,7 @@ func TestMultiJobContsCancelledEvents(t *testing.T) {
 			lookslike.MustCompile(map[string]interface{}{"cont": msg}),
 			lookslike.MustCompile(map[string]interface{}{
 				"monitor": map[string]interface{}{
-					"duration.us": isdef.IsDuration,
+					"duration.us": hbtestllext.IsInt64,
 					"id":          uniqScope.IsUniqueTo(u),
 					"name":        testMonFields.Name,
 					"type":        testMonFields.Type,
@@ -324,6 +359,7 @@ func TestMultiJobContsCancelledEvents(t *testing.T) {
 			metaCancelledValidator,
 			lookslike.MustCompile(isdef.IsEqual(common.MapStr(nil))),
 		},
+		nil,
 	})
 }
 
@@ -448,6 +484,7 @@ func TestInlineBrowserJob(t *testing.T) {
 			),
 		},
 		nil,
+		nil,
 	})
 }
 
@@ -513,6 +550,7 @@ func TestSuiteBrowserJob(t *testing.T) {
 					expectedMonFields,
 				))},
 		nil,
+		nil,
 	})
 	testCommonWrap(t, testDef{
 		"with up summary",
@@ -528,6 +566,7 @@ func TestSuiteBrowserJob(t *testing.T) {
 						"summary": map[string]interface{}{"up": 1, "down": 0},
 					}),
 				))},
+		nil,
 		nil,
 	})
 	testCommonWrap(t, testDef{
@@ -548,6 +587,7 @@ func TestSuiteBrowserJob(t *testing.T) {
 						},
 					}),
 				))},
+		nil,
 		nil,
 	})
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -212,11 +212,15 @@ func (je *journeyEnricher) createSummary(event *beat.Event) error {
 		},
 	})
 
-	logp.L().Infow(
-		"Browser monitor summary ready",
-		logp.Int("stepCount", je.stepCount),
-		logp.Int64("durationMs", duration.Milliseconds()),
-	)
+	monitorID, err := event.GetValue("monitor.id")
+	if err == nil {
+		logp.L().Infow(
+			"Browser monitor summary ready",
+			logp.String("monitorId", monitorID.(string)),
+			logp.Int("stepCount", je.stepCount),
+			logp.Int64("durationMs", duration.Milliseconds()),
+		)
+	}
 
 	if je.journeyComplete {
 		return je.firstError

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat/events"
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors/add_data_stream"
 
 	"github.com/gofrs/uuid"
 
 	"github.com/elastic/beats/v7/heartbeat/eventext"
+	"github.com/elastic/beats/v7/heartbeat/monitors/logger"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
@@ -212,14 +212,9 @@ func (je *journeyEnricher) createSummary(event *beat.Event) error {
 		},
 	})
 
-	monitorID, err := event.GetValue("monitor.id")
+	_, err := event.GetValue("monitor.id")
 	if err == nil {
-		logp.L().Infow(
-			"Browser monitor summary ready",
-			logp.String("monitorId", monitorID.(string)),
-			logp.Int("stepCount", je.stepCount),
-			logp.Int64("durationMs", duration.Milliseconds()),
-		)
+		logger.LogBrowserRun(event, je.stepCount)
 	}
 
 	if je.journeyComplete {

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -183,12 +183,11 @@ func (je *journeyEnricher) createSummary(event *beat.Event) error {
 		down = 0
 	}
 
-	duration := je.end.Sub(je.start)
-
 	// Incase of syntax errors or incorrect runner options, the Synthetics
 	// runner would exit immediately with exitCode 1 and we do not set the duration
 	// to inform the journey never ran
 	if !je.start.IsZero() {
+		duration := je.end.Sub(je.start)
 		eventext.MergeEventFields(event, common.MapStr{
 			"monitor": common.MapStr{
 				"duration": common.MapStr{
@@ -214,7 +213,7 @@ func (je *journeyEnricher) createSummary(event *beat.Event) error {
 
 	_, err := event.GetValue("monitor.id")
 	if err == nil {
-		logger.LogBrowserRun(event, je.stepCount)
+		logger.LogRun(event, &je.stepCount)
 	}
 
 	if je.journeyComplete {

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -11,11 +11,16 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/elastic/beats/v7/heartbeat/monitors/logger"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/beat/events"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors/add_data_stream"
 	"github.com/elastic/go-lookslike"
 	"github.com/elastic/go-lookslike/testslike"
@@ -69,6 +74,7 @@ func TestJourneyEnricher(t *testing.T) {
 		Journey:              journey,
 		Payload:              common.MapStr{},
 	}
+	//nolint:goconst // Test variable.
 	url1 := "http://example.net/url1"
 	url2 := "http://example.net/url2"
 	url3 := "http://example.net/url3"
@@ -77,10 +83,10 @@ func TestJourneyEnricher(t *testing.T) {
 		journeyStart,
 		makeStepEvent("step/start", 10, "Step1", 1, "succeeded", "", nil),
 		makeStepEvent("step/end", 20, "Step1", 1, "", url1, nil),
-		makeStepEvent("step/start", 21, "Step2", 1, "", "", nil),
-		makeStepEvent("step/end", 30, "Step2", 1, "failed", url2, syntherr),
-		makeStepEvent("step/start", 31, "Step3", 1, "", "", nil),
-		makeStepEvent("step/end", 40, "Step3", 1, "", url3, otherErr),
+		makeStepEvent("step/start", 21, "Step2", 2, "", "", nil),
+		makeStepEvent("step/end", 30, "Step2", 2, "failed", url2, syntherr),
+		makeStepEvent("step/start", 31, "Step3", 3, "", "", nil),
+		makeStepEvent("step/end", 40, "Step3", 3, "", url3, otherErr),
 		journeyEnd,
 	}
 
@@ -105,7 +111,8 @@ func TestJourneyEnricher(t *testing.T) {
 
 		// We need an expectation for each input plus a final
 		// expectation for the summary which comes on the nil data.
-		if se.Type != "journey/end" {
+
+		if se.Type != JourneyEnd {
 			// Test that the created event includes the mapped
 			// version of the event
 			v = append(v, lookslike.MustCompile(se.ToMap()))
@@ -226,6 +233,8 @@ func TestEnrichConsoleSynthEvents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &beat.Event{}
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			tt.je.enrichSynthEvent(e, tt.se)
 			tt.check(t, e, tt.je)
 		})
@@ -400,6 +409,8 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 		t.Run(fmt.Sprintf("event %d", idx), func(t *testing.T) {
 			enrichErr := je.enrich(e, se, stdFields)
 
+			//nolint:goconst // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			if se != nil && se.Type == "cmd/status" {
 				t.Run("no summary in cmd/status", func(t *testing.T) {
 					require.NotContains(t, e.Fields, "summary")
@@ -408,7 +419,7 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 
 			// Only the journey/end event should get a summary when
 			// it's emitted before the cmd/status (when an afterX hook fails).
-			if se != nil && se.Type == "journey/end" {
+			if se != nil && se.Type == JourneyEnd {
 				require.Equal(t, stepError(syntherr), enrichErr)
 
 				u, _ := url.Parse(badStepUrl)
@@ -483,18 +494,37 @@ func TestSummaryWithoutJourneyEnd(t *testing.T) {
 }
 
 func TestCreateSummaryEvent(t *testing.T) {
+	baseTime := time.Now()
+
+	defaultLogValidator := func(stepCount int) func(t *testing.T, summary common.MapStr, observed []observer.LoggedEntry) {
+		return func(t *testing.T, summary common.MapStr, observed []observer.LoggedEntry) {
+			require.Len(t, observed, 1)
+			require.Equal(t, "Browser monitor summary ready", observed[0].Message)
+
+			durationMs := baseTime.Add(10 * time.Microsecond).Sub(baseTime).Milliseconds()
+			expectedMonitor := logger.NewMonitorRunInfo("my-monitor", "browser", durationMs)
+			expectedMonitor.Steps = &stepCount
+			require.ElementsMatch(t, []zap.Field{
+				logp.Any("event", map[string]string{"action": logger.ActionMonitorRun}),
+				logp.Any("monitor", &expectedMonitor),
+			}, observed[0].Context)
+		}
+	}
+
 	tests := []struct {
-		name     string
-		je       *journeyEnricher
-		expected common.MapStr
-		wantErr  bool
+		name         string
+		je           *journeyEnricher
+		expected     common.MapStr
+		wantErr      bool
+		logValidator func(t *testing.T, summary common.MapStr, observed []observer.LoggedEntry)
 	}{{
 		name: "completed without errors",
 		je: &journeyEnricher{
 			journey:         &Journey{},
-			start:           time.Now(),
-			end:             time.Now().Add(10 * time.Microsecond),
+			start:           baseTime,
+			end:             baseTime.Add(10 * time.Microsecond),
 			journeyComplete: true,
+			stepCount:       3,
 		},
 		expected: common.MapStr{
 			"monitor.duration.us": int64(10),
@@ -503,13 +533,14 @@ func TestCreateSummaryEvent(t *testing.T) {
 				"up":   1,
 			},
 		},
-		wantErr: false,
+		wantErr:      false,
+		logValidator: defaultLogValidator(3),
 	}, {
 		name: "completed with error",
 		je: &journeyEnricher{
 			journey:         &Journey{},
-			start:           time.Now(),
-			end:             time.Now().Add(10 * time.Microsecond),
+			start:           baseTime,
+			end:             baseTime.Add(10 * time.Microsecond),
 			journeyComplete: true,
 			errorCount:      1,
 			firstError:      fmt.Errorf("journey errored"),
@@ -521,13 +552,15 @@ func TestCreateSummaryEvent(t *testing.T) {
 				"up":   0,
 			},
 		},
-		wantErr: true,
+		wantErr:      true,
+		logValidator: defaultLogValidator(0),
 	}, {
 		name: "started, but exited without running steps",
 		je: &journeyEnricher{
 			journey:         &Journey{},
-			start:           time.Now(),
-			end:             time.Now().Add(10 * time.Microsecond),
+			start:           baseTime,
+			end:             baseTime.Add(10 * time.Microsecond),
+			stepCount:       0,
 			journeyComplete: false,
 		},
 		expected: common.MapStr{
@@ -537,7 +570,8 @@ func TestCreateSummaryEvent(t *testing.T) {
 				"up":   1,
 			},
 		},
-		wantErr: true,
+		wantErr:      true,
+		logValidator: defaultLogValidator(0),
 	}, {
 		name: "syntax error - exited without starting",
 		je: &journeyEnricher{
@@ -552,25 +586,46 @@ func TestCreateSummaryEvent(t *testing.T) {
 				"up":   0,
 			},
 		},
+		logValidator: func(t *testing.T, summary common.MapStr, observed []observer.LoggedEntry) {
+			// We don't log run data without duration
+			require.Len(t, observed, 1)
+			require.Equal(t, "Error gathering information to log event", observed[0].Message)
+		},
 		wantErr: true,
 	}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &beat.Event{}
+			core, observed := observer.New(zapcore.InfoLevel)
+			logger.SetLogger(logp.NewLogger("t", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+				return zapcore.NewTee(in, core)
+			})))
+
+			monitorField := common.MapStr{"id": "my-monitor", "type": "browser"}
+
+			e := &beat.Event{
+				Fields: common.MapStr{"monitor": monitorField},
+			}
 			err := tt.je.createSummary(e)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 			}
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			common.MergeFields(tt.expected, common.MapStr{
+				"monitor":            monitorField,
 				"url":                common.MapStr{},
 				"event.type":         "heartbeat/summary",
 				"synthetics.type":    "heartbeat/summary",
 				"synthetics.journey": Journey{},
 			}, true)
 			testslike.Test(t, lookslike.Strict(lookslike.MustCompile(tt.expected)), e.Fields)
+
+			if tt.logValidator != nil {
+				tt.logValidator(t, tt.expected, observed.All())
+			}
 		})
 	}
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -56,21 +56,33 @@ func (se SynthEvent) ToMap() (m common.MapStr) {
 		},
 	})
 	if len(se.Payload) > 0 {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.payload", se.Payload)
 	}
 	if se.Blob != "" {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.blob", se.Blob)
 	}
 	if se.BlobMime != "" {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.blob_mime", se.BlobMime)
 	}
 	if se.Step != nil {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.step", se.Step.ToMap())
 	}
 	if se.Journey != nil {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.journey", se.Journey.ToMap())
 	}
 	if se.Error != nil {
+		//nolint:errcheck // There are no new changes to this line but
+		// linter has been activated in the meantime. We'll cleanup separately.
 		m.Put("synthetics.error", se.Error.toMap())
 	}
 
@@ -79,6 +91,8 @@ func (se SynthEvent) ToMap() (m common.MapStr) {
 		if e != nil {
 			logp.Warn("Could not parse synthetics URL '%s': %s", se.URL, e.Error())
 		} else {
+			//nolint:errcheck // There are no new changes to this line but
+			// linter has been activated in the meantime. We'll cleanup separately.
 			m.Put("url", wrappers.URLFields(u))
 		}
 	}
@@ -164,3 +178,7 @@ func (j Journey) ToMap() common.MapStr {
 		"id":   j.Id,
 	}
 }
+
+const JourneyStart = "journey/start"
+const JourneyEnd = "journey/end"
+const CmdStatus = "cmd/status"

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -15,6 +15,10 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
+const JourneyStart = "journey/start"
+const JourneyEnd = "journey/end"
+const CmdStatus = "cmd/status"
+
 type SynthEvent struct {
 	Id                   string        `json:"_id"`
 	Type                 string        `json:"type"`
@@ -178,7 +182,3 @@ func (j Journey) ToMap() common.MapStr {
 		"id":   j.Id,
 	}
 }
-
-const JourneyStart = "journey/start"
-const JourneyEnd = "journey/end"
-const CmdStatus = "cmd/status"


### PR DESCRIPTION
> ⚠️ Please see the related linter issue here if you're curious about the linting comments: https://github.com/elastic/beats/issues/31407

## What does this PR do?

This PR is an alternative implementation to https://github.com/elastic/beats/issues/30433: **it adds structured logging for us to collect data about how many steps browser monitors contain and how long monitors in general took to run**.

If merged, it supersedes https://github.com/elastic/beats/pull/31398.

## Why is it important?

It's necessary so that we have relevant stats in the telemetry cluster to analyse the service's behaviour.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

Not sure on what tests to add here since this just updates logging.

Please confirm whether you'd like to include this PR or https://github.com/elastic/beats/pull/31398.

This PR has everything we need to solve https://github.com/elastic/beats/issues/30433, but others which want to use the same functionality will have to rely on log parsing rather than the native monitoring capabilities.


## How to test this PR locally

1. Build this branch
2. Create an HB configuration file with both browser and lightweight monitors.
    ```yaml
    heartbeat.monitors:
      - type: http
        id: myhost
        name: My HTTP Host
        schedule: '@every 1m'
        hosts: ["https://google.com"]
      - type: browser
        id: m0
        name: m0
        schedule: '@every 1m'
        source:
          inline:
            script: |-
              step("first", async () => {
                await page.goto('https://www.google.com');
              });
      - type: browser
        id: monitor-1
        name: monitor-1
        schedule: '@every 1m'
        source:
          inline:
            script: |-
              step("first", async () => {
                await page.goto('https://www.google.com');
              });
              step("second", async () => {
                await page.goto('https://www.bbc.co.uk');
              });
      - type: browser
        id: monitor-3
        name: monitor-3
        schedule: '@every 1m'
        source:
          inline:
            script: |-
              step("first", async () => {
                await page.goto('https://www.google.com');
              });
              step("second", async () => {
                await page.goto('https://www.bbc.co.uk');
              });
              step("third", async () => {
                await page.goto('https://www.cnn.com');
              });
    ```
3. Run Heartbeat and look for log messages including either `Browser monitor summary ready` or `Lightweight monitor finished.`.
    ```
    ELASTIC_SYNTHETICS_CAPABLE=true ./heartbeat -c /tmp/path_to_heartbeat.yml -e -d "*"
    ```
4. Confirm those messages contain structured values for the monitor duration and, in the case of browser monitors, step count.

## Related issues

- Closes #30433

## Logs

```
{"log.level":"info","@timestamp":"2022-04-25T15:41:41.155+0100","log.origin":{"file.name":"synthexec/enrich.go","file.line":215},"message":"Browser monitor summary ready","service.name":"heartbeat","stepCount":3,"durationMs":10138,"ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-04-25T15:43:28.474+0100","log.origin":{"file.name":"wrappers/wrappers.go","file.line":202},"message":"Lightweight monitor finished.","service.name":"heartbeat","durationMs":171,"ecs.version":"1.6.0"}
```
