### PR TITLE
improve disk queue performance by coalescing writes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,7 +80,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Affecting all Beats*
 
 - Add new config option `timestamp.precision` to configure timestamps. {pull}31682[31682]
-
+- Improve performance of disk queue by coalescing writes. {pull}31935[31935]
 
 *Auditbeat*
 


### PR DESCRIPTION


Improves speed and lowers allocations


## What does this PR do?

Improves speed and lowers allocations in disk queue by coalescing writes.


## Why is it important?

lowers performance cost of using disk queue.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Tested with `libbeat/publisher/queue/diskqueue/benchmark_test.go`

before change
`go test -bench=. -benchtime 1x -count 10 -timeout 120m -benchmem > baseline.txt`

after change
`go test -bench=. -benchtime 1x -count 10 -timeout 120m -benchmem > gather_w.txt`

```
benchstat baseline.txt gather_w.txt
name       old time/op    new time/op    delta
1M_10-16      38.7s ± 2%     21.8s ± 0%  -43.58%  (p=0.000 n=10+7)
1M_100-16     38.7s ± 1%     21.8s ± 1%  -43.74%  (p=0.000 n=10+10)
1M_1k-16      38.6s ± 1%     21.9s ± 1%  -43.36%  (p=0.000 n=10+10)
1M_10k-16     38.7s ± 2%     21.7s ± 0%  -43.78%  (p=0.000 n=10+10)

name       old alloc/op   new alloc/op   delta
1M_10-16     3.47GB ± 0%    3.43GB ± 0%   -1.16%  (p=0.000 n=8+10)
1M_100-16    3.47GB ± 0%    3.43GB ± 0%   -1.17%  (p=0.000 n=10+8)
1M_1k-16     3.47GB ± 0%    3.43GB ± 0%   -1.18%  (p=0.000 n=10+8)
1M_10k-16    3.47GB ± 0%    3.43GB ± 0%   -1.18%  (p=0.000 n=10+10)

name       old allocs/op  new allocs/op  delta
1M_10-16      43.4M ± 0%     40.6M ± 0%   -6.32%  (p=0.000 n=8+10)
1M_100-16     43.4M ± 0%     40.6M ± 0%   -6.42%  (p=0.000 n=10+9)
1M_1k-16      43.4M ± 0%     40.6M ± 0%   -6.49%  (p=0.000 n=10+10)
1M_10k-16     43.4M ± 0%     40.6M ± 0%   -6.49%  (p=0.000 n=10+10)
```

## Related issues

- Relates elastic/elastic-agent-shipper#33 
