### PR TITLE
packetbeat: wire default interface selection into config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -146,6 +146,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Packetbeat*
 
+- Add support for specifying default route interface sniffing. {issue}31905[31905] {pull}31950[31950]
 
 *Functionbeat*
 

--- a/packetbeat/_meta/config/beat.reference.yml.tmpl
+++ b/packetbeat/_meta/config/beat.reference.yml.tmpl
@@ -10,7 +10,8 @@
 {{header "Network device"}}
 
 # Select the network interface to sniff the data. You can use the "any"
-# keyword to sniff on all connected interfaces.
+# keyword to sniff on all connected interfaces. On all platforms, you
+# can use "default_route" to sniff on the device carrying the default route.
 packetbeat.interfaces.device: {{ call .device .GOOS }}
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/_meta/config/beat.reference.yml.tmpl
+++ b/packetbeat/_meta/config/beat.reference.yml.tmpl
@@ -11,7 +11,8 @@
 
 # Select the network interface to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces. On all platforms, you
-# can use "default_route" to sniff on the device carrying the default route.
+# can use "default_route", "default_route_ipv4" or "default_route_ipv6"
+# to sniff on the device carrying the default route.
 packetbeat.interfaces.device: {{ call .device .GOOS }}
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/_meta/config/beat.yml.tmpl
+++ b/packetbeat/_meta/config/beat.yml.tmpl
@@ -10,7 +10,8 @@
 {{header "Network device"}}
 
 # Select the network interface to sniff the data. On Linux, you can use the
-# "any" keyword to sniff on all connected interfaces.
+# "any" keyword to sniff on all connected interfaces. On all platforms, you
+# can use "default_route" to sniff on the device carrying the default route.
 packetbeat.interfaces.device: {{ call .device .GOOS }}
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/_meta/config/beat.yml.tmpl
+++ b/packetbeat/_meta/config/beat.yml.tmpl
@@ -11,7 +11,8 @@
 
 # Select the network interface to sniff the data. On Linux, you can use the
 # "any" keyword to sniff on all connected interfaces. On all platforms, you
-# can use "default_route" to sniff on the device carrying the default route.
+# can use "default_route", "default_route_ipv4" or "default_route_ipv6"
+# to sniff on the device carrying the default route.
 packetbeat.interfaces.device: {{ call .device .GOOS }}
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/config/agent.go
+++ b/packetbeat/config/agent.go
@@ -41,16 +41,11 @@ type agentInput struct {
 	Streams    []map[string]interface{} `config:"streams"`
 }
 
-var osDefaultDevices = map[string]string{
-	"darwin": "en0",
-	"linux":  "any",
-}
-
 func defaultDevice() string {
-	if device, found := osDefaultDevices[runtime.GOOS]; found {
-		return device
+	if runtime.GOOS == "linux" {
+		return "any"
 	}
-	return "0"
+	return "default_route"
 }
 
 func (i agentInput) addProcessorsAndIndex(cfg *conf.C) (*conf.C, error) {

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -122,9 +122,12 @@ packetbeat.interfaces.device: 0
 
 Specifying the index is especially useful on Windows where device names can be long.
 
-Alternatively the `default_route` device may be specified. This will set the capture
-device to be the device that is associated with the first default IPv4 route identified
-on Packetbeat start-up. The selected interface is not altered after it is chosen.
+Alternatively the `default_route`, `default_route_ipv4` or `default_route_ipv6` device
+may be specified. This will set the capture device to be the device that is associated
+with the first default route identified on Packetbeat start-up. `default_route` will
+select the first default route from either IPv4 or IPv6 with a preference for the IPv4
+route, while `default_route_ipv4` and `default_route_ipv6` will only select from the
+specified stack. The selected interface is not altered after it is chosen.
 
 [float]
 ==== `snaplen`

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -124,7 +124,7 @@ Specifying the index is especially useful on Windows where device names can be l
 
 Alternatively the `default_route` device may be specified. This will set the capture
 device to be the device that is associated with the first default IPv4 route identified
-on Packetbeat start-up.
+on Packetbeat start-up. The selected interface is not altered after it is chosen.
 
 [float]
 ==== `snaplen`

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -122,6 +122,10 @@ packetbeat.interfaces.device: 0
 
 Specifying the index is especially useful on Windows where device names can be long.
 
+Alternatively the `default_route` device may be specified. This will set the capture
+device to be the device that is associated with the first default IPv4 route identified
+on Packetbeat start-up.
+
 [float]
 ==== `snaplen`
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -11,7 +11,8 @@
 
 # Select the network interface to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces. On all platforms, you
-# can use "default_route" to sniff on the device carrying the default route.
+# can use "default_route", "default_route_ipv4" or "default_route_ipv6"
+# to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -10,7 +10,8 @@
 # =============================== Network device ===============================
 
 # Select the network interface to sniff the data. You can use the "any"
-# keyword to sniff on all connected interfaces.
+# keyword to sniff on all connected interfaces. On all platforms, you
+# can use "default_route" to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -11,7 +11,8 @@
 
 # Select the network interface to sniff the data. On Linux, you can use the
 # "any" keyword to sniff on all connected interfaces. On all platforms, you
-# can use "default_route" to sniff on the device carrying the default route.
+# can use "default_route", "default_route_ipv4" or "default_route_ipv6"
+# to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -10,7 +10,8 @@
 # =============================== Network device ===============================
 
 # Select the network interface to sniff the data. On Linux, you can use the
-# "any" keyword to sniff on all connected interfaces.
+# "any" keyword to sniff on all connected interfaces. On all platforms, you
+# can use "default_route" to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/packetbeat/scripts/mage/config.go
+++ b/packetbeat/scripts/mage/config.go
@@ -23,18 +23,11 @@ import (
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
 )
 
-var defaultDevice = map[string]string{
-	"darwin":  "en0",
-	"linux":   "any",
-	"windows": "0",
-}
-
 func device(goos string) string {
-	dev, found := defaultDevice[goos]
-	if found {
-		return dev
+	if goos == "linux" {
+		return "any"
 	}
-	return "any"
+	return "default_route"
 }
 
 // ConfigFileParams returns the default ConfigFileParams for generating

--- a/packetbeat/sniffer/device.go
+++ b/packetbeat/sniffer/device.go
@@ -22,9 +22,11 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/google/gopacket/pcap"
 
+	"github.com/elastic/beats/v7/packetbeat/route"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -65,7 +67,7 @@ func formatDeviceNames(devices []pcap.Interface, withDescription, withIP bool) [
 			if len(dev.Addresses) == 0 {
 				buf.WriteString("Not assigned ip address")
 			} else {
-				for i, address := range []pcap.InterfaceAddress(dev.Addresses) {
+				for i, address := range dev.Addresses {
 					if i != 0 {
 						buf.WriteByte(' ')
 					}
@@ -81,31 +83,65 @@ func formatDeviceNames(devices []pcap.Interface, withDescription, withIP bool) [
 
 func resolveDeviceName(name string) (string, error) {
 	if name == "" {
-		return "any", nil
+		if runtime.GOOS == "linux" {
+			return "any", nil
+		}
+		name = "default_route"
 	}
-
-	if index, err := strconv.Atoi(name); err == nil { // Device is numeric id
+	if name == "default_route" {
+		iface, _, err := route.Default(syscall.AF_INET)
+		if err != nil {
+			return "", fmt.Errorf("failed to get default route device: %w", err)
+		}
 		devices, err := ListDeviceNames(false, false)
 		if err != nil {
-			return "", fmt.Errorf("Error getting devices list: %v", err)
+			return "", fmt.Errorf("failed to get device list: %w", err)
 		}
-
-		name, err = deviceNameFromIndex(index, devices)
-		if err != nil {
-			return "", fmt.Errorf("Couldn't understand device index %d: %v", index, err)
+		// The order of devices returned by pcap differs from the order
+		// obtained by route, so search by iface name.
+		for _, dev := range devices {
+			if sameDevice(iface, dev) {
+				return dev, nil
+			}
 		}
-
-		logp.Info("Resolved device index %d to device: %s", index, name)
 	}
 
+	index, err := strconv.Atoi(name)
+	if err != nil {
+		return name, nil //nolint:nilerr // This is a non-numeric interface identifier.
+	}
+
+	// The device is an index into the interface list.
+	devices, err := ListDeviceNames(false, false)
+	if err != nil {
+		return "", fmt.Errorf("failed to get device list: %w", err)
+	}
+
+	name, err = deviceNameFromIndex(index, devices)
+	if err != nil {
+		return "", fmt.Errorf("invalid device index %d: %w", index, err)
+	}
+
+	logp.Info("Resolved device index %d to device: %s", index, name)
 	return name, nil
+}
+
+func sameDevice(route, pcap string) bool {
+	if runtime.GOOS == "windows" {
+		// The device returned by route does not have the same device tree
+		// as the device obtained from npcap, so rely on the GUID to match.
+		idx := strings.Index(pcap, "_") // Replace this with strings.Cut.
+		if idx > -1 {
+			pcap = pcap[idx+1:]
+		}
+	}
+	return route == pcap
 }
 
 func deviceNameFromIndex(index int, devices []string) (string, error) {
 	if index >= len(devices) {
-		return "", fmt.Errorf("Looking for device index %d, but there are only %d devices",
+		return "", fmt.Errorf("looking for device index %d, but there are only %d devices",
 			index, len(devices))
 	}
-
 	return devices[index], nil
 }

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -2,7 +2,8 @@
 
 # Select the network interfaces to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces. On all platforms, you
-# can use "default_route" to sniff on the device carrying the default route.
+# can use "default_route", "default_route_ipv4" or "default_route_ipv6"
+# to sniff on the device carrying the default route.
 packetbeat.interfaces.device: {{ iface_device|default("any") }}
 packetbeat.interfaces.internal_networks:
   - private

--- a/packetbeat/tests/system/config/packetbeat.yml.j2
+++ b/packetbeat/tests/system/config/packetbeat.yml.j2
@@ -1,7 +1,8 @@
 #################### Packetbeat Configuration Template #########################
 
 # Select the network interfaces to sniff the data. You can use the "any"
-# keyword to sniff on all connected interfaces.
+# keyword to sniff on all connected interfaces. On all platforms, you
+# can use "default_route" to sniff on the device carrying the default route.
 packetbeat.interfaces.device: {{ iface_device|default("any") }}
 packetbeat.interfaces.internal_networks:
   - private

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -11,7 +11,8 @@
 
 # Select the network interface to sniff the data. You can use the "any"
 # keyword to sniff on all connected interfaces. On all platforms, you
-# can use "default_route" to sniff on the device carrying the default route.
+# can use "default_route", "default_route_ipv4" or "default_route_ipv6"
+# to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -10,7 +10,8 @@
 # =============================== Network device ===============================
 
 # Select the network interface to sniff the data. You can use the "any"
-# keyword to sniff on all connected interfaces.
+# keyword to sniff on all connected interfaces. On all platforms, you
+# can use "default_route" to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -11,7 +11,8 @@
 
 # Select the network interface to sniff the data. On Linux, you can use the
 # "any" keyword to sniff on all connected interfaces. On all platforms, you
-# can use "default_route" to sniff on the device carrying the default route.
+# can use "default_route", "default_route_ipv4" or "default_route_ipv6"
+# to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -10,7 +10,8 @@
 # =============================== Network device ===============================
 
 # Select the network interface to sniff the data. On Linux, you can use the
-# "any" keyword to sniff on all connected interfaces.
+# "any" keyword to sniff on all connected interfaces. On all platforms, you
+# can use "default_route" to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
 # The network CIDR blocks that are considered "internal" networks for


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This allows users to specify sniffing on the default route interface for all platforms rather than having to specify a hard-coded interface or interface index on non-linux platforms.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This makes setting up large installations more robust for non-linux hosts as the interface identities do not need to be known during configuration.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Depends #31914 
- Updates #31905

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
