### PR TITLE
Increase the number of required occurences for `goconst` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,8 +89,8 @@ linters-settings:
   goconst:
     # minimal length of string constant, 3 by default
     min-len: 3
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 2
+    # minimal occurrences count to trigger
+    min-occurrences: 5
 
   dupl:
     # tokens count to trigger issue, 150 by default

--- a/dev-tools/templates/.golangci.yml
+++ b/dev-tools/templates/.golangci.yml
@@ -86,8 +86,8 @@ linters-settings:
   goconst:
     # minimal length of string constant, 3 by default
     min-len: 3
-    # minimal occurrences count to trigger, 3 by default
-    min-occurrences: 2
+    # minimal occurrences count to trigger
+    min-occurrences: 5
 
   dupl:
     # tokens count to trigger issue, 150 by default


### PR DESCRIPTION
## What does this PR do?

This PR increases the number of required occurrences from 2 to 5.

## Why is it important?

The threshold for making a string a constant was too low and the linter was triggered all the time. It reports errors for unnecessary things like checking OSes with `windows` or `linux` strings.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
