### PR TITLE
Skip metricbeat/module/mongodb/replstatus.TestFetch

### DIFF
--- a/metricbeat/module/mongodb/replstatus/replstatus_integration_test.go
+++ b/metricbeat/module/mongodb/replstatus/replstatus_integration_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestFetch(t *testing.T) {
+	t.Skip("Flaky Test: https://github.com/elastic/beats/issues/31768")
+
 	service := compose.EnsureUp(t, "mongodb")
 
 	err := initiateReplicaSet(t, service.Host())


### PR DESCRIPTION
This test is failing regularly and blocking multiple PRs now. I'm skipping it until we can make it pass reliably. This test seems to be cursed, it has been flaky through multiple implementation changes now.

- Relates https://github.com/elastic/beats/issues/31768

