### PR TITLE
[automation] update elastic stack version for testing 8.3.0-729c5564

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-fdf97a2e-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-729c5564-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -31,7 +31,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.3.0-fdf97a2e-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.3.0-729c5564-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -44,7 +44,7 @@ services:
       - 5055:5055
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.3.0-fdf97a2e-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.3.0-729c5564-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 28 Jun 2022 12:14:21 GMT, release_branch:8.3, prefix:, end_time:Tue, 28 Jun 2022 16:47:11 GMT, manifest_version:2.1.0, version:8.3.0-SNAPSHOT, branch:8.3, build_id:8.3.0-729c5564, build_duration_seconds:16370]