### PR TITLE
Port `test_type_in_message` to filestream Golang tests

### DIFF
--- a/libbeat/reader/parser/parser_test.go
+++ b/libbeat/reader/parser/parser_test.go
@@ -337,7 +337,7 @@ func TestJSONParsersWithFields(t *testing.T) {
 		config          map[string]interface{}
 		expectedMessage reader.Message
 	}{
-		"no postprocesser, no processing": {
+		"no postprocessor, no processing": {
 			message: reader.Message{
 				Content: []byte("line 1"),
 			},
@@ -346,7 +346,7 @@ func TestJSONParsersWithFields(t *testing.T) {
 				Content: []byte("line 1"),
 			},
 		},
-		"JSON post processer with keys_under_root": {
+		"JSON post processor with keys_under_root": {
 			message: reader.Message{
 				Content: []byte("{\"key\":\"value\"}"),
 				Fields:  mapstr.M{},
@@ -367,7 +367,7 @@ func TestJSONParsersWithFields(t *testing.T) {
 				},
 			},
 		},
-		"JSON post processer with document ID": {
+		"JSON post processor with document ID": {
 			message: reader.Message{
 				Content: []byte("{\"key\":\"value\", \"my-id-field\":\"my-id\"}"),
 				Fields:  mapstr.M{},
@@ -392,7 +392,7 @@ func TestJSONParsersWithFields(t *testing.T) {
 				},
 			},
 		},
-		"JSON post processer with overwrite keys and under root": {
+		"JSON post processor with overwrite keys and under root": {
 			message: reader.Message{
 				Content: []byte("{\"key\": \"value\"}"),
 				Fields: mapstr.M{
@@ -418,7 +418,7 @@ func TestJSONParsersWithFields(t *testing.T) {
 				},
 			},
 		},
-		"JSON post processer with type in message": {
+		"JSON post processor with type in message": {
 			message: reader.Message{
 				Content: []byte(`{"timestamp":"2016-04-05T18:47:18.444Z","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended", "type": "test"}`),
 				Fields:  mapstr.M{},
@@ -459,7 +459,7 @@ func TestJSONParsersWithFields(t *testing.T) {
 				},
 			},
 		},
-		"JSON post processer on invalid type in message": {
+		"JSON post processor on invalid type in message": {
 			message: reader.Message{
 				Content: []byte(`{"timestamp":"2016-04-05T18:47:18.444Z","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended", "type": 5}`),
 				Fields:  mapstr.M{},
@@ -503,7 +503,7 @@ func TestJSONParsersWithFields(t *testing.T) {
 				},
 			},
 		},
-		"JSON post processer on invalid struct under type in message": {
+		"JSON post processor on invalid struct under type in message": {
 			message: reader.Message{
 				Content: []byte(`{"timestamp":"2016-04-05T18:47:18.444Z","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended", "type": {"hello": "shouldn't work"}}`),
 				Fields:  mapstr.M{},

--- a/libbeat/reader/parser/parser_test.go
+++ b/libbeat/reader/parser/parser_test.go
@@ -418,6 +418,135 @@ func TestJSONParsersWithFields(t *testing.T) {
 				},
 			},
 		},
+		"JSON post processer with type in message": {
+			message: reader.Message{
+				Content: []byte(`{"timestamp":"2016-04-05T18:47:18.444Z","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended", "type": "test"}`),
+				Fields:  mapstr.M{},
+			},
+			config: map[string]interface{}{
+				"parsers": []map[string]interface{}{
+					map[string]interface{}{
+						"ndjson": map[string]interface{}{
+							"target":         "",
+							"overwrite_keys": true,
+							"add_error_key":  true,
+							"message_key":    "msg",
+						},
+					},
+				},
+			},
+			expectedMessage: reader.Message{
+				Content: []byte("FetchActiveSessionToken process ended"),
+				Fields: mapstr.M{
+					"appInfo": mapstr.M{
+						"appname": "SessionManager",
+						"appid":   "Pooler",
+						"host":    "demohost.mydomain.com",
+						"ip":      "192.168.128.113",
+						"pid":     int64(13982),
+					},
+					"level":  "INFO",
+					"logger": "iapi.logger",
+					"userFields": mapstr.M{
+						"ApplicationId":     "PROFAPP_001",
+						"RequestTrackingId": "RetrieveTBProfileToken-6066477",
+					},
+					"msg":       "FetchActiveSessionToken process ended",
+					"source":    "DataAccess/FetchActiveSessionToken.process",
+					"thread":    "JobCourier4",
+					"type":      "test",
+					"timestamp": "2016-04-05T18:47:18.444Z",
+				},
+			},
+		},
+		"JSON post processer on invalid type in message": {
+			message: reader.Message{
+				Content: []byte(`{"timestamp":"2016-04-05T18:47:18.444Z","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended", "type": 5}`),
+				Fields:  mapstr.M{},
+			},
+			config: map[string]interface{}{
+				"parsers": []map[string]interface{}{
+					map[string]interface{}{
+						"ndjson": map[string]interface{}{
+							"target":         "",
+							"overwrite_keys": true,
+							"add_error_key":  true,
+							"message_key":    "msg",
+						},
+					},
+				},
+			},
+			expectedMessage: reader.Message{
+				Content: []byte("FetchActiveSessionToken process ended"),
+				Fields: mapstr.M{
+					"appInfo": mapstr.M{
+						"appname": "SessionManager",
+						"appid":   "Pooler",
+						"host":    "demohost.mydomain.com",
+						"ip":      "192.168.128.113",
+						"pid":     int64(13982),
+					},
+					"level":  "INFO",
+					"logger": "iapi.logger",
+					"userFields": mapstr.M{
+						"ApplicationId":     "PROFAPP_001",
+						"RequestTrackingId": "RetrieveTBProfileToken-6066477",
+					},
+					"msg":       "FetchActiveSessionToken process ended",
+					"source":    "DataAccess/FetchActiveSessionToken.process",
+					"thread":    "JobCourier4",
+					"timestamp": "2016-04-05T18:47:18.444Z",
+					"error": mapstr.M{
+						"message": "type not overwritten (not string)",
+						"type":    "json",
+					},
+				},
+			},
+		},
+		"JSON post processer on invalid struct under type in message": {
+			message: reader.Message{
+				Content: []byte(`{"timestamp":"2016-04-05T18:47:18.444Z","level":"INFO","logger":"iapi.logger","thread":"JobCourier4","appInfo":{"appname":"SessionManager","appid":"Pooler","host":"demohost.mydomain.com","ip":"192.168.128.113","pid":13982},"userFields":{"ApplicationId":"PROFAPP_001","RequestTrackingId":"RetrieveTBProfileToken-6066477"},"source":"DataAccess\/FetchActiveSessionToken.process","msg":"FetchActiveSessionToken process ended", "type": {"hello": "shouldn't work"}}`),
+				Fields:  mapstr.M{},
+			},
+			config: map[string]interface{}{
+				"parsers": []map[string]interface{}{
+					map[string]interface{}{
+						"ndjson": map[string]interface{}{
+							"target":         "",
+							"overwrite_keys": true,
+							"add_error_key":  true,
+							"message_key":    "msg",
+						},
+					},
+				},
+			},
+			expectedMessage: reader.Message{
+				Content: []byte("FetchActiveSessionToken process ended"),
+				Fields: mapstr.M{
+					"appInfo": mapstr.M{
+						"appname": "SessionManager",
+						"appid":   "Pooler",
+						"host":    "demohost.mydomain.com",
+						"ip":      "192.168.128.113",
+						"pid":     int64(13982),
+					},
+					"level":  "INFO",
+					"logger": "iapi.logger",
+					"userFields": mapstr.M{
+						"ApplicationId":     "PROFAPP_001",
+						"RequestTrackingId": "RetrieveTBProfileToken-6066477",
+					},
+					"msg":       "FetchActiveSessionToken process ended",
+					"source":    "DataAccess/FetchActiveSessionToken.process",
+					"thread":    "JobCourier4",
+					"timestamp": "2016-04-05T18:47:18.444Z",
+					"error": mapstr.M{
+						"message": "type not overwritten (not string)",
+						"type":    "json",
+					},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
## What does this PR do?

This PR ports existing Python tests of `log` input to `filesteam`. The PR contains the test cases for `test_type_in_message`. Thus, the tests in Python can be disabled/removed.

## Why is it important?

Decrease the amount of low-quality E2E tests.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
