### PR TITLE
[libbeat] Fix flaky TestTimeString/empty_config

### DIFF
--- a/libbeat/common/datetime.go
+++ b/libbeat/common/datetime.go
@@ -104,16 +104,15 @@ func (p *TimestampPrecision) Unpack(v string) error {
 
 // SetTimestampPrecision sets the precision of timestamps in the Beat.
 // It is only supposed to be called during init because it changes
-// the format of the timestamps globally.
+// the format of the timestamps globally. Calling it with a nil value
+// resets it to the default format.
 func SetTimestampPrecision(c *conf.C) error {
-	if c == nil {
-		return nil
-	}
-
 	p := defaultTimestampConfig()
-	err := c.Unpack(&p)
-	if err != nil {
-		return fmt.Errorf("failed to set timestamp precision: %w", err)
+
+	if c != nil {
+		if err := c.Unpack(&p); err != nil {
+			return fmt.Errorf("failed to set timestamp precision: %w", err)
+		}
 	}
 
 	tsFmt = precisions[p.Precision]


### PR DESCRIPTION
## What does this PR do?

The sub-tests are not independent because `common.SetTimestampPrecision`
modifies a global. So this modifies `SetTimestampPrecision` to provide
a way to reset the global value to its default. Now each test
sets the global before executing.

There error was:
```
 === RUN   TestTimeString/empty_config
    datetime_test.go:158:
        	Error Trace:	datetime_test.go:158
        	Error:      	Not equal:
        	            	expected: "2015-03-01T11:19:05.000Z"
        	            	actual  : "2015-03-01T11:19:05.000001Z"
```

## Why is it important?

The test was flaky.

## Testing

You can reproduce the original failure with:

```
go test -count=1000 -run TestTimeString -race ./libbeat/common
```

