### PR TITLE
system/socket: propagate backpressure from output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -49,7 +49,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - auditd module: Fix parsing of audit rules where arguments are quoted (like file paths containing spaces). {pull}32421[32421]
 - auditd module: Fix minimum AuditStatus length so that library can support kernels from 2.6.32. {pull}32421[32421]
-
+- system/socket: Reduce memory usage of the dataset. {issue}32191[32191] {pull}32192[32192]
 
 *Filebeat*
 
@@ -96,7 +96,6 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Auditbeat*
 
 - Add `immutable` option to the auditd module. {issue}8352[8352] {pull}32381[32381]
-- system: Reduce memory usage of the `socket` dataset. {issue}32191[32191] {pull}32192[32192]
 
 *Filebeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -96,7 +96,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Auditbeat*
 
 - Add `immutable` option to the auditd module. {issue}8352[8352] {pull}32381[32381]
-
+- system: Reduce memory usage of the `socket` dataset. {issue}32191[32191] {pull}32192[32192]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
@@ -121,7 +121,7 @@ func (l *LinkedList) Remove(e LinkedElement) {
 //
 // This callback is expected to return true if it removed the element from
 // the Linked list. Otherwise, it will be removed by this function.
-func (l *LinkedList) RemoveOlder(deadline time.Time, callback func(LinkedElement) bool) {
+func (l *LinkedList) RemoveOlder(deadline time.Time, callback func(LinkedElement) (removed bool)) {
 	for l.head != nil && l.head.Timestamp().Before(deadline) {
 		if !callback(l.head) {
 			l.Get()

--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
@@ -86,6 +86,7 @@ func (l *LinkedList) Get() LinkedElement {
 }
 
 // Remove removes the given LinkedElement from the LinkedList.
+// The element `e` must be in `l` before this call.
 func (l *LinkedList) Remove(e LinkedElement) {
 	l.size--
 	if e.Prev() != nil {

--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
@@ -1,0 +1,130 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package helper
+
+import "time"
+
+// LinkedList represents a linked list that can be used
+// to construct an LRU.
+type LinkedList struct {
+	head, tail LinkedElement
+	size       uint
+}
+
+// LinkedElement is the interface that must be implemented
+// by types stored to a LinkedList.
+type LinkedElement interface {
+	// SetPrev links this element to the previous.
+	SetPrev(LinkedElement)
+
+	// SetNext links this element to the next.
+	SetNext(LinkedElement)
+
+	// Prev returns the LinkedElement set by SetPrev.
+	Prev() LinkedElement
+
+	// Next returns the LinkedElement set by SetNext.
+	Next() LinkedElement
+
+	// Timestamp returns the last-used time for this element.
+	Timestamp() time.Time
+}
+
+// Size returns the number of elements in the LinkedList.
+func (l *LinkedList) Size() uint {
+	return l.size
+}
+
+// Append removes all elements from b and adds them
+// to the end (tail) of the linked list.
+func (l *LinkedList) Append(b *LinkedList) {
+	if b.size == 0 {
+		return
+	}
+	if l.size == 0 {
+		*l = *b
+		*b = LinkedList{}
+		return
+	}
+	l.tail.SetNext(b.head)
+	b.head.SetPrev(l.tail)
+	l.tail = b.tail
+	l.size += b.size
+	*b = LinkedList{}
+}
+
+// Add adds the given element at the back (tail) of the
+// linked list.
+func (l *LinkedList) Add(f LinkedElement) {
+	if f == nil || f.Next() != nil || f.Prev() != nil {
+		panic("bad flow in Linked list")
+	}
+	l.size++
+	if l.tail == nil {
+		l.head = f
+		l.tail = f
+		f.SetNext(nil)
+		f.SetPrev(nil)
+		return
+	}
+	l.tail.SetNext(f)
+	f.SetPrev(l.tail)
+	l.tail = f
+	f.SetNext(nil)
+}
+
+// Get removes and returns the first element in the LinkedList.
+// If the list is empty, returns nil.
+func (l *LinkedList) Get() LinkedElement {
+	f := l.head
+	if f != nil {
+		l.Remove(f)
+	}
+	return f
+}
+
+// Remove removes the given LinkedElement from the LinkedList.
+func (l *LinkedList) Remove(e LinkedElement) {
+	l.size--
+	if e.Prev() != nil {
+		e.Prev().SetNext(e.Next())
+	} else {
+		l.head = e.Next()
+	}
+	if e.Next() != nil {
+		e.Next().SetPrev(e.Prev())
+	} else {
+		l.tail = e.Prev()
+	}
+	e.SetPrev(nil)
+	e.SetNext(nil)
+}
+
+// RemoveOlder sequentially scans the head of the Linked list for elements
+// with a Timestamp() before the given deadline and calls the provided callback
+// on them. The LinkedList must be sorted by incremental Timestamp() (LRU).
+//
+// This callback is expected to return true if it removed the element from
+// the Linked list. Otherwise, it will be removed by this function.
+func (l *LinkedList) RemoveOlder(deadline time.Time, callback func(LinkedElement) bool) {
+	for l.head != nil && l.head.Timestamp().Before(deadline) {
+		if !callback(l.head) {
+			l.Get()
+		}
+	}
+}

--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
@@ -1,19 +1,6 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
 
 package helper
 

--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist_test.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist_test.go
@@ -1,0 +1,179 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package helper
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type intElement struct {
+	value int
+	prev  LinkedElement
+	next  LinkedElement
+}
+
+func (i *intElement) Prev() LinkedElement {
+	return i.prev
+}
+
+func (i *intElement) Next() LinkedElement {
+	return i.next
+}
+
+func (i *intElement) SetPrev(element LinkedElement) {
+	i.prev = element
+}
+
+func (i *intElement) SetNext(element LinkedElement) {
+	i.next = element
+}
+
+func (i *intElement) Timestamp() time.Time {
+	return time.Unix(int64(i.value), 0)
+}
+
+func benchmarkLinkedListAdd(b *testing.B) {
+	var input, output LinkedList
+	for i := 0; i < b.N; i++ {
+		input.Add(&intElement{})
+	}
+	// Enable allocations reporting
+	b.ReportAllocs()
+	// Reset timer and allocation counters
+	b.ResetTimer()
+	// Consuming a linked list and constructing a new linked list from the
+	// original elements must result in zero allocations.
+	for elem := input.Get(); elem != nil; elem = input.Get() {
+		output.Add(elem)
+	}
+}
+
+func benchmarkLinkedListAppend(b *testing.B) {
+	var dst LinkedList
+	elems := make([]intElement, b.N)
+	getList := func() (ret LinkedList) {
+		if n := len(elems) - 1; n >= 0 {
+			ret.Add(&elems[n])
+			elems = elems[:n]
+		}
+		return ret
+	}
+	// Enable allocations reporting
+	b.ReportAllocs()
+	// Reset timer and allocation counters
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lst := getList()
+		dst.Append(&lst)
+	}
+}
+
+func benchmarkLinkedListRemoveOlder(b *testing.B) {
+	var ll LinkedList
+	for i := 0; i < b.N; i++ {
+		ll.Add(&intElement{})
+	}
+	// Enable allocations reporting
+	b.ReportAllocs()
+	// Reset timer and allocation counters
+	b.ResetTimer()
+	remove := true
+	ll.RemoveOlder(time.Now(), func(e LinkedElement) bool {
+		time.Sleep(time.Millisecond)
+		if remove = !remove; remove {
+			ll.Remove(e)
+		}
+		return remove
+	})
+}
+
+func TestLinkedListAddNoAllocs(t *testing.T) {
+	result := testing.Benchmark(benchmarkLinkedListAdd)
+	assert.Zero(t, result.AllocsPerOp())
+	assert.Zero(t, result.AllocedBytesPerOp())
+}
+
+func TestLinkedListAppendNoAllocs(t *testing.T) {
+	result := testing.Benchmark(benchmarkLinkedListAppend)
+	assert.Zero(t, result.AllocsPerOp())
+	assert.Zero(t, result.AllocedBytesPerOp())
+}
+
+func TestLinkedListRemoveOlderNoAllocs(t *testing.T) {
+	result := testing.Benchmark(benchmarkLinkedListRemoveOlder)
+	assert.Zero(t, result.AllocsPerOp())
+	assert.Zero(t, result.AllocedBytesPerOp())
+}
+
+func TestLinkedListRemoveOlder(t *testing.T) {
+	callbacks := map[string]func(*LinkedList) func(LinkedElement) bool{
+		"self_removed": func(ll *LinkedList) func(LinkedElement) bool {
+			return func(e LinkedElement) bool {
+				ll.Remove(e)
+				return true
+			}
+		},
+		"caller_removed": func(*LinkedList) func(LinkedElement) bool {
+			return func(LinkedElement) bool {
+				return false
+			}
+		},
+	}
+
+	deadline := time.Unix(10, 0)
+	for idx, testCase := range []struct {
+		input    []int
+		expected []int
+	}{
+		{
+			input:    nil,
+			expected: nil,
+		},
+		{
+			input:    []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			expected: nil,
+		},
+		{
+			input:    []int{1, 1, 10},
+			expected: []int{10},
+		},
+		{
+			input:    []int{11, 12, 13},
+			expected: []int{11, 12, 13},
+		},
+	} {
+		for name, callback := range callbacks {
+			t.Run(fmt.Sprintf("case#%d-%s", idx+1, name), func(t *testing.T) {
+				var input LinkedList
+				for _, v := range testCase.input {
+					input.Add(&intElement{value: v})
+				}
+				input.RemoveOlder(deadline, callback(&input))
+				var remaining []int
+				for item := input.Get(); item != nil; item = input.Get() {
+					remaining = append(remaining, item.(*intElement).value)
+				}
+				assert.Equal(t, testCase.expected, remaining)
+			})
+		}
+	}
+}

--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist_test.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist_test.go
@@ -1,19 +1,6 @@
-// Licensed to Elasticsearch B.V. under one or more contributor
-// license agreements. See the NOTICE file distributed with
-// this work for additional information regarding copyright
-// ownership. Elasticsearch B.V. licenses this file to you under
-// the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
 
 package helper
 

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -498,7 +498,7 @@ func (s *state) logStateLoop() {
 func (s *state) ExpireFlows() {
 	start := s.clock()
 	toReport := s.expireFlows()
-	if sent := s.reportFlows(&toReport); sent > 0 {
+	if sent := s.reportFlows(&toReport); sent != 0 {
 		s.log.Debugf("ExpireOlder took %v reported=%d", s.clock().Sub(start), sent)
 	}
 }

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/joeshaw/multierror"
-
 	"golang.org/x/sys/unix"
 
 	"github.com/elastic/beats/v7/libbeat/common"

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -506,7 +506,8 @@ func (s *state) ExpireFlows() {
 func (s *state) expireFlows() (toReport linkedList) {
 	s.Lock()
 	defer s.Unlock()
-	deadline := s.clock().Add(-s.inactiveTimeout)
+	now := s.clock()
+	deadline := now.Add(-s.inactiveTimeout)
 	for item := s.flowLRU.peek(); item != nil && item.Timestamp().Before(deadline); {
 		if flow, ok := item.(*flow); ok {
 			flows := s.onFlowTerminated(flow)
@@ -516,7 +517,7 @@ func (s *state) expireFlows() (toReport linkedList) {
 		}
 		item = s.flowLRU.peek()
 	}
-	deadline = s.clock().Add(-s.socketTimeout)
+	deadline = now.Add(-s.socketTimeout)
 	for item := s.socketLRU.peek(); item != nil && item.Timestamp().Before(deadline); {
 		if sock, ok := item.(*socket); ok {
 			s.onSockDestroyed(sock.sock, sock, 0)
@@ -525,7 +526,7 @@ func (s *state) expireFlows() (toReport linkedList) {
 		}
 		item = s.socketLRU.peek()
 	}
-	deadline = s.clock().Add(-s.closeTimeout)
+	deadline = now.Add(-s.closeTimeout)
 	for item := s.closing.peek(); item != nil && item.Timestamp().Before(deadline); {
 		if sock, ok := item.(*socket); ok {
 			flows := s.onSockTerminated(sock)

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -477,11 +477,7 @@ func (s *state) expireLoop() {
 		case <-s.reporter.Done():
 			return
 		case <-reportTicker.C:
-			start := s.clock()
-			toReport := s.ExpireOlder()
-			if sent := s.reportFlows(&toReport); sent > 0 {
-				s.log.Debugf("ExpireOlder took %v reported=%d", s.clock().Sub(start), sent)
-			}
+			s.ExpireFlows()
 		}
 	}
 }
@@ -499,7 +495,15 @@ func (s *state) logStateLoop() {
 	}
 }
 
-func (s *state) ExpireOlder() (toReport linkedList) {
+func (s *state) ExpireFlows() {
+	start := s.clock()
+	toReport := s.expireFlows()
+	if sent := s.reportFlows(&toReport); sent > 0 {
+		s.log.Debugf("ExpireOlder took %v reported=%d", s.clock().Sub(start), sent)
+	}
+}
+
+func (s *state) expireFlows() (toReport linkedList) {
 	s.Lock()
 	defer s.Unlock()
 	deadline := s.clock().Add(-s.inactiveTimeout)

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -844,22 +844,23 @@ func (f *flow) updateWith(ref flow, s *state) {
 	f.remote.updateWith(ref.remote)
 }
 
-func (s *state) reportFlow(f *flow) {
+func (s *state) reportFlow(f *flow) (reported bool) {
 	if f != nil && f.isValid() && int(f.pid) != s.currentPID {
-		ev, err := f.toEvent(true)
-		if err != nil {
+		if ev, err := f.toEvent(true); err == nil {
+			reported = s.reporter.Event(ev)
+		} else {
 			s.log.Errorf("Failed to convert flow=%v err=%v", f, err)
-			return
 		}
-		s.reporter.Event(ev)
 	}
+	return reported
 }
 
 func (s *state) reportFlows(l *helper.LinkedList) (count int) {
 	for item := l.Get(); item != nil; item = l.Get() {
 		if f, ok := item.(*flow); ok {
-			s.reportFlow(f)
-			count++
+			if s.reportFlow(f) {
+				count++
+			}
 		}
 	}
 	return count

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -387,6 +387,7 @@ type state struct {
 	// Decouple time.Now()
 	clock func() time.Time
 
+	// currentPID is the PID of the beat.
 	currentPID int
 }
 

--- a/x-pack/auditbeat/module/system/socket/state.go
+++ b/x-pack/auditbeat/module/system/socket/state.go
@@ -866,9 +866,7 @@ func (s *state) reportFlow(f *flow) {
 			s.log.Errorf("Failed to convert flow=%v err=%v", f, err)
 			return
 		}
-		if !s.reporter.Event(ev) {
-			return
-		}
+		s.reporter.Event(ev)
 	}
 }
 

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -813,3 +813,24 @@ func TestProcessDNSRace(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+func benchmarkLinkedListAllocs(b *testing.B) {
+	var input, output linkedList
+	for i := 0; i < b.N; i++ {
+		input.add(&flow{})
+	}
+	// Enable allocations reporting
+	b.ReportAllocs()
+	// Reset timer and allocation counters
+	b.ResetTimer()
+	// Consuming a linked list and constructing a new linked list from the
+	// original elements must result in zero allocations.
+	for elem := input.get(); elem != nil; elem = input.get() {
+		output.add(elem)
+	}
+}
+
+func TestLinkedListNoAllocs(t *testing.T) {
+	result := testing.Benchmark(benchmarkLinkedListAllocs)
+	assert.Zero(t, result.AllocsPerOp())
+}

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -504,10 +504,6 @@ func ipv6(ip string) (hi uint64, lo uint64) {
 	return tracing.MachineEndian.Uint64(netIP[:]), tracing.MachineEndian.Uint64(netIP[8:])
 }
 
-func all(*flow) bool {
-	return true
-}
-
 func callExecve(meta tracing.Metadata, args []string) *execveCall {
 	ptr := &execveCall{
 		Meta: meta,

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -814,24 +814,3 @@ func TestProcessDNSRace(t *testing.T) {
 	}()
 	wg.Wait()
 }
-
-func benchmarkLinkedListAllocs(b *testing.B) {
-	var input, output linkedList
-	for i := 0; i < b.N; i++ {
-		input.add(&flow{})
-	}
-	// Enable allocations reporting
-	b.ReportAllocs()
-	// Reset timer and allocation counters
-	b.ResetTimer()
-	// Consuming a linked list and constructing a new linked list from the
-	// original elements must result in zero allocations.
-	for elem := input.get(); elem != nil; elem = input.get() {
-		output.add(elem)
-	}
-}
-
-func TestLinkedListNoAllocs(t *testing.T) {
-	result := testing.Benchmark(benchmarkLinkedListAllocs)
-	assert.Zero(t, result.AllocsPerOp())
-}

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -55,7 +55,7 @@ func (ts *testingState) Event(event mb.Event) bool {
 	return true
 }
 
-func (ts *testingState) Error(_ error) bool {
+func (ts *testingState) Error(error) bool {
 	return true
 }
 
@@ -64,6 +64,7 @@ func (ts *testingState) Done() <-chan struct{} {
 }
 
 func (ts *testingState) feedEvents(evs []event) {
+	ts.t.Helper()
 	for idx, ev := range evs {
 		ts.t.Logf("Delivering event %d: %s", idx, ev.String())
 		if err := ev.Update(&ts.state); err != nil {

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -473,18 +473,6 @@ func be16(val uint16) uint16 {
 	return tracing.MachineEndian.Uint16(buf[:])
 }
 
-func be32(val uint32) uint32 {
-	var buf [4]byte
-	binary.BigEndian.PutUint32(buf[:], val)
-	return tracing.MachineEndian.Uint32(buf[:])
-}
-
-func be64(val uint64) uint64 {
-	var buf [8]byte
-	binary.BigEndian.PutUint64(buf[:], val)
-	return tracing.MachineEndian.Uint64(buf[:])
-}
-
 func ipv4(ip string) uint32 {
 	netIP := net.ParseIP(ip).To4()
 	if netIP == nil {
@@ -514,12 +502,6 @@ func feedEvents(evs []event, st *state, t *testing.T) error {
 
 func all(*flow) bool {
 	return true
-}
-
-type noDNSResolution struct{}
-
-func (noDNSResolution) ResolveIP(pid uint32, ip net.IP) (domain string, found bool) {
-	return "", false
 }
 
 func getFlows(list linkedList, filter func(*flow) bool) (evs []beat.Event, err error) {
@@ -809,7 +791,7 @@ func TestSocketReuse(t *testing.T) {
 			LPort:    lPort,
 			AltRPort: rPort,
 		},
-		// Asume inetRelease lost.
+		// Assume inetRelease lost.
 		&inetCreate{Meta: meta(1234, 1235, 5), Proto: 0},
 		&sockInitData{Meta: meta(1234, 1235, 5), Sock: sock},
 		&udpSendMsgCall{

--- a/x-pack/auditbeat/module/system/socket/state_test.go
+++ b/x-pack/auditbeat/module/system/socket/state_test.go
@@ -96,8 +96,8 @@ func TestTCPConnWithProcess(t *testing.T) {
 	if err := feedEvents(evs, st, t); err != nil {
 		t.Fatal(err)
 	}
-	st.ExpireOlder()
-	flows, err := getFlows(st.DoneFlows(), all)
+
+	flows, err := getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,9 +183,9 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	if err := feedEvents(evs, st, t); err != nil {
 		t.Fatal(err)
 	}
-	st.ExpireOlder()
+
 	// Nothing expired just yet.
-	flows, err := getFlows(st.DoneFlows(), all)
+	flows, err := getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,8 +225,7 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	}
 	// Expire the first socket
 	now = now.Add(closeTimeout + 1)
-	st.ExpireOlder()
-	flows, err = getFlows(st.DoneFlows(), all)
+	flows, err = getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,8 +261,7 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 	// Wait until sock+1 expires due to inactivity. It won't be available
 	// just yet.
 	now = now.Add(socketTimeout + 1)
-	st.ExpireOlder()
-	flows, err = getFlows(st.DoneFlows(), all)
+	flows, err = getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,8 +269,7 @@ func TestTCPConnWithProcessSocketTimeouts(t *testing.T) {
 
 	// Wait until the sock is closed completely.
 	now = now.Add(closeTimeout + 1)
-	st.ExpireOlder()
-	flows, err = getFlows(st.DoneFlows(), all)
+	flows, err = getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,8 +358,7 @@ func TestUDPOutgoingSinglePacketWithProcess(t *testing.T) {
 	if err := feedEvents(evs, st, t); err != nil {
 		t.Fatal(err)
 	}
-	st.ExpireOlder()
-	flows, err := getFlows(st.DoneFlows(), all)
+	flows, err := getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,8 +429,7 @@ func TestUDPIncomingSinglePacketWithProcess(t *testing.T) {
 	if err := feedEvents(evs, st, t); err != nil {
 		t.Fatal(err)
 	}
-	st.ExpireOlder()
-	flows, err := getFlows(st.DoneFlows(), all)
+	flows, err := getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -830,8 +825,7 @@ func TestSocketReuse(t *testing.T) {
 	if err := feedEvents(evs, st, t); err != nil {
 		t.Fatal(err)
 	}
-	st.ExpireOlder()
-	flows, err := getFlows(st.DoneFlows(), all)
+	flows, err := getFlows(st.ExpireOlder(), all)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What does this PR do?

This PR modifies the socket dataset so that it is affected by output backpressure.

Originally, it operated as two separate goroutines. One would read kernel tracing events as fast as possible and maintain a view of the open sockets/flows on the system. Once a flow is deemed terminated, it would be stored on a linked list (`done`) for it to be published to the output.

A separate goroutine consumes that linked list and publishes the flows.

Under heavy network load, it can generate flows faster than the output is able to accept. Due to the linked list being unbounded, it would store more and more flows, causing Auditbeat's memory usage to grow over time.

This PR simplifies flow publication in such a way that if the output blocks, the main reader goroutine will block too, preventing the consumption of new kernel events and the generation of additional flows until the output is able to accept more documents.

Also it contains a necessary refactor: Moving the linked list implementation to a helper package. This adds a bit of noise.
## Why is it important?

To prevent high-memory usage of Auditbeat under heavy network I/O.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

With the below code it's easy to increase the memory usage of Auditbeat dramatically. With this patch, it will stabilize.

<details>
  <summary>Flow flooder script</summary>

```go
package main

import (
	"fmt"
	"math/rand"
	"net"
	"os"
)

const (
	NSOCKS     = 8000
	ADDR       = "127.0.0.1"
	ADDRLISTEN = ADDR + ":0"
)

func main() {
	addr, err := net.ResolveUDPAddr("udp4", ADDRLISTEN)
	if err != nil {
		panic(fmt.Errorf("ResolveUDPAddr(%s): %w", ADDRLISTEN, err))
	}
	var sock [NSOCKS]*net.UDPConn
	for idx := range sock {
		c, err := net.ListenUDP("udp4", addr)
		if err != nil {
			panic(fmt.Errorf("ListenUDP(%s): %w", addr, err))
		}
		sock[idx] = c
		laddr := c.LocalAddr().(*net.UDPAddr)
		fmt.Fprintf(os.Stderr, "sock[%d] is at %d\n", idx, laddr.Port)
	}
	data := []byte("Some random data")
	for {
		for _, src := range sock {
			dst := sock[rand.Intn(NSOCKS)]
			if _, err = src.WriteTo(data, dst.LocalAddr()); err != nil {
				panic(fmt.Errorf("WriteTo(%v -> %v): %w", src.LocalAddr(), dst.LocalAddr(), err))
			}
		}
	}
}
```
</details>

## Related issues

- Closes https://github.com/elastic/beats/issues/32191

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
