### PR TITLE
Let filebeat tests connect to older ES versions.

### DIFF
--- a/dev-tools/mage/integtest_docker.go
+++ b/dev-tools/mage/integtest_docker.go
@@ -194,6 +194,11 @@ func WithGoIntegTestHostEnv(env map[string]string) map[string]string {
 	env["REDIS_HOST"] = dockerServiceHostname
 	env["SREDIS_HOST"] = dockerServiceHostname
 	env["LS_HOST"] = dockerServiceHostname
+
+	// Allow connecting to older versions in tests. There can be a delay producing the snapshot
+	// images for the next release after a feature freeze, which causes temporary test failures.
+	env["TESTING_FILEBEAT_ALLOW_OLDER"] = "1"
+
 	return env
 }
 

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -204,5 +204,9 @@ func GoIntegTest(ctx context.Context) error {
 // PythonIntegTest starts the docker containers and executes the Python integration tests.
 func PythonIntegTest(ctx context.Context) error {
 	mg.Deps(Fields, Dashboards, devtools.BuildSystemTestBinary)
-	return devtools.PythonIntegTestFromHost(devtools.DefaultPythonTestIntegrationFromHostArgs())
+	// Allow connecting to older versions in tests. There can be a delay producing the snapshot
+	// images for the next release after a feature freeze, which causes temporary test failures.
+	args := devtools.DefaultPythonTestIntegrationFromHostArgs()
+	args.Env["TESTING_FILEBEAT_ALLOW_OLDER"] = "1"
+	return devtools.PythonIntegTestFromHost(args)
 }

--- a/filebeat/magefile.go
+++ b/filebeat/magefile.go
@@ -204,9 +204,5 @@ func GoIntegTest(ctx context.Context) error {
 // PythonIntegTest starts the docker containers and executes the Python integration tests.
 func PythonIntegTest(ctx context.Context) error {
 	mg.Deps(Fields, Dashboards, devtools.BuildSystemTestBinary)
-	// Allow connecting to older versions in tests. There can be a delay producing the snapshot
-	// images for the next release after a feature freeze, which causes temporary test failures.
-	args := devtools.DefaultPythonTestIntegrationFromHostArgs()
-	args.Env["TESTING_FILEBEAT_ALLOW_OLDER"] = "1"
-	return devtools.PythonIntegTestFromHost(args)
+	return devtools.PythonIntegTestFromHost(devtools.DefaultPythonTestIntegrationFromHostArgs())
 }

--- a/filebeat/tests/system/test_pipeline.py
+++ b/filebeat/tests/system/test_pipeline.py
@@ -43,15 +43,19 @@ class Test(BaseTest):
             pass
         self.wait_until(lambda: not self.es.indices.exists(index_name))
 
+        elasticsearch_config = {
+            'host': self.elasticsearch_url,
+            'pipeline': "estest",
+            'index': index_name,
+            'user': os.getenv("ES_USER"),
+            'pass': os.getenv("ES_PASS")
+        }
+        if os.getenv("TESTING_FILEBEAT_ALLOW_OLDER"):
+            elasticsearch_config["allow_older_versions"] = "true"
+
         self.render_config_template(
             path=os.path.abspath(self.working_dir) + "/log/*",
-            elasticsearch={
-                'host': self.elasticsearch_url,
-                'pipeline': "estest",
-                'index': index_name,
-                'user': os.getenv("ES_USER"),
-                'pass': os.getenv("ES_PASS")
-            },
+            elasticsearch=elasticsearch_config,
             pipeline="test",
             setup_template_name=index_name,
             setup_template_pattern=index_name + "*",

--- a/libbeat/tests/system/config/libbeat.yml.j2
+++ b/libbeat/tests/system/config/libbeat.yml.j2
@@ -87,6 +87,9 @@ output:
   {% if elasticsearch.timeout %}
     timeout: {{elasticsearch.timeout}}
   {% endif %}
+  {% if elasticsearch.allow_older_versions %}
+    allow_older_versions: {{elasticsearch.allow_older_versions}}
+  {% endif %}
 {%- endif %}
 
 {% if logstash %}


### PR DESCRIPTION
Still waiting for 8.4.0 snapshot to be produced, in the meantime the beats version has been bumped to 8.4.0 and the filebeat system tests are all failing trying to connect to the 8.3.0 version of Elasticsearch.

As far as I can tell only the filebeat tests are failing with this problem which is interesting because all the beats should implement the same behaviour connecting to elasticsearch. Likely most of ES interaction is tested in the libbeat system tests using mockbeat that is set to allow older versions by default.
