### PR TITLE
packetbeat/procs: be more careful in recovering process names on linux

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Packetbeat*
 
+- Use /proc/<pid>/comm for linux process names where possible. {pull}31527[31527]
 
 *Winlogbeat*
 

--- a/packetbeat/procs/procs_linux.go
+++ b/packetbeat/procs/procs_linux.go
@@ -35,8 +35,23 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/packetbeat/protos/applayer"
+	"github.com/elastic/go-sysinfo/types"
 	"github.com/elastic/gosigar"
 )
+
+// procName makes a best effort attempt to get a good name for the process. It
+// uses /proc/<pid>/comm if it is less than 16 bytes long (TASK_COMM_LEN) and
+// otherwise uses argv[0] if it is available, but falling back to the comm string
+// if it is not.
+func procName(info types.ProcessInfo) string {
+	// We cannot know that a 16 byte string is not truncated,
+	// so assume the worst and get the first argument if we
+	// are at TASK_COMM_LEN and the arg is available.
+	if len(info.Name) < 16 || len(info.Args) == 0 {
+		return info.Name
+	}
+	return filepath.Base(info.Args[0])
+}
 
 type socketInfo struct {
 	srcIP, dstIP     net.IP
@@ -115,25 +130,25 @@ func findSocketsOfPid(prefix string, pid int) (inodes []uint64, err error) {
 	dirname := filepath.Join(prefix, "/proc", strconv.Itoa(pid), "fd")
 	procfs, err := os.Open(dirname)
 	if err != nil {
-		return []uint64{}, fmt.Errorf("Open: %s", err)
+		return nil, err
 	}
 	defer procfs.Close()
 	names, err := procfs.Readdirnames(0)
 	if err != nil {
-		return []uint64{}, fmt.Errorf("Readdirnames: %s", err)
+		return nil, err
 	}
 
 	for _, name := range names {
 		link, err := os.Readlink(filepath.Join(dirname, name))
 		if err != nil {
-			logp.Debug("procs", "Readlink %s: %s", name, err)
+			logp.Debug("procs", err.Error())
 			continue
 		}
 
 		if strings.HasPrefix(link, "socket:[") {
 			inode, err := strconv.ParseInt(link[8:len(link)-1], 10, 64)
 			if err != nil {
-				logp.Debug("procs", "ParseInt: %s:", err)
+				logp.Debug("procs", err.Error())
 				continue
 			}
 
@@ -155,18 +170,13 @@ func socketsFromProc(filename string, ipv6 bool) ([]*socketInfo, error) {
 
 // Parses the /proc/net/(tcp|udp)6? file
 func parseProcNetProto(input io.Reader, ipv6 bool) ([]*socketInfo, error) {
-	buf := bufio.NewReader(input)
-
-	sockets := []*socketInfo{}
-	var err error
-	var line []byte
-	for err != io.EOF {
-		line, err = buf.ReadBytes('\n')
-		if err != nil && err != io.EOF {
-			logp.Err("Error reading proc net file: %s", err)
-			return nil, err
-		}
-		words := bytes.Fields(line)
+	var (
+		sockets []*socketInfo
+		err     error
+	)
+	sc := bufio.NewScanner(input)
+	for sc.Scan() {
+		words := bytes.Fields(sc.Bytes())
 		// Ignore empty lines and the header
 		if len(words) == 0 || bytes.Equal(words[0], []byte("sl")) {
 			continue
@@ -177,14 +187,11 @@ func parseProcNetProto(input io.Reader, ipv6 bool) ([]*socketInfo, error) {
 		}
 
 		var sock socketInfo
-		var err error
-
 		sock.srcIP, sock.srcPort, err = hexToIPPort(words[1], ipv6)
 		if err != nil {
 			logp.Debug("procs", "Error parsing IP and port: %s", err)
 			continue
 		}
-
 		sock.dstIP, sock.dstPort, err = hexToIPPort(words[2], ipv6)
 		if err != nil {
 			logp.Debug("procs", "Error parsing IP and port: %s", err)
@@ -198,13 +205,18 @@ func parseProcNetProto(input io.Reader, ipv6 bool) ([]*socketInfo, error) {
 
 		sockets = append(sockets, &sock)
 	}
+	err = sc.Err()
+	if err != nil {
+		logp.Err("Error reading proc net file: %s", err)
+		return nil, err
+	}
 	return sockets, nil
 }
 
 func hexToIPPort(str []byte, ipv6 bool) (net.IP, uint16, error) {
-	words := bytes.Split(str, []byte(":"))
+	words := bytes.SplitN(str, []byte(":"), 2) // Use bytes.Cut when it becomes available.
 	if len(words) < 2 {
-		return nil, 0, errors.New("Didn't find ':' as a separator")
+		return nil, 0, errors.New("could not find port separator")
 	}
 
 	ip, err := hexToIP(string(words[0]), ipv6)

--- a/packetbeat/procs/procs_other.go
+++ b/packetbeat/procs/procs_other.go
@@ -20,7 +20,15 @@
 
 package procs
 
-import "github.com/elastic/beats/v7/packetbeat/protos/applayer"
+import (
+	"github.com/elastic/beats/v7/packetbeat/protos/applayer"
+	"github.com/elastic/go-sysinfo/types"
+)
+
+// procName returns the name for the process.
+func procName(info types.ProcessInfo) string {
+	return info.Name
+}
 
 // GetLocalPortToPIDMapping returns the list of local port numbers and the PID
 // that owns them.

--- a/packetbeat/procs/procs_windows.go
+++ b/packetbeat/procs/procs_windows.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sys/windows"
 
 	"github.com/elastic/beats/v7/packetbeat/protos/applayer"
+	"github.com/elastic/go-sysinfo/types"
 )
 
 var machineEndiannes = getMachineEndiannes()
@@ -70,6 +71,11 @@ var tablesByTransport = map[applayer.Transport][]struct {
 	},
 }
 
+// procName returns the name for the process.
+func procName(info types.ProcessInfo) string {
+	return info.Name
+}
+
 // GetLocalPortToPIDMapping returns the list of local port numbers and the PID
 // that owns them.
 func (proc *ProcessesWatcher) GetLocalPortToPIDMapping(transport applayer.Transport) (ports map[endpoint]int, err error) {
@@ -107,7 +113,7 @@ func getNetTable(fn GetExtendedTableFn, order bool, family uint32, tableClass ui
 			ptr = make([]byte, size)
 			addr = uintptr(unsafe.Pointer(&ptr[0]))
 		} else {
-			return nil, fmt.Errorf("getNetTable failed: code=%v err=%v", code, err)
+			return nil, fmt.Errorf("getNetTable failed: code=%v err=%w", code, err)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This changes the behaviour of process name recovery for linux hosts so that `/proc/<pid>/comm` is used unless it cannot be guaranteed to be a complete name.

Also do a little de-linting.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The first argument of a command line is under the control of the invoker and so is more easily spoofed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] This could be argued to be a breaking change since the names provided to processes by using /proc/\<pid\>/comm may differ from the strings returned by examining the argv.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates elastic/integrations#2720

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
