### PR TITLE
Fix bug in filtering, cleanup

### DIFF
--- a/libbeat/metric/system/process/process.go
+++ b/libbeat/metric/system/process/process.go
@@ -131,7 +131,7 @@ func ListStates(hostfs resolve.Resolver) ([]ProcState, error) {
 	}
 
 	// actually fetch the PIDs from the OS-specific code
-	_, plist, err := init.FetchPids()
+	_, plist, err := init.FetchPids() //nolint:typecheck // platform-specific code
 	if err != nil {
 		return nil, fmt.Errorf("error gathering PIDs: %w", err)
 	}
@@ -199,7 +199,7 @@ func (procStats *Stats) Get() ([]mapstr.M, []mapstr.M, error) {
 	}
 
 	// actually fetch the PIDs from the OS-specific code
-	pidMap, plist, err := procStats.FetchPids()
+	pidMap, plist, err := procStats.FetchPids() //nolint:typecheck // platform-specific code
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error gathering PIDs: %w", err)
@@ -302,7 +302,7 @@ func (procStats *Stats) pidFill(pid int, filter bool) (ProcState, bool, error) {
 	// Fetch proc state so we can get the name for filtering based on user's filter.
 
 	// OS-specific entrypoint, get basic info so we can at least run matchProcess
-	status, err := GetInfoForPid(procStats.Hostfs, pid)
+	status, err := GetInfoForPid(procStats.Hostfs, pid) //nolint:typecheck // platform-specific code
 	if err != nil {
 		return status, true, fmt.Errorf("GetInfoForPid: %w", err)
 	}
@@ -319,7 +319,7 @@ func (procStats *Stats) pidFill(pid int, filter bool) (ProcState, bool, error) {
 	}
 
 	//If we've passed the filter, continue to fill out the rest of the metrics
-	status, err = FillPidMetrics(procStats.Hostfs, pid, status, procStats.isWhitelistedEnvVar)
+	status, err = FillPidMetrics(procStats.Hostfs, pid, status, procStats.isWhitelistedEnvVar) //nolint:typecheck // platform-specific code
 	if err != nil {
 		return status, true, fmt.Errorf("FillPidMetrics: %w", err)
 	}

--- a/libbeat/metric/system/process/process_aix.go
+++ b/libbeat/metric/system/process/process_aix.go
@@ -26,8 +26,6 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/metric/system/resolve"
 	"github.com/elastic/beats/v7/libbeat/opt"
 )
@@ -44,7 +42,7 @@ func (procStats *Stats) FetchPids() (ProcsMap, []ProcState, error) {
 		// getprocs first argument is a void*
 		num, err := C.getprocs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, nil, 0, &pid, 1)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "error fetching PIDs")
+			return nil, nil, fmt.Errorf("error fetching PIDs: %w", err)
 		}
 		procMap, plist = procStats.pidIter(int(info.pi_pid), procMap, plist)
 
@@ -62,7 +60,7 @@ func GetInfoForPid(_ resolve.Resolver, pid int) (ProcState, error) {
 
 	num, err := C.getprocs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, nil, 0, &cpid, 1)
 	if err != nil {
-		return ProcState{}, errors.Wrap(err, "error in getprocs")
+		return ProcState{}, fmt.Errorf("error in getprocs: %w", err)
 	}
 	if num != 1 {
 		return ProcState{}, syscall.ESRCH
@@ -110,7 +108,7 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 
 	num, err := C.getprocs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, nil, 0, &cpid, 1)
 	if err != nil {
-		return state, errors.Wrap(err, "error in getprocs")
+		return state, fmt.Errorf("error in getprocs: %w", err)
 	}
 	if num != 1 {
 		return state, syscall.ESRCH
@@ -131,7 +129,7 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 	info.pi_pid = C.pid_t(pid)
 
 	if _, err := C.getargs(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, (*C.char)(&buf[0]), 8192); err != nil {
-		return state, errors.Wrap(err, "error in gitargs")
+		return state, fmt.Errorf("error in gitargs: %w", err)
 	}
 
 	bbuf := bytes.NewBuffer(buf)
@@ -143,7 +141,7 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 			break
 		}
 		if err != nil {
-			return state, errors.Wrap(err, "error reading args buffer")
+			return state, fmt.Errorf("error reading args buffer: %w", err)
 		}
 
 		args = append(args, stripNullByte(arg))
@@ -155,7 +153,7 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 	buf = make([]byte, 8192)
 
 	if _, err := C.getevars(unsafe.Pointer(&info), C.sizeof_struct_procsinfo64, (*C.char)(&buf[0]), 8192); err != nil {
-		return state, errors.Wrap(err, "error in getevars")
+		return state, fmt.Errorf("error in getevars: %w", err)
 	}
 
 	if state.Env != nil {
@@ -171,12 +169,12 @@ func FillPidMetrics(_ resolve.Resolver, pid int, state ProcState, filter func(st
 			break
 		}
 		if err != nil {
-			return state, errors.Wrap(err, "error")
+			return state, fmt.Errorf("error: %w", err)
 		}
 
 		pair := bytes.SplitN(stripNullByteRaw(line), delim, 2)
 		if len(pair) != 2 {
-			return state, errors.Wrap(err, "error reading environment")
+			return state, fmt.Errorf("error reading environment: %w", err)
 		}
 		eKey := string(pair[0])
 		if filter == nil || filter(eKey) {

--- a/libbeat/metric/system/process/process_aix.go
+++ b/libbeat/metric/system/process/process_aix.go
@@ -19,6 +19,7 @@ package process
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/user"

--- a/libbeat/metric/system/process/process_test.go
+++ b/libbeat/metric/system/process/process_test.go
@@ -37,20 +37,17 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-// numCPU is the number of CPUs of the host
-var numCPU = runtime.NumCPU()
-
 func TestGetOne(t *testing.T) {
 	testConfig := Stats{
 		Procs:        []string{".*"},
 		Hostfs:       resolve.NewTestResolver("/"),
-		CPUTicks:     true,
+		CPUTicks:     false,
 		CacheCmdLine: true,
 		EnvWhitelist: []string{".*"},
 		IncludeTop: IncludeTopConfig{
 			Enabled:  true,
 			ByCPU:    4,
-			ByMemory: 4,
+			ByMemory: 0,
 		},
 		EnableCgroups: false,
 		CgroupOpts: cgroup.ReaderOptions{
@@ -61,9 +58,54 @@ func TestGetOne(t *testing.T) {
 	err := testConfig.Init()
 	assert.NoError(t, err, "Init")
 
-	procData, err := testConfig.GetOne(os.Getpid())
+	_, _, err = testConfig.Get()
 	assert.NoError(t, err, "GetOne")
-	t.Logf("Proc: %s", procData.StringToPrint())
+
+	time.Sleep(time.Second * 2)
+
+	procData, _, err := testConfig.Get()
+	assert.NoError(t, err, "GetOne")
+
+	t.Logf("Proc: %s", procData[0].StringToPrint())
+}
+
+func TestFilter(t *testing.T) {
+	//The logic itself is os-independent, so we'll only test this on the platform least likly to have CI issues
+	if runtime.GOOS != "linux" {
+		t.Skip("Run on Linux only")
+	}
+	testConfig := Stats{
+		Procs:  []string{".*"},
+		Hostfs: resolve.NewTestResolver("/"),
+		IncludeTop: IncludeTopConfig{
+			Enabled:  true,
+			ByCPU:    1,
+			ByMemory: 1,
+		},
+	}
+	err := testConfig.Init()
+	assert.NoError(t, err, "Init")
+
+	procData, _, err := testConfig.Get()
+	assert.NoError(t, err, "GetOne")
+	assert.Equal(t, 2, len(procData))
+
+	testZero := Stats{
+		Procs:  []string{".*"},
+		Hostfs: resolve.NewTestResolver("/"),
+		IncludeTop: IncludeTopConfig{
+			Enabled:  true,
+			ByCPU:    0,
+			ByMemory: 1,
+		},
+	}
+
+	err = testZero.Init()
+	assert.NoError(t, err, "Init")
+
+	oneData, _, err := testZero.Get()
+	assert.NoError(t, err, "GetOne with one event")
+	assert.Equal(t, 1, len(oneData))
 }
 
 func TestProcessList(t *testing.T) {
@@ -90,14 +132,14 @@ func TestGetProcess(t *testing.T) {
 	assert.NotEqual(t, "unknown", process.State)
 
 	// Memory Checks
-	assert.True(t, (process.Memory.Size.ValueOr(0) >= 0))
-	assert.True(t, (process.Memory.Rss.Bytes.ValueOr(0) >= 0))
-	assert.True(t, (process.Memory.Share.ValueOr(0) >= 0))
+	assert.True(t, process.Memory.Size.Exists())
+	assert.True(t, (process.Memory.Rss.Bytes.ValueOr(0) > 0))
+	assert.True(t, process.Memory.Share.Exists())
 
 	// CPU Checks
 	assert.True(t, (process.CPU.Total.Value.ValueOr(0) >= 0))
-	assert.True(t, (process.CPU.User.Ticks.ValueOr(0) >= 0))
-	assert.True(t, (process.CPU.System.Ticks.ValueOr(0) >= 0))
+	assert.True(t, process.CPU.User.Ticks.Exists())
+	assert.True(t, process.CPU.System.Ticks.Exists())
 
 	assert.True(t, (process.SampleTime.Unix() <= time.Now().Unix()))
 
@@ -444,7 +486,7 @@ func TestIncludeTopProcesses(t *testing.T) {
 }
 
 func initTestResolver() (Stats, error) {
-	logp.DevelopmentSetup()
+	_ = logp.DevelopmentSetup()
 	testConfig := Stats{
 		Procs:        []string{".*"},
 		Hostfs:       resolve.NewTestResolver("/"),

--- a/libbeat/metric/system/process/process_types.go
+++ b/libbeat/metric/system/process/process_types.go
@@ -113,6 +113,7 @@ func (t ProcFDInfo) IsZero() bool {
 	return t.Open.IsZero() && t.Limit.Hard.IsZero() && t.Limit.Soft.IsZero()
 }
 
+// FormatForRoot shuffles around events to fit in the ECS root fields
 func (p *ProcState) FormatForRoot() ProcStateRootEvent {
 	root := ProcStateRootEvent{}
 
@@ -151,12 +152,12 @@ func (p *ProcState) FormatForRoot() ProcStateRootEvent {
 
 // ProcStateRootEvent represents the "root" beat/agent ECS event fields that are copied from the integration-level event.
 type ProcStateRootEvent struct {
-	Process ProcessRoot `struct:"process,omitempty"`
-	User    Name        `struct:"user,omitempty"`
+	Process ProcRoot `struct:"process,omitempty"`
+	User    Name     `struct:"user,omitempty"`
 }
 
-// ProcessRoot wraps the process metrics for the root ECS fields
-type ProcessRoot struct {
+// ProcRoot wraps the process metrics for the root ECS fields
+type ProcRoot struct {
 	Cmdline string        `struct:"command_line,omitempty"`
 	State   PidState      `struct:"state,omitempty"`
 	CPU     RootCPUFields `struct:"cpu,omitempty"`
@@ -170,14 +171,17 @@ type ProcessRoot struct {
 	Pgid    opt.Int       `struct:"pgid,omitempty"`
 }
 
+// Parent is the wrapper struct for the parent.pid field
 type Parent struct {
 	Pid opt.Int `struct:"pid,omitempty"`
 }
 
+// Name is the wrapper struct for the name.pid field
 type Name struct {
 	Name string `struct:"name,omitempty"`
 }
 
+// RootCPUFields is the wrapper for the cpu.* root fields
 type RootCPUFields struct {
 	StartTime string    `struct:"start_time,omitempty"`
 	Pct       opt.Float `struct:"pct,omitempty"`


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug results in the `top_n` filtering options not being applied in `system/process`, as well as refactors a bunch of components to make the new linter happy.

## Why is it important?

This is an actual bug. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Pull down and build, make sure the `include_top_n` flags work in metricbeat.
