### PR TITLE
Make Beat generator deprecation and removal more obvious in the docs

### DIFF
--- a/libbeat/docs/communitybeats.asciidoc
+++ b/libbeat/docs/communitybeats.asciidoc
@@ -4,25 +4,35 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[community-beats]]
-== Community Beats
+== Community {beats}
 
-Please note that generating new Beats is deprecated since 7.16.
+****
+**Custom Beat generator code no longer available in 8.0 and later**
 
-The open source community has been hard at work developing new Beats. You can check
-out some of them here.
+The custom Beat generator was a helper tool that allowed developers to bootstrap
+their custom {beats}. This tool was deprecated in 7.16 and is no longer
+available starting in 8.0.
+
+Developers can continue to create custom {beats} to address specific and targeted
+use cases. If you need to create a Beat from scratch, you can use the custom
+Beat generator tool available in version 7.16 or 7.17 to generate the custom
+Beat, then upgrade its various components to the 8.x release. 
+****
+
+This page lists some of the {beats} developed by the open source community.
 
 Have a question about developing a community Beat? You can post questions and discuss issues in the
-https://discuss.elastic.co/tags/c/elastic-stack/beats/28/beats-development[Beats discussion forum].
+https://discuss.elastic.co/tags/c/elastic-stack/beats/28/beats-development[{beats} discussion forum].
 
 Have you created a Beat that's not listed? Add the name and description of your Beat to the source document for
-https://github.com/elastic/beats/blob/main/libbeat/docs/communitybeats.asciidoc[Community Beats] and https://help.github.com/articles/using-pull-requests[open a pull request] in the https://github.com/elastic/beats[Beats GitHub repository] to get your change merged. When you're ready, go ahead and https://discuss.elastic.co/c/announcements[announce] your new Beat in the Elastic
+https://github.com/elastic/beats/blob/main/libbeat/docs/communitybeats.asciidoc[Community {beats}] and https://help.github.com/articles/using-pull-requests[open a pull request] in the https://github.com/elastic/beats[{beats} GitHub repository] to get your change merged. When you're ready, go ahead and https://discuss.elastic.co/c/announcements[announce] your new Beat in the Elastic
 discussion forum.
 
 ifndef::dev-guide[]
 Want to contribute? See <<contributing-to-beats>>.
 endif::[]
 
-NOTE: Elastic provides no warranty or support for community-sourced Beats.
+NOTE: Elastic provides no warranty or support for community-sourced {beats}.
 
 [horizontal]
 https://github.com/awormuth/amazonbeat[amazonbeat]:: Reads data from a specified Amazon product.


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/1444

Also replaced "Beats" with "{beats}" because the linter will flag it if we decide to run it against these docs someday.
