### PR TITLE
Save file size to registry of ignored files

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix MISP documentation for `var.filters` config option. {pull}31434[31434]
 - Fix type mapping of client.as.number in okta module. {pull}31676[31676]
 - Fix last write pagination commit checkpoint on `aws-s3` input for s3 direct polling when using the same bucket and different list prefixes. {pull}31776[31776]
+- If a file is ignored by `filestream` because of ignore_older settings, when it is updated, only the new lines are shipped to the output. {issue}31924[31924] {pull}31972[31972]
 
 *Heartbeat*
 

--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -168,8 +168,8 @@ The files affected by this setting fall into two categories:
 * Files that were harvested but weren't updated for longer than `ignore_older`
 
 For files which were never seen before, the offset state is set to the end of
-the file. If a state already exists, the offset is not changed. If a file is
-updated again later, reading continues at the set offset position.
+the file. If a state already exists, the offset is reset to the size of the file.
+If a file is updated again later, reading continues at the set offset position.
 
 The `ignore_older` setting relies on the modification time of the file to
 determine if a file is ignored. If the modification time of the file is not

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -19,7 +19,6 @@ package filestream
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -145,14 +144,12 @@ func TestCopyTruncateProspector_Create(t *testing.T) {
 			for originalFile, rotatedFiles := range test.expectedRotatedFiles {
 				rFile, ok := p.rotatedFiles.table[originalFile]
 				if !ok {
-					fmt.Printf("cannot find %s in original files\n", originalFile)
-					t.FailNow()
+					t.Fatalf("cannot find %s in original files\n", originalFile)
 				}
 				require.Equal(t, len(rotatedFiles), len(rFile.rotated))
 				for i, rotatedFile := range rotatedFiles {
 					if rFile.rotated[i].path != rotatedFile {
-						fmt.Printf("%s is not a rotated file, instead %s is\n", rFile.rotated[i].path, rotatedFile)
-						t.FailNow()
+						t.Fatalf("%s is not a rotated file, instead %s is\n", rFile.rotated[i].path, rotatedFile)
 					}
 				}
 			}

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -129,7 +129,7 @@ func TestCopyTruncateProspector_Create(t *testing.T) {
 					filewatcher: newMockFileWatcher(test.events, len(test.events)),
 					identifier:  mustPathIdentifier(false),
 				},
-				regexp.MustCompile("\\.\\d$"),
+				regexp.MustCompile(`\.\d$`),
 				&rotatedFilestreams{make(map[string]*rotatedFilestream), newNumericSorter()},
 			}
 			ctx := input.Context{Logger: logp.L(), Cancelation: context.Background()}

--- a/filebeat/input/filestream/copytruncate_prospector_test.go
+++ b/filebeat/input/filestream/copytruncate_prospector_test.go
@@ -126,7 +126,7 @@ func TestCopyTruncateProspector_Create(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			p := copyTruncateFileProspector{
 				fileProspector{
-					filewatcher: &mockFileWatcher{events: test.events},
+					filewatcher: newMockFileWatcher(test.events, len(test.events)),
 					identifier:  mustPathIdentifier(false),
 				},
 				regexp.MustCompile("\\.\\d$"),

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -187,7 +187,9 @@ func (p *fileProspector) onFSEvent(
 
 		if p.isFileIgnored(log, event, ignoreSince) {
 			err := updater.ResetCursor(src, state{Offset: event.Info.Size()})
-			log.Errorf("setting cursor for ignored file: %v", err)
+			if err != nil {
+				log.Errorf("setting cursor for ignored file: %v", err)
+			}
 			return
 		}
 
@@ -197,7 +199,9 @@ func (p *fileProspector) onFSEvent(
 		log.Debugf("File %s has been truncated", event.NewPath)
 
 		err := updater.ResetCursor(src, state{Offset: 0})
-		log.Errorf("resseting cursor on truncated file: %v", err)
+		if err != nil {
+			log.Errorf("reseting cursor on truncated file: %v", err)
+		}
 		group.Restart(ctx, src)
 
 	case loginp.OpDelete:

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -186,6 +186,8 @@ func (p *fileProspector) onFSEvent(
 		}
 
 		if p.isFileIgnored(log, event, ignoreSince) {
+			err := updater.ResetCursor(src, state{Offset: event.Info.Size()})
+			log.Errorf("setting cursor for ignored file: %v", err)
 			return
 		}
 

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -200,7 +200,7 @@ func (p *fileProspector) onFSEvent(
 
 		err := updater.ResetCursor(src, state{Offset: 0})
 		if err != nil {
-			log.Errorf("reseting cursor on truncated file: %v", err)
+			log.Errorf("resetting cursor on truncated file: %v", err)
 		}
 		group.Restart(ctx, src)
 

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -297,7 +297,7 @@ func TestProspectorHarvesterUpdateIgnoredFiles(t *testing.T) {
 		wg.Done()
 	}()
 
-	// The prospector must persist the size of the to the state
+	// The prospector must persist the size of the file to the state
 	// as the offset, so when the file is updated only the new
 	// lines are sent to the output.
 	assert.Eventually(

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -571,7 +571,7 @@ func (mu *mockMetadataUpdater) ResetCursor(s loginp.Source, cur interface{}) err
 }
 
 func (mu *mockMetadataUpdater) UpdateMetadata(s loginp.Source, v interface{}) error {
-	mu.set(s.Name())
+	mu.table[s.Name()] = v
 	return nil
 }
 

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -258,7 +258,7 @@ func TestProspectorNewAndUpdatedFiles(t *testing.T) {
 	}
 }
 
-// TestProspectorNewAndUpdatedFiles checks if the prospector can
+// TestProspectorHarvesterUpdateIgnoredFiles checks if the prospector can
 // save the size of an ignored file to the registry. If the ignored
 // file is updated, and has to be collected, a new harvester is started.
 func TestProspectorHarvesterUpdateIgnoredFiles(t *testing.T) {

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -290,9 +290,8 @@ func TestProspectorHarvesterUpdateIgnoredFiles(t *testing.T) {
 	hg := newTestHarvesterGroup()
 	testStore := newMockMetadataUpdater()
 	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
-
 		p.Run(ctx, testStore, hg)
 
 		wg.Done()

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -517,7 +517,6 @@ AGAIN:
 		if m.ctx != nil && m.ctx.Err() == nil {
 			goto AGAIN
 		}
-		fmt.Println("nincs")
 		return loginp.FSEvent{}
 	}
 	evt := m.events[m.nextIdx]
@@ -543,7 +542,6 @@ func (mu *mockMetadataUpdater) set(id string) { mu.table[id] = struct{}{} }
 
 func (mu *mockMetadataUpdater) has(id string) bool {
 	_, ok := mu.table[id]
-	fmt.Println("has", id, ok)
 	return ok
 }
 
@@ -568,7 +566,6 @@ func (mu *mockMetadataUpdater) FindCursorMeta(s loginp.Source, v interface{}) er
 }
 
 func (mu *mockMetadataUpdater) ResetCursor(s loginp.Source, cur interface{}) error {
-	fmt.Println(s, cur)
 	mu.table[s.Name()] = cur
 	return nil
 }


### PR DESCRIPTION
## What does this PR do?

This PR saves the size of the ignored files. Thus, if the file is updated, `filestream` input only reads the new log lines, not the whole file.

The PR also fixes a minor logging problem. Previously, resetting the cursor due to truncation was always logged at an error level. Not it is only logged if the cursor is not reset properly.

## Why is it important?

Now `filestream` input starts to read from the beginning of the file. This is not what we promise in the documentation:
> For files which were never seen before, the offset state is set to the end of the file... If a file is updated again later, reading continues at the set offset position.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Create a `test.log` file with the following contents:
```
ignored line
ignored line
ignored line

```
2. Start Filebeat with the following input configuration:
```
- type: filestream
  enabled: true
  id: my-filestream-id
  paths:
    - test.log
  ignore_older: 10s
```

3. Update `test.log` with a new line:
```
published line

```
4. Check if only the message `"published line"` is published.

## Related issues

Closes #31924