### PR TITLE
Change library used by libbeat queue metrics

### DIFF
--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -23,10 +23,10 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/feature"
-	"github.com/elastic/beats/v7/libbeat/opt"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	c "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/opt"
 )
 
 const (

--- a/libbeat/publisher/queue/queue.go
+++ b/libbeat/publisher/queue/queue.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/opt"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/opt"
 )
 
 // Factory for creating a queue used by a pipeline instance.


### PR DESCRIPTION
## What does this PR do?

The only consumer of the queue metrics is currently the shipper, which is using the `opt` type out of `elastic-agent-libs`. This fixes the import to use the correct type.

Theoretically, the `libbeat/opt` should be removed, but this is currently blocking https://github.com/elastic/elastic-agent-shipper/pull/47, so I'd like to unblock that before we go and clean up the rest of the codebase.

