### PR TITLE
[7.17](backport #312) Improve sync handling and errors

### DIFF
--- a/libbeat/common/file/helper_aix.go
+++ b/libbeat/common/file/helper_aix.go
@@ -24,7 +24,6 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string) error {
-	parent := filepath.Dir(path)
 
 	if e := os.Rename(tempfile, path); e != nil {
 		return e
@@ -35,6 +34,14 @@ func SafeFileRotate(path, tempfile string) error {
 	// contain the new file being rotated in.
 	// On AIX, fsync will fail if the file is opened in read-only mode,
 	// which is the case with os.Open.
+	return SyncParent(path)
+
+}
+
+// SyncParent fsyncs parent directory
+func SyncParent(path string) error {
+	parent := filepath.Dir(path)
+
 	f, err := os.OpenFile(parent, os.O_RDWR, 0)
 	if err != nil {
 		return nil // ignore error

--- a/libbeat/common/file/helper_other.go
+++ b/libbeat/common/file/helper_other.go
@@ -27,7 +27,6 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string) error {
-	parent := filepath.Dir(path)
 
 	if e := os.Rename(tempfile, path); e != nil {
 		return e
@@ -36,9 +35,17 @@ func SafeFileRotate(path, tempfile string) error {
 	// best-effort fsync on parent directory. The fsync is required by some
 	// filesystems, so to update the parents directory metadata to actually
 	// contain the new file being rotated in.
+	return SyncParent(path)
+}
+
+// SyncParent fsyncs parent directory
+func SyncParent(path string) error {
+	parent := filepath.Dir(path)
 	f, err := os.Open(parent)
+
+	// nolint: nilerr // ignore error
 	if err != nil {
-		return nil // ignore error
+		return nil
 	}
 	defer f.Close()
 

--- a/x-pack/elastic-agent/pkg/agent/storage/disk_store.go
+++ b/x-pack/elastic-agent/pkg/agent/storage/disk_store.go
@@ -55,14 +55,23 @@ func (d *DiskStore) Save(in io.Reader) error {
 	defer os.Remove(tmpFile)
 
 	if _, err := io.Copy(fd, in); err != nil {
-		_ = fd.Close()
+		if err := fd.Close(); err != nil {
+			return errors.New(err, "could not close temporary file",
+				errors.TypeFilesystem,
+				errors.M(errors.MetaKeyPath, tmpFile))
+		}
 
 		return errors.New(err, "could not save content on disk",
 			errors.TypeFilesystem,
 			errors.M(errors.MetaKeyPath, tmpFile))
 	}
 
-	_ = fd.Sync()
+	if err := fd.Sync(); err != nil {
+		return errors.New(err,
+			fmt.Sprintf("could not sync temporary file %s", d.target),
+			errors.TypeFilesystem,
+			errors.M(errors.MetaKeyPath, tmpFile))
+	}
 
 	if err := fd.Close(); err != nil {
 		return errors.New(err, "could not close temporary file",


### PR DESCRIPTION
## What does this PR do?

Improve sync handling and errors

## Why is it important?

Improve sync handling and errors
Related to https://github.com/elastic/elastic-agent/issues/98

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

Will update https://github.com/elastic/elastic-agent/blob/main/internal/pkg/agent/storage/replace_store.go#L44 by adding `SyncParent` once it's available in the repo.


## Related issues


- Relates https://github.com/elastic/elastic-agent/pull/312 https://github.com/elastic/elastic-agent-libs/pull/36  https://github.com/elastic/elastic-agent/issues/98

