### PR TITLE
Pin the protobuf version in system tests.

### DIFF
--- a/auditbeat/tests/system/requirements.txt
+++ b/auditbeat/tests/system/requirements.txt
@@ -1,0 +1,1 @@
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/auditbeat/tests/system/requirements.txt
+++ b/auditbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/dev-tools/requirements.txt
+++ b/dev-tools/requirements.txt
@@ -1,2 +1,3 @@
 elasticsearch
 requests
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/dev-tools/requirements.txt
+++ b/dev-tools/requirements.txt
@@ -1,3 +1,3 @@
 elasticsearch
 requests
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/heartbeat/tests/system/requirements.txt
+++ b/heartbeat/tests/system/requirements.txt
@@ -1,0 +1,1 @@
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/heartbeat/tests/system/requirements.txt
+++ b/heartbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -48,4 +48,4 @@ urllib3==1.26.5
 wcwidth==0.2.5
 websocket-client==0.47.0
 zipp>=1.2.0,<=3.1.0
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -48,3 +48,4 @@ urllib3==1.26.5
 wcwidth==0.2.5
 websocket-client==0.47.0
 zipp>=1.2.0,<=3.1.0
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
+++ b/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
@@ -10,3 +10,4 @@ rsa==4.7.2
 s3transfer==0.3.3
 six==1.14.0
 urllib3==1.26.5
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
+++ b/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
@@ -10,4 +10,4 @@ rsa==4.7.2
 s3transfer==0.3.3
 six==1.14.0
 urllib3==1.26.5
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,3 +1,4 @@
 kafka-python==1.4.3
 elasticsearch==7.1.0
 semver==2.8.1
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/metricbeat/tests/system/requirements.txt
+++ b/metricbeat/tests/system/requirements.txt
@@ -1,4 +1,4 @@
 kafka-python==1.4.3
 elasticsearch==7.1.0
 semver==2.8.1
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/packetbeat/tests/system/gen/memcache/requirements.txt
+++ b/packetbeat/tests/system/gen/memcache/requirements.txt
@@ -1,2 +1,2 @@
 pylibmc
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/packetbeat/tests/system/gen/memcache/requirements.txt
+++ b/packetbeat/tests/system/gen/memcache/requirements.txt
@@ -1,1 +1,2 @@
 pylibmc
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/x-pack/functionbeat/tests/system/requirements.txt
+++ b/x-pack/functionbeat/tests/system/requirements.txt
@@ -1,0 +1,1 @@
+protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051

--- a/x-pack/functionbeat/tests/system/requirements.txt
+++ b/x-pack/functionbeat/tests/system/requirements.txt
@@ -1,1 +1,1 @@
-protobuf==3.20.1 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051
+protobuf==3.19.4 #Temporary change because of protobuf new version bug: https://github.com/protocolbuffers/protobuf/issues/10051


### PR DESCRIPTION
Same problem as https://github.com/elastic/e2e-testing/pull/2569

All the Python system tests for every beat fail to run because `pip install` is failing trying to install transitive protobuf dependencies.