### PR TITLE
ci: create GitHub issue if build failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@current') _
+@Library('apm@test/notify-github') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }
@@ -74,6 +74,7 @@ pipeline {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
           }
         }
+        sh 'exit 1'
         dir("${BASE_DIR}"){
           setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
         }
@@ -204,7 +205,10 @@ VERSION=${env.VERSION}-SNAPSHOT""")
         notifyBuildResult(prComment: true,
                           slackComment: true,
                           analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: getFlakyBranch()),
-                          githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS", githubAssignees: 'elastic/elastic-agent-data-plane')
+                          githubIssue: true,
+                          githubAssignees: 'v1v')
+                          //githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
+                          //githubAssignees: 'elastic/elastic-agent-data-plane')
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ pipeline {
         // Here we do a checkout into a temporary directory in order to have the
         // side-effect of setting up the git environment correctly.
         gitCheckout(basedir: "${pwd(tmp: true)}", githubNotifyFirstTimeContributor: true)
+        sh 'exit 1'
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         dir("${BASE_DIR}") {
             // We use a raw checkout to avoid the many extra objects which are brought in
@@ -74,7 +75,6 @@ pipeline {
             retryWithSleep(retries: 2, seconds: 5){ sh(label: "Install Go ${env.GO_VERSION}", script: '.ci/scripts/install-go.sh') }
           }
         }
-        sh 'exit 1'
         dir("${BASE_DIR}"){
           setEnvVar('VERSION', sh(label: 'Get beat version', script: 'make get-version', returnStdout: true)?.trim())
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,7 +206,8 @@ VERSION=${env.VERSION}-SNAPSHOT""")
                           slackComment: true,
                           analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: getFlakyBranch()),
                           githubIssue: true,
-                          githubAssignees: 'v1v')
+                          githubAssignees: 'v1v',
+                          githubLabels: 'Team:Elastic-Agent-Data-Plane')
                           //githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
                           //githubAssignees: 'elastic/elastic-agent-data-plane')
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,10 +206,9 @@ VERSION=${env.VERSION}-SNAPSHOT""")
                           slackComment: true,
                           analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: getFlakyBranch()),
                           githubIssue: true,
-                          githubAssignees: 'v1v',
-                          githubLabels: 'Team:Elastic-Agent-Data-Plane')
+                          githubAssignees: 'v1v')
                           //githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
-                          //githubAssignees: 'elastic/elastic-agent-data-plane')
+                          //githubLabels: 'Team:Elastic-Agent-Data-Plane')
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -203,7 +203,8 @@ VERSION=${env.VERSION}-SNAPSHOT""")
       dir("${BASE_DIR}"){
         notifyBuildResult(prComment: true,
                           slackComment: true,
-                          analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: getFlakyBranch()))
+                          analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: getFlakyBranch()),
+                          githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS", githubAssignees: 'elastic/elastic-agent-data-plane')
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@test/notify-github') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'ubuntu-18 && immutable' }
@@ -57,7 +57,6 @@ pipeline {
         // Here we do a checkout into a temporary directory in order to have the
         // side-effect of setting up the git environment correctly.
         gitCheckout(basedir: "${pwd(tmp: true)}", githubNotifyFirstTimeContributor: true)
-        sh 'exit 1'
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         dir("${BASE_DIR}") {
             // We use a raw checkout to avoid the many extra objects which are brought in
@@ -205,10 +204,8 @@ VERSION=${env.VERSION}-SNAPSHOT""")
         notifyBuildResult(prComment: true,
                           slackComment: true,
                           analyzeFlakey: !isTag(), jobName: getFlakyJobName(withBranch: getFlakyBranch()),
-                          githubIssue: true,
-                          githubAssignees: 'v1v')
-                          //githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
-                          //githubLabels: 'Team:Elastic-Agent-Data-Plane')
+                          githubIssue: isBranch() && currentBuild.currentResult != "SUCCESS",
+                          githubLabels: 'Team:Elastic-Agent-Data-Plane')
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Create a GitHub issue:
* As soon as a build is failing an issue should be created
* It should be assigned to Elastic Agent Data Plane team (it relies on the GitHub labels to do so)

## Why is it important?

Use GitHub to drive the on-call process when the CI fails

## Test

https://github.com/elastic/beats/issues/31958 was created automatically

## Related issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1731