### PR TITLE
Linters: remove `godox` and add exclude rule for `forbidigo` in mage files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,9 @@ issues:
     - linters:
         - stylecheck
       text: "ST1003:"
+    # From mage we are priting to the console to ourselves
+    - path: (.*magefile.go|.*dev-tools/mage/.*)
+      linters: forbidigo
 
 output:
   sort-results: true
@@ -68,7 +71,6 @@ linters:
     - noctx # noctx finds sending http request without context.Context
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.
-    - godox # tool for detection of FIXME, TODO and other comment keywords
     - gomodguard # check for blocked dependencies
 
 # all available settings of specific linters

--- a/dev-tools/templates/.golangci.yml
+++ b/dev-tools/templates/.golangci.yml
@@ -18,6 +18,9 @@ issues:
     - text: "ST1003:"
       linters:
         - stylecheck
+    # From mage we are priting to the console to ourselves
+    - path: (.*magefile.go|.*dev-tools/mage/.*)
+      linters: forbidigo
 
 output:
   sort-results: true
@@ -65,7 +68,6 @@ linters:
     - noctx # noctx finds sending http request without context.Context
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.
-    - godox # tool for detection of FIXME, TODO and other comment keywords
     - gomodguard # check for blocked dependencies
 
 # all available settings of specific linters


### PR DESCRIPTION
## What does this PR do?

This PR adjusts the linter configuration, so we get less noise. The two impacted linters are `godox` and `forbidigo`.

## Why is it important?

`godox` is used to track down TODO, FIXME, etc. comments. Instead developers should open tickets in their issue trackers. Beats code is full of such comments without actual issues to back them up. I think the comments are valuable when we are debugging. But let's be honest, we are not going to fix all of the problems. Also, we cannot really open a valuable follow-up issue for such comments because we lack the required context.

`forbidigo` forbids us to use `fmt.Print*`. In the product code it makes sense. However, in `mage` we constantly print to stdout to give feedback to the developer. In mage targets and mage files, using `fmt.Print*` is the standard and should be valid.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
