### PR TITLE
Update getting-started.asciidoc

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -164,7 +164,7 @@ environment. If you're using a different output, such as {ls}, see:
 * <<load-ingest-pipelines>>
 =====
 
-NOTE: Filebeat should not be used to ingest its own log as it may lead to indefinite loop.
+NOTE: Filebeat should not be used to ingest its own log as this may lead to an infinite loop.
 
 [float]
 [[start]]

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -164,6 +164,8 @@ environment. If you're using a different output, such as {ls}, see:
 * <<load-ingest-pipelines>>
 =====
 
+NOTE: Filebeat should not be used to ingest its own log as it may lead to indefinite loop.
+
 [float]
 [[start]]
 === Step 5: Start {beatname_uc}


### PR DESCRIPTION
Warn users about potential infinite loop when filebeat ingest its own logs.

Close https://github.com/elastic/observability-docs/issues/1636
