### PR TITLE
Add ascii documentation for regexp support in drop_fields processor

### DIFF
--- a/libbeat/processors/actions/docs/drop_fields.asciidoc
+++ b/libbeat/processors/actions/docs/drop_fields.asciidoc
@@ -27,5 +27,9 @@ are dropped.
 
 The `drop_fields` processor has the following configuration settings:
 
+`fields`:: If non-empty, a list of matching field names will be removed.
+Any element in array can contain a regular expression delimited by two
+slashes ('/reg_exp/'), in order to match (name) and remove more than one field.
+
 `ignore_missing`:: (Optional) If `true` the processor will not return an error
 when a specified field does not exist. Defaults to `false`.


### PR DESCRIPTION
## What does this PR do?

I've added a description in docs for the regexp functionality from #31424 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
