### PR TITLE
List the CHANGELOG files without code owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,11 @@
 
 * @elastic/elastic-agent-data-plane
 
+# List the CHANGELOG files without an owner. This will prevent the data plane team from being added
+# as a reviewer every time a change to files they do not own also adds a changelog entry.
+# https://github.community/t/codeowners-file-with-a-not-file-type-condition/1423/9
+CHANGELOG*
+
 /.ci/ @elastic/elastic-agent-data-plane
 /.github/ @elastic/elastic-agent-data-plane
 /auditbeat/ @elastic/security-external-integrations


### PR DESCRIPTION
This should prevent the data plane team from being added as a reviewer
every time a changelog entry is added regardless of if they own the code
in the rest of the review.