### PR TITLE
Add new `parser` called `include_message` to filter messages

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -118,6 +118,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add `auth.oauth2.google.jwt_json` option to `httpjson` input. {pull}31750[31750]
 - Add authentication fields to RabbitMQ module documents. {issue}31159[31159] {pull}31680[31680]
 - Add template helper function for decoding hexadecimal strings. {pull}31886[31886]
+- Add new `parser` called `include_message` to filter based on message contents. {issue}31794[31794] {pull}32094[32094]
 
 *Auditbeat*
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -267,11 +267,15 @@ filebeat.inputs:
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, no lines are dropped.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #exclude_lines: ['^DBG']
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, all the lines are exported.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #include_lines: ['^ERR', '^WARN']
 
   ### Prospector options
@@ -326,6 +330,16 @@ filebeat.inputs:
       # unmarshaling errors or when a text key is defined in the configuration but cannot
       # be used.
       #add_error_key: false
+
+  #### Filtering messages
+
+  # You can filter messsages in the parsers pipeline. Use this method if you would like to
+  # include or exclude lines before they are aggregated into multiline or the JSON contents
+  # are parsed.
+
+  #parsers:
+    #- incluce_message.patterns:
+      - ["WARN", "ERR"]
 
   #### Multiline options
 

--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -338,7 +338,7 @@ filebeat.inputs:
   # are parsed.
 
   #parsers:
-    #- incluce_message.patterns:
+    #- include_message.patterns:
       - ["WARN", "ERR"]
 
   #### Multiline options

--- a/filebeat/_meta/config/filebeat.inputs.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.yml.tmpl
@@ -22,10 +22,14 @@ filebeat.inputs:
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #exclude_lines: ['^DBG']
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #include_lines: ['^ERR', '^WARN']
 
   # Exclude files. A list of regular expressions to match. Filebeat drops the files that

--- a/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
@@ -318,3 +318,25 @@ The RFC 5424 format accepts the following forms of timestamps:
 ** `2003-10-11T22:14:15.123456-06:00`
 
 Formats with an asterisk (*) are a non-standard allowance.
+
+[float]
+===== `include_message`
+
+Use the `include_message` parser to filter messages in the parsers pipeline. Messages that
+match the provided pattern are passed to the next parser, the others are dropped.
+
+You should use `include_message` instead of `include_lines` if you would like to
+control when the filtering happens. `include_lines` runs after the parsers, `include_message`
+runs in the parsers pipeline.
+
+*`patterns`*:: List of regexp patterns to match.
+
+This example shows you how to include messages that start with the string ERR or WARN:
+
+[source,yaml]
+----
+  paths:
+    - "/var/log/containers/*.log"
+  parsers:
+    - include_message.patterns: ["^ERR", "^WARN"]
+----

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -674,11 +674,15 @@ filebeat.inputs:
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, no lines are dropped.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #exclude_lines: ['^DBG']
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, all the lines are exported.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #include_lines: ['^ERR', '^WARN']
 
   ### Prospector options
@@ -733,6 +737,16 @@ filebeat.inputs:
       # unmarshaling errors or when a text key is defined in the configuration but cannot
       # be used.
       #add_error_key: false
+
+  #### Filtering messages
+
+  # You can filter messsages in the parsers pipeline. Use this method if you would like to
+  # include or exclude lines before they are aggregated into multiline or the JSON contents
+  # are parsed.
+
+  #parsers:
+    #- incluce_message.patterns:
+      - ["WARN", "ERR"]
 
   #### Multiline options
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -745,7 +745,7 @@ filebeat.inputs:
   # are parsed.
 
   #parsers:
-    #- incluce_message.patterns:
+    #- include_message.patterns:
       - ["WARN", "ERR"]
 
   #### Multiline options

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -34,10 +34,14 @@ filebeat.inputs:
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #exclude_lines: ['^DBG']
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #include_lines: ['^ERR', '^WARN']
 
   # Exclude files. A list of regular expressions to match. Filebeat drops the files that

--- a/libbeat/reader/filter/filter.go
+++ b/libbeat/reader/filter/filter.go
@@ -28,7 +28,7 @@ import (
 )
 
 type Config struct {
-	Filters []match.Matcher `config:"patterns" validate:"required"`
+	Patterns []match.Matcher `config:"patterns" validate:"required"`
 }
 
 func DefaultConfig() Config {
@@ -51,7 +51,7 @@ func NewParser(r reader.Reader, c *Config) *FilterParser {
 		ctx:      ctxtool.WithCancelContext(context.Background()),
 		logger:   logp.NewLogger("filter_parser"),
 		r:        r,
-		matchers: c.Filters,
+		matchers: c.Patterns,
 	}
 }
 

--- a/libbeat/reader/filter/filter.go
+++ b/libbeat/reader/filter/filter.go
@@ -32,7 +32,7 @@ type Config struct {
 }
 
 func DefaultConfig() Config {
-	return &Config{}
+	return Config{}
 }
 
 // FilterParser accepts a list of matchers to determine if a line

--- a/libbeat/reader/filter/filter.go
+++ b/libbeat/reader/filter/filter.go
@@ -31,6 +31,10 @@ type Config struct {
 	Filters []match.Matcher `config:"patterns" validate:"required"`
 }
 
+// FilterParser accepts a list of matchers to determine if a line
+// should be kept or not. If one of the patterns matches the
+// contents of the message, it is returned to the next reader.
+// If not, the message is dropped.
 type FilterParser struct {
 	ctx      ctxtool.CancelContext
 	logger   *logp.Logger
@@ -47,7 +51,6 @@ func NewFilterParser(r reader.Reader, c *Config) *FilterParser {
 	}
 }
 
-// Next decodes JSON and returns the filled Line object.
 func (p *FilterParser) Next() (reader.Message, error) {
 	for p.ctx.Err() == nil {
 		message, err := p.r.Next()

--- a/libbeat/reader/filter/filter.go
+++ b/libbeat/reader/filter/filter.go
@@ -31,7 +31,7 @@ type Config struct {
 	Filters []match.Matcher `config:"patterns" validate:"required"`
 }
 
-func DefaultConfig() *Config {
+func DefaultConfig() Config {
 	return &Config{}
 }
 

--- a/libbeat/reader/filter/filter.go
+++ b/libbeat/reader/filter/filter.go
@@ -31,6 +31,10 @@ type Config struct {
 	Filters []match.Matcher `config:"patterns" validate:"required"`
 }
 
+func DefaultConfig() *Config {
+	return &Config{}
+}
+
 // FilterParser accepts a list of matchers to determine if a line
 // should be kept or not. If one of the patterns matches the
 // contents of the message, it is returned to the next reader.
@@ -42,7 +46,7 @@ type FilterParser struct {
 	matchers []match.Matcher
 }
 
-func NewFilterParser(r reader.Reader, c *Config) *FilterParser {
+func NewParser(r reader.Reader, c *Config) *FilterParser {
 	return &FilterParser{
 		ctx:      ctxtool.WithCancelContext(context.Background()),
 		logger:   logp.NewLogger("filter_parser"),

--- a/libbeat/reader/filter/filter.go
+++ b/libbeat/reader/filter/filter.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filter
+
+import (
+	"context"
+	"io"
+
+	"github.com/elastic/beats/v7/libbeat/reader"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/match"
+	"github.com/elastic/go-concert/ctxtool"
+)
+
+type Config struct {
+	Filters []match.Matcher `config:"patterns" validate:"required"`
+}
+
+type FilterParser struct {
+	ctx      ctxtool.CancelContext
+	logger   *logp.Logger
+	r        reader.Reader
+	matchers []match.Matcher
+}
+
+func NewFilterParser(r reader.Reader, c *Config) *FilterParser {
+	return &FilterParser{
+		ctx:      ctxtool.WithCancelContext(context.Background()),
+		logger:   logp.NewLogger("filter_parser"),
+		r:        r,
+		matchers: c.Filters,
+	}
+}
+
+// Next decodes JSON and returns the filled Line object.
+func (p *FilterParser) Next() (reader.Message, error) {
+	for p.ctx.Err() == nil {
+		message, err := p.r.Next()
+		if err != nil {
+			return message, err
+		}
+		if p.matchAny(string(message.Content)) {
+			return message, err
+		}
+		p.logger.Debug("dropping message because it does not match any of the provided patterns [%v]: %s", p.matchers, string(message.Content))
+	}
+	return reader.Message{}, io.EOF
+}
+
+func (p *FilterParser) matchAny(text string) bool {
+	for _, m := range p.matchers {
+		if m.MatchString(text) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *FilterParser) Close() error {
+	p.ctx.Cancel()
+	return p.r.Close()
+}

--- a/libbeat/reader/filter/filter_test.go
+++ b/libbeat/reader/filter/filter_test.go
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filter
+
+import (
+	"io"
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/reader"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParser(t *testing.T) {
+	tests := map[string]struct {
+		config                 map[string]interface{}
+		input                  []reader.Message
+		expectedMessageContent [][]byte
+	}{
+		"keep all messages": {
+			config: map[string]interface{}{
+				"pattern": "this matches*",
+			},
+			input: []reader.Message{
+				{
+					Content: []byte("this matches"),
+				},
+				{
+					Content: []byte("this matches again"),
+				},
+			},
+			expectedMessageContent: [][]byte{
+				[]byte("this matches"),
+				[]byte("this matches again"),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var c Config
+			cfg := config.MustNewConfigFrom(test.config)
+			err := cfg.Unpack(&c)
+			r := NewFilterParser(newTestReader(test.input), &c)
+
+			contents := make([][]byte, 0)
+			msg, err := r.Next()
+			for err == nil {
+				contents = append(contents, msg.Content)
+				msg, err = r.Next()
+			}
+			require.ElementsMatch(t, test.expectedMessageContent, contents)
+		})
+
+	}
+}
+
+type testReader struct {
+	msg []reader.Message
+	idx int
+}
+
+func newTestReader(input []reader.Message) reader.Reader {
+	return &testReader{
+		msg: input,
+		idx: 0,
+	}
+}
+
+func (r *testReader) Next() (reader.Message, error) {
+	if r.idx == len(r.msg) {
+		return reader.Message{}, io.EOF
+	}
+
+	m := r.msg[r.idx]
+	r.idx += 1
+	return m, nil
+}
+
+func (r *testReader) Close() error { return nil }

--- a/libbeat/reader/filter/filter_test.go
+++ b/libbeat/reader/filter/filter_test.go
@@ -21,9 +21,10 @@ import (
 	"io"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/libbeat/reader"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParser(t *testing.T) {

--- a/libbeat/reader/filter/filter_test.go
+++ b/libbeat/reader/filter/filter_test.go
@@ -34,7 +34,7 @@ func TestParser(t *testing.T) {
 	}{
 		"keep all messages": {
 			config: map[string]interface{}{
-				"pattern": "this matches*",
+				"patterns": []string{"this matches*"},
 			},
 			input: []reader.Message{
 				{
@@ -49,6 +49,22 @@ func TestParser(t *testing.T) {
 				[]byte("this matches again"),
 			},
 		},
+		"keep one message": {
+			config: map[string]interface{}{
+				"patterns": []string{"this matches*"},
+			},
+			input: []reader.Message{
+				{
+					Content: []byte("this matches"),
+				},
+				{
+					Content: []byte("this does not match"),
+				},
+			},
+			expectedMessageContent: [][]byte{
+				[]byte("this matches"),
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -56,6 +72,7 @@ func TestParser(t *testing.T) {
 			var c Config
 			cfg := config.MustNewConfigFrom(test.config)
 			err := cfg.Unpack(&c)
+			require.NoError(t, err)
 			r := NewFilterParser(newTestReader(test.input), &c)
 
 			contents := make([][]byte, 0)

--- a/libbeat/reader/filter/filter_test.go
+++ b/libbeat/reader/filter/filter_test.go
@@ -49,6 +49,23 @@ func TestParser(t *testing.T) {
 				[]byte("this matches again"),
 			},
 		},
+		"keep all messages with multiple patterns": {
+			config: map[string]interface{}{
+				"patterns": []string{"this matches*", "should match as well*"},
+			},
+			input: []reader.Message{
+				{
+					Content: []byte("this matches"),
+				},
+				{
+					Content: []byte("should match as well"),
+				},
+			},
+			expectedMessageContent: [][]byte{
+				[]byte("this matches"),
+				[]byte("should match as well"),
+			},
+		},
 		"keep one message": {
 			config: map[string]interface{}{
 				"patterns": []string{"this matches*"},

--- a/libbeat/reader/filter/filter_test.go
+++ b/libbeat/reader/filter/filter_test.go
@@ -91,7 +91,7 @@ func TestParser(t *testing.T) {
 			cfg := config.MustNewConfigFrom(test.config)
 			err := cfg.Unpack(&c)
 			require.NoError(t, err)
-			r := NewFilterParser(newTestReader(test.input), &c)
+			r := NewParser(newTestReader(test.input), &c)
 
 			contents := make([][]byte, 0)
 			msg, err := r.Next()

--- a/libbeat/reader/parser/parser.go
+++ b/libbeat/reader/parser/parser.go
@@ -173,6 +173,14 @@ func (c *Config) Create(in reader.Reader) Parser {
 				return p
 			}
 			p = syslog.NewParser(p, &config)
+		case "include_message":
+			config := filter.DefaultConfig()
+			cfg := ns.Config()
+			err := cfg.Unpack(&config)
+			if err != nil {
+				return p
+			}
+			p = filter.NewParser(p, &config)
 		default:
 			return p
 		}

--- a/libbeat/reader/parser/parser.go
+++ b/libbeat/reader/parser/parser.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/common/cfgtype"
 	"github.com/elastic/beats/v7/libbeat/reader"
+	"github.com/elastic/beats/v7/libbeat/reader/filter"
 	"github.com/elastic/beats/v7/libbeat/reader/multiline"
 	"github.com/elastic/beats/v7/libbeat/reader/readfile"
 	"github.com/elastic/beats/v7/libbeat/reader/readjson"

--- a/libbeat/reader/parser/parser.go
+++ b/libbeat/reader/parser/parser.go
@@ -122,7 +122,7 @@ func NewConfig(pCfg CommonConfig, parsers []config.Namespace) (*Config, error) {
 				return nil, fmt.Errorf("error while parsing syslog parser config: %w", err)
 			}
 		default:
-			return nil, fmt.Errorf("%s: %s", ErrNoSuchParser, name)
+			return nil, fmt.Errorf("%s: %w", name, ErrNoSuchParser)
 		}
 	}
 

--- a/libbeat/reader/parser/parser.go
+++ b/libbeat/reader/parser/parser.go
@@ -92,21 +92,21 @@ func NewConfig(pCfg CommonConfig, parsers []config.Namespace) (*Config, error) {
 			cfg := ns.Config()
 			err := cfg.Unpack(&config)
 			if err != nil {
-				return nil, fmt.Errorf("error while parsing multiline parser config: %+v", err)
+				return nil, fmt.Errorf("error while parsing multiline parser config: %w", err)
 			}
 		case "ndjson":
 			var config readjson.ParserConfig
 			cfg := ns.Config()
 			err := cfg.Unpack(&config)
 			if err != nil {
-				return nil, fmt.Errorf("error while parsing ndjson parser config: %+v", err)
+				return nil, fmt.Errorf("error while parsing ndjson parser config: %w", err)
 			}
 		case "container":
 			config := readjson.DefaultContainerConfig()
 			cfg := ns.Config()
 			err := cfg.Unpack(&config)
 			if err != nil {
-				return nil, fmt.Errorf("error while parsing container parser config: %+v", err)
+				return nil, fmt.Errorf("error while parsing container parser config: %w", err)
 			}
 			if config.Stream != readjson.All {
 				if suffix != "" {

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2909,7 +2909,7 @@ filebeat.inputs:
   # are parsed.
 
   #parsers:
-    #- incluce_message.patterns:
+    #- include_message.patterns:
       - ["WARN", "ERR"]
 
   #### Multiline options

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2838,11 +2838,15 @@ filebeat.inputs:
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, no lines are dropped.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #exclude_lines: ['^DBG']
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list. The include_lines is called before
   # exclude_lines. By default, all the lines are exported.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #include_lines: ['^ERR', '^WARN']
 
   ### Prospector options
@@ -2897,6 +2901,16 @@ filebeat.inputs:
       # unmarshaling errors or when a text key is defined in the configuration but cannot
       # be used.
       #add_error_key: false
+
+  #### Filtering messages
+
+  # You can filter messsages in the parsers pipeline. Use this method if you would like to
+  # include or exclude lines before they are aggregated into multiline or the JSON contents
+  # are parsed.
+
+  #parsers:
+    #- incluce_message.patterns:
+      - ["WARN", "ERR"]
 
   #### Multiline options
 

--- a/x-pack/filebeat/filebeat.yml
+++ b/x-pack/filebeat/filebeat.yml
@@ -34,10 +34,14 @@ filebeat.inputs:
 
   # Exclude lines. A list of regular expressions to match. It drops the lines that are
   # matching any regular expression from the list.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #exclude_lines: ['^DBG']
 
   # Include lines. A list of regular expressions to match. It exports the lines that are
   # matching any regular expression from the list.
+  # Line filtering happens after the parsers pipeline. If you would like to filter lines
+  # before parsers, use include_message parser.
   #include_lines: ['^ERR', '^WARN']
 
   # Exclude files. A list of regular expressions to match. Filebeat drops the files that


### PR DESCRIPTION
## What does this PR do?

This PR adds a new parser to filter messages. If a message matches one of the patterns from the list, it is passed on to the next parser, otherwise it is dropped.

## Why is it important?

The existing `include_lines` and `exlcude_lines` filtering runs after the `parsers` pipeline, so it is not possible to select messages before parsing them.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

Closes https://github.com/elastic/beats/issues/31794