### PR TITLE
[automation] update elastic stack version for testing 8.4.0-03bd6f3f

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-3ad82aa8-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-03bd6f3f-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -31,7 +31,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.4.0-3ad82aa8-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.4.0-03bd6f3f-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -44,7 +44,7 @@ services:
       - 5055:5055
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-3ad82aa8-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-03bd6f3f-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 4 Jul 2022 12:16:14 GMT, release_branch:master, prefix:, end_time:Mon, 4 Jul 2022 17:02:59 GMT, manifest_version:2.1.0, version:8.4.0-SNAPSHOT, branch:master, build_id:8.4.0-03bd6f3f, build_duration_seconds:17205]