### PR TITLE
ci: support terraform for windows 2008 r2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -683,22 +683,8 @@ def withBeatsEnv(Map args = [:], Closure body) {
           }
           withOtelEnv() {
             // for windows-2008-r2 there is a requirement to install terraform without the certificate validation
-            // see https://github.com/elastic/beats/pull/32219
-            if (label?.contains('windows-2008')) {
-              def location = pwd(tmp: true)
-              withEnv(["PATH+TERRAFORM=${location}"]) {
-                def url = "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_windows_amd64.zip"
-                def zipfile = 'terraform.zip'
-                dir(location) {
-                  downloadWithWget(url: url, output: zipfile, flags: '--no-check-certificate')
-                  unzip(quiet: true, zipFile: zipfile)
-                }
-                body()
-              }
-            } else {
-              withTerraformEnv(version: env.TERRAFORM_VERSION) {
-                body()
-              }
+            withTerraformEnv(version: env.TERRAFORM_VERSION, noCheckCertificate: label?.contains('windows-2008')) {
+              body()
             }
           }
         } catch(err) {


### PR DESCRIPTION
It reached EOL on January 14, 2020

Cannot fetch terraform binaries and images are not anymore built so, let's delegate the complexity when to enable/disable the certificate check to the pipeline and the implementation to the shared library

Requires https://github.com/elastic/beats/pull/32221

Related to https://github.com/elastic/beats/issues/32102

> Ah, also, one more thing. On some EOL windows versions (I only tested windows-2008-r2), I noted that the terraform download step is failing with an exit code of `5`.
> 
> ```
> [2022-06-23T10:16:14.330Z] 
> [2022-06-23T10:16:14.330Z] C:\Users\jenkins\workspace\7.17-364-d3690f67-759e-4941-99fe-f6da81bd48da\src\github.com\elastic\beats@tmp>wget -q -O terraform.zip https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_windows_amd64.zip 
> script returned exit code 5
> ```
> 
> If you look at the `wget` man page, [exit code 5](https://www.man7.org/linux/man-pages/man1/wget.1.html#EXIT_STATUS) corresponds to `SSL verification failure.` If you run the `wget` command without the `-q` argument, and with the `--debug` argument you can see that the reason the download is failing is that `wget` is unable to verify the certificate presented by the hashicorp download site:
> 
> ```
> Initiating SSL handshake.
> Handshake successful; connected socket 4 to SSL handle 0x0000000000316830
> certificate:
>   subject: CN=releases.hashicorp.com
>   issuer:  CN=GlobalSign Atlas R3 DV TLS CA 2022 Q2,O=GlobalSign nv-sa,C=BE
> ERROR: cannot verify releases.hashicorp.com's certificate, issued by 'CN=GlobalSign Atlas R3 D
> V TLS CA 2022 Q2,O=GlobalSign nv-sa,C=BE':
>   Unable to locally verify the issuer's authority.
> To connect to releases.hashicorp.com insecurely, use `--no-check-certificate'.
> Closed 4/SSL 0x0000000000316830
> ```
> 
> So unfortunately no amount of retries are going to fix that :) I don't know how to solve that with `wget` on these ancient windows versions, but using `curl` instead does seem to work if that's an option for you.

