### PR TITLE
[Heartbeat] 'event.type: foo' should be 'event: {type: foo}' for browser

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Fix unintentional use of no-op logger. {pull}31543[31543]
 - Send targetted error message for unexpected synthetics exits. {pull}31936[31936]
+- Fix regression where we write a dotted (non-nested) key `event.type`. {pull}32097[32097]
 
 *Metricbeat*
 

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -93,7 +93,7 @@ func (je *journeyEnricher) enrich(event *beat.Event, se *SynthEvent) error {
 	}
 
 	eventext.MergeEventFields(event, mapstr.M{
-		"event.type": se.Type,
+		"event": mapstr.M{"type": se.Type},
 	})
 
 	return je.enrichSynthEvent(event, se)

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich_test.go
@@ -97,7 +97,8 @@ func TestJourneyEnricher(t *testing.T) {
 		} else {
 			u, _ := url.Parse(url1)
 			// journey end gets a summary
-			v = append(v, lookslike.MustCompile(mapstr.M{
+			v = append(v, lookslike.MustCompile(map[string]interface{}{
+				"event.type":          "heartbeat/summary",
 				"synthetics.type":     "heartbeat/summary",
 				"url":                 wrappers.URLFields(u),
 				"monitor.duration.us": int64(journeyEnd.Timestamp().Sub(journeyStart.Timestamp()) / time.Microsecond),


### PR DESCRIPTION
As part of https://github.com/elastic/beats/pull/31877/files#diff-b6c88c98d3a0073b9edf475ef0c1e713ba39dccff126a1b99ac107cafea863edR92
a regression was introduced where we write both a dotted (non-nested) key `event.type` when we meant to create an `event` object with an inner `type` key.

This was a mistake in the aforementioned PR.

Interestingly, this is hard to test with lookslike, which equivocates those two conditions in the name of simplifying test syntax.

To test this you'll want to manually run heartbeat with a browser
monitor and check that the correct object is set.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Logs

From my own testing using the console output:

```
mage build && env ELASTIC_SYNTHETICS_CAPABLE=true ./heartbeat -e | jq '{st: .synthetics.type, et: .event, ett: .["event.type"]}'
{
  "st": "journey/start",
  "et": {
    "type": "journey/start",
    "dataset": "browser"
  },
  "ett": null
}
```
