### PR TITLE
Revert "ci: e2e-testing should fail the build (#31135)"

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -433,22 +433,24 @@ def runE2ETests(){
 
   def suites = '' // empty value represents all suites in the E2E tests
 
-  def suitesSet = e2eTestSuites.toSet()
+  catchError(buildResult: 'UNSTABLE', message: 'Unable to run e2e tests', stageResult: 'FAILURE') {
+    def suitesSet = e2eTestSuites.toSet()
 
-  if (!suitesSet.contains('ALL')) {
-    suitesSet.each { suite ->
-      suites += "${suite},"
-    };
+    if (!suitesSet.contains('ALL')) {
+      suitesSet.each { suite ->
+        suites += "${suite},"
+      };
+    }
+    echo 'runE2E will run now in a sync mode to validate packages can be published.'
+    runE2E(runTestsSuites: suites,
+          testMatrixFile: '.ci/.e2e-tests-beats.yaml',
+          beatVersion: "${env.BEAT_VERSION}-SNAPSHOT",
+          gitHubCheckName: env.GITHUB_CHECK_E2E_TESTS_NAME,
+          gitHubCheckRepo: env.REPO,
+          gitHubCheckSha1: env.GIT_BASE_COMMIT,
+          propagate: true,
+          wait: true)
   }
-  echo 'runE2E will run now in a sync mode to validate packages can be published.'
-  runE2E(runTestsSuites: suites,
-         testMatrixFile: '.ci/.e2e-tests-beats.yaml',
-         beatVersion: "${env.BEAT_VERSION}-SNAPSHOT",
-         gitHubCheckName: env.GITHUB_CHECK_E2E_TESTS_NAME,
-         gitHubCheckRepo: env.REPO,
-         gitHubCheckSha1: env.GIT_BASE_COMMIT,
-         propagate: true,
-         wait: true)
 }
 
 /**


### PR DESCRIPTION
This reverts commit 2241413626b9bdd87245c4dbd29675cee6400358.

Allow the E2E tests to keep running but do not have them fail the build when they do not pass.

Part of https://github.com/elastic/beats/issues/32076. The E2E tests are not reliable enough to act as a quality gate for the DRA process yet. The team doesn't have the capacity to improve the tests fast enough. We previously went 2+ weeks without publishing a beats snapshot image.

