### PR TITLE
Update packages in dockerfile for the Dockerlogbeat

### DIFF
--- a/x-pack/dockerlogbeat/Dockerfile.tmpl
+++ b/x-pack/dockerlogbeat/Dockerfile.tmpl
@@ -1,4 +1,4 @@
 FROM {{ .from }}
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates libc6-compat
 COPY build/plugin/dockerlogbeat /usr/bin/
 


### PR DESCRIPTION
## What does this PR do?

This is a quick fix for https://github.com/elastic/beats/issues/29468 

## Why is it important?

This is a bug, the plugin cannot otherwise initialize itself.

## Checklist

- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

