### PR TITLE
[Heartbeat] Add 'playwright_options' browser option

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Add support for `pushed` browser monitor source from the synthetics agent. {pull}31428[31428]
 - Add ARM64 seccomp profile. {issue}31285[31285] {pull}31422[31422]
+- Add new `playwright_options` config for browser monitors. {issue}28197[28196] {pull}31737[31737]
 
 
 *Metricbeat*

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -247,6 +247,13 @@ Example configuration:
 *`match`*:: run only journeys with a name or tags that matches the configured glob
 
 [float]
+[[monitor-browser-playwright-options]]
+==== `playwright_options`
+
+A map of extra options to pass in to the synthetics agent. These are used as the context for the Playwright
+browser object. See https://playwright.dev/docs/api/class-browser#browser-new-context[the playwright browser context docs] for more information.
+
+[float]
 [[monitor-browser-synthetics-args]]
 ==== `synthetics_args`
 

--- a/x-pack/heartbeat/monitors/browser/config.go
+++ b/x-pack/heartbeat/monitors/browser/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Throttling        interface{}                   `config:"throttling"`
 	Screenshots       string                        `config:"screenshots"`
 	SyntheticsArgs    []string                      `config:"synthetics_args"`
+	PlaywrightOpts    map[string]interface{}        `config:"playwright_options"`
 	FilterJourneys    synthexec.FilterJourneyConfig `config:"filter_journeys"`
 	IgnoreHTTPSErrors bool                          `config:"ignore_https_errors"`
 }

--- a/x-pack/heartbeat/monitors/browser/project.go
+++ b/x-pack/heartbeat/monitors/browser/project.go
@@ -89,6 +89,15 @@ func (p *Project) Close() error {
 
 func (p *Project) extraArgs() []string {
 	extraArgs := p.projectCfg.SyntheticsArgs
+	if len(p.projectCfg.PlaywrightOpts) > 0 {
+		s, err := json.Marshal(p.projectCfg.PlaywrightOpts)
+		if err != nil {
+			// This should never happen, if it was parsed as a config it should be serializable
+			logp.L().Warn("could not serialize playwright options '%v': %w", p.projectCfg.PlaywrightOpts, err)
+		} else {
+			extraArgs = append(extraArgs, "--playwright-options", string(s))
+		}
+	}
 	if p.projectCfg.IgnoreHTTPSErrors {
 		extraArgs = append(extraArgs, "--ignore-https-errors")
 	}

--- a/x-pack/heartbeat/monitors/browser/project_test.go
+++ b/x-pack/heartbeat/monitors/browser/project_test.go
@@ -5,6 +5,7 @@
 package browser
 
 import (
+	"encoding/json"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -123,6 +124,14 @@ func TestEmptySource(t *testing.T) {
 }
 
 func TestExtraArgs(t *testing.T) {
+	playWrightOpts := map[string]interface{}{
+		"simpleOption": "simpleValue",
+		"extraHTTPHeaders": map[string]interface{}{
+			"foo": "bar",
+		},
+	}
+	playwrightOptsJsonBytes, err := json.Marshal(playWrightOpts)
+	require.NoError(t, err)
 	tests := []struct {
 		name string
 		cfg  *Config
@@ -181,6 +190,13 @@ func TestExtraArgs(t *testing.T) {
 			"capabilities",
 			&Config{SyntheticsArgs: []string{"--capability", "trace", "ssblocks"}},
 			[]string{"--capability", "trace", "ssblocks"},
+		},
+		{
+			"playwright options",
+			&Config{
+				PlaywrightOpts: playWrightOpts,
+			},
+			[]string{"--playwright-options", string(playwrightOptsJsonBytes)},
 		},
 		{
 			"kitchen sink",


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/28197

Adds the new `playwright_options` browser option.

Tested with the following config manually:

```yaml
- type: browser
  enabled: true
  id: browser-inline
  name: browser-inline
    ignoreHTTPSErrors: true
  throttling:
    download: 1.6
    upload: 0.75
    latency: 150
  source:
    inline:
      script:
        step("load homepage", async () => {
            await page.goto('https://www.elastic.co');
        });
        step("hover over products menu", async () => {
            await page.hover('css=[data-nav-item=products]');
        });
        step("failme", async () => {
            await page.hhover('css=[data-nav-item=products]');
        });
  schedule: "@every 1m"
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
