### PR TITLE
Fix typo in log message

### DIFF
--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -291,7 +291,7 @@ func (p *fileProspector) onRename(log *logp.Logger, ctx input.Context, fe loginp
 func (p *fileProspector) stopHarvesterGroup(log *logp.Logger, hg loginp.HarvesterGroup) {
 	err := hg.StopGroup()
 	if err != nil {
-		log.Errorf("Error while stopping harverster group: %v", err)
+		log.Errorf("Error while stopping harvester group: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes typo in log message: harverster -> harvester, e.g.:

2022-07-06T10:23:57.578+0200	ERROR	[input.filestream]	filestream/prospector.go:291	Error while stopping **harverster** group: task failures

## Why is it important?

Error might be skipped if someone searches by "harvester" term.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

## How to test this PR locally

## Related issues

## Use cases

## Screenshots

## Logs

2022-07-06T10:23:57.578+0200	ERROR	[input.filestream]	filestream/prospector.go:291	Error while stopping **harverster** group: task failures