### PR TITLE
Automatically update the golangci-lint Go versions

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -24,6 +24,9 @@ echo "Update go version ${GO_RELEASE_VERSION}"
 echo "${GO_RELEASE_VERSION}" > .go-version
 git add .go-version
 
+${SED} -E -e "s#(go:) \"[0-9]+\.[0-9]+\.[0-9]+\"#\1 \"${GO_RELEASE_VERSION}\"#g" .golangci.yml
+git add .golangci.yml
+
 find . -maxdepth 3 -name Dockerfile -print0 |
     while IFS= read -r -d '' line; do
         ${SED} -E -e "s#(FROM golang):[0-9]+\.[0-9]+\.[0-9]+#\1:${GO_RELEASE_VERSION}#g" "$line"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -109,7 +109,7 @@ linters-settings:
 
   gosimple:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.9"
+    go: "1.17.10"
 
   misspell:
     # Correct spellings using locale preferences for US or UK.
@@ -144,12 +144,12 @@ linters-settings:
 
   staticcheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.9"
+    go: "1.17.10"
     checks: ["all"]
 
   stylecheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.9"
+    go: "1.17.10"
     checks: ["all"]
 
   unparam:
@@ -161,4 +161,4 @@ linters-settings:
 
   unused:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.9"
+    go: "1.17.10"


### PR DESCRIPTION
## What does this PR do?

Updates the script used to automatically bump the Go version with a sed command to update the Go version used by the linters.

There is a `mage:updateGoVersion` command but I'm not sure the CI worker used to run this script has Go installed. It definitely doesn't have mage installed, see related failure from https://github.com/elastic/elastic-agent-shipper/pull/39

```
12:22:29  [Pipeline] sh (Prepare changes for elastic-agent-shipper)
12:22:30  + .ci/bump-go-release-version.sh 1.18.2
12:22:30  Update go version 1.18.2
12:22:30  .ci/bump-go-release-version.sh: line 27: mage: command not found
12:22:30  [Pipeline] }
```

## Why is it important?

The Go version of our linters needs to be kept in sync with our build.

## Checklist

~- [ ] My code follows the style guidelines of this project~
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

Run the script to bump the Go version manually.
