### PR TITLE
Fix keystore secrets parsing

### DIFF
--- a/libbeat/keystore/file_keystore_test.go
+++ b/libbeat/keystore/file_keystore_test.go
@@ -31,7 +31,10 @@ import (
 )
 
 var keyValue = "output.elasticsearch.password"
-var secretValue = []byte("secret")
+
+// Include uppercase, lowercase, symbols, and whitespace in the password.
+// Commas in particular have caused parsing issues before: https://github.com/elastic/beats/issues/29789
+var secretValue = []byte(",s3cRet~`! @#$%^&*()_-+={[}]|\\:;\"'<,>.?/")
 
 func TestCanCreateAKeyStore(t *testing.T) {
 	path := GetTemporaryKeystoreFile()
@@ -232,7 +235,7 @@ func TestGetConfig(t *testing.T) {
 
 	secret, err := cfg.String("output.elasticsearch.password", 0)
 	assert.NoError(t, err)
-	assert.Equal(t, secret, "secret")
+	assert.Equal(t, secret, string(secretValue))
 
 	port, err := cfg.String("super.nested", 0)
 	assert.Equal(t, port, "hello")

--- a/libbeat/keystore/keystore.go
+++ b/libbeat/keystore/keystore.go
@@ -79,8 +79,6 @@ type Provider interface {
 	GetKeystore(event bus.Event) Keystore
 }
 
-var parseConfig = parse.DefaultConfig
-
 // ResolverWrap wrap a config resolver around an existing keystore.
 func ResolverWrap(keystore Keystore) func(string) (string, parse.Config, error) {
 	return func(keyName string) (string, parse.Config, error) {
@@ -90,17 +88,17 @@ func ResolverWrap(keystore Keystore) func(string) (string, parse.Config, error) 
 			// If we cannot find the key, its a non fatal error
 			// and we pass to other resolver.
 			if err == ErrKeyDoesntExists {
-				return "", parseConfig, ucfg.ErrMissing
+				return "", parse.NoopConfig, ucfg.ErrMissing
 			}
-			return "", parseConfig, err
+			return "", parse.NoopConfig, err
 		}
 
 		v, err := key.Get()
 		if err != nil {
-			return "", parseConfig, err
+			return "", parse.NoopConfig, err
 		}
 
-		return string(v), parseConfig, nil
+		return string(v), parse.NoopConfig, nil
 	}
 }
 

--- a/libbeat/keystore/keystore.go
+++ b/libbeat/keystore/keystore.go
@@ -79,6 +79,8 @@ type Provider interface {
 	GetKeystore(event bus.Event) Keystore
 }
 
+var parseConfig = parse.DefaultConfig
+
 // ResolverWrap wrap a config resolver around an existing keystore.
 func ResolverWrap(keystore Keystore) func(string) (string, parse.Config, error) {
 	return func(keyName string) (string, parse.Config, error) {
@@ -88,17 +90,17 @@ func ResolverWrap(keystore Keystore) func(string) (string, parse.Config, error) 
 			// If we cannot find the key, its a non fatal error
 			// and we pass to other resolver.
 			if err == ErrKeyDoesntExists {
-				return "", parse.DefaultConfig, ucfg.ErrMissing
+				return "", parseConfig, ucfg.ErrMissing
 			}
-			return "", parse.DefaultConfig, err
+			return "", parseConfig, err
 		}
 
 		v, err := key.Get()
 		if err != nil {
-			return "", parse.DefaultConfig, err
+			return "", parseConfig, err
 		}
 
-		return string(v), parse.DefaultConfig, nil
+		return string(v), parseConfig, nil
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes parsing values from the keystore that contain commas. Disable all go-ucfg parsing features when loading from the keystore.

Requires https://github.com/elastic/go-ucfg/pull/192 to work.

## Why is it important?

If a value from the keystore contains a comma, it will fail to parse when resolved through go-ucfg. This is both broken, and can lead to logging secrets in plaintext because go-ucfg has no concept of a secure string. 

## Checklist

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
~- [ ] I have made corresponding change to the default configuration files~
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/beats/issues/29789
- Relates https://github.com/elastic/go-ucfg/pull/192


