### PR TITLE
Remove unneeded queue metrics test

### DIFF
--- a/libbeat/publisher/queue/queuetest/queuetest.go
+++ b/libbeat/publisher/queue/queuetest/queuetest.go
@@ -18,12 +18,8 @@
 package queuetest
 
 import (
-	"errors"
-	"io"
 	"sync"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -213,26 +209,10 @@ func runTestCases(t *testing.T, tests []testCase, queueFactory QueueFactory) {
 
 			go test.producers(&wg, nil, log, queue)()
 			go test.consumers(&wg, nil, log, queue)()
-			go testFetchMetrics(t, queue)
+
 			wg.Wait()
 		}))
 	}
-}
-
-func testFetchMetrics(t *testing.T, mon queue.Queue) {
-	_, err := mon.Metrics()
-	if errors.Is(err, queue.ErrMetricsNotImplemented) {
-		return
-	}
-
-	metrics, err := mon.Metrics()
-	// EOF is returned if the queue is closing, so the only "good" error is that
-	if err != nil {
-		assert.ErrorIs(t, err, io.EOF)
-	}
-
-	assert.True(t, metrics.EventCount.Exists() || metrics.ByteCount.Exists())
-
 }
 
 func multiple(


### PR DESCRIPTION
## What does this PR do?

This is a fix for https://github.com/elastic/beats/issues/31916. This just removes the test, as shortly after I made this test, I made a series of much more comprehensive tests for the metrics that ended up in `memqueue/queue_test.go`, so I don't really think this is actually necessary. 

## Why is it important?
This is causing some intermittent test failures.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
