### PR TITLE
Expand fields in `decode_json_fields` if target is set

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -39,6 +39,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Allow loading secrets that contain commas from the keystore {pull}31694{pull}.
 - Fix Windows service timeouts when the "TCP/IP NetBIOS Helper" service is disabled. {issue}31810[31810] {pull}31835[31835]
+- Expand fields in `decode_json_fields` if target is set. {issue}31712[31712] {pull}32010[32010]
 
 *Auditbeat*
 

--- a/libbeat/common/jsontransform/expand.go
+++ b/libbeat/common/jsontransform/expand.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -52,7 +50,7 @@ func expandFields(m mapstr.M) error {
 		newMap, newIsMap := getMap(v)
 		if newIsMap {
 			if err := expandFields(newMap); err != nil {
-				return errors.Wrapf(err, "error expanding %q", k)
+				return fmt.Errorf("error expanding %q: %w", k, err)
 			}
 		}
 		if dot := strings.IndexRune(k, '.'); dot < 0 {
@@ -79,10 +77,10 @@ func expandFields(m mapstr.M) error {
 		} else {
 			oldMap, oldIsMap := getMap(old)
 			if !oldIsMap {
-				return fmt.Errorf("cannot expand %q: found conflicting key", k)
+				return fmt.Errorf("cannot expand %q: found conflicting key: %w", k, err)
 			}
 			if err := mergeObjects(newMap, oldMap); err != nil {
-				return errors.Wrapf(err, "cannot expand %q", k)
+				return fmt.Errorf("cannot expand %q: %w", k, err)
 			}
 		}
 	}
@@ -111,7 +109,7 @@ func mergeObjects(lhs, rhs mapstr.M) error {
 			return fmt.Errorf("cannot merge %q: found (%T) value", k, rhsValue)
 		}
 		if err := mergeObjects(lhsMap, rhsMap); err != nil {
-			return errors.Wrapf(err, "cannot merge %q", k)
+			return fmt.Errorf("cannot merge %q: %w", k, err)
 		}
 	}
 	return nil

--- a/libbeat/common/jsontransform/expand.go
+++ b/libbeat/common/jsontransform/expand.go
@@ -33,11 +33,11 @@ import (
 //
 // Note that expandFields is destructive, and in the case of an error the
 // map may be left in a semi-expanded state.
-func expandFields(m mapstr.M) error {
+func ExpandFields(m mapstr.M) error {
 	for k, v := range m {
 		newMap, newIsMap := getMap(v)
 		if newIsMap {
-			if err := expandFields(newMap); err != nil {
+			if err := ExpandFields(newMap); err != nil {
 				return errors.Wrapf(err, "error expanding %q", k)
 			}
 		}

--- a/libbeat/common/jsontransform/expand.go
+++ b/libbeat/common/jsontransform/expand.go
@@ -67,7 +67,7 @@ func expandFields(m mapstr.M) error {
 		old, err := m.Put(k, v)
 		if err != nil {
 			// Put will return an error if we attempt to insert into a non-object value.
-			return fmt.Errorf("cannot expand %q: found conflicting key", k)
+			return fmt.Errorf("cannot expand %q: found conflicting key: %w", k, err)
 		}
 		if old == nil {
 			continue
@@ -77,7 +77,7 @@ func expandFields(m mapstr.M) error {
 		} else {
 			oldMap, oldIsMap := getMap(old)
 			if !oldIsMap {
-				return fmt.Errorf("cannot expand %q: found conflicting key: %w", k, err)
+				return fmt.Errorf("cannot expand %q: found conflicting key", k)
 			}
 			if err := mergeObjects(newMap, oldMap); err != nil {
 				return fmt.Errorf("cannot expand %q: %w", k, err)

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -41,7 +41,7 @@ var (
 func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, expandKeys, overwriteKeys, addErrKey bool) {
 	logger := logp.NewLogger("jsonhelper")
 	if expandKeys {
-		if err := ExpandFields(keys); err != nil {
+		if err := expandFields(keys); err != nil {
 			logger.Errorf("JSON: failed to expand fields: %s", err)
 			event.SetErrorWithOption(createJSONError(err.Error()), addErrKey)
 			return

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -41,7 +41,7 @@ var (
 func WriteJSONKeys(event *beat.Event, keys map[string]interface{}, expandKeys, overwriteKeys, addErrKey bool) {
 	logger := logp.NewLogger("jsonhelper")
 	if expandKeys {
-		if err := expandFields(keys); err != nil {
+		if err := ExpandFields(keys); err != nil {
 			logger.Errorf("JSON: failed to expand fields: %s", err)
 			event.SetErrorWithOption(createJSONError(err.Error()), addErrKey)
 			return

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -214,7 +214,7 @@ func unmarshal(maxDepth int, text string, fields *interface{}, processArray bool
 	}
 
 	// try to deep unmarshal fields
-	switch O := fields.(type) {
+	switch O := (*fields).(type) {
 	case map[string]interface{}:
 		for k, v := range O {
 			if decoded, ok := tryUnmarshal(v); ok {
@@ -253,7 +253,7 @@ func decodeJSON(text string, to *interface{}) error {
 		return err
 	}
 
-	switch O := to.(type) {
+	switch O := (*to).(type) {
 	case map[string]interface{}:
 		jsontransform.TransformNumbers(O)
 	}

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -152,12 +152,9 @@ func (f *decodeJSONFields) Run(event *beat.Event) (*beat.Event, error) {
 			if f.expandKeys {
 				switch t := output.(type) {
 				case map[string]interface{}:
-					if err := jsontransform.ExpandFields(t); err != nil {
-						f.logger.Errorf("JSON: failed to expand fields: %s", err)
-						event.SetErrorWithOption(mapstr.M{"json": mapstr.M{"error": err.Error()}}, f.addErrorKey)
-					}
+					jsontransform.ExpandFields(f.logger, event, t, f.addErrorKey)
 				default:
-					errs = append(errs, "failed to add target to root")
+					errs = append(errs, "failed to expand keys")
 				}
 			}
 			_, err = event.PutValue(target, output)

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -19,11 +19,10 @@ package actions
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/beat/events"
@@ -84,7 +83,7 @@ func NewDecodeJSONFields(c *cfg.C) (processors.Processor, error) {
 	err := c.Unpack(&config)
 	if err != nil {
 		logger.Warn("Error unpacking config for decode_json_fields")
-		return nil, fmt.Errorf("fail to unpack the decode_json_fields configuration: %s", err)
+		return nil, fmt.Errorf("fail to unpack the decode_json_fields configuration: %w", err)
 	}
 
 	f := &decodeJSONFields{
@@ -142,7 +141,7 @@ func (f *decodeJSONFields) Run(event *beat.Event) (*beat.Event, error) {
 				if tmp, err := mapstr.M(dict).GetValue(key); err == nil {
 					if v, ok := tmp.(string); ok {
 						id = v
-						mapstr.M(dict).Delete(key)
+						_ = mapstr.M(dict).Delete(key)
 					}
 				}
 			}
@@ -208,14 +207,14 @@ func unmarshal(maxDepth int, text string, fields *interface{}, processArray bool
 		var tmp interface{}
 		err := unmarshal(maxDepth, str, &tmp, processArray)
 		if err != nil {
-			return v, err == errProcessingSkipped
+			return v, errors.Is(err, errProcessingSkipped)
 		}
 
 		return tmp, true
 	}
 
 	// try to deep unmarshal fields
-	switch O := interface{}(*fields).(type) {
+	switch O := fields.(type) {
 	case map[string]interface{}:
 		for k, v := range O {
 			if decoded, ok := tryUnmarshal(v); ok {
@@ -250,11 +249,11 @@ func decodeJSON(text string, to *interface{}) error {
 		return errors.New("multiple json elements found")
 	}
 
-	if _, err := dec.Token(); err != nil && err != io.EOF {
+	if _, err := dec.Token(); err != nil && !errors.Is(err, io.EOF) {
 		return err
 	}
 
-	switch O := interface{}(*to).(type) {
+	switch O := to.(type) {
 	case map[string]interface{}:
 		jsontransform.TransformNumbers(O)
 	}

--- a/libbeat/processors/actions/decode_json_fields.go
+++ b/libbeat/processors/actions/decode_json_fields.go
@@ -149,6 +149,17 @@ func (f *decodeJSONFields) Run(event *beat.Event) (*beat.Event, error) {
 		}
 
 		if target != "" {
+			if f.expandKeys {
+				switch t := output.(type) {
+				case map[string]interface{}:
+					if err := jsontransform.ExpandFields(t); err != nil {
+						f.logger.Errorf("JSON: failed to expand fields: %s", err)
+						event.SetErrorWithOption(mapstr.M{"json": mapstr.M{"error": err.Error()}}, f.addErrorKey)
+					}
+				default:
+					errs = append(errs, "failed to add target to root")
+				}
+			}
 			_, err = event.PutValue(target, output)
 		} else {
 			switch t := output.(type) {

--- a/libbeat/processors/actions/decode_json_fields_test.go
+++ b/libbeat/processors/actions/decode_json_fields_test.go
@@ -485,32 +485,58 @@ func TestExpandKeys(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestExpandKeysError(t *testing.T) {
+func TestExpandKeysWithTarget(t *testing.T) {
 	testConfig := conf.MustNewConfigFrom(map[string]interface{}{
-		"fields":        fields,
-		"expand_keys":   true,
-		"add_error_key": true,
-		"target":        "",
+		"fields":      fields,
+		"expand_keys": true,
+		"target":      "my_target",
 	})
-	input := mapstr.M{"msg": `{"a.b": "c", "a.b.c": "d"}`}
+	input := mapstr.M{"msg": `{"a.b": {"c": "c"}, "a.b.d": "d"}`}
 	expected := mapstr.M{
-		"msg": `{"a.b": "c", "a.b.c": "d"}`,
-		"error": mapstr.M{
-			"message": "cannot expand ...",
-			"type":    "json",
+		"msg": `{"a.b": {"c": "c"}, "a.b.d": "d"}`,
+		"my_target": map[string]interface{}{
+			"a": mapstr.M{
+				"b": map[string]interface{}{
+					"c": "c",
+					"d": "d",
+				},
+			},
 		},
 	}
-
 	actual := getActualValue(t, testConfig, input)
-	assert.Contains(t, actual, "error")
-	errorField := actual["error"].(mapstr.M)
-	assert.Contains(t, errorField, "message")
-
-	// The order in which keys are processed is not defined, so the error
-	// message is not defined. Apart from that, the outcome is the same.
-	assert.Regexp(t, `cannot expand ".*": .*`, errorField["message"])
-	errorField["message"] = "cannot expand ..."
 	assert.Equal(t, expected, actual)
+}
+
+func TestExpandKeysError(t *testing.T) {
+	for _, target := range []string{"", "my_target"} {
+		t.Run(fmt.Sprintf("target set to '%s'", target), func(t *testing.T) {
+			testConfig := conf.MustNewConfigFrom(map[string]interface{}{
+				"fields":        fields,
+				"expand_keys":   true,
+				"add_error_key": true,
+				"target":        "",
+			})
+			input := mapstr.M{"msg": `{"a.b": "c", "a.b.c": "d"}`}
+			expected := mapstr.M{
+				"msg": `{"a.b": "c", "a.b.c": "d"}`,
+				"error": mapstr.M{
+					"message": "cannot expand ...",
+					"type":    "json",
+				},
+			}
+
+			actual := getActualValue(t, testConfig, input)
+			assert.Contains(t, actual, "error")
+			errorField := actual["error"].(mapstr.M)
+			assert.Contains(t, errorField, "message")
+
+			// The order in which keys are processed is not defined, so the error
+			// message is not defined. Apart from that, the outcome is the same.
+			assert.Regexp(t, `cannot expand ".*": .*`, errorField["message"])
+			errorField["message"] = "cannot expand ..."
+			assert.Equal(t, expected, actual)
+		})
+	}
 }
 
 func TestOverwriteMetadata(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

This PR applies the settings in `expand_keys` to the event even if the target is not empty. 

## Why is it important?

Previously, if target was set to anything besides `""`, `expand_keys` did not work. So you could not expand the keys of the parsed JSON if you wanted to put it under a custom field.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Config:
```yaml
filebeat.inputs:
- type: filestream
  id: my-filestream-id
  paths:
    - test.log
  processors:
    - decode_json_fields:
      target: "my_target"
      expand_fields: true
      fields: ["message"]
output.console:
  enabled: true
```

Example input file:
```
{"my.field": "interesting value"}

```

Check if the keys are expanded in the published event:
```json
{
    "message": "{\"my.field\": \"interesting value\"}",
    "my_target": {
        "my": {
          "field": "interesting value"
        }
    }
}
```

## Related issues

Closes https://github.com/elastic/beats/issues/31712