### PR TITLE
Add parsing for 434001 and 434003

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,6 +99,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Add `application/zip` decoder to the `httpsjon` input. {issue}31282[31282] {pull}31304[31304]
 - Sanitize the Azure storage account container names with underscores (_). {pull}31384[31384]
 - Add missing docs for the `delegated_account` option in the `httpjson` input. {pull}31498[31498]
+- Cisco ASA/FTD: Add support for messages 434001 and 434003. {pull}31533[31533]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/module/cisco/asa/test/sample.log
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log
@@ -85,3 +85,5 @@ Jan 15 2021 19:12:37: %ASA-6-302015: Built inbound UDP connection 261311655 for 
 Jan 15 2021 19:12:37: %ASA-6-302016: Teardown UDP connection 261311655 for OUTSIDE:89.160.20.156/63790(LOCAL\domain\USER001) to INSIDE:192.168.0.1/53 duration 0:00:00 bytes 139 (domain\USER001)
 Jan 15 2021 19:12:37: %ASA-6-302013: Built inbound TCP connection 261246338 for OUTSIDE:89.160.20.156/50120 (67.43.156.13/50120)(LOCAL\domain\USER001) to OUTSIDE:40.0.0.1/443 (40.0.0.1/443) (domain\USER001)
 Jul 29 2021 08:35:29: %ASA-6-602304: IPSEC: An outbound LAN-to-LAN SA (SPI= 0xABCXYZ) between 81.2.69.1452 and 81.2.69.1452 (user= 81.2.69.1452) has been deleted.
+<13>Apr 26 2022 10:24:37: %ASA-4-434001: SFR card not up and fail-close mode used, dropping TCP packet from outside:54.239.28.85/443 to Inside:10.12.128.89/57388
+<13>May 30 2019 09:18:59: %ASA-4-434003: SFR requested to reset TCP connection from outside:54.239.28.85/443 to Inside:10.12.128.89/57388

--- a/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
@@ -4747,6 +4747,7 @@
         "event.dataset": "cisco.asa",
         "event.module": "cisco",
         "event.original": "%ASA-4-434001: SFR card not up and fail-close mode used, dropping TCP packet from outside:54.239.28.85/443 to Inside:10.12.128.89/57388",
+        "event.outcome": "unknown",
         "event.severity": 4,
         "event.timezone": "-02:00",
         "fileset.name": "asa",

--- a/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
+++ b/x-pack/filebeat/module/cisco/asa/test/sample.log-expected.json
@@ -4733,5 +4733,86 @@
             "forwarded"
         ],
         "user.name": "81.2.69.1452"
+    },
+    {
+        "@timestamp": "2022-04-26T10:24:37.000-02:00",
+        "cisco.asa.destination_interface": "Inside",
+        "cisco.asa.message_id": "434001",
+        "cisco.asa.source_interface": "outside",
+        "destination.address": "10.12.128.89",
+        "destination.ip": "10.12.128.89",
+        "destination.port": 57388,
+        "event.action": "drop",
+        "event.code": 434001,
+        "event.dataset": "cisco.asa",
+        "event.module": "cisco",
+        "event.original": "%ASA-4-434001: SFR card not up and fail-close mode used, dropping TCP packet from outside:54.239.28.85/443 to Inside:10.12.128.89/57388",
+        "event.severity": 4,
+        "event.timezone": "-02:00",
+        "fileset.name": "asa",
+        "input.type": "log",
+        "log.file.path": "sample.log",
+        "log.level": "warning",
+        "log.offset": 13909,
+        "network.protocol": "tcp",
+        "observer.egress.interface.name": "Inside",
+        "observer.ingress.interface.name": "outside",
+        "observer.product": "asa",
+        "observer.type": "firewall",
+        "observer.vendor": "Cisco",
+        "related.ip": [
+            "10.12.128.89",
+            "54.239.28.85"
+        ],
+        "service.type": "cisco",
+        "source.address": "54.239.28.85",
+        "source.ip": "54.239.28.85",
+        "source.port": 443,
+        "syslog.facility": 13,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
+    },
+    {
+        "@timestamp": "2019-05-30T09:18:59.000-02:00",
+        "cisco.asa.destination_interface": "Inside",
+        "cisco.asa.message_id": "434003",
+        "cisco.asa.source_interface": "outside",
+        "destination.address": "10.12.128.89",
+        "destination.ip": "10.12.128.89",
+        "destination.port": 57388,
+        "event.action": "reset",
+        "event.code": 434003,
+        "event.dataset": "cisco.asa",
+        "event.module": "cisco",
+        "event.original": "%ASA-4-434003: SFR requested to reset TCP connection from outside:54.239.28.85/443 to Inside:10.12.128.89/57388",
+        "event.outcome": "unknown",
+        "event.severity": 4,
+        "event.timezone": "-02:00",
+        "fileset.name": "asa",
+        "input.type": "log",
+        "log.file.path": "sample.log",
+        "log.level": "warning",
+        "log.offset": 14071,
+        "network.protocol": "tcp",
+        "observer.egress.interface.name": "Inside",
+        "observer.ingress.interface.name": "outside",
+        "observer.product": "asa",
+        "observer.type": "firewall",
+        "observer.vendor": "Cisco",
+        "related.ip": [
+            "10.12.128.89",
+            "54.239.28.85"
+        ],
+        "service.type": "cisco",
+        "source.address": "54.239.28.85",
+        "source.ip": "54.239.28.85",
+        "source.port": 443,
+        "syslog.facility": 13,
+        "tags": [
+            "cisco-asa",
+            "forwarded"
+        ]
     }
 ]

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -698,9 +698,17 @@ processors:
       separator: ",\\s+"
       ignore_missing: true
   - dissect:
+      if: "ctx._temp_.cisco.message_id == '434001'"
+      field: "message"
+      pattern: "SFR card not up and fail-close mode used, %{event.action}ping %{network.protocol} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+  - dissect:
       if: "ctx._temp_.cisco.message_id == '434002'"
       field: "message"
       pattern: "SFR requested to %{event.action} %{network.protocol} packet from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
+  - dissect:
+      if: "ctx._temp_.cisco.message_id == '434003'"
+      field: "message"
+      pattern: "SFR requested to %{event.action} %{network.protocol} connection from %{_temp_.cisco.source_interface}:%{source.address}/%{source.port} to %{_temp_.cisco.destination_interface}:%{destination.address}/%{destination.port}"
   - dissect:
       if: "ctx._temp_.cisco.message_id == '434004'"
       field: "message"
@@ -740,7 +748,7 @@ processors:
       - "^(Group = %{IP}, )?(IP = %{IP:source.address}, )?%{GREEDYDATA:event.reason}$"
    # Handle ecs action outcome protocol
   - set:
-      if: '["434002", "434004"].contains(ctx._temp_.cisco.message_id)'
+      if: '["434002", "434003", "434004"].contains(ctx._temp_.cisco.message_id)'
       field: "event.outcome"
       value: "unknown"
   - set:

--- a/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
+++ b/x-pack/filebeat/module/cisco/shared/ingest/asa-ftd-pipeline.yml
@@ -748,7 +748,7 @@ processors:
       - "^(Group = %{IP}, )?(IP = %{IP:source.address}, )?%{GREEDYDATA:event.reason}$"
    # Handle ecs action outcome protocol
   - set:
-      if: '["434002", "434003", "434004"].contains(ctx._temp_.cisco.message_id)'
+      if: '["434001", "434002", "434003", "434004"].contains(ctx._temp_.cisco.message_id)'
       field: "event.outcome"
       value: "unknown"
   - set:


### PR DESCRIPTION
## What does this PR do?
This PR adds parsing for Cisco ASA 434001 and 434003 using the precise style currently used for parsing Cisco ASA 434002.

## Why is it important?
We need parsing for ASA 434001, 434002, and 434003; right now only 434002 is supported, despite the others being substantially similar dissections.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~ 
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
The PR uses the patterns specified here: https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslog-messages-400000-to-450001.html#con_7199521.
For testing the actual messages, these are sample logs:
For 434001:
<13>Apr 26 2022 10:24:37: %ASA-4-434001: SFR card not up and fail-close mode used, dropping TCP packet from outside:54.239.28.85/443 to Inside:10.12.128.89/57388

For 434003:
<13>May 30 2019 09:18:59: %ASA-4-434003: SFR requested to reset TCP connection from outside:54.239.28.85/443 to Inside:10.12.128.89/57388

Ideally a test would send these messages through filebeat with the Cisco ASA module enabled, although in this case the change is small enough to be visually inspected and compared with the working 434002 dissection that neighbors the changes and the Cisco specified log patterns from https://www.cisco.com/c/en/us/td/docs/security/asa/syslog/b_syslog/syslog-messages-400000-to-450001.html#con_7199521.
