### PR TITLE
Osquerybeat: Exit osquerybeat process if orphaned

### DIFF
--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -66,6 +66,9 @@ type osquerybeat struct {
 	// Beat lifecycle context, cancelled on Stop
 	cancel context.CancelFunc
 	mx     sync.Mutex
+
+	// parent process watcher
+	watcher *Watcher
 }
 
 // New creates an instance of osquerybeat.
@@ -87,7 +90,7 @@ func New(b *beat.Beat, cfg *conf.C) (beat.Beater, error) {
 	return bt, nil
 }
 
-func (bt *osquerybeat) initContext() (context.Context, error) {
+func (bt *osquerybeat) init() (context.Context, error) {
 	bt.mx.Lock()
 	defer bt.mx.Unlock()
 	if bt.cancel != nil {
@@ -95,6 +98,11 @@ func (bt *osquerybeat) initContext() (context.Context, error) {
 	}
 	var ctx context.Context
 	ctx, bt.cancel = context.WithCancel(context.Background())
+
+	if bt.watcher != nil {
+		bt.watcher.Close()
+	}
+	bt.watcher = NewWatcher(bt.log)
 	return ctx, nil
 }
 
@@ -108,11 +116,18 @@ func (bt *osquerybeat) close() {
 		bt.cancel()
 		bt.cancel = nil
 	}
+
+	// Start watching the parent process.
+	// The beat exits if the process gets orphaned.
+	if bt.watcher != nil {
+		go bt.watcher.Run()
+		bt.watcher = nil
+	}
 }
 
 // Run starts osquerybeat.
 func (bt *osquerybeat) Run(b *beat.Beat) error {
-	ctx, err := bt.initContext()
+	ctx, err := bt.init()
 	if err != nil {
 		return err
 	}

--- a/x-pack/osquerybeat/beater/watcher.go
+++ b/x-pack/osquerybeat/beater/watcher.go
@@ -1,0 +1,79 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beater
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+const watchFrequency = 10 * time.Second
+
+type Watcher struct {
+	log  *logp.Logger
+	ppid int
+
+	mx     sync.Mutex
+	cancel context.CancelFunc
+}
+
+func NewWatcher(log *logp.Logger) *Watcher {
+	w := &Watcher{
+		log:  log,
+		ppid: os.Getppid(),
+	}
+	return w
+}
+
+func (w *Watcher) Start() {
+	go w.Run()
+}
+
+func (w *Watcher) Run() {
+	w.mx.Lock()
+	defer w.mx.Unlock()
+
+	if w.cancel != nil {
+		w.log.Debug("watcher is already running")
+		return
+	}
+
+	var ctx context.Context
+	ctx, w.cancel = context.WithCancel(context.Background())
+
+	ticker := time.NewTicker(watchFrequency)
+	defer ticker.Stop()
+
+	f := func() {
+		ppid := os.Getppid()
+		if ppid != w.ppid {
+			w.log.Errorf("orphaned osquerybeat, expected ppid: %v, found ppid: %v, quitting", w.ppid, ppid)
+			os.Exit(1)
+		}
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			f()
+		case <-ctx.Done():
+			w.log.Info("exit watcher on context done")
+		}
+	}
+}
+
+func (w *Watcher) Close() {
+	w.mx.Lock()
+	defer w.mx.Unlock()
+
+	if w.cancel != nil {
+		w.cancel()
+		w.cancel = nil
+	}
+}

--- a/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
+++ b/x-pack/osquerybeat/internal/osqd/osqueryd_unix.go
@@ -58,5 +58,8 @@ func setpgid() *syscall.SysProcAttr {
 // For clean process tree kill
 func killProcessGroup(cmd *exec.Cmd) error {
 	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	return fmt.Errorf("kill process group %d, %w", cmd.Process.Pid, err)
+	if err != nil {
+		return fmt.Errorf("kill process group %d, %w", cmd.Process.Pid, err)
+	}
+	return nil
 }


### PR DESCRIPTION
## What does this PR do?

Added a parent process watcher to osquerybeat that:
1. Initialized when the osquerybeat start with the parent process ID.
2. Starts checking PPID every 10 seconds(hardcoded) when the beater.Stop is called.
3. Exits osquerybeat process if the PPID doesn't match with the original process ID.

## Why is it important?


This addresses the issue where the Osquerybeat process is left running orphaned when the Agent is uninstalled.
This a workaround to the original issue with libeat, beats managements and beats shutdown, see the link for more details:
https://github.com/elastic/elastic-agent/issues/556

This workaround allows for a fallback for osquerybeat if something gets broken in the shutdown logic up the stack. 

This problem is important to get solved for 8.3 release for osquerybeat.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

1. Install the agent normally for the policy that has "osquery manager" enabled
2. Verify that the agent is running including the child "osquerybeat" process
3. Uninstall the agent.
4. Observe osquerybeat process exited in 10 secs after the beat is stopped by the agent in the worst case scenario.

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/556

## Logs

This is the log entry that is logged when the osquerybeat exits due being orphaned

```
{"log.level":"error","@timestamp":"2022-06-14T15:18:38.631-0400","log.logger":"osquerybeat", "log.origin":{"file.name":"beater/watcher.go","file.line":57},
"message":"orphaned osquerybeat, expected ppid: 88643, found ppid: 1, quitting","service.name":"osquerybeat","ecs.version":"1.6.0"} 
```