### PR TITLE
Remove outdated setting in Kafka output documentation

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -217,10 +217,6 @@ output.kafka:
 
 The configurable ClientID used for logging, debugging, and auditing purposes. The default is "beats".
 
-===== `worker`
-
-The number of concurrent load-balanced Kafka output workers.
-
 ===== `codec`
 
 Output codec configuration. If the `codec` section is missing, events will be json encoded.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Remove the outdated `worker` setting in the Kafka output documentation.

## Why is it important?

Set this setting does not have any effect.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Relates #4492: Before this PR, the `worker` setting was used to create multiple `sarama.AsyncProducer`. After it, the `worker` setting only makes [`hosts` entries duplicated](https://github.com/elastic/beats/blob/7102be4e5594f158c2b80ff075246d5eab94bebe/libbeat/outputs/hosts.go#L43-L43) for [calling `sarama.NewAsyncProducer`](https://github.com/elastic/beats/blob/7102be4e5594f158c2b80ff075246d5eab94bebe/libbeat/outputs/kafka/client.go#L123-L123), which does not have any positive effect, but a little overhead for [metadata refresh](https://github.com/Shopify/sarama/blob/30b9203a2d27a1d723a223093753453436084e73/client.go#L891-L891).
