### PR TITLE
[automation] update elastic stack version for testing 8.3.0-6ba9f710

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-a1c5cfff-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-6ba9f710-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -31,7 +31,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.3.0-a1c5cfff-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.3.0-6ba9f710-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -41,7 +41,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.3.0-a1c5cfff-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.3.0-6ba9f710-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Fri, 6 May 2022 00:14:54 GMT, release_branch:master, prefix:, end_time:Fri, 6 May 2022 04:20:36 GMT, manifest_version:2.0.0, version:8.3.0-SNAPSHOT, branch:master, build_id:8.3.0-6ba9f710, build_duration_seconds:14742]