### PR TITLE
Small cleaner script

### DIFF
--- a/dev-tools/cleanup_changelog.next.sh
+++ b/dev-tools/cleanup_changelog.next.sh
@@ -1,0 +1,6 @@
+# Source this file from the root of the beats repository
+cat CHANGELOG.asciidoc | perl -n -e'/\{pull\}(\d+)\[(\d+)\]/ && print "{pull}$1\[$2\]\n"' > changelog-exps.txt
+cat CHANGELOG.asciidoc | perl -n -e'/\{issue\}(\d+)\[(\d+)\]/ && print "{issue}$1\[$2\]\n"' >> changelog-exps.txt
+grep -f changelog-exps.txt -F -v CHANGELOG.next.asciidoc > CHANGELOG.next.clean.asciidoc
+mv CHANGELOG.next.clean.asciidoc CHANGELOG.next.asciidoc
+rm changelog-exps.txt


### PR DESCRIPTION
This PR adds a small helper script that helps with forward ports of the changelog.

As PRs and backports as merged in different order in different branches the forward port might not detect all the lines that need to be removed, as they might be in different position / order.

By sourcing this script `. dev-tools/cleanup_changelog_next.sh` from the root of the repository we can remove some of the lines that might have not been picked up by the cherry-pick.

