### PR TITLE
Check if cache of add_kubernetes_metadata processors is already closed before closing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Improve syslog parser/processor error handling. {issue}31246[31246] {pull}31798[31798]
 - Expand fields in `decode_json_fields` if target is set. {issue}31712[31712] {pull}32010[32010]
+- Gracefully close `add_kubernetes_metadata` processor cache. {pull}32010[32010]
 
 *Auditbeat*
 

--- a/libbeat/processors/add_kubernetes_metadata/cache.go
+++ b/libbeat/processors/add_kubernetes_metadata/cache.go
@@ -94,18 +94,5 @@ func (c *cache) cleanup() {
 }
 
 func (c *cache) stop() {
-	if !isClosed(c.done) {
-		close(c.done)
-	}
-}
-
-// isClosed checks if a given chan is already closed
-func isClosed(ch <-chan struct{}) bool {
-	select {
-	case <-ch:
-		return true
-	default:
-	}
-
-	return false
+	close(c.done)
 }

--- a/libbeat/processors/add_kubernetes_metadata/cache.go
+++ b/libbeat/processors/add_kubernetes_metadata/cache.go
@@ -94,5 +94,18 @@ func (c *cache) cleanup() {
 }
 
 func (c *cache) stop() {
-	close(c.done)
+	if !isClosed(c.done) {
+		close(c.done)
+	}
+}
+
+// isClosed checks if a given chan is already closed
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+	}
+
+	return false
 }

--- a/libbeat/processors/add_kubernetes_metadata/kubernetes.go
+++ b/libbeat/processors/add_kubernetes_metadata/kubernetes.go
@@ -309,6 +309,7 @@ func (k *kubernetesAnnotator) Close() error {
 	}
 	if k.cache != nil {
 		k.cache.stop()
+		k.cache = nil
 	}
 	return nil
 }


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR checks if the `add_kubernetes_metadata` processors cache is already closed before closing.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
In case the cache channel is already closed then the code panics leading to filebeat restarting 

```
{"log.level":"debug","@timestamp":"2022-06-28T10:53:11.919Z","log.logger":"input.filestream","log.origin":{"file.name":"filestream/input.go","file.line":143},"message":"Closing reader of filestream","service.name":"filebeat","id":"8DDE18B49C8C362C","source":"filestream::.global::native::10637969-66305","path":"/var/log/containers/filebeat-prod-kxqkf_kube-system_filebeat-9f7ebdc5dbef23f6785804c9b07d0cdf301382e3cf5e7bd1c8e1c82a94250012.log","state-id":"native::10637969-66305","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:53:11.919Z","log.logger":"publisher","log.origin":{"file.name":"pipeline/client.go","file.line":158},"message":"client: closing acker","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:53:11.919Z","log.logger":"publisher","log.origin":{"file.name":"pipeline/client.go","file.line":163},"message":"client: done closing acker","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:53:11.919Z","log.logger":"publisher","log.origin":{"file.name":"pipeline/client.go","file.line":165},"message":"client: unlink from queue","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:53:11.919Z","log.logger":"publisher","log.origin":{"file.name":"pipeline/client.go","file.line":187},"message":"client: cancelled 0 events","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:53:11.919Z","log.logger":"publisher","log.origin":{"file.name":"pipeline/client.go","file.line":167},"message":"client: done unlink","service.name":"filebeat","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2022-06-28T10:53:11.919Z","log.logger":"publisher","log.origin":{"file.name":"pipeline/client.go","file.line":170},"message":"client: closing processors","service.name":"filebeat","ecs.version":"1.6.0"}
panic: close of closed channel

goroutine 214 [running]:
github.com/elastic/beats/v7/libbeat/processors/add_kubernetes_metadata.(*cache).stop(...)
  /go/src/github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata/cache.go:97
github.com/elastic/beats/v7/libbeat/processors/add_kubernetes_metadata.(*kubernetesAnnotator).Close(0xc000a72700)
  /go/src/github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata/kubernetes.go:311 +0x4f
github.com/elastic/beats/v7/libbeat/processors.Close(...)
  /go/src/github.com/elastic/beats/libbeat/processors/processor.go:57
github.com/elastic/beats/v7/libbeat/publisher/processing.(*group).Close(0x1)
  /go/src/github.com/elastic/beats/libbeat/publisher/processing/processors.go:94 +0x14b
github.com/elastic/beats/v7/libbeat/processors.Close(...)
  /go/src/github.com/elastic/beats/libbeat/processors/processor.go:57
github.com/elastic/beats/v7/libbeat/publisher/processing.(*group).Close(0x0)
  /go/src/github.com/elastic/beats/libbeat/publisher/processing/processors.go:94 +0x14b
github.com/elastic/beats/v7/libbeat/processors.Close(...)
  /go/src/github.com/elastic/beats/libbeat/processors/processor.go:57
github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close.func1()
  /go/src/github.com/elastic/beats/libbeat/publisher/pipeline/client.go:171 +0x2d9
sync.(*Once).doSlow(0x0, 0xc00142dd78)
  /usr/local/go/src/sync/once.go:68 +0xd2
sync.(*Once).Do(...)
  /usr/local/go/src/sync/once.go:59
github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*client).Close(0xc00186c000)
  /go/src/github.com/elastic/beats/libbeat/publisher/pipeline/client.go:152 +0x59
github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*Pipeline).runSignalPropagation(0xc001392fb8)
  /go/src/github.com/elastic/beats/libbeat/publisher/pipeline/pipeline.go:394 +0x22b
created by github.com/elastic/beats/v7/libbeat/publisher/pipeline.(*Pipeline).registerSignalPropagation.func1
  /go/src/github.com/elastic/beats/libbeat/publisher/pipeline/pipeline.go:347 +0x9b
```
## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
