### PR TITLE
Disable goconst and dupl linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,9 +18,9 @@ issues:
   exclude-rules:
     # Exclude package name contains '-' issue because we have at least one package with
     # it on its name.
-    - linters:
+    - text: "ST1003:"
+      linters:
         - stylecheck
-      text: "ST1003:"
     # From mage we are priting to the console to ourselves
     - path: (.*magefile.go|.*dev-tools/mage/.*)
       linters: forbidigo
@@ -42,8 +42,6 @@ linters:
     - deadcode # finds unused code
     - errcheck # checking for unchecked errors in go programs
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - goconst # finds repeated strings that could be replaced by a constant
-    - dupl # tool for code clone detection
     - forbidigo # forbids identifiers	matched by reg exps
     - gosimple # linter for Go source code that specializes in simplifying a code
     - misspell # finds commonly misspelled English words in comments
@@ -54,7 +52,6 @@ linters:
     - stylecheck # a replacement for golint
     - unparam # reports unused function parameters
     - unused # checks Go code for unused constants, variables, functions and types
-
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
     - structcheck # finds unused struct fields
@@ -87,16 +84,6 @@ linters-settings:
     asserts: true
     # Check for plain error comparisons
     comparison: true
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimal occurrences count to trigger
-    min-occurrences: 5
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
 
   forbidigo:
     # Forbid the following identifiers

--- a/dev-tools/templates/.golangci.yml
+++ b/dev-tools/templates/.golangci.yml
@@ -39,8 +39,6 @@ linters:
     - deadcode # finds unused code
     - errcheck # checking for unchecked errors in go programs
     - errorlint # errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - goconst # finds repeated strings that could be replaced by a constant
-    - dupl # tool for code clone detection
     - forbidigo # forbids identifiers	matched by reg exps
     - gosimple # linter for Go source code that specializes in simplifying a code
     - misspell # finds commonly misspelled English words in comments
@@ -51,7 +49,6 @@ linters:
     - stylecheck # a replacement for golint
     - unparam # reports unused function parameters
     - unused # checks Go code for unused constants, variables, functions and types
-
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
     - structcheck # finds unused struct fields
@@ -84,16 +81,6 @@ linters-settings:
     asserts: true
     # Check for plain error comparisons
     comparison: true
-
-  goconst:
-    # minimal length of string constant, 3 by default
-    min-len: 3
-    # minimal occurrences count to trigger
-    min-occurrences: 5
-
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 100
 
   forbidigo:
     # Forbid the following identifiers

--- a/heartbeat/monitors/active/http/checkjson_test.go
+++ b/heartbeat/monitors/active/http/checkjson_test.go
@@ -99,7 +99,7 @@ func TestCheckJsonExpression(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests[6:] { //nolint:dupl // similar to other lines, but with a different type. Not worth refactoring
+	for _, test := range tests[6:] {
 		t.Run(test.description, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintln(w, test.body)
@@ -203,7 +203,7 @@ func TestCheckJsonCondition(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests { //nolint:dupl // similar to other lines, but with a different type. Not worth refactoring
+	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintln(w, test.body)

--- a/packetbeat/protos/sip/plugin.go
+++ b/packetbeat/protos/sip/plugin.go
@@ -260,7 +260,6 @@ func (p *plugin) populateHeadersFields(m *message, evt beat.Event, pbf *pb.Field
 	}
 }
 
-//nolint:dupl // These are not readily refactorable in the short term as the ProtocolFields is constrained to be flat.
 func populateFromFields(m *message, pbf *pb.Fields, fields *ProtocolFields) {
 	if len(m.from) > 0 {
 		displayInfo, uri, params := parseFromToContact(m.from)
@@ -279,7 +278,6 @@ func populateFromFields(m *message, pbf *pb.Fields, fields *ProtocolFields) {
 	}
 }
 
-//nolint:dupl // These are not readily refactorable in the short term as the ProtocolFields is constrained to be flat.
 func populateToFields(m *message, pbf *pb.Fields, fields *ProtocolFields) {
 	if len(m.to) > 0 {
 		displayInfo, uri, params := parseFromToContact(m.to)

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -813,7 +813,7 @@ func paginationHandler() http.HandlerFunc {
 		case 0:
 			_, _ = w.Write([]byte(`{"@timestamp":"2002-10-02T15:00:00Z","nextPageToken":"bar","items":[{"foo":"a"}]}`))
 		case 1:
-			if r.URL.Query().Get("page") != "bar" { //nolint:goconst // Bad linter! Tests should be explicit and local.
+			if r.URL.Query().Get("page") != "bar" {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte(`{"error":"wrong page token value"}`))
 				return

--- a/x-pack/filebeat/input/httpjson/rate_limiter_test.go
+++ b/x-pack/filebeat/input/httpjson/rate_limiter_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:dupl // Bad linter! Tests should be explicit and local.
 package httpjson
 
 import (

--- a/x-pack/filebeat/input/httpjson/transform_append.go
+++ b/x-pack/filebeat/input/httpjson/transform_append.go
@@ -91,7 +91,6 @@ func newAppendPagination(cfg *conf.C, log *logp.Logger) (transform, error) {
 	return &append, nil
 }
 
-//nolint:dupl // Bad linter! Claims duplication with newSet. The duplication exists but is not resolvable without parameterised types.
 func newAppend(cfg *conf.C, log *logp.Logger) (appendt, error) {
 	c := &appendConfig{}
 	if err := cfg.Unpack(c); err != nil {

--- a/x-pack/filebeat/input/httpjson/transform_append_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_append_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:dupl,goconst // Bad linter! Tests should be explicit and local.
 package httpjson
 
 import (

--- a/x-pack/filebeat/input/httpjson/transform_delete_test.go
+++ b/x-pack/filebeat/input/httpjson/transform_delete_test.go
@@ -2,7 +2,6 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
-//nolint:dupl // Bad linter!
 package httpjson
 
 import (

--- a/x-pack/filebeat/input/httpjson/transform_set.go
+++ b/x-pack/filebeat/input/httpjson/transform_set.go
@@ -77,7 +77,6 @@ func newSetResponse(cfg *conf.C, log *logp.Logger) (transform, error) {
 	return &set, nil
 }
 
-//nolint:dupl // Bad linter! Claims duplication with newAppend. The duplication exists but is not resolvable without parameterised types.
 func newSet(cfg *conf.C, log *logp.Logger) (set, error) {
 	c := &setConfig{}
 	if err := cfg.Unpack(c); err != nil {


### PR DESCRIPTION
These linters generate a lot of noise that isn't really worth fixing in the existing beats code. They are better used when writing new code for the first time.

I don't think it would be worth anyones time to go through and fix all the issues they report in the beats repository. The `dupl` linter in particular has a high rate of changes that aren't worth fixing or are false positives.