### PR TITLE
Enhance SQL module to accept raw responses

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Extend documentation about `orchestrator.cluster` fields {pull}30518[30518]
 - Enhance Oracle Module: Change tablespace metricset collection period {issue}30948[30948] {pull}31259[#31259]
 - Add orchestrator cluster ECS fields in kubernetes events {pull}31341[31341]
+- Enhance SQL module to accept raw responses {31532}31532[31532]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
-	
+
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/metricbeat/helper/sql"
 	"github.com/elastic/beats/v7/metricbeat/mb"

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -128,8 +128,6 @@ func (m *MetricSet) reportEvent(ms mapstr.M, reporter mb.ReporterV2) {
 	} else {
 		reporter.Event(*getUserEvent(ms, m.config.Driver, m.config.Query))
 	}
-
-	return
 }
 
 // composeEventFromRoot using the provided metrics and organizing their position in the event by using the rootLevelName
@@ -205,7 +203,8 @@ func inferTypeFromMetrics(ms mapstr.M) mapstr.M {
 	if len(boolMetrics) > 0 {
 		ret["bool"] = boolMetrics
 	}
-	return nil
+
+	return ret
 }
 
 // Close closes the connection pool releasing its resources

--- a/x-pack/metricbeat/module/sql/query/query.go
+++ b/x-pack/metricbeat/module/sql/query/query.go
@@ -7,11 +7,13 @@ package query
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/beats/v7/libbeat/common"
+
+	"github.com/jmoiron/sqlx"
+	
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/v7/metricbeat/helper/sql"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/jmoiron/sqlx"
+	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 // represents the response format of the query
@@ -108,7 +110,7 @@ func (m *MetricSet) Fetch(ctx context.Context, report mb.ReporterV2) error {
 	return nil
 }
 
-func (m *MetricSet) Report(ms common.MapStr, report mb.ReporterV2) {
+func (m *MetricSet) Report(ms mapstr.M, report mb.ReporterV2) {
 	if !m.config.RawData.Enabled {
 		report.Event(m.getEvent(ms))
 	} else {
@@ -124,8 +126,8 @@ func (m *MetricSet) Report(ms common.MapStr, report mb.ReporterV2) {
 		}
 
 		report.Event(mb.Event{
-			RootFields: common.MapStr{
-				m.config.RawData.RootLevelName: common.MapStr{
+			RootFields: mapstr.M{
+				m.config.RawData.RootLevelName: mapstr.M{
 					m.config.RawData.DataLevelName: ms,
 				},
 			},
@@ -135,10 +137,10 @@ func (m *MetricSet) Report(ms common.MapStr, report mb.ReporterV2) {
 	}
 }
 
-func (m *MetricSet) getEvent(ms common.MapStr) mb.Event {
+func (m *MetricSet) getEvent(ms mapstr.M) mb.Event {
 	return mb.Event{
-		RootFields: common.MapStr{
-			"sql": common.MapStr{
+		RootFields: mapstr.M{
+			"sql": mapstr.M{
 				"driver":  m.config.Driver,
 				"query":   m.config.Query,
 				"metrics": getMetrics(ms),
@@ -147,12 +149,12 @@ func (m *MetricSet) getEvent(ms common.MapStr) mb.Event {
 	}
 }
 
-func getMetrics(ms common.MapStr) (ret common.MapStr) {
-	ret = common.MapStr{}
+func getMetrics(ms mapstr.M) (ret mapstr.M) {
+	ret = mapstr.M{}
 
-	numericMetrics := common.MapStr{}
-	stringMetrics := common.MapStr{}
-	boolMetrics := common.MapStr{}
+	numericMetrics := mapstr.M{}
+	stringMetrics := mapstr.M{}
+	boolMetrics := mapstr.M{}
 
 	for k, v := range ms {
 		switch v.(type) {

--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -42,9 +42,7 @@ func TestMySQL(t *testing.T) {
 			Query:          "select table_schema, table_name, engine, table_rows from information_schema.tables where table_rows > 0;",
 			ResponseFormat: "",
 			RawData: struct {
-				Enabled       bool   `config:"enabled"`
-				RootLevelName string `config:"root_level_name"`
-				DataLevelName string `config:"data_level_name"`
+				Enabled bool `config:"enabled"`
 			}{},
 		},
 		Host:      mysql.GetMySQLEnvDSN(service.Host()),
@@ -144,14 +142,12 @@ func TestPostgreSQL(t *testing.T) {
 					Query:          "select name, setting from pg_settings",
 					ResponseFormat: variableResponseFormat,
 					RawData: rawData{
-						Enabled:       true,
-						RootLevelName: "postgres",
-						DataLevelName: "settings",
+						Enabled: true,
 					},
 				},
 				Host: fmt.Sprintf("postgres://%s:%s@%s:%s/?sslmode=disable", user, password, host, port),
 				Assertion: func(t *testing.T, event beat.Event) {
-					value, err := event.GetValue("postgres.settings")
+					value, err := event.GetValue("sql.query")
 					assert.NoError(t, err)
 					require.NotEmpty(t, value.(map[string]interface{}))
 				},
@@ -166,14 +162,12 @@ func TestPostgreSQL(t *testing.T) {
 					Query:          "select * from pg_settings",
 					ResponseFormat: tableResponseFormat,
 					RawData: rawData{
-						Enabled:       true,
-						RootLevelName: "postgres",
-						DataLevelName: "settings",
+						Enabled: true,
 					},
 				},
 				Host: fmt.Sprintf("postgres://%s:%s@%s:%s/?sslmode=disable", user, password, host, port),
 				Assertion: func(t *testing.T, event beat.Event) {
-					value, err := event.GetValue("postgres.settings")
+					value, err := event.GetValue("sql.query")
 					assert.NoError(t, err)
 					require.NotEmpty(t, value.(map[string]interface{}))
 				},


### PR DESCRIPTION
## What does this PR do?

This PR gives greater flexibility to Metricbeat and Integration developers by allowing the a raw return of custom queries by adding some parameters.

Right now the module infers the type of the returned value and does a best effort in generating a mapping without knowing in advance the nature of the data that will be returned by custom queries.

With this enhancement, a configuration like the following can be passed:

```yml
- module: sql
  metricsets:
    - query
  period: 10s
  hosts: ["postgresql://postgres:mysecretpassword@172.17.0.2:5432/postgres?sslmode=disable"]

  driver: "postgres"
  sql_query: "select * from pg_settings"
  sql_response_format: table
  raw_data.enabled: true

  processors:
    - rename:
        ignore_missing: true
        fields:
          - from: "sql"
            to: "postgresql.settings"
```

> New part is the `raw_data` dictionary.

And the response won't have a known mapping, but will attempt to follow the current conventions in Metricbeat:

```json
{
  "@timestamp": "2022-05-06T10:11:42.434Z",
  "@metadata": {
    "beat": "metricbeat",
    "type": "_doc",
    "version": "8.3.0"
  },
  "agent": {
    "name": "thinkpad",
    "type": "metricbeat",
    "version": "8.3.0",
    "ephemeral_id": "b379296b-2e88-463c-b3ab-607170262241",
    "id": "b858b3b8-696a-4b5f-903d-d162a25a6ec6"
  },
  "event": {
    "module": "sql",
    "duration": 12142840,
    "dataset": "sql.query"
  },
  "metricset": {
    "period": 10000,
    "name": "query"
  },
  "service": {
    "address": "172.17.0.2:5432",
    "type": "sql"
  },
  "postgresql": {
    "settings": {
      "short_desc": "Continues processing past damaged page headers.",
      "setting": "off",
      "vartype": "bool",
      "name": "zero_damaged_pages",
      "boot_val": "off",
      "source": "default",
      "extra_desc": "Detection of a damaged page header normally causes PostgreSQL to report an error, aborting the current transaction. Setting zero_damaged_pages to true causes the system to instead report a warning, zero out the damaged page, and continue processing. This behavior will destroy data, namely all the rows on the damaged page.",
      "category": "Developer Options",
      "context": "superuser",
      "pending_restart": false,
      "reset_val": "off"
    }
  },
  "ecs": {
    "version": "8.0.0"
  },
  "host": {
    "name": "thinkpad"
  }
}
```

### What to look at in this JSON
* `postresl.settings` has been set to the values provided in the config, overriding the default for this particular module (default: `sql.query`)

### Is anything missing?

* `event.module` still has the value `sql` instead of `postgres` which would be the correct value in this example.
* `event.dataset` still has the value `sql.query` instead of `postgres.settings` which would be the correct value in this example.
* `metricset.name` still has the value `query` instead of `settings` which would be the correct value in this example.
* `service.type` still has the value `sql` instead of `postgres` which would be the correct value in this example.

## Why is it important?

With this enhancement, an Integration developer might create Data Streams easily by providing a small config and a mapping.