### PR TITLE
[libbeat] Store syslog version as string 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,6 +47,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Fix docs reference for syslog processor {pull}31087[31087]
 - Fix AWS config initialization issue when using a role {issue}30999[30999] {pull}31014[31014]
 - Fix group write permissions on runtime directories. {pull}30869[30869]
+- Store syslog version as string. {pull}xxxx[xxxx]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -47,7 +47,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Fix docs reference for syslog processor {pull}31087[31087]
 - Fix AWS config initialization issue when using a role {issue}30999[30999] {pull}31014[31014]
 - Fix group write permissions on runtime directories. {pull}30869[30869]
-- Store syslog version as string. {pull}xxxx[xxxx]
+- Store syslog version as string. {pull}31446[31446]
 
 *Auditbeat*
 

--- a/libbeat/processors/syslog/syslog_test.go
+++ b/libbeat/processors/syslog/syslog_test.go
@@ -105,7 +105,7 @@ var syslogCases = map[string]struct {
 					"appname":  "evntslog",
 					"procid":   "1024",
 					"msgid":    "ID47",
-					"version":  1,
+					"version":  "1",
 					"structured_data": map[string]map[string]string{
 						"examplePriority@32473": {
 							"class": "high",

--- a/libbeat/reader/syslog/message.go
+++ b/libbeat/reader/syslog/message.go
@@ -18,6 +18,7 @@
 package syslog
 
 import (
+	"strconv"
 	"strings"
 	"time"
 
@@ -199,7 +200,7 @@ func (m message) fields() common.MapStr {
 		_, _ = f.Put("log.syslog.msgid", m.msgID)
 	}
 	if m.version != 0 {
-		_, _ = f.Put("log.syslog.version", m.version)
+		_, _ = f.Put("log.syslog.version", strconv.Itoa(m.version))
 	}
 	if len(m.structuredData) > 0 {
 		_, _ = f.Put("log.syslog.structured_data", m.structuredData)

--- a/libbeat/reader/syslog/message_test.go
+++ b/libbeat/reader/syslog/message_test.go
@@ -26,22 +26,28 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func mustParseTime(layout string, value string) time.Time {
-	t, err := time.Parse(layout, value)
+// mustParseTime will parse value into a time.Time using the provided layout. If value
+// cannot be parsed, this function will panic. If layout does not specify a time zone,
+// then a time.Location should be provided by loc. If layout does specify a time zone,
+// then loc should be nil. Layouts that do not specify a year will be enriched with
+// the current year relative to the location specified for the parsed timestamp.
+func mustParseTime(layout, value string, loc *time.Location) time.Time {
+	var t time.Time
+	var err error
+
+	if loc != nil {
+		t, err = time.ParseInLocation(layout, value, loc)
+	} else {
+		t, err = time.Parse(layout, value)
+	}
 	if err != nil {
 		panic(err)
 	}
 
-	return t
-}
-
-func mustParseTimeLoc(layout string, value string, loc *time.Location) time.Time {
-	t, err := time.ParseInLocation(layout, value, loc)
-	if err != nil {
-		panic(err)
-	}
-	if layout == time.Stamp {
-		t = t.AddDate(time.Now().Year(), 0, 0)
+	// Timestamps that do not include a year will be enriched using the
+	// current year relative to the location specified for the timestamp.
+	if t.Year() == 0 {
+		t = t.AddDate(time.Now().In(t.Location()).Year(), 0, 0)
 	}
 
 	return t
@@ -56,12 +62,12 @@ func TestMessage_SetTimestampBSD(t *testing.T) {
 		"bsd-timestamp": {
 			In:    "Oct 1 22:04:15",
 			InLoc: time.Local,
-			Want:  mustParseTimeLoc(time.Stamp, "Oct 1 22:04:15", time.Local),
+			Want:  mustParseTime(time.Stamp, "Oct 1 22:04:15", time.Local),
 		},
 		"loc-nil": {
 			In:    "Oct 1 22:04:15",
 			InLoc: nil,
-			Want:  mustParseTimeLoc(time.Stamp, "Oct 1 22:04:15", time.Local),
+			Want:  mustParseTime(time.Stamp, "Oct 1 22:04:15", time.Local),
 		},
 		"invalid-timestamp-1": {
 			In:    "1985-04-12T23:20:50.52Z",
@@ -96,23 +102,23 @@ func TestMessage_SetTimestampRFC3339(t *testing.T) {
 	}{
 		"rfc3339-timestamp": {
 			In:   "1985-04-12T23:20:50.52Z",
-			Want: mustParseTime(time.RFC3339Nano, "1985-04-12T23:20:50.52Z"),
+			Want: mustParseTime(time.RFC3339Nano, "1985-04-12T23:20:50.52Z", nil),
 		},
 		"rfc3339-timestamp-with-tz": {
 			In:   "1985-04-12T19:20:50.52-04:00",
-			Want: mustParseTime(time.RFC3339Nano, "1985-04-12T19:20:50.52-04:00"),
+			Want: mustParseTime(time.RFC3339Nano, "1985-04-12T19:20:50.52-04:00", nil),
 		},
 		"rfc3339-timestamp-with-milliseconds": {
 			In:   "2003-10-11T22:14:15.123Z",
-			Want: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123Z"),
+			Want: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123Z", nil),
 		},
 		"rfc3339-timestamp-with-microseconds": {
 			In:   "2003-10-11T22:14:15.123456Z",
-			Want: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123456Z"),
+			Want: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123456Z", nil),
 		},
 		"rfc3339-timestamp-with-microseconds-with-tz": {
 			In:   "2003-10-11T22:14:15.123456-06:00",
-			Want: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123456-06:00"),
+			Want: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123456-06:00", nil),
 		},
 		"invalid-timestamp-1": {
 			In: "Oct 1 22:04:15",
@@ -467,7 +473,7 @@ func TestMessage_Fields(t *testing.T) {
 	}{
 		"valid": {
 			In: &message{
-				timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123456-06:00"),
+				timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.123456-06:00", nil),
 				facility:  1,
 				severity:  5,
 				priority:  13,

--- a/libbeat/reader/syslog/message_test.go
+++ b/libbeat/reader/syslog/message_test.go
@@ -499,7 +499,7 @@ func TestMessage_Fields(t *testing.T) {
 						"appname":  "su",
 						"procid":   "1024",
 						"msgid":    "msg123",
-						"version":  1,
+						"version":  "1",
 						"structured_data": map[string]map[string]string{
 							"a": {
 								"b": "c",

--- a/libbeat/reader/syslog/rfc3164_test.go
+++ b/libbeat/reader/syslog/rfc3164_test.go
@@ -32,7 +32,7 @@ var parseRFC3164Cases = map[string]struct {
 	"ok": {
 		In: "<13>Oct 11 22:14:15 test-host this is the message",
 		Want: message{
-			timestamp: mustParseTimeLoc(time.Stamp, "Oct 11 22:14:15", time.Local),
+			timestamp: mustParseTime(time.Stamp, "Oct 11 22:14:15", time.Local),
 			priority:  13,
 			facility:  1,
 			severity:  5,
@@ -43,7 +43,7 @@ var parseRFC3164Cases = map[string]struct {
 	"ok-rfc3339": {
 		In: "<13>2003-08-24T05:14:15.000003-07:00 test-host this is the message",
 		Want: message{
-			timestamp: mustParseTime(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00"),
+			timestamp: mustParseTime(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00", nil),
 			priority:  13,
 			facility:  1,
 			severity:  5,
@@ -54,7 +54,7 @@ var parseRFC3164Cases = map[string]struct {
 	"ok-process": {
 		In: "<13>Oct 11 22:14:15 test-host su: this is the message",
 		Want: message{
-			timestamp: mustParseTimeLoc(time.Stamp, "Oct 11 22:14:15", time.Local),
+			timestamp: mustParseTime(time.Stamp, "Oct 11 22:14:15", time.Local),
 			priority:  13,
 			facility:  1,
 			severity:  5,
@@ -66,7 +66,7 @@ var parseRFC3164Cases = map[string]struct {
 	"ok-process-pid": {
 		In: "<13>Oct 11 22:14:15 test-host su[1024]: this is the message",
 		Want: message{
-			timestamp: mustParseTimeLoc(time.Stamp, "Oct 11 22:14:15", time.Local),
+			timestamp: mustParseTime(time.Stamp, "Oct 11 22:14:15", time.Local),
 			priority:  13,
 			facility:  1,
 			severity:  5,
@@ -79,7 +79,7 @@ var parseRFC3164Cases = map[string]struct {
 	"non-standard-date": {
 		In: "<123>Sep 01 02:03:04 hostname message",
 		Want: message{
-			timestamp: mustParseTimeLoc(time.Stamp, "Sep 1 02:03:04", time.Local),
+			timestamp: mustParseTime(time.Stamp, "Sep 1 02:03:04", time.Local),
 			priority:  123,
 			facility:  15,
 			severity:  3,

--- a/libbeat/reader/syslog/rfc5424_test.go
+++ b/libbeat/reader/syslog/rfc5424_test.go
@@ -32,7 +32,7 @@ var parseRFC5424Cases = map[string]struct {
 	"example-1": {
 		In: "<13>1 2003-08-24T05:14:15.000003-07:00 test-host su 1234 msg-5678 - This is a test message",
 		Want: message{
-			timestamp: mustParseTime(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00"),
+			timestamp: mustParseTime(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00", nil),
 			priority:  13,
 			facility:  1,
 			severity:  5,
@@ -47,7 +47,7 @@ var parseRFC5424Cases = map[string]struct {
 	"example-2": {
 		In: `<13>1 2003-08-24T05:14:15.000003-07:00 test-host su 1234 msg-5678 [sd-id-1 foo="bar"] This is a test message`,
 		Want: message{
-			timestamp: mustParseTime(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00"),
+			timestamp: mustParseTime(time.RFC3339Nano, "2003-08-24T05:14:15.000003-07:00", nil),
 			priority:  13,
 			facility:  1,
 			severity:  5,
@@ -76,7 +76,7 @@ var parseRFC5424Cases = map[string]struct {
 	"example-4": {
 		In: `<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 - ` + utf8BOM + `'su root' failed for user1 on /dev/pts/8`,
 		Want: message{
-			timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
+			timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.003Z", nil),
 			priority:  34,
 			facility:  4,
 			severity:  2,
@@ -90,7 +90,7 @@ var parseRFC5424Cases = map[string]struct {
 	"example-5": {
 		In: `<165>1 2003-10-11T22:14:15.003Z mymachine.example.com evntslog - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`,
 		Want: message{
-			timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
+			timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.003Z", nil),
 			priority:  165,
 			facility:  20,
 			severity:  5,

--- a/libbeat/reader/syslog/syslog_test.go
+++ b/libbeat/reader/syslog/syslog_test.go
@@ -80,7 +80,7 @@ func TestNewParser(t *testing.T) {
 			},
 			Want: []testResult{
 				{
-					Timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.003Z"),
+					Timestamp: mustParseTime(time.RFC3339Nano, "2003-10-11T22:14:15.003Z", nil),
 					Content:   []byte("this is the message"),
 					Fields: common.MapStr{
 						"log": common.MapStr{
@@ -115,7 +115,7 @@ func TestNewParser(t *testing.T) {
 					},
 				},
 				{
-					Timestamp: mustParseTimeLoc(time.Stamp, "Oct 11 22:14:15", time.Local),
+					Timestamp: mustParseTime(time.Stamp, "Oct 11 22:14:15", time.Local),
 					Content:   []byte("this is the message"),
 					Fields: common.MapStr{
 						"log": common.MapStr{

--- a/libbeat/reader/syslog/syslog_test.go
+++ b/libbeat/reader/syslog/syslog_test.go
@@ -98,7 +98,7 @@ func TestNewParser(t *testing.T) {
 								"appname":  "evntslog",
 								"procid":   "1024",
 								"msgid":    "ID47",
-								"version":  1,
+								"version":  "1",
 								"structured_data": map[string]map[string]string{
 									"examplePriority@32473": {
 										"class": "high",


### PR DESCRIPTION
## What does this PR do?

The `log.syslog.version` field in ECS expects the value to be a keyword (string). This PR changes how we store the value of this field, from an int to a string.

## Why is it important?

System tests fail due to type mismatch. This PR aligns the type with what ECS expects.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
go test github.com/elastic/beats/v7/libbeat/reader/syslog
go test github.com/elastic/beats/v7/libbeat/processors/syslog
```

## Logs

Error raised by system test:

```
panw/panos udp:
[0] parsing field value failed: field "log.syslog.version"'s Go type, float64, does not match the expected field type: keyword (field value: 1)
```
