### PR TITLE
Oracle_30974:  Ingest pipeline date parsing issue

### DIFF
--- a/x-pack/filebeat/module/oracle/database_audit/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/oracle/database_audit/ingest/pipeline.yml
@@ -85,7 +85,7 @@ processors:
       field: tmp_timestamp
       target_field: "@timestamp"
       formats:
-        - EEE MMM  d HH:mm:ss uuuu XXX
+        - EEE MMM [ d][dd] HH:mm:ss uuuu XXX
   - grok:
       field: tmp_timestamp
       patterns:

--- a/x-pack/filebeat/module/oracle/database_audit/test/ORCLCDB_j002_28264_20201007122838056263426565.aud.log
+++ b/x-pack/filebeat/module/oracle/database_audit/test/ORCLCDB_j002_28264_20201007122838056263426565.aud.log
@@ -13,7 +13,7 @@ Redo thread mounted by this instance: 1
 Oracle process number: 51
 Unix process pid: 28264, image: oracle@testlab.local (J002)
 
-Wed Oct  7 12:28:38 2020 -04:00
+Wed Oct 21 12:28:38 2020 -04:00
 LENGTH : '370'
 ACTION :[123] 'SELECT moving_window_size
       FROM AWR_PDB_baseline_metadata

--- a/x-pack/filebeat/module/oracle/database_audit/test/ORCLCDB_j002_28264_20201007122838056263426565.aud.log-expected.json
+++ b/x-pack/filebeat/module/oracle/database_audit/test/ORCLCDB_j002_28264_20201007122838056263426565.aud.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2020-10-07T16:28:38.000Z",
+        "@timestamp": "2020-10-21T16:28:38.000Z",
         "event.action": "database_audit",
         "event.category": "database",
         "event.dataset": "oracle.database_audit",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR parses a 2 digit month day format for the oracle's ingest pipeline

## Why is it important?

This is important, as otherwise it would not be possible to parse logs with timestamps > 9th day of the month

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

The test log file can be changed to a 2 month day. Without the change the particular changed log will not be parsed. With the change, the parsing of the 2 month day will happen successfully. 

## Related issues

- Closes: https://github.com/elastic/beats/issues/30974
