### PR TITLE
7.17: Skip flaky agent TestDownloadBodyError test on Windows

### DIFF
--- a/x-pack/elastic-agent/pkg/artifact/download/http/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/downloader_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -27,6 +28,10 @@ import (
 func TestDownloadBodyError(t *testing.T) {
 	// This tests the scenario where the download encounters a network error
 	// part way through the download, while copying the response body.
+	// Skipped on Windows where it frequently but not always fails.
+	if runtime.GOOS == "windows" {
+		t.Skip("Flaky test: https://github.com/elastic/beats/issues/31996")
+	}
 
 	type connKey struct{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This test fails constantly in the 7.17 branch. See https://github.com/elastic/beats/issues/31996. It appears it still fails regularly in the elastic-agent repository as well (https://github.com/elastic/elastic-agent/issues/629), so once it is fixed there it can be backported to 7.17 here

- Closes #31996
