### PR TITLE
[Heartbeat] Include cmd/status errs , add ECS Errs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Heartbeat*
 
 - Fix unintentional use of no-op logger. {pull}31543[31543]
+- Send targetted error message for unexpected synthetics exits. {pull}31936[31936]
 
 *Metricbeat*
 

--- a/heartbeat/ecserr/ecserr.go
+++ b/heartbeat/ecserr/ecserr.go
@@ -47,7 +47,7 @@ type SynthErrType string
 
 func NewBadCmdStatusErr(exitCode int, cmd string) *ECSErr {
 	return NewECSErr(
-		ETYPE_IO,
+		"IO",
 		"BAD_CMD_STATUS",
 		fmt.Sprintf("command '%s' exited unexpectedly with code: %d", cmd, exitCode),
 	)

--- a/heartbeat/ecserr/ecserr.go
+++ b/heartbeat/ecserr/ecserr.go
@@ -1,0 +1,54 @@
+package ecserr
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gofrs/uuid"
+)
+
+type ECSErr struct {
+	ID         uuid.UUID `json:"id"`
+	Message    string    `json:"message"`
+	Code       string    `json:"code"`
+	StackTrace string    `json:"stack_trace"`
+	Type       string    `json:"type"`
+}
+
+func NewECSErr(typ string, code string, message string, stackTrace ...string) *ECSErr {
+	id, _ := uuid.NewV4()
+	return &ECSErr{
+		ID:         id,
+		Type:       typ,
+		Code:       code,
+		Message:    message,
+		StackTrace: strings.Join(stackTrace, "\n"),
+	}
+}
+
+func (e *ECSErr) Error() string {
+	// We don't get fancy here because we
+	// want to allow wrapped errors to invoke this without duplicating fields
+	// see wrappers.go for more info on how we set the final errors value for
+	// events.
+	return e.Message
+}
+
+func (e *ECSErr) String() string {
+	// This can be fancy, see note in Error()
+	return fmt.Sprintf("error %s (type='%s', code='%s', id='%s' stacktrace='%s')", e.Message, e.Type, e.Code, e.ID.String(), e.StackTrace)
+}
+
+const (
+	ETYPE_IO = "io"
+)
+
+type SynthErrType string
+
+func NewBadCmdStatusErr(exitCode int, cmd string) *ECSErr {
+	return NewECSErr(
+		ETYPE_IO,
+		"BAD_CMD_STATUS",
+		fmt.Sprintf("command '%s' exited unexpectedly with code: %d", cmd, exitCode),
+	)
+}

--- a/heartbeat/ecserr/ecserr.go
+++ b/heartbeat/ecserr/ecserr.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ecserr
 
 import (

--- a/heartbeat/ecserr/ecserr_test.go
+++ b/heartbeat/ecserr/ecserr_test.go
@@ -1,0 +1,37 @@
+package ecserr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const typ = "mytype"
+const code = "mycode"
+const message = "mymessage"
+
+// A var since it's often used as a pointer
+var stackTrace = "mystacktrace"
+
+func TestEcsErrNewWithStack(t *testing.T) {
+	e := NewECSErrWithStack(typ, code, message, &stackTrace)
+
+	// Ensure that it implments the error interface
+	var eErr error = e
+
+	// check that wrapping it still includes the right message
+	require.Equal(t, message, eErr.Error())
+	require.Equal(t, message, e.Message)
+
+	require.Equal(t, typ, e.Type)
+	require.Equal(t, code, e.Code)
+	require.Equal(t, stackTrace, *e.StackTrace)
+}
+
+func TestEcsErrNew(t *testing.T) {
+	e := NewECSErr(typ, code, message)
+
+	require.Equal(t, message, e.Message)
+	require.Equal(t, typ, e.Type)
+	require.Equal(t, code, e.Code)
+}

--- a/heartbeat/ecserr/ecserr_test.go
+++ b/heartbeat/ecserr/ecserr_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package ecserr
 
 import (

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -692,6 +692,7 @@ func TestECSErrors(t *testing.T) {
 
 	j := WrapCommon([]jobs.Job{makeProjectBrowserJob(t, "http://example.net", true, wrappedEcsErr, projectMonitorValues)}, testBrowserMonFields)
 	event := &beat.Event{}
-	j[0](event)
+	_, err := j[0](event)
+	require.NoError(t, err)
 	require.Equal(t, event.Fields["error"], expectedEcsErr)
 }

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
+	"github.com/elastic/beats/v7/heartbeat/ecserr"
 	"github.com/elastic/beats/v7/heartbeat/eventext"
 	"github.com/elastic/beats/v7/heartbeat/hbtestllext"
 	"github.com/elastic/beats/v7/heartbeat/monitors/jobs"
@@ -678,4 +679,19 @@ func TestProjectBrowserJob(t *testing.T) {
 		nil,
 		nil,
 	})
+}
+
+func TestECSErrors(t *testing.T) {
+	ecse := ecserr.NewBadCmdStatusErr(123, "mycommand")
+	wrappedEcsErr := fmt.Errorf("wrapped: %w", ecse)
+	expectedEcsErr := ecserr.NewECSErr(
+		ecse.Type,
+		ecse.Code,
+		wrappedEcsErr.Error(),
+	)
+
+	j := WrapCommon([]jobs.Job{makeProjectBrowserJob(t, "http://example.net", true, wrappedEcsErr, projectMonitorValues)}, testBrowserMonFields)
+	event := &beat.Event{}
+	j[0](event)
+	require.Equal(t, event.Fields["error"], expectedEcsErr)
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -23,13 +23,12 @@ import (
 type enricher func(event *beat.Event, se *SynthEvent) error
 
 type streamEnricher struct {
-	je        *journeyEnricher
-	sFields   stdfields.StdMonitorFields
-	evtWriter func(se *SynthEvent)
+	je      *journeyEnricher
+	sFields stdfields.StdMonitorFields
 }
 
-func newStreamEnricher(sFields stdfields.StdMonitorFields, evtWriter func(se *SynthEvent)) *streamEnricher {
-	return &streamEnricher{sFields: sFields, evtWriter: evtWriter}
+func newStreamEnricher(sFields stdfields.StdMonitorFields) *streamEnricher {
+	return &streamEnricher{sFields: sFields}
 }
 
 func (senr *streamEnricher) enrich(event *beat.Event, se *SynthEvent) error {

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -116,7 +116,9 @@ func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent) e
 		// when an `afterAll` hook fails, for example, we don't wan't to include
 		// a summary in the cmd/status event.
 		if !je.journeyComplete {
-			je.error = se.Error.toECSErr()
+			if se.Error != nil {
+				je.error = se.Error.toECSErr()
+			}
 			return je.createSummary(event)
 		}
 	case JourneyEnd:

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -604,5 +604,5 @@ func TestCreateSummaryEvent(t *testing.T) {
 }
 
 func makeTestJourneyEnricher(sFields stdfields.StdMonitorFields) *journeyEnricher {
-	return &journeyEnricher{streamEnricher: newStreamEnricher(sFields, func(se *SynthEvent) {})}
+	return &journeyEnricher{streamEnricher: newStreamEnricher(sFields)}
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -141,7 +141,8 @@ func TestJourneyEnricher(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sFields.IsLegacyBrowserSource = tt.IsLegacyBrowserSource
-			je := &journeyEnricher{streamEnricher: &streamEnricher{sFields: sFields}}
+
+			je := makeTestJourneyEnricher(sFields)
 			for _, se := range synthEvents {
 				check(t, se, je)
 			}
@@ -377,7 +378,7 @@ func TestNoSummaryOnAfterHook(t *testing.T) {
 	}
 
 	stdFields := stdfields.StdMonitorFields{}
-	je := &journeyEnricher{streamEnricher: &streamEnricher{sFields: stdFields}}
+	je := makeTestJourneyEnricher(stdFields)
 	for idx, se := range synthEvents {
 		e := &beat.Event{}
 
@@ -439,7 +440,7 @@ func TestSummaryWithoutJourneyEnd(t *testing.T) {
 	hasCmdStatus := false
 
 	stdFields := stdfields.StdMonitorFields{}
-	je := &journeyEnricher{streamEnricher: &streamEnricher{sFields: stdFields}}
+	je := makeTestJourneyEnricher(stdFields)
 	for idx, se := range synthEvents {
 		e := &beat.Event{}
 		t.Run(fmt.Sprintf("event %d", idx), func(t *testing.T) {
@@ -515,7 +516,7 @@ func TestCreateSummaryEvent(t *testing.T) {
 			end:             baseTime.Add(10 * time.Microsecond),
 			journeyComplete: true,
 			errorCount:      1,
-			firstError:      fmt.Errorf("journey errored"),
+			error:           fmt.Errorf("journey errored"),
 		},
 		expected: mapstr.M{
 			"monitor.duration.us": int64(10),
@@ -600,4 +601,8 @@ func TestCreateSummaryEvent(t *testing.T) {
 			}
 		})
 	}
+}
+
+func makeTestJourneyEnricher(sFields stdfields.StdMonitorFields) *journeyEnricher {
+	return &journeyEnricher{streamEnricher: newStreamEnricher(sFields, func(se *SynthEvent) {})}
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -161,7 +161,7 @@ func TestEnrichConsoleSynthEvents(t *testing.T) {
 			"stderr",
 			&journeyEnricher{},
 			&SynthEvent{
-				Type: "stderr",
+				Type: Stderr,
 				Payload: mapstr.M{
 					"message": "Error from synthetics",
 				},
@@ -173,7 +173,7 @@ func TestEnrichConsoleSynthEvents(t *testing.T) {
 						"payload": mapstr.M{
 							"message": "Error from synthetics",
 						},
-						"type":            "stderr",
+						"type":            Stderr,
 						"package_version": "1.0.0",
 						"index":           0,
 					},
@@ -185,7 +185,7 @@ func TestEnrichConsoleSynthEvents(t *testing.T) {
 			"stdout",
 			&journeyEnricher{},
 			&SynthEvent{
-				Type: "stdout",
+				Type: Stdout,
 				Payload: mapstr.M{
 					"message": "debug output",
 				},
@@ -197,7 +197,7 @@ func TestEnrichConsoleSynthEvents(t *testing.T) {
 						"payload": mapstr.M{
 							"message": "debug output",
 						},
-						"type":            "stdout",
+						"type":            Stdout,
 						"package_version": "1.0.0",
 						"index":           0,
 					},

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -83,7 +83,7 @@ func startCmdJob(ctx context.Context, newCmd func() *exec.Cmd, stdinStr *string,
 		if err != nil {
 			return nil, err
 		}
-		senr := newStreamEnricher(sFields, mpx.writeSynthEvent)
+		senr := newStreamEnricher(sFields)
 		return []jobs.Job{readResultsJob(ctx, mpx.SynthEvents(), senr.enrich)}, nil
 	}
 }

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -82,7 +82,7 @@ func startCmdJob(ctx context.Context, newCmd func() *exec.Cmd, stdinStr *string,
 		if err != nil {
 			return nil, err
 		}
-		senr := streamEnricher{sFields: sFields}
+		senr := newStreamEnricher(sFields, mpx.writeSynthEvent)
 		return []jobs.Job{readResultsJob(ctx, mpx.SynthEvents(), senr.enrich)}, nil
 	}
 }
@@ -219,7 +219,7 @@ func runCmd(
 		}
 
 		mpx.writeSynthEvent(&SynthEvent{
-			Type:                 "cmd/status",
+			Type:                 CmdStatus,
 			Error:                cmdError,
 			TimestampEpochMicros: float64(time.Now().UnixMicro()),
 		})

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -257,8 +257,8 @@ func scanToSynthEvents(rdr io.ReadCloser, transform func(bytes []byte, text stri
 	return nil
 }
 
-var stdoutToSynthEvent = lineToSynthEventFactory("stdout")
-var stderrToSynthEvent = lineToSynthEventFactory("stderr")
+var stdoutToSynthEvent = lineToSynthEventFactory(Stdout)
+var stderrToSynthEvent = lineToSynthEventFactory(Stderr)
 
 // lineToSynthEventFactory is a factory that can take a line from the scanner and transform it into a *SynthEvent.
 func lineToSynthEventFactory(typ string) func(bytes []byte, text string) (res *SynthEvent, err error) {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec.go
@@ -212,15 +212,15 @@ func runCmd(
 		jsonReader.Close()
 		logp.Info("Command has completed(%d): %s", cmd.ProcessState.ExitCode(), loggableCmd.String())
 
-		var cmdError *ecserr.ECSErr = nil
+		var cmdError *SynthError = nil
 		if err != nil {
-			cmdError = ecserr.NewBadCmdStatusErr(cmd.ProcessState.ExitCode(), loggableCmd.String())
+			cmdError = ECSErrToSynthError(ecserr.NewBadCmdStatusErr(cmd.ProcessState.ExitCode(), loggableCmd.String()))
 			logp.Warn("Error executing command '%s' (%d): %s", loggableCmd.String(), cmd.ProcessState.ExitCode(), err)
 		}
 
 		mpx.writeSynthEvent(&SynthEvent{
 			Type:                 CmdStatus,
-			Error:                ECSErrToSynthError(cmdError),
+			Error:                cmdError,
 			TimestampEpochMicros: float64(time.Now().UnixMicro()),
 		})
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
@@ -147,10 +147,10 @@ Loop:
 	})
 
 	expectedEventTypes := []string{
-		"journey/start",
-		"step/end",
-		"journey/end",
-		"cmd/status",
+		JourneyStart,
+		StepEnd,
+		JourneyEnd,
+		CmdStatus,
 	}
 	for _, typ := range expectedEventTypes {
 		t.Run(fmt.Sprintf("Should have at least one event of type %s", typ), func(t *testing.T) {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthexec_test.go
@@ -195,7 +195,7 @@ func eventsWithType(typ string, synthEvents []*SynthEvent) (matched []*SynthEven
 			matched = append(matched, se)
 		}
 	}
-	return
+	return matched
 }
 
 func TestProjectCommandFactory(t *testing.T) {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -138,22 +138,31 @@ func (se *SynthError) toECSErr() *ecserr.ECSErr {
 		t = se.Name
 
 	}
-	return ecserr.NewECSErr(
+
+	var stack *string
+	if se.Stack != "" {
+		stack = &se.Stack
+	}
+	return ecserr.NewECSErrWithStack(
 		t,
 		se.Code,
 		se.Message,
-		se.Stack,
+		stack,
 	)
 }
 
 // ECSErrToSynthError does a simple type conversion. Hopefully at
 // some point we can move away from SynthError.
 func ECSErrToSynthError(ee *ecserr.ECSErr) *SynthError {
+	var stack string
+	if ee.StackTrace != nil {
+		stack = *ee.StackTrace
+	}
 	return &SynthError{
 		Type:    ee.Type,
 		Code:    ee.Code,
 		Message: ee.Message,
-		Stack:   ee.StackTrace,
+		Stack:   stack,
 	}
 }
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
+// These constants define all known synthetics event types
 const (
 	JourneyStart       = "journey/start"
 	JourneyEnd         = "journey/end"
@@ -26,8 +27,8 @@ const (
 	StepScreenshot     = "step/screenshot"
 	StepScreenshotRef  = "step/screenshot_ref"
 	ScreenshotBlock    = "screenshot/block"
-	Stdout             = "stdout"
-	Stderr             = "stderr"
+	Stdout             = "stdout" // special type for non-JSON content read off stdout
+	Stderr             = "stderr" // special type for content read off stderr
 )
 
 type SynthEvent struct {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -133,7 +133,7 @@ func (se *SynthError) toMap() mapstr.M {
 func (se *SynthError) toECSErr() *ecserr.ECSErr {
 	// Type is more ECS friendly, so we prefer it
 	t := se.Type
-	if t != "" {
+	if t == "" {
 		// Legacy support for the 'name' field
 		t = se.Name
 
@@ -144,6 +144,17 @@ func (se *SynthError) toECSErr() *ecserr.ECSErr {
 		se.Message,
 		se.Stack,
 	)
+}
+
+// ECSErrToSynthError does a simple type conversion. Hopefully at
+// some point we can move away from SynthError.
+func ECSErrToSynthError(ee *ecserr.ECSErr) *SynthError {
+	return &SynthError{
+		Type:    ee.Type,
+		Code:    ee.Code,
+		Message: ee.Message,
+		Stack:   ee.StackTrace,
+	}
 }
 
 func (se *SynthError) Error() string {

--- a/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/synthtypes.go
@@ -26,6 +26,8 @@ const (
 	StepScreenshot     = "step/screenshot"
 	StepScreenshotRef  = "step/screenshot_ref"
 	ScreenshotBlock    = "screenshot/block"
+	Stdout             = "stdout"
+	Stderr             = "stderr"
 )
 
 type SynthEvent struct {

--- a/x-pack/heartbeat/monitors/browser/synthexec/testcmd/main.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/testcmd/main.go
@@ -15,6 +15,11 @@ func main() {
 	// For sending JSON results
 	pipe := os.NewFile(3, "pipe")
 
+	// Exit immediately to test this error condition
+	if len(os.Args) > 1 && os.Args[1] == "exit" {
+		os.Exit(123)
+	}
+
 	file, err := os.Open("sample.ndjson")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "could not open samplerun.ndjson: %s\n", err)


### PR DESCRIPTION
Fixes #30170 by taking a slightly different approach than previously thought.

We apparently suffered a regression in two places simultaneously:

1. Kibana stopped rendering components like [console output event list](https://github.com/elastic/kibana/blob/main/x-pack/plugins/synthetics/public/legacy_uptime/components/synthetics/console_output_event_list.tsx)
2. Heartbeat didn't really report these in a way that made sense in its schema, choosing between a final `cmd/status` and `summary` event.

This PR fixes the dilemma by always outputting a final summary event, and, in the case of an exit code `> 0` for the synthetics agent, adding a special error to that summary event. When we fix the UI regression we can look for that special error. That being said, I think this is somewhat overkill, for now, after investigating the Kibana UI further. Even with that being the case, I think this improves our error handling by bringing it more inline with ECS, so it's probably still worth merging as-is. See the detailed notes below for more info.

One issue we have here is that our error types are a bit of a mess. We have our standard `error.{type,message}` fields, which the synthetics agent traditionally did not use, in favor of its own `synthetics.error.{name,message,stack}` fields. 

Another problem is that the `error.type` field has always been quite coarse in heartbeat's usage, having only two values `validation` and `io`. One of our longer term aims is to integrate error codes for specific issues. This PR adds all of the ECS defined [error fields](https://www.elastic.co/guide/en/ecs/current/ecs-error.html) as optional in heartbeat. This lets us use a specific code to indicate a `cmd/status` error. See the new `ecserrs` package for more details there.

The implementation here is go-like, but perhaps not entirely intuitive. Heartbeat's continuation based job system has a signature like `type Job func (event) (conts []Job, err error)`, with a wrapper in `wrappers.go` actually filling in the top level `errors` JSON field at exactly one spot. So, we to make it possible to pack all the ECS error fields into a standard go error. This is done by implementing the `error` interface in the new `*ecserrs.ECSError` type, and using `errors.As` from the go stdlib to unpack ECS errors at serialization-time.

This PR also makes the `*SynthErr` type a superset of `*ecserrs.ECSError`, meaning that in the future we can just use ECS format in the synthetics agent for consistency.

A consequence of this work is that errors generated by synthetics will now be dual-indexed in the top level `error` field and the current `synthetics.error` field. Perhaps we can remove this dual storage in GA.

Given that there is no urgent bug here, and that this fix needs supporting Kibana changes to be useful, and that there's a decent amount of code churn here, I'm only targeting this at 8.4, not 8.3

This also moves our synthetic event type names over to constants, which is cleaner.

Finally, check the bottom of this ticket for some manual testing instructions. Ideally we'd have integration tests, but it's not easy to add those for browser monitors. This PR already makes a good number of improvements, and we can't justify the investment there right this minute.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

The following monitor (can be placed in `monitors.d` will the synthetics agent to exit uncleanly and trigger the status code error:

```yaml
- type: browser
  enabled: true
  id: browser-inline
  name: browser-inline
  playwright_options:
    ignoreHTTPSErrors: true
  throttling:
    download: 1.6
    upload: 0.75
    latency: 150
  source:
    inline:
      script:
        step("load homepage", async () => {
            await page.goto('https://www.elastic.co');
        });
        step("hover over products menu", async () => {
            await page.hover('css=[data-nav-item=products]');
        });
        step("failme", async () => {
            process.exit(123)
            await page.hhover('css=[data-nav-item=products]');
        });
  schedule: "@every 1m"
```

Produces the following in kibana

<img width="1658" alt="image" src="https://user-images.githubusercontent.com/131427/173728107-3f92c289-11d5-4c23-9335-05356b2fe9ec.png">

and

<img width="1705" alt="image" src="https://user-images.githubusercontent.com/131427/173728202-ea3ed505-73eb-42e8-997e-8e4f2cde9232.png">

in discover:

<img width="1663" alt="image" src="https://user-images.githubusercontent.com/131427/173728529-e6029600-7561-4e91-b5fb-8910324ca3f1.png">

