### PR TITLE
[auditbeat] Add backlog_wait_time_actual to show-status output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -82,6 +82,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Auditbeat*
 
+- Add `backlog_wait_time_actual` to the output of the `auditbeat auditd show-status` command. {pull}31535[31535]
 
 *Filebeat*
 

--- a/auditbeat/module/auditd/show_linux.go
+++ b/auditbeat/module/auditd/show_linux.go
@@ -123,6 +123,7 @@ func showAuditdStatus() error {
 		"lost %d%c"+
 		"backlog %d%c"+
 		"backlog_wait_time %d%c"+
+		"backlog_wait_time_actual %d%c"+
 		"features %s\n",
 		status.Enabled, separator,
 		status.Failure, separator,
@@ -132,6 +133,7 @@ func showAuditdStatus() error {
 		status.Lost, separator,
 		status.Backlog, separator,
 		status.BacklogWaitTime, separator,
+		status.BacklogWaitTimeActual, separator,
 		fmt.Sprintf("%#x", status.FeatureBitmap))
 
 	return nil

--- a/auditbeat/module/auditd/show_linux.go
+++ b/auditbeat/module/auditd/show_linux.go
@@ -19,6 +19,7 @@ package auditd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -41,8 +42,8 @@ func init() {
 		Short:   "Show currently installed auditd rules",
 		Aliases: []string{"audit-rules", "audit_rules", "rules", "auditdrules", "auditrules"},
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := showAuditdRules(); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to show auditd rules: %v\n", err)
+			if err := showAuditdRules(cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to show auditd rules: %v\n", err)
 				os.Exit(1)
 			}
 		},
@@ -55,8 +56,8 @@ func init() {
 		Short:   "Show kernel auditd status",
 		Aliases: []string{"audit-status", "audit_status", "status", "auditdstatus", "auditrules"},
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := showAuditdStatus(); err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to show auditd rules: %v\n", err)
+			if err := showAuditdStatus(cmd.OutOrStdout()); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Failed to show auditd rules: %v\n", err)
 				os.Exit(1)
 			}
 		},
@@ -65,7 +66,7 @@ func init() {
 	cmd.ShowCmd.AddCommand(&showRules, &showStatus)
 }
 
-func showAuditdRules() error {
+func showAuditdRules(stdout, stderr io.Writer) error {
 	client, err := libaudit.NewAuditClient(nil)
 	if err != nil {
 		return fmt.Errorf("failed to create audit client: %w", err)
@@ -80,19 +81,19 @@ func showAuditdRules() error {
 	for idx, raw := range rules {
 		r, err := rule.ToCommandLine(raw, !dontResolveIDs)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error decoding rule %d: %v\n", idx, err)
-			fmt.Fprintf(os.Stderr, "Raw dump: <<<%v>>>\n", raw)
+			fmt.Fprintf(stderr, "Error decoding rule %d: %v\n", idx, err)
+			fmt.Fprintf(stderr, "Raw dump: <<<%v>>>\n", raw)
 		}
-		fmt.Println(r)
+		fmt.Fprintln(stdout, r)
 	}
 
 	if !noOutputIfEmpty && len(rules) == 0 {
-		fmt.Println("No rules")
+		fmt.Fprintln(stdout, "No rules")
 	}
 	return nil
 }
 
-func showAuditdStatus() error {
+func showAuditdStatus(out io.Writer) error {
 	client, err := libaudit.NewAuditClient(nil)
 	if err != nil {
 		return fmt.Errorf("failed to create audit client: %w", err)
@@ -115,7 +116,7 @@ func showAuditdStatus() error {
 		separator = ' '
 	}
 
-	fmt.Printf("enabled %d%c"+
+	fmt.Fprintf(out, "enabled %d%c"+
 		"failure %d%c"+
 		"pid %d%c"+
 		"rate_limit %d%c"+


### PR DESCRIPTION
## What does this PR do?

Now that go-libaudit support [backlog_wait_time_actual](https://github.com/torvalds/linux/commit/b43870c74f3fdf0cd06bf5f1b7a5ed70a2cd4ed2) this field
can be output from the show-status command on Linux 5.9+ kernels.

There were no tests for this code so I did a quick manual smoke test
on 5.10.

Relates #31519

## Why is it important?

To make it easier to reliably track degraded performance to backlog waiting.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## Related issues

- Relates #31519

