### PR TITLE
Osquerybeat: Fix curl queries for HTTPS

### DIFF
--- a/x-pack/osquerybeat/beater/install.go
+++ b/x-pack/osquerybeat/beater/install.go
@@ -31,7 +31,7 @@ func installOsqueryWithDir(ctx context.Context, dir string) error {
 	log := logp.NewLogger("osqueryd_install").With("dir", dir)
 	log.Info("Check if osqueryd needs to be installed")
 
-	fn := distro.OsquerydDistroFilename()
+	fp := filepath.Join(dir, distro.OsquerydDistroFilename())
 	var installFunc func(context.Context, string, string, bool) error
 
 	if runtime.GOOS == "darwin" {
@@ -39,16 +39,16 @@ func installOsqueryWithDir(ctx context.Context, dir string) error {
 	}
 
 	installing := false
-	ilog := log.With("file", fn)
+	ilog := log.With("file", fp)
 	if installFunc != nil {
-		exists, err := fileutil.FileExists(fn)
+		exists, err := fileutil.FileExists(fp)
 		if err != nil {
 			ilog.Errorf("Failed to access the install package file, error: %v", err)
 			return err
 		}
 		if exists {
 			ilog.Info("Found install package file, installing")
-			err = installFunc(ctx, fn, dir, true)
+			err = installFunc(ctx, fp, dir, true)
 			if err != nil {
 				ilog.Errorf("Failed to extract from install package, error: %v", err)
 				return err
@@ -65,8 +65,9 @@ func installOsqueryWithDir(ctx context.Context, dir string) error {
 		if runtime.GOOS == "darwin" {
 			osqfn = distro.OsquerydDarwinApp()
 		}
-		flog := log.With("file", osqfn)
-		exists, err := fileutil.FileExists(osqfn)
+		osqfp := filepath.Join(dir, osqfn)
+		flog := log.With("file", osqfp)
+		exists, err := fileutil.FileExists(osqfp)
 		if err != nil {
 			flog.Errorf("Failed to access the file, error: %v", err)
 			return err
@@ -78,7 +79,7 @@ func installOsqueryWithDir(ctx context.Context, dir string) error {
 			return os.ErrNotExist
 		}
 
-		if derr := os.Remove(fn); derr != nil {
+		if derr := os.Remove(fp); derr != nil {
 			ilog.Warn("Failed to delete install package after install")
 		}
 		log.Info("Successfully installed osqueryd")

--- a/x-pack/osquerybeat/internal/distro/distro.go
+++ b/x-pack/osquerybeat/internal/distro/distro.go
@@ -29,10 +29,16 @@ const (
 	osqueryDarwinApp       = "osquery.app"
 	osqueryDarwinPath      = "opt/osquery/lib/" + osqueryDarwinApp
 
-	osqueryLinuxPath = "opt/osquery/bin"
-	osqueryVersion   = "5.2.2"
-	osqueryMSIExt    = ".msi"
-	osqueryPkgExt    = ".pkg"
+	osqueryCertsPEM         = "certs.pem"
+	osqueryCertsPath        = "certs/" + osqueryCertsPEM
+	osqueryLinuxPath        = "opt/osquery/bin"
+	osqueryCertsLinuxPath   = "opt/osquery/share/osquery/certs/" + osqueryCertsPEM
+	osqueryCertsDarwinPath  = "private/var/osquery/certs/" + osqueryCertsPEM
+	osqueryCertsWindowsPath = "osquery/certs/" + osqueryCertsPEM
+
+	osqueryVersion = "5.2.2"
+	osqueryMSIExt  = ".msi"
+	osqueryPkgExt  = ".pkg"
 
 	osqueryDistroDarwinSHA256   = "c1db00554f65a1f240e9c827c73e0a768fbda66475b18bd68786b3a12e04200f"
 	osqueryDistroLinuxSHA256    = "e86e4cec2f941782a6223a09c2e9d7bdc6cfea0e30ba9792056749b0e79f4576"
@@ -80,12 +86,28 @@ func OsquerydPath(dir string) string {
 	return OsquerydPathForOS(runtime.GOOS, dir)
 }
 
+func OsquerydCertsPath(dir string) string {
+	return filepath.Join(dir, osqueryCertsPath)
+}
+
 func OsquerydDarwinDistroPath() string {
 	return osqueryDarwinPath
 }
 
 func OsquerydLinuxDistroPath() string {
 	return OsquerydPath(osqueryLinuxPath)
+}
+
+func OsquerydCertsLinuxDistroPath() string {
+	return osqueryCertsLinuxPath
+}
+
+func OsquerydCertsDarwinDistroPath() string {
+	return osqueryCertsDarwinPath
+}
+
+func OsquerydCertsWindowsDistroPath() string {
+	return osqueryCertsWindowsPath
 }
 
 func OsquerydDistroFilename() string {

--- a/x-pack/osquerybeat/internal/install/install.go
+++ b/x-pack/osquerybeat/internal/install/install.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 
@@ -20,6 +19,10 @@ import (
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/command"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/distro"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/fileutil"
+)
+
+const (
+	payloadPath = "Payload"
 )
 
 func InstallFromPkg(ctx context.Context, srcPkg, dstDir string, force bool) error {
@@ -34,26 +37,14 @@ func InstallFromPkg(ctx context.Context, srcPkg, dstDir string, force bool) erro
 		return err
 	}
 
-	// Copy over the osqueryd from under Payload into the dstDir directory
-	return devtools.Copy(filepath.Join(dir, "Payload", distro.OsquerydDarwinDistroPath()), filepath.Join(dstDir, distro.OsquerydDarwinApp()))
-}
-
-func InstallFromMSI(ctx context.Context, srcMSI, dstDir string, force bool) error {
-	dstfp := filepath.Join(dstDir, distro.OsquerydFilename())
-
-	// Winderz is odd, passing params to msiexec as usual didn't work
-	dir, err := installFromCommon(ctx, srcMSI, dstDir, dstfp, force, "msiexec", `/quiet /a "`+srcMSI+`"`)
-
-	// Remove the directory that was created could have been created by msiexec
-	// In case if the process was killed or finished with error but still left a directory behind
-	defer os.RemoveAll(dir)
-
+	// Copy over certs
+	err = devtools.Copy(filepath.Join(dir, payloadPath, distro.OsquerydCertsDarwinDistroPath()), distro.OsquerydCertsPath(dstDir))
 	if err != nil {
 		return err
 	}
 
-	// Copy over the or osquery.app osqueryd from under osquery/osqueryd into the dstDir directory
-	return devtools.Copy(path.Join(dir, "osquery", distro.OsquerydPath("osqueryd")), dstfp)
+	// Copy over the osqueryd from under Payload into the dstDir directory
+	return devtools.Copy(filepath.Join(dir, payloadPath, distro.OsquerydDarwinDistroPath()), filepath.Join(dstDir, distro.OsquerydDarwinApp()))
 }
 
 func installFromCommon(ctx context.Context, srcfp, dstDir, dstfp string, force bool, name string, arg ...string) (dir string, err error) {

--- a/x-pack/osquerybeat/internal/osqd/args.go
+++ b/x-pack/osquerybeat/internal/osqd/args.go
@@ -85,6 +85,9 @@ var protectedFlags = Flags{
 	// Osquery does not expect that frequent policy/configuration changes
 	// and can tolerate non real-time configuration change application.
 	"config_refresh": 60,
+
+	// certificates to use for curl table for example
+	"tls_server_certs": "certs.pem",
 }
 
 func init() {

--- a/x-pack/osquerybeat/magefile.go
+++ b/x-pack/osquerybeat/magefile.go
@@ -125,6 +125,12 @@ func extractFromMSI() error {
 			return err
 		}
 
+		fmt.Println("copy certs.pem from MSI")
+		err = devtools.Copy(filepath.Join(dip, distro.OsquerydCertsWindowsDistroPath()), distro.OsquerydCertsPath(dip))
+		if err != nil {
+			return err
+		}
+
 		fmt.Println("copy osqueryd.exe from MSI")
 		dp := distro.OsquerydPathForOS(osarch.OS, dip)
 		err = devtools.Copy(filepath.Join(dip, "osquery", "osqueryd", "osqueryd.exe"), dp)

--- a/x-pack/osquerybeat/scripts/mage/distro.go
+++ b/x-pack/osquerybeat/scripts/mage/distro.go
@@ -53,8 +53,7 @@ func FetchOsqueryDistros() error {
 		// Currently the only supported is tar.gz extraction.
 		// There is no good Go library for extraction the cpio compressed "Payload" from Mac OS X .pkg,
 		// the few that I tried are limited and do not work. Maybe something to write for fun when time.
-		// The MSI is tricky as well to do the crossplatform extraction, no good Go library.
-		// So for Mac OS and Winderz the whole distro package is included and extracted
+		// So for Mac OS the whole distro package is included and extracted
 		// on the first run on the platform for now.
 		if fetched || !installFileExists {
 			err = extractOrCopy(osarch, spec)
@@ -162,10 +161,23 @@ func extractOrCopy(osarch distro.OSArch, spec distro.Spec) error {
 		defer os.RemoveAll(tmpdir)
 
 		osdp := distro.OsquerydLinuxDistroPath()
-		if err := tar.ExtractFile(src, tmpdir, osdp); err != nil {
+		osdcp := distro.OsquerydCertsLinuxDistroPath()
+		if err := tar.ExtractFile(src, tmpdir, osdp, osdcp); err != nil {
 			return err
 		}
 
+		// Copy over certs directory
+		certsDir := filepath.Dir(distro.OsquerydCertsPath(dir))
+		err = os.MkdirAll(certsDir, 0750)
+		if err != nil {
+			return err
+		}
+		err = devtools.Copy(filepath.Join(tmpdir, osdcp), distro.OsquerydCertsPath(dir))
+		if err != nil {
+			return err
+		}
+
+		// Copy over the osqueryd binary
 		return devtools.Copy(filepath.Join(tmpdir, osdp), distro.OsquerydPath(dir))
 	}
 	return fmt.Errorf("unsupported file: %s", src)

--- a/x-pack/osquerybeat/scripts/mage/package.go
+++ b/x-pack/osquerybeat/scripts/mage/package.go
@@ -35,5 +35,17 @@ func CustomizePackaging() {
 			Source: filepath.Join(distro.GetDataInstallDir(distro.OSArch{OS: args.OS, Arch: arch}), distFile),
 		}
 		args.Spec.Files[distFile] = packFile
+
+		// Skip packaging certs.pem for darwin
+		if args.OS == "darwin" {
+			continue
+		}
+
+		// Certs
+		certsFile := devtools.PackageFile{
+			Mode:   0640,
+			Source: filepath.Join(distro.GetDataInstallDir(distro.OSArch{OS: args.OS, Arch: arch}), "certs", "certs.pem"),
+		}
+		args.Spec.Files[filepath.Join("certs", "certs.pem")] = certsFile
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Fix curl queries for HTTPS

* Bundle and install certs.pem from the official osquery distribution
* Use `--tls_server_certs` option to point to the locally installed
  certs.pem file.
* Disable `curl` and `carves` table by default. User has an option to
  enable these options with advanced configuration settings.


## Why is it important?

This addresses the issue
https://github.com/elastic/beats/issues/31715
based on the users feedback:
https://discuss.elastic.co/t/osquery-manager-does-not-return-results-from-curl-table/305019

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

1. Add osquery manager integration to the agent policy
2. Execute the query ```SELECT * FROM curl WHERE url = 'https://www.google.com'```
3. Verify that query failed with the error message ```no such table: curl```
4. Enable curl table via the advanced configuration:
<img width="852" alt="Screen Shot 2022-05-23 at 2 49 41 PM" src="https://user-images.githubusercontent.com/872351/169910960-53b74085-ac85-4ed3-b129-66c235405a9b.png">
5. Verify that the query returns result once the policy is applied to the agent (can take few moments depending on many factors)
<img width="1252" alt="Screen Shot 2022-05-23 at 2 43 29 PM" src="https://user-images.githubusercontent.com/872351/169911142-7c570ca9-f691-4616-a6f5-173596f9b0d3.png">



## Related issues

- Closes https://github.com/elastic/beats/issues/31715
