### PR TITLE
Add support for nanosecond precision timestamps

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,6 +81,8 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 
 *Affecting all Beats*
 
+- Add support for nanosecond precision timestamps. {issue}15871[15871] {pull}31553[31553]
+
 
 *Auditbeat*
 

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -60,10 +60,10 @@ func (t Time) MarshalJSON() ([]byte, error) {
 // format.
 func (t *Time) UnmarshalJSON(data []byte) (err error) {
 	if data[0] != []byte(`"`)[0] || data[len(data)-1] != []byte(`"`)[0] {
-		return errors.New("Not quoted")
+		return errors.New("not quoted")
 	}
 	*t, err = ParseTime(string(data[1 : len(data)-1]))
-	return
+	return err
 }
 
 func (t Time) Hash32(h hash.Hash32) error {

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -23,19 +23,36 @@ import (
 	"errors"
 	"hash"
 	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common/dtfmt"
 )
 
-// TsLayout is the layout to be used in the timestamp marshaling/unmarshaling everywhere.
-// The timezone must always be UTC.
-const TsLayout = "2006-01-02T15:04:05.000Z"
+const (
+	// TsLayout is the seconds layout to be used in the timestamp marshaling/unmarshaling everywhere.
+	// The timezone must always be UTC.
+	TsLayout = "2006-01-02T15:04:05.000Z"
+
+	tsLayoutMillis = "2006-01-02T15:04:05.000Z"
+	tsLayoutMicros = "2006-01-02T15:04:05.000000Z"
+	tsLayoutNanos  = "2006-01-02T15:04:05.000000000Z"
+)
 
 // Time is an abstraction for the time.Time type
 type Time time.Time
 
+var defaultTimeFormatter = dtfmt.MustNewFormatter("yyyy-MM-dd'T'HH:mm:ss.fffffffff'Z'")
+
+var defaultParseFormats = []string{
+	tsLayoutMillis,
+	tsLayoutMicros,
+	tsLayoutNanos,
+}
+
 // MarshalJSON implements json.Marshaler interface.
 // The time is a quoted string in the JsTsLayout format.
 func (t Time) MarshalJSON() ([]byte, error) {
-	return json.Marshal(time.Time(t).UTC().Format(TsLayout))
+	str, _ := defaultTimeFormatter.Format(time.Time(t).UTC())
+	return json.Marshal(str)
 }
 
 // UnmarshalJSON implements js.Unmarshaler interface.
@@ -54,14 +71,24 @@ func (t Time) Hash32(h hash.Hash32) error {
 	return err
 }
 
-// ParseTime parses a time in the TsLayout format.
+// ParseTime parses a time in the NanoTsLayout format first, then use millisTsLayout format
 func ParseTime(timespec string) (Time, error) {
-	t, err := time.Parse(TsLayout, timespec)
+	var err error
+	var t time.Time
+
+	for _, layout := range defaultParseFormats {
+		t, err = time.Parse(layout, timespec)
+		if err == nil {
+			break
+		}
+	}
+
 	return Time(t), err
 }
 
 func (t Time) String() string {
-	return time.Time(t).UTC().Format(TsLayout)
+	str, _ := defaultTimeFormatter.Format(time.Time(t).UTC())
+	return str
 }
 
 // MustParseTime is a convenience equivalent of the ParseTime function

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -71,7 +71,7 @@ func (t Time) Hash32(h hash.Hash32) error {
 	return err
 }
 
-// ParseTime parses a time in the NanoTsLayout format first, then use millisTsLayout format
+// ParseTime parses a time in the MillisTsLayout, then micros and finally nanos.
 func ParseTime(timespec string) (Time, error) {
 	var err error
 	var t time.Time

--- a/libbeat/common/datetime_test.go
+++ b/libbeat/common/datetime_test.go
@@ -67,7 +67,7 @@ func TestParseTimeNegative(t *testing.T) {
 	tests := []inputOutput{
 		{
 			Input: "2015-02-29TT14:06:05.071Z",
-			Err:   "parsing time \"2015-02-29TT14:06:05.071Z\" as \"2006-01-02T15:04:05.000Z\": cannot parse \"T14:06:05.071Z\" as \"15\"",
+			Err:   "parsing time \"2015-02-29TT14:06:05.071Z\" as \"2006-01-02T15:04:05.000000000Z\": cannot parse \"T14:06:05.071Z\" as \"15\"",
 		},
 	}
 

--- a/libbeat/common/dtfmt/builder.go
+++ b/libbeat/common/dtfmt/builder.go
@@ -134,16 +134,8 @@ func (b *builder) secondOfMinute(digits int) {
 	b.appendDecimal(ftSecondOfMinute, digits, 2)
 }
 
-func (b *builder) secondOfDay(digits int) {
-	b.appendDecimal(ftSecondOfDay, digits, 5)
-}
-
 func (b *builder) minuteOfHour(digits int) {
 	b.appendDecimal(ftMinuteOfHour, digits, 2)
-}
-
-func (b *builder) minuteOfDay(digits int) {
-	b.appendDecimal(ftMinuteOfDay, digits, 4)
 }
 
 func (b *builder) hourOfDay(digits int) {

--- a/libbeat/common/dtfmt/builder.go
+++ b/libbeat/common/dtfmt/builder.go
@@ -97,26 +97,37 @@ func (b *builder) add(e element) {
 	b.elements = append(b.elements, e)
 }
 
-func (b *builder) millisOfSecond(digits int) {
+func (b *builder) nanoOfSecond(digits int) {
 	if digits <= 0 {
 		return
 	}
 
-	switch digits {
-	case 1:
-		b.appendExtDecimal(ftMillisOfSecond, 100, 1, 1)
-	case 2:
-		b.appendExtDecimal(ftMillisOfSecond, 10, 2, 2)
-	case 3:
-		b.appendExtDecimal(ftMillisOfSecond, 0, 3, 3)
-	default:
-		b.appendExtDecimal(ftMillisOfSecond, 0, 3, 3)
-		b.appendZeros(digits - 3)
+	if digits <= 9 {
+		b.appendExtDecimal(ftNanoOfSecond, 9-digits, digits, digits)
+	} else {
+		b.appendExtDecimal(ftNanoOfSecond, 0, 9, 9)
+		b.appendZeros(digits - 9)
 	}
 }
 
-func (b *builder) millisOfDay(digits int) {
-	b.appendDecimal(ftMillisOfDay, digits, 8)
+func (b *builder) fractNanoOfSecond(digits int) {
+	const fractDigits = 3
+
+	if digits <= 0 {
+		return
+	}
+
+	// cap number of digits at 9, as we do not support higher precision and
+	// would remove trailing zeroes anyway.
+	if digits > 9 {
+		digits = 9
+	}
+
+	minDigits := fractDigits
+	if digits < minDigits {
+		minDigits = digits
+	}
+	b.add(paddedNumber{ftNanoOfSecond, 9 - digits, minDigits, digits, fractDigits, false})
 }
 
 func (b *builder) secondOfMinute(digits int) {
@@ -233,12 +244,12 @@ func (b *builder) appendDecimalValue(ft fieldType, minDigits, maxDigits int, sig
 	if minDigits <= 1 {
 		b.add(unpaddedNumber{ft, maxDigits, signed})
 	} else {
-		b.add(paddedNumber{ft, 0, minDigits, maxDigits, signed})
+		b.add(paddedNumber{ft, 0, minDigits, maxDigits, 0, signed})
 	}
 }
 
-func (b *builder) appendExtDecimal(ft fieldType, div, minDigits, maxDigits int) {
-	b.add(paddedNumber{ft, div, minDigits, maxDigits, false})
+func (b *builder) appendExtDecimal(ft fieldType, divExp, minDigits, maxDigits int) {
+	b.add(paddedNumber{ft, divExp, minDigits, maxDigits, 0, false})
 }
 
 func (b *builder) appendDecimal(ft fieldType, minDigits, maxDigits int) {

--- a/libbeat/common/dtfmt/ctx.go
+++ b/libbeat/common/dtfmt/ctx.go
@@ -31,7 +31,7 @@ type ctx struct {
 	isoWeek, isoYear int
 
 	hour, min, sec int
-	millis         int
+	nano           int
 
 	tzOffset int
 
@@ -43,7 +43,7 @@ type ctxConfig struct {
 	clock    bool
 	weekday  bool
 	yearday  bool
-	millis   bool
+	nano     bool
 	iso      bool
 	tzOffset bool
 }
@@ -59,8 +59,8 @@ func (c *ctx) initTime(config *ctxConfig, t time.Time) {
 		c.isoYear, c.isoWeek = t.ISOWeek()
 	}
 
-	if config.millis {
-		c.millis = t.Nanosecond() / 1000000
+	if config.nano {
+		c.nano = t.Nanosecond()
 	}
 
 	if config.yearday {
@@ -84,8 +84,8 @@ func (c *ctxConfig) enableClock() {
 	c.clock = true
 }
 
-func (c *ctxConfig) enableMillis() {
-	c.millis = true
+func (c *ctxConfig) enableNano() {
+	c.nano = true
 }
 
 func (c *ctxConfig) enableWeekday() {

--- a/libbeat/common/dtfmt/ctx.go
+++ b/libbeat/common/dtfmt/ctx.go
@@ -103,7 +103,3 @@ func (c *ctxConfig) enableISO() {
 func (c *ctxConfig) enableTimeZoneOffset() {
 	c.tzOffset = true
 }
-
-func isLeap(year int) bool {
-	return year%4 == 0 && (year%100 != 0 || year%400 == 0)
-}

--- a/libbeat/common/dtfmt/doc.go
+++ b/libbeat/common/dtfmt/doc.go
@@ -22,30 +22,31 @@
 //
 //  Symbol  Meaning                      Type     Supported Examples
 //  ------  -------                      -------  --------- -------
-//  G       era                          text      no       AD
-//  C       century of era (&gt;=0)      number    no       20
-//  Y       year of era (&gt;=0)         year      yes      1996
+//  G       era                          text           no       AD
+//  C       century of era (&gt;=0)      number         no       20
+//  Y       year of era (&gt;=0)         year           yes      1996
 //
-//  x       weekyear                     year      yes      1996
-//  w       week of weekyear             number    yes      27
-//  e       day of week                  number    yes      2
-//  E       day of week                  text      yes      Tuesday; Tue
+//  x       weekyear                     year           yes      1996
+//  w       week of weekyear             number         yes      27
+//  e       day of week                  number         yes      2
+//  E       day of week                  text           yes      Tuesday; Tue
 //
-//  y       year                         year      yes      1996
-//  D       day of year                  number    yes      189
-//  M       month of year                month     yes      July; Jul; 07
-//  d       day of month                 number    yes      10
+//  y       year                         year           yes      1996
+//  D       day of year                  number         yes      189
+//  M       month of year                month          yes      July; Jul; 07
+//  d       day of month                 number         yes      10
 //
-//  a       halfday of day               text      yes      PM
-//  K       hour of halfday (0~11)       number    yes      0
-//  h       clockhour of halfday (1~12)  number    yes      12
+//  a       halfday of day               text           yes      PM
+//  K       hour of halfday (0~11)       number         yes      0
+//  h       clockhour of halfday (1~12)  number         yes      12
 //
-//  H       hour of day (0~23)           number    yes      0
-//  k       clockhour of day (1~24)      number    yes      24
-//  m       minute of hour               number    yes      30
-//  s       second of minute             number    yes      55
-//  S       fraction of second           millis    no       978
-//
+//  H       hour of day (0~23)           number         yes      0
+//  k       clockhour of day (1~24)      number         yes      24
+//  m       minute of hour               number         yes      30
+//  s       second of minute             number         yes      55
+//  S       fraction of second           nanoseconds    yes     978000
+//  f       fraction of seconds          nanoseconds    yes     123456789
+//          multiple of 3
 //  z       time zone                    text      no       Pacific Standard Time; PST
 //  Z       time zone offset/id          zone      no       -0800; -08:00; America/Los_Angeles
 //

--- a/libbeat/common/dtfmt/dtfmt_test.go
+++ b/libbeat/common/dtfmt/dtfmt_test.go
@@ -82,10 +82,37 @@ func TestFormat(t *testing.T) {
 		{mkTime(8, 5, 24, 0), "kk:mm:ss aa", "09:05:24 AM"},
 		{mkTime(20, 5, 24, 0), "k:m:s a", "21:5:24 PM"},
 		{mkTime(20, 5, 24, 0), "kk:mm:ss aa", "21:05:24 PM"},
-		{mkTime(1, 2, 3, 123), "S", "1"},
-		{mkTime(1, 2, 3, 123), "SS", "12"},
-		{mkTime(1, 2, 3, 123), "SSS", "123"},
-		{mkTime(1, 2, 3, 123), "SSSS", "1230"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "S", "1"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "SS", "12"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "SSS", "123"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "SSSS", "1230"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "f", "1"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "ff", "12"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "fff", "123"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "ffff", "123"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "fffff", "123"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "ffffff", "123"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "fffffff", "123"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "ffffffff", "123"},
+		{mkTime(1, 2, 3, 123*time.Millisecond), "fffffffff", "123"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "f", "0"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "ff", "00"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "fff", "000"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "ffff", "0001"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "fffff", "00012"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "ffffff", "000123"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "fffffff", "000123"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "ffffffff", "000123"},
+		{mkTime(1, 2, 3, 123*time.Microsecond), "fffffffff", "000123"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "f", "0"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "ff", "00"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "fff", "000"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "ffff", "000"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "fffff", "000"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "ffffff", "000"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "fffffff", "0000001"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "ffffffff", "00000012"},
+		{mkTime(1, 2, 3, 123*time.Nanosecond), "fffffffff", "000000123"},
 
 		// literals
 		{time.Now(), "--=++,_!/?\\[]{}@#$%^&*()", "--=++,_!/?\\[]{}@#$%^&*()"},
@@ -94,14 +121,26 @@ func TestFormat(t *testing.T) {
 		{time.Now(), "'plain' '' 'text'", "plain ' text"},
 		{time.Now(), "'plain '' text'", "plain ' text"},
 
-		// beats timestamp
-		{mkDateTime(2017, 1, 2, 4, 6, 7, 123),
+		// timestamps with microseconds precision only
+		{mkDateTime(2017, 1, 2, 4, 6, 7, 123*time.Millisecond),
+			"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+			"2017-01-02T04:06:07.123Z"},
+		{mkDateTime(2017, 1, 2, 4, 6, 7, 123456*time.Microsecond),
 			"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
 			"2017-01-02T04:06:07.123Z"},
 
 		// beats timestamp
-		{mkDateTimeWithLocation(2017, 1, 2, 4, 6, 7, 123, time.FixedZone("PST", -8*60*60)),
-			"yyyy-MM-dd'T'HH:mm:ss.SSSz",
+		{mkDateTimeWithLocation(2017, 1, 2, 4, 6, 7, 123*time.Millisecond, time.FixedZone("PST", -8*60*60)),
+			"yyyy-MM-dd'T'HH:mm:ss.fffffffffz",
+			"2017-01-02T04:06:07.123-08:00"},
+
+		// beats nanoseconds timestamp
+		{mkDateTime(2017, 1, 2, 4, 6, 7, 123*time.Nanosecond),
+			"yyyy-MM-dd'T'HH:mm:ss.fffffffff'Z'",
+			"2017-01-02T04:06:07.000000123Z"},
+
+		{mkDateTimeWithLocation(2017, 1, 2, 4, 6, 7, 123*time.Millisecond, time.FixedZone("PST", -8*60*60)),
+			"yyyy-MM-dd'T'HH:mm:ss.fffffffffz",
 			"2017-01-02T04:06:07.123-08:00"},
 	}
 
@@ -123,14 +162,14 @@ func mkDate(y, m, d int) time.Time {
 	return mkDateTime(y, m, d, 0, 0, 0, 0)
 }
 
-func mkTime(h, m, s, S int) time.Time {
+func mkTime(h, m, s int, S time.Duration) time.Time {
 	return mkDateTime(2000, 1, 1, h, m, s, S)
 }
 
-func mkDateTime(y, M, d, h, m, s, S int) time.Time {
+func mkDateTime(y, M, d, h, m, s int, S time.Duration) time.Time {
 	return mkDateTimeWithLocation(y, M, d, h, m, s, S, time.UTC)
 }
 
-func mkDateTimeWithLocation(y, M, d, h, m, s, S int, l *time.Location) time.Time {
-	return time.Date(y, time.Month(M), d, h, m, s, S*1000000, l)
+func mkDateTimeWithLocation(y, M, d, h, m, s int, S time.Duration, l *time.Location) time.Time {
+	return time.Date(y, time.Month(M), d, h, m, s, int(S), l)
 }

--- a/libbeat/common/dtfmt/elems.go
+++ b/libbeat/common/dtfmt/elems.go
@@ -179,7 +179,7 @@ func (r runeLiteral) compile() (prog, error) {
 }
 
 func (s stringLiteral) compile() (prog, error) {
-	return makeCopy([]byte(s.s))
+	return makeCopy(s.s)
 }
 
 func (n unpaddedNumber) compile() (prog, error) {

--- a/libbeat/common/dtfmt/elems.go
+++ b/libbeat/common/dtfmt/elems.go
@@ -44,10 +44,10 @@ type unpaddedNumber struct {
 }
 
 type paddedNumber struct {
-	ft                   fieldType
-	div                  int
-	minDigits, maxDigits int
-	signed               bool
+	ft                                fieldType
+	divExp                            int
+	minDigits, maxDigits, fractDigits int
+	signed                            bool
 }
 
 type textField struct {
@@ -123,12 +123,8 @@ func numRequires(c *ctxConfig, ft fieldType) error {
 		ftSecondOfMinute:
 		c.enableClock()
 
-	case ftMillisOfDay:
-		c.enableClock()
-		c.enableMillis()
-
-	case ftMillisOfSecond:
-		c.enableMillis()
+	case ftNanoOfSecond:
+		c.enableNano()
 	}
 
 	return nil
@@ -191,10 +187,14 @@ func (n unpaddedNumber) compile() (prog, error) {
 }
 
 func (n paddedNumber) compile() (prog, error) {
-	if n.div == 0 {
+	switch {
+	case n.fractDigits != 0:
+		return makeProg(opExtNumFractPadded, byte(n.ft), byte(n.divExp), byte(n.maxDigits), byte(n.fractDigits))
+	case n.divExp == 0:
 		return makeProg(opNumPadded, byte(n.ft), byte(n.maxDigits))
+	default:
+		return makeProg(opExtNumPadded, byte(n.ft), byte(n.divExp), byte(n.maxDigits))
 	}
-	return makeProg(opExtNumPadded, byte(n.ft), byte(n.div), byte(n.maxDigits))
 }
 
 func (n twoDigitYear) compile() (prog, error) {

--- a/libbeat/common/dtfmt/fields.go
+++ b/libbeat/common/dtfmt/fields.go
@@ -41,9 +41,8 @@ const (
 	ftMinuteOfHour
 	ftSecondOfDay
 	ftSecondOfMinute
-	ftMillisOfDay
-	ftMillisOfSecond
 	ftTimeZoneOffset
+	ftNanoOfSecond
 )
 
 func getIntField(ft fieldType, ctx *ctx, t time.Time) (int, error) {
@@ -105,14 +104,12 @@ func getIntField(ft fieldType, ctx *ctx, t time.Time) (int, error) {
 	case ftSecondOfMinute:
 		return ctx.sec, nil
 
-	case ftMillisOfDay:
-		return ((ctx.hour*60+ctx.min)*60+ctx.sec)*1000 + ctx.millis, nil
-
-	case ftMillisOfSecond:
-		return ctx.millis, nil
+	case ftNanoOfSecond:
+		return ctx.nano, nil
 	}
 
 	return 0, nil
+
 }
 
 func getTextField(ft fieldType, ctx *ctx, t time.Time) (string, error) {

--- a/libbeat/common/dtfmt/fields.go
+++ b/libbeat/common/dtfmt/fields.go
@@ -19,7 +19,6 @@ package dtfmt
 
 import (
 	"errors"
-	"time"
 )
 
 type fieldType uint8
@@ -45,7 +44,7 @@ const (
 	ftNanoOfSecond
 )
 
-func getIntField(ft fieldType, ctx *ctx, t time.Time) (int, error) {
+func getIntField(ft fieldType, ctx *ctx) (int, error) {
 	switch ft {
 	case ftYear:
 		return ctx.year, nil
@@ -112,7 +111,7 @@ func getIntField(ft fieldType, ctx *ctx, t time.Time) (int, error) {
 
 }
 
-func getTextField(ft fieldType, ctx *ctx, t time.Time) (string, error) {
+func getTextField(ft fieldType, ctx *ctx) (string, error) {
 	switch ft {
 	case ftHalfdayOfDay:
 		if ctx.hour < 12 {
@@ -151,7 +150,7 @@ func tzOffsetString(ctx *ctx) (string, error) {
 	return string(buf), nil
 }
 
-func getTextFieldShort(ft fieldType, ctx *ctx, t time.Time) (string, error) {
+func getTextFieldShort(ft fieldType, ctx *ctx) (string, error) {
 	switch ft {
 	case ftHalfdayOfDay:
 		if ctx.hour < 12 {

--- a/libbeat/common/dtfmt/fields.go
+++ b/libbeat/common/dtfmt/fields.go
@@ -44,70 +44,70 @@ const (
 	ftNanoOfSecond
 )
 
-func getIntField(ft fieldType, ctx *ctx) (int, error) {
+func getIntField(ft fieldType, ctx *ctx) int {
 	switch ft {
 	case ftYear:
-		return ctx.year, nil
+		return ctx.year
 
 	case ftDayOfYear:
-		return ctx.yearday, nil
+		return ctx.yearday
 
 	case ftMonthOfYear:
-		return int(ctx.month), nil
+		return int(ctx.month)
 
 	case ftDayOfMonth:
-		return ctx.day, nil
+		return ctx.day
 
 	case ftWeekyear:
-		return ctx.isoYear, nil
+		return ctx.isoYear
 
 	case ftWeekOfWeekyear:
-		return ctx.isoWeek, nil
+		return ctx.isoWeek
 
 	case ftDayOfWeek:
-		return int(ctx.weekday), nil
+		return int(ctx.weekday)
 
 	case ftHalfdayOfDay:
 		if ctx.hour < 12 {
-			return 0, nil // AM
+			return 0 // AM
 		}
-		return 1, nil // PM
+		return 1 // PM
 
 	case ftHourOfHalfday:
 		if ctx.hour < 12 {
-			return ctx.hour, nil
+			return ctx.hour
 		}
-		return ctx.hour - 12, nil
+		return ctx.hour - 12
 
 	case ftClockhourOfHalfday:
 		if ctx.hour < 12 {
-			return ctx.hour + 1, nil
+			return ctx.hour + 1
 		}
-		return ctx.hour - 12 + 1, nil
+		return ctx.hour - 12 + 1
 
 	case ftClockhourOfDay:
-		return ctx.hour + 1, nil
+		return ctx.hour + 1
 
 	case ftHourOfDay:
-		return ctx.hour, nil
+		return ctx.hour
 
 	case ftMinuteOfDay:
-		return ctx.hour*60 + ctx.min, nil
+		return ctx.hour*60 + ctx.min
 
 	case ftMinuteOfHour:
-		return ctx.min, nil
+		return ctx.min
 
 	case ftSecondOfDay:
-		return (ctx.hour*60+ctx.min)*60 + ctx.sec, nil
+		return (ctx.hour*60+ctx.min)*60 + ctx.sec
 
 	case ftSecondOfMinute:
-		return ctx.sec, nil
+		return ctx.sec
 
 	case ftNanoOfSecond:
-		return ctx.nano, nil
+		return ctx.nano
 	}
 
-	return 0, nil
+	return 0
 
 }
 

--- a/libbeat/common/dtfmt/fmt.go
+++ b/libbeat/common/dtfmt/fmt.go
@@ -105,7 +105,7 @@ func (f *Formatter) EstimateSize() int {
 
 func (f *Formatter) appendTo(ctx *ctx, b []byte, t time.Time) ([]byte, error) {
 	ctx.initTime(&f.config, t)
-	return f.prog.eval(b, ctx, t)
+	return f.prog.eval(b, ctx)
 }
 
 // AppendTo appends the formatted time value to the given byte buffer.

--- a/libbeat/common/dtfmt/fmt.go
+++ b/libbeat/common/dtfmt/fmt.go
@@ -55,6 +55,16 @@ func releaseCtx(c *ctx) {
 	ctxPool.Put(c)
 }
 
+// MustNewFormatter creates a new time formatter based on the provided pattern.
+// The functions panics if the pattern is invalid
+func MustNewFormatter(pattern string) *Formatter {
+	f, err := NewFormatter(pattern)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
 // NewFormatter creates a new time formatter based on provided pattern.
 // If pattern is invalid an error is returned.
 func NewFormatter(pattern string) (*Formatter, error) {
@@ -209,7 +219,17 @@ func parsePatternTo(b *builder, pattern string) error {
 			b.secondOfMinute(tokLen)
 
 		case 'S': // fraction of second
-			b.millisOfSecond(tokLen)
+			b.nanoOfSecond(tokLen)
+
+		case 'f': // faction of second (without zeros)
+			b.fractNanoOfSecond(tokLen)
+
+		case 'n': // nano second
+			// if timestamp layout use `n`, it always return 9 digits nanoseconds.
+			if tokLen != 9 {
+				tokLen = 9
+			}
+			b.nanoOfSecond(tokLen)
 
 		case 'z': // timezone offset
 			b.timeZoneOffsetText()

--- a/libbeat/common/dtfmt/prog.go
+++ b/libbeat/common/dtfmt/prog.go
@@ -19,7 +19,6 @@ package dtfmt
 
 import (
 	"errors"
-	"time"
 )
 
 type prog struct {
@@ -54,7 +53,7 @@ func init() {
 	}
 }
 
-func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
+func (p prog) eval(bytes []byte, ctx *ctx) ([]byte, error) {
 	for i := 0; i < len(p.p); {
 		op := p.p[i]
 		i++
@@ -87,7 +86,7 @@ func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
 		case opNum:
 			ft := fieldType(p.p[i])
 			i++
-			v, err := getIntField(ft, ctx, t)
+			v, err := getIntField(ft, ctx)
 			if err != nil {
 				return bytes, err
 			}
@@ -95,7 +94,7 @@ func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
 		case opNumPadded:
 			ft, digits := fieldType(p.p[i]), int(p.p[i+1])
 			i += 2
-			v, err := getIntField(ft, ctx, t)
+			v, err := getIntField(ft, ctx)
 			if err != nil {
 				return bytes, err
 			}
@@ -104,7 +103,7 @@ func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
 			ft, divExp, digits := fieldType(p.p[i]), int(p.p[i+1]), int(p.p[i+2])
 			div := pow10Table[divExp]
 			i += 3
-			v, err := getIntField(ft, ctx, t)
+			v, err := getIntField(ft, ctx)
 			if err != nil {
 				return bytes, err
 			}
@@ -113,7 +112,7 @@ func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
 			ft, divExp, digits, fractDigits := fieldType(p.p[i]), int(p.p[i+1]), int(p.p[i+2]), int(p.p[i+3])
 			div := pow10Table[divExp]
 			i += 4
-			v, err := getIntField(ft, ctx, t)
+			v, err := getIntField(ft, ctx)
 			if err != nil {
 				return bytes, err
 			}
@@ -127,7 +126,7 @@ func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
 		case opTwoDigit:
 			ft := fieldType(p.p[i])
 			i++
-			v, err := getIntField(ft, ctx, t)
+			v, err := getIntField(ft, ctx)
 			if err != nil {
 				return bytes, err
 			}
@@ -135,7 +134,7 @@ func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
 		case opTextShort:
 			ft := fieldType(p.p[i])
 			i++
-			s, err := getTextFieldShort(ft, ctx, t)
+			s, err := getTextFieldShort(ft, ctx)
 			if err != nil {
 				return bytes, err
 			}
@@ -143,7 +142,7 @@ func (p prog) eval(bytes []byte, ctx *ctx, t time.Time) ([]byte, error) {
 		case opTextLong:
 			ft := fieldType(p.p[i])
 			i++
-			s, err := getTextField(ft, ctx, t)
+			s, err := getTextField(ft, ctx)
 			if err != nil {
 				return bytes, err
 			}

--- a/libbeat/common/dtfmt/prog.go
+++ b/libbeat/common/dtfmt/prog.go
@@ -86,36 +86,24 @@ func (p prog) eval(bytes []byte, ctx *ctx) ([]byte, error) {
 		case opNum:
 			ft := fieldType(p.p[i])
 			i++
-			v, err := getIntField(ft, ctx)
-			if err != nil {
-				return bytes, err
-			}
+			v := getIntField(ft, ctx)
 			bytes = appendUnpadded(bytes, v)
 		case opNumPadded:
 			ft, digits := fieldType(p.p[i]), int(p.p[i+1])
 			i += 2
-			v, err := getIntField(ft, ctx)
-			if err != nil {
-				return bytes, err
-			}
+			v := getIntField(ft, ctx)
 			bytes = appendPadded(bytes, v, digits)
 		case opExtNumPadded:
 			ft, divExp, digits := fieldType(p.p[i]), int(p.p[i+1]), int(p.p[i+2])
 			div := pow10Table[divExp]
 			i += 3
-			v, err := getIntField(ft, ctx)
-			if err != nil {
-				return bytes, err
-			}
+			v := getIntField(ft, ctx)
 			bytes = appendPadded(bytes, v/div, digits)
 		case opExtNumFractPadded:
 			ft, divExp, digits, fractDigits := fieldType(p.p[i]), int(p.p[i+1]), int(p.p[i+2]), int(p.p[i+3])
 			div := pow10Table[divExp]
 			i += 4
-			v, err := getIntField(ft, ctx)
-			if err != nil {
-				return bytes, err
-			}
+			v := getIntField(ft, ctx)
 			bytes = appendFractPadded(bytes, v/div, digits, fractDigits)
 		case opZeros:
 			digits := int(p.p[i])
@@ -126,10 +114,7 @@ func (p prog) eval(bytes []byte, ctx *ctx) ([]byte, error) {
 		case opTwoDigit:
 			ft := fieldType(p.p[i])
 			i++
-			v, err := getIntField(ft, ctx)
-			if err != nil {
-				return bytes, err
-			}
+			v := getIntField(ft, ctx)
 			bytes = appendPadded(bytes, v%100, 2)
 		case opTextShort:
 			ft := fieldType(p.p[i])

--- a/libbeat/common/dtfmt/util.go
+++ b/libbeat/common/dtfmt/util.go
@@ -18,44 +18,122 @@
 package dtfmt
 
 import (
-	"math"
 	"strconv"
 )
 
+// appendUnpadded appends the string representation of the integer value to the
+// buffer.
 func appendUnpadded(bs []byte, i int) []byte {
 	return strconv.AppendInt(bs, int64(i), 10)
 }
 
-func appendPadded(bs []byte, i, sz int) []byte {
-	if i < 0 {
+// appendPadded appends a number value as string to the buffer. The string will
+// be prefixed with '0' in case the encoded string value is takes less then
+// 'digits' bytes.
+//
+// for example:
+//   appendPadded(..., 10, 5) -> 00010
+//   appendPadded(..., 12345, 5) -> 12345
+func appendPadded(bs []byte, val, digits int) []byte {
+	if val < 0 {
 		bs = append(bs, '-')
-		i = -i
+		val = -1
 	}
 
-	if i < 10 {
-		for ; sz > 1; sz-- {
-			bs = append(bs, '0')
+	// compute number of initial padding zeroes
+	var padDigits int
+	switch {
+	case val < 10:
+		padDigits = digits - 1
+	case val < 100:
+		padDigits = digits - 2
+	case val < 1000:
+		padDigits = digits - 3
+	case val < 10000:
+		padDigits = digits - 4
+	case val < 100000:
+		padDigits = digits - 5
+	case val < 1000000:
+		padDigits = digits - 6
+	case val < 10000000:
+		padDigits = digits - 7
+	case val < 100000000:
+		padDigits = digits - 8
+	case val < 1000000000:
+		padDigits = digits - 9
+	default:
+		padDigits = digits - 1
+		for tmp := val; tmp > 10; tmp = tmp / 10 {
+			padDigits--
 		}
-		return append(bs, byte(i)+'0')
 	}
-	if i < 100 {
-		for ; sz > 2; sz-- {
-			bs = append(bs, '0')
-		}
-		return strconv.AppendInt(bs, int64(i), 10)
-	}
-
-	digits := 0
-	if i < 1000 {
-		digits = 3
-	} else if i < 10000 {
-		digits = 4
-	} else {
-		digits = int(math.Log10(float64(i))) + 1
-	}
-	for ; sz > digits; sz-- {
+	for i := 0; i < padDigits; i++ {
 		bs = append(bs, '0')
 	}
 
-	return strconv.AppendInt(bs, int64(i), 10)
+	// encode value
+	if val < 10 {
+		return append(bs, byte(val)+'0')
+	}
+	return strconv.AppendInt(bs, int64(val), 10)
+}
+
+// appendFractPadded appends a number value as string to the buffer.
+// The string will be prefixed with '0' in case the value is smaller than
+// a value that can be represented with 'digits'.
+// Trailing zeroes at the end will be removed, such that only a multiple of fractSz
+// digits will be printed. If the value is 0, a total of 'fractSz' zeros will
+// be printed.
+//
+// for example:
+//    appendFractPadded(..., 0, 9, 3) -> "000"
+//    appendFractPadded(..., 123000, 9, 3) -> "000123"
+//    appendFractPadded(..., 120000, 9, 3) -> "000120"
+//    appendFractPadded(..., 120000010, 9, 3) -> "000120010"
+//    appendFractPadded(..., 123456789, 6, 3) -> "123456"
+func appendFractPadded(bs []byte, val, digits, fractSz int) []byte {
+	if fractSz == 0 || digits <= fractSz {
+		return appendPadded(bs, val, digits)
+	}
+
+	initalLen := len(bs)
+	bs = appendPadded(bs, val, digits)
+
+	// find and remove trailing zeroes, such that a multiple of fractSz is still
+	// serialized
+
+	// find index range of last digits in buffer, such that a multiple of fractSz
+	// will be kept if the range of digits is removed.
+	// invariant: 0 <= end - begin <= fractSz
+	end := len(bs)
+	digits = end - initalLen
+	begin := initalLen + ((digits-1)/fractSz)*fractSz
+
+	// remove trailing zeros, such that a multiple of fractSz digits will be
+	// present in the final buffer. At minimum fractSz digits will always be
+	// reported.
+	for {
+		if !allZero(bs[begin:end]) {
+			break
+		}
+
+		digits -= (end - begin)
+		end = begin
+		begin -= fractSz
+
+		if digits <= fractSz {
+			break
+		}
+	}
+
+	return bs[:end]
+}
+
+func allZero(buf []byte) bool {
+	for _, b := range buf {
+		if b != '0' {
+			return false
+		}
+	}
+	return true
 }

--- a/libbeat/outputs/codec/common.go
+++ b/libbeat/outputs/codec/common.go
@@ -36,9 +36,9 @@ func MakeTimestampEncoder() func(*time.Time, structform.ExtVisitor) error {
 func MakeUTCOrLocalTimestampEncoder(localTime bool) func(*time.Time, structform.ExtVisitor) error {
 	var dtPattern string
 	if localTime {
-		dtPattern = "yyyy-MM-dd'T'HH:mm:ss.SSSz"
+		dtPattern = "yyyy-MM-dd'T'HH:mm:ss.fffffffffz"
 	} else {
-		dtPattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+		dtPattern = "yyyy-MM-dd'T'HH:mm:ss.fffffffff'Z'"
 	}
 
 	formatter, err := dtfmt.NewFormatter(dtPattern)

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/fmtstr"
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
@@ -545,24 +544,7 @@ func checkEvent(t *testing.T, ls, es map[string]interface{}) {
 	lsEvent := ls["_source"].(map[string]interface{})
 	esEvent := es["_source"].(map[string]interface{})
 
-	mustParseTs := func(spec string) time.Time {
-		ts, err := common.ParseTime(spec)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return time.Time(ts)
-	}
-
-	// XXX: Logstash only support millsecond precisions. We assume that is still the case
-	// and round esTimestamp to millseconds as well
-	lsTimestamp := mustParseTs(lsEvent["@timestamp"].(string))
-	esTimestamp := mustParseTs(esEvent["@timestamp"].(string))
-	nanos := time.Duration(esTimestamp.Nanosecond())
-	delta := nanos % time.Millisecond
-	esTimestamp = esTimestamp.Add(-delta)
-	assert.Equal(t, lsTimestamp, esTimestamp)
-
-	commonFields := []string{"host", "type", "message"}
+	commonFields := []string{"@timestamp", "host", "type", "message"}
 	for _, field := range commonFields {
 		assert.NotNil(t, lsEvent[field])
 		assert.NotNil(t, esEvent[field])

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/fmtstr"
 	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
@@ -543,7 +544,24 @@ func testLogstashElasticOutputPluginBulkCompatibleMessage(t *testing.T, name str
 func checkEvent(t *testing.T, ls, es map[string]interface{}) {
 	lsEvent := ls["_source"].(map[string]interface{})
 	esEvent := es["_source"].(map[string]interface{})
-	commonFields := []string{"@timestamp", "host", "type", "message"}
+
+	mustParseTs := func(spec string) time.Time {
+		ts, err := common.ParseTime(spec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return time.Time(ts)
+	}
+
+	// XXX: Logstash only support millsecond precisions. We assume that is still the case
+	// and round esTimestamp to millseconds as well
+	lsTimestamp := mustParseTs(lsEvent["@timestamp"].(string))
+	esTimestamp := mustParseTs(esEvent["@timestamp"].(string))
+	nanos := time.Duration(esTimestamp.Nanosecond())
+	esTimestamp = esTimestamp.Add(-(nanos % time.Millisecond))
+	assert.Equal(t, lsTimestamp, esTimestamp)
+
+	commonFields := []string{"host", "type", "message"}
 	for _, field := range commonFields {
 		assert.NotNil(t, lsEvent[field])
 		assert.NotNil(t, esEvent[field])

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -543,7 +543,6 @@ func testLogstashElasticOutputPluginBulkCompatibleMessage(t *testing.T, name str
 func checkEvent(t *testing.T, ls, es map[string]interface{}) {
 	lsEvent := ls["_source"].(map[string]interface{})
 	esEvent := es["_source"].(map[string]interface{})
-
 	commonFields := []string{"@timestamp", "host", "type", "message"}
 	for _, field := range commonFields {
 		assert.NotNil(t, lsEvent[field])

--- a/libbeat/outputs/logstash/logstash_integration_test.go
+++ b/libbeat/outputs/logstash/logstash_integration_test.go
@@ -558,7 +558,8 @@ func checkEvent(t *testing.T, ls, es map[string]interface{}) {
 	lsTimestamp := mustParseTs(lsEvent["@timestamp"].(string))
 	esTimestamp := mustParseTs(esEvent["@timestamp"].(string))
 	nanos := time.Duration(esTimestamp.Nanosecond())
-	esTimestamp = esTimestamp.Add(-(nanos % time.Millisecond))
+	delta := nanos % time.Millisecond
+	esTimestamp = esTimestamp.Add(-delta)
 	assert.Equal(t, lsTimestamp, esTimestamp)
 
 	commonFields := []string{"host", "type", "message"}

--- a/packetbeat/tests/system/test_0032_dns.py
+++ b/packetbeat/tests/system/test_0032_dns.py
@@ -26,8 +26,8 @@ class Test(BaseTest):
         assert o["network.transport"] == "udp"
         assert o["network.bytes"] == 312
         assert "network.community_id" in o
-        assert o["event.start"] == "2015-08-27T08:00:55.638Z"
-        assert o["event.end"] == "2015-08-27T08:00:55.700Z"
+        assert o["event.start"] == "2015-08-27T08:00:55.638957Z"
+        assert o["event.end"] == "2015-08-27T08:00:55.700739Z"
         assert o["event.duration"] == 61782000
         assert o["client.ip"] == "192.168.238.68"
         assert o["source.ip"] == "192.168.238.68"

--- a/packetbeat/tests/system/test_0050_icmp.py
+++ b/packetbeat/tests/system/test_0050_icmp.py
@@ -9,9 +9,9 @@ class Test(BaseTest):
         objs = self.read_output()
         assert len(objs) == 2
         assert all([o["icmp.version"] == 4 for o in objs])
-        assert objs[0]["@timestamp"] == "2015-10-19T21:47:49.900Z"
+        assert objs[0]["@timestamp"] == "2015-10-19T21:47:49.900657Z"
         assert objs[0]["event.duration"] == 12152000
-        assert objs[1]["@timestamp"] == "2015-10-19T21:47:49.924Z"
+        assert objs[1]["@timestamp"] == "2015-10-19T21:47:49.924909Z"
         assert objs[1]["event.duration"] == 11935000
         self.assert_common_fields(objs)
         self.assert_common_icmp4_fields(objs[0])
@@ -24,7 +24,7 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         assert objs[0]["icmp.version"] == 4
-        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.817Z"
+        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.817185Z"
         assert objs[0]["event.duration"] == 20130000
         self.assert_common_fields(objs)
         self.assert_common_icmp4_fields(objs[0])
@@ -36,7 +36,7 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         assert objs[0]["icmp.version"] == 4
-        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.849Z"
+        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.849085Z"
         assert objs[0]["event.duration"] == 12192000
         self.assert_common_fields(objs)
         self.assert_common_icmp4_fields(objs[0])
@@ -48,7 +48,7 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         assert objs[0]["icmp.version"] == 6
-        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.872Z"
+        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.872952Z"
         assert objs[0]["event.duration"] == 16439000
         self.assert_common_fields(objs)
         self.assert_common_icmp6_fields(objs[0])
@@ -60,7 +60,7 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         assert objs[0]["icmp.version"] == 6
-        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.901Z"
+        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.901349Z"
         assert objs[0]["event.duration"] == 12333000
         self.assert_common_fields(objs)
         self.assert_common_icmp6_fields(objs[0])

--- a/packetbeat/tests/system/test_0060_flows.py
+++ b/packetbeat/tests/system/test_0060_flows.py
@@ -1,6 +1,6 @@
 from packetbeat import (BaseTest, FLOWS_REQUIRED_FIELDS)
 from pprint import PrettyPrinter
-from datetime import datetime
+from datetime import datetime, timedelta
 import six
 import os
 
@@ -14,7 +14,14 @@ def check_fields(flow, fields):
 
 
 def parse_timestamp(ts):
-    return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%S.%fZ")
+    if ts[-1] != 'Z':
+        raise Exception("missing time zone marker Z")
+    ts = ts[:-1]
+    parts = ts.split(".")
+    ts = datetime.strptime(parts[0], "%Y-%m-%dT%H:%M:%S")
+    if len(parts[1]) > 6:
+        parts[1] = parts[1][:6]  # ensure we always parse microseconds
+    return ts + timedelta(microseconds=datetime.strptime(parts[1], "%f").microsecond)
 
 
 class Test(BaseTest):

--- a/packetbeat/tests/system/test_0062_cassandra.py
+++ b/packetbeat/tests/system/test_0062_cassandra.py
@@ -26,7 +26,7 @@ class Test(BaseTest):
         assert o["event.dataset"] == "cassandra"
         assert o["event.duration"] == 62453000
         assert o["event.start"] == o["@timestamp"]
-        assert o["event.end"] == "2016-06-28T09:03:53.502Z"
+        assert o["event.end"] == "2016-06-28T09:03:53.502299Z"
         assert o["client.ip"] == "127.0.0.1"
         assert o["client.port"] == 52749
         assert o["client.bytes"] == 133

--- a/x-pack/filebeat/module/gcp/audit/test/audit-log-entries.json.log-expected.json
+++ b/x-pack/filebeat/module/gcp/audit/test/audit-log-entries.json.log-expected.json
@@ -197,7 +197,7 @@
         "user_agent.version": "71.0."
     },
     {
-        "@timestamp": "2020-08-05T21:07:30.974Z",
+        "@timestamp": "2020-08-05T21:07:30.974750Z",
         "cloud.project.id": "elastic-siem",
         "event.action": "io.k8s.authorization.v1beta1.subjectaccessreviews.create",
         "event.dataset": "gcp.audit",
@@ -347,7 +347,7 @@
         "user_agent.version": "79.0."
     },
     {
-        "@timestamp": "2021-04-23T14:47:07.535Z",
+        "@timestamp": "2021-04-23T14:47:07.535383Z",
         "cloud.project.id": "elastic-siem",
         "event.action": "io.k8s.core.v1.nodes.list",
         "event.dataset": "gcp.audit",
@@ -389,7 +389,7 @@
         "user_agent.original": "GoogleCloudConsole"
     },
     {
-        "@timestamp": "2021-04-23T14:16:07.574Z",
+        "@timestamp": "2021-04-23T14:16:07.574776Z",
         "cloud.project.id": "elastic-siem",
         "event.action": "io.k8s.extensions.v1beta1.ingresses.list",
         "event.dataset": "gcp.audit",
@@ -432,7 +432,7 @@
         "user_agent.original": "GoogleCloudConsole"
     },
     {
-        "@timestamp": "2021-04-29T08:19:20.805Z",
+        "@timestamp": "2021-04-29T08:19:20.805810Z",
         "cloud.project.id": "elastic-siem",
         "event.action": "io.k8s.get",
         "event.dataset": "gcp.audit",
@@ -473,7 +473,7 @@
         "user_agent.original": "kube-probe/1.19+"
     },
     {
-        "@timestamp": "2021-04-29T08:23:18.899Z",
+        "@timestamp": "2021-04-29T08:23:18.899153Z",
         "cloud.project.id": "elastic-siem",
         "event.action": "io.k8s.get",
         "event.dataset": "gcp.audit",

--- a/x-pack/filebeat/module/gcp/firewall/test/rare.log-expected.json
+++ b/x-pack/filebeat/module/gcp/firewall/test/rare.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-11-06T16:41:38.394Z",
+        "@timestamp": "2019-11-06T16:41:38.394575419Z",
         "destination.address": "10.128.0.16",
         "destination.domain": "local-adrian-test",
         "destination.ip": "10.128.0.16",
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-06T16:41:38.394Z",
+        "@timestamp": "2019-11-06T16:41:38.394575419Z",
         "destination.address": "10.128.0.10",
         "destination.domain": "test-es",
         "destination.ip": "10.128.0.10",

--- a/x-pack/filebeat/module/gcp/firewall/test/test.log-expected.json
+++ b/x-pack/filebeat/module/gcp/firewall/test/test.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-11-12T12:35:17.214Z",
+        "@timestamp": "2019-11-12T12:35:17.214711274Z",
         "destination.address": "175.16.199.1",
         "destination.geo.city_name": "Changchun",
         "destination.geo.continent_name": "Asia",
@@ -67,7 +67,7 @@
         ]
     },
     {
-        "@timestamp": "2019-10-30T13:52:42.191Z",
+        "@timestamp": "2019-10-30T13:52:42.191988835Z",
         "destination.address": "10.42.0.2",
         "destination.domain": "test-windows",
         "destination.ip": "10.42.0.2",
@@ -131,7 +131,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:31:19.421Z",
+        "@timestamp": "2019-11-11T12:31:19.421478847Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -198,7 +198,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:41:31.079Z",
+        "@timestamp": "2019-11-11T12:41:31.079508196Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -263,7 +263,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:41:34.190Z",
+        "@timestamp": "2019-11-11T12:41:34.190831607Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -328,7 +328,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:48:41.449Z",
+        "@timestamp": "2019-11-11T12:48:41.449552758Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -395,7 +395,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T13:10:24.214Z",
+        "@timestamp": "2019-11-11T13:10:24.214995318Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -462,7 +462,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T13:35:23.504Z",
+        "@timestamp": "2019-11-11T13:35:23.504719962Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -529,7 +529,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T13:36:52.135Z",
+        "@timestamp": "2019-11-11T13:36:52.135887769Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -596,7 +596,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T14:06:16.593Z",
+        "@timestamp": "2019-11-11T14:06:16.593531820Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -663,7 +663,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T14:06:22.930Z",
+        "@timestamp": "2019-11-11T14:06:22.930570324Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -730,7 +730,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T14:32:07.407Z",
+        "@timestamp": "2019-11-11T14:32:07.407039908Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",
@@ -797,7 +797,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-12T12:41:20.972Z",
+        "@timestamp": "2019-11-12T12:41:20.972747063Z",
         "destination.address": "175.16.199.1",
         "destination.geo.city_name": "Changchun",
         "destination.geo.continent_name": "Asia",
@@ -864,7 +864,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-12T12:42:26.505Z",
+        "@timestamp": "2019-11-12T12:42:26.505329210Z",
         "destination.address": "175.16.199.1",
         "destination.geo.city_name": "Changchun",
         "destination.geo.continent_name": "Asia",
@@ -931,7 +931,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:54:13.531Z",
+        "@timestamp": "2019-11-11T12:54:13.531819246Z",
         "destination.address": "10.42.0.10",
         "destination.domain": "test-es",
         "destination.ip": "10.42.0.10",
@@ -1002,7 +1002,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:54:13.551Z",
+        "@timestamp": "2019-11-11T12:54:13.551617516Z",
         "destination.address": "10.42.0.10",
         "destination.domain": "test-es",
         "destination.ip": "10.42.0.10",
@@ -1073,7 +1073,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:54:15.771Z",
+        "@timestamp": "2019-11-11T12:54:15.771161946Z",
         "destination.address": "10.42.0.2",
         "destination.domain": "test-windows",
         "destination.ip": "10.42.0.2",
@@ -1139,7 +1139,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:54:35.850Z",
+        "@timestamp": "2019-11-11T12:54:35.850729583Z",
         "destination.address": "10.42.0.10",
         "destination.domain": "test-es",
         "destination.ip": "10.42.0.10",
@@ -1210,7 +1210,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-11T12:54:35.850Z",
+        "@timestamp": "2019-11-11T12:54:35.850234650Z",
         "destination.address": "10.42.0.10",
         "destination.domain": "test-es",
         "destination.ip": "10.42.0.10",
@@ -1281,7 +1281,7 @@
         ]
     },
     {
-        "@timestamp": "2019-11-06T16:41:38.394Z",
+        "@timestamp": "2019-11-06T16:41:38.394575419Z",
         "destination.address": "10.28.0.16",
         "destination.domain": "adrian-test",
         "destination.ip": "10.28.0.16",

--- a/x-pack/filebeat/module/gcp/vpcflow/test/vpc-flow-log-entries.json.log-expected.json
+++ b/x-pack/filebeat/module/gcp/vpcflow/test/vpc-flow-log-entries.json.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -54,7 +54,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -115,7 +115,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -176,7 +176,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -231,7 +231,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -285,7 +285,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -339,7 +339,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -400,7 +400,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -461,7 +461,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -522,7 +522,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -583,7 +583,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -638,7 +638,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -699,7 +699,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -760,7 +760,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -821,7 +821,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -882,7 +882,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -943,7 +943,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -994,7 +994,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1048,7 +1048,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1109,7 +1109,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1165,7 +1165,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1226,7 +1226,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1277,7 +1277,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1331,7 +1331,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1392,7 +1392,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1448,7 +1448,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1509,7 +1509,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1570,7 +1570,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:10.845Z",
+        "@timestamp": "2019-06-14T03:50:10.845445834Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1624,7 +1624,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1680,7 +1680,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1741,7 +1741,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1795,7 +1795,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1856,7 +1856,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1917,7 +1917,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -1973,7 +1973,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2034,7 +2034,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2095,7 +2095,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2149,7 +2149,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2205,7 +2205,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2266,7 +2266,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2327,7 +2327,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2388,7 +2388,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2449,7 +2449,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2510,7 +2510,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2571,7 +2571,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2625,7 +2625,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2681,7 +2681,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2735,7 +2735,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2791,7 +2791,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2847,7 +2847,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2908,7 +2908,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -2969,7 +2969,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3030,7 +3030,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3086,7 +3086,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3142,7 +3142,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3196,7 +3196,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3250,7 +3250,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3306,7 +3306,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3367,7 +3367,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3428,7 +3428,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:11.981Z",
+        "@timestamp": "2019-06-14T03:50:11.981912845Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3484,7 +3484,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3538,7 +3538,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3592,7 +3592,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3653,7 +3653,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3707,7 +3707,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3761,7 +3761,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3822,7 +3822,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3876,7 +3876,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3937,7 +3937,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -3998,7 +3998,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4059,7 +4059,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4120,7 +4120,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4174,7 +4174,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4235,7 +4235,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4289,7 +4289,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4350,7 +4350,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4404,7 +4404,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4458,7 +4458,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4512,7 +4512,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4566,7 +4566,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4620,7 +4620,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4674,7 +4674,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4728,7 +4728,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4789,7 +4789,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4850,7 +4850,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4904,7 +4904,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -4965,7 +4965,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5019,7 +5019,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5073,7 +5073,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5127,7 +5127,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5188,7 +5188,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5249,7 +5249,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:13.921Z",
+        "@timestamp": "2019-06-14T03:50:13.921248755Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5310,7 +5310,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5371,7 +5371,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5432,7 +5432,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5493,7 +5493,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5554,7 +5554,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5615,7 +5615,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5676,7 +5676,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",
@@ -5737,7 +5737,7 @@
         ]
     },
     {
-        "@timestamp": "2019-06-14T03:50:16.453Z",
+        "@timestamp": "2019-06-14T03:50:16.453102376Z",
         "cloud.availability_zone": "us-east1-b",
         "cloud.project.id": "my-sample-project",
         "cloud.region": "us-east1",

--- a/x-pack/filebeat/module/suricata/eve/test/eve-6.0.log-expected.json
+++ b/x-pack/filebeat/module/suricata/eve/test/eve-6.0.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2021-01-27T00:28:11.488Z",
+        "@timestamp": "2021-01-27T00:28:11.488362Z",
         "destination.address": "10.31.64.240",
         "destination.bytes": 876,
         "destination.domain": "testmynids.org",

--- a/x-pack/filebeat/module/suricata/eve/test/eve-alerts.log-expected.json
+++ b/x-pack/filebeat/module/suricata/eve/test/eve-alerts.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-10-03T14:42:44.836Z",
+        "@timestamp": "2018-10-03T14:42:44.836744Z",
         "destination.address": "93.184.216.34",
         "destination.bytes": 1654,
         "destination.domain": "example.net",
@@ -72,7 +72,7 @@
         "user_agent.version": "7.58.0"
     },
     {
-        "@timestamp": "2018-10-03T16:16:26.711Z",
+        "@timestamp": "2018-10-03T16:16:26.711841Z",
         "destination.address": "93.184.216.34",
         "destination.bytes": 1654,
         "destination.domain": "example.net",
@@ -144,7 +144,7 @@
         "user_agent.version": "7.58.0"
     },
     {
-        "@timestamp": "2018-10-03T16:44:50.813Z",
+        "@timestamp": "2018-10-03T16:44:50.813100Z",
         "destination.address": "93.184.216.34",
         "destination.bytes": 1654,
         "destination.domain": "example.net",
@@ -216,7 +216,7 @@
         "user_agent.version": "7.58.0"
     },
     {
-        "@timestamp": "2018-10-03T16:45:09.267Z",
+        "@timestamp": "2018-10-03T16:45:09.267308Z",
         "destination.address": "93.184.216.34",
         "destination.bytes": 1654,
         "destination.domain": "example.org",
@@ -288,7 +288,7 @@
         "user_agent.version": "7.58.0"
     },
     {
-        "@timestamp": "2018-10-03T16:45:34.481Z",
+        "@timestamp": "2018-10-03T16:45:34.481113Z",
         "destination.address": "93.184.216.34",
         "destination.bytes": 1654,
         "destination.domain": "example.org",
@@ -360,7 +360,7 @@
         "user_agent.version": "7.58.0"
     },
     {
-        "@timestamp": "2018-10-03T17:02:38.900Z",
+        "@timestamp": "2018-10-03T17:02:38.900976Z",
         "destination.address": "93.184.216.34",
         "destination.bytes": 1654,
         "destination.domain": "example.org",
@@ -432,7 +432,7 @@
         "user_agent.version": "7.58.0"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.009Z",
+        "@timestamp": "2018-10-04T09:34:59.009897Z",
         "destination.address": "91.189.88.152",
         "destination.bytes": 1654,
         "destination.domain": "security.ubuntu.com",
@@ -504,7 +504,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.168Z",
+        "@timestamp": "2018-10-04T09:34:59.168340Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 417,
         "destination.domain": "archive.ubuntu.com",
@@ -576,7 +576,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.288Z",
+        "@timestamp": "2018-10-04T09:34:59.288862Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 3445,
         "destination.domain": "archive.ubuntu.com",
@@ -648,7 +648,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.289Z",
+        "@timestamp": "2018-10-04T09:34:59.289324Z",
         "destination.address": "91.189.88.152",
         "destination.bytes": 90543,
         "destination.domain": "security.ubuntu.com",
@@ -720,7 +720,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.356Z",
+        "@timestamp": "2018-10-04T09:34:59.356132Z",
         "destination.address": "91.189.88.152",
         "destination.bytes": 145014,
         "destination.domain": "security.ubuntu.com",
@@ -792,7 +792,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.456Z",
+        "@timestamp": "2018-10-04T09:34:59.456919Z",
         "destination.address": "91.189.88.152",
         "destination.bytes": 330525,
         "destination.domain": "security.ubuntu.com",
@@ -864,7 +864,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.747Z",
+        "@timestamp": "2018-10-04T09:34:59.747122Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 96554,
         "destination.domain": "archive.ubuntu.com",
@@ -936,7 +936,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:34:59.953Z",
+        "@timestamp": "2018-10-04T09:34:59.953886Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 174843,
         "destination.domain": "archive.ubuntu.com",
@@ -1008,7 +1008,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:35:00.250Z",
+        "@timestamp": "2018-10-04T09:35:00.250560Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 376452,
         "destination.domain": "archive.ubuntu.com",
@@ -1080,7 +1080,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:35:00.401Z",
+        "@timestamp": "2018-10-04T09:35:00.401788Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 468170,
         "destination.domain": "archive.ubuntu.com",
@@ -1152,7 +1152,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:35:00.776Z",
+        "@timestamp": "2018-10-04T09:35:00.776438Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 880323,
         "destination.domain": "archive.ubuntu.com",
@@ -1224,7 +1224,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:35:00.897Z",
+        "@timestamp": "2018-10-04T09:35:00.897009Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 884342,
         "destination.domain": "archive.ubuntu.com",
@@ -1296,7 +1296,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:35:01.362Z",
+        "@timestamp": "2018-10-04T09:35:01.362208Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 1467603,
         "destination.domain": "archive.ubuntu.com",
@@ -1367,7 +1367,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:35:01.575Z",
+        "@timestamp": "2018-10-04T09:35:01.575088Z",
         "destination.address": "91.189.91.23",
         "destination.bytes": 1618380,
         "destination.domain": "archive.ubuntu.com",
@@ -1438,7 +1438,7 @@
         "user_agent.version": "1.3"
     },
     {
-        "@timestamp": "2018-10-04T09:35:02.796Z",
+        "@timestamp": "2018-10-04T09:35:02.796615Z",
         "destination.address": "10.232.0.237",
         "destination.domain": "hostname.domain.net",
         "destination.ip": "10.232.0.237",
@@ -1512,7 +1512,7 @@
         "tls.version_protocol": "tls"
     },
     {
-        "@timestamp": "2020-06-26T15:00:03.342Z",
+        "@timestamp": "2020-06-26T15:00:03.342282Z",
         "destination.address": "10.128.2.48",
         "destination.bytes": 4660,
         "destination.domain": "host.domain.net",

--- a/x-pack/filebeat/module/suricata/eve/test/eve-dns-4.1.4.log-expected.json
+++ b/x-pack/filebeat/module/suricata/eve/test/eve-dns-4.1.4.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2019-08-22T23:48:27.924Z",
+        "@timestamp": "2019-08-22T23:48:27.924120Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -48,7 +48,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T23:48:27.924Z",
+        "@timestamp": "2019-08-22T23:48:27.924282Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -96,7 +96,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T23:48:27.950Z",
+        "@timestamp": "2019-08-22T23:48:27.950946Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 36993,
@@ -161,7 +161,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T23:48:27.957Z",
+        "@timestamp": "2019-08-22T23:48:27.957906Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 46686,
@@ -226,7 +226,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T23:48:48.839Z",
+        "@timestamp": "2019-08-22T23:48:48.839495Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -275,7 +275,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T23:48:48.839Z",
+        "@timestamp": "2019-08-22T23:48:48.839714Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -324,7 +324,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T23:48:48.901Z",
+        "@timestamp": "2019-08-22T23:48:48.901548Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 50720,
@@ -420,7 +420,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-22T23:48:48.902Z",
+        "@timestamp": "2019-08-22T23:48:48.902685Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 41979,
@@ -516,7 +516,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.812Z",
+        "@timestamp": "2019-08-23T01:22:31.812655Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -565,7 +565,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.812Z",
+        "@timestamp": "2019-08-23T01:22:31.812828Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -614,7 +614,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.846Z",
+        "@timestamp": "2019-08-23T01:22:31.846575Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 44773,
@@ -673,7 +673,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.846Z",
+        "@timestamp": "2019-08-23T01:22:31.846575Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 44773,
@@ -736,7 +736,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.846Z",
+        "@timestamp": "2019-08-23T01:22:31.846575Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 44773,
@@ -799,7 +799,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.846Z",
+        "@timestamp": "2019-08-23T01:22:31.846575Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 44773,
@@ -862,7 +862,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.846Z",
+        "@timestamp": "2019-08-23T01:22:31.846575Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 44773,
@@ -925,7 +925,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.847Z",
+        "@timestamp": "2019-08-23T01:22:31.847379Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 55246,
@@ -984,7 +984,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.847Z",
+        "@timestamp": "2019-08-23T01:22:31.847379Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 55246,
@@ -1047,7 +1047,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.847Z",
+        "@timestamp": "2019-08-23T01:22:31.847379Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 55246,
@@ -1110,7 +1110,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.847Z",
+        "@timestamp": "2019-08-23T01:22:31.847379Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 55246,
@@ -1173,7 +1173,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T01:22:31.847Z",
+        "@timestamp": "2019-08-23T01:22:31.847379Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 55246,
@@ -1236,7 +1236,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T02:03:36.578Z",
+        "@timestamp": "2019-08-23T02:03:36.578089Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -1285,7 +1285,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T02:03:36.578Z",
+        "@timestamp": "2019-08-23T02:03:36.578262Z",
         "destination.address": "10.0.2.3",
         "destination.ip": "10.0.2.3",
         "destination.port": 53,
@@ -1334,7 +1334,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T02:03:36.619Z",
+        "@timestamp": "2019-08-23T02:03:36.619381Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 48288,
@@ -1430,7 +1430,7 @@
         ]
     },
     {
-        "@timestamp": "2019-08-23T02:03:36.626Z",
+        "@timestamp": "2019-08-23T02:03:36.626559Z",
         "destination.address": "10.0.2.15",
         "destination.ip": "10.0.2.15",
         "destination.port": 59203,

--- a/x-pack/filebeat/module/suricata/eve/test/eve-metadata.log-expected.json
+++ b/x-pack/filebeat/module/suricata/eve/test/eve-metadata.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2021-01-27T00:28:11.488Z",
+        "@timestamp": "2021-01-27T00:28:11.488362Z",
         "destination.address": "10.31.64.240",
         "destination.bytes": 876,
         "destination.domain": "testmynids.org",

--- a/x-pack/filebeat/module/suricata/eve/test/eve-small.log-expected.json
+++ b/x-pack/filebeat/module/suricata/eve/test/eve-small.log-expected.json
@@ -1,6 +1,6 @@
 [
     {
-        "@timestamp": "2018-07-05T19:01:09.820Z",
+        "@timestamp": "2018-07-05T19:01:09.820360Z",
         "destination.address": "192.168.253.112",
         "destination.ip": "192.168.253.112",
         "destination.port": 22,
@@ -41,7 +41,7 @@
         ]
     },
     {
-        "@timestamp": "2018-07-05T19:07:20.910Z",
+        "@timestamp": "2018-07-05T19:07:20.910626Z",
         "destination.address": "192.168.156.70",
         "destination.bytes": 343,
         "destination.domain": "l2.io",
@@ -105,7 +105,7 @@
         "tls.version_protocol": "tls"
     },
     {
-        "@timestamp": "2018-07-05T19:43:47.690Z",
+        "@timestamp": "2018-07-05T19:43:47.690014Z",
         "destination.address": "192.168.86.28",
         "destination.domain": "192.168.86.28",
         "destination.ip": "192.168.86.28",
@@ -166,7 +166,7 @@
         "user_agent.version": "67.0.3396.99"
     },
     {
-        "@timestamp": "2018-07-05T19:44:33.222Z",
+        "@timestamp": "2018-07-05T19:44:33.222441Z",
         "destination.address": "192.168.86.85",
         "destination.domain": "192.168.86.85",
         "destination.ip": "192.168.86.85",
@@ -229,7 +229,7 @@
         "user_agent.version": "67.0.3396.99"
     },
     {
-        "@timestamp": "2018-07-05T19:51:20.213Z",
+        "@timestamp": "2018-07-05T19:51:20.213418Z",
         "destination.address": "192.168.86.85",
         "destination.ip": "192.168.86.85",
         "destination.port": 39464,
@@ -288,7 +288,7 @@
         ]
     },
     {
-        "@timestamp": "2018-07-05T19:51:23.009Z",
+        "@timestamp": "2018-07-05T19:51:23.009510Z",
         "event.category": [
             "network"
         ],
@@ -422,7 +422,7 @@
         ]
     },
     {
-        "@timestamp": "2018-07-05T19:51:50.666Z",
+        "@timestamp": "2018-07-05T19:51:50.666597Z",
         "destination.address": "17.142.164.13",
         "destination.domain": "p33-btmmdns.icloud.com",
         "destination.ip": "17.142.164.13",
@@ -491,7 +491,7 @@
         "tls.version_protocol": "tls"
     },
     {
-        "@timestamp": "2018-07-05T19:51:54.001Z",
+        "@timestamp": "2018-07-05T19:51:54.001329Z",
         "destination.address": "ff02:0000:0000:0000:0000:0000:0001:0002",
         "destination.bytes": 0,
         "destination.ip": "ff02:0000:0000:0000:0000:0000:0001:0002",
@@ -540,7 +540,7 @@
         ]
     },
     {
-        "@timestamp": "2020-12-09T16:02:43.000Z",
+        "@timestamp": "2020-12-09T16:02:43.000505Z",
         "destination.address": "192.168.50.1",
         "destination.domain": "ctldl.windowsupdate.com",
         "destination.ip": "192.168.50.1",
@@ -596,7 +596,7 @@
         "user_agent.version": "10.0"
     },
     {
-        "@timestamp": "2020-12-09T16:02:58.005Z",
+        "@timestamp": "2020-12-09T16:02:58.005716Z",
         "destination.address": "192.168.50.1",
         "destination.ip": "192.168.50.1",
         "destination.port": 443,
@@ -663,7 +663,7 @@
         "tls.version_protocol": "tls"
     },
     {
-        "@timestamp": "2020-12-09T16:03:00.179Z",
+        "@timestamp": "2020-12-09T16:03:00.179037Z",
         "destination.address": "192.168.50.1",
         "destination.domain": "192.168.50.1",
         "destination.ip": "192.168.50.1",
@@ -720,7 +720,7 @@
         "user_agent.version": "84.0."
     },
     {
-        "@timestamp": "2020-12-09T16:03:50.083Z",
+        "@timestamp": "2020-12-09T16:03:50.083307Z",
         "destination.address": "192.168.50.1",
         "destination.domain": "www.example.com",
         "destination.ip": "192.168.50.1",


### PR DESCRIPTION
## What does this PR do?

This PR adds support for nanosecond precision timestamps in Beats. It is the updated version of https://github.com/elastic/beats/pull/15872

## Why is it important?

When events come faster then milliseconds, ingested events might have the same `@timestamp` field. So there is no way to order them correctly. By making the timestamp more precise we can avoid such problems.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes https://github.com/elastic/beats/issues/15871

