### PR TITLE
[libbeat] Modify npipe to get directly get the user SID

### DIFF
--- a/libbeat/api/npipe/listener_windows.go
+++ b/libbeat/api/npipe/listener_windows.go
@@ -22,13 +22,16 @@ package npipe
 
 import (
 	"context"
+	"fmt"
 	"net"
-	"os/user"
 	"strings"
+	"syscall"
 
-	winio "github.com/Microsoft/go-winio"
-	"github.com/pkg/errors"
+	"github.com/Microsoft/go-winio"
 )
+
+// ntAuthoritySystemSID is a well-known SID used by the NT AUTHORITY\SYSTEM account.
+const ntAuthoritySystemSID = "S-1-5-18"
 
 // NewListener creates a new Listener receiving events over a named pipe.
 func NewListener(name, sd string) (net.Listener, error) {
@@ -38,22 +41,18 @@ func NewListener(name, sd string) (net.Listener, error) {
 
 	l, err := winio.ListenPipe(name, c)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to listen on the named pipe %s", name)
+		return nil, fmt.Errorf("failed to listen on the named pipe %s: %w", name, err)
 	}
 
 	return l, nil
 }
 
-// TransformString takes an input type name defined as a URI like `npipe:///hello` and transform it into
-// `\\.\pipe\hello`
+// TransformString takes an input type name defined as a URI like
+// `npipe:///hello` and transforms it into // `\\.\pipe\hello`
 func TransformString(name string) string {
 	if strings.HasPrefix(name, "npipe:///") {
 		path := strings.TrimPrefix(name, "npipe:///")
 		return `\\.\pipe\` + path
-	}
-
-	if strings.HasPrefix(name, `\\.\pipe\`) {
-		return name
 	}
 
 	return name
@@ -73,24 +72,14 @@ func Dial(npipe string) func(string, string) (net.Conn, error) {
 	}
 }
 
-// DefaultSD returns a default SecurityDescriptor which is the minimal required permissions to be
+// DefaultSD returns a default SecurityDescriptor that specifies the minimal required permissions to be
 // able to write to the named pipe. The security descriptor is returned in SDDL format.
 //
 // Docs: https://docs.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
 func DefaultSD(forUser string) (string, error) {
-	var u *user.User
-	var err error
-	// No user configured we fallback to the current running user.
-	if len(forUser) == 0 {
-		u, err = user.Current()
-		if err != nil {
-			return "", errors.Wrap(err, "failed to retrieve the current user")
-		}
-	} else {
-		u, err = user.Lookup(forUser)
-		if err != nil {
-			return "", errors.Wrapf(err, "failed to retrieve the user %s", forUser)
-		}
+	sid, err := lookupSID(forUser)
+	if err != nil {
+		return "", err
 	}
 
 	// Named pipe security and access rights.
@@ -98,12 +87,55 @@ func DefaultSD(forUser string) (string, error) {
 	// See docs: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights
 	// String definition: https://docs.microsoft.com/en-us/windows/win32/secauthz/ace-strings
 	// Give generic read/write access to the specified user.
-	descriptor := "D:P(A;;GA;;;" + u.Uid + ")"
-	if u.Username == "NT AUTHORITY\\SYSTEM" {
+	descriptor := "D:P(A;;GA;;;" + sid + ")"
+	if sid == ntAuthoritySystemSID {
 		// running as SYSTEM, include Administrators group so Administrators can talk over
 		// the named pipe to the running Elastic Agent system process
 		// https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
 		descriptor += "(A;;GA;;;S-1-5-32-544)" // Administrators group
 	}
 	return descriptor, nil
+}
+
+// lookupSID returns the SID of the specified username. If username is empty the
+// SID of the current user is returned.
+func lookupSID(username string) (string, error) {
+	if username == "" {
+		sid, err := currentUserSID()
+		if err != nil {
+			return "", fmt.Errorf("failed to lookup the SID of current user: %w", err)
+		}
+		return sid, nil
+	}
+
+	sid, _, _, err := syscall.LookupSID("", username)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup the SID for user %q: %w", username, err)
+	}
+	sidString, err := sid.String()
+	if err != nil {
+		return "", fmt.Errorf("failed to convert the SID for user %q to string: %w", username, err)
+	}
+	return sidString, nil
+}
+
+// currentUserSID returns the SID of the user running the current process.
+func currentUserSID() (string, error) {
+	t, err := syscall.OpenCurrentProcessToken()
+	if err != nil {
+		return "", err
+	}
+	defer t.Close()
+
+	u, err := t.GetTokenUser()
+	if err != nil {
+		return "", err
+	}
+
+	sid, err := u.User.Sid.String()
+	if err != nil {
+		return "", err
+	}
+
+	return sid, nil
 }


### PR DESCRIPTION
## What does this PR do?

Remove the dependency on user.Current(). It fetches more information than
is required to configure the named pipe. This only needs to know the SID
in order to build the SDDL.

This avoids the possibility of lengthy delays fetching the unnecessary
metadata about the current user.

Relates #31810

## Why is it important?

On Windows, if the "TCP/IP NetBIOS Helper" is disabled then `calling user.Current()` can take up to 60 seconds.
This allows the process to initialize more quickly, and in the case of Agent, the Beat can respond to API requests earlier.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author Checklist

- [ ] Port this change over to elastic/elastic-agent-libs https://github.com/elastic/elastic-agent-libs/blob/main/api/npipe/listener_windows.go

## Related issues

- Relates #31810

