### PR TITLE
List individual beat docs without a CODEOWNER.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@ CHANGELOG*
 /dev-tools/ @elastic/elastic-agent-data-plane
 /docs/ @elastic/elastic-agent-data-plane
 /filebeat @elastic/elastic-agent-data-plane
+/filebeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /filebeat/input/syslog/ @elastic/security-external-integrations
 /filebeat/input/winlog/ @elastic/security-external-integrations
 /filebeat/module/ @elastic/integrations
@@ -57,6 +58,7 @@ CHANGELOG*
 /libbeat/processors/translate_sid/ @elastic/security-external-integrations
 /licenses/ @elastic/elastic-agent-data-plane
 /metricbeat/ @elastic/elastic-agent-data-plane
+/metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /metricbeat/module/ @elastic/integrations
 /metricbeat/module/beat/ @elastic/infra-monitoring-ui
 /metricbeat/module/elasticsearch/ @elastic/infra-monitoring-ui
@@ -71,6 +73,7 @@ CHANGELOG*
 /x-pack/auditbeat/ @elastic/security-external-integrations
 /x-pack/elastic-agent/ @elastic/elastic-agent-control-plane
 /x-pack/filebeat @elastic/elastic-agent-data-plane
+/x-pack/filebeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /x-pack/filebeat/input/gcppubsub/ @elastic/security-external-integrations
 /x-pack/filebeat/input/http_endpoint/ @elastic/security-external-integrations
 /x-pack/filebeat/input/httpjson/ @elastic/security-external-integrations
@@ -128,6 +131,7 @@ CHANGELOG*
 /x-pack/filebeat/processors/decode_cef/ @elastic/security-external-integrations
 /x-pack/heartbeat/ @elastic/uptime
 /x-pack/metricbeat/ @elastic/elastic-agent-data-plane
+/x-pack/metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /x-pack/metricbeat/module/ @elastic/integrations
 /x-pack/metricbeat/module/enterprisesearch @elastic/ent-search-application-backend
 /x-pack/packetbeat/ @elastic/security-external-integrations


### PR DESCRIPTION
This avoids having to maintain the correct codeowner for the entire docs
tree, which is assignee that data plane team as reviewers for changes to
code they do not own.

The documentation for inputs and modules is frequently changed along with
their code, so in practice a reasonable owner is assigned the majority of the time.

When changes are made exclusively to these docs without any code change
a reviewer will have to be manually assigned.
