### PR TITLE
Fix import errors in `journald` input after `config.C` adoption

### DIFF
--- a/filebeat/input/journald/config_test.go
+++ b/filebeat/input/journald/config_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
 func TestConfigIncludeMatches(t *testing.T) {
@@ -34,11 +36,11 @@ func TestConfigIncludeMatches(t *testing.T) {
 		c, err := conf.NewConfigWithYAML([]byte(yml), "source")
 		require.NoError(t, err)
 
-		conf := defaultConfig()
-		require.NoError(t, c.Unpack(&conf))
+		config := defaultConfig()
+		require.NoError(t, c.Unpack(&config))
 
-		assert.EqualValues(t, "_SYSTEMD_UNIT=foo.service", conf.Matches.OR[0].Matches[0].String())
-		assert.EqualValues(t, "_SYSTEMD_UNIT=bar.service", conf.Matches.OR[1].Matches[0].String())
+		assert.EqualValues(t, "_SYSTEMD_UNIT=foo.service", config.Matches.OR[0].Matches[0].String())
+		assert.EqualValues(t, "_SYSTEMD_UNIT=bar.service", config.Matches.OR[1].Matches[0].String())
 	}
 
 	t.Run("normal", func(t *testing.T) {

--- a/filebeat/input/journald/environment_test.go
+++ b/filebeat/input/journald/environment_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/go-concert/unison"
 )
 

--- a/filebeat/input/journald/input.go
+++ b/filebeat/input/journald/input.go
@@ -35,6 +35,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/reader"
 	"github.com/elastic/beats/v7/libbeat/reader/parser"
+	conf "github.com/elastic/elastic-agent-libs/config"
 )
 
 type journald struct {
@@ -105,7 +106,7 @@ func configure(cfg *conf.C) ([]cursor.Source, cursor.Input, error) {
 		Backoff:            config.Backoff,
 		MaxBackoff:         config.MaxBackoff,
 		Seek:               config.Seek,
-		CursorSeekFallback: conf.CursorSeekFallback,
+		CursorSeekFallback: config.CursorSeekFallback,
 		Matches:            journalfield.IncludeMatches(config.Matches),
 		Units:              config.Units,
 		Transports:         config.Transports,


### PR DESCRIPTION
## What does this PR do?

This PR fixes the imports in `journald` input. Unfortunately, the input is behind a build tag, so the problem slipped through the integration tests on the CI.

## Why is it important?

Filebeat cannot be packaged at the moment.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~