### PR TITLE
Add encryption to diskqueue

### DIFF
--- a/libbeat/publisher/queue/diskqueue/acks_test.go
+++ b/libbeat/publisher/queue/diskqueue/acks_test.go
@@ -66,7 +66,7 @@ func TestAddFrames(t *testing.T) {
 						rf(0, 0, true, 100),
 					},
 					frameID(1),
-					&queuePosition{0, segmentHeaderSize + 100, 1},
+					&queuePosition{0, segmentHeaderSizeV1 + 100, 1},
 					nil,
 				},
 				{
@@ -85,7 +85,7 @@ func TestAddFrames(t *testing.T) {
 						rf(0, 1, false, 75),
 					},
 					frameID(2),
-					&queuePosition{0, segmentHeaderSize + 175, 2},
+					&queuePosition{0, segmentHeaderSizeV1 + 175, 2},
 					nil,
 				},
 				{
@@ -94,7 +94,7 @@ func TestAddFrames(t *testing.T) {
 						rf(0, 2, false, 100),
 					},
 					frameID(5),
-					&queuePosition{1, segmentHeaderSize + 150, 2},
+					&queuePosition{1, segmentHeaderSizeV1 + 150, 2},
 					// This time we crossed a boundary so we should get an ACK for segment
 					// 0 on the notification channel.
 					segmentIDRef(0),
@@ -122,7 +122,7 @@ func TestAddFrames(t *testing.T) {
 						rf(0, 0, true, 100),
 					},
 					frameID(2),
-					&queuePosition{0, segmentHeaderSize + 150, 2},
+					&queuePosition{0, segmentHeaderSizeV1 + 150, 2},
 					nil,
 				},
 				{
@@ -131,7 +131,7 @@ func TestAddFrames(t *testing.T) {
 						rf(0, 2, false, 75),
 					},
 					frameID(3),
-					&queuePosition{0, segmentHeaderSize + 225, 3},
+					&queuePosition{0, segmentHeaderSizeV1 + 225, 3},
 					nil,
 				},
 				{
@@ -140,7 +140,7 @@ func TestAddFrames(t *testing.T) {
 						rf(1, 3, false, 100),
 					},
 					frameID(7),
-					&queuePosition{2, segmentHeaderSize + 100, 1},
+					&queuePosition{2, segmentHeaderSizeV1 + 100, 1},
 					segmentIDRef(1),
 				},
 				{
@@ -149,7 +149,7 @@ func TestAddFrames(t *testing.T) {
 						rf(2, 7, false, 100),
 					},
 					frameID(9),
-					&queuePosition{2, segmentHeaderSize + 300, 3},
+					&queuePosition{2, segmentHeaderSizeV1 + 300, 3},
 					nil,
 				},
 			},
@@ -165,7 +165,7 @@ func TestAddFrames(t *testing.T) {
 						rf(0, 0, true, 100),
 					},
 					frameID(4),
-					&queuePosition{3, segmentHeaderSize + 100, 1},
+					&queuePosition{3, segmentHeaderSizeV1 + 100, 1},
 					// We advanced from segment 0 to segment 3, so we expect
 					// segmentID 2 on the ACK channel.
 					segmentIDRef(2),
@@ -182,7 +182,7 @@ func TestAddFrames(t *testing.T) {
 						rf(10, 35, true, 100),
 					},
 					frameID(36),
-					&queuePosition{10, segmentHeaderSize + 100, 1},
+					&queuePosition{10, segmentHeaderSizeV1 + 100, 1},
 					// We advanced to segment 10, so we expect segmentID 9 on
 					// the ACK channel.
 					segmentIDRef(9),
@@ -218,7 +218,7 @@ func TestAddFrames(t *testing.T) {
 					[]*readFrame{
 						{
 							segment: &queueSegment{
-								schemaVersion: uint32Ref(0),
+								schemaVersion: 0,
 							},
 							bytesOnDisk: 100,
 						},
@@ -299,15 +299,11 @@ func (dqa *diskQueueACKs) assertACKedSegment(
 	}
 }
 
-func uint32Ref(v uint32) *uint32 {
-	return &v
-}
-
 // rf assembles a readFrame with the given parameters and a spoofed
 // queue segment, whose firstFrameID field is set to match the given frame
 // if "first" is true.
 func rf(seg segmentID, frame frameID, first bool, size uint64) *readFrame {
-	s := &queueSegment{id: seg}
+	s := &queueSegment{id: seg, schemaVersion: 1}
 	if first {
 		s.firstFrameID = frame
 	}

--- a/libbeat/publisher/queue/diskqueue/config.go
+++ b/libbeat/publisher/queue/diskqueue/config.go
@@ -29,6 +29,9 @@ import (
 	"github.com/elastic/elastic-agent-libs/paths"
 )
 
+//defaultSchemaVersion specifies which on disk schema (0,1,2) is the default.
+const defaultSchemaVersion = 1
+
 // Settings contains the configuration fields to create a new disk queue
 // or open an existing one.
 type Settings struct {
@@ -68,6 +71,13 @@ type Settings struct {
 	// use exponential backoff up to the specified limit.
 	RetryInterval    time.Duration
 	MaxRetryInterval time.Duration
+
+	// Schema Version specifies which on-disk format, serialization, and encryption to use.
+	// 0, 1, or 2 are valid options
+	SchemaVersion uint32
+
+	// EncryptionKey is used to encrypt data if SchemaVersion 2 is used.
+	EncryptionKey []byte
 }
 
 // userConfig holds the parameters for a disk queue that are configurable
@@ -129,6 +139,8 @@ func DefaultSettings() Settings {
 
 		RetryInterval:    1 * time.Second,
 		MaxRetryInterval: 30 * time.Second,
+
+		SchemaVersion: defaultSchemaVersion,
 	}
 }
 
@@ -192,7 +204,16 @@ func (settings Settings) segmentPath(segmentID segmentID) string {
 // maxValidFrameSize returns the size of the largest possible frame that
 // can be stored with the current queue settings.
 func (settings Settings) maxValidFrameSize() uint64 {
-	return settings.MaxSegmentSize - segmentHeaderSize
+	switch settings.SchemaVersion {
+	case 0:
+		return settings.MaxSegmentSize - segmentHeaderSizeV0
+	case 1:
+		return settings.MaxSegmentSize - segmentHeaderSizeV1
+	case 2:
+		return settings.MaxSegmentSize - segmentHeaderSizeV2
+	default:
+		return uint64(0)
+	}
 }
 
 // Given a retry interval, nextRetryInterval returns the next higher level

--- a/libbeat/publisher/queue/diskqueue/docs/Makefile
+++ b/libbeat/publisher/queue/diskqueue/docs/Makefile
@@ -1,0 +1,9 @@
+all : schemaV0.svg frameV0.svg schemaV1.svg frameV1.svg schemaV2.svg frameV2.svg
+
+.PHONY : clean
+
+%.svg : %.pic
+	pikchr --svg-only $< > $@
+
+clean :
+	-rm *.svg

--- a/libbeat/publisher/queue/diskqueue/docs/frameV0.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV0.pic
@@ -1,0 +1,9 @@
+boxht = 0.25
+down
+box "size (uint32)" wid 4;
+down
+box "JSON serialized data" dashed wid 4 ht 2;
+down
+box "checksum (uint32)" wid 4;
+down
+box "size (uint32)" wid 4;

--- a/libbeat/publisher/queue/diskqueue/docs/frameV0.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV0.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 400.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">JSON serialized data</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">checksum (uint32)</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/frameV1.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV1.pic
@@ -1,0 +1,9 @@
+boxht = 0.25
+down
+box "size (uint32)" wid 4;
+down
+box "CBOR serialized data" dashed wid 4 ht 2;
+down
+box "checksum (uint32)" wid 4;
+down
+box "size (uint32)" wid 4;

--- a/libbeat/publisher/queue/diskqueue/docs/frameV1.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV1.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 400.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">CBOR serialized data</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">checksum (uint32)</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/frameV2.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV2.pic
@@ -1,0 +1,5 @@
+boxht = 0.25
+SIZE1: box "size (uint32)" wid 4;
+DATA: box "CBOR serialized data" dashed wid 4 ht 2 with .nw at SIZE1.sw;
+CHECKSUM: box "checksum (uint32)" wid 4 with .nw at DATA.sw;
+SIZE2: box "size (uint32)" wid 4 with nw at CHECKSUM.sw;

--- a/libbeat/publisher/queue/diskqueue/docs/frameV2.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV2.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 400.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">CBOR serialized data</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">checksum (uint32)</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
+++ b/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
@@ -1,0 +1,76 @@
+# Disk Queue On Disk Structures
+
+The disk queue is a directory on disk that contains files.  Each
+file is called a segment.  The name of the file is the segment id in
+base 10 with the ".seg" suffix.  For example: "42.seg".  Each segment
+contains multiple frames.  Each frame contains one event.
+
+There are currently 3 versions of the disk queue, and the current code
+base is able to write versions 1 & 2, while it is able to read version
+0, 1, and 2.
+
+## Version 0
+
+In version 0, the segments are made up of a header, followed by
+frames.  The header contains one field which is an unsigned 32-bit
+integer in little-endian byte order, which signifies the version number.
+
+![Segment Schema Version 0](./schemaV0.svg)
+
+The frames for version 0, consist of a header, followed by the
+serialized event and a footer.  The header contains one field which is
+the size of the frame, which is an unsigned 32-bit integer in
+little-endian byte order.  The serialization format is JSON.  The
+footer contains 2 fields, the first of which is a checksum which is an
+unsigned 32-bit integer in little-endian format, followed by a repeat
+of the size from the header.
+
+![Frame Version 0](./frameV0.svg)
+
+## Version 1
+
+In version 1, the segments are made up of a header, followed by
+frames.  The header contains two fields.  The first field in the
+version number, which is an unsigned 32-bit integer in little-endian
+format.  The second field is a count of the number of frames in the
+segment, which is an unsigned 32-bit integer in little-endian format.
+
+![Segment Schema Version 1](./schemaV1.svg)
+
+The frames for version 1, consist of a header, followed by the
+serialized event and a footer.  The header contains one field which is
+the size of the frame, which is an unsigned 32-bit integer in
+little-endian format.  The serialization format is CBOR.  The footer
+contains 2 fields, the first of which is a checksum which is an
+unsigned 32-bit integer in little-endian format, followed by a repeat
+of the size from the header.
+
+![Frame Version 1](./frameV1.svg)
+
+## Version 2
+
+In version 2, encryption is added to version 1.  The
+segments are made of a header followed by an initialization vector,
+and then encrypted frames.  The header consists of one field, the
+version number which is an unsigned 32-bit integer in little-endian
+format.  The initialization vector is 128-bits in length.  The count
+was dropped from version 1 for 2 reasons.  The first, if it was
+outside the encrypted portion of the segment then it would be easy for
+an attacker to modify.  The second, is that adding it to the encrypted
+segment in a meaningful way was problematic.  The count is not known
+until the last frame is written.  With encryption you cannot seek to
+the beginning of the segment and update the value.  Adding the count
+to the end is less useful because you have to decrypt the entire
+segment before it can be read.
+
+![Segment Schema Version 2](./schemaV2.svg)
+
+The frames for version 2, consist of a header, followed by the
+serialized event and a footer.  The header contains one field which is
+the size of the frame, which is an unsigned 32-bit integer in
+little-endian format.  The serialization format is CBOR.  The footer
+contains 2 fields, the first of which is a checksum which is an
+unsigned 32-bit integer in little-endian format, followed by a repeat
+of the size from the header.  This is the same as version 1.
+
+![Frame Version 2](./frameV2.svg)

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV0.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV0.pic
@@ -1,0 +1,9 @@
+boxht = 0.25
+down;
+box "version (uint32)" wid 4;
+down;
+box "frame 0" wid 4 ht 2;
+down;
+box "..." dashed wid 4;
+down;
+box "frame n" wid 4 ht 2;

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV0.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV0.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 652.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">version (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame 0</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">...</text>
+<path d="M2,650L578,650L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="506" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame n</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV1.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV1.pic
@@ -1,0 +1,11 @@
+boxht = 0.25
+down;
+box "version (uint32)" wid 4;
+down;
+box "count (uint32)" wid 4;
+down;
+box "frame 0" wid 4 ht 2;
+down;
+box "..." dashed wid 4;
+down;
+box "frame (count - 1)" wid 4 ht 2;

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV1.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV1.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 688.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">version (uint32)</text>
+<path d="M2,74L578,74L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="56" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">count (uint32)</text>
+<path d="M2,362L578,362L578,74L2,74Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="218" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame 0</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">...</text>
+<path d="M2,686L578,686L578,398L2,398Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="542" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame (count - 1)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV2.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV2.pic
@@ -1,0 +1,4 @@
+boxht = 0.25
+VERSION: box "version (uint32)" wid 4;
+IV: box "initialization vector (128 bits)" wid 4 ht 1 with .nw at VERSION.sw
+FRAME: box "Encrypted Frames" dashed wid 4 ht 2 with .nw at IV.sw;

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV2.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV2.svg
@@ -1,0 +1,9 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 472.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">version (uint32)</text>
+<path d="M2,182L578,182L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="110" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">initialization vector (128 bits)</text>
+<path d="M2,470L578,470L578,182L2,182Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="326" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">Encrypted Frames</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/encryption.go
+++ b/libbeat/publisher/queue/diskqueue/encryption.go
@@ -1,0 +1,166 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+const (
+	// KeySize is 128-bit
+	KeySize = 16
+)
+
+//EncryptionReader allows reading from a AES-128-CTR stream
+type EncryptionReader struct {
+	src        io.ReadCloser
+	stream     cipher.Stream
+	block      cipher.Block
+	iv         []byte
+	ciphertext []byte
+}
+
+//NewEncryptionReader returns a new AES-128-CTR decrypter
+func NewEncryptionReader(r io.ReadCloser, key []byte) (*EncryptionReader, error) {
+	if len(key) != KeySize {
+		return nil, fmt.Errorf("key must be %d bytes long", KeySize)
+	}
+
+	er := &EncryptionReader{}
+	er.src = r
+
+	// turn key into block & save
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	er.block = block
+
+	// read IV from the io.ReadCloser
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(er.src, iv); err != nil {
+		return nil, err
+	}
+	er.iv = iv
+
+	// create Stream
+	er.stream = cipher.NewCTR(block, iv)
+
+	return er, nil
+}
+
+func (er *EncryptionReader) Read(buf []byte) (int, error) {
+	if cap(er.ciphertext) >= len(buf) {
+		er.ciphertext = er.ciphertext[:len(buf)]
+	} else {
+		er.ciphertext = make([]byte, len(buf))
+	}
+	n, err := er.src.Read(er.ciphertext)
+	if err != nil {
+		return n, err
+	}
+	er.stream.XORKeyStream(buf, er.ciphertext)
+	return n, nil
+}
+
+func (er *EncryptionReader) Close() error {
+	return er.src.Close()
+}
+
+//Reset Sets up stream again, assumes that caller has already set the
+// src to the iv
+func (er *EncryptionReader) Reset() error {
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(er.src, iv); err != nil {
+		return err
+	}
+	if !bytes.Equal(iv, er.iv) {
+		return fmt.Errorf("different iv, something is wrong")
+	}
+
+	// create Stream
+	er.stream = cipher.NewCTR(er.block, iv)
+	return nil
+}
+
+//EncryptionWriter allows writing to a AES-128-CTR stream
+type EncryptionWriter struct {
+	dst        WriteCloseSyncer
+	stream     cipher.Stream
+	ciphertext []byte
+}
+
+//NewEncryptionWriter returns a new AES-128-CTR stream encryptor
+func NewEncryptionWriter(w WriteCloseSyncer, key []byte) (*EncryptionWriter, error) {
+	if len(key) != KeySize {
+		return nil, fmt.Errorf("key must be %d bytes long", KeySize)
+	}
+
+	ew := &EncryptionWriter{}
+
+	// turn key into block
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// create random IV
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+
+	// create stream
+	stream := cipher.NewCTR(block, iv)
+
+	//write IV
+	n, err := w.Write(iv)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(iv) {
+		return nil, io.ErrShortWrite
+	}
+
+	ew.dst = w
+	ew.stream = stream
+	return ew, nil
+}
+
+func (ew *EncryptionWriter) Write(buf []byte) (int, error) {
+	if cap(ew.ciphertext) >= len(buf) {
+		ew.ciphertext = ew.ciphertext[:len(buf)]
+	} else {
+		ew.ciphertext = make([]byte, len(buf))
+	}
+	ew.stream.XORKeyStream(ew.ciphertext, buf)
+	return ew.dst.Write(ew.ciphertext)
+}
+
+func (ew *EncryptionWriter) Close() error {
+	return ew.dst.Close()
+}
+
+func (ew *EncryptionWriter) Sync() error {
+	return ew.dst.Sync()
+}

--- a/libbeat/publisher/queue/diskqueue/encryption_test.go
+++ b/libbeat/publisher/queue/diskqueue/encryption_test.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"bytes"
+	"crypto/aes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func NopWriteCloseSyncer(w io.WriteCloser) WriteCloseSyncer {
+	return nopWriteCloseSyncer{w}
+}
+
+type nopWriteCloseSyncer struct {
+	io.WriteCloser
+}
+
+func (nopWriteCloseSyncer) Sync() error { return nil }
+
+func TestEncryptionRoundTrip(t *testing.T) {
+	tests := map[string]struct {
+		plaintext []byte
+	}{
+		"8 bits":   {plaintext: []byte("a")},
+		"128 bits": {plaintext: []byte("bbbbbbbbbbbbbbbb")},
+		"136 bits": {plaintext: []byte("ccccccccccccccccc")},
+	}
+	for name, tc := range tests {
+		pr, pw := io.Pipe()
+		src := bytes.NewReader(tc.plaintext)
+		var dst bytes.Buffer
+		var teeBuf bytes.Buffer
+		key := []byte("kkkkkkkkkkkkkkkk")
+
+		go func() {
+			//NewEncryptionWriter writes iv, so needs to be in go routine
+			ew, err := NewEncryptionWriter(NopWriteCloseSyncer(pw), key)
+			assert.Nil(t, err, name)
+			_, err = io.Copy(ew, src)
+			assert.Nil(t, err, name)
+			ew.Close()
+		}()
+
+		tr := io.TeeReader(pr, &teeBuf)
+		er, err := NewEncryptionReader(io.NopCloser(tr), key)
+		assert.Nil(t, err, name)
+		_, err = io.Copy(&dst, er)
+		assert.Nil(t, err, name)
+		// Check round trip worked
+		assert.Equal(t, tc.plaintext, dst.Bytes(), name)
+		// Check that iv & cipher text were written
+		assert.Equal(t, len(tc.plaintext)+aes.BlockSize, teeBuf.Len(), name)
+		// Check that cipher text and plaintext don't match
+		assert.NotEqual(t, tc.plaintext, teeBuf.Bytes()[aes.BlockSize:], name)
+	}
+}

--- a/libbeat/publisher/queue/diskqueue/queue.go
+++ b/libbeat/publisher/queue/diskqueue/queue.go
@@ -267,10 +267,11 @@ func (dq *diskQueue) BufferConfig() queue.BufferConfig {
 }
 
 func (dq *diskQueue) Producer(cfg queue.ProducerConfig) queue.Producer {
+	encoder := newEventEncoder()
 	return &diskQueueProducer{
 		queue:   dq,
 		config:  cfg,
-		encoder: newEventEncoder(),
+		encoder: encoder,
 		done:    make(chan struct{}),
 	}
 }

--- a/libbeat/publisher/queue/diskqueue/reader_loop.go
+++ b/libbeat/publisher/queue/diskqueue/reader_loop.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"os"
 )
 
 // startPosition and endPosition are absolute byte offsets into the segment
@@ -71,13 +70,14 @@ type readerLoop struct {
 }
 
 func newReaderLoop(settings Settings) *readerLoop {
+	decoder := newEventDecoder()
 	return &readerLoop{
 		settings: settings,
 
 		requestChan:  make(chan readerLoopRequest, 1),
 		responseChan: make(chan readerLoopResponse),
 		output:       make(chan *readFrame, settings.ReadAheadLimit),
-		decoder:      newEventDecoder(),
+		decoder:      decoder,
 	}
 }
 
@@ -106,12 +106,13 @@ func (rl *readerLoop) processRequest(request readerLoopRequest) readerLoopRespon
 		return readerLoopResponse{err: err}
 	}
 	defer handle.Close()
+
 	_, err = handle.Seek(int64(request.startPosition), io.SeekStart)
 	if err != nil {
 		return readerLoopResponse{err: err}
 	}
 
-	targetLength := uint64(request.endPosition - request.startPosition)
+	targetLength := request.endPosition - request.startPosition
 	for {
 		remainingLength := targetLength - byteCount
 
@@ -173,9 +174,7 @@ func (rl *readerLoop) processRequest(request readerLoopRequest) readerLoopRespon
 // it does not exceed the given length bound. The returned frame leaves the
 // segment and frame IDs unset.
 // The returned error will be set if and only if the returned frame is nil.
-func (rl *readerLoop) nextFrame(
-	handle *os.File, maxLength uint64,
-) (*readFrame, error) {
+func (rl *readerLoop) nextFrame(handle *segmentReader, maxLength uint64) (*readFrame, error) {
 	// Ensure we are allowed to read the frame header.
 	if maxLength < frameHeaderSize {
 		return nil, fmt.Errorf(

--- a/libbeat/publisher/queue/diskqueue/segments.go
+++ b/libbeat/publisher/queue/diskqueue/segments.go
@@ -408,7 +408,7 @@ func readSegmentHeader(in io.Reader) (*segmentHeader, error) {
 		return nil, err
 	}
 	switch header.version {
-	case 0:
+	case 0: // do nothing
 	case 1:
 		err = binary.Read(in, binary.LittleEndian, &header.frameCount)
 		if err != nil {

--- a/libbeat/publisher/queue/diskqueue/segments.go
+++ b/libbeat/publisher/queue/diskqueue/segments.go
@@ -414,7 +414,7 @@ func readSegmentHeader(in io.Reader) (*segmentHeader, error) {
 		if err != nil {
 			return nil, err
 		}
-	case 2:
+	case 2: // do nothing
 	default:
 		return nil, fmt.Errorf("unrecognized schema version %d", header.version)
 	}

--- a/libbeat/publisher/queue/diskqueue/segments_test.go
+++ b/libbeat/publisher/queue/diskqueue/segments_test.go
@@ -1,0 +1,149 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemasRoundTrip(t *testing.T) {
+	tests := map[string]struct {
+		id            segmentID
+		schemaVersion uint32
+		plaintext     []byte
+	}{
+		"version 0": {
+			id:            0,
+			schemaVersion: uint32(0),
+			plaintext:     []byte("abc"),
+		},
+		"version 1": {
+			id:            1,
+			schemaVersion: uint32(1),
+			plaintext:     []byte("abc"),
+		},
+		"version 2": {
+			id:            2,
+			schemaVersion: uint32(2),
+			plaintext:     []byte("abc"),
+		},
+	}
+	dir, err := os.MkdirTemp("", t.Name())
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+	for name, tc := range tests {
+		dst := make([]byte, len(tc.plaintext))
+		settings := DefaultSettings()
+		settings.Path = dir
+		settings.SchemaVersion = tc.schemaVersion
+		settings.EncryptionKey = []byte("keykeykeykeykeyk")
+		qs := &queueSegment{
+			id: tc.id,
+		}
+		sw, err := qs.getWriter(settings)
+		assert.Nil(t, err, name)
+
+		n, err := sw.Write(tc.plaintext)
+		assert.Nil(t, err, name)
+		assert.Equal(t, len(tc.plaintext), n, name)
+
+		err = sw.Close()
+		assert.Nil(t, err, name)
+
+		sr, err := qs.getReader(settings)
+		assert.Nil(t, err, name)
+
+		n, err = sr.Read(dst)
+		assert.Nil(t, err, name)
+
+		err = sr.Close()
+		assert.Nil(t, err, name)
+		assert.Equal(t, len(dst), n, name)
+
+		//make sure we read back what we wrote
+		assert.Equal(t, tc.plaintext, dst, name)
+
+	}
+}
+
+func TestSegmentReaderSeek(t *testing.T) {
+	tests := map[string]struct {
+		id            segmentID
+		schemaVersion uint32
+		headerSize    int64
+		plaintexts    [][]byte
+	}{
+		"version 0": {
+			id:            0,
+			schemaVersion: uint32(0),
+			headerSize:    segmentHeaderSizeV0,
+			plaintexts:    [][]byte{[]byte("abc"), []byte("defg")},
+		},
+		"version 1": {
+			id:            1,
+			schemaVersion: uint32(1),
+			headerSize:    segmentHeaderSizeV1,
+			plaintexts:    [][]byte{[]byte("abc"), []byte("defg")},
+		},
+		"version 2": {
+			id:            2,
+			schemaVersion: uint32(2),
+			headerSize:    segmentHeaderSizeV2,
+			plaintexts:    [][]byte{[]byte("abc"), []byte("defg")},
+		},
+	}
+	dir, err := os.MkdirTemp("", t.Name())
+	assert.Nil(t, err)
+	//	defer os.RemoveAll(dir)
+	for name, tc := range tests {
+		settings := DefaultSettings()
+		settings.Path = dir
+		settings.SchemaVersion = tc.schemaVersion
+		settings.EncryptionKey = []byte("keykeykeykeykeyk")
+		qs := &queueSegment{
+			id: tc.id,
+		}
+		sw, err := qs.getWriter(settings)
+		assert.Nil(t, err, name)
+		for _, plaintext := range tc.plaintexts {
+			n, err := sw.Write(plaintext)
+			assert.Nil(t, err, name)
+			assert.Equal(t, len(plaintext), n, name)
+			err = sw.Sync()
+			assert.Nil(t, err, name)
+		}
+		sw.Close()
+		sr, err := qs.getReader(settings)
+		assert.Nil(t, err, name)
+		//seek to second data piece
+		n, err := sr.Seek(tc.headerSize+int64(len(tc.plaintexts[0])), io.SeekStart)
+		assert.Nil(t, err, name)
+		assert.Equal(t, tc.headerSize+int64(len(tc.plaintexts[0])), n, name)
+		dst := make([]byte, len(tc.plaintexts[1]))
+
+		_, err = sr.Read(dst)
+		assert.Nil(t, err, name)
+		assert.Equal(t, tc.plaintexts[1], dst, name)
+
+		sw.Close()
+	}
+}

--- a/libbeat/publisher/queue/diskqueue/serialize.go
+++ b/libbeat/publisher/queue/diskqueue/serialize.go
@@ -107,11 +107,8 @@ func (e *eventEncoder) encode(evt interface{}) ([]byte, error) {
 		return nil, err
 	}
 
-	// Copy the encoded bytes to a new array owned by the caller.
-	bytes := e.buf.Bytes()
-	result := make([]byte, len(bytes))
-	copy(result, bytes)
-
+	result := make([]byte, e.buf.Len())
+	copy(result, e.buf.Bytes())
 	return result, nil
 }
 


### PR DESCRIPTION
## What does this PR do?

Adds support for AES 128 CTR encryption to disk queue.

## Why is it important?

Necessary for endpoint running under elastic-agent

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

```
go test -bench=1M -benchtime 1x -count 10 -timeout 600m -benchmem > results.txt

benchstat results.txt
name           time/op
V1Async1M-16    38.8s ± 2%
V2Async1M-16    37.9s ± 8%
V1Sync1M-16     37.7s ± 1%
V2Sync1M-16     40.3s ± 0%

name           alloc/op
V1Async1M-16   3.47GB ± 0%
V2Async1M-16   3.46GB ± 0%
V1Sync1M-16    3.44GB ± 0%
V2Sync1M-16    3.45GB ± 0%


name           allocs/op
V1Async1M-16    43.4M ± 0%
V2Async1M-16    42.0M ± 0%
V1Sync1M-16     40.5M ± 0%
V2Sync1M-16     41.2M ± 0%
```


## Related issues

- Relates elastic-agent-shipper#33
- Relates #31935 

