### PR TITLE
Remove ambiguity on Dockerfile CMD.

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -143,6 +143,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Add Github action for linting
 - Add regex support for drop_fields processor.
 - Improve compatibility and reduce flakyness of Python tests {pull}31588[31588]
+- Remove ambiguity on Dockerfile CMD. {pull}31500[31550]
 
 ==== Deprecated
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Improve syslog parser/processor error handling. {issue}31246[31246] {pull}31798[31798]
 - Fix Windows service timeouts when the "TCP/IP NetBIOS Helper" service is disabled. {issue}31810[31810] {pull}31835[31835]
 - Expand fields in `decode_json_fields` if target is set. {issue}31712[31712] {pull}32010[32010]
+- Fix environment flag in Dockerfile CMD. {pull}31500[31550]
 
 *Auditbeat*
 

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -195,4 +195,4 @@ ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
 
 WORKDIR {{ $beatHome }}
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/docker-entrypoint"]
-CMD ["-environment", "container"]
+CMD ["--environment", "container"]

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -1050,7 +1050,7 @@ messages.
 *`-e, --e`*::
 Logs to stderr and disables syslog/file output.
 
-*`-environment`*::
+*`--environment`*::
 For logging purposes, specifies the environment that {beatname_uc} is running in.
 This setting is used to select a default log output when no log output is configured.
 Supported values are: `systemd`, `container`, `macos_service`, and `windows_service`.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Beat binaries have two options, `-e` and `--environment` have different use.

This MR reveals new Dockerfile, use of `--environment` instead `-environment`, and some change on document.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Use of `-environment` increases ambiguity, since beats have `-e` options, which sends logs for stderr.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Additional Checklist

- [x] Checked any `environment` flag usage in entire repository with single minus character

## Related issues

- Relates #19959
   - Other PR, that changes `-environment`  to `--environment`
