### PR TITLE
Document nested fields support for fingerprints

### DIFF
--- a/libbeat/processors/fingerprint/docs/fingerprint.asciidoc
+++ b/libbeat/processors/fingerprint/docs/fingerprint.asciidoc
@@ -11,6 +11,8 @@ specified subset of its fields.
 The value that is hashed is constructed as a concatenation of the field name and
 field value separated by `|`. For example `|field1|value1|field2|value2|`.
 
+Nested fields are supported in the following format: `"field1.field2"` e.g: `["log.path.file", "foo"]`
+
 [source,yaml]
 -----------------------------------------------------
 processors:


### PR DESCRIPTION
## What does this PR do?
This PR documents how to create a fingerprint from nested fields. I spent a short while figuring out the pattern whilst trying to migrate from the logstash format of `[log][path][file]`

## Why is it important?
Hopefully developers spend less time implementing config changes

## Checklist
- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist
- [ ] Check the language used and examples are okay

## How to test this PR locally
Configure a filebeat fingerprint processor with a nested field

## Related issues
n/a

## Use cases
n/a

## Screenshots
n/a

## Logs
n/a