### PR TITLE
Fix invalid changelog entry

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,7 +63,6 @@ https://github.com/elastic/beats/compare/v8.2.0\...v8.2.1[View commits]
 - Generic SQL code reorganization, with support for raw metrics and query lists {pull}31568[31568]
 - Add metadata for missing k8s resources/metricsets {pull}31590[31590]
 - Fix `include_top_n` fields in system/process {pull}31595[31595]
-- Upgrade Mongodb library in Beats to v5 {pull}31185[31185]
 
 [[release-notes-8.2.0]]
 === Beats version 8.2.0

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -131,6 +131,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add orchestrator cluster ECS fields in kubernetes events {pull}31341[31341]
 - Add new Kubernetes module dashboards {pull}31341[31341]
 - system/core: add cpuinfo information for Linux hosts {pull}31643[31643]
+- Upgrade Mongodb library in Beats to v5 {pull}31185[31185]
 
 *Packetbeat*
 


### PR DESCRIPTION
See https://github.com/elastic/beats/pull/32046. Besides removing the invalid entry it is added back in `CHANGELOG.next.asciidoc`. This needs to be forward-ported to `main`.

