### PR TITLE
[Heartbeat] Fix unintentional use of no-op logger

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -56,6 +56,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Supporting the double digit date parsing in ingest pipeline for oracle logs {pull}31514[31514]
 
 *Heartbeat*
+- Fix unintentional use of no-op logger. {pull}31543[31543]
 
 
 *Metricbeat*

--- a/heartbeat/autodiscover/builder/hints/monitors.go
+++ b/heartbeat/autodiscover/builder/hints/monitors.go
@@ -57,7 +57,7 @@ func NewHeartbeatHints(cfg *conf.C) (autodiscover.Builder, error) {
 		return nil, fmt.Errorf("unable to unpack hints config due to error: %w", err)
 	}
 
-	return &heartbeatHints{config, logp.NewLogger("hints.builder")}, nil
+	return &heartbeatHints{config, logp.L()}, nil
 }
 
 // Create config based on input hints in the bus event

--- a/heartbeat/autodiscover/builder/hints/monitors_test.go
+++ b/heartbeat/autodiscover/builder/hints/monitors_test.go
@@ -201,7 +201,7 @@ func TestGenerateHints(t *testing.T) {
 
 		m := heartbeatHints{
 			config: defaultConfig(),
-			logger: logp.NewLogger("hints.builder"),
+			logger: logp.L(),
 		}
 		cfgs := m.CreateConfig(test.event)
 		assert.Equal(t, len(cfgs), test.len, test.message)

--- a/heartbeat/monitors/active/icmp/stdloop.go
+++ b/heartbeat/monitors/active/icmp/stdloop.go
@@ -36,8 +36,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-var logger = logp.NewLogger("ICMP-Stdloop")
-
 type stdICMPLoop struct {
 	conn4, conn6 *icmp.PacketConn
 	recv         chan packet
@@ -167,7 +165,7 @@ func (l *stdICMPLoop) runICMPRecv(conn *icmp.PacketConn, proto int) {
 		bytes := make([]byte, 512)
 		err := conn.SetReadDeadline(time.Now().Add(time.Second))
 		if err != nil {
-			logger.Error("could not set read deadline for ICMP: %w", err)
+			logp.L().Error("could not set read deadline for ICMP: %w", err)
 			return
 		}
 		_, addr, err := conn.ReadFrom(bytes)

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -76,7 +76,7 @@ func NewFactory(info beat.Info, addTask scheduler.AddTask, pluginsReg *plugin.Pl
 		byId:       map[string]*Monitor{},
 		mtx:        &sync.Mutex{},
 		pluginsReg: pluginsReg,
-		logger:     logp.NewLogger("monitor-factory"),
+		logger:     logp.L(),
 		runOnce:    runOnce,
 	}
 }

--- a/heartbeat/monitors/logger/logger.go
+++ b/heartbeat/monitors/logger/logger.go
@@ -55,7 +55,7 @@ func SetLogger(l *logp.Logger) *logp.Logger {
 
 func getLogger() *logp.Logger {
 	if eventLogger == nil {
-		return SetLogger(logp.NewLogger("heartbeat.events"))
+		return SetLogger(logp.L())
 	}
 
 	return eventLogger

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -174,6 +174,8 @@ func newMonitorUnsafe(
 		// Note, needed to hoist err to this scope, not just to add a prefix
 		fullErr := fmt.Errorf("job could not be initialized: %w", err)
 		// A placeholder job that always returns an error
+
+		logp.L().Error(fullErr)
 		p.Jobs = []jobs.Job{func(event *beat.Event) ([]jobs.Job, error) {
 			return nil, fullErr
 		}}
@@ -226,9 +228,9 @@ func (m *Monitor) Start() {
 
 	for _, t := range m.configuredJobs {
 		if m.runOnce {
-			client, err := pipeline.NewSyncClient(logp.NewLogger("monitor_task"), t.monitor.pipelineConnector, beat.ClientConfig{})
+			client, err := pipeline.NewSyncClient(logp.L(), t.monitor.pipelineConnector, beat.ClientConfig{})
 			if err != nil {
-				logp.Err("could not start monitor: %v", err)
+				logp.L().Errorf("could not start monitor: %v", err)
 				continue
 			}
 			t.Start(&WrappedClient{
@@ -241,7 +243,7 @@ func (m *Monitor) Start() {
 		} else {
 			client, err := m.pipelineConnector.Connect()
 			if err != nil {
-				logp.Err("could not start monitor: %v", err)
+				logp.L().Errorf("could not start monitor: %v", err)
 				continue
 			}
 			t.Start(&WrappedClient{
@@ -273,7 +275,7 @@ func (m *Monitor) Stop() {
 	if m.close != nil {
 		err := m.close()
 		if err != nil {
-			logp.Error(fmt.Errorf("error closing monitor %s: %w", m.String(), err))
+			logp.L().Error("error closing monitor %s: %w", m.String(), err)
 		}
 	}
 

--- a/heartbeat/scheduler/schedjob.go
+++ b/heartbeat/scheduler/schedjob.go
@@ -28,8 +28,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
-var logger = logp.NewLogger("schedjob")
-
 type schedJob struct {
 	id          string
 	ctx         context.Context
@@ -65,7 +63,7 @@ func (sj *schedJob) run() (startedAt time.Time) {
 	if sj.jobLimitSem != nil {
 		err := sj.jobLimitSem.Acquire(sj.ctx, 1)
 		if err != nil {
-			logger.Errorf("could not acquire semaphore: %w", err)
+			logp.L().Errorf("could not acquire semaphore: %w", err)
 		}
 	}
 


### PR DESCRIPTION
We mostly use the global logp.{warn,err,etc.} functions throughout heartbeat, which is deprecated.

Some parts of heartbeat incorrectly attempt to use 'logger =
logp.NewLogger' at the top of a file, which just creates a noop logger.

The correct way to do things, apparently, is to create a single logger
with the correct options at the root of your program and pass it
everywhere. IMHO this adds a ton of unncessary boilerplate, and is a
major painful change.

This PR fixes the short term issue of incorrectly using a noop logger by
using logp.L() to grab a non-deprecated global logger.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Use the following monitor config in `monitors.d` that is missing a `hosts` config. Without this patch it will silently fail to log any errors (they will appear in the Uptime UI though). With it you will see: `job could not be initialized: hosts is a mandatory parameter accessing config`

```
- type: http
  id: my-http-monitor
  name: Lightweight HTTP Monitor
  schedule: '@every 5s'
  # hosts field is missing!
  ipv4: true
  ipv6: false
  mode: any
```
