### PR TITLE
github-action: export github actions telemetry traces

### DIFF
--- a/.github/workflows/macos-xpack-osquerybeat.yml
+++ b/.github/workflows/macos-xpack-osquerybeat.yml
@@ -1,4 +1,4 @@
-name: x-pack-heartbeat
+name: x-pack-osquerybeat
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
       - 8.*
 
 env:
-  BEAT_MODULE: 'x-pack/heartbeat'
+  BEAT_MODULE: 'x-pack/osquerybeat'
 
 jobs:
   macos:

--- a/.github/workflows/macos-xpack-packetbeat.yml
+++ b/.github/workflows/macos-xpack-packetbeat.yml
@@ -1,4 +1,4 @@
-name: x-pack-metricbeat
+name: x-pack-packetbeat
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ on:
       - 8.*
 
 env:
-  BEAT_MODULE: 'x-pack/metricbeat'
+  BEAT_MODULE: 'x-pack/packetbeat'
 
 jobs:
   macos:

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,0 +1,32 @@
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    workflows:
+      - golangci-lint
+      - auditbeat
+      - filebeat
+      - heartbeat
+      - metricbeat
+      - packetbeat
+      - x-pack-auditbeat
+      - x-pack-filebeat
+      - x-pack-functionbeat
+      - x-pack-heartbeat
+      - x-pack-metricbeat
+      - x-pack-osquerybeat
+      - x-pack-packetbeat
+    types: [completed]
+
+jobs:
+  otel-export-trace:
+    name: OpenTelemetry Export Trace
+    runs-on: ubuntu-latest
+    steps:
+      - name: Export Workflow Trace
+        uses: inception-health/otel-export-trace-action@latest
+        with:
+          otlpEndpoint: "${{ secrets.APM_SERVER }}"
+          otlpHeaders: "Authorization=Bearer ${{ secrets.APM_TOKEN }}"
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## What does this PR do?

Export GitHub actions execution as OpenTelemetry traces

## Why is it important?

This will help to gather insights and contribute to the GitHub action that empowers this functionality.

I also additionally, fixed some cosmetic changes in a couple of MacOS GitHub actions regarding their name and folder where to run the tests

## Issue

Similar to https://github.com/elastic/apm-agent-nodejs/pull/2805

## Tasks

- [x] Secrets have been created. 

## Follow up

To ingest the test-data in a follow up. Since all the GitHub actions together won't work