### PR TITLE
Remove broken link from Oracle module docs.

### DIFF
--- a/metricbeat/docs/modules/oracle.asciidoc
+++ b/metricbeat/docs/modules/oracle.asciidoc
@@ -108,7 +108,6 @@ in <<configuration-metricbeat>>. Here is an example configuration:
 ----
 metricbeat.modules:
 # Module: oracle
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-oracle.html
 
 - module: oracle
   period: 10m

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1186,7 +1186,6 @@ metricbeat.modules:
 
 #-------------------------------- Oracle Module --------------------------------
 # Module: oracle
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-oracle.html
 
 - module: oracle
   period: 10m

--- a/x-pack/metricbeat/module/oracle/_meta/config.yml
+++ b/x-pack/metricbeat/module/oracle/_meta/config.yml
@@ -1,5 +1,4 @@
 # Module: oracle
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-oracle.html
 
 - module: oracle
   period: 10m

--- a/x-pack/metricbeat/modules.d/oracle.yml.disabled
+++ b/x-pack/metricbeat/modules.d/oracle.yml.disabled
@@ -2,7 +2,6 @@
 # Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-oracle.html
 
 # Module: oracle
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-oracle.html
 
 - module: oracle
   period: 10m


### PR DESCRIPTION
This is breaking the docs build as the referenced URL does not exist
yet. I suspect it might only exist after this module has been published
at least once.

Broken in https://github.com/elastic/beats/pull/31368
