### PR TITLE
Osquerybeat: Address all the new linter complains as of today

### DIFF
--- a/x-pack/osquerybeat/beater/action_handler_test.go
+++ b/x-pack/osquerybeat/beater/action_handler_test.go
@@ -6,7 +6,6 @@ package beater
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -156,8 +155,6 @@ func TestActionHandlerExecute(t *testing.T) {
 					t.Fatal("Unexpected error, got none in the result")
 				}
 			}
-
-			fmt.Println(res)
 			_ = res
 		})
 	}

--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -54,8 +54,8 @@ type ConfigPlugin struct {
 	// and we would not be able to resolve types or ECS mapping or the namespace.
 	newQueryInfoMap queryInfoMap
 
-	// Datastream namesapces map that allows to lookup the namespace per query.
-	// The datastream namespaces map is handled separatelly from query info
+	// Datastream namespaces map that allows to lookup the namespace per query.
+	// The datastream namespaces map is handled separately from query info
 	// because if we delay updating it until the osqueryd config refresh (up to 1 minute, the way we do with queryinfo)
 	// we could be sending data into the datastream with namespace that we don't have permissions meanwhile
 	namespaces map[string]string
@@ -214,7 +214,7 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) (err error) {
 			Query:      qi.Query,
 			ECSMapping: ecsm,
 		}
-		namespaces[name] = p.namespace
+		namespaces[name] = ns
 		queriesCount++
 
 		qi.Snapshot = true

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -161,7 +160,7 @@ func TestFlattenECSMappingEdges(t *testing.T) {
 	// max + 1 depth key map should return error
 	m = generateTestMapping(maxECSMappingDepth+1, "value", 2)
 	_, err = flattenECSMapping(m)
-	if err != ErrECSMappingIsTooDeep {
+	if !errors.Is(err, ErrECSMappingIsTooDeep) {
 		t.Fatalf("expected error: %v", ErrECSMappingIsTooDeep)
 	}
 }
@@ -369,7 +368,6 @@ func TestSet(t *testing.T) {
 
 			diff = cmp.Diff(tc.scfg, scfg)
 			if diff != "" {
-				fmt.Println(scfg)
 				t.Error(diff)
 			}
 

--- a/x-pack/osquerybeat/beater/osquery_runner_test.go
+++ b/x-pack/osquerybeat/beater/osquery_runner_test.go
@@ -59,7 +59,8 @@ func TestOsqueryRunnerCancellable(t *testing.T) {
 
 	runCh := make(chan struct{}, 1)
 
-	runfn := func(ctx context.Context, flags osqd.Flags, inputCh <-chan []config.InputConfig) error {
+	//nolint:unparam // false positive on returning nil error, need this signature
+	runfn := func(ctx context.Context, _ osqd.Flags, _ <-chan []config.InputConfig) error {
 		runCh <- struct{}{}
 		<-ctx.Done()
 		return nil
@@ -77,10 +78,13 @@ func TestOsqueryRunnerCancellable(t *testing.T) {
 	})
 
 	// Sent input that will start the runner function
-	runner.Update(ctx, nil)
+	err := runner.Update(ctx, nil)
+	if err != nil {
+		t.Fatal("failed runner update:", err)
+	}
 
 	// Wait for runner start
-	err := waitForStart(ctx, runCh, to)
+	err = waitForStart(ctx, runCh, to)
 	if err != nil {
 		t.Fatal("failed starting:", err)
 	}
@@ -105,7 +109,8 @@ func TestOsqueryRunnerRestart(t *testing.T) {
 
 	var runs int
 
-	runfn := func(ctx context.Context, flags osqd.Flags, inputCh <-chan []config.InputConfig) error {
+	//nolint:unparam // false positive on returning nil error, need this signature
+	runfn := func(ctx context.Context, _ osqd.Flags, _ <-chan []config.InputConfig) error {
 		runs++
 		runCh <- struct{}{}
 		<-ctx.Done()
@@ -124,10 +129,13 @@ func TestOsqueryRunnerRestart(t *testing.T) {
 	})
 
 	// Sent input that will start the runner function
-	runner.Update(ctx, nil)
+	err := runner.Update(ctx, nil)
+	if err != nil {
+		t.Fatal("failed runner update:", err)
+	}
 
 	// Wait for runner start
-	err := waitForStart(ctx, runCh, to)
+	err = waitForStart(ctx, runCh, to)
 	if err != nil {
 		t.Fatal("failed starting:", err)
 	}
@@ -143,7 +151,10 @@ func TestOsqueryRunnerRestart(t *testing.T) {
 	}
 
 	// Update flags, this should restart the run function
-	runner.Update(ctx, inputConfigs)
+	err = runner.Update(ctx, inputConfigs)
+	if err != nil {
+		t.Fatal("failed runner update:", err)
+	}
 
 	// Should get another run
 	err = waitForStart(ctx, runCh, to)
@@ -152,11 +163,14 @@ func TestOsqueryRunnerRestart(t *testing.T) {
 	}
 
 	// Update with the same flags, should not restart the runner function
-	runner.Update(ctx, inputConfigs)
+	err = runner.Update(ctx, inputConfigs)
+	if err != nil {
+		t.Fatal("failed runner update:", err)
+	}
 
 	// Should timeout on waiting for another run
 	err = waitForStart(ctx, runCh, 300*time.Millisecond)
-	if err != context.DeadlineExceeded {
+	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatal("unexpected error type after update with the same flags:", err)
 	}
 

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -38,8 +38,7 @@ var (
 )
 
 const (
-	scheduledOsqueriesTypesCacheSize = 256 // Default number of queries types kept in memory to avoid fetching GetQueryColumns all the time
-	adhocOsqueriesTypesCacheSize     = 256 // The final cache size equals the number of periodic queries plus this value, in order to have additional cache for ad-hoc queries
+	adhocOsqueriesTypesCacheSize = 256 // The final cache size equals the number of periodic queries plus this value, in order to have additional cache for ad-hoc queries
 
 	// The interval in second for configuration refresh;
 	// osqueryd child process requests configuration from the configuration plugin implemented in osquerybeat
@@ -75,7 +74,7 @@ func New(b *beat.Beat, cfg *conf.C) (beat.Beater, error) {
 
 	c := config.DefaultConfig
 	if err := cfg.Unpack(&c); err != nil {
-		return nil, fmt.Errorf("error reading config file: %v", err)
+		return nil, fmt.Errorf("error reading config file: %w", err)
 	}
 
 	bt := &osquerybeat{
@@ -166,7 +165,7 @@ func (bt *osquerybeat) Run(b *beat.Beat) error {
 	// This way we don't need to persist the configuration for configuration plugin, because osquery is not running until
 	// we have the first valid configuration
 	if len(bt.config.Inputs) > 0 {
-		runner.Update(ctx, bt.config.Inputs)
+		_ = runner.Update(ctx, bt.config.Inputs)
 	}
 
 	// Ensure that all the hooks and actions are ready before starting the Manager
@@ -193,12 +192,15 @@ func (bt *osquerybeat) Run(b *beat.Beat) error {
 				bt.log.Info("osquerybeat context cancelled, exiting")
 				return ctx.Err()
 			case inputConfigs := <-inputConfigCh:
-				bt.pub.Configure(inputConfigs)
+				err = bt.pub.Configure(inputConfigs)
 				if err != nil {
 					bt.log.Errorf("Failed to connect beat publisher client, err: %v", err)
 					return err
 				}
-				runner.Update(ctx, inputConfigs)
+				err = runner.Update(ctx, inputConfigs)
+				if err != nil {
+					bt.log.Errorf("Failed to configure osquery runner, err: %v", err)
+				}
 			}
 		}
 	})
@@ -262,7 +264,7 @@ func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.O
 		}
 		defer cli.Close()
 
-		// Run extensions only after succesful connect, otherwise the extension server fails with windows pipes if the pipe was not created by osqueryd yet
+		// Run extensions only after successful connect, otherwise the extension server fails with windows pipes if the pipe was not created by osqueryd yet
 		g.Go(func() error {
 			return runExtensionServer(ctx, socketPath, configPlugin, loggerPlugin, osqueryTimeout)
 		})

--- a/x-pack/osquerybeat/ext/osquery-extension/main.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/main.go
@@ -45,7 +45,7 @@ var (
 	socket   = flag.String("socket", "", "Path to the extensions UNIX domain socket")
 	timeout  = flag.Int("timeout", 3, "Seconds to wait for autoloaded extensions")
 	interval = flag.Int("interval", 3, "Seconds delay between connectivity checks")
-	verbose  = flag.Bool("verbose", false, "Verbose logging")
+	_        = flag.Bool("verbose", false, "Verbose logging")
 )
 
 func main() {
@@ -74,7 +74,7 @@ func main() {
 		log.Fatalf("Error creating extension: %s\n", err)
 	}
 
-	// Register the tables avaiable for the specific pltaform build
+	// Register the tables available for the specific pltaform build
 	RegisterTables(server)
 
 	if err := server.Run(); err != nil {
@@ -93,15 +93,14 @@ func monitorForParent() {
 	f := func() {
 		ppid := os.Getppid()
 		if ppid <= 1 {
-			fmt.Println("extension process no longer owned by osqueryd, quitting")
+			fmt.Fprintln(os.Stderr, "extension process no longer owned by osqueryd, quitting")
 			os.Exit(1)
 		}
 	}
 
 	f()
 
-	select {
-	case <-ticker.C:
+	for range ticker.C {
 		f()
 	}
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/list.go
@@ -16,6 +16,7 @@ func List(root string) ([]string, error) {
 }
 
 func ListFS(sysfs fs.FS) ([]string, error) {
+	//nolint:prealloc // saving on alloc and not breaking the existing expected behavior
 	var pids []string
 
 	dirs, err := fs.ReadDir(sysfs, "proc")
@@ -31,9 +32,8 @@ func ListFS(sysfs fs.FS) ([]string, error) {
 
 		name := dir.Name()
 		// Check if directory is number
-		_, err := strconv.Atoi(name)
+		_, err = strconv.Atoi(name)
 		if err != nil {
-			err = nil
 			continue
 		}
 		pids = append(pids, name)

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/host_processes.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/tables/host_processes.go
@@ -18,8 +18,6 @@ import (
 )
 
 const (
-	procDir = "/proc"
-
 	// https://groups.google.com/g/fa.linux.kernel/c/JndVy0RgHHI/m/Nu7nkRfZ-c0J
 	// CLK_TCK is 100 on x86. As it has always been. User land should never
 	// care about whatever random value the kernel happens to use for the
@@ -109,12 +107,13 @@ func genProcesses(root string, queryContext table.QueryContext) ([]map[string]st
 }
 
 func dirExists(dirp string) (ok bool, err error) {
-	if stat, err := os.Stat(dirp); err == nil && stat.IsDir() {
+	var stat os.FileInfo
+	if stat, err = os.Stat(dirp); err == nil && stat.IsDir() {
 		ok = true
 	} else if os.IsNotExist(err) {
 		err = nil
 	}
-	return
+	return ok, err
 }
 
 func getProcList(root string, queryContext table.QueryContext) ([]string, error) {
@@ -135,7 +134,7 @@ func getProcList(root string, queryContext table.QueryContext) ([]string, error)
 	}
 
 	pids := make([]string, 0, len(pidset))
-	for pid, _ := range pidset {
+	for pid := range pidset {
 		pids = append(pids, pid)
 	}
 	return pids, nil

--- a/x-pack/osquerybeat/internal/action/action.go
+++ b/x-pack/osquerybeat/internal/action/action.go
@@ -119,5 +119,5 @@ func parseECSMapping(m map[string]interface{}) (ecsm ecs.Mapping, err error) {
 			Value: value,
 		}
 	}
-	return
+	return ecsm, err
 }

--- a/x-pack/osquerybeat/internal/command/command.go
+++ b/x-pack/osquerybeat/internal/command/command.go
@@ -64,8 +64,7 @@ func Execute(ctx context.Context, name string, arg ...string) (out string, err e
 			return "", fmt.Errorf("%s: %w", s, err)
 		}
 	case <-ctx.Done():
-		cmd.Process.Kill()
-		err = ctx.Err()
+		_ = cmd.Process.Kill()
 	}
 
 	return outbuf.String(), nil

--- a/x-pack/osquerybeat/internal/config/watcher.go
+++ b/x-pack/osquerybeat/internal/config/watcher.go
@@ -35,7 +35,7 @@ func (r *reloader) debugLogConfig(cfg *reload.ConfigWithMeta) {
 
 func (r *reloader) Reload(configs []*reload.ConfigWithMeta) error {
 	r.log.Debug("Inputs reloader got configuration update")
-	var inputConfigs []InputConfig
+	inputConfigs := make([]InputConfig, 0)
 	for _, cfg := range configs {
 		var icfg InputConfig
 		err := cfg.Config.Unpack(&icfg)

--- a/x-pack/osquerybeat/internal/ecs/mapping.go
+++ b/x-pack/osquerybeat/internal/ecs/mapping.go
@@ -60,7 +60,7 @@ func (d Doc) Get(key string) (val interface{}, ok bool) {
 	if node != nil {
 		val, ok = node[keys[len(keys)-1]]
 	}
-	return
+	return val, ok
 }
 
 func (d Doc) Set(key string, val interface{}) {

--- a/x-pack/osquerybeat/internal/fileutil/fileutil.go
+++ b/x-pack/osquerybeat/internal/fileutil/fileutil.go
@@ -12,5 +12,5 @@ func FileExists(fp string) (ok bool, err error) {
 	} else if os.IsNotExist(err) {
 		err = nil
 	}
-	return
+	return ok, err
 }

--- a/x-pack/osquerybeat/internal/install/verify.go
+++ b/x-pack/osquerybeat/internal/install/verify.go
@@ -19,7 +19,7 @@ import (
 func execDir() (exedir string, err error) {
 	exefp, err := os.Executable()
 	if err != nil {
-		return exedir, nil
+		return "", err
 	}
 	exedir = filepath.Dir(exefp)
 	return exedir, nil

--- a/x-pack/osquerybeat/internal/install/verify_test.go
+++ b/x-pack/osquerybeat/internal/install/verify_test.go
@@ -31,7 +31,7 @@ func setupFiles(testdataBaseDir string, files []string) (string, error) {
 			return "", err
 		}
 
-		err = ioutil.WriteFile(fp, nil, 0750)
+		err = ioutil.WriteFile(fp, nil, 0600)
 		if err != nil {
 			return "", err
 		}

--- a/x-pack/osquerybeat/internal/osqdcli/client.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client.go
@@ -167,8 +167,7 @@ func (c *Client) withReconnect(ctx context.Context, fn func() error) error {
 	// The current osquery go library github.com/osquery/osquery-go uses the older version of thrift library that
 	// doesn't not wrap the original error, so we have to use this ugly check for the error message suffix here.
 	// The latest version of thrift library is wrapping the error, so adding this check first here.
-	if (errors.As(err, &netErr) && (netErr.Err == syscall.EPIPE || netErr.Err ==
-		syscall.ECONNRESET)) ||
+	if (errors.As(err, &netErr) && (errors.Is(netErr.Err, syscall.EPIPE) || errors.Is(netErr.Err, syscall.ECONNRESET))) ||
 		strings.HasSuffix(err.Error(), " broken pipe") {
 
 		c.log.Debugf("osquery error: %v, reconnect", err)

--- a/x-pack/osquerybeat/internal/osqdcli/retry_test.go
+++ b/x-pack/osquerybeat/internal/osqdcli/retry_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRetryRun(t *testing.T) {
-	logp.Configure(logp.Config{
+	_ = logp.Configure(logp.Config{
 		Level:     logp.DebugLevel,
 		ToStderr:  true,
 		Selectors: []string{"*"},

--- a/x-pack/osquerybeat/main_test.go
+++ b/x-pack/osquerybeat/main_test.go
@@ -24,8 +24,7 @@ func init() {
 }
 
 // Test started when the test binary is started. Only calls main.
-func TestSystem(t *testing.T) {
-
+func TestSystem(_ *testing.T) {
 	if *systemTest {
 		main()
 	}


### PR DESCRIPTION
## What does this PR do?

Address all the new linter complains as of today. 

## Why is it important?

1. Makes the code up to date with the linter requirements
2. Reduces the scope of future PRs when one change in the file would require the author of PR to delintify the whole file. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

