### PR TITLE
Osquerybeat: Handle broken pipe (linux) error gracefully

### DIFF
--- a/x-pack/osquerybeat/beater/errors.go
+++ b/x-pack/osquerybeat/beater/errors.go
@@ -1,0 +1,20 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beater
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"syscall"
+)
+
+// isBrokenPipeOrEOFError checks for broken pipe, diconnect or EOF errors from osquery
+// This is to workaround the known and possibly future defects with osquery implementation, allowing us to gracefully recover, restart osquery and rerun failed queries
+func isBrokenPipeOrEOFError(err error) bool {
+	var netErr *net.OpError
+	return (errors.As(err, &netErr) && (errors.Is(netErr.Err, syscall.EPIPE) || errors.Is(netErr.Err, syscall.ECONNRESET))) ||
+		strings.HasSuffix(err.Error(), " broken pipe") || strings.HasSuffix(err.Error(), " EOF")
+}

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -221,7 +221,17 @@ func (bt *osquerybeat) Run(b *beat.Beat) error {
 	})
 
 	// Wait for clean exit
-	return g.Wait()
+	err = g.Wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			bt.log.Debugf("osquerybeat Run exited, context cancelled")
+		} else {
+			bt.log.Errorf("osquerybeat Run exited with error: %v", err)
+		}
+	} else {
+		bt.log.Debugf("osquerybeat Run exited")
+	}
+	return err
 }
 
 func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.OSQueryD, flags osqd.Flags, inputCh <-chan []config.InputConfig) error {
@@ -304,7 +314,19 @@ func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.O
 			}
 		}
 	})
-	return g.Wait()
+
+	err = g.Wait()
+	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			bt.log.Debugf("runOsquery exited, context cancelled")
+		} else {
+			bt.log.Errorf("runOsquery exited with error: %v", err)
+		}
+		bt.log.Errorf("runOsquery exited with error: %v", err)
+	} else {
+		bt.log.Debugf("runOsquery exited")
+	}
+	return err
 }
 
 func runExtensionServer(ctx context.Context, socketPath string, configPlugin *ConfigPlugin, loggerPlugin *LoggerPlugin, timeout time.Duration) (err error) {

--- a/x-pack/osquerybeat/beater/osquerybeat.go
+++ b/x-pack/osquerybeat/beater/osquerybeat.go
@@ -164,6 +164,10 @@ func (bt *osquerybeat) Run(b *beat.Beat) error {
 		return err
 	}
 
+	// Set reseable action handler
+	rah := newResetableActionHandler(bt.log)
+	defer rah.Clear()
+
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Start osquery runner.
@@ -172,7 +176,7 @@ func (bt *osquerybeat) Run(b *beat.Beat) error {
 	runner := newOsqueryRunner(bt.log)
 	g.Go(func() error {
 		return runner.Run(ctx, func(ctx context.Context, flags osqd.Flags, inputCh <-chan []config.InputConfig) error {
-			return bt.runOsquery(ctx, b, osq, flags, inputCh)
+			return bt.runOsquery(ctx, b, osq, flags, inputCh, rah)
 		})
 	})
 
@@ -234,7 +238,7 @@ func (bt *osquerybeat) Run(b *beat.Beat) error {
 	return err
 }
 
-func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.OSQueryD, flags osqd.Flags, inputCh <-chan []config.InputConfig) error {
+func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.OSQueryD, flags osqd.Flags, inputCh <-chan []config.InputConfig, rah *resetableActionHandler) error {
 	socketPath := osq.SocketPath()
 
 	// Create a cache for queries types resolution
@@ -295,8 +299,8 @@ func (bt *osquerybeat) runOsquery(ctx context.Context, b *beat.Beat, osq *osqd.O
 		})
 
 		// Register action handler
-		ah := bt.registerActionHandler(b, cli, configPlugin)
-		defer bt.unregisterActionHandler(b, ah)
+		bt.registerActionHandler(b, cli, configPlugin, rah)
+		defer bt.unregisterActionHandler(b, rah)
 
 		// Process input
 		for {
@@ -394,9 +398,9 @@ func (bt *osquerybeat) Stop() {
 	bt.close()
 }
 
-func (bt *osquerybeat) registerActionHandler(b *beat.Beat, cli *osqdcli.Client, configPlugin *ConfigPlugin) *actionHandler {
+func (bt *osquerybeat) registerActionHandler(b *beat.Beat, cli *osqdcli.Client, configPlugin *ConfigPlugin, rah *resetableActionHandler) {
 	if b.Manager == nil {
-		return nil
+		return
 	}
 
 	ah := &actionHandler{
@@ -406,12 +410,12 @@ func (bt *osquerybeat) registerActionHandler(b *beat.Beat, cli *osqdcli.Client, 
 		queryExec: cli,
 		np:        configPlugin,
 	}
-	b.Manager.RegisterAction(ah)
-	return ah
+	rah.Attach(ah)
+	b.Manager.RegisterAction(rah)
 }
 
-func (bt *osquerybeat) unregisterActionHandler(b *beat.Beat, ah *actionHandler) {
-	if b.Manager != nil && ah != nil {
-		b.Manager.UnregisterAction(ah)
+func (bt *osquerybeat) unregisterActionHandler(b *beat.Beat, rah *resetableActionHandler) {
+	if b.Manager != nil && rah != nil {
+		b.Manager.UnregisterAction(rah)
 	}
 }

--- a/x-pack/osquerybeat/beater/resetable_action_handler.go
+++ b/x-pack/osquerybeat/beater/resetable_action_handler.go
@@ -1,0 +1,181 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package beater
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+const defaultTimeout = 15 * time.Second // expecting the osquery to be restarted within 15 secs for the action to be retried
+
+var (
+	errActionHandlerIsNotSet = errors.New("action handler is not set")
+	errActionTimeout         = errors.New("action timeout")
+	errActionCanceled        = errors.New("action canceled")
+)
+
+// resetableActionHandler implements the client.Action interface for the action handling.
+// This wrapper for the action hanler:
+// 1. Captures the "broken pipe" error. The osquery restart is expected after this.
+// 2. Blocks the Execute call until the new action handler is set.
+// 3. Retries the action with the new action handler once
+//
+// The lifetime of this should the a scope of the beat Run
+type resetableActionHandler struct {
+	log *logp.Logger
+
+	ah client.Action
+
+	mx sync.Mutex
+
+	chSignals []chan struct{}
+	timeout   time.Duration
+}
+
+type resetableActionHandlerResponse struct {
+	res map[string]interface{}
+	err error
+}
+
+func newResetableActionHandler(log *logp.Logger) *resetableActionHandler {
+	a := &resetableActionHandler{
+		log:     log,
+		timeout: defaultTimeout,
+	}
+	return a
+}
+
+func (a *resetableActionHandler) Execute(ctx context.Context, req map[string]interface{}) (res map[string]interface{}, err error) {
+	a.log.Debug(formatLogMessage("execute"))
+
+	// Normalize error on exit, always return nil as error and encode it into result as per current contract
+	defer func() {
+		if err != nil {
+			res = renderResult(res, err)
+			err = nil
+		}
+	}()
+
+	res, err = a.execute(ctx, req)
+	if err != nil {
+		a.log.Error(formatLogMessage("execute error: %v", err))
+		if !isBrokenPipeOrEOFError(err) {
+			return nil, err
+		}
+
+		a.log.Info(formatLogMessage("broken pipe error, retry the action with timeout: %v", a.timeout))
+
+		// Signal channel is used for waiting for the new action handler to be set in order to retry
+		chSig := make(chan struct{}, 1)
+
+		a.mx.Lock()
+		a.chSignals = append(a.chSignals, chSig)
+		a.mx.Unlock()
+
+		// Set the timer for timeout
+		t := time.NewTimer(a.timeout)
+		defer t.Stop()
+
+		// Wait for either:
+		// 1. New action handler set signal
+		// 2. Timeout
+		// 3. Context cancelation
+		select {
+		case _, ok := <-chSig:
+			if ok {
+				a.log.Debug(formatLogMessage("got new action handler signal, retrying the action"))
+				return a.execute(ctx, req)
+			}
+			a.log.Debug(formatLogMessage("got cancel signal, exiting"))
+			return nil, errActionCanceled
+		case <-t.C:
+			a.log.Debug(formatLogMessage("action retry timed out, with timeout value: %v", a.timeout))
+			return nil, errActionTimeout
+		case <-ctx.Done():
+			a.log.Debug(formatLogMessage("action retry canceled, context: %v", ctx.Err()))
+			return nil, ctx.Err()
+		}
+	}
+	return res, nil
+}
+
+func formatLogMessage(format string, args ...interface{}) string {
+	return "resetable action handler: " + fmt.Sprintf(format, args...)
+}
+
+func renderResult(res map[string]interface{}, err error) map[string]interface{} {
+	if res == nil {
+		now := time.Now().UTC()
+		res = map[string]interface{}{
+			"started_at":   now.Format(time.RFC3339Nano),
+			"completed_at": now.Format(time.RFC3339Nano),
+		}
+	}
+	if err != nil {
+		res["error"] = err.Error()
+	}
+	return res
+}
+
+func (a *resetableActionHandler) execute(ctx context.Context, req map[string]interface{}) (map[string]interface{}, error) {
+	a.mx.Lock()
+	defer a.mx.Unlock()
+
+	if a.ah == nil {
+		return nil, errActionHandlerIsNotSet
+	}
+
+	// The current action handler always returns result and error set as a property in the result
+	var err error
+	res, _ := a.ah.Execute(ctx, req)
+	if e, ok := res["error"]; ok {
+		if emsg, ok := e.(string); ok {
+			err = errors.New(emsg)
+		}
+	}
+	return res, err
+}
+
+func (a *resetableActionHandler) Name() string {
+	a.mx.Lock()
+	defer a.mx.Unlock()
+	if a.ah == nil {
+		return ""
+	}
+	return a.ah.Name()
+}
+
+func (a *resetableActionHandler) Attach(ah *actionHandler) {
+	a.mx.Lock()
+	a.ah = ah
+	chSignals := a.chSignals
+	a.chSignals = make([]chan struct{}, 0)
+	a.mx.Unlock()
+
+	// signal pending
+	for _, chSig := range chSignals {
+		chSig <- struct{}{}
+	}
+}
+
+func (a *resetableActionHandler) Clear() {
+	a.mx.Lock()
+	a.ah = nil
+	chSignals := a.chSignals
+	a.chSignals = make([]chan struct{}, 0)
+	a.mx.Unlock()
+
+	// signal pending to cancel by closing channel
+	for _, chSig := range chSignals {
+		close(chSig)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Handle osquery broken pipe/EOF error gracefully.
Addresses: https://github.com/elastic/security-team/issues/4164

This PR:
1. Implements resetableActionHandler wrapper that detects broken pipe/EOF errors and attempts to retry the same action upon the osqueryd restart
2. Updates osquery runner code to recover on brocken pipe error, by restarting osqueryd with extensions, applying the last known config
3. Removes withReconnect blocks for the query and columns types resolution, it was not quite correct. The approach now is to reconnect the client with osquery restart. 
4. Added additional logging.

## Why is it important?

This is to workaround addresses the current issue with osquery, where after running queries against these 3 tables: rpm_packages (linux), deb_packages (linux), apt_sources (linux), the osquery returns broken pipe or EOF error.

The plan is to pickup the next release of osquery 5.4.0 with the fix for that, but it would be good to handle and recover gracefully from these similar issues in the future.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## How to test this PR locally

1. Install the agent with osquery enabled on linux for example Ubuntu (for deb packages table tests)
2. Run the live query against deb_packages for example something like this:
```
select deb_packages.version as new_version,  REPLACE(ki.version,'-generic','') as loaded_version, dv.version as dockerversion from deb_packages left join kernel_info as ki on 1 = 1 join docker_version as dv on 1=1 where name like 'linux-headers-5.13.0-51%';
```
3. Usually on the third query run, the osquerybeat should show the "broken pipe" error. With this update you should observe the recovery/restart of osquery and successful completion of the query.

## Related issues

- Closes https://github.com/elastic/security-team/issues/4164

## Screenshots
<img width="1233" alt="Screen Shot 2022-06-28 at 10 40 26 AM" src="https://user-images.githubusercontent.com/872351/176219977-c3433b12-9ee8-4e90-b715-62fdab785c88.png">


## Logs
Example of the log when osquerybeat recovers from broken pipe (look for "resetable action handler: " prefixed log messages here):

```
{"log.level":"debug","@timestamp":"2022-06-28T10:04:17.983-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/action_handler.go","file.line":94},"message":"Execute query: select deb_packages.version as new_version,  REPLACE(ki.version,'-generic','') as loaded_version, dv.version as dockerversion from deb_packages left join kernel_info as ki on 1 = 1 join docker_version as dv on 1=1 where name like 'linux-headers-5.13.0-51%';","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-06-28T10:04:18.033-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/action_handler.go","file.line":101},"message":"Failed to execute query, err: osquery get query columns failed: write unix @->/var/run/1379628246/osquery.sock: write: broken pipe","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-06-28T10:04:18.033-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/resetable_action_handler.go","file.line":70},"message":"resetable action handler: execute error: osquery get query columns failed: write unix @->/var/run/1379628246/osquery.sock: write: broken pipe","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-06-28T10:04:18.033-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/resetable_action_handler.go","file.line":75},"message":"resetable action handler: broken pipe error, retry the action with timeout: 15s","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.383-0400","log.logger":"osquerybeat","log.origin":{"file.name":"osqd/osqueryd.go","file.line":239},"message":"kill process group on context done","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-06-28T10:04:20.383-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquerybeat.go","file.line":309},"message":"runOsquery context cancelled, exiting","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquerybeat.go","file.line":264},"message":"osqueryd process exited","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquerybeat.go","file.line":327},"message":"runOsquery exited with error: deregistering extension: write unix @->/var/run/1379628246/osquery.sock: write: broken pipe","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquerybeat.go","file.line":329},"message":"runOsquery exited with error: deregistering extension: write unix @->/var/run/1379628246/osquery.sock: write: broken pipe","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquery_runner.go","file.line":95},"message":"Forward osquery run error to the main runner loop: deregistering extension: write unix @->/var/run/1379628246/osquery.sock: write: broken pipe","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquery_runner.go","file.line":115},"message":"Failed to run osquery:deregistering extension: write unix @->/var/run/1379628246/osquery.sock: write: broken pipe","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquery_runner.go","file.line":117},"message":"Recover osquery after broken pipe error","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquery_runner.go","file.line":109},"message":"Got configuration update","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-06-28T10:04:20.385-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/osquery_runner.go","file.line":82},"message":"Start osqueryd","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.386-0400","log.logger":"osquerybeat","log.origin":{"file.name":"osqdcli/client.go","file.line":107},"message":"connect osquery client: socket_path: /var/run/1379628246/osquery.sock, retries: 10","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.386-0400","log.logger":"osquerybeat","log.origin":{"file.name":"osqdcli/retry.go","file.line":26},"message":"attempt 1 out of 11","service.name":"osquerybeat","context":"osquery client connect","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.386-0400","log.logger":"osquerybeat","log.origin":{"file.name":"osqd/osqueryd.go","file.line":321},"message":"Extensions autoload file osquery/osquery.autoload exists, verify the first extension is ours","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.386-0400","log.logger":"osquerybeat","log.origin":{"file.name":"osqd/osqueryd.go","file.line":168},"message":"start osqueryd process: args: [/home/amaus/work/elastic-agent-8.4.0-SNAPSHOT-linux-x86_64/data/elastic-agent-d77a91/install/osquerybeat-8.4.0-SNAPSHOT-linux-x86_64/osqueryd --disable_watchdog=true --force=true --config_plugin=osq_config --config_refresh=60 --disable_logging=false --extensions_autoload=osquery/osquery.autoload --logger_plugin=osq_logger --utc=true --extensions_socket=/var/run/1379628246/osquery.sock --extensions_interval=3 --pack_delimiter=_ --extensions_timeout=10 --verbose=true --database_path=osquery/osquery.db --tls_server_certs=certs/certs.pem --disable_tables=carves,curl --events_expiry=1 --flagfile=osquery/osquery.flags --pidfile=osquery/osquery.pid]","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.586-0400","log.logger":"osquerybeat","log.origin":{"file.name":"osqdcli/retry.go","file.line":46},"message":"attempt 1 out of 11 succeeded","service.name":"osquerybeat","context":"osquery client connect","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-06-28T10:04:20.587-0400","log.logger":"osquerybeat","log.origin":{"file.name":"osqdcli/client.go","file.line":119},"message":"osquery client is connected","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.587-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/resetable_action_handler.go","file.line":95},"message":"resetable action handler: got new action handler signal, retrying the action","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.587-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/action_handler.go","file.line":94},"message":"Execute query: select deb_packages.version as new_version,  REPLACE(ki.version,'-generic','') as loaded_version, dv.version as dockerversion from deb_packages left join kernel_info as ki on 1 = 1 join docker_version as dv on 1=1 where name like 'linux-headers-5.13.0-51%';","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.636-0400","log.logger":"osquerybeat","log.origin":{"file.name":"beater/action_handler.go","file.line":105},"message":"Completed query in: 49.434823ms","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:04:20.636-0400","log.logger":"processors","log.origin":{"file.name":"processing/processors.go","file.line":210},"message":"Publish event: {\n  \"@timestamp\": \"2022-06-28T14:04:20.636Z\",\n  \"@metadata\": {\n    \"beat\": \"osquerybeat\",\n    \"type\": \"_doc\",\n    \"version\": \"8.4.0\",\n    \"raw_index\": \"logs-osquery_manager.result-default\",\n    \"input_id\": \"2862bcc0-b247-4a6e-a695-c0307059be27\"\n  },\n  \"type\": \"ubuntu\",\n  \"action_id\": \"7ff88daa-13a3-4e22-a87d-e19513dd88a5\",\n  \"elastic_agent\": {\n    \"version\": \"8.4.0\",\n    \"id\": \"eafd8dd8-5adc-4807-b555-683ca2c65366\",\n    \"snapshot\": true\n  },\n  \"agent\": {\n    \"id\": \"eafd8dd8-5adc-4807-b555-683ca2c65366\",\n    \"ephemeral_id\": \"7800d0a2-eb7f-4baa-bdf3-a810b38dc3a3\",\n    \"name\": \"ubuntu\",\n    \"type\": \"osquerybeat\",\n    \"version\": \"8.4.0\"\n  },\n  \"host\": {\n    \"containerized\": false,\n    \"ip\": [\n      \"172.16.140.128\",\n      \"fe80::1b48:cdf1:50ba:2ad7\"\n    ],\n    \"name\": \"ubuntu\",\n    \"mac\": [\n      \"00:0c:29:10:56:76\",\n      \"02:42:51:e8:8e:fc\",\n      \"02:42:5c:0c:ed:b0\"\n    ],\n    \"hostname\": \"ubuntu\",\n    \"architecture\": \"x86_64\",\n    \"os\": {\n      \"family\": \"debian\",\n      \"name\": \"Ubuntu\",\n      \"kernel\": \"5.13.0-51-generic\",\n      \"codename\": \"focal\",\n      \"type\": \"linux\",\n      \"platform\": \"ubuntu\",\n      \"version\": \"20.04.3 LTS (Focal Fossa)\"\n    },\n    \"id\": \"b62e91be682a4108bbb080152cc5eeac\"\n  },\n  \"event\": {\n    \"module\": \"osquery_manager\"\n  },\n  \"osquery\": {\n    \"dockerversion\": \"20.10.7\",\n    \"loaded_version\": \"5.13.0-51\",\n    \"new_version\": \"5.13.0-51.58~20.04.1\"\n  },\n  \"action_data\": {\n    \"id\": \"abff719b-aaff-4134-8fef-2cc8acddc4d1\",\n    \"query\": \"select deb_packages.version as new_version,  REPLACE(ki.version,'-generic','') as loaded_version, dv.version as dockerversion from deb_packages left join kernel_info as ki on 1 = 1 join docker_version as dv on 1=1 where name like 'linux-headers-5.13.0-51%';\"\n  },\n  \"ecs\": {\n    \"version\": \"8.0.0\"\n  }\n}","service.name":"osquerybeat","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2022-06-28T10:04:20.636-0400","log.logger":"osquerybeat","log.origin":{"file.name":"pub/publisher.go","file.line":80},"message":"1 events sent to index logs-osquery_manager.result-default","service.name":"osquerybeat","ecs.version":"1.6.0"}

```