### PR TITLE
ci: revisit windows support for packetbeat

### DIFF
--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -62,10 +62,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended_win
-    windows-8:
+    windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
-            - "windows-8"
+            - "windows-7"
         stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -52,16 +52,6 @@ stages:
                 - "macosTest"
             tags: true         ## for all the tags
         stage: extended
-    windows-2022:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2022"
-        stage: mandatory
-    windows-2019:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
@@ -71,11 +61,6 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended_win
-    windows-10:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-10"
         stage: extended_win
     windows-8:
         mage: "mage build unitTest"

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -56,25 +56,14 @@ stages:
                 - "macosTest"
             tags: true         ## for all the tags
         stage: extended
-    windows-2022:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2022"
-        stage: mandatory
-    windows-2022-system:
-        mage: "mage systemTest"
-        withGCP: true
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2022"
-        stage: mandatory
-    windows-2019:
-        mage: "mage build unitTest"
-        withModule: true
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2019"
-        stage: extended_win
     windows-2016:
         mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-2016"
+        stage: mandatory
+    windows-2016-system:
+        mage: "mage systemTest"
+        withGCP: true
         platforms:             ## override default labels in this specific stage.
             - "windows-2016"
         stage: mandatory
@@ -82,17 +71,6 @@ stages:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
-        stage: extended_win
-    windows-10:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-10"
-        stage: extended_win
-    windows-10-system:
-        mage: "mage systemTest"
-        withGCP: true
-        platforms:             ## override default labels in this specific stage.
-            - "windows-10"
         stage: extended_win
     windows-8:
         mage: "mage build unitTest"

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -72,10 +72,10 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended_win
-    windows-8:
+    windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.
-            - "windows-8"
+            - "windows-7"
         stage: extended_win
     packaging-linux:
         packaging-linux: "mage package"


### PR DESCRIPTION
As stated in https://www.elastic.co/support/matrix
 add support for Windows-7 and remove support for windows-2019, 2022, 8, 10 in `packetbeat`

We cannot add support for `Windows 2008 R2` yet, see https://github.com/elastic/beats/issues/32220