### PR TITLE
Fix flags for dev build

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -75,7 +75,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
 - Drop event batch when get HTTP status 413 from Elasticsearch to avoid infinite loop {issue}14350[14350] {pull}29368[29368]
 - Allow to use metricbeat for named mssql instances. {issue}24076[24076] {pull}30859[30859]
-- Setting DEV=true when running `mage build` now correctly generates binaries without optmisations and with debug symbols {pull}31955[31955]
+- Setting DEV=true when running `mage build` now correctly generates binaries without optimisations and with debug symbols {pull}31955[31955]
 
 ==== Added
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -75,6 +75,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
 - Drop event batch when get HTTP status 413 from Elasticsearch to avoid infinite loop {issue}14350[14350] {pull}29368[29368]
 - Allow to use metricbeat for named mssql instances. {issue}24076[24076] {pull}30859[30859]
+- Setting DEV=true when running `mage build` now correctly generates binaries without optmisations and with debug symbols {pull}31955[31955]
 
 ==== Added
 

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -67,7 +67,7 @@ func DefaultBuildArgs() BuildArgs {
 
 	if DevBuild {
 		// Disable optimizations (-N) and inlining (-l) for debugging.
-		args.ExtraFlags = append(args.ExtraFlags, `-gcflags`, `"all=-N -l"`)
+		args.ExtraFlags = append(args.ExtraFlags, `-gcflags=all=-N -l`)
 	} else {
 		// Strip all debug symbols from binary (does not affect Go stack traces).
 		args.LDFlags = append(args.LDFlags, "-s")


### PR DESCRIPTION
## What does this PR do?

Fix the flags used when the environmet varialbe DEV=true is set. This
allows to generate binaries without code optmisation and debug
symbols.

## Why is it important?

It allows us to easily generate binaries for debugging.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~