### PR TITLE
Extend multiline documentation with filestream syntax

### DIFF
--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -38,7 +38,7 @@ parsers:
 
 -------------------------------------------------------------------------------------
 
-If you still use `log` input, there is no need to use `parsers`.
+If you still use the deprecated `log` input, there is no need to use `parsers`.
 
 [source,yaml]
 -------------------------------------------------------------------------------------

--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -29,6 +29,19 @@ The following example shows how to configure {beatname_uc} to handle a multiline
 
 [source,yaml]
 -------------------------------------------------------------------------------------
+parsers:
+- multiline:
+    type: pattern
+    pattern: '^\['
+    negate: true
+    match: after
+
+-------------------------------------------------------------------------------------
+
+If you still use `log` input, there is no need to use `parsers`.
+
+[source,yaml]
+-------------------------------------------------------------------------------------
 multiline.type: pattern
 multiline.pattern: '^\['
 multiline.negate: true
@@ -106,7 +119,19 @@ Exception in thread "main" java.lang.NullPointerException
         at com.example.myproject.Bootstrap.main(Bootstrap.java:14)
 -------------------------------------------------------------------------------------
 
-To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration:
+To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration with `filestream`:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+parsers:
+- multiline:
+    type: pattern
+    pattern: '^[[:space:]]'
+    negate: false
+    match: after
+-------------------------------------------------------------------------------------
+
+Using `log` input:
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -132,6 +157,18 @@ Caused by: java.lang.NullPointerException
 -------------------------------------------------------------------------------------
 
 To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+parsers:
+- multiline:
+    type: pattern
+    pattern: '^[[:space:]]+(at|\.{3})[[:space:]]+\b|^Caused by:'
+    negate: false
+    match: after
+-------------------------------------------------------------------------------------
+
+Using `log` input:
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -162,6 +199,18 @@ To consolidate these lines into a single event in {beatname_uc}, use the followi
 
 [source,yaml]
 -------------------------------------------------------------------------------------
+parsers:
+- multiline:
+    type: pattern
+    pattern: '\\$'
+    negate: false
+    match: before
+-------------------------------------------------------------------------------------
+
+Using `log` input:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
 multiline.type: pattern
 multiline.pattern: '\\$'
 multiline.negate: false
@@ -183,6 +232,18 @@ specific activity, as in this example:
 -------------------------------------------------------------------------------------
 
 To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+parsers:
+- multiline:
+    type: pattern
+    pattern: '^\[[0-9]{4}-[0-9]{2}-[0-9]{2}'
+    negate: true
+    match: after
+-------------------------------------------------------------------------------------
+
+Using `log` input:
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -208,6 +269,19 @@ Sometimes your application logs contain events, that begin and end with custom m
 -------------------------------------------------------------------------------------
 
 To consolidate this as a single event in {beatname_uc}, use the following multiline configuration:
+
+[source,yaml]
+-------------------------------------------------------------------------------------
+parsers:
+- multiline:
+    type: pattern
+    pattern: 'Start new event'
+    negate: true
+    match: after
+    flush_pattern: 'End event'
+-------------------------------------------------------------------------------------
+
+Using `log` input:
 
 [source,yaml]
 -------------------------------------------------------------------------------------

--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -156,7 +156,7 @@ Caused by: java.lang.NullPointerException
        ... 1 more
 -------------------------------------------------------------------------------------
 
-To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration:
+To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration with `filestream`:
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -195,7 +195,7 @@ printf ("%10.10ld  \t %10.10ld \t %s\
   %f", w, x, y, z );
 -------------------------------------------------------------------------------------
 
-To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration:
+To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration with `filestream`:
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -231,7 +231,7 @@ specific activity, as in this example:
 (/dev/disk1)]], net usable_space [34.5gb], net total_space [118.9gb], types [hfs]
 -------------------------------------------------------------------------------------
 
-To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration:
+To consolidate these lines into a single event in {beatname_uc}, use the following multiline configuration with `filestream`:
 
 [source,yaml]
 -------------------------------------------------------------------------------------
@@ -268,7 +268,7 @@ Sometimes your application logs contain events, that begin and end with custom m
 [2015-08-24 11:49:14,399] End event
 -------------------------------------------------------------------------------------
 
-To consolidate this as a single event in {beatname_uc}, use the following multiline configuration:
+To consolidate this as a single event in {beatname_uc}, use the following multiline configuration with `filestream`:
 
 [source,yaml]
 -------------------------------------------------------------------------------------

--- a/filebeat/docs/multiline.asciidoc
+++ b/filebeat/docs/multiline.asciidoc
@@ -25,7 +25,9 @@ You can specify the following options in the +{beatname_lc}.inputs+ section of
 the +{beatname_lc}.yml+ config file to control how {beatname_uc} deals with messages
 that span multiple lines.
 
-The following example shows how to configure {beatname_uc} to handle a multiline message where the first line of the message begins with a bracket (`[`).
+The following example shows how to configure `filestream` input in {beatname_uc} to handle a multiline message where the first line of the message begins with a bracket (`[`).
+
+Please note that the example below only works with `filestream` input, and not with `log` input.
 
 [source,yaml]
 -------------------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

This PR adds `filestream` `parser` configuration to multiline examples.

## Why is it important?

Avoid user confusion.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

Closes https://github.com/elastic/beats/issues/31578
