### PR TITLE
Memqueue metrics

### DIFF
--- a/libbeat/publisher/queue/memqueue/eventloop.go
+++ b/libbeat/publisher/queue/memqueue/eventloop.go
@@ -121,11 +121,18 @@ func (l *directEventLoop) run() {
 		case req := <-getChan: // consumer asking for next batch
 			l.handleGetRequest(&req)
 
+		case req := <-l.broker.metricChan:
+			l.handleMetricsRequest(&req)
+
 		case schedACKs <- l.pendingACKs:
 			// on send complete list of pending batches has been forwarded -> clear list
 			l.pendingACKs = chanList{}
 		}
 	}
+}
+
+func (l *directEventLoop) handleMetricsRequest(req *metricsRequest) {
+	req.responseChan <- memQueueMetrics{currentQueueSize: len(l.buf.entries)}
 }
 
 // Returns true if the queue is full after handling the insertion request.

--- a/libbeat/publisher/queue/memqueue/internal_api.go
+++ b/libbeat/publisher/queue/memqueue/internal_api.go
@@ -49,3 +49,13 @@ type getResponse struct {
 }
 
 type batchAckMsg struct{}
+
+// Metrics API
+
+type metricsRequest struct {
+	responseChan chan memQueueMetrics
+}
+
+type memQueueMetrics struct {
+	currentQueueSize int
+}


### PR DESCRIPTION
## What does this PR do?

First step towards https://github.com/elastic/beats/issues/31113

This adds the basic framework for reporting queue metrics to the memqueue in libbeat. Right now this only adds the two most basic metrics, as I wanted to get feedback from @faec and make sure I was on the right track before I got into anything more in-depth.

This also appends a somewhat simplistic change to an existing test, which should probably be broken into a separate test on its own later.

## Why is it important?

This helps address the queue metrics defined in https://github.com/elastic/beats/issues/31113

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
