### PR TITLE
[elastic/beats] [HttpJson] - Improves request chaining with new 'while' step & client creation per step 

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -1095,8 +1095,8 @@ Collect and make events from response in any format supported by httpjson for al
 ==== `chain[].while`
 
 Contains basic request and response configuration for chained while calls. Chained while calls will keep making the requests for a given number of times until a condition is met
-or the maximum number of attempts gets exhausted. While chain has an attribute `till` which holds the expression to be evaluated. Ideally the `till` field should always be used 
-together with the attributes `request.retry.max_attempts` and `request.retry.wait_min` which specifies the maximum number of attempts to evaluate `till` before giving up and the 
+or the maximum number of attempts gets exhausted. While chain has an attribute `until` which holds the expression to be evaluated. Ideally the `until` field should always be used 
+together with the attributes `request.retry.max_attempts` and `request.retry.wait_min` which specifies the maximum number of attempts to evaluate `until` before giving up and the 
 maximum wait time in between such requests. If `request.retry.max_attempts` is not specified, it will only try to evaluate the expression once and give up if it fails. If 
 `request.retry.wait_min` is not specified the default wait time will always be `0` as in successive calls will be made immediately.
 
@@ -1152,7 +1152,7 @@ filebeat.inputs:
         request.url: http://example.com/services/data/v1.0/$.exportId/export_ids/status
         request.method: GET
         replace: $.exportId
-        till: '[[ eq .last_response.body.status "completed" ]]'
+        until: '[[ eq .last_response.body.status "completed" ]]'
         request.retry.max_attempts: 5
         request.retry.wait_min: 5s
     # third call

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -1103,7 +1103,7 @@ maximum wait time in between such requests. If `request.retry.max_attempts` is n
 [float]
 ==== `chain[].while.request`
 
-Please refer <<request-parameters,request parameters>>. Required.
+Please refer to <<request-parameters,request parameters>> for more information. Required.
 
 Example:
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -1091,7 +1091,158 @@ request_url using file_name as 'file_2': https://example.com/services/data/v1.0/
 +
 Collect and make events from response in any format supported by httpjson for all calls.
 
-NOTE: httpjson chain will only create and ingest events from last call on chained configurations. Also, the current chain only supports the following: `request.url`, `request.method`, `request.transforms`, `request.body`, `response.transforms` and `response.split`.
+[float]
+==== `chain[].while`
+
+Contains basic request and response configuration for chained while calls. Chained while calls keep making the requests for a given number of times until a condition is met.
+
+[float]
+==== `chain[].while.request`
+
+Please refer <<request-parameters,request parameters>>. Required.
+
+Example:
+
+First call: http://example.com/services/data/v1.0/exports
+
+Second call: http://example.com/services/data/v1.0/9ef0e6a5/export_ids/status
+
+Third call: http://example.com/services/data/v1.0/export_ids/1/info
+
+[float]
+==== `chain[].while.response.split`
+
+Please refer <<response-split,response split parameter>>.
+
+[float]
+==== `chain[].while.replace`
+
+Please refer `chain[].step.replace`.
+
+Example:
+
+- First call: http://example.com/services/data/v1.0/exports
++
+<<response-json1-while,response>>
+
+- Second call: http://example.com/services/data/v1.0/`$.exportId`/export_ids/status
++
+<<response-json2-while,response>>
+
+- Third call: http://example.com/services/data/v1.0/export_ids/`$.files[:].id`/info
++
+<<response-json3-while,response 1>> , <<response-json4-while,response 2>>
+
+["source","yaml",subs="attributes"]
+----
+filebeat.inputs:
+- type: httpjson
+  enabled: true
+  # first call
+  id: my-httpjson-id
+  request.url: http://example.com/services/data/v1.0/exports
+  interval: 1h
+  chain:
+    # second call
+    - while:
+        request.url: http://example.com/services/data/v1.0/$.exportId/export_ids/status
+        request.method: GET
+        replace: $.exportId
+        till: '[[ eq .last_response.body.status "completed" ]]'
+        request.retry.max_attempts: 5
+        request.retry.wait_min: 5s
+    # third call
+    - step:
+        request.url: http://example.com/services/data/v1.0/export_ids/$.files[:].id/info
+        request.method: GET
+        replace: $.files[:].id
+----
+
+Example:
+
+- First call to collect export ids
+
++
+request_url: https://example.com/services/data/v1.0/exports
+
++
+response_json:
+
++
+[[response-json1-while]]
+["source","json",subs="attributes"]
+----
+{
+    "exportId": "9ef0e6a5"
+}
+----
+
+- Second call to collect `file_ids` using collected id from first call when `response.body.sataus == "completed"`. This call continues until the condition is satisfied or the maximum number of attempts gets exhausted.
+
++
+request_url using id as '9ef0e6a5': https://example.com/services/data/v1.0/9ef0e6a5/export_ids/status
+
++
+response_json using id as '9ef0e6a5':
+
++
+[[response-json2-while]]
+["source","json",subs="attributes"]
+----
+{
+    "status": "completed",
+    "files": [
+      {
+        "id": 1
+      },
+      {
+        "id": 2
+      },
+      {
+        "id": 3
+      }
+    ]
+}
+----
+
+- Third call to collect `files` using collected `file_id` from second call.
+
++
+request_url using file_id as '1': https://example.com/services/data/v1.0/export_ids/1/info
+
++
+request_url using file_id as '2': https://example.com/services/data/v1.0/export_ids/2/info
+
++
+response_json using id as '1':
+
++
+[[response-json3-while]]
+["source","json",subs="attributes"]
+----
+{
+    "file_name": "file_1",
+    "file_data": "some data"
+}
+----
+
++
+response_json using id as '2':
+
++
+[[response-json4-while]]
+["source","json",subs="attributes"]
+----
+{
+    "file_name": "file_2",
+    "file_data": "some data"
+}
+----
+
++
+Collect and make events from response in any format supported by httpjson for all calls.
+
+NOTE: httpjson chain will only create and ingest events from last call on chained configurations. Also, the current chain only supports the following: all <<request-parameters, request parameters>>, `response.transforms` and `response.split`.
 
 [[cursor]]
 [float]

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -1094,7 +1094,11 @@ Collect and make events from response in any format supported by httpjson for al
 [float]
 ==== `chain[].while`
 
-Contains basic request and response configuration for chained while calls. Chained while calls keep making the requests for a given number of times until a condition is met.
+Contains basic request and response configuration for chained while calls. Chained while calls will keep making the requests for a given number of times until a condition is met
+or the maximum number of attempts gets exhausted. While chain has an attribute `till` which holds the expression to be evaluated. Ideally the `till` field should always be used 
+together with the attributes `request.retry.max_attempts` and `request.retry.wait_min` which specifies the maximum number of attempts to evaluate `till` before giving up and the 
+maximum wait time in between such requests. If `request.retry.max_attempts` is not specified, it will only try to evaluate the expression once and give up if it fails. If 
+`request.retry.wait_min` is not specified the default wait time will always be `0` as in successive calls will be made immediately.
 
 [float]
 ==== `chain[].while.request`

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -113,8 +113,8 @@ The state has the following elements:
 - `first_event`: A map representing the first event sent to the output (result from applying transforms to `last_response.body`).
 - `last_event`: A map representing the last event of the current request in the requests chain (result from applying transforms to `last_response.body`).
 - `url`: The last requested URL as a raw https://pkg.go.dev/net/url#URL[`url.URL`] Go type.
-- `header`: A map containing the headers. References the next request headers when used in <<request-transforms>> or <<response-pagination>> configuration sections, and to the last response headers when used in <<response-transforms>>, <<response-split>>, or <<request-rate-limit>> configuration sections.
-- `body`: A map containing the body. References the next request body when used in <<request-transforms>> or <<response-pagination>> configuration sections, and to the last response body when used in <<response-transforms>> or <<response-split>> configuration sections.
+- `header`: A map containing the headers. References the next request headers when used in <<request-transforms-headers>> or <<response-pagination>> configuration sections, and to the last response headers when used in <<response-transforms>>, <<response-split>>, or <<request-rate-limit>> configuration sections.
+- `body`: A map containing the body. References the next request body when used in <<request-transforms-headers>> or <<response-pagination>> configuration sections, and to the last response body when used in <<response-transforms>> or <<response-split>> configuration sections.
 - `cursor`: A map containing any data the user configured to be stored between restarts (See <<cursor>>).
 
 All of the mentioned objects are only stored at runtime, except `cursor`, which has values that are persisted between restarts.
@@ -501,7 +501,7 @@ If the `remaining` header is missing from the Response, no rate-limiting will oc
 The value of the response that specifies the epoch time when the rate limit will reset.
 It is defined with a Go template value. Can read state from: [`.last_response.header`]
 
-[[request-transforms]]
+[[request-transforms-headers]]
 [float]
 ==== `request.rate_limit.early_limit`
 
@@ -521,6 +521,7 @@ e.g. instead of rate-limiting when `remaining` hits `0`, rate-limiting will occu
 
 It is not set by default (by default the rate-limiting as specified in the Response is followed).
 
+[[request-transforms]]
 [float]
 ==== `request.transforms`
 
@@ -607,7 +608,7 @@ Defines the field type of the target. Allowed values: `array`, `map`, `string`. 
 [float]
 ==== `response.split[].transforms`
 
-A set of transforms can be defined. This list will be applied after `response.transforms` and after the object has been modified based on `response.split[].keep_parent` and `response.split[].key_field`.
+A set of transforms can be defined. This list will be applied after <<response-transforms, response.transforms>> and after the object has been modified based on `response.split[].keep_parent` and `response.split[].key_field`.
 
 Available transforms for response: [`append`, `delete`, `set`].
 
@@ -651,7 +652,7 @@ If set to true, the values in `request.body` are sent for pagination requests. D
 [float]
 ==== `response.pagination`
 
-List of transforms that will be applied to the response to every new page request. All the transforms from `request.transform` will be executed and then `response.pagination` will be added to modify the next request as needed. For subsequent responses, the usual `response.transforms` and `response.split` will be executed normally.
+List of transforms that will be applied to the response to every new page request. All the transforms from `request.transform` will be executed and then `response.pagination` will be added to modify the next request as needed. For subsequent responses, the usual <<response-transforms, response.transforms>> and <<response-split, response.split>> will be executed normally.
 
 Available transforms for pagination: [`append`, `delete`, `set`].
 
@@ -967,7 +968,7 @@ Contains basic request and response configuration for chained calls.
 [float]
 ==== `chain[].step.request`
 
-Please refer <<request-parameters,request parameters>>. Required.
+See <<request-parameters,request parameters>>. Required.
 
 Example:
 
@@ -980,12 +981,14 @@ Third call: https://example.com/services/data/v1.0/export_ids/file_1/info
 [float]
 ==== `chain[].step.response.split`
 
-Please refer <<response-split,response split parameter>>.
+See <<response-split,response split parameter>>.
 
++
+[[chain-step-replace]]
 [float]
 ==== `chain[].step.replace`
 
-A [JSONPath](https://goessner.net/articles/JsonPath/index.html#e2[JSONPath]) string to parse values from responses JSON, collected from previous chain steps. Place same replace string in url where collected values from previous call should be placed. Required.
+A link:https://goessner.net/articles/JsonPath/index.html#e2[JSONPath] string to parse values from responses JSON, collected from previous chain steps. Place same replace string in url where collected values from previous call should be placed. Required.
 
 Example:
 
@@ -1103,7 +1106,7 @@ maximum wait time in between such requests. If `request.retry.max_attempts` is n
 [float]
 ==== `chain[].while.request`
 
-Please refer to <<request-parameters,request parameters>> for more information. Required.
+See  <<request-parameters,request parameters>> .
 
 Example:
 
@@ -1116,12 +1119,12 @@ Third call: http://example.com/services/data/v1.0/export_ids/1/info
 [float]
 ==== `chain[].while.response.split`
 
-Please refer <<response-split,response split parameter>>.
+See  <<response-split,response split parameter>> .
 
 [float]
 ==== `chain[].while.replace`
 
-Please refer `chain[].step.replace`.
+See  <<chain-step-replace, chain[].step.replace>> .
 
 Example:
 
@@ -1246,7 +1249,7 @@ response_json using id as '2':
 +
 Collect and make events from response in any format supported by httpjson for all calls.
 
-NOTE: httpjson chain will only create and ingest events from last call on chained configurations. Also, the current chain only supports the following: all <<request-parameters, request parameters>>, `response.transforms` and `response.split`.
+NOTE: httpjson chain will only create and ingest events from last call on chained configurations. Also, the current chain only supports the following: all <<request-parameters, request parameters>>, <<response-transforms, response.transforms>> and <<response-split, response.split>>.
 
 [[cursor]]
 [float]
@@ -1289,11 +1292,11 @@ filebeat.inputs:
 image:images/input-httpjson-lifecycle.png[Request lifecycle]
 
 . At every defined interval a new request is created.
-. The request is transformed using the configured `request.transforms`.
+. The request is transformed using the configured <<request-transforms, request.transforms>>.
 . The resulting transformed request is executed.
 . The server responds (here is where any retry or rate limit policy takes place when configured).
-. The response is transformed using the configured `response.transforms` and `response.split`.
-. If a chain step is configured. Each step will generate new requests based on collected IDs from responses. The requests will be transformed using configured `request.transforms` and the resulting generated transformed requests will be executed. This process will happen for all the steps mentioned in the chain.
+. The response is transformed using the configured <<response-transforms, response.transforms>> and <<response-split, response.split>>.
+. If a chain step is configured. Each step will generate new requests based on collected IDs from responses. The requests will be transformed using configured <<request-transforms, request.transforms>> and the resulting generated transformed requests will be executed. This process will happen for all the steps mentioned in the chain.
 . Each resulting event is published to the output.
 . If a `response.pagination` is configured and there are more pages, a new request is created using it, otherwise the process ends until the next interval.
 

--- a/x-pack/filebeat/input/httpjson/chain.go
+++ b/x-pack/filebeat/input/httpjson/chain.go
@@ -102,14 +102,11 @@ func defaultChainConfig() config {
 				Auth:     chaincfg.Auth,
 				Request:  *chaincfg.Request,
 				Response: responseChainConfig{},
-				Replace:  "",
-				Till:     nil,
 			},
 			Step: &stepConfig{
 				Auth:     chaincfg.Auth,
 				Request:  *chaincfg.Request,
 				Response: responseChainConfig{},
-				Replace:  "",
 			},
 		},
 	}

--- a/x-pack/filebeat/input/httpjson/chain.go
+++ b/x-pack/filebeat/input/httpjson/chain.go
@@ -75,6 +75,12 @@ type stepConfig struct {
 	Replace  string              `config:"replace,omitempty"`
 }
 
+// whileConfig will contain basic properties like auth parameters, request parameters,
+// response parameters , a replace parameter and an expression parameter called till.
+// While is similar to stepConfig with the addition of till. Till holds an expression
+// and with the combination of "request.retry.max_attempts" retries a request till the
+// expression is evaluated to "true" or request.retry.max_attempts is exhausted. If
+// request.retry.max_attempts is not specified , the max_attempts is always 1.
 type whileConfig struct {
 	Auth     *authConfig         `config:"auth"`
 	Request  requestConfig       `config:"request" validate:"required"`

--- a/x-pack/filebeat/input/httpjson/chain.go
+++ b/x-pack/filebeat/input/httpjson/chain.go
@@ -76,9 +76,9 @@ type stepConfig struct {
 }
 
 // whileConfig will contain basic properties like auth parameters, request parameters,
-// response parameters , a replace parameter and an expression parameter called till.
-// While is similar to stepConfig with the addition of till. Till holds an expression
-// and with the combination of "request.retry.max_attempts" retries a request till the
+// response parameters , a replace parameter and an expression parameter called 'until'.
+// While is similar to stepConfig with the addition of 'until'. 'until' holds an expression
+// and with the combination of "request.retry.max_attempts" retries a request 'until' the
 // expression is evaluated to "true" or request.retry.max_attempts is exhausted. If
 // request.retry.max_attempts is not specified , the max_attempts is always 1.
 type whileConfig struct {
@@ -86,7 +86,7 @@ type whileConfig struct {
 	Request  requestConfig       `config:"request" validate:"required"`
 	Response responseChainConfig `config:"response,omitempty"`
 	Replace  string              `config:"replace,omitempty"`
-	Till     *valueTpl           `config:"till" validate:"required"`
+	Until    *valueTpl           `config:"until" validate:"required"`
 }
 
 type responseChainConfig struct {

--- a/x-pack/filebeat/input/httpjson/chain.go
+++ b/x-pack/filebeat/input/httpjson/chain.go
@@ -65,7 +65,8 @@ import (
 // Following contains basic call structure for each call after normal httpjson
 // call.
 type chainConfig struct {
-	Step stepConfig `config:"step" validate:"required"`
+	Step  *stepConfig  `config:"step,omitempty"`
+	While *whileConfig `config:"while,omitempty"`
 }
 
 // stepConfig will contain basic properties like, request.url,
@@ -77,7 +78,12 @@ type stepConfig struct {
 	Response responseChainConfig `config:"response,omitempty"`
 	Replace  string              `config:"replace,omitempty"`
 }
-
+type whileConfig struct {
+	Request  requestChainConfig  `config:"request"`
+	Response responseChainConfig `config:"response,omitempty"`
+	Replace  string              `config:"replace,omitempty"`
+	Till     *valueTpl           `config:"till" validate:"required"`
+}
 type requestChainConfig struct {
 	URL        *urlConfig       `config:"url" validate:"required"`
 	Method     string           `config:"method" validate:"required"`

--- a/x-pack/filebeat/input/httpjson/chain.go
+++ b/x-pack/filebeat/input/httpjson/chain.go
@@ -93,3 +93,26 @@ type responseChainConfig struct {
 	Transforms transformsConfig `config:"transforms"`
 	Split      *splitConfig     `config:"split"`
 }
+
+func defaultChainConfig() config {
+	chaincfg := defaultConfig()
+	chaincfg.Chain = []chainConfig{
+		{
+			While: &whileConfig{
+				Auth:     chaincfg.Auth,
+				Request:  *chaincfg.Request,
+				Response: responseChainConfig{},
+				Replace:  "",
+				Till:     nil,
+			},
+			Step: &stepConfig{
+				Auth:     chaincfg.Auth,
+				Request:  *chaincfg.Request,
+				Response: responseChainConfig{},
+				Replace:  "",
+			},
+		},
+	}
+
+	return chaincfg
+}

--- a/x-pack/filebeat/input/httpjson/chain.go
+++ b/x-pack/filebeat/input/httpjson/chain.go
@@ -86,7 +86,7 @@ type whileConfig struct {
 	Request  requestConfig       `config:"request" validate:"required"`
 	Response responseChainConfig `config:"response,omitempty"`
 	Replace  string              `config:"replace,omitempty"`
-	Till     *valueTpl           `config:"till"`
+	Till     *valueTpl           `config:"till" validate:"required"`
 }
 
 type responseChainConfig struct {

--- a/x-pack/filebeat/input/httpjson/chain.go
+++ b/x-pack/filebeat/input/httpjson/chain.go
@@ -56,11 +56,6 @@
 
 package httpjson
 
-import (
-	"github.com/elastic/elastic-agent-libs/mapstr"
-	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
-)
-
 // chainConfig for chain request.
 // Following contains basic call structure for each call after normal httpjson
 // call.
@@ -74,23 +69,18 @@ type chainConfig struct {
 // will contain replace string with original URL to make a skeleton for the
 // call request.
 type stepConfig struct {
-	Request  requestChainConfig  `config:"request"`
+	Auth     *authConfig         `config:"auth"`
+	Request  requestConfig       `config:"request" validate:"required"`
 	Response responseChainConfig `config:"response,omitempty"`
 	Replace  string              `config:"replace,omitempty"`
 }
-type whileConfig struct {
-	Request  requestChainConfig  `config:"request"`
-	Response responseChainConfig `config:"response,omitempty"`
-	Replace  string              `config:"replace,omitempty"`
-	Till     *valueTpl           `config:"till" validate:"required"`
-}
-type requestChainConfig struct {
-	URL        *urlConfig       `config:"url" validate:"required"`
-	Method     string           `config:"method" validate:"required"`
-	Body       *mapstr.M        `config:"body"`
-	Transforms transformsConfig `config:"transforms"`
 
-	Transport httpcommon.HTTPTransportSettings `config:",inline"`
+type whileConfig struct {
+	Auth     *authConfig         `config:"auth"`
+	Request  requestConfig       `config:"request" validate:"required"`
+	Response responseChainConfig `config:"response,omitempty"`
+	Replace  string              `config:"replace,omitempty"`
+	Till     *valueTpl           `config:"till"`
 }
 
 type responseChainConfig struct {

--- a/x-pack/filebeat/input/httpjson/config.go
+++ b/x-pack/filebeat/input/httpjson/config.go
@@ -36,6 +36,11 @@ func (c config) Validate() error {
 	if c.Interval <= 0 {
 		return errors.New("interval must be greater than 0")
 	}
+	for _, v := range c.Chain {
+		if v.Step == nil && v.While == nil {
+			return errors.New("both step & while blocks in a chain cannot be empty")
+		}
+	}
 	return nil
 }
 

--- a/x-pack/filebeat/input/httpjson/config_request.go
+++ b/x-pack/filebeat/input/httpjson/config_request.go
@@ -49,8 +49,10 @@ func (c retryConfig) getWaitMin() time.Duration {
 }
 
 func (c retryConfig) getWaitMax() time.Duration {
-	if c.WaitMax == nil {
+	if c.WaitMax == nil && c.WaitMin == nil {
 		return 0
+	} else if c.WaitMax == nil && c.WaitMin != nil {
+		return *c.WaitMin
 	}
 	return *c.WaitMax
 }

--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -112,7 +112,11 @@ func run(
 		return err
 	}
 
-	requestFactory := newRequestFactory(config, log)
+	requestFactory, err := newRequestFactory(stdCtx, config, log)
+	if err != nil {
+		log.Errorf("Error while creating requestFactory: %v", err)
+		return err
+	}
 	pagination := newPagination(config, httpClient, log)
 	responseProcessor := newResponseProcessor(config, pagination, log)
 	requester := newRequester(httpClient, requestFactory, responseProcessor, log)

--- a/x-pack/filebeat/input/httpjson/policy.go
+++ b/x-pack/filebeat/input/httpjson/policy.go
@@ -103,6 +103,12 @@ func (p *Policy) CustomRetryPolicy(ctx context.Context, resp *http.Response, err
 			return retry, fmt.Errorf("failed to read http response body : %w", err)
 		}
 
+		err = resp.Body.Close()
+		if err != nil {
+			return retry, fmt.Errorf("error closing response body : %w", err)
+		}
+		resp.Body = io.NopCloser(bytes.NewBuffer(body))
+
 		result, err := p.fn(p.expression, body, p.log)
 		if err != nil {
 			return retry, err
@@ -111,7 +117,6 @@ func (p *Policy) CustomRetryPolicy(ctx context.Context, resp *http.Response, err
 		if !result {
 			retry = true
 		}
-		resp.Body = io.NopCloser(bytes.NewBuffer(body))
 
 		return retry, nil
 	}

--- a/x-pack/filebeat/input/httpjson/policy.go
+++ b/x-pack/filebeat/input/httpjson/policy.go
@@ -38,7 +38,7 @@ var (
 // containing a field "status" under the field "body" , and value status should be equal to the string "completed"
 type Evaluate func(expression *valueTpl, data []byte, log *logp.Logger) (bool, error)
 
-// Responsible for maintaining different http client policies
+// Policy is responsible for maintaining different http client policies
 // Currently just contains a retry policy function
 type Policy struct {
 	fn         Evaluate

--- a/x-pack/filebeat/input/httpjson/policy.go
+++ b/x-pack/filebeat/input/httpjson/policy.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -57,7 +58,8 @@ func (p *Policy) CustomRetryPolicy(ctx context.Context, resp *http.Response, err
 	}
 
 	if err != nil {
-		if v, ok := err.(*url.Error); ok {
+		var v *url.Error
+		if errors.As(err, &v) {
 			// Don't retry if the error was due to too many redirects.
 			if redirectsErrorRe.MatchString(v.Error()) {
 				return false, nil
@@ -69,7 +71,8 @@ func (p *Policy) CustomRetryPolicy(ctx context.Context, resp *http.Response, err
 			}
 
 			// Don't retry if the error was due to TLS cert verification failure.
-			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+			var k x509.UnknownAuthorityError
+			if errors.As(v.Err, &k) {
 				return false, nil
 			}
 		}

--- a/x-pack/filebeat/input/httpjson/policy.go
+++ b/x-pack/filebeat/input/httpjson/policy.go
@@ -89,23 +89,20 @@ func (p *Policy) CustomRetryPolicy(ctx context.Context, resp *http.Response, err
 	// Evaluate custom
 	if p.fn != nil && p.expression != nil {
 		var retry bool
+
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return false, fmt.Errorf("failed to read http response body : %w", err)
+			return retry, fmt.Errorf("failed to read http response body : %w", err)
 		}
 
 		result, err := p.fn(p.expression, body, p.log)
 		if err != nil {
-			return false, err
+			return retry, err
 		}
 
-		if result {
-			fmt.Println("RESPONSE MATCHED EXPRESSION")
-			retry = false
-		} else {
+		if !result {
 			retry = true
 		}
-
 		resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 
 		return retry, nil

--- a/x-pack/filebeat/input/httpjson/policy.go
+++ b/x-pack/filebeat/input/httpjson/policy.go
@@ -1,0 +1,115 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package httpjson
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+var (
+
+	// A regular expression to match the error returned by net/http when the
+	// configured number of redirects is exhausted. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	redirectsErrorRe = regexp.MustCompile(`stopped after \d+ redirects\z`)
+
+	// A regular expression to match the error returned by net/http when the
+	// scheme specified in the URL is invalid. This error isn't typed
+	// specifically so we resort to matching on the error string.
+	schemeErrorRe = regexp.MustCompile(`unsupported protocol scheme`)
+)
+
+type Evaluate func(expression *valueTpl, data []byte, log *logp.Logger) (bool, error)
+
+// Responsible for maintaining different http client policies
+// Currently just contains a retry policy function
+type Policy struct {
+	fn         Evaluate
+	expression *valueTpl
+	log        *logp.Logger
+}
+
+func newHTTPPolicy(fn Evaluate, expression *valueTpl, log *logp.Logger) *Policy {
+	return &Policy{
+		fn:         fn,
+		expression: expression,
+		log:        log,
+	}
+}
+
+// CustomRetryPolicy provides a custom callback for Client.CheckRetry, which
+// will retry on connection errors and server errors.
+func (p *Policy) CustomRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// do not retry on context.Canceled or context.DeadlineExceeded
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	if err != nil {
+		if v, ok := err.(*url.Error); ok {
+			// Don't retry if the error was due to too many redirects.
+			if redirectsErrorRe.MatchString(v.Error()) {
+				return false, nil
+			}
+
+			// Don't retry if the error was due to an invalid protocol scheme.
+			if schemeErrorRe.MatchString(v.Error()) {
+				return false, nil
+			}
+
+			// Don't retry if the error was due to TLS cert verification failure.
+			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+				return false, nil
+			}
+		}
+
+		// The error is likely recoverable so retry.
+		return true, nil
+	}
+
+	// Check the response code. We retry on 500-range responses to allow
+	// the server time to recover, as 500's are typically not permanent
+	// errors and may relate to outages on the server side. This will catch
+	// invalid response codes as well, like 0 and 999.
+	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != 501) {
+		return true, nil
+	}
+
+	// Evaluate custom
+	if p.fn != nil && p.expression != nil {
+		var retry bool
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return false, fmt.Errorf("failed to read http response body : %w", err)
+		}
+
+		result, err := p.fn(p.expression, body, p.log)
+		if err != nil {
+			return false, err
+		}
+
+		if result {
+			fmt.Println("RESPONSE MATCHED EXPRESSION")
+			retry = false
+		} else {
+			retry = true
+		}
+
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+		return retry, nil
+	}
+
+	return false, nil
+}

--- a/x-pack/filebeat/input/httpjson/policy_test.go
+++ b/x-pack/filebeat/input/httpjson/policy_test.go
@@ -1,0 +1,153 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package httpjson
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicy_CustomRetryPolicy(t *testing.T) {
+	statusCompleted := `{"status":"completed"}`
+	statusInitiated := `{"status":"cmnsmc"}`
+
+	exp := &valueTpl{}
+	err := exp.Unpack(`[[ eq .last_response.body.status "completed" ]]`)
+	assert.NoError(t, err)
+
+	expErr := &valueTpl{}
+	err = exp.Unpack("")
+	assert.NoError(t, err)
+	type fields struct {
+		fn         Evaluate
+		expression *valueTpl
+		log        *logp.Logger
+	}
+	type args struct {
+		ctx  context.Context
+		resp *http.Response
+		err  error
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		want          bool
+		expectedError string
+	}{
+		{
+			name: "customRetryPolicy_doNotRetryFurther",
+			fields: fields{
+				fn:         evaluateResponse,
+				expression: exp,
+				log:        logp.NewLogger(""),
+			},
+			args: args{
+				ctx:  context.Background(),
+				resp: getTestResponse(statusCompleted, 200),
+				err:  nil,
+			},
+			want:          false,
+			expectedError: "",
+		},
+		{
+			name: "customRetryPolicy_keepRetrying",
+			fields: fields{
+				fn:         evaluateResponse,
+				expression: exp,
+				log:        logp.NewLogger(""),
+			},
+			args: args{
+				ctx:  context.Background(),
+				resp: getTestResponse(statusInitiated, 200),
+				err:  nil,
+			},
+			want:          true,
+			expectedError: "",
+		},
+		{
+			name: "customRetryPolicy_emptyTemplateError",
+			fields: fields{
+				fn:         evaluateResponse,
+				expression: expErr,
+				log:        logp.NewLogger(""),
+			},
+			args: args{
+				ctx:  context.Background(),
+				resp: getTestResponse(statusCompleted, 200),
+				err:  nil,
+			},
+			want:          false,
+			expectedError: "error while evaluating expression : the template result is empty",
+		},
+		{
+			name: "customRetryPolicy_internalServerError",
+			fields: fields{
+				fn:         evaluateResponse,
+				expression: exp,
+				log:        logp.NewLogger(""),
+			},
+			args: args{
+				ctx:  context.Background(),
+				resp: getTestResponse(statusCompleted, 500),
+				err:  nil,
+			},
+			want:          true,
+			expectedError: "",
+		},
+		{
+			name: "customRetryPolicy_unknownCertError",
+			fields: fields{
+				fn:         evaluateResponse,
+				expression: exp,
+				log:        logp.NewLogger(""),
+			},
+			args: args{
+				ctx:  context.Background(),
+				resp: getTestResponse(statusCompleted, 200),
+				err:  &url.Error{Err: x509.UnknownAuthorityError{}},
+			},
+			want:          false,
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Policy{
+				fn:         tt.fields.fn,
+				expression: tt.fields.expression,
+				log:        tt.fields.log,
+			}
+			got, err := p.CustomRetryPolicy(tt.args.ctx, tt.args.resp, tt.args.err)
+			if err != nil {
+				assert.Error(t, err, tt.expectedError)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func getTestResponse(exprStr string, statusCode int) *http.Response {
+	return &http.Response{
+		StatusCode:    statusCode,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          io.NopCloser(bytes.NewBufferString(exprStr)),
+		ContentLength: int64(len(string(exprStr))),
+		Request:       nil,
+		Header:        make(http.Header, 0),
+	}
+}

--- a/x-pack/filebeat/input/httpjson/policy_test.go
+++ b/x-pack/filebeat/input/httpjson/policy_test.go
@@ -34,7 +34,7 @@ func TestPolicy_CustomRetryPolicy(t *testing.T) {
 	defer statusCompletedResponse.Body.Close()
 	statusInitiatedResponse := getTestResponse(statusInitiated, 200)
 	defer statusInitiatedResponse.Body.Close()
-	internalServerErrorResponse := getTestResponse(statusCompleted, 200)
+	internalServerErrorResponse := getTestResponse(statusCompleted, 500)
 	defer internalServerErrorResponse.Body.Close()
 
 	type fields struct {

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -132,7 +132,7 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger) ([]
 			ch.Step.Auth = tryAssignAuth(config.Auth, ch.Step.Auth)
 			httpClient, err := newChainHTTPClient(ctx, ch.Step.Auth, &ch.Step.Request, log)
 			if err != nil {
-				return nil, fmt.Errorf("failed in creating chain http client with error : %v", err)
+				return nil, fmt.Errorf("failed in creating chain http client with error : %w", err)
 			}
 			if ch.Step.Auth != nil && ch.Step.Auth.Basic.isEnabled() {
 				rf.user = ch.Step.Auth.Basic.User
@@ -155,7 +155,7 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger) ([]
 			ch.While.Auth = tryAssignAuth(config.Auth, ch.While.Auth)
 			httpClient, err := newChainHTTPClient(ctx, ch.While.Auth, &ch.While.Request, log, policy)
 			if err != nil {
-				return nil, fmt.Errorf("failed in creating chain http client with error : %v", err)
+				return nil, fmt.Errorf("failed in creating chain http client with error : %w", err)
 			}
 			if ch.While.Auth != nil && ch.While.Auth.Basic.isEnabled() {
 				rf.user = ch.While.Auth.Basic.User

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -102,7 +102,7 @@ type requestFactory struct {
 	encoder         encoderFunc
 	replace         string
 	isChain         bool
-	till            *valueTpl
+	until           *valueTpl
 	chainHTTPClient *httpClient
 }
 
@@ -151,7 +151,7 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger) ([]
 			}
 		} else if ch.While != nil {
 			ts, _ := newBasicTransformsFromConfig(ch.While.Request.Transforms, requestNamespace, log)
-			policy := newHTTPPolicy(evaluateResponse, ch.While.Till, log)
+			policy := newHTTPPolicy(evaluateResponse, ch.While.Until, log)
 			ch.While.Auth = tryAssignAuth(config.Auth, ch.While.Auth)
 			httpClient, err := newChainHTTPClient(ctx, ch.While.Auth, &ch.While.Request, log, policy)
 			if err != nil {
@@ -169,7 +169,7 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger) ([]
 				log:             log,
 				encoder:         registeredEncoders[config.Request.EncodeAs],
 				replace:         ch.While.Replace,
-				till:            ch.While.Till,
+				until:           ch.While.Until,
 				isChain:         true,
 				chainHTTPClient: httpClient,
 			}

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -129,9 +129,10 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger) ([]
 		// chain calls requestFactory object
 		if ch.Step != nil {
 			ts, _ := newBasicTransformsFromConfig(ch.Step.Request.Transforms, requestNamespace, log)
+			ch.Step.Auth = tryAssignAuth(config.Auth, ch.Step.Auth)
 			httpClient, err := newChainHTTPClient(ctx, ch.Step.Auth, &ch.Step.Request, log)
 			if err != nil {
-				return nil, fmt.Errorf("failed in creating chain http client with error : %w", err)
+				return nil, fmt.Errorf("failed in creating chain http client with error : %v", err)
 			}
 			if ch.Step.Auth != nil && ch.Step.Auth.Basic.isEnabled() {
 				rf.user = ch.Step.Auth.Basic.User
@@ -151,9 +152,10 @@ func newRequestFactory(ctx context.Context, config config, log *logp.Logger) ([]
 		} else if ch.While != nil {
 			ts, _ := newBasicTransformsFromConfig(ch.While.Request.Transforms, requestNamespace, log)
 			policy := newHTTPPolicy(evaluateResponse, ch.While.Till, log)
+			ch.While.Auth = tryAssignAuth(config.Auth, ch.While.Auth)
 			httpClient, err := newChainHTTPClient(ctx, ch.While.Auth, &ch.While.Request, log, policy)
 			if err != nil {
-				return nil, fmt.Errorf("failed in creating chain http client with error : %w", err)
+				return nil, fmt.Errorf("failed in creating chain http client with error : %v", err)
 			}
 			if ch.While.Auth != nil && ch.While.Auth.Basic.isEnabled() {
 				rf.user = ch.While.Auth.Basic.User

--- a/x-pack/filebeat/input/httpjson/request_chain_helper.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper.go
@@ -64,7 +64,7 @@ func evaluateResponse(expression *valueTpl, data []byte, log *logp.Logger) (bool
 
 	err := json.Unmarshal(data, &dataMap)
 	if err != nil {
-		return false, fmt.Errorf("error while unmarshalling data %w", err)
+		return false, fmt.Errorf("error while unmarshalling data : %w", err)
 	}
 	tr := transformable{}
 	paramCtx := &transformContext{
@@ -75,11 +75,11 @@ func evaluateResponse(expression *valueTpl, data []byte, log *logp.Logger) (bool
 
 	val, err := expression.Execute(paramCtx, tr, nil, log)
 	if err != nil {
-		return false, fmt.Errorf("error while evaluating expression %w", err)
+		return false, fmt.Errorf("error while evaluating expression : %w", err)
 	}
 	result, err := strconv.ParseBool(val)
 	if err != nil {
-		return false, fmt.Errorf("error while parsing boolean value of string %w", err)
+		return false, fmt.Errorf("error while parsing boolean value of string : %w", err)
 	}
 
 	return result, nil

--- a/x-pack/filebeat/input/httpjson/request_chain_helper.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper.go
@@ -74,15 +74,12 @@ func evaluateResponse(expression *valueTpl, data []byte, log *logp.Logger) (bool
 
 	val, err := expression.Execute(paramCtx, tr, nil, log)
 	if err != nil {
-		fmt.Printf("\nERROR = %v\n", err)
 		return false, fmt.Errorf("error while evaluating expression %w", err)
 	}
 	result, err := strconv.ParseBool(val)
 	if err != nil {
 		return false, fmt.Errorf("error while parsing boolean value of string %w", err)
 	}
-
-	fmt.Println("VALUE = ", val)
 
 	return result, nil
 }

--- a/x-pack/filebeat/input/httpjson/request_chain_helper.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper.go
@@ -10,10 +10,11 @@ import (
 	"fmt"
 	"strconv"
 
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
 func newChainHTTPClient(ctx context.Context, authCfg *authConfig, requestCfg *requestConfig, log *logp.Logger, p ...*Policy) (*httpClient, error) {

--- a/x-pack/filebeat/input/httpjson/request_chain_helper.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper.go
@@ -1,0 +1,88 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package httpjson
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+)
+
+func newChainHTTPClient(ctx context.Context, authCfg *authConfig, requestCfg *requestConfig, log *logp.Logger, p ...*Policy) (*httpClient, error) {
+	// Make retryable HTTP client
+	netHTTPClient, err := requestCfg.Transport.Client(
+		httpcommon.WithAPMHTTPInstrumentation(),
+		httpcommon.WithKeepaliveSettings{Disable: true},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	netHTTPClient.CheckRedirect = checkRedirect(requestCfg, log)
+
+	var retryPolicyFunc retryablehttp.CheckRetry
+	if len(p) != 0 {
+		retryPolicyFunc = p[0].CustomRetryPolicy
+	} else {
+		retryPolicyFunc = retryablehttp.DefaultRetryPolicy
+	}
+
+	client := &retryablehttp.Client{
+		HTTPClient:   netHTTPClient,
+		Logger:       newRetryLogger(log),
+		RetryWaitMin: requestCfg.Retry.getWaitMin(),
+		RetryWaitMax: requestCfg.Retry.getWaitMax(),
+		RetryMax:     requestCfg.Retry.getMaxAttempts(),
+		CheckRetry:   retryPolicyFunc,
+		Backoff:      retryablehttp.DefaultBackoff,
+	}
+
+	limiter := newRateLimiterFromConfig(requestCfg.RateLimit, log)
+
+	if authCfg != nil && authCfg.OAuth2.isEnabled() {
+		authClient, err := authCfg.OAuth2.client(ctx, client.StandardClient())
+		if err != nil {
+			return nil, err
+		}
+		return &httpClient{client: authClient, limiter: limiter}, nil
+	}
+
+	return &httpClient{client: client.StandardClient(), limiter: limiter}, nil
+}
+
+func evaluateResponse(expression *valueTpl, data []byte, log *logp.Logger) (bool, error) {
+	var dataMap mapstr.M
+
+	err := json.Unmarshal(data, &dataMap)
+	if err != nil {
+		return false, fmt.Errorf("error while unmarshalling data %w", err)
+	}
+	tr := transformable{}
+	paramCtx := &transformContext{
+		firstEvent:   &mapstr.M{},
+		lastEvent:    &mapstr.M{},
+		lastResponse: &response{body: dataMap},
+	}
+
+	val, err := expression.Execute(paramCtx, tr, nil, log)
+	if err != nil {
+		fmt.Printf("\nERROR = %v\n", err)
+		return false, fmt.Errorf("error while evaluating expression %w", err)
+	}
+	result, err := strconv.ParseBool(val)
+	if err != nil {
+		return false, fmt.Errorf("error while parsing boolean value of string %w", err)
+	}
+
+	fmt.Println("VALUE = ", val)
+
+	return result, nil
+}

--- a/x-pack/filebeat/input/httpjson/request_chain_helper.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper.go
@@ -83,3 +83,10 @@ func evaluateResponse(expression *valueTpl, data []byte, log *logp.Logger) (bool
 
 	return result, nil
 }
+
+func tryAssignAuth(parentConfig *authConfig, childConfig *authConfig) *authConfig {
+	if parentConfig != nil && childConfig == nil {
+		return parentConfig
+	}
+	return childConfig
+}

--- a/x-pack/filebeat/input/httpjson/request_chain_helper_test.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper_test.go
@@ -1,0 +1,140 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package httpjson
+
+import (
+	"context"
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+func Test_newChainHTTPClient(t *testing.T) {
+	cfg := defaultChainConfig()
+	ctx := context.Background()
+	log := logp.NewLogger("newChainClientTestLogger")
+
+	type args struct {
+		ctx        context.Context
+		authCfg    *authConfig
+		requestCfg *requestConfig
+		log        *logp.Logger
+		p          []*Policy
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "newChainClientTest",
+			args: args{
+				ctx:        ctx,
+				authCfg:    cfg.Auth,
+				requestCfg: cfg.Request,
+				log:        log,
+				p:          nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := newChainHTTPClient(tt.args.ctx, tt.args.authCfg, tt.args.requestCfg, tt.args.log, tt.args.p...)
+			assert.NoError(t, err)
+			assert.NotNil(t, got)
+		})
+	}
+}
+
+func Test_evaluateResponse(t *testing.T) {
+	log := logp.NewLogger("newEvaluateResponseTestLogger")
+	responseTrue, err := json.Marshal(map[string]interface{}{
+		"status": "completed",
+	})
+	assert.NoError(t, err)
+	responseFalse, err := json.Marshal(map[string]interface{}{
+		"status": "initiated",
+	})
+	assert.NoError(t, err)
+
+	type args struct {
+		expression string
+		data       []byte
+		log        *logp.Logger
+	}
+	tests := []struct {
+		name          string
+		args          args
+		expectedError string
+		want          bool
+	}{
+		{
+			name: "newEvaluateResponse_resultIsTrue",
+			args: args{
+				expression: `[[ eq .last_response.body.status "completed" ]]`,
+				data:       responseTrue,
+				log:        log,
+			},
+			want:          true,
+			expectedError: "",
+		},
+		{
+			name: "newEvaluateResponse_resultIsFalse",
+			args: args{
+				expression: `[[ eq .last_response.body.status "completed" ]]`,
+				data:       responseFalse,
+				log:        log,
+			},
+			want:          false,
+			expectedError: "",
+		},
+		{
+			name: "newEvaluateResponse_invalidExpressionError",
+			args: args{
+				expression: `eq .last_response.body.status "completed" ]]`,
+				data:       responseFalse,
+				log:        log,
+			},
+			want:          false,
+			expectedError: "error while parsing boolean value of string : strconv.ParseBool: parsing \"eq .last_response.body.status \\\"completed\\\" ]]\": invalid syntax",
+		},
+		{
+			name: "newEvaluateResponse_emptyExpressionError",
+			args: args{
+				expression: "",
+				data:       responseFalse,
+				log:        log,
+			},
+			want:          false,
+			expectedError: "error while evaluating expression : the template result is empty",
+		},
+		{
+			name: "newEvaluateResponse_incompleteExpressionError",
+			args: args{
+				expression: `[[.last_response.body.status]]`,
+				data:       responseFalse,
+				log:        log,
+			},
+			want:          false,
+			expectedError: "error while parsing boolean value of string : strconv.ParseBool: parsing \"initiated\": invalid syntax",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			expression := &valueTpl{}
+			err := expression.Unpack(tt.args.expression)
+			assert.NoError(t, err)
+
+			got, err := evaluateResponse(expression, tt.args.data, tt.args.log)
+			if err != nil {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/x-pack/filebeat/input/httpjson/request_chain_helper_test.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper_test.go
@@ -5,12 +5,13 @@
 package httpjson
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 func Test_newChainHTTPClient(t *testing.T) {
@@ -51,14 +52,8 @@ func Test_newChainHTTPClient(t *testing.T) {
 
 func Test_evaluateResponse(t *testing.T) {
 	log := logp.NewLogger("newEvaluateResponseTestLogger")
-	responseTrue, err := json.Marshal(map[string]interface{}{
-		"status": "completed",
-	})
-	assert.NoError(t, err)
-	responseFalse, err := json.Marshal(map[string]interface{}{
-		"status": "initiated",
-	})
-	assert.NoError(t, err)
+	responseTrue := bytes.NewBufferString(`{"status": "completed"}`).Bytes()
+	responseFalse := bytes.NewBufferString(`{"status": "initiated"}`).Bytes()
 
 	type args struct {
 		expression string

--- a/x-pack/filebeat/input/httpjson/request_test.go
+++ b/x-pack/filebeat/input/httpjson/request_test.go
@@ -62,7 +62,8 @@ func TestCtxAfterDoRequest(t *testing.T) {
 	client, err := newHTTPClient(ctx, config, log)
 	assert.NoError(t, err)
 
-	requestFactory := newRequestFactory(config, log)
+	requestFactory, err := newRequestFactory(ctx, config, log)
+	assert.NoError(t, err)
 	pagination := newPagination(config, client, log)
 	responseProcessor := newResponseProcessor(config, pagination, log)
 

--- a/x-pack/filebeat/input/httpjson/response.go
+++ b/x-pack/filebeat/input/httpjson/response.go
@@ -81,9 +81,13 @@ func newResponseProcessor(config config, pagination *pagination, log *logp.Logge
 			log:        log,
 		}
 		// chain calls responseProcessor object
-		split, _ := newSplitResponse(ch.Step.Response.Split, log)
-
-		rp.split = split
+		if ch.Step != nil {
+			split, _ := newSplitResponse(ch.Step.Response.Split, log)
+			rp.split = split
+		} else if ch.While != nil {
+			split, _ := newSplitResponse(ch.While.Response.Split, log)
+			rp.split = split
+		}
 
 		rps = append(rps, rp)
 	}

--- a/x-pack/filebeat/input/httpjson/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl.go
@@ -61,6 +61,7 @@ func (t *valueTpl) Unpack(in string) error {
 			"add":                 add,
 			"mul":                 mul,
 			"div":                 div,
+			"equals":              equals,
 			"hmac":                hmacStringHex,
 			"hash":                hashStringHex,
 			"hexDecode":           hexDecode,
@@ -259,6 +260,10 @@ func add(vs ...int64) int64 {
 
 func mul(a, b int64) int64 {
 	return a * b
+}
+
+func equals(a, b interface{}) bool {
+	return a == b
 }
 
 func div(a, b int64) int64 {

--- a/x-pack/filebeat/input/httpjson/value_tpl.go
+++ b/x-pack/filebeat/input/httpjson/value_tpl.go
@@ -61,7 +61,6 @@ func (t *valueTpl) Unpack(in string) error {
 			"add":                 add,
 			"mul":                 mul,
 			"div":                 div,
-			"equals":              equals,
 			"hmac":                hmacStringHex,
 			"hash":                hashStringHex,
 			"hexDecode":           hexDecode,
@@ -260,10 +259,6 @@ func add(vs ...int64) int64 {
 
 func mul(a, b int64) int64 {
 	return a * b
-}
-
-func equals(a, b interface{}) bool {
-	return a == b
 }
 
 func div(a, b int64) int64 {


### PR DESCRIPTION
## Type of change
### - Enhancement

## What does this PR do?

 1.  Introduced new request chain step **'while'** to tackle scenarios as reported in this ticket : #29959 
 
 2.  Added support for creation of of new http client per step in the request chain , thereby enabling individual steps to 
      take advantage of unique auth's per step if required and access to all request parameters. This also helps solve the issue 
      in the ticket : #31117. 
      **[Note] : if an auth per step is not defined , the steps shall inherit  any auth that is used in the root request call.**

 3.  Added an improvement which now removes the requirement for **request.retry.wait_max** field to be specified everywhere 
      even when it is not required. Now you can simply specify **request.retry.wait_min** for the retry config and the wait will occur. 
      You can still specify both fields ..when they have different values. Previously only specifying **request.retry.wait_min** caused 
       the wait not not occur.
 
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `input-httpjson.asciidoc` .

## Related issues

- Closes #29959 
- Closes #31117