### PR TITLE
Add metadata for missing k8s resources/metricsets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -122,6 +122,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...main[Check the HEAD dif
 - Extend documentation about `orchestrator.cluster` fields {pull}30518[30518]
 - Enhance Oracle Module: Change tablespace metricset collection period {issue}30948[30948] {pull}31259[#31259]
 - Add orchestrator cluster ECS fields in kubernetes events {pull}31341[31341]
+- Add metadata for missing k8s resources/metricsets {pull}31590[31590]
 
 *Packetbeat*
 

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -279,6 +279,8 @@ rules:
   - events
   - pods
   - services
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs: ["get", "list", "watch"]
 # Enable this rule only if planing to use Kubernetes keystore
 #- apiGroups: [""]
@@ -294,6 +296,7 @@ rules:
   - statefulsets
   - deployments
   - replicasets
+  - daemonsets
   verbs: ["get", "list", "watch"]
 - apiGroups: ["batch"]
   resources:

--- a/deploy/kubernetes/metricbeat/metricbeat-role.yaml
+++ b/deploy/kubernetes/metricbeat/metricbeat-role.yaml
@@ -12,6 +12,8 @@ rules:
   - events
   - pods
   - services
+  - persistentvolumes
+  - persistentvolumeclaims
   verbs: ["get", "list", "watch"]
 # Enable this rule only if planing to use Kubernetes keystore
 #- apiGroups: [""]
@@ -27,6 +29,7 @@ rules:
   - statefulsets
   - deployments
   - replicasets
+  - daemonsets
   verbs: ["get", "list", "watch"]
 - apiGroups: ["batch"]
   resources:

--- a/libbeat/common/kubernetes/informer.go
+++ b/libbeat/common/kubernetes/informer.go
@@ -137,6 +137,18 @@ func NewInformer(client kubernetes.Interface, resource Resource, opts WatchOptio
 		}
 
 		objType = "statefulset"
+	case *DaemonSet:
+		ss := client.AppsV1().DaemonSets(opts.Namespace)
+		listwatch = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return ss.List(ctx, options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return ss.Watch(ctx, options)
+			},
+		}
+
+		objType = "daemonset"
 	case *Service:
 		svc := client.CoreV1().Services(opts.Namespace)
 		listwatch = &cache.ListWatch{
@@ -185,7 +197,30 @@ func NewInformer(client kubernetes.Interface, resource Resource, opts WatchOptio
 		}
 
 		objType = "job"
+	case *PersistentVolume:
+		ss := client.CoreV1().PersistentVolumes()
+		listwatch = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return ss.List(ctx, options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return ss.Watch(ctx, options)
+			},
+		}
 
+		objType = "persistentvolume"
+	case *PersistentVolumeClaim:
+		ss := client.CoreV1().PersistentVolumeClaims(opts.Namespace)
+		listwatch = &cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return ss.List(ctx, options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				return ss.Watch(ctx, options)
+			},
+		}
+
+		objType = "persistentvolumeclaim"
 	case *Role:
 		r := client.RbacV1().Roles(opts.Namespace)
 		listwatch = &cache.ListWatch{

--- a/libbeat/common/kubernetes/types.go
+++ b/libbeat/common/kubernetes/types.go
@@ -73,6 +73,9 @@ type ReplicaSet = appsv1.ReplicaSet
 // StatefulSet data
 type StatefulSet = appsv1.StatefulSet
 
+// DaemonSet data
+type DaemonSet = appsv1.DaemonSet
+
 // Service data
 type Service = v1.Service
 
@@ -84,6 +87,12 @@ type Job = batchv1.Job
 
 // CronJob data
 type CronJob = batchv1.CronJob
+
+// PersistentVolume data
+type PersistentVolume = v1.PersistentVolume
+
+// PersistentVolumeClaim data
+type PersistentVolumeClaim = v1.PersistentVolumeClaim
 
 // Role data
 type Role = rbacv1.Role

--- a/metricbeat/module/kubernetes/_meta/test/docs/01_playground/metricbeat.yaml
+++ b/metricbeat/module/kubernetes/_meta/test/docs/01_playground/metricbeat.yaml
@@ -269,6 +269,8 @@ rules:
       - events
       - pods
       - services
+      - persistentvolumes
+      - persistentvolumeclaims
     verbs: ["get", "list", "watch"]
   # Enable this rule only if planing to use Kubernetes keystore
   #- apiGroups: [""]
@@ -284,6 +286,12 @@ rules:
       - statefulsets
       - deployments
       - replicasets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
     verbs: ["get", "list", "watch"]
   - apiGroups:
       - ""

--- a/metricbeat/module/kubernetes/event/event.go
+++ b/metricbeat/module/kubernetes/event/event.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 	"time"
 
-	k8sclient "k8s.io/client-go/kubernetes"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
-	"github.com/elastic/beats/v7/libbeat/common/kubernetes/metadata"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -101,7 +98,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 	// add ECS orchestrator fields
 	cfg, _ := conf.NewConfigFrom(&config)
-	ecsClusterMeta, err := getClusterECSMeta(cfg, client, ms.Logger())
+	ecsClusterMeta, err := util.GetClusterECSMeta(cfg, client, ms.Logger())
 	if err != nil {
 		ms.Logger().Debugf("could not retrieve cluster metadata: %w", err)
 	}
@@ -110,21 +107,6 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	return ms, nil
-}
-
-func getClusterECSMeta(cfg *conf.C, client k8sclient.Interface, logger *logp.Logger) (mapstr.M, error) {
-	clusterInfo, err := metadata.GetKubernetesClusterIdentifier(cfg, client)
-	if err != nil {
-		return nil, fmt.Errorf("fail to get kubernetes cluster metadata: %w", err)
-	}
-	ecsClusterMeta := mapstr.M{}
-	if clusterInfo.Url != "" {
-		util.ShouldPut(ecsClusterMeta, "orchestrator.cluster.url", clusterInfo.Url, logger)
-	}
-	if clusterInfo.Name != "" {
-		util.ShouldPut(ecsClusterMeta, "orchestrator.cluster.name", clusterInfo.Name, logger)
-	}
-	return ecsClusterMeta, nil
 }
 
 // Run method provides the Kubernetes event watcher with a reporter with which events can be reported.

--- a/metricbeat/module/kubernetes/state_container/_meta/test/ksm.v2.0.0.expected
+++ b/metricbeat/module/kubernetes/state_container/_meta/test/ksm.v2.0.0.expected
@@ -2,59 +2,6 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "3101d1525d6133851881f4b7cd439033663daefeb4849e5322d1428f09620628",
-				"image": {
-					"name": "k8s.gcr.io/coredns:1.6.2"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "kind-control-plane"
-			},
-			"pod": {
-				"name": "coredns-5644d7b6d9-zgdsx"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "containerd://3101d1525d6133851881f4b7cd439033663daefeb4849e5322d1428f09620628",
-			"memory": {
-				"limit": {
-					"bytes": 178257920
-				},
-				"request": {
-					"bytes": 73400320
-				}
-			},
-			"name": "coredns",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 4
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
 				"id": "ffdc200c097349d8ed96f5768387d276751497297730121e6335a31c2d3332a4",
 				"image": {
 					"name": "k8s.gcr.io/kube-apiserver:v1.16.15"
@@ -83,267 +30,6 @@
 				"phase": "running",
 				"ready": true,
 				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "f2926bdf120aa838838aa55640b5511291e7279eb07ee8c17e01bf23a8695c2c",
-				"image": {
-					"name": "k8s.gcr.io/kube-proxy:v1.16.15"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "kind-worker2"
-			},
-			"pod": {
-				"name": "kube-proxy-lf6md"
-			}
-		},
-		"MetricSetFields": {
-			"id": "containerd://f2926bdf120aa838838aa55640b5511291e7279eb07ee8c17e01bf23a8695c2c",
-			"name": "kube-proxy",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 4
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "8af6de6644ef1e5bb36b9d1f87d65e9b893096ae2c0f3e57061fad70f094d1be",
-				"image": {
-					"name": "k8s.gcr.io/kube-proxy:v1.16.15"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "kind-worker"
-			},
-			"pod": {
-				"name": "kube-proxy-22znl"
-			}
-		},
-		"MetricSetFields": {
-			"id": "containerd://8af6de6644ef1e5bb36b9d1f87d65e9b893096ae2c0f3e57061fad70f094d1be",
-			"name": "kube-proxy",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 4
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "02b0705f60dc6131a6b5d4e9a48e2510463f89a0f77e7e1bafa6b5f45cc595e8",
-				"image": {
-					"name": "docker.io/odise/busybox-python:latest"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "default",
-			"node": {
-				"name": "kind-worker"
-			},
-			"pod": {
-				"name": "hello-python-566b5479f5-ndwdl"
-			}
-		},
-		"MetricSetFields": {
-			"id": "containerd://02b0705f60dc6131a6b5d4e9a48e2510463f89a0f77e7e1bafa6b5f45cc595e8",
-			"name": "hello-python",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 18
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "09603a8146bd6aacb32d55a1e52e929143f003ea30c84052f765efca129fd90a",
-				"image": {
-					"name": "docker.io/kindest/kindnetd:v20210326-1e038dc5"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "kind-control-plane"
-			},
-			"pod": {
-				"name": "kindnet-kch2v"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"limit": {
-					"cores": 0.1
-				},
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "containerd://09603a8146bd6aacb32d55a1e52e929143f003ea30c84052f765efca129fd90a",
-			"memory": {
-				"limit": {
-					"bytes": 52428800
-				},
-				"request": {
-					"bytes": 52428800
-				}
-			},
-			"name": "kindnet-cni",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 4
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "cd368e1731c278b039642fab2fe90902e2cfa470fd70a7ccfd5c2549a552cea5",
-				"image": {
-					"name": "k8s.gcr.io/kube-scheduler:v1.16.15"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "kind-control-plane"
-			},
-			"pod": {
-				"name": "kube-scheduler-kind-control-plane"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "containerd://cd368e1731c278b039642fab2fe90902e2cfa470fd70a7ccfd5c2549a552cea5",
-			"name": "kube-scheduler",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 4
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "1a223dbb8b51a7404836789fd049701a9e4df7bb69878fb893ab10419ff4eb29",
-				"image": {
-					"name": "docker.io/rancher/local-path-provisioner:v0.0.14"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "local-path-storage",
-			"node": {
-				"name": "kind-control-plane"
-			},
-			"pod": {
-				"name": "local-path-provisioner-5bf465b47d-h8hjn"
-			}
-		},
-		"MetricSetFields": {
-			"id": "containerd://1a223dbb8b51a7404836789fd049701a9e4df7bb69878fb893ab10419ff4eb29",
-			"name": "local-path-provisioner",
-			"status": {
-				"last_terminated_reason": "Error",
-				"phase": "running",
-				"ready": true,
-				"restarts": 8
 			}
 		},
 		"Index": "",
@@ -392,107 +78,6 @@
 				}
 			},
 			"name": "metricbeat",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 1
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "33315399455b7213d316f6f799155d890659ca407f80d58307075b3ee70e7e07",
-				"image": {
-					"name": "k8s.gcr.io/coredns:1.6.2"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "kube-system",
-			"node": {
-				"name": "kind-control-plane"
-			},
-			"pod": {
-				"name": "coredns-5644d7b6d9-nnwmb"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "containerd://33315399455b7213d316f6f799155d890659ca407f80d58307075b3ee70e7e07",
-			"memory": {
-				"limit": {
-					"bytes": 178257920
-				},
-				"request": {
-					"bytes": 73400320
-				}
-			},
-			"name": "coredns",
-			"status": {
-				"last_terminated_reason": "Unknown",
-				"phase": "running",
-				"ready": true,
-				"restarts": 4
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
-				"id": "fae8ef6fa6ea716f5ce0a65a1b2407d1e4839b04452d6013cdb6d5be8db8ada0",
-				"image": {
-					"name": "docker.io/library/redis:5.0.4"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "default",
-			"node": {
-				"name": "kind-worker2"
-			},
-			"pod": {
-				"name": "redis"
-			}
-		},
-		"MetricSetFields": {
-			"cpu": {
-				"limit": {
-					"cores": 0.1
-				},
-				"request": {
-					"cores": 0.1
-				}
-			},
-			"id": "containerd://fae8ef6fa6ea716f5ce0a65a1b2407d1e4839b04452d6013cdb6d5be8db8ada0",
-			"name": "redis",
 			"status": {
 				"last_terminated_reason": "Unknown",
 				"phase": "running",
@@ -570,9 +155,57 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "ae513b826459c9382984bea986eb3546aa45fd0e650051cb9591ab7a8efed6ea",
+				"id": "fae8ef6fa6ea716f5ce0a65a1b2407d1e4839b04452d6013cdb6d5be8db8ada0",
 				"image": {
-					"name": "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0"
+					"name": "docker.io/library/redis:5.0.4"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "default",
+			"node": {
+				"name": "kind-worker2"
+			},
+			"pod": {
+				"name": "redis"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"limit": {
+					"cores": 0.1
+				},
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "containerd://fae8ef6fa6ea716f5ce0a65a1b2407d1e4839b04452d6013cdb6d5be8db8ada0",
+			"name": "redis",
+			"status": {
+				"last_terminated_reason": "Unknown",
+				"phase": "running",
+				"ready": true,
+				"restarts": 1
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "8af6de6644ef1e5bb36b9d1f87d65e9b893096ae2c0f3e57061fad70f094d1be",
+				"image": {
+					"name": "k8s.gcr.io/kube-proxy:v1.16.15"
 				},
 				"runtime": "containerd"
 			}
@@ -583,17 +216,110 @@
 				"name": "kind-worker"
 			},
 			"pod": {
-				"name": "kube-state-metrics-f655d484d-hj69w"
+				"name": "kube-proxy-22znl"
 			}
 		},
 		"MetricSetFields": {
-			"id": "containerd://ae513b826459c9382984bea986eb3546aa45fd0e650051cb9591ab7a8efed6ea",
-			"name": "kube-state-metrics",
+			"id": "containerd://8af6de6644ef1e5bb36b9d1f87d65e9b893096ae2c0f3e57061fad70f094d1be",
+			"name": "kube-proxy",
 			"status": {
-				"last_terminated_reason": "Error",
+				"last_terminated_reason": "Unknown",
 				"phase": "running",
 				"ready": true,
-				"restarts": 2
+				"restarts": 4
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "f2926bdf120aa838838aa55640b5511291e7279eb07ee8c17e01bf23a8695c2c",
+				"image": {
+					"name": "k8s.gcr.io/kube-proxy:v1.16.15"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "kind-worker2"
+			},
+			"pod": {
+				"name": "kube-proxy-lf6md"
+			}
+		},
+		"MetricSetFields": {
+			"id": "containerd://f2926bdf120aa838838aa55640b5511291e7279eb07ee8c17e01bf23a8695c2c",
+			"name": "kube-proxy",
+			"status": {
+				"last_terminated_reason": "Unknown",
+				"phase": "running",
+				"ready": true,
+				"restarts": 4
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "3101d1525d6133851881f4b7cd439033663daefeb4849e5322d1428f09620628",
+				"image": {
+					"name": "k8s.gcr.io/coredns:1.6.2"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "kind-control-plane"
+			},
+			"pod": {
+				"name": "coredns-5644d7b6d9-zgdsx"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "containerd://3101d1525d6133851881f4b7cd439033663daefeb4849e5322d1428f09620628",
+			"memory": {
+				"limit": {
+					"bytes": 178257920
+				},
+				"request": {
+					"bytes": 73400320
+				}
+			},
+			"name": "coredns",
+			"status": {
+				"last_terminated_reason": "Unknown",
+				"phase": "running",
+				"ready": true,
+				"restarts": 4
 			}
 		},
 		"Index": "",
@@ -663,46 +389,6 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "a84953a247df489898d85ecfd0f893c2655ed1915ac902b309ee6e3658c7e258",
-				"image": {
-					"name": "docker.io/library/busybox:latest"
-				},
-				"runtime": "containerd"
-			}
-		},
-		"ModuleFields": {
-			"namespace": "default",
-			"node": {
-				"name": "kind-worker"
-			},
-			"pod": {
-				"name": "hello-zf6gh"
-			}
-		},
-		"MetricSetFields": {
-			"id": "containerd://a84953a247df489898d85ecfd0f893c2655ed1915ac902b309ee6e3658c7e258",
-			"name": "hello",
-			"status": {
-				"phase": "terminated",
-				"ready": false,
-				"reason": "Completed",
-				"restarts": 0
-			}
-		},
-		"Index": "",
-		"ID": "",
-		"Namespace": "kubernetes.container",
-		"Timestamp": "0001-01-01T00:00:00Z",
-		"Error": null,
-		"Host": "",
-		"Service": "",
-		"Took": 0,
-		"Period": 0,
-		"DisableTimeSeries": false
-	},
-	{
-		"RootFields": {
-			"container": {
 				"id": "a55ee307ef431d293c02a7eb96417963d7b81b298a8ebfac2f77fe4ca58e1461",
 				"image": {
 					"name": "k8s.gcr.io/kube-proxy:v1.16.15"
@@ -743,9 +429,49 @@
 	{
 		"RootFields": {
 			"container": {
-				"id": "3f9250f160ca15f681b8c7da78fdf34cd8be8a86fde3910b682ad413b940a8c5",
+				"id": "1a223dbb8b51a7404836789fd049701a9e4df7bb69878fb893ab10419ff4eb29",
 				"image": {
-					"name": "k8s.gcr.io/etcd:3.3.15-0"
+					"name": "docker.io/rancher/local-path-provisioner:v0.0.14"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "local-path-storage",
+			"node": {
+				"name": "kind-control-plane"
+			},
+			"pod": {
+				"name": "local-path-provisioner-5bf465b47d-h8hjn"
+			}
+		},
+		"MetricSetFields": {
+			"id": "containerd://1a223dbb8b51a7404836789fd049701a9e4df7bb69878fb893ab10419ff4eb29",
+			"name": "local-path-provisioner",
+			"status": {
+				"last_terminated_reason": "Error",
+				"phase": "running",
+				"ready": true,
+				"restarts": 8
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "33315399455b7213d316f6f799155d890659ca407f80d58307075b3ee70e7e07",
+				"image": {
+					"name": "k8s.gcr.io/coredns:1.6.2"
 				},
 				"runtime": "containerd"
 			}
@@ -756,16 +482,126 @@
 				"name": "kind-control-plane"
 			},
 			"pod": {
-				"name": "etcd-kind-control-plane"
+				"name": "coredns-5644d7b6d9-nnwmb"
 			}
 		},
 		"MetricSetFields": {
-			"id": "containerd://3f9250f160ca15f681b8c7da78fdf34cd8be8a86fde3910b682ad413b940a8c5",
-			"name": "etcd",
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "containerd://33315399455b7213d316f6f799155d890659ca407f80d58307075b3ee70e7e07",
+			"memory": {
+				"limit": {
+					"bytes": 178257920
+				},
+				"request": {
+					"bytes": 73400320
+				}
+			},
+			"name": "coredns",
 			"status": {
+				"last_terminated_reason": "Unknown",
 				"phase": "running",
 				"ready": true,
-				"restarts": 0
+				"restarts": 4
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "ae513b826459c9382984bea986eb3546aa45fd0e650051cb9591ab7a8efed6ea",
+				"image": {
+					"name": "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.0"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "kind-worker"
+			},
+			"pod": {
+				"name": "kube-state-metrics-f655d484d-hj69w"
+			}
+		},
+		"MetricSetFields": {
+			"id": "containerd://ae513b826459c9382984bea986eb3546aa45fd0e650051cb9591ab7a8efed6ea",
+			"name": "kube-state-metrics",
+			"status": {
+				"last_terminated_reason": "Error",
+				"phase": "running",
+				"ready": true,
+				"restarts": 2
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "09603a8146bd6aacb32d55a1e52e929143f003ea30c84052f765efca129fd90a",
+				"image": {
+					"name": "docker.io/kindest/kindnetd:v20210326-1e038dc5"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "kind-control-plane"
+			},
+			"pod": {
+				"name": "kindnet-kch2v"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"limit": {
+					"cores": 0.1
+				},
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "containerd://09603a8146bd6aacb32d55a1e52e929143f003ea30c84052f765efca129fd90a",
+			"memory": {
+				"limit": {
+					"bytes": 52428800
+				},
+				"request": {
+					"bytes": 52428800
+				}
+			},
+			"name": "kindnet-cni",
+			"status": {
+				"last_terminated_reason": "Unknown",
+				"phase": "running",
+				"ready": true,
+				"restarts": 4
 			}
 		},
 		"Index": "",
@@ -838,6 +674,46 @@
 	{
 		"RootFields": {
 			"container": {
+				"id": "a84953a247df489898d85ecfd0f893c2655ed1915ac902b309ee6e3658c7e258",
+				"image": {
+					"name": "docker.io/library/busybox:latest"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "default",
+			"node": {
+				"name": "kind-worker"
+			},
+			"pod": {
+				"name": "hello-zf6gh"
+			}
+		},
+		"MetricSetFields": {
+			"id": "containerd://a84953a247df489898d85ecfd0f893c2655ed1915ac902b309ee6e3658c7e258",
+			"name": "hello",
+			"status": {
+				"phase": "terminated",
+				"ready": false,
+				"reason": "Completed",
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
 				"id": "1c1919c3b07bf3369b5e1a4bf187762f2724b3bc7eb113239af3919f12202337",
 				"image": {
 					"name": "k8s.gcr.io/kube-controller-manager:v1.16.15"
@@ -867,6 +743,130 @@
 				"phase": "running",
 				"ready": true,
 				"restarts": 4
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "3f9250f160ca15f681b8c7da78fdf34cd8be8a86fde3910b682ad413b940a8c5",
+				"image": {
+					"name": "k8s.gcr.io/etcd:3.3.15-0"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "kind-control-plane"
+			},
+			"pod": {
+				"name": "etcd-kind-control-plane"
+			}
+		},
+		"MetricSetFields": {
+			"id": "containerd://3f9250f160ca15f681b8c7da78fdf34cd8be8a86fde3910b682ad413b940a8c5",
+			"name": "etcd",
+			"status": {
+				"phase": "running",
+				"ready": true,
+				"restarts": 0
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "cd368e1731c278b039642fab2fe90902e2cfa470fd70a7ccfd5c2549a552cea5",
+				"image": {
+					"name": "k8s.gcr.io/kube-scheduler:v1.16.15"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "kube-system",
+			"node": {
+				"name": "kind-control-plane"
+			},
+			"pod": {
+				"name": "kube-scheduler-kind-control-plane"
+			}
+		},
+		"MetricSetFields": {
+			"cpu": {
+				"request": {
+					"cores": 0.1
+				}
+			},
+			"id": "containerd://cd368e1731c278b039642fab2fe90902e2cfa470fd70a7ccfd5c2549a552cea5",
+			"name": "kube-scheduler",
+			"status": {
+				"last_terminated_reason": "Unknown",
+				"phase": "running",
+				"ready": true,
+				"restarts": 4
+			}
+		},
+		"Index": "",
+		"ID": "",
+		"Namespace": "kubernetes.container",
+		"Timestamp": "0001-01-01T00:00:00Z",
+		"Error": null,
+		"Host": "",
+		"Service": "",
+		"Took": 0,
+		"Period": 0,
+		"DisableTimeSeries": false
+	},
+	{
+		"RootFields": {
+			"container": {
+				"id": "02b0705f60dc6131a6b5d4e9a48e2510463f89a0f77e7e1bafa6b5f45cc595e8",
+				"image": {
+					"name": "docker.io/odise/busybox-python:latest"
+				},
+				"runtime": "containerd"
+			}
+		},
+		"ModuleFields": {
+			"namespace": "default",
+			"node": {
+				"name": "kind-worker"
+			},
+			"pod": {
+				"name": "hello-python-566b5479f5-ndwdl"
+			}
+		},
+		"MetricSetFields": {
+			"id": "containerd://02b0705f60dc6131a6b5d4e9a48e2510463f89a0f77e7e1bafa6b5f45cc595e8",
+			"name": "hello-python",
+			"status": {
+				"last_terminated_reason": "Unknown",
+				"phase": "running",
+				"ready": true,
+				"restarts": 18
 			}
 		},
 		"Index": "",

--- a/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
+++ b/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
@@ -127,7 +127,6 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
 		}
 	}
 
-	return
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
+++ b/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
@@ -89,7 +89,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	return &MetricSet{
 		BaseMetricSet: base,
 		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.ReplicaSet{}, false),
+		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.DaemonSet{}, false),
 		mod:           mod,
 	}, nil
 }

--- a/metricbeat/module/kubernetes/state_persistentvolume/_meta/test/ksm.unit.v1.8.0.expected
+++ b/metricbeat/module/kubernetes/state_persistentvolume/_meta/test/ksm.unit.v1.8.0.expected
@@ -1,6 +1,6 @@
 [
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"name": "test-pv-bound",
@@ -18,7 +18,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"capacity": {
@@ -38,7 +38,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"name": "test-pv-pending",
@@ -56,7 +56,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"name": "test-pv-available",
@@ -74,7 +74,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"capacity": {
@@ -95,7 +95,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"name": "test-pv-released",
@@ -113,7 +113,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"name": "test-pv-failed",
@@ -131,7 +131,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": {
 			"labels": {
 				"app": "mysql-server"

--- a/metricbeat/module/kubernetes/state_persistentvolume/_meta/test/ksm.v1.8.0.expected
+++ b/metricbeat/module/kubernetes/state_persistentvolume/_meta/test/ksm.v1.8.0.expected
@@ -1,6 +1,6 @@
 [
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"capacity": {
@@ -22,7 +22,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"capacity": {

--- a/metricbeat/module/kubernetes/state_persistentvolume/_meta/test/ksm.v2.0.0.expected
+++ b/metricbeat/module/kubernetes/state_persistentvolume/_meta/test/ksm.v2.0.0.expected
@@ -1,6 +1,6 @@
 [
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"capacity": {

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
@@ -110,8 +110,7 @@ func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
 			return
 		}
 	}
-
-	return
+	
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
@@ -110,7 +110,7 @@ func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
 			return
 		}
 	}
-	
+
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
@@ -20,6 +20,9 @@ package state_persistentvolume
 import (
 	"fmt"
 
+	"github.com/elastic/beats/v7/libbeat/common/kubernetes"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
+
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
@@ -38,6 +41,7 @@ type PersistentVolumeMetricSet struct {
 	prometheus p.Prometheus
 	mapping    *p.MetricsMapping
 	mod        k8smod.Module
+	enricher   util.Enricher
 }
 
 // NewPersistentVolumeMetricSet returns a prometheus based metricset for Persistent Volumes
@@ -54,6 +58,7 @@ func NewPersistentVolumeMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		BaseMetricSet: base,
 		prometheus:    prometheus,
 		mod:           mod,
+		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.PersistentVolume{}, false),
 		mapping: &p.MetricsMapping{
 			Metrics: map[string]p.MetricMap{
 				"kube_persistentvolume_capacity_bytes": p.Metric("capacity.bytes"),
@@ -77,6 +82,8 @@ func NewPersistentVolumeMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
 // module rooted fields at the event that gets reported
 func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
+	m.enricher.Start()
+
 	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
 	if err != nil {
 		m.Logger().Error(err)
@@ -90,6 +97,7 @@ func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
 		return
 	}
 
+	m.enricher.Enrich(events)
 	for _, event := range events {
 		event[mb.NamespaceKey] = "persistentvolume"
 		reported := reporter.Event(mb.TransformMapStrToEvent("kubernetes", event, nil))
@@ -99,4 +107,10 @@ func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
 		}
 	}
 	return
+}
+
+// Close stops this metricset
+func (m *PersistentVolumeMetricSet) Close() error {
+	m.enricher.Stop()
+	return nil
 }

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
@@ -99,13 +99,18 @@ func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
 
 	m.enricher.Enrich(events)
 	for _, event := range events {
-		event[mb.NamespaceKey] = "persistentvolume"
-		reported := reporter.Event(mb.TransformMapStrToEvent("kubernetes", event, nil))
-		if !reported {
+
+		e, err := util.CreateEvent(event, "kubernetes.persistentvolume")
+		if err != nil {
+			m.Logger().Error(err)
+		}
+
+		if reported := reporter.Event(e); !reported {
 			m.Logger().Debug("error trying to emit event")
 			return
 		}
 	}
+
 	return
 }
 

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/_meta/test/ksm.unit.v1.8.0.expected
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/_meta/test/ksm.unit.v1.8.0.expected
@@ -1,6 +1,6 @@
 [
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": {
 			"labels": {
 				"app": "mysql-server"
@@ -29,7 +29,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": {
 			"namespace": "default"
 		},
@@ -52,7 +52,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": null,
 		"MetricSetFields": {
 			"access_mode": "ReadWriteOnce",

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/_meta/test/ksm.v1.8.0.expected
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/_meta/test/ksm.v1.8.0.expected
@@ -1,6 +1,6 @@
 [
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": {
 			"labels": {
 				"app": "nginx"
@@ -29,7 +29,7 @@
 		"DisableTimeSeries": false
 	},
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": {
 			"labels": {
 				"app": "nginx"

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/_meta/test/ksm.v2.0.0.expected
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/_meta/test/ksm.v2.0.0.expected
@@ -1,6 +1,6 @@
 [
 	{
-		"RootFields": {},
+		"RootFields": null,
 		"ModuleFields": {
 			"namespace": "default"
 		},

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
@@ -115,7 +115,6 @@ func (m *persistentvolumeclaimMetricSet) Fetch(reporter mb.ReporterV2) {
 		}
 	}
 
-	return
 }
 
 // Close stops this metricset

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -23,6 +23,8 @@ import (
 	"sync"
 	"time"
 
+	k8sclient "k8s.io/client-go/kubernetes"
+
 	"github.com/elastic/beats/v7/libbeat/common/kubernetes/metadata"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
@@ -81,7 +83,7 @@ func NewResourceMetadataEnricher(
 	res kubernetes.Resource,
 	nodeScope bool) Enricher {
 
-	config := validatedConfig(base)
+	config := ValidatedConfig(base)
 	if config == nil {
 		logp.Info("Kubernetes metricset enriching is disabled")
 		return &nilEnricher{}
@@ -146,6 +148,12 @@ func NewResourceMetadataEnricher(
 				m[id] = metaGen.Generate("namespace", r)
 			case *kubernetes.ReplicaSet:
 				m[id] = metaGen.Generate("replicaset", r)
+			case *kubernetes.DaemonSet:
+				m[id] = metaGen.Generate("daemonset", r)
+			case *kubernetes.PersistentVolume:
+				m[id] = metaGen.Generate("persistentvolume", r)
+			case *kubernetes.PersistentVolumeClaim:
+				m[id] = metaGen.Generate("persistentvolumeclaim", r)
 			default:
 				m[id] = metaGen.Generate(r.GetObjectKind().GroupVersionKind().Kind, r)
 			}
@@ -176,7 +184,7 @@ func NewContainerMetadataEnricher(
 	base mb.BaseMetricSet,
 	nodeScope bool) Enricher {
 
-	config := validatedConfig(base)
+	config := ValidatedConfig(base)
 	if config == nil {
 		logp.Info("Kubernetes metricset enriching is disabled")
 		return &nilEnricher{}
@@ -322,7 +330,7 @@ func GetDefaultDisabledMetaConfig() *kubernetesConfig {
 	}
 }
 
-func validatedConfig(base mb.BaseMetricSet) *kubernetesConfig {
+func ValidatedConfig(base mb.BaseMetricSet) *kubernetesConfig {
 	config := kubernetesConfig{
 		AddMetadata:         true,
 		SyncPeriod:          time.Minute * 10,
@@ -522,4 +530,19 @@ func ShouldDelete(event mapstr.M, field string, logger *logp.Logger) {
 	if err != nil {
 		logger.Debugf("Failed to delete field '%s': %s", field, err)
 	}
+}
+
+func GetClusterECSMeta(cfg *conf.C, client k8sclient.Interface, logger *logp.Logger) (mapstr.M, error) {
+	clusterInfo, err := metadata.GetKubernetesClusterIdentifier(cfg, client)
+	if err != nil {
+		return nil, fmt.Errorf("fail to get kubernetes cluster metadata: %w", err)
+	}
+	ecsClusterMeta := mapstr.M{}
+	if clusterInfo.Url != "" {
+		ShouldPut(ecsClusterMeta, "orchestrator.cluster.url", clusterInfo.Url, logger)
+	}
+	if clusterInfo.Name != "" {
+		ShouldPut(ecsClusterMeta, "orchestrator.cluster.name", clusterInfo.Name, logger)
+	}
+	return ecsClusterMeta, nil
 }


### PR DESCRIPTION
## What does this PR do?
Adds metadata for metricsets that were missing. For `volume` we can only add orchestrator related metadata since it's not an actual k8s object.

## Why is it important?
To better filter objects in dashboards and visualisations. 

## Screenshots

<img width="1792" alt="Screenshot 2022-05-11 at 2 10 36 PM" src="https://user-images.githubusercontent.com/11754898/167837149-1bd418c9-c0ba-43ea-b938-52690c5061dc.png">
<img width="1792" alt="Screenshot 2022-05-11 at 2 10 16 PM" src="https://user-images.githubusercontent.com/11754898/167837250-7409d689-ed00-4aae-bc85-01343899ecac.png">
<img width="1792" alt="Screenshot 2022-05-11 at 2 22 37 PM" src="https://user-images.githubusercontent.com/11754898/167838170-4c32ad9f-67e9-41b8-95aa-2c274d5fe80a.png">
<img width="1792" alt="Screenshot 2022-05-11 at 2 22 25 PM" src="https://user-images.githubusercontent.com/11754898/167838240-cdb9f313-f580-4f28-b088-066c11669b6d.png">

