### PR TITLE
[Heartbeat] Fix formatting error in throttling docs

### DIFF
--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -196,7 +196,7 @@ in two different supported formats.
 -------------------------------------------------------------------------------
 - type: browser
   schedule: '@every 1m'
-  throttling: "1.6d/0.75u/150l"
+  throttling:
     download: 1.6
     upload: 0.75
     latency: 150


### PR DESCRIPTION
https://github.com/elastic/beats/pull/31544/files/0459dfe5489536518971a1c0ddfef416cc0221a0#diff-78caaded11693dea25f1b7170ca2a65ff0720630cd8ff118993893394adebf98 accidentally introduced this formatting error, this fixes it. No changelog necessary, purely docs.


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
