### PR TITLE
Osquerybeat: Implement namespace info as a part of proc osquery_extension

### DIFF
--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace.go
@@ -1,0 +1,69 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package proc
+
+import (
+	"errors"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrInvalidProcNsPidContent   = errors.New("invalid /proc/ns/pid content")
+	ErrInvalidProcNsPidInoNumber = errors.New("invalid /proc/ns/pid ino number")
+)
+
+type NamespaceInfo struct {
+	Ino string
+}
+
+// ReadStat reads process namespace information from /proc/<pid>/ns/pid.
+// Due to https://github.com/golang/go/issues/49580 implementing without FS.
+func ReadNamespace(root string, pid string) (nsInfo NamespaceInfo, err error) {
+
+	// ReadLink content in order to pull the namespace ino
+	nsLink, err := ReadLink(root, pid, filepath.Join("ns", "pid"))
+	if err != nil {
+		return
+	}
+
+	// Parse the namespace ino from link content
+	nsIno, err := parseNamespaceIno(nsLink)
+	if err != nil {
+		return
+	}
+
+	// Set the parsed ino
+	nsInfo.Ino = nsIno
+
+	return nsInfo, nil
+}
+
+func parseNamespaceIno(nsLink string) (string, error) {
+	// Proc ns pid link example
+	// pid:[4026532605]
+
+	// Split the link content into two parts
+	details := strings.Split(nsLink, ":")
+
+	// Fail if more than two parts and ino isn't wrapped as expected
+	if len(details) != 2 ||
+		!strings.HasSuffix(details[1], "]") ||
+		!strings.HasPrefix(details[1], "[") {
+		return "", ErrInvalidProcNsPidContent
+	}
+
+	// Slice the wrapping from the ino
+	ino := details[1][1 : len(details[1])-1]
+
+	// Check if ino is number
+	_, err := strconv.Atoi(ino)
+	if len(ino) == 0 || err != nil {
+		return "", ErrInvalidProcNsPidInoNumber
+	}
+
+	return ino, nil
+}

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build !windows
+// +build !windows
+
 package proc
 
 import (
@@ -27,7 +30,6 @@ func ReadNamespace(root string, pid string) (nsInfo NamespaceInfo, err error) {
 }
 
 func ReadNamespaceFS(fsys fs.FS, pid string) (nsInfo NamespaceInfo, err error) {
-
 	// Get the namespace stat
 	nsStat, err := getNamespaceStat(fsys, pid)
 	if err != nil {
@@ -38,11 +40,9 @@ func ReadNamespaceFS(fsys fs.FS, pid string) (nsInfo NamespaceInfo, err error) {
 	nsInfo.Ino = nsStat.Ino
 
 	return nsInfo, nil
-
 }
 
 func getNamespaceStat(fsys fs.FS, pid string) (*syscall.Stat_t, error) {
-
 	// Path for the ns pid file
 	fn := filepath.Join("proc", pid, filepath.Join("ns", "pid"))
 
@@ -65,5 +65,4 @@ func getNamespaceStat(fsys fs.FS, pid string) (*syscall.Stat_t, error) {
 	}
 
 	return dsStat, nil
-
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace_test.go
@@ -54,7 +54,6 @@ func TestNamespaceFS(t *testing.T) {
 
 // Used in order to get a mocked syscall.Stat_t structure with assigned ino
 func dummyStat(t *testing.T, ino uint64) *syscall.Stat_t {
-
 	f, err := ioutil.TempFile("", "dummy")
 	if err != nil {
 		t.Fatal(err)
@@ -79,5 +78,4 @@ func dummyStat(t *testing.T, ino uint64) *syscall.Stat_t {
 	mockDsStat.Ino = ino
 
 	return mockDsStat
-
 }

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace_test.go
@@ -8,7 +8,6 @@
 package proc
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -54,16 +53,7 @@ func TestNamespaceFS(t *testing.T) {
 
 // Used in order to get a mocked syscall.Stat_t structure with assigned ino
 func dummyStat(t *testing.T, ino uint64) *syscall.Stat_t {
-	f, err := ioutil.TempFile("", "dummy")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	name := f.Name()
-	defer func() {
-		f.Close()
-		os.Remove(f.Name())
-	}()
+	name := t.TempDir()
 
 	info, err := os.Stat(name)
 	if err != nil {

--- a/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace_test.go
+++ b/x-pack/osquerybeat/ext/osquery-extension/pkg/proc/namespace_test.go
@@ -1,0 +1,86 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !windows
+// +build !windows
+
+package proc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var ino = "26041992"
+
+func TestParseNamespaceIno(t *testing.T) {
+	testCases := []struct {
+		nsLink string
+		assert func(string, error)
+	}{
+		{
+			fmt.Sprintf("pid:[%s]", ino),
+			func(result string, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, result, "26041992")
+			}},
+		{
+			fmt.Sprintf("pid:%s", ino),
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			fmt.Sprintf("pid:[%s", ino),
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			fmt.Sprintf("pid:%s]", ino),
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			fmt.Sprintf("pid[%s]", ino),
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			fmt.Sprintf("pid%s", ino),
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			fmt.Sprintf("pid:[%s]:[%s]", ino, ino),
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			"",
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			"pid:",
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			"pid:[]",
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+		{
+			"pid:[mock]",
+			func(result string, err error) {
+				assert.Error(t, err)
+			}},
+	}
+
+	for _, testCase := range testCases {
+		result, err := parseNamespaceIno(testCase.nsLink)
+		testCase.assert(result, err)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Implements namespace info as a part of our osquery_extension for processes.
The expectation is that the /proc is available in the container under /hostfs as: /hostfs/proc.
Initial code fetches the namespace inode number.

## Why is it important?

Addresses:
- https://github.com/elastic/security-team/issues/3532#issuecomment-1115805066

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

- [ ] Review `namespace.go` file
- [ ] Review `namespace_test.go` file test cases

## How to test this PR locally

I've added local unit tests (`namespace_test.go`) for the parsing functionality.

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^TestNamespaceFS$ github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/proc

=== RUN   TestNamespaceFS
--- PASS: TestNamespaceFS (0.00s)
PASS
ok      github.com/elastic/beats/v7/x-pack/osquerybeat/ext/osquery-extension/pkg/proc   0.675s


> Test run finished at 6/13/2022, 11:18:39 PM <
```

## Related issues

Relates https://github.com/elastic/security-team/issues/3532
Relates https://github.com/elastic/cloudbeat/issues/76
