### PR TITLE
[Filebeat] keep track of bytes read when max_bytes exceeded

### DIFF
--- a/libbeat/reader/readfile/line.go
+++ b/libbeat/reader/readfile/line.go
@@ -235,7 +235,7 @@ func (r *LineReader) skipUntilNewLine() (int, error) {
 
 			if idx != -1 {
 				r.inBuffer.Write(r.tempBuffer[idx+len(r.nl) : n])
-				skipped += idx
+				skipped += idx + len(r.nl)
 			} else {
 				skipped += n
 			}

--- a/libbeat/reader/readfile/line_test.go
+++ b/libbeat/reader/readfile/line_test.go
@@ -364,9 +364,13 @@ func TestMaxBytesLimit(t *testing.T) {
 	}
 
 	// Read decodec lines and test
-	var idx int
+	var (
+		idx     int
+		readLen int
+	)
+
 	for i := 0; ; i++ {
-		b, _, err := reader.Next()
+		b, n, err := reader.Next()
 		if err != nil {
 			if err == io.EOF {
 				break
@@ -387,10 +391,15 @@ func TestMaxBytesLimit(t *testing.T) {
 			break
 		}
 
+		readLen += n
 		s := string(b[:len(b)-len(nl)])
 		if line != s {
 			t.Fatalf("lines do not match, expected: %s got: %s", line, s)
 		}
+	}
+
+	if len(input) != readLen {
+		t.Fatalf("the bytes read are not equal to the bytes input, expected: %d got: %d", len(input), readLen)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Newlines also need to be recorded in the skipped characters

## Why is it important?

The skipped newline character is not recorded in the registry when the `max_bytes`(maximum limit of a single line) is exceeded. as the number of long lines increases, it will cause repeated reading problems


The relevant PR is #28352