### PR TITLE
[automation] update elastic stack version for testing 8.3.0-ed7759bd

### DIFF
--- a/libbeat/docker-compose.yml
+++ b/libbeat/docker-compose.yml
@@ -86,7 +86,6 @@ services:
       start_period: 60s
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=true"
@@ -150,7 +149,6 @@ services:
   #     - "TERM=linux"
   #     - "ELASTIC_PASSWORD=changeme"
   #     - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Djava.security.krb5.conf=/etc/krb5.conf"
-  #     - "network.host="
   #     - "transport.host=127.0.0.1"
   #     - "http.host=0.0.0.0"
   #     - "xpack.security.enabled=true"

--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -24,7 +24,6 @@ services:
         ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-8.1.2}
     environment:
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
-      - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=false"

--- a/metricbeat/module/logstash/docker-compose.yml
+++ b/metricbeat/module/logstash/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       args:
         ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-8.1.0-aa69d697-SNAPSHOT}
     environment:
-      - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
     ports:

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -10,7 +10,6 @@ services:
       interval: 1s
     environment:
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-      - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=false"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-c655cda8-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-ed7759bd-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -32,7 +32,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.3.0-c655cda8-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.3.0-ed7759bd-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.3.0-c655cda8-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.3.0-ed7759bd-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -12,7 +12,6 @@ services:
     #   interval: 1s
     environment:
     - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-    - "network.host="
     - "transport.host=127.0.0.1"
     - "http.host=0.0.0.0"
     - "xpack.security.enabled=true"

--- a/x-pack/libbeat/docker-compose.yml
+++ b/x-pack/libbeat/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       start_period: 60s
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-      - "network.host="
       - "transport.host=127.0.0.1"
       - "http.host=0.0.0.0"
       - "xpack.security.enabled=true"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 26 Apr 2022 00:25:14 GMT, release_branch:master, prefix:, end_time:Tue, 26 Apr 2022 04:35:41 GMT, manifest_version:2.0.0, version:8.3.0-SNAPSHOT, branch:master, build_id:8.3.0-ed7759bd, build_duration_seconds:15027]