### PR TITLE
ci: remove support for windows-2008-r2

### DIFF
--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -74,11 +74,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -72,11 +72,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -44,11 +44,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -72,11 +72,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -69,11 +69,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -85,11 +85,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -70,11 +70,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -90,11 +90,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -58,11 +58,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -73,11 +73,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -54,11 +54,6 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
It reached EOL on January 14, 2020

Cannot fetch terraform binaries and images are not anymore built so, the complexity to add support for terraform will imply to add the complexity to the shared library pipeline or do some hacks in the pipeline.

Related to https://github.com/elastic/beats/issues/32102

> Ah, also, one more thing. On some EOL windows versions (I only tested windows-2008-r2), I noted that the terraform download step is failing with an exit code of `5`.
> 
> ```
> [2022-06-23T10:16:14.330Z] 
> [2022-06-23T10:16:14.330Z] C:\Users\jenkins\workspace\7.17-364-d3690f67-759e-4941-99fe-f6da81bd48da\src\github.com\elastic\beats@tmp>wget -q -O terraform.zip https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_windows_amd64.zip 
> script returned exit code 5
> ```
> 
> If you look at the `wget` man page, [exit code 5](https://www.man7.org/linux/man-pages/man1/wget.1.html#EXIT_STATUS) corresponds to `SSL verification failure.` If you run the `wget` command without the `-q` argument, and with the `--debug` argument you can see that the reason the download is failing is that `wget` is unable to verify the certificate presented by the hashicorp download site:
> 
> ```
> Initiating SSL handshake.
> Handshake successful; connected socket 4 to SSL handle 0x0000000000316830
> certificate:
>   subject: CN=releases.hashicorp.com
>   issuer:  CN=GlobalSign Atlas R3 DV TLS CA 2022 Q2,O=GlobalSign nv-sa,C=BE
> ERROR: cannot verify releases.hashicorp.com's certificate, issued by 'CN=GlobalSign Atlas R3 D
> V TLS CA 2022 Q2,O=GlobalSign nv-sa,C=BE':
>   Unable to locally verify the issuer's authority.
> To connect to releases.hashicorp.com insecurely, use `--no-check-certificate'.
> Closed 4/SSL 0x0000000000316830
> ```
> 
> So unfortunately no amount of retries are going to fix that :) I don't know how to solve that with `wget` on these ancient windows versions, but using `curl` instead does seem to work if that's an option for you.

