### PR TITLE
Add encryption to diskqueue

### DIFF
--- a/libbeat/publisher/queue/diskqueue/benchmark_test.go
+++ b/libbeat/publisher/queue/diskqueue/benchmark_test.go
@@ -15,8 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// example: go test -bench=. -benchtime 3x -timeout 60m
+// Usage:
 //
+// go test -bench=1M -benchtime 1x -count 10 -timeout 600m -benchmem > results.txt
+//
+// then
+//
+// benchstat results.txt
+//
+// you can give benchstat multiple files to analyse and it will
+// compare the results between them.
+// https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
+
 package diskqueue
 
 import (

--- a/libbeat/publisher/queue/diskqueue/config.go
+++ b/libbeat/publisher/queue/diskqueue/config.go
@@ -68,6 +68,9 @@ type Settings struct {
 	// use exponential backoff up to the specified limit.
 	RetryInterval    time.Duration
 	MaxRetryInterval time.Duration
+
+	// EncryptionKey is used to encrypt data if SchemaVersion 2 is used.
+	EncryptionKey []byte
 }
 
 // userConfig holds the parameters for a disk queue that are configurable

--- a/libbeat/publisher/queue/diskqueue/core_loop.go
+++ b/libbeat/publisher/queue/diskqueue/core_loop.go
@@ -277,7 +277,7 @@ func (dq *diskQueue) handleShutdown() {
 	dq.acks.lock.Lock()
 	finalPosition := dq.acks.nextPosition
 	// We won't be updating the position anymore, so we can close the file.
-	dq.acks.positionFile.Sync()
+	_ = dq.acks.positionFile.Sync()
 	dq.acks.positionFile.Close()
 	dq.acks.lock.Unlock()
 

--- a/libbeat/publisher/queue/diskqueue/core_loop_test.go
+++ b/libbeat/publisher/queue/diskqueue/core_loop_test.go
@@ -486,11 +486,9 @@ func TestMaybeReadPending(t *testing.T) {
 				nextReadFrameID: 5,
 			},
 			expectedRequest: &readerLoopRequest{
-				segment:      &queueSegment{id: 1},
-				startFrameID: 5,
-				// startPosition is 8, the end of the segment header in the
-				// current file schema.
-				startPosition: 8,
+				segment:       &queueSegment{id: 1},
+				startFrameID:  5,
+				startPosition: segmentHeaderSize,
 				endPosition:   1000,
 			},
 		},
@@ -533,7 +531,7 @@ func TestMaybeReadPending(t *testing.T) {
 			},
 			expectedRequest: &readerLoopRequest{
 				segment:       &queueSegment{id: 1},
-				startPosition: 8,
+				startPosition: segmentHeaderSize,
 				endPosition:   1000,
 			},
 		},
@@ -573,7 +571,7 @@ func TestMaybeReadPending(t *testing.T) {
 			},
 			expectedRequest: &readerLoopRequest{
 				segment:       &queueSegment{id: 2},
-				startPosition: 8,
+				startPosition: segmentHeaderSize,
 				endPosition:   500,
 			},
 			expectedACKingSegment: segmentIDRef(1),

--- a/libbeat/publisher/queue/diskqueue/docs/Makefile
+++ b/libbeat/publisher/queue/diskqueue/docs/Makefile
@@ -1,0 +1,9 @@
+all : schemaV0.svg frameV0.svg schemaV1.svg frameV1.svg schemaV2.svg frameV2.svg
+
+.PHONY : clean
+
+%.svg : %.pic
+	pikchr --svg-only $< > $@
+
+clean :
+	-rm *.svg

--- a/libbeat/publisher/queue/diskqueue/docs/frameV0.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV0.pic
@@ -1,0 +1,9 @@
+boxht = 0.25
+down
+box "size (uint32)" wid 4;
+down
+box "JSON serialized data" dashed wid 4 ht 2;
+down
+box "checksum (uint32)" wid 4;
+down
+box "size (uint32)" wid 4;

--- a/libbeat/publisher/queue/diskqueue/docs/frameV0.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV0.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 400.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">JSON serialized data</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">checksum (uint32)</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/frameV1.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV1.pic
@@ -1,0 +1,9 @@
+boxht = 0.25
+down
+box "size (uint32)" wid 4;
+down
+box "CBOR serialized data" dashed wid 4 ht 2;
+down
+box "checksum (uint32)" wid 4;
+down
+box "size (uint32)" wid 4;

--- a/libbeat/publisher/queue/diskqueue/docs/frameV1.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV1.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 400.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">CBOR serialized data</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">checksum (uint32)</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/frameV2.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV2.pic
@@ -1,0 +1,5 @@
+boxht = 0.25
+SIZE1: box "size (uint32)" wid 4;
+DATA: box "CBOR serialized data" dashed wid 4 ht 2 with .nw at SIZE1.sw;
+CHECKSUM: box "checksum (uint32)" wid 4 with .nw at DATA.sw;
+SIZE2: box "size (uint32)" wid 4 with nw at CHECKSUM.sw;

--- a/libbeat/publisher/queue/diskqueue/docs/frameV2.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/frameV2.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 400.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">CBOR serialized data</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">checksum (uint32)</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">size (uint32)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
+++ b/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
@@ -55,10 +55,10 @@ of three fields.  The first field in the version number, which is an
 unsigned 32-bit integer in little-endian format.  The second field is
 a count of the number of frames in the segment, which is an unsigned
 32-bit integer in little-endian format.  The third field holds bit
-flags, which signify options.  The size of options is 8-bits in
+flags, which signify options.  The size of options is 32-bits in
 little-endian format.
 
-If the options field has the 0x1 bit set, then encryption is enabled.  In
+If the options field has the first bit set, then encryption is enabled.  In
 which case, the next 128-bits are the initialization vector and the
 rest of the file is encrypted frames.  If the field is not set,
 un-encrypted frames follow the header.

--- a/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
+++ b/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
@@ -55,7 +55,7 @@ of three fields.  The first field in the version number, which is an
 unsigned 32-bit integer in little-endian format.  The second field is
 a count of the number of frames in the segment, which is an unsigned
 32-bit integer in little-endian format.  The third field holds bit
-flags, which signify options.  The size of options in 8-bits in
+flags, which signify options.  The size of options is 8-bits in
 little-endian format.
 
 If the options field has the 0x1 bit set, then encryption is enabled.  In

--- a/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
+++ b/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
@@ -1,0 +1,77 @@
+# Disk Queue On Disk Structures
+
+The disk queue is a directory on disk that contains files.  Each
+file is called a segment.  The name of the file is the segment id in
+base 10 with the ".seg" suffix.  For example: "42.seg".  Each segment
+contains multiple frames.  Each frame contains one event.
+
+There are currently 3 versions of the disk queue, and the current code
+base is able to write versions 1 & 2, while it is able to read version
+0, 1, and 2.
+
+## Version 0
+
+In version 0, the segments are made up of a header, followed by
+frames.  The header contains one field which is an unsigned 32-bit
+integer in little-endian byte order, which signifies the version number.
+
+![Segment Schema Version 0](./schemaV0.svg)
+
+The frames for version 0, consist of a header, followed by the
+serialized event and a footer.  The header contains one field which is
+the size of the frame, which is an unsigned 32-bit integer in
+little-endian byte order.  The serialization format is JSON.  The
+footer contains 2 fields, the first of which is a checksum which is an
+unsigned 32-bit integer in little-endian format, followed by a repeat
+of the size from the header.
+
+![Frame Version 0](./frameV0.svg)
+
+## Version 1
+
+In version 1, the segments are made up of a header, followed by
+frames.  The header contains two fields.  The first field in the
+version number, which is an unsigned 32-bit integer in little-endian
+format.  The second field is a count of the number of frames in the
+segment, which is an unsigned 32-bit integer in little-endian format.
+
+![Segment Schema Version 1](./schemaV1.svg)
+
+The frames for version 1, consist of a header, followed by the
+serialized event and a footer.  The header contains one field which is
+the size of the frame, which is an unsigned 32-bit integer in
+little-endian format.  The serialization format is CBOR.  The footer
+contains 2 fields, the first of which is a checksum which is an
+unsigned 32-bit integer in little-endian format, followed by a repeat
+of the size from the header.
+
+![Frame Version 1](./frameV1.svg)
+
+## Version 2
+
+In version 2, the segments are made of a header followed by an
+optional initialization vector, and then frames.  The header consists
+of three fields.  The first field in the version number, which is an
+unsigned 32-bit integer in little-endian format.  The second field is
+a count of the number of frames in the segment, which is an unsigned
+32-bit integer in little-endian format.  The third field holds bit
+flags, which signify options.  The size of options in 8-bits in
+little-endian format.
+
+If the options field has the 0x1 bit set, then encryption is enabled.  In
+which case, the next 128-bits are the initialization vector and the
+rest of the file is encrypted frames.  If the field is not set,
+un-encrypted frames follow the header.
+
+
+![Segment Schema Version 2](./schemaV2.svg)
+
+The frames for version 2, consist of a header, followed by the
+serialized event and a footer.  The header contains one field which is
+the size of the frame, which is an unsigned 32-bit integer in
+little-endian format.  The serialization format is CBOR.  The footer
+contains 2 fields, the first of which is a checksum which is an
+unsigned 32-bit integer in little-endian format, followed by a repeat
+of the size from the header.  This is the same as version 1.
+
+![Frame Version 2](./frameV2.svg)

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV0.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV0.pic
@@ -1,0 +1,9 @@
+boxht = 0.25
+down;
+box "version (uint32)" wid 4;
+down;
+box "frame 0" wid 4 ht 2;
+down;
+box "..." dashed wid 4;
+down;
+box "frame n" wid 4 ht 2;

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV0.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV0.svg
@@ -1,0 +1,11 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 652.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">version (uint32)</text>
+<path d="M2,326L578,326L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame 0</text>
+<path d="M2,362L578,362L578,326L2,326Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="344" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">...</text>
+<path d="M2,650L578,650L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="506" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame n</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV1.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV1.pic
@@ -1,0 +1,11 @@
+boxht = 0.25
+down;
+box "version (uint32)" wid 4;
+down;
+box "count (uint32)" wid 4;
+down;
+box "frame 0" wid 4 ht 2;
+down;
+box "..." dashed wid 4;
+down;
+box "frame (count - 1)" wid 4 ht 2;

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV1.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV1.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 688.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">version (uint32)</text>
+<path d="M2,74L578,74L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="56" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">count (uint32)</text>
+<path d="M2,362L578,362L578,74L2,74Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="218" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame 0</text>
+<path d="M2,398L578,398L578,362L2,362Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="380" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">...</text>
+<path d="M2,686L578,686L578,398L2,398Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="542" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">frame (count - 1)</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV2.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV2.pic
@@ -1,6 +1,6 @@
 boxht = 0.25
 VERSION: box "version (uint32)" wid 4;
 COUNT: box "count (uint32)" wid 4 with .nw at VERSION.sw;
-OPTIONS: box "options (uint8)" wid 1 with .nw at COUNT.sw;
+OPTIONS: box "options (uint32)" wid 4 with .nw at COUNT.sw;
 IV: box "initialization vector (128 bits)" wid 4 ht 1 with .nw at OPTIONS.sw
 FRAME: box "Encrypted Frames" dashed wid 4 ht 2 with .nw at IV.sw;

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV2.pic
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV2.pic
@@ -1,0 +1,6 @@
+boxht = 0.25
+VERSION: box "version (uint32)" wid 4;
+COUNT: box "count (uint32)" wid 4 with .nw at VERSION.sw;
+OPTIONS: box "options (uint8)" wid 1 with .nw at COUNT.sw;
+IV: box "initialization vector (128 bits)" wid 4 ht 1 with .nw at OPTIONS.sw
+FRAME: box "Encrypted Frames" dashed wid 4 ht 2 with .nw at IV.sw;

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV2.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV2.svg
@@ -3,8 +3,8 @@
 <text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">version (uint32)</text>
 <path d="M2,74L578,74L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
 <text x="290" y="56" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">count (uint32)</text>
-<path d="M2,110L146,110L146,74L2,74Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
-<text x="74" y="92" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">options (uint8)</text>
+<path d="M2,110L578,110L578,74L2,74Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="92" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">options (uint32)</text>
 <path d="M2,254L578,254L578,110L2,110Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
 <text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">initialization vector (128 bits)</text>
 <path d="M2,542L578,542L578,254L2,254Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />

--- a/libbeat/publisher/queue/diskqueue/docs/schemaV2.svg
+++ b/libbeat/publisher/queue/diskqueue/docs/schemaV2.svg
@@ -1,0 +1,13 @@
+<svg xmlns='http://www.w3.org/2000/svg' class="pikchr" viewBox="0 0 580.32 544.32">
+<path d="M2,38L578,38L578,2L2,2Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="20" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">version (uint32)</text>
+<path d="M2,74L578,74L578,38L2,38Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="56" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">count (uint32)</text>
+<path d="M2,110L146,110L146,74L2,74Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="74" y="92" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">options (uint8)</text>
+<path d="M2,254L578,254L578,110L2,110Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);" />
+<text x="290" y="182" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">initialization vector (128 bits)</text>
+<path d="M2,542L578,542L578,254L2,254Z"  style="fill:none;stroke-width:2.16;stroke:rgb(0,0,0);stroke-dasharray:7.2,7.2;" />
+<text x="290" y="398" text-anchor="middle" fill="rgb(0,0,0)" dominant-baseline="central">Encrypted Frames</text>
+</svg>
+

--- a/libbeat/publisher/queue/diskqueue/encryption.go
+++ b/libbeat/publisher/queue/diskqueue/encryption.go
@@ -1,0 +1,166 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+const (
+	// KeySize is 128-bit
+	KeySize = 16
+)
+
+//EncryptionReader allows reading from a AES-128-CTR stream
+type EncryptionReader struct {
+	src        io.ReadCloser
+	stream     cipher.Stream
+	block      cipher.Block
+	iv         []byte
+	ciphertext []byte
+}
+
+//NewEncryptionReader returns a new AES-128-CTR decrypter
+func NewEncryptionReader(r io.ReadCloser, key []byte) (*EncryptionReader, error) {
+	if len(key) != KeySize {
+		return nil, fmt.Errorf("key must be %d bytes long", KeySize)
+	}
+
+	er := &EncryptionReader{}
+	er.src = r
+
+	// turn key into block & save
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	er.block = block
+
+	// read IV from the io.ReadCloser
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(er.src, iv); err != nil {
+		return nil, err
+	}
+	er.iv = iv
+
+	// create Stream
+	er.stream = cipher.NewCTR(block, iv)
+
+	return er, nil
+}
+
+func (er *EncryptionReader) Read(buf []byte) (int, error) {
+	if cap(er.ciphertext) >= len(buf) {
+		er.ciphertext = er.ciphertext[:len(buf)]
+	} else {
+		er.ciphertext = make([]byte, len(buf))
+	}
+	n, err := er.src.Read(er.ciphertext)
+	if err != nil {
+		return n, err
+	}
+	er.stream.XORKeyStream(buf, er.ciphertext)
+	return n, nil
+}
+
+func (er *EncryptionReader) Close() error {
+	return er.src.Close()
+}
+
+//Reset Sets up stream again, assumes that caller has already set the
+// src to the iv
+func (er *EncryptionReader) Reset() error {
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(er.src, iv); err != nil {
+		return err
+	}
+	if !bytes.Equal(iv, er.iv) {
+		return fmt.Errorf("different iv, something is wrong")
+	}
+
+	// create Stream
+	er.stream = cipher.NewCTR(er.block, iv)
+	return nil
+}
+
+//EncryptionWriter allows writing to a AES-128-CTR stream
+type EncryptionWriter struct {
+	dst        WriteCloseSyncer
+	stream     cipher.Stream
+	ciphertext []byte
+}
+
+//NewEncryptionWriter returns a new AES-128-CTR stream encryptor
+func NewEncryptionWriter(w WriteCloseSyncer, key []byte) (*EncryptionWriter, error) {
+	if len(key) != KeySize {
+		return nil, fmt.Errorf("key must be %d bytes long", KeySize)
+	}
+
+	ew := &EncryptionWriter{}
+
+	// turn key into block
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// create random IV
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, err
+	}
+
+	// create stream
+	stream := cipher.NewCTR(block, iv)
+
+	//write IV
+	n, err := w.Write(iv)
+	if err != nil {
+		return nil, err
+	}
+	if n != len(iv) {
+		return nil, io.ErrShortWrite
+	}
+
+	ew.dst = w
+	ew.stream = stream
+	return ew, nil
+}
+
+func (ew *EncryptionWriter) Write(buf []byte) (int, error) {
+	if cap(ew.ciphertext) >= len(buf) {
+		ew.ciphertext = ew.ciphertext[:len(buf)]
+	} else {
+		ew.ciphertext = make([]byte, len(buf))
+	}
+	ew.stream.XORKeyStream(ew.ciphertext, buf)
+	return ew.dst.Write(ew.ciphertext)
+}
+
+func (ew *EncryptionWriter) Close() error {
+	return ew.dst.Close()
+}
+
+func (ew *EncryptionWriter) Sync() error {
+	return ew.dst.Sync()
+}

--- a/libbeat/publisher/queue/diskqueue/encryption_test.go
+++ b/libbeat/publisher/queue/diskqueue/encryption_test.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"bytes"
+	"crypto/aes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func NopWriteCloseSyncer(w io.WriteCloser) WriteCloseSyncer {
+	return nopWriteCloseSyncer{w}
+}
+
+type nopWriteCloseSyncer struct {
+	io.WriteCloser
+}
+
+func (nopWriteCloseSyncer) Sync() error { return nil }
+
+func TestEncryptionRoundTrip(t *testing.T) {
+	tests := map[string]struct {
+		plaintext []byte
+	}{
+		"8 bits":   {plaintext: []byte("a")},
+		"128 bits": {plaintext: []byte("bbbbbbbbbbbbbbbb")},
+		"136 bits": {plaintext: []byte("ccccccccccccccccc")},
+	}
+	for name, tc := range tests {
+		pr, pw := io.Pipe()
+		src := bytes.NewReader(tc.plaintext)
+		var dst bytes.Buffer
+		var teeBuf bytes.Buffer
+		key := []byte("kkkkkkkkkkkkkkkk")
+
+		go func() {
+			//NewEncryptionWriter writes iv, so needs to be in go routine
+			ew, err := NewEncryptionWriter(NopWriteCloseSyncer(pw), key)
+			assert.Nil(t, err, name)
+			_, err = io.Copy(ew, src)
+			assert.Nil(t, err, name)
+			ew.Close()
+		}()
+
+		tr := io.TeeReader(pr, &teeBuf)
+		er, err := NewEncryptionReader(io.NopCloser(tr), key)
+		assert.Nil(t, err, name)
+		_, err = io.Copy(&dst, er)
+		assert.Nil(t, err, name)
+		// Check round trip worked
+		assert.Equal(t, tc.plaintext, dst.Bytes(), name)
+		// Check that iv & cipher text were written
+		assert.Equal(t, len(tc.plaintext)+aes.BlockSize, teeBuf.Len(), name)
+		// Check that cipher text and plaintext don't match
+		assert.NotEqual(t, tc.plaintext, teeBuf.Bytes()[aes.BlockSize:], name)
+	}
+}

--- a/libbeat/publisher/queue/diskqueue/reader_loop.go
+++ b/libbeat/publisher/queue/diskqueue/reader_loop.go
@@ -21,7 +21,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"os"
 )
 
 // startPosition and endPosition are absolute byte offsets into the segment
@@ -106,12 +105,13 @@ func (rl *readerLoop) processRequest(request readerLoopRequest) readerLoopRespon
 		return readerLoopResponse{err: err}
 	}
 	defer handle.Close()
+
 	_, err = handle.Seek(int64(request.startPosition), io.SeekStart)
 	if err != nil {
 		return readerLoopResponse{err: err}
 	}
 
-	targetLength := uint64(request.endPosition - request.startPosition)
+	targetLength := request.endPosition - request.startPosition
 	for {
 		remainingLength := targetLength - byteCount
 
@@ -173,9 +173,7 @@ func (rl *readerLoop) processRequest(request readerLoopRequest) readerLoopRespon
 // it does not exceed the given length bound. The returned frame leaves the
 // segment and frame IDs unset.
 // The returned error will be set if and only if the returned frame is nil.
-func (rl *readerLoop) nextFrame(
-	handle *os.File, maxLength uint64,
-) (*readFrame, error) {
+func (rl *readerLoop) nextFrame(handle *segmentReader, maxLength uint64) (*readFrame, error) {
 	// Ensure we are allowed to read the frame header.
 	if maxLength < frameHeaderSize {
 		return nil, fmt.Errorf(

--- a/libbeat/publisher/queue/diskqueue/segments.go
+++ b/libbeat/publisher/queue/diskqueue/segments.go
@@ -137,7 +137,7 @@ type segmentHeader struct {
 	frameCount uint32
 
 	// options holds flags to enable features, for example encryption.
-	options uint8
+	options uint32
 }
 
 type WriteCloseSyncer interface {
@@ -152,9 +152,9 @@ const currentSegmentVersion = 2
 // In contexts where the segment may have been created by an earlier version,
 // instead use (queueSegment).headerSize() which accounts for the schema
 // version of the target segment.
-const segmentHeaderSize = 9
+const segmentHeaderSize = 12
 
-const ENABLE_ENCRYPTION uint8 = 0x1
+const ENABLE_ENCRYPTION uint32 = 0x1
 
 // Sort order: we store loaded segments in ascending order by their id.
 type bySegmentID []*queueSegment
@@ -256,7 +256,7 @@ func (segment *queueSegment) getReader(queueSettings Settings) (*segmentReader, 
 
 // Should only be called from the writer loop.
 func (segment *queueSegment) getWriter(queueSettings Settings) (*segmentWriter, error) {
-	var options uint8
+	var options uint32
 	path := queueSettings.segmentPath(segment.id)
 	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
@@ -497,7 +497,7 @@ func (w *segmentWriter) Sync() error {
 	return w.dst.Sync()
 }
 
-func (w *segmentWriter) WriteHeader(options uint8) error {
+func (w *segmentWriter) WriteHeader(options uint32) error {
 	if _, err := w.dst.Seek(0, io.SeekStart); err != nil {
 		return err
 	}

--- a/libbeat/publisher/queue/diskqueue/segments.go
+++ b/libbeat/publisher/queue/diskqueue/segments.go
@@ -237,7 +237,7 @@ func (segment *queueSegment) getReader(queueSettings Settings) (*segmentReader, 
 	header, err := readSegmentHeader(file)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"couldn't header for segment %d: %w", segment.id, err)
+			"couldn't read header for segment %d: %w", segment.id, err)
 	}
 
 	sr := &segmentReader{}

--- a/libbeat/publisher/queue/diskqueue/segments_test.go
+++ b/libbeat/publisher/queue/diskqueue/segments_test.go
@@ -1,0 +1,138 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSegmentsRoundTrip(t *testing.T) {
+	tests := map[string]struct {
+		id        segmentID
+		encrypt   bool
+		plaintext []byte
+	}{
+		"No Encryption": {
+			id:        0,
+			encrypt:   false,
+			plaintext: []byte("abc"),
+		},
+		"Encryption": {
+			id:        1,
+			encrypt:   true,
+			plaintext: []byte("abc"),
+		},
+	}
+	dir, err := os.MkdirTemp("", t.Name())
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+	for name, tc := range tests {
+		dst := make([]byte, len(tc.plaintext))
+		settings := DefaultSettings()
+		settings.Path = dir
+		if tc.encrypt {
+			settings.EncryptionKey = []byte("keykeykeykeykeyk")
+		}
+		qs := &queueSegment{
+			id: tc.id,
+		}
+		sw, err := qs.getWriter(settings)
+		assert.Nil(t, err, name)
+
+		n, err := sw.Write(tc.plaintext)
+		assert.Nil(t, err, name)
+		assert.Equal(t, len(tc.plaintext), n, name)
+
+		err = sw.Close()
+		assert.Nil(t, err, name)
+
+		sr, err := qs.getReader(settings)
+		assert.Nil(t, err, name)
+
+		n, err = sr.Read(dst)
+		assert.Nil(t, err, name)
+
+		err = sr.Close()
+		assert.Nil(t, err, name)
+		assert.Equal(t, len(dst), n, name)
+
+		//make sure we read back what we wrote
+		assert.Equal(t, tc.plaintext, dst, name)
+
+	}
+}
+
+func TestSegmentReaderSeek(t *testing.T) {
+	tests := map[string]struct {
+		id         segmentID
+		encrypt    bool
+		plaintexts [][]byte
+	}{
+		"No Encryption": {
+			id:         0,
+			encrypt:    false,
+			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
+		},
+		"Encryption": {
+			id:         1,
+			encrypt:    true,
+			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
+		},
+	}
+	dir, err := os.MkdirTemp("", t.Name())
+	assert.Nil(t, err)
+	//	defer os.RemoveAll(dir)
+	for name, tc := range tests {
+		settings := DefaultSettings()
+		settings.Path = dir
+		if tc.encrypt {
+			settings.EncryptionKey = []byte("keykeykeykeykeyk")
+		}
+
+		qs := &queueSegment{
+			id: tc.id,
+		}
+		sw, err := qs.getWriter(settings)
+		assert.Nil(t, err, name)
+		for _, plaintext := range tc.plaintexts {
+			n, err := sw.Write(plaintext)
+			assert.Nil(t, err, name)
+			assert.Equal(t, len(plaintext), n, name)
+			err = sw.Sync()
+			assert.Nil(t, err, name)
+		}
+		sw.Close()
+		sr, err := qs.getReader(settings)
+		assert.Nil(t, err, name)
+		//seek to second data piece
+		n, err := sr.Seek(segmentHeaderSize+int64(len(tc.plaintexts[0])), io.SeekStart)
+		assert.Nil(t, err, name)
+		assert.Equal(t, segmentHeaderSize+int64(len(tc.plaintexts[0])), n, name)
+		dst := make([]byte, len(tc.plaintexts[1]))
+
+		_, err = sr.Read(dst)
+		assert.Nil(t, err, name)
+		assert.Equal(t, tc.plaintexts[1], dst, name)
+
+		sw.Close()
+	}
+}

--- a/libbeat/publisher/queue/diskqueue/segments_test.go
+++ b/libbeat/publisher/queue/diskqueue/segments_test.go
@@ -104,7 +104,7 @@ func TestSegmentReaderSeek(t *testing.T) {
 	}
 	dir, err := os.MkdirTemp("", t.Name())
 	assert.Nil(t, err)
-	//	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
 	for name, tc := range tests {
 		settings := DefaultSettings()
 		settings.Path = dir
@@ -163,7 +163,7 @@ func TestSegmentReaderSeekLocations(t *testing.T) {
 	}
 	dir, err := os.MkdirTemp("", t.Name())
 	assert.Nil(t, err)
-	//	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
 	for name, tc := range tests {
 		settings := DefaultSettings()
 		settings.Path = dir

--- a/libbeat/publisher/queue/diskqueue/segments_test.go
+++ b/libbeat/publisher/queue/diskqueue/segments_test.go
@@ -76,7 +76,7 @@ func TestSegmentsRoundTrip(t *testing.T) {
 		//make sure we read back what we wrote
 		assert.Equal(t, tc.plaintext, dst, name)
 
-		n, err = sr.Read(dst)
+		_, err = sr.Read(dst)
 		assert.ErrorIs(t, err, io.EOF, name)
 
 		err = sr.Close()

--- a/libbeat/publisher/queue/diskqueue/serialize.go
+++ b/libbeat/publisher/queue/diskqueue/serialize.go
@@ -54,7 +54,7 @@ type eventDecoder struct {
 
 type entry struct {
 	Timestamp int64
-	Flags     uint8
+	Flags     uint32
 	Meta      mapstr.M
 	Fields    mapstr.M
 }
@@ -98,7 +98,7 @@ func (e *eventEncoder) encode(evt interface{}) ([]byte, error) {
 
 	err := e.folder.Fold(entry{
 		Timestamp: event.Content.Timestamp.UTC().UnixNano(),
-		Flags:     uint8(event.Flags),
+		Flags:     uint32(event.Flags),
 		Meta:      event.Content.Meta,
 		Fields:    event.Content.Fields,
 	})


### PR DESCRIPTION
## What does this PR do?

Adds support for AES 128 CTR encryption to disk queue.

## Why is it important?

Necessary for endpoint running under elastic-agent

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

```
go test -bench=1M -benchtime 1x -count 10 -timeout 600m -benchmem > results.txt

benchstat results.txt
name               time/op
Async1M-16          22.0s ± 1%
EncryptAsync1M-16   20.5s ± 1%
Sync1M-16           25.2s ± 1%
EncryptSync1M-16    27.5s ± 0%

name               alloc/op
Async1M-16         3.43GB ± 0%
EncryptAsync1M-16  3.43GB ± 0%
Sync1M-16          3.42GB ± 0%
EncryptSync1M-16   3.42GB ± 0%

name               allocs/op
Async1M-16          40.6M ± 0%
EncryptAsync1M-16   40.5M ± 0%
Sync1M-16           39.5M ± 0%
EncryptSync1M-16    40.1M ± 0%
```


## Related issues

- Relates elastic-agent-shipper#33
- Relates #31935 
- Relates #31949

