### PR TITLE
[7.17](backport elastic/elastic-agent#570) Add filemod times to contents of diagnostics collect command

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -92,6 +92,7 @@
 - Fix lazy acker to only add new actions to the batch. {pull}27981[27981]
 - Allow HTTP metrics to run in bootstrap mode. Add ability to adjust timeouts for Fleet Server. {pull}28260[28260]
 - Increase the download artifact timeout to 10mins and add log download statistics. {pull}31461[31461]
+- Add filemod times to files in diagnostics collect bundle. {pull}31986[31986]
 
 ==== New features
 


### PR DESCRIPTION
Backport https://github.com/elastic/elastic-agent/pull/570

* Add filemod times to contents of diagnostics collect command

Add filemod times to the files and directories in the zip archive.
Log files (and sub dirs) will use the modtime returned by the fileinfo
for the source. Others will use the timestamp from when the zip is
created.

* Fix linter