### PR TITLE
Feature/cache expiration

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -27,7 +27,7 @@ data:
             - config:
                 - module: kubernetes
                   hosts: ["kube-state-metrics:8080"]
-                  period: 10s
+                  period: 3m
                   add_metadata: true
                   metricsets:
                     - state_node
@@ -115,7 +115,7 @@ data:
         - pod
         - container
         - volume
-      period: 10s
+      period: 4m
       host: ${NODE_NAME}
       hosts: ["https://${NODE_NAME}:10250"]
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -72,6 +72,7 @@ data:
       hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
       username: ${ELASTICSEARCH_USERNAME}
       password: ${ELASTICSEARCH_PASSWORD}
+      allow_older_versions: True
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -83,7 +84,7 @@ metadata:
 data:
   system.yml: |-
     - module: system
-      period: 10s
+      period: 1m
       metricsets:
         - cpu
         - load
@@ -115,7 +116,7 @@ data:
         - pod
         - container
         - volume
-      period: 4m
+      period: 3m
       host: ${NODE_NAME}
       hosts: ["https://${NODE_NAME}:10250"]
       bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -156,7 +157,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        # image: docker.elastic.co/beats/metricbeat:8.4.0
+        # image: docker.elastic.co/beats/metricbeat:8.3.0-SNAPSHOT
         image: metricbeat-debugger-image:latest
         imagePullPolicy: Never
         args: [

--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -156,12 +156,18 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: metricbeat
-        image: docker.elastic.co/beats/metricbeat:8.4.0
+        # image: docker.elastic.co/beats/metricbeat:8.4.0
+        image: metricbeat-debugger-image:latest
+        imagePullPolicy: Never
         args: [
           "-c", "/etc/metricbeat.yml",
           "-e",
           "-system.hostfs=/hostfs",
         ]
+        ports:
+          - containerPort: 56268
+            hostPort: 56268
+            protocol: TCP
         env:
         - name: ELASTICSEARCH_HOST
           value: elasticsearch

--- a/metricbeat/Dockerfile.debug
+++ b/metricbeat/Dockerfile.debug
@@ -1,0 +1,28 @@
+FROM golang:alpine3.15 as builder
+
+ENV PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/go/bin:/usr/local/go/bin
+
+ENV CGO_ENABLED=0
+
+RUN apk add --no-cache git
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.3
+
+COPY metricbeat /usr/share/metricbeat/metricbeat
+
+FROM alpine:3.15
+
+ENV PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/go/bin
+
+WORKDIR /usr/share/metricbeat
+
+ENV ELASTICSEARCH_PASSWORD=changeme
+ENV ELASTICSEARCH_USERNAME=elastic
+ENV ELASTICSEARCH_HOST=elasticsearch
+
+COPY --from=builder /go/bin/dlv /go/bin/dlv
+COPY --from=builder /usr/share/metricbeat/metricbeat /usr/share/metricbeat/metricbeat
+
+# dlv exec --headless --listen=:56268 --api-version=2 --log exec ./metricbeat -- -c ./metricbeat.yaml -e
+ENTRYPOINT ["dlv", "--headless=true", "--listen=:56268", "--api-version=2", "--log", "exec", "./metricbeat", "--"]
+
+CMD [ "-e" ]

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -72,6 +72,12 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	if !ok {
 		return nil, fmt.Errorf("must be child of kubernetes module")
 	}
+
+	newTimeout := base.Module().Config().Period * 3
+	if util.PerfMetrics.Timeout < newTimeout {
+		util.PerfMetrics = util.NewPerfMetricsCache(newTimeout)
+	}
+	
 	return &MetricSet{
 		BaseMetricSet: base,
 		http:          http,

--- a/metricbeat/module/kubernetes/container/container.go
+++ b/metricbeat/module/kubernetes/container/container.go
@@ -73,7 +73,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, fmt.Errorf("must be child of kubernetes module")
 	}
 
-	newTimeout := base.Module().Config().Period * 3
+	newTimeout := base.Module().Config().Period * 2
 	if util.PerfMetrics.Timeout < newTimeout {
 		util.PerfMetrics = util.NewPerfMetricsCache(newTimeout)
 	}

--- a/metricbeat/module/kubernetes/container/container_test.go
+++ b/metricbeat/module/kubernetes/container/container_test.go
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 	body, err := ioutil.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
-	cache := util.NewPerfMetricsCache()
+	cache := util.NewPerfMetricsCache(0)
 	cache.NodeCoresAllocatable.Set("gke-beats-default-pool-a5b33e2e-hdww", 2)
 	cache.NodeMemAllocatable.Set("gke-beats-default-pool-a5b33e2e-hdww", 146227200)
 	cache.ContainerMemLimit.Set(util.ContainerUID("default", "nginx-deployment-2303442956-pcqfc", "nginx"), 14622720)

--- a/metricbeat/module/kubernetes/pod/pod_test.go
+++ b/metricbeat/module/kubernetes/pod/pod_test.go
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 	body, err := ioutil.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
-	cache := util.NewPerfMetricsCache()
+	cache := util.NewPerfMetricsCache(0)
 	cache.NodeCoresAllocatable.Set("gke-beats-default-pool-a5b33e2e-hdww", 2)
 	cache.NodeMemAllocatable.Set("gke-beats-default-pool-a5b33e2e-hdww", 146227200)
 	cache.ContainerMemLimit.Set(util.ContainerUID("default", "nginx-deployment-2303442956-pcqfc", "nginx"), 14622720)

--- a/metricbeat/module/kubernetes/util/metrics_cache.go
+++ b/metricbeat/module/kubernetes/util/metrics_cache.go
@@ -39,12 +39,13 @@ func NewPerfMetricsCache(timeout time.Duration) *PerfMetricsCache {
 	}
 
 	return &PerfMetricsCache{
-		Timeout: timeout,
 		NodeMemAllocatable:   newValueMap(timeout),
 		NodeCoresAllocatable: newValueMap(timeout),
 
 		ContainerMemLimit:   newValueMap(timeout),
 		ContainerCoresLimit: newValueMap(timeout),
+
+		Timeout: timeout,
 	}
 }
 


### PR DESCRIPTION

## What does this PR do?

Make the internal cache used by various kubernetes metricset to never expire so as to avoid missing metrics or calculate incorrect metrics as explained in this issue https://github.com/elastic/beats/issues/31778.

## Why is it important?

It fixes a bug reported by a customer at https://github.com/elastic/sdh-beats/issues/2098

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- [ ] Manually debug behaviour by using the instructions at https://github.com/elastic/beats/pull/31748

## Related issues

Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes [#123](https://github.com/elastic/beats/pull/31748)
- Relates https://github.com/elastic/sdh-beats/issues/2098
