### PR TITLE
Add v1.24 k8s version in testing list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,8 @@ pipeline {
     SNAPSHOT = 'true'
     TERRAFORM_VERSION = "0.13.7"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
-    KIND_VERSION = 'v0.12.0'
-    K8S_VERSION = 'v1.23.4'
+    KIND_VERSION = 'v0.14.0'
+    K8S_VERSION = 'v1.24.0'
   }
   options {
     timeout(time: 6, unit: 'HOURS')

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: checks
     k8sTest:
-        k8sTest: "v1.23.4,v1.22.7,v1.21.10"
+        k8sTest: "v1.24.0,v1.23.6,v1.22.9,v1.21.12"
         stage: mandatory

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -157,7 +157,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.21.x, 1.22.x, 1.23.x
+1.21.x, 1.22.x, 1.23.x, 1.24.x
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -146,7 +146,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.21.x, 1.22.x, 1.23.x
+1.21.x, 1.22.x, 1.23.x, 1.24.x
 
 [float]
 === Dashboard


### PR DESCRIPTION
## What does this PR do?

Adds the new version of `v1.24.0` in the list of the supported/tested versions.

Part of https://github.com/elastic/observability-dev/issues/2178.