### PR TITLE
Fix breaking link in oracle.asciidoc

### DIFF
--- a/metricbeat/docs/modules/oracle.asciidoc
+++ b/metricbeat/docs/modules/oracle.asciidoc
@@ -107,8 +107,6 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 [source,yaml]
 ----
 metricbeat.modules:
-# Module: oracle
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-oracle.html
 
 - module: oracle
   period: 10m


### PR DESCRIPTION
This link fix will hopefully resolve docs build break:

```
13:42:08 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/beats/metricbeat/master/metricbeat-module-oracle.html contains broken links to:
13:42:08 INFO:build_docs:   - en/beats/metricbeat/main/metricbeat-module-oracle.html
```