### PR TITLE
[libbeat] Register uid/gid monitoring metrics asychronously

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -39,7 +39,6 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Allow loading secrets that contain commas from the keystore {pull}31694{pull}.
 - Fix Windows service timeouts when the "TCP/IP NetBIOS Helper" service is disabled. {issue}31810[31810] {pull}31835[31835]
-- Fix an issue that could lead Windows service timeouts. {issue}31810[31810]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Affecting all Beats*
 
 - Allow loading secrets that contain commas from the keystore {pull}31694{pull}.
+- Fix Windows service timeouts when the "TCP/IP NetBIOS Helper" service is disabled. {issue}31810[31810] {pull}31835[31835]
 
 *Auditbeat*
 


### PR DESCRIPTION
## What does this PR do?

This refactors the Beat initialization code to consolidate the metric registration into a
helper method and changes the call to lookup user info (`user.Current()`) to be 
asynchronous from the main initialization goroutine. This prevents the lookup from blocking
the process initialization and delaying the `StartServiceCtrlDispatcher` call that is required
by Windows services within a particular time period.

The user.Current() call can take up to 60 sec in some cases which causes Windows to
timeout the service and kill the process.

Relates #31810

## Why is it important?

It allows Beats to start as a Windows service.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #31810
