### PR TITLE
[DOCS] Removed reference to the Stack GS (#32083)

### DIFF
--- a/libbeat/docs/tab-widgets/spinup-stack.asciidoc
+++ b/libbeat/docs/tab-widgets/spinup-stack.asciidoc
@@ -5,5 +5,5 @@ available on AWS, GCP, and Azure. {ess-trial}[Try it out for free].
 // end::cloud[]
 
 // tag::self-managed[]
-See {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
+To install and run {es} and {kib}, see {stack-ref}/installing-elastic-stack.html[Installing the {stack}].
 // end::self-managed[]


### PR DESCRIPTION
We're retiring the Stack Getting Started guide in favor of the new onboarding content introduced in 8.2. (Cherry-picked from master...)