### PR TITLE
[automation] update elastic stack version for testing 8.2.3-a46e98e9

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.3-7def4c60-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.3-a46e98e9-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -32,7 +32,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.2.3-7def4c60-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.2.3-a46e98e9-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -42,7 +42,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.3-7def4c60-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.3-a46e98e9-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 8 Jun 2022 17:14:46 GMT, release_branch:8.2, prefix:, end_time:Wed, 8 Jun 2022 21:22:41 GMT, manifest_version:2.1.0, version:8.2.3-SNAPSHOT, branch:8.2, build_id:8.2.3-a46e98e9, build_duration_seconds:14875]