### PR TITLE
Add compression to disk queue

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -13835,6 +13835,44 @@ THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/pierrec/lz4/v4
+Version: v4.1.15
+Licence type (autodetected): BSD-3-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/pierrec/lz4/v4@v4.1.15/LICENSE:
+
+Copyright (c) 2015, Pierre Curto
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of xxHash nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/pierrre/gotestcover
 Version: v0.0.0-20160517101806-924dca7d15f0
 Licence type (autodetected): MIT

--- a/go.mod
+++ b/go.mod
@@ -164,6 +164,7 @@ require (
 	github.com/elastic/elastic-agent-libs v0.2.5
 	github.com/elastic/elastic-agent-system-metrics v0.4.1
 	github.com/elastic/go-elasticsearch/v8 v8.2.0
+	github.com/pierrec/lz4/v4 v4.1.15
 	github.com/shirou/gopsutil/v3 v3.21.12
 	go.elastic.co/apm/module/apmelasticsearch/v2 v2.0.0
 	go.elastic.co/apm/module/apmhttp/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -1412,6 +1412,8 @@ github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4 v2.6.0+incompatible h1:Ix9yFKn1nSPBLFl/yZknTp8TU5G4Ps0JDmguYK6iH1A=
 github.com/pierrec/lz4 v2.6.0+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pierrec/lz4/v4 v4.1.15 h1:MO0/ucJhngq7299dKLwIMtgTfbkoSPF6AoMYDd8Q4q0=
+github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0 h1:i5VIxp6QB8oWZ8IkK8zrDgeT6ORGIUeiN+61iETwJbI=
 github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0/go.mod h1:4xpMLz7RBWyB+ElzHu8Llua96TRCB3YwX+l5EP1wmHk=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=

--- a/libbeat/publisher/queue/diskqueue/compression.go
+++ b/libbeat/publisher/queue/diskqueue/compression.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"io"
+
+	lz4V4 "github.com/pierrec/lz4/v4"
+)
+
+//CompressionReader allows reading a stream compressed with LZ4
+type CompressionReader struct {
+	src        io.ReadCloser
+	pLZ4Reader *lz4V4.Reader
+}
+
+//NewCompressionReader returns a new LZ4 frame decoder
+func NewCompressionReader(r io.ReadCloser) *CompressionReader {
+	zr := lz4V4.NewReader(r)
+	return &CompressionReader{
+		src:        r,
+		pLZ4Reader: zr,
+	}
+}
+
+func (r *CompressionReader) Read(buf []byte) (int, error) {
+	return r.pLZ4Reader.Read(buf)
+}
+
+func (r *CompressionReader) Close() error {
+	return r.src.Close()
+}
+
+//Reset Sets up compression again, assumes that caller has already set
+// the src to the correct position
+func (r *CompressionReader) Reset() error {
+	r.pLZ4Reader.Reset(r.src)
+	return nil
+}
+
+//CompressionWriter allows writing an LZ4 stream
+type CompressionWriter struct {
+	dst        WriteCloseSyncer
+	pLZ4Writer *lz4V4.Writer
+}
+
+//NewCompressionWriter returns a new LZ4 frame encoder
+func NewCompressionWriter(w WriteCloseSyncer) *CompressionWriter {
+	zw := lz4V4.NewWriter(w)
+	return &CompressionWriter{
+		dst:        w,
+		pLZ4Writer: zw,
+	}
+}
+
+func (w *CompressionWriter) Write(p []byte) (int, error) {
+	return w.pLZ4Writer.Write(p)
+}
+
+func (w *CompressionWriter) Close() error {
+	err := w.pLZ4Writer.Close()
+	if err != nil {
+		return err
+	}
+	return w.dst.Close()
+}
+
+func (w *CompressionWriter) Sync() error {
+	w.pLZ4Writer.Flush()
+	return w.dst.Sync()
+}

--- a/libbeat/publisher/queue/diskqueue/compression_test.go
+++ b/libbeat/publisher/queue/diskqueue/compression_test.go
@@ -1,0 +1,157 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func NopWriteCloser(w io.Writer) io.WriteCloser {
+	return nopWriteCloser{w}
+}
+func (nopWriteCloser) Close() error { return nil }
+
+func TestCompressionReader(t *testing.T) {
+	tests := map[string]struct {
+		plaintext  []byte
+		compressed []byte
+	}{
+		"abc 1.9.3 lz4": {
+			plaintext: []byte("abc"),
+			compressed: []byte{
+				0x04, 0x22, 0x4d, 0x18,
+				0x64, 0x40, 0xa7, 0x04,
+				0x00, 0x00, 0x80, 0x61,
+				0x62, 0x63, 0x0a, 0x00,
+				0x00, 0x00, 0x00, 0x6c,
+				0x3e, 0x7b, 0x08, 0x00},
+		},
+		"abc pierrec lz4": {
+			plaintext: []byte("abc"),
+			compressed: []byte{
+				0x04, 0x22, 0x4d, 0x18,
+				0x64, 0x70, 0xb9, 0x03,
+				0x00, 0x00, 0x80, 0x61,
+				0x62, 0x63, 0x00, 0x00,
+				0x00, 0x00, 0xff, 0x53,
+				0xd1, 0x32},
+		},
+	}
+
+	for name, tc := range tests {
+		dst := make([]byte, len(tc.plaintext))
+		src := bytes.NewReader(tc.compressed)
+		cr := NewCompressionReader(io.NopCloser(src))
+		n, err := cr.Read(dst)
+		assert.Nil(t, err, name)
+		assert.Equal(t, len(tc.plaintext), n, name)
+		assert.Equal(t, tc.plaintext, dst, name)
+	}
+}
+
+func TestCompressionWriter(t *testing.T) {
+	tests := map[string]struct {
+		plaintext  []byte
+		compressed []byte
+	}{
+		"abc pierrec lz4": {
+			plaintext: []byte("abc"),
+			compressed: []byte{
+				0x04, 0x22, 0x4d, 0x18,
+				0x64, 0x70, 0xb9, 0x03,
+				0x00, 0x00, 0x80, 0x61,
+				0x62, 0x63, 0x00, 0x00,
+				0x00, 0x00, 0xff, 0x53,
+				0xd1, 0x32},
+		},
+	}
+
+	for name, tc := range tests {
+		var dst bytes.Buffer
+		cw := NewCompressionWriter(NopWriteCloseSyncer(NopWriteCloser(&dst)))
+		n, err := cw.Write(tc.plaintext)
+		cw.Close()
+		assert.Nil(t, err, name)
+		assert.Equal(t, len(tc.plaintext), n, name)
+		assert.Equal(t, tc.compressed, dst.Bytes(), name)
+	}
+}
+
+func TestCompressionRoundTrip(t *testing.T) {
+	tests := map[string]struct {
+		plaintext []byte
+	}{
+		"no repeat":  {plaintext: []byte("abcdefghijklmnopqrstuvwxzy01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ")},
+		"256 repeat": {plaintext: []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+	}
+	for name, tc := range tests {
+		pr, pw := io.Pipe()
+		src := bytes.NewReader(tc.plaintext)
+		var dst bytes.Buffer
+
+		go func() {
+			cw := NewCompressionWriter(NopWriteCloseSyncer(pw))
+			_, err := io.Copy(cw, src)
+			assert.Nil(t, err, name)
+			cw.Close()
+		}()
+
+		cr := NewCompressionReader(pr)
+		_, err := io.Copy(&dst, cr)
+		assert.Nil(t, err, name)
+		assert.Equal(t, tc.plaintext, dst.Bytes(), name)
+	}
+}
+
+func TestCompressionSync(t *testing.T) {
+	tests := map[string]struct {
+		plaintext []byte
+	}{
+		"no repeat":  {plaintext: []byte("abcdefghijklmnopqrstuvwxzy01234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ")},
+		"256 repeat": {plaintext: []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")},
+	}
+	for name, tc := range tests {
+		pr, pw := io.Pipe()
+		var dst bytes.Buffer
+		go func() {
+			cw := NewCompressionWriter(NopWriteCloseSyncer(pw))
+			src1 := bytes.NewReader(tc.plaintext)
+			_, err := io.Copy(cw, src1)
+			assert.Nil(t, err, name)
+			err = cw.Sync()
+			assert.Nil(t, err, name)
+			src2 := bytes.NewReader(tc.plaintext)
+			_, err = io.Copy(cw, src2)
+			assert.Nil(t, err, name)
+			cw.Close()
+		}()
+		cr := NewCompressionReader(pr)
+		_, err := io.Copy(&dst, cr)
+		assert.Nil(t, err, name)
+		assert.Equal(t, tc.plaintext, dst.Bytes()[:len(tc.plaintext)], name)
+		assert.Equal(t, tc.plaintext, dst.Bytes()[len(tc.plaintext):], name)
+	}
+}

--- a/libbeat/publisher/queue/diskqueue/compression_test.go
+++ b/libbeat/publisher/queue/diskqueue/compression_test.go
@@ -39,7 +39,7 @@ func TestCompressionReader(t *testing.T) {
 		plaintext  []byte
 		compressed []byte
 	}{
-		"abc 1.9.3 lz4": {
+		"abc compressed with https://github.com/lz4/lz4 v1.9.3": {
 			plaintext: []byte("abc"),
 			compressed: []byte{
 				0x04, 0x22, 0x4d, 0x18,
@@ -49,7 +49,7 @@ func TestCompressionReader(t *testing.T) {
 				0x00, 0x00, 0x00, 0x6c,
 				0x3e, 0x7b, 0x08, 0x00},
 		},
-		"abc pierrec lz4": {
+		"abc compressed with pierrec lz4": {
 			plaintext: []byte("abc"),
 			compressed: []byte{
 				0x04, 0x22, 0x4d, 0x18,
@@ -141,6 +141,9 @@ func TestCompressionSync(t *testing.T) {
 			src1 := bytes.NewReader(tc.plaintext)
 			_, err := io.Copy(cw, src1)
 			assert.Nil(t, err, name)
+			//prior to v4.1.15 of pierrec/lz4 there was a
+			// bug that prevented writing after a Flush.
+			// The call to Sync here exercises Flush.
 			err = cw.Sync()
 			assert.Nil(t, err, name)
 			src2 := bytes.NewReader(tc.plaintext)

--- a/libbeat/publisher/queue/diskqueue/config.go
+++ b/libbeat/publisher/queue/diskqueue/config.go
@@ -71,6 +71,9 @@ type Settings struct {
 
 	// EncryptionKey is used to encrypt data if SchemaVersion 2 is used.
 	EncryptionKey []byte
+
+	// UseCompression enables or disables LZ4 compression
+	UseCompression bool
 }
 
 // userConfig holds the parameters for a disk queue that are configurable

--- a/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
+++ b/libbeat/publisher/queue/diskqueue/docs/on-disk-structures.md
@@ -58,11 +58,20 @@ a count of the number of frames in the segment, which is an unsigned
 flags, which signify options.  The size of options is 32-bits in
 little-endian format.
 
-If the options field has the first bit set, then encryption is enabled.  In
-which case, the next 128-bits are the initialization vector and the
-rest of the file is encrypted frames.  If the field is not set,
-un-encrypted frames follow the header.
+If no fields are set in the options field, then un-encrypted frames
+follow the header.
 
+If the options field has the first bit set, then encryption is
+enabled.  In which case, the next 128-bits are the initialization
+vector and the rest of the file is encrypted frames.
+
+If the options field has the second bit set, then compression is
+enabled.  In which case, LZ4 compressed frames follow the header.
+
+If both the first and second bit of the options field are set, then
+both compression and encryption are enabled.  The next 128-bits are
+the initialization vector and the rest of the file is LZ4 compressed
+frames.
 
 ![Segment Schema Version 2](./schemaV2.svg)
 

--- a/libbeat/publisher/queue/diskqueue/enc_compress_test.go
+++ b/libbeat/publisher/queue/diskqueue/enc_compress_test.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package diskqueue
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncryptionCompressionRoundTrip(t *testing.T) {
+	tests := map[string]struct {
+		plaintext []byte
+	}{
+		"1 rune":     {plaintext: []byte("a")},
+		"16 runes":   {plaintext: []byte("bbbbbbbbbbbbbbbb")},
+		"17 runes":   {plaintext: []byte("ccccccccccccccccc")},
+		"small json": {plaintext: []byte("{\"message\":\"2 123456789010 eni-1235b8ca123456789 - - - - - - - 1431280876 1431280934 - NODATA\"}")},
+		"large json": {plaintext: []byte("{\"message\":\"{\\\"CacheCacheStatus\\\":\\\"hit\\\",\\\"CacheResponseBytes\\\":26888,\\\"CacheResponseStatus\\\":200,\\\"CacheTieredFill\\\":true,\\\"ClientASN\\\":1136,\\\"ClientCountry\\\":\\\"nl\\\",\\\"ClientDeviceType\\\":\\\"desktop\\\",\\\"ClientIP\\\":\\\"89.160.20.156\\\",\\\"ClientIPClass\\\":\\\"noRecord\\\",\\\"ClientRequestBytes\\\":5324,\\\"ClientRequestHost\\\":\\\"eqlplayground.io\\\",\\\"ClientRequestMethod\\\":\\\"GET\\\",\\\"ClientRequestPath\\\":\\\"/40865/bundles/plugin/securitySolution/8.0.0/securitySolution.chunk.9.js\\\",\\\"ClientRequestProtocol\\\":\\\"HTTP/1.1\\\",\\\"ClientRequestReferer\\\":\\\"https://eqlplayground.io/s/eqldemo/app/security/timelines/default?sourcerer=(default:!(.siem-signals-eqldemo))&timerange=(global:(linkTo:!(),timerange:(from:%272021-03-03T19:55:15.519Z%27,fromStr:now-24h,kind:relative,to:%272021-03-04T19:55:15.519Z%27,toStr:now)),timeline:(linkTo:!(),timerange:(from:%272020-03-04T19:55:28.684Z%27,fromStr:now-1y,kind:relative,to:%272021-03-04T19:55:28.692Z%27,toStr:now)))&timeline=(activeTab:eql,graphEventId:%27%27,id:%2769f93840-7d23-11eb-866c-79a0609409ba%27,isOpen:!t)\\\",\\\"ClientRequestURI\\\":\\\"/40865/bundles/plugin/securitySolution/8.0.0/securitySolution.chunk.9.js\\\",\\\"ClientRequestUserAgent\\\":\\\"Mozilla/5.0(WindowsNT10.0;Win64;x64)AppleWebKit/537.36(KHTML,likeGecko)Chrome/91.0.4472.124Safari/537.36\\\",\\\"ClientSSLCipher\\\":\\\"NONE\\\",\\\"ClientSSLProtocol\\\":\\\"none\\\",\\\"ClientSrcPort\\\":0,\\\"ClientXRequestedWith\\\":\\\"\\\",\\\"EdgeColoCode\\\":\\\"33.147.138.217\\\",\\\"EdgeColoID\\\":20,\\\"EdgeEndTimestamp\\\":1625752958875000000,\\\"EdgePathingOp\\\":\\\"wl\\\",\\\"EdgePathingSrc\\\":\\\"macro\\\",\\\"EdgePathingStatus\\\":\\\"nr\\\",\\\"EdgeRateLimitAction\\\":\\\"\\\",\\\"EdgeRateLimitID\\\":0,\\\"EdgeRequestHost\\\":\\\"eqlplayground.io\\\",\\\"EdgeResponseBytes\\\":24743,\\\"EdgeResponseCompressionRatio\\\":0,\\\"EdgeResponseContentType\\\":\\\"application/javascript\\\",\\\"EdgeResponseStatus\\\":200,\\\"EdgeServerIP\\\":\\\"89.160.20.156\\\",\\\"EdgeStartTimestamp\\\":1625752958812000000,\\\"FirewallMatchesActions\\\":[],\\\"FirewallMatchesRuleIDs\\\":[],\\\"FirewallMatchesSources\\\":[],\\\"OriginIP\\\":\\\"\\\",\\\"OriginResponseBytes\\\":0,\\\"OriginResponseHTTPExpires\\\":\\\"\\\",\\\"OriginResponseHTTPLastModified\\\":\\\"\\\",\\\"OriginResponseStatus\\\":0,\\\"OriginResponseTime\\\":0,\\\"OriginSSLProtocol\\\":\\\"unknown\\\",\\\"ParentRayID\\\":\\\"66b9d9f88b5b4c4f\\\",\\\"RayID\\\":\\\"66b9d9f890ae4c4f\\\",\\\"SecurityLevel\\\":\\\"off\\\",\\\"WAFAction\\\":\\\"unknown\\\",\\\"WAFFlags\\\":\\\"0\\\",\\\"WAFMatchedVar\\\":\\\"\\\",\\\"WAFProfile\\\":\\\"unknown\\\",\\\"WAFRuleID\\\":\\\"\\\",\\\"WAFRuleMessage\\\":\\\"\\\",\\\"WorkerCPUTime\\\":0,\\\"WorkerStatus\\\":\\\"unknown\\\",\\\"WorkerSubrequest\\\":true,\\\"WorkerSubrequestCount\\\":0,\\\"ZoneID\\\":393347122}\"}")},
+	}
+
+	for name, tc := range tests {
+		pr, pw := io.Pipe()
+		key := []byte("keykeykeykeykeyk")
+		src := bytes.NewReader(tc.plaintext)
+		var dst bytes.Buffer
+		var tEncBuf bytes.Buffer
+		var tCompBuf bytes.Buffer
+
+		go func() {
+			ew, err := NewEncryptionWriter(NopWriteCloseSyncer(pw), key)
+			assert.Nil(t, err, name)
+			cw := NewCompressionWriter(ew)
+			_, err = io.Copy(cw, src)
+			assert.Nil(t, err, name)
+			err = cw.Close()
+			assert.Nil(t, err, name)
+		}()
+
+		ter := io.TeeReader(pr, &tEncBuf)
+		er, err := NewEncryptionReader(io.NopCloser(ter), key)
+		assert.Nil(t, err, name)
+
+		tcr := io.TeeReader(er, &tCompBuf)
+
+		cr := NewCompressionReader(io.NopCloser(tcr))
+
+		_, err = io.Copy(&dst, cr)
+		assert.Nil(t, err, name)
+		// Check round trip worked
+		assert.Equal(t, tc.plaintext, dst.Bytes(), name)
+		// Check that cipher text and plaintext don't match
+		assert.NotEqual(t, tc.plaintext, tEncBuf.Bytes(), name)
+		// Check that compressed text and plaintext don't match
+		assert.NotEqual(t, tc.plaintext, tCompBuf.Bytes(), name)
+		// Check that compressed text and ciphertext don't match
+		assert.NotEqual(t, tEncBuf.Bytes(), tCompBuf.Bytes(), name)
+	}
+}

--- a/libbeat/publisher/queue/diskqueue/segments.go
+++ b/libbeat/publisher/queue/diskqueue/segments.go
@@ -154,7 +154,10 @@ const currentSegmentVersion = 2
 // version of the target segment.
 const segmentHeaderSize = 12
 
-const ENABLE_ENCRYPTION uint32 = 0x1
+const (
+	ENABLE_ENCRYPTION  uint32 = 0x1
+	ENABLE_COMPRESSION uint32 = 0x2
+)
 
 // Sort order: we store loaded segments in ascending order by their id.
 type bySegmentID []*queueSegment
@@ -250,7 +253,13 @@ func (segment *queueSegment) getReader(queueSettings Settings) (*segmentReader, 
 			return nil, fmt.Errorf("couldn't create encryption reader: %w", err)
 		}
 	}
-
+	if (header.options & ENABLE_COMPRESSION) == ENABLE_COMPRESSION {
+		if sr.er != nil {
+			sr.cr = NewCompressionReader(sr.er)
+		} else {
+			sr.cr = NewCompressionReader(sr.src)
+		}
+	}
 	return sr, nil
 }
 
@@ -266,6 +275,11 @@ func (segment *queueSegment) getWriter(queueSettings Settings) (*segmentWriter, 
 	if len(queueSettings.EncryptionKey) > 0 {
 		options = options | ENABLE_ENCRYPTION
 	}
+
+	if queueSettings.UseCompression {
+		options = options | ENABLE_COMPRESSION
+	}
+
 	sw := &segmentWriter{}
 	sw.dst = file
 
@@ -278,6 +292,14 @@ func (segment *queueSegment) getWriter(queueSettings Settings) (*segmentWriter, 
 		if err != nil {
 			sw.dst.Close()
 			return nil, fmt.Errorf("couldn't create encryption writer: %w", err)
+		}
+	}
+
+	if (options & ENABLE_COMPRESSION) == ENABLE_COMPRESSION {
+		if sw.ew != nil {
+			sw.cw = NewCompressionWriter(sw.ew)
+		} else {
+			sw.cw = NewCompressionWriter(sw.dst)
 		}
 	}
 
@@ -385,7 +407,7 @@ func readSegmentHeader(in io.Reader) (*segmentHeader, error) {
 	header := &segmentHeader{}
 	err := binary.Read(in, binary.LittleEndian, &header.version)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not read segment version: %w", err)
 	}
 
 	if header.version > currentSegmentVersion {
@@ -395,13 +417,13 @@ func readSegmentHeader(in io.Reader) (*segmentHeader, error) {
 	if header.version >= 1 {
 		err = binary.Read(in, binary.LittleEndian, &header.frameCount)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not read segment count: %w", err)
 		}
 	}
 	if header.version >= 2 {
 		err = binary.Read(in, binary.LittleEndian, &header.options)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not read segment options: %w", err)
 		}
 	}
 
@@ -430,9 +452,13 @@ func (segments *diskQueueSegments) sizeOnDisk() uint64 {
 type segmentReader struct {
 	src io.ReadSeekCloser
 	er  *EncryptionReader
+	cr  *CompressionReader
 }
 
 func (r *segmentReader) Read(p []byte) (int, error) {
+	if r.cr != nil {
+		return r.cr.Read(p)
+	}
 	if r.er != nil {
 		return r.er.Read(p)
 	}
@@ -440,6 +466,9 @@ func (r *segmentReader) Read(p []byte) (int, error) {
 }
 
 func (r *segmentReader) Close() error {
+	if r.cr != nil {
+		return r.cr.Close()
+	}
 	if r.er != nil {
 		return r.er.Close()
 	}
@@ -447,16 +476,35 @@ func (r *segmentReader) Close() error {
 }
 
 func (r *segmentReader) Seek(offset int64, whence int) (int64, error) {
+	if r.cr != nil {
+		//can't seek before segment header
+		if (offset + int64(whence)) < segmentHeaderSize {
+			return 0, fmt.Errorf("illegal seek offset %d, whence %d", offset, whence)
+		}
+		if _, err := r.src.Seek(segmentHeaderSize, io.SeekStart); err != nil {
+			return 0, fmt.Errorf("could not seek past segment header: %w", err)
+		}
+		if r.er != nil {
+			if err := r.er.Reset(); err != nil {
+				return 0, fmt.Errorf("could not reset encryption: %w", err)
+			}
+		}
+		if err := r.cr.Reset(); err != nil {
+			return 0, fmt.Errorf("could not reset compression: %w", err)
+		}
+		written, err := io.CopyN(io.Discard, r.cr, (offset+int64(whence))-segmentHeaderSize)
+		return written + segmentHeaderSize, err
+	}
 	if r.er != nil {
 		//can't seek before segment header
 		if (offset + int64(whence)) < segmentHeaderSize {
 			return 0, fmt.Errorf("illegal seek offset %d, whence %d", offset, whence)
 		}
 		if _, err := r.src.Seek(segmentHeaderSize, io.SeekStart); err != nil {
-			return 0, err
+			return 0, fmt.Errorf("could not seek past segment header: %w", err)
 		}
 		if err := r.er.Reset(); err != nil {
-			return 0, err
+			return 0, fmt.Errorf("could not reset encryption: %w", err)
 		}
 		written, err := io.CopyN(io.Discard, r.er, (offset+int64(whence))-segmentHeaderSize)
 		return written + segmentHeaderSize, err
@@ -467,9 +515,13 @@ func (r *segmentReader) Seek(offset int64, whence int) (int64, error) {
 type segmentWriter struct {
 	dst *os.File
 	ew  *EncryptionWriter
+	cw  *CompressionWriter
 }
 
 func (w *segmentWriter) Write(p []byte) (int, error) {
+	if w.cw != nil {
+		return w.cw.Write(p)
+	}
 	if w.ew != nil {
 		return w.ew.Write(p)
 	}
@@ -477,6 +529,9 @@ func (w *segmentWriter) Write(p []byte) (int, error) {
 }
 
 func (w *segmentWriter) Close() error {
+	if w.cw != nil {
+		return w.cw.Close()
+	}
 	if w.ew != nil {
 		return w.ew.Close()
 	}
@@ -484,6 +539,9 @@ func (w *segmentWriter) Close() error {
 }
 
 func (w *segmentWriter) Seek(offset int64, whence int) (int64, error) {
+	if w.cw != nil {
+		return 0, fmt.Errorf("seek not supported with compression")
+	}
 	if w.ew != nil {
 		return 0, fmt.Errorf("seek not supported with encryption")
 	}
@@ -491,6 +549,9 @@ func (w *segmentWriter) Seek(offset int64, whence int) (int64, error) {
 }
 
 func (w *segmentWriter) Sync() error {
+	if w.cw != nil {
+		return w.cw.Sync()
+	}
 	if w.ew != nil {
 		return w.ew.Sync()
 	}
@@ -498,32 +559,52 @@ func (w *segmentWriter) Sync() error {
 }
 
 func (w *segmentWriter) WriteHeader(options uint32) error {
-	if _, err := w.dst.Seek(0, io.SeekStart); err != nil {
-		return err
+	_, err := w.dst.Seek(0, io.SeekStart)
+	if err != nil {
+		return fmt.Errorf("could not seek to beginning of segment: %w", err)
 	}
 
 	//write version
-	if err := binary.Write(w.dst, binary.LittleEndian, uint32(2)); err != nil {
-		return err
+	err = binary.Write(w.dst, binary.LittleEndian, uint32(2))
+	if err != nil {
+		return fmt.Errorf("could not write version to segment: %w", err)
 	}
 
 	//write count
-	if err := binary.Write(w.dst, binary.LittleEndian, uint32(0)); err != nil {
-		return err
+	err = binary.Write(w.dst, binary.LittleEndian, uint32(0))
+	if err != nil {
+		return fmt.Errorf("could not write count to segment: %w", err)
 	}
 
 	//write options
-	if err := binary.Write(w.dst, binary.LittleEndian, options); err != nil {
-		return err
+	err = binary.Write(w.dst, binary.LittleEndian, options)
+	if err != nil {
+		return fmt.Errorf("could not write options to segment: %w", err)
 	}
 
 	return nil
 }
 
 func (w *segmentWriter) UpdateCount(count uint32) error {
-	// Seek to count on disk
-	if _, err := w.dst.Seek(4, io.SeekStart); err != nil {
-		return err
+	//get current offset
+	offset, err := w.dst.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return fmt.Errorf("could not get current position: %w", err)
 	}
-	return binary.Write(w.dst, binary.LittleEndian, count)
+	// Seek to count on disk
+	_, err = w.dst.Seek(4, io.SeekStart)
+	if err != nil {
+		return fmt.Errorf("cound not seek to count position: %w", err)
+	}
+	// Write the count
+	err = binary.Write(w.dst, binary.LittleEndian, count)
+	if err != nil {
+		return fmt.Errorf("cound not write count: %w", err)
+	}
+	// Return to previous location
+	_, err = w.dst.Seek(offset, io.SeekStart)
+	if err != nil {
+		return fmt.Errorf("cound not seek back to count position: %w", err)
+	}
+	return nil
 }

--- a/libbeat/publisher/queue/diskqueue/segments_test.go
+++ b/libbeat/publisher/queue/diskqueue/segments_test.go
@@ -29,17 +29,32 @@ func TestSegmentsRoundTrip(t *testing.T) {
 	tests := map[string]struct {
 		id        segmentID
 		encrypt   bool
+		compress  bool
 		plaintext []byte
 	}{
-		"No Encryption": {
+		"No Encryption or Compression": {
 			id:        0,
 			encrypt:   false,
-			plaintext: []byte("abc"),
+			compress:  false,
+			plaintext: []byte("no encryption or compression"),
 		},
-		"Encryption": {
+		"Encryption Only": {
 			id:        1,
 			encrypt:   true,
-			plaintext: []byte("abc"),
+			compress:  false,
+			plaintext: []byte("encryption only"),
+		},
+		"Compression Only": {
+			id:        2,
+			encrypt:   false,
+			compress:  true,
+			plaintext: []byte("compression only"),
+		},
+		"Encryption and Compression": {
+			id:        3,
+			encrypt:   true,
+			compress:  true,
+			plaintext: []byte("encryption and compression"),
 		},
 	}
 	dir, err := os.MkdirTemp("", t.Name())
@@ -52,6 +67,7 @@ func TestSegmentsRoundTrip(t *testing.T) {
 		if tc.encrypt {
 			settings.EncryptionKey = []byte("keykeykeykeykeyk")
 		}
+		settings.UseCompression = tc.compress
 		qs := &queueSegment{
 			id: tc.id,
 		}
@@ -89,16 +105,31 @@ func TestSegmentReaderSeek(t *testing.T) {
 	tests := map[string]struct {
 		id         segmentID
 		encrypt    bool
+		compress   bool
 		plaintexts [][]byte
 	}{
-		"No Encryption": {
+		"No Encryption or compression": {
 			id:         0,
 			encrypt:    false,
+			compress:   false,
 			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
 		},
-		"Encryption": {
+		"Encryption Only": {
 			id:         1,
 			encrypt:    true,
+			compress:   false,
+			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
+		},
+		"Compression Only": {
+			id:         2,
+			encrypt:    false,
+			compress:   true,
+			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
+		},
+		"Encryption and Compression": {
+			id:         3,
+			encrypt:    true,
+			compress:   true,
 			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
 		},
 	}
@@ -111,6 +142,7 @@ func TestSegmentReaderSeek(t *testing.T) {
 		if tc.encrypt {
 			settings.EncryptionKey = []byte("keykeykeykeykeyk")
 		}
+		settings.UseCompression = tc.compress
 
 		qs := &queueSegment{
 			id: tc.id,
@@ -145,18 +177,35 @@ func TestSegmentReaderSeekLocations(t *testing.T) {
 	tests := map[string]struct {
 		id         segmentID
 		encrypt    bool
+		compress   bool
 		plaintexts [][]byte
 		location   int64
 	}{
-		"No Encryption": {
+		"No Encryption or Compression": {
 			id:         0,
 			encrypt:    false,
+			compress:   false,
 			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
 			location:   -1,
 		},
 		"Encryption": {
 			id:         1,
 			encrypt:    true,
+			compress:   false,
+			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
+			location:   2,
+		},
+		"Compression": {
+			id:         1,
+			encrypt:    false,
+			compress:   true,
+			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
+			location:   2,
+		},
+		"Encryption and Compression": {
+			id:         1,
+			encrypt:    true,
+			compress:   true,
 			plaintexts: [][]byte{[]byte("abc"), []byte("defg")},
 			location:   2,
 		},
@@ -170,6 +219,7 @@ func TestSegmentReaderSeekLocations(t *testing.T) {
 		if tc.encrypt {
 			settings.EncryptionKey = []byte("keykeykeykeykeyk")
 		}
+		settings.UseCompression = tc.compress
 		qs := &queueSegment{
 			id: tc.id,
 		}


### PR DESCRIPTION
## What does this PR do?

Adds option for compression to beats disk queue.  Works with or without encryption.

## Why is it important?

For certain workloads this can dramatically reduce the amount of data written to disk reducing both encryption overhead and disk I/O

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

```
go test -bench=1M -benchtime 1x -count 10 -timeout 600m -benchmem > results.txt

benchstat results.txt
name                       time/op
Async1M-16                  21.9s ± 1%
EncryptAsync1M-16           20.9s ± 1%
CompressAsync1M-16          12.4s ± 0%
EncryptCompressAsync1M-16   12.4s ± 1%
Sync1M-16                   25.0s ± 1%
EncryptSync1M-16            27.3s ± 0%
CompressSync1M-16           14.2s ± 0%
EncryptCompressSync1M-16    14.2s ± 0%

name                       alloc/op
Async1M-16                 3.43GB ± 0%
EncryptAsync1M-16          3.43GB ± 0%
CompressAsync1M-16         7.51GB ± 0%
EncryptCompressAsync1M-16  7.51GB ± 0%
Sync1M-16                  3.42GB ± 0%
EncryptSync1M-16           3.42GB ± 0%
CompressSync1M-16          3.52GB ± 0%
EncryptCompressSync1M-16   3.53GB ± 0%

name                       allocs/op
Async1M-16                  40.6M ± 0%
EncryptAsync1M-16           40.4M ± 0%
CompressAsync1M-16          36.9M ± 0%
EncryptCompressAsync1M-16   36.9M ± 0%
Sync1M-16                   39.5M ± 0%
EncryptSync1M-16            40.1M ± 0%
CompressSync1M-16           36.9M ± 0%
EncryptCompressSync1M-16    36.9M ± 0%
```

Also comparing against a run done before this PR, show no significant change in runtime or allocations.

```
benchstat results_previous.txt results.txt

name               old time/op    new time/op    delta
Async1M-16            22.0s ± 1%     21.9s ± 1%    ~     (p=0.436 n=10+10)
EncryptAsync1M-16     20.5s ± 1%     20.9s ± 1%  +1.93%  (p=0.000 n=10+10)
Sync1M-16             25.2s ± 1%     25.0s ± 1%  -0.85%  (p=0.000 n=10+9)
EncryptSync1M-16      27.5s ± 0%     27.3s ± 0%  -0.85%  (p=0.000 n=10+8)

name               old alloc/op   new alloc/op   delta
Async1M-16           3.43GB ± 0%    3.43GB ± 0%    ~     (p=0.529 n=10+10)
EncryptAsync1M-16    3.43GB ± 0%    3.43GB ± 0%    ~     (p=0.089 n=10+10)
Sync1M-16            3.42GB ± 0%    3.42GB ± 0%  +0.00%  (p=0.004 n=10+9)
EncryptSync1M-16     3.42GB ± 0%    3.42GB ± 0%    ~     (p=0.666 n=9+9)

name               old allocs/op  new allocs/op  delta
Async1M-16            40.6M ± 0%     40.6M ± 0%    ~     (p=0.684 n=10+10)
EncryptAsync1M-16     40.5M ± 0%     40.4M ± 0%  -0.19%  (p=0.000 n=10+10)
Sync1M-16             39.5M ± 0%     39.5M ± 0%  +0.05%  (p=0.010 n=10+9)
EncryptSync1M-16      40.1M ± 0%     40.1M ± 0%    ~     (p=0.931 n=9+9)

```

## Related issues

- Relates #31961 
- Relates elastic/elastic-agent-shipper#33
