### PR TITLE
New option `timestamp.precision` to control timestamp precision

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -89,6 +89,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Update to Go 1.17.10 {issue}31636[31636]
 - Add support for nanosecond precision timestamps. {issue}15871[15871] {pull}31553[31553]
+- Add new config option `timestamp.precision` to configure timestamps. {pull}31682[31682]
 
 
 *Auditbeat*

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -141,6 +141,10 @@ auditbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Auditbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -143,7 +143,7 @@ auditbeat.modules:
 
 # Configure the precision of all timestamps in Auditbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1260,6 +1260,10 @@ filebeat.inputs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Filebeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1262,7 +1262,7 @@ filebeat.inputs:
 
 # Configure the precision of all timestamps in Filebeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/filebeat/tests/system/config/filebeat_modules.yml.j2
+++ b/filebeat/tests/system/config/filebeat_modules.yml.j2
@@ -38,3 +38,4 @@ setup.ilm:
   {% endif %}
 {% endif %}
 
+timestamp.precision: nanosecond

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -287,6 +287,10 @@ heartbeat.jobs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Heartbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -289,7 +289,7 @@ heartbeat.jobs:
 
 # Configure the precision of all timestamps in Heartbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -16,7 +16,7 @@
 
 # Configure the precision of all timestamps in {{ .BeatName | title }}.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 {{if not .ExcludeDashboards }}
 #============================== Dashboards =====================================

--- a/libbeat/_meta/config.yml.tmpl
+++ b/libbeat/_meta/config.yml.tmpl
@@ -14,6 +14,10 @@
 #fields:
 #  env: staging
 
+# Configure the precision of all timestamps in {{ .BeatName | title }}.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 {{if not .ExcludeDashboards }}
 #============================== Dashboards =====================================
 # These settings control loading the sample dashboards to the Kibana index. Loading

--- a/libbeat/_meta/config/general.reference.yml.tmpl
+++ b/libbeat/_meta/config/general.reference.yml.tmpl
@@ -23,7 +23,7 @@
 
 # Configure the precision of all timestamps in {{ .BeatName | title }}.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/libbeat/_meta/config/general.reference.yml.tmpl
+++ b/libbeat/_meta/config/general.reference.yml.tmpl
@@ -21,6 +21,10 @@
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in {{ .BeatName | title }}.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -920,7 +920,7 @@ func (b *Beat) registerESIndexManagement() error {
 
 	_, err := elasticsearch.RegisterConnectCallback(b.indexSetupCallback())
 	if err != nil {
-		return fmt.Errorf("failed to register index management with elasticsearch: %+v", err)
+		return fmt.Errorf("failed to register index management with elasticsearch: %w", err)
 	}
 	return nil
 }
@@ -1188,11 +1188,11 @@ func initPaths(cfg *config.C) error {
 	}{}
 
 	if err := cfg.Unpack(&partialConfig); err != nil {
-		return fmt.Errorf("error extracting default paths: %+v", err)
+		return fmt.Errorf("error extracting default paths: %w", err)
 	}
 
 	if err := paths.InitPaths(&partialConfig.Path); err != nil {
-		return fmt.Errorf("error setting default paths: %+v", err)
+		return fmt.Errorf("error setting default paths: %w", err)
 	}
 	return nil
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -129,6 +129,8 @@ type beatConfig struct {
 
 	// Migration config to migration from 6 to 7
 	Migration *config.C `config:"migration.6_to_7"`
+	// TimestampPrecision sets the precision of all timestamps in the Beat.
+	TimestampPrecision *config.C `config:"timestamp_precision"`
 }
 
 var debugf = logp.MakeDebug("beat")
@@ -681,6 +683,8 @@ func (b *Beat) configure(settings Settings) error {
 	if name := b.Config.Name; name != "" {
 		b.Info.Name = name
 	}
+
+	common.SetTimestampPrecision(b.Config.TimestampPrecision)
 
 	if err := configure.Logging(b.Info.Beat, b.Config.Logging); err != nil {
 		return fmt.Errorf("error initializing logging: %w", err)

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -684,7 +684,9 @@ func (b *Beat) configure(settings Settings) error {
 		b.Info.Name = name
 	}
 
-	common.SetTimestampPrecision(b.Config.TimestampPrecision)
+	if err := common.SetTimestampPrecision(b.Config.TimestampPrecision); err != nil {
+		return fmt.Errorf("error setting timestamp precision: %w", err)
+	}
 
 	if err := configure.Logging(b.Info.Beat, b.Config.Logging); err != nil {
 		return fmt.Errorf("error initializing logging: %w", err)

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -130,7 +130,7 @@ type beatConfig struct {
 	// Migration config to migration from 6 to 7
 	Migration *config.C `config:"migration.6_to_7"`
 	// TimestampPrecision sets the precision of all timestamps in the Beat.
-	TimestampPrecision *config.C `config:"timestamp_precision"`
+	TimestampPrecision *config.C `config:"timestamp"`
 }
 
 var debugf = logp.MakeDebug("beat")

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	microsecPrecision TimestampPrecision = iota + 1
-	millisecPrecision
+	millisecPrecision TimestampPrecision = iota + 1
+	microsecPrecision
 	nanosecPrecision
 
 	DefaultTimestampPrecision = millisecPrecision
@@ -44,8 +44,8 @@ const (
 	tsLayoutMicros = "2006-01-02T15:04:05.000000Z"
 	tsLayoutNanos  = "2006-01-02T15:04:05.000000000Z"
 
-	microsecPrecisionFmt = "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
-	millisecPrecisionFmt = "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"
+	millisecPrecisionFmt = "yyyy-MM-dd'T'HH:mm:ss.fff'Z'"
+	microsecPrecisionFmt = "yyyy-MM-dd'T'HH:mm:ss.ffffff'Z'"
 	nanosecPrecisionFmt  = "yyyy-MM-dd'T'HH:mm:ss.fffffffff'Z'"
 )
 
@@ -57,8 +57,8 @@ var (
 	}
 
 	precisions = map[TimestampPrecision]string{
-		microsecPrecision: microsecPrecisionFmt,
 		millisecPrecision: millisecPrecisionFmt,
+		microsecPrecision: microsecPrecisionFmt,
 		nanosecPrecision:  nanosecPrecisionFmt,
 	}
 
@@ -69,6 +69,14 @@ var (
 type Time time.Time
 
 type TimestampPrecision uint8
+
+type TimestampConfig struct {
+	Precision TimestampPrecision `config:"precision"`
+}
+
+func defaultTimestampConfig() TimestampConfig {
+	return TimestampConfig{Precision: DefaultTimestampPrecision}
+}
 
 func (p *TimestampPrecision) Unpack(v string) error {
 	switch v {
@@ -89,13 +97,13 @@ func SetTimestampPrecision(c *conf.C) error {
 		return nil
 	}
 
-	p := DefaultTimestampPrecision
+	p := defaultTimestampConfig()
 	err := c.Unpack(&p)
 	if err != nil {
 		return fmt.Errorf("failed to set timestamp precision: %w", err)
 	}
 
-	timeFormatter = dtfmt.MustNewFormatter(precisions[p])
+	timeFormatter = dtfmt.MustNewFormatter(precisions[p.Precision])
 
 	return nil
 }

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -86,6 +86,10 @@ func (p *TimestampPrecision) Unpack(v string) error {
 }
 
 func SetTimestampPrecision(c *conf.C) error {
+	if c == nil {
+		return nil
+	}
+
 	p := DefaultTimestampPrecision
 	err := c.Unpack(&p)
 	if err != nil {

--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	invalidTimestampPrecision TimestampPrecision = iota
-	microsecPrecision
+	microsecPrecision TimestampPrecision = iota + 1
 	millisecPrecision
 	nanosecPrecision
 

--- a/libbeat/common/datetime_test.go
+++ b/libbeat/common/datetime_test.go
@@ -51,6 +51,16 @@ func TestParseTime(t *testing.T) {
 			Input:  "2015-02-28T11:19:05.112Z",
 			Output: time.Date(2015, time.February, 28, 11, 19, 05, 112*1e6, time.UTC),
 		},
+		// ParseTime must be able to parse microsecond precision timestamps
+		{
+			Input:  "2015-02-28T11:19:05.000001Z",
+			Output: time.Date(2015, time.February, 28, 11, 19, 05, 1000, time.UTC),
+		},
+		// ParseTime must be able to parse nanosecond precision timestamps
+		{
+			Input:  "2015-02-28T11:19:05.000001122Z",
+			Output: time.Date(2015, time.February, 28, 11, 19, 05, 1122, time.UTC),
+		},
 	}
 
 	for _, test := range tests {
@@ -114,7 +124,7 @@ func TestTimeString(t *testing.T) {
 		precisionCfg *conf.C
 		ts           string
 	}{
-		"emtpy config": {
+		"empty config": {
 			nil,
 			"2015-03-01T11:19:05.000Z",
 		},

--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -111,5 +111,5 @@ default is the number of logical CPUs available in the system.
 [float]
 ==== `timestamp.precision`
 
-Configure the precision of all timestamps.
+Configure the precision of all timestamps. By default it is set to microsecond.
 Available options: millisecond, microsecond, nanosecond

--- a/libbeat/docs/generalconfig.asciidoc
+++ b/libbeat/docs/generalconfig.asciidoc
@@ -107,3 +107,9 @@ processors in your config.
 
 Sets the maximum number of CPUs that can be executing simultaneously. The
 default is the number of logical CPUs available in the system.
+
+[float]
+==== `timestamp.precision`
+
+Configure the precision of all timestamps.
+Available options: millisecond, microsecond, nanosecond

--- a/libbeat/outputs/codec/common.go
+++ b/libbeat/outputs/codec/common.go
@@ -34,14 +34,7 @@ func MakeTimestampEncoder() func(*time.Time, structform.ExtVisitor) error {
 // MakeUTCOrLocalTimestampEncoder creates encoder function that formats time into RFC3339 representation
 // with UTC or local timezone in the output (based on localTime boolean parameter).
 func MakeUTCOrLocalTimestampEncoder(localTime bool) func(*time.Time, structform.ExtVisitor) error {
-	var dtPattern string
-	if localTime {
-		dtPattern = "yyyy-MM-dd'T'HH:mm:ss.fffffffffz"
-	} else {
-		dtPattern = "yyyy-MM-dd'T'HH:mm:ss.fffffffff'Z'"
-	}
-
-	formatter, err := dtfmt.NewFormatter(dtPattern)
+	formatter, err := dtfmt.NewFormatter(common.TimestampFormat(localTime))
 	if err != nil {
 		panic(err)
 	}

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1014,6 +1014,10 @@ metricbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Metricbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1016,7 +1016,7 @@ metricbeat.modules:
 
 # Configure the precision of all timestamps in Metricbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -636,6 +636,10 @@ packetbeat.ignore_outgoing: false
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Packetbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -638,7 +638,7 @@ packetbeat.ignore_outgoing: false
 
 # Configure the precision of all timestamps in Packetbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -248,3 +248,7 @@ output.file:
   rotate_every_kb: {{ rotate_every_kb | default(1000) }}
   #number_of_files: 7
 {%- endif %}
+
+{% if timestamp_precision %}
+timestamp.precision: {{ timestamp_precision }}
+{%- endif %}

--- a/packetbeat/tests/system/test_0032_dns.py
+++ b/packetbeat/tests/system/test_0032_dns.py
@@ -13,6 +13,7 @@ class Test(BaseTest):
         """
         self.render_config_template(
             dns_ports=[53],
+            timestamp_precision="nanosecond",
         )
         self.run_packetbeat(pcap="dns_google_com.pcap")
 

--- a/packetbeat/tests/system/test_0050_icmp.py
+++ b/packetbeat/tests/system/test_0050_icmp.py
@@ -4,7 +4,9 @@ from packetbeat import BaseTest
 class Test(BaseTest):
 
     def test_2_pings(self):
-        self.render_config_template()
+        self.render_config_template(
+            timestamp_precision="nanosecond",
+        )
         self.run_packetbeat(pcap="icmp/icmp_2_pings.pcap", debug_selectors=["*"])
         objs = self.read_output()
         assert len(objs) == 2
@@ -24,13 +26,15 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         assert objs[0]["icmp.version"] == 4
-        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.817185Z"
+        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.817Z"
         assert objs[0]["event.duration"] == 20130000
         self.assert_common_fields(objs)
         self.assert_common_icmp4_fields(objs[0])
 
     def test_icmp4_ping_over_vlan(self):
-        self.render_config_template()
+        self.render_config_template(
+            timestamp_precision="nanosecond",
+        )
         self.run_packetbeat(pcap="icmp/icmp4_ping_over_vlan.pcap", debug_selectors=["*"])
         objs = self.read_output()
 
@@ -48,13 +52,15 @@ class Test(BaseTest):
 
         assert len(objs) == 1
         assert objs[0]["icmp.version"] == 6
-        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.872952Z"
+        assert objs[0]["@timestamp"] == "2015-10-19T20:49:23.872Z"
         assert objs[0]["event.duration"] == 16439000
         self.assert_common_fields(objs)
         self.assert_common_icmp6_fields(objs[0])
 
     def test_icmp6_ping_over_vlan(self):
-        self.render_config_template()
+        self.render_config_template(
+            timestamp_precision="nanosecond",
+        )
         self.run_packetbeat(pcap="icmp/icmp6_ping_over_vlan.pcap", debug_selectors=["*"])
         objs = self.read_output()
 

--- a/packetbeat/tests/system/test_0062_cassandra.py
+++ b/packetbeat/tests/system/test_0062_cassandra.py
@@ -26,7 +26,7 @@ class Test(BaseTest):
         assert o["event.dataset"] == "cassandra"
         assert o["event.duration"] == 62453000
         assert o["event.start"] == o["@timestamp"]
-        assert o["event.end"] == "2016-06-28T09:03:53.502299Z"
+        assert o["event.end"] == "2016-06-28T09:03:53.502Z"
         assert o["client.ip"] == "127.0.0.1"
         assert o["client.port"] == 52749
         assert o["client.bytes"] == 133

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -77,6 +77,10 @@ winlogbeat.event_logs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Winlogbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -79,7 +79,7 @@ winlogbeat.event_logs:
 
 # Configure the precision of all timestamps in Winlogbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -197,6 +197,10 @@ auditbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Auditbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -199,7 +199,7 @@ auditbeat.modules:
 
 # Configure the precision of all timestamps in Auditbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3460,6 +3460,10 @@ filebeat.inputs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Filebeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3462,7 +3462,7 @@ filebeat.inputs:
 
 # Configure the precision of all timestamps in Filebeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/filebeat/tests/system/config/filebeat_modules.yml.j2
+++ b/x-pack/filebeat/tests/system/config/filebeat_modules.yml.j2
@@ -25,3 +25,5 @@ setup.kibana.host: {{ kibana_url }}
 {% if kibana_path %}
 setup.dashboards.directory: {{ kibana_path }}
 {% endif %}
+
+timestamp.precision: nanosecond

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -319,6 +319,10 @@ functionbeat.provider.aws.functions:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Functionbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -321,7 +321,7 @@ functionbeat.provider.aws.functions:
 
 # Configure the precision of all timestamps in Functionbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -287,6 +287,10 @@ heartbeat.jobs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Heartbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -289,7 +289,7 @@ heartbeat.jobs:
 
 # Configure the precision of all timestamps in Heartbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1554,7 +1554,7 @@ metricbeat.modules:
 
 # Configure the precision of all timestamps in Metricbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1552,6 +1552,10 @@ metricbeat.modules:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Metricbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -38,6 +38,10 @@ seccomp.enabled: false
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Osquerybeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -40,7 +40,7 @@ seccomp.enabled: false
 
 # Configure the precision of all timestamps in Osquerybeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -636,6 +636,10 @@ packetbeat.ignore_outgoing: false
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Packetbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -638,7 +638,7 @@ packetbeat.ignore_outgoing: false
 
 # Configure the precision of all timestamps in Packetbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -79,6 +79,10 @@ winlogbeat.event_logs:
 # sub-dictionary. Default is false.
 #fields_under_root: false
 
+# Configure the precision of all timestamps in Winlogbeat.
+# Available options: millisecond, microsecond, nanosecond
+#timestamp_precision: millisecond
+
 # Internal queue configuration for buffering events to be published.
 #queue:
   # Queue type by name (default 'mem')

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -81,7 +81,7 @@ winlogbeat.event_logs:
 
 # Configure the precision of all timestamps in Winlogbeat.
 # Available options: millisecond, microsecond, nanosecond
-#timestamp_precision: millisecond
+#timestamp.precision: millisecond
 
 # Internal queue configuration for buffering events to be published.
 #queue:


### PR DESCRIPTION
## What does this PR do?

This PR makes timestamp precision configurable. A new config option is added called `timestamp.precision`. Available options are `millisecond` `microseconds` and `nanosecond`. Default value is `millisecond`.

## Why is it important?

We made nanosecond support default in https://github.com/elastic/beats/pull/31553. But such timestamps require more storage. Thus, we are making it opt-in.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
