### PR TITLE
[Filebeat] keep track of bytes read when max_bytes exceeded in last line

### DIFF
--- a/libbeat/reader/readfile/line.go
+++ b/libbeat/reader/readfile/line.go
@@ -88,7 +88,10 @@ func (r *LineReader) Next() (b []byte, n int, err error) {
 		// read next 'potential' line from input buffer/reader
 		err := r.advance()
 		if err != nil {
-			return nil, 0, err
+			// return and reset consumed bytes count
+			sz := r.byteCount
+			r.byteCount = 0
+			return nil, sz, err
 		}
 
 		// Check last decoded byte really being newline also unencoded

--- a/libbeat/reader/readfile/line_test.go
+++ b/libbeat/reader/readfile/line_test.go
@@ -373,6 +373,7 @@ func TestMaxBytesLimit(t *testing.T) {
 		b, n, err := reader.Next()
 		if err != nil {
 			if err == io.EOF {
+				readLen += n
 				break
 			} else {
 				t.Fatal("unexpected error:", err)


### PR DESCRIPTION
fix this issue #31863 

## What does this PR do?

When the last line exceeds the maximum number of bytes, the text will be skipped directly, and then EOF will be returned, but the length of discarded bytes will not be returned, which will result in not being recorded in the registry, further causing repeated reading problems
