### PR TITLE
Update monitoring-metricbeat.asciidoc

### DIFF
--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -100,7 +100,7 @@ http.host: xxx.xxx.xxx.xxx
 +
 --
 // tag::set-cluster-uuid[]
-To see the Beats monitoring section in Kibana if you have a cluster, you need to associate the {beatname_uc} with cluster UUID:
+Cluster UUID is necessary if you want to see beats monitoring in Kibana stack monitoring view. It will be grouped under the cluster for that uuid. To see the Beats monitoring section in Kibana if you have a cluster, you need to associate the {beatname_uc} with cluster UUID.  :
 
 [source,yaml]
 ----------------------------------

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -96,7 +96,7 @@ http.host: xxx.xxx.xxx.xxx
 // end::set-http-host[]
 --
 
-. Configure cluster uuid (optional). +
+. Configure cluster UUID. +
 +
 --
 // tag::set-cluster-uuid[]

--- a/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -100,7 +100,7 @@ http.host: xxx.xxx.xxx.xxx
 +
 --
 // tag::set-cluster-uuid[]
-Cluster UUID is necessary if you want to see beats monitoring in Kibana stack monitoring view. It will be grouped under the cluster for that uuid. To see the Beats monitoring section in Kibana if you have a cluster, you need to associate the {beatname_uc} with cluster UUID.  :
+The cluster UUID is necessary if you want to see {beats} monitoring in the {kib} stack monitoring view. The monitoring data will be grouped under the cluster for that UUID. To associate {beatname_uc} with the cluster UUID, set:
 
 [source,yaml]
 ----------------------------------


### PR DESCRIPTION
This is miss leading, cluster_uuid, is required to be able to see the monitoring data. It will only in kibana stack monitoring view if it is assigned a cluster_uuid to group the beats under.  So, requires a cluster_uuid. If not the data has empty cluster_uuid and will not be visible in stack monitoring area.  Index populate just not visibile in SM UI

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
