### PR TITLE
ci: publish docker images in the internal docker registry

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -367,7 +367,7 @@ def tagAndPush(Map args = [:]) {
   pushDockerImages(
     registry: env.DOCKER_REGISTRY,
     secret: env.DOCKERELASTIC_SECRET,
-    snapshot: env.SNAPSHOT,
+    snapshot: true,
     version: env.BEAT_VERSION,
     images: images
   )


### PR DESCRIPTION
## What does this PR do?

Publish docker images to the internal docker registry as they are only snapshot based.

## Why is it important?

https://github.com/elastic/beats/pull/31092 introduced a change and the env variable was removed, therefore docker images are not published but only GCP artifacts

## Test

<img width="1684" alt="image" src="https://user-images.githubusercontent.com/2871786/169825285-010f9e9d-0fdf-46e0-ad87-2ef60694b0ed.png">

versus

<img width="1456" alt="image" src="https://user-images.githubusercontent.com/2871786/169825404-c3bba6a5-6462-48fa-9226-5bff6ab43a8d.png">
