### PR TITLE
[Metricbeat] Stop continual error with multiple Logstash pipelines

### DIFF
--- a/metricbeat/module/logstash/node/data.go
+++ b/metricbeat/module/logstash/node/data.go
@@ -115,11 +115,11 @@ func eventMapping(r mb.ReporterV2, content []byte, pipelines []logstash.Pipeline
 				ModuleFields: mapstr.M{},
 			}
 
+			event.MetricSetFields.Update(fields)
+
 			if err = commonFieldsMapping(&event, fields); err != nil {
 				return err
 			}
-
-			event.MetricSetFields.Update(fields)
 
 			if clusterUUID != "" {
 				event.ModuleFields.Put("cluster.id", clusterUUID)


### PR DESCRIPTION
## What does this PR do?

This PR closes https://github.com/elastic/beats/issues/31739.

This PR stops multiple errors being logged when using Logstash with multiple pipelines.

⚠️ **Please see the fields / mapping inconsistency section I've added in this description, because whilst this PR fixes the logging issue, there are some questions.** ⚠️ 

## Why is it important?

The Logs are noisy.

## Checklist

- [x] My code follows the style guidelines of this project (I think so, couldn't find a STYLEGUIDE file)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally

- Follow the docs to setup your environment to build Beats (here: https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html#setting-up-dev-environment)

- Checkout this branch, and then`cd metricbeat`, and then `mage build`.

- Make a Metricbeat config file that contains the following (change the credentials):

```yml
http.enabled: true
metricbeat.modules:
  - module: system

  - module: logstash
    xpack.enabled: true
    period: 10s
    hosts: [ "localhost:9600" ]

output.elasticsearch:
  hosts: [ "localhost:9200" ]
  username: "elastic"
  password: "changeme"
```

- Then run `./metricbeat -e -c PATH_TO_YOUR_METRICBEAT_YML_FILE`

- [Run Logstash with multiple pipelines](https://github.com/elastic/kibana/blob/main/x-pack/plugins/monitoring/dev_docs/how_to/local_setup.md#standalone-cluster).

```
docker run --name logstash \
  --pull always --rm \
  --hostname=logstash \
  --publish=9600:9600 \
  --volume="$(pwd)/x-pack/plugins/monitoring/dev_docs/reference/logstash.yml:/usr/share/logstash/config/logstash.yml:ro" \
  --volume="$(pwd)/x-pack/plugins/monitoring/dev_docs/reference/pipelines.yml:/usr/share/logstash/config/pipelines.yml:ro" \
  docker.elastic.co/logstash/logstash:master-SNAPSHOT
```


You should **not** see excessive logging, e.g.:

![Screenshot 2022-06-17 at 17 19 20](https://user-images.githubusercontent.com/471693/174350731-511ad4f7-e8e3-4113-acaf-e8d656556993.png)


## Related issues

Closes https://github.com/elastic/beats/issues/31739.


## Logs

Excessive logging before:

![Screenshot 2022-06-17 at 17 19 20](https://user-images.githubusercontent.com/471693/174350731-511ad4f7-e8e3-4113-acaf-e8d656556993.png)

## Fields / mapping inconsistency

It is noted in the issue that: 

> The deletions seem to have been added in https://github.com/elastic/beats/pull/10350 presumably to avoid leaving fields in the document that don't comply with ECS

and this seemed like a very reasonable assumption. As such I originally moved 

```go
event.MetricSetFields.Update(fields)
```

below 

```go
if err = commonFieldsMapping(&event, fields); err != nil {
  return err
}
```

because it's `commonFieldsMapping` that calls `fields.Delete()`. This means things like `host` and `version` wouldn't end up on `logstash.node`. [This also aligned with the documentation](https://www.elastic.co/guide/en/beats/metricbeat/master/exported-fields-logstash.html). We can see there that `logstash.node.host` and co are supposed to be an alias. However, that's not the way the mappings seem to work. [These are not aliased](https://github.com/elastic/elasticsearch/blob/master/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json#L286). So having `event.MetricSetFields.Update(fields)` copy everything (the full set of fields) seems necessary. It doesn't align with the docs, but it aligns with the mappings (and most likely how solutions are accessing these fields). There definitely seems to be confusion here in expectation, unless I'm misunderstanding.

[I have also added a Gist here](https://gist.github.com/Kerry350/278c337888b3e457e919c1ce4cdc5b69) with results produced by all three. Before changes, after changes with field deletion, and after changes with no field deletion. We can see that in terms of indexed data before and after changes with no field deletion match. 

As such, this PR just fixes the logging problem by making a new `fields` map each time, which [aligns with this loop example](https://github.com/elastic/beats/blob/main/metricbeat/module/elasticsearch/enrich/data.go#L88).

I am not sure how we want to approach the fields and mappings. It seems that we should update the mappings to accurately reflect the docs regarding aliases, and `id`, `host`, `version` should no longer exist on `logstash.node`.


