### PR TITLE
Osquerybeat: Populate host.name field

### DIFF
--- a/x-pack/osquerybeat/cmd/root.go
+++ b/x-pack/osquerybeat/cmd/root.go
@@ -48,7 +48,7 @@ func Osquerybeat() *cmd.BeatsRootCmd {
 	return command
 }
 
-func genVerifyCmd(settings instance.Settings) *cobra.Command {
+func genVerifyCmd(_ instance.Settings) *cobra.Command {
 	return &cobra.Command{
 		Use:   "verify",
 		Short: "Verify installation",

--- a/x-pack/osquerybeat/cmd/root.go
+++ b/x-pack/osquerybeat/cmd/root.go
@@ -37,7 +37,7 @@ var RootCmd = Osquerybeat()
 func Osquerybeat() *cmd.BeatsRootCmd {
 	settings := instance.Settings{
 		Name:            Name,
-		Processing:      processing.MakeDefaultSupport(true, withECSVersion, processing.WithAgentMeta()),
+		Processing:      processing.MakeDefaultSupport(true, withECSVersion, processing.WithHost, processing.WithAgentMeta()),
 		ElasticLicensed: true,
 	}
 	command := cmd.GenRootCmdWithSettings(beater.New, settings)


### PR DESCRIPTION
## What does this PR do?

Populates host.name field in the beats output documents.

## Why is it important?

Addresses: https://github.com/elastic/security-team/issues/3572

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## How to test this PR locally

1. Enroll the agent with osquery_manager integration added to the policy
2. Run live query, for example ```select * from osquery_info``` 
3. Verify that the host.name field exists and is populated with value

## Related issues

- Closes https://github.com/elastic/security-team/issues/3572

## Screenshots
<img width="591" alt="Screen Shot 2022-05-12 at 1 59 23 PM" src="https://user-images.githubusercontent.com/872351/168143770-2bd54274-8e3d-47c9-8f4c-04c5883bd82c.png">

