### PR TITLE
Fix Winlogbeat registry flush not working

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -75,6 +75,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Fix resource handle leak during event log enrichment. {pull}31504[31504]
 - Sysmon: Drop fields with "-" value (unset) {pull}31556[31556]
+- Fix winlogbeat.registry_flush being ignored. {issue}31666[31666] {pull}31669[31669]
 
 *Functionbeat*
 

--- a/winlogbeat/checkpoint/checkpoint.go
+++ b/winlogbeat/checkpoint/checkpoint.go
@@ -190,7 +190,7 @@ func (c *Checkpoint) PersistState(st EventLogState) {
 }
 
 // persist writes the current state to disk if the in-memory state is dirty.
-func (c *Checkpoint) persist() bool {
+func (c *Checkpoint) persist() bool { //nolint:unparam // ignoring return value for now as long as failure is logged
 	if c.numUpdates == 0 {
 		return false
 	}
@@ -222,7 +222,7 @@ func (c *Checkpoint) flush() error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Failed to flush state to disk. %v", err)
+		return fmt.Errorf("failed to flush state to disk. %w", err)
 	}
 
 	// Sort persisted eventLogs by name.
@@ -243,15 +243,15 @@ func (c *Checkpoint) flush() error {
 	data, err := yaml.Marshal(ps)
 	if err != nil {
 		file.Close()
-		return fmt.Errorf("Failed to flush state to disk. Could not marshal "+
-			"data to YAML. %v", err)
+		return fmt.Errorf("failed to flush state to disk. Could not marshal "+
+			"data to YAML. %w", err)
 	}
 
 	_, err = file.Write(data)
 	if err != nil {
 		file.Close()
-		return fmt.Errorf("Failed to flush state to disk. Could not write to "+
-			"%s. %v", tempFile, err)
+		return fmt.Errorf("failed to flush state to disk. Could not write to "+
+			"%s. %w", tempFile, err)
 	}
 
 	file.Close()

--- a/winlogbeat/checkpoint/checkpoint_test.go
+++ b/winlogbeat/checkpoint/checkpoint_test.go
@@ -75,7 +75,8 @@ func TestWriteTimedFlush(t *testing.T) {
 		return
 	}
 
-	cp, err := NewCheckpoint(file, time.Second)
+	const timeout = 5 * time.Second
+	cp, err := NewCheckpoint(file, timeout)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,12 +84,14 @@ func TestWriteTimedFlush(t *testing.T) {
 
 	// Send update then wait longer than the flush interval and it should be
 	// on disk.
+	start := time.Now()
 	cp.Persist("App", 1, time.Now(), "")
 	eventually(t, func() (bool, error) {
 		ps, err := cp.read()
 		return ps != nil && len(ps.States) > 0, err
-	}, time.Second*15)
-
+	}, 3*timeout)
+	took := time.Since(start)
+	assert.True(t, took >= timeout)
 	ps, err := cp.read()
 	if err != nil {
 		t.Fatal("read failed", err)


### PR DESCRIPTION
## What does this PR do?

Fixes the logic handling Winlogbeat's checkpoint timeout (`winlogbeat.registry_flush`).

Also took the opportunity to refactor the handling of the timeout timer a little so it's only started when it needs to.

## Why is it important?

A mistake was causing the registry to be flushed to disk at each update, causing a lot of disk I/O.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #31666