### PR TITLE
Revert "Fix flags for dev build (#31955)"

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -75,7 +75,6 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
 - Drop event batch when get HTTP status 413 from Elasticsearch to avoid infinite loop {issue}14350[14350] {pull}29368[29368]
 - Allow to use metricbeat for named mssql instances. {issue}24076[24076] {pull}30859[30859]
-- Setting DEV=true when running `mage build` now correctly generates binaries without optimisations and with debug symbols {pull}31955[31955]
 
 ==== Added
 

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -67,7 +67,7 @@ func DefaultBuildArgs() BuildArgs {
 
 	if DevBuild {
 		// Disable optimizations (-N) and inlining (-l) for debugging.
-		args.ExtraFlags = append(args.ExtraFlags, `-gcflags=all=-N -l`)
+		args.ExtraFlags = append(args.ExtraFlags, `-gcflags`, `"all=-N -l"`)
 	} else {
 		// Strip all debug symbols from binary (does not affect Go stack traces).
 		args.LDFlags = append(args.LDFlags, "-s")


### PR DESCRIPTION
This reverts commit a7871690d2b1559c7dd06240cd23d94069d64d76.

This change unexpectedly breaks the packaging step on Mac. Reverting until we can find a cross-platform solution or just make these flags a Linux only option.
