### PR TITLE
chore: use a different e2e profile for running them from Beats

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -436,7 +436,7 @@ def runE2ETests(){
   }
   echo 'runE2E will run now in a sync mode to validate packages can be published.'
   runE2E(runTestsSuites: suites,
-         testMatrixFile: '.ci/e2e-tests-beats.yml',
+         testMatrixFile: '.ci/e2e-tests-beats.yaml',
          beatVersion: "${env.BEAT_VERSION}-SNAPSHOT",
          gitHubCheckName: env.GITHUB_CHECK_E2E_TESTS_NAME,
          gitHubCheckRepo: env.REPO,

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -436,6 +436,7 @@ def runE2ETests(){
   }
   echo 'runE2E will run now in a sync mode to validate packages can be published.'
   runE2E(runTestsSuites: suites,
+         testMatrixFile: '.ci/e2e-tests-beats.yml',
          beatVersion: "${env.BEAT_VERSION}-SNAPSHOT",
          gitHubCheckName: env.GITHUB_CHECK_E2E_TESTS_NAME,
          gitHubCheckRepo: env.REPO,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
It passes the name of a profile that will be used to add/retire specific tests from the e2e test suite when it's called from Beats pipeline.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
We'd like to remove scenarios that the team consider flaky while they are investigating them, to avoid adding noise to the rest of pull-requests.

I personally don't like to skip a test without further investigation because it's easily forgotten to be re-added. On the other hand, I understand that this PR would improve the reliability of the tests, therefore the team would work more smoothly and with more confidence in the CI system.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] A PR on the e2e-tests adding the test suites needs to be created


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

Requires https://github.com/elastic/e2e-testing/pull/2482


<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->



<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->



<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
