### PR TITLE
[Heartbeat] Use stream ID for monitors with origin

### DIFF
--- a/heartbeat/monitors/stdfields/unnest.go
+++ b/heartbeat/monitors/stdfields/unnest.go
@@ -75,7 +75,10 @@ func UnnestStream(config *conf.C) (res *conf.C, err error) {
 		return nil, fmt.Errorf("could not determine base stream for config: %s", id)
 	}
 
-	res.Merge(mapstr.M{"data_stream": optS.DataStream})
+	err = res.Merge(mapstr.M{"data_stream": optS.DataStream})
+	if err != nil {
+		return nil, err
+	}
 
 	// We only override the ID for the original fleet integration, not monitors configured
 	// through monitor mgmt. See https://github.com/elastic/beats/issues/32224

--- a/heartbeat/monitors/stdfields/unnest.go
+++ b/heartbeat/monitors/stdfields/unnest.go
@@ -35,7 +35,8 @@ type OptionalStream struct {
 }
 
 type BaseStream struct {
-	Type string `config:"type"`
+	Type   string `config:"type"`
+	Origin string `config:"origin"`
 }
 
 // UnnestStream detects configs that come from fleet and transforms the config into something compatible
@@ -55,12 +56,14 @@ func UnnestStream(config *conf.C) (res *conf.C, err error) {
 	// Find the 'base' stream, that is the one stream that has `type` set.
 	// The other streams are sort of ancillary and only for fleet internals, the
 	// base stream has the full monitor config contained within
+	var origin string
 	for _, stream := range optS.Streams {
 		bs := &BaseStream{}
 		err = stream.Unpack(bs)
 		if err != nil {
 			return nil, fmt.Errorf("could not unpack stream: %w", err)
 		}
+		origin = bs.Origin
 		if bs.Type != "" {
 			res = stream
 			break
@@ -72,6 +75,12 @@ func UnnestStream(config *conf.C) (res *conf.C, err error) {
 		return nil, fmt.Errorf("could not determine base stream for config: %s", id)
 	}
 
-	err = res.Merge(mapstr.M{"id": optS.Id, "data_stream": optS.DataStream})
+	res.Merge(mapstr.M{"data_stream": optS.DataStream})
+
+	// We only override the ID for the original fleet integration, not monitors configured
+	// through monitor mgmt. See https://github.com/elastic/beats/issues/32224
+	if origin == "" {
+		err = res.Merge(mapstr.M{"id": optS.Id})
+	}
 	return res, err
 }

--- a/heartbeat/monitors/stdfields/unnest_test.go
+++ b/heartbeat/monitors/stdfields/unnest_test.go
@@ -30,6 +30,14 @@ import (
 )
 
 func TestUnnestStream(t *testing.T) {
+	testRootId := "rootId"
+	testStreamId := "streamId"
+	testType := "montype"
+	testOrigin := "testOrigin"
+	testSched := "@every 10s"
+	testNs := "mynamespace"
+	testDs := "mydataset"
+
 	type testCase struct {
 		name string
 		cfg  mapstr.M
@@ -37,65 +45,115 @@ func TestUnnestStream(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			name: "simple",
+			name: "no datastream",
 			cfg: mapstr.M{
-				"id": "myuuid",
+				"id":       testRootId,
+				"type":     testType,
+				"schedule": testSched,
+			},
+			v: lookslike.MustCompile(mapstr.M{
+				"id":       testRootId,
+				"type":     testType,
+				"schedule": testSched,
+			}),
+		},
+		{
+			name: "simple datastream, with origin uses streamId",
+			cfg: mapstr.M{
+				"id": testRootId,
 				"streams": []mapstr.M{
 					{
-						"type":     "montype",
-						"streamid": "mystreamid",
+						"id":       testStreamId,
+						"type":     testType,
+						"schedule": testSched,
+						"origin":   testOrigin,
 						"data_stream": mapstr.M{
-							"namespace": "mynamespace",
-							"dataset":   "mydataset",
-							"type":      "mytype",
+							"namespace": testNs,
+							"dataset":   testDs,
+							"type":      testType,
 						},
 					},
 				},
 			},
 			v: lookslike.MustCompile(mapstr.M{
-				"id":   "myuuid",
-				"type": "montype",
+				"id":       testStreamId,
+				"type":     testType,
+				"schedule": testSched,
+				"origin":   testOrigin,
 				"data_stream": mapstr.M{
-					"namespace": "mynamespace",
-					"dataset":   "mydataset",
-					"type":      "mytype",
+					"namespace": testNs,
+					"dataset":   testDs,
+					"type":      testType,
+				},
+			}),
+		},
+		{
+			name: "simple datastream, no origin, uses rootId",
+			cfg: mapstr.M{
+				"id": testRootId,
+				"streams": []mapstr.M{
+					{
+						"id":       testStreamId,
+						"type":     testType,
+						"schedule": testSched,
+						"data_stream": mapstr.M{
+							"namespace": testNs,
+							"dataset":   testDs,
+							"type":      testType,
+						},
+					},
+				},
+			},
+			v: lookslike.MustCompile(mapstr.M{
+				"id":       testRootId,
+				"type":     testType,
+				"schedule": testSched,
+				"data_stream": mapstr.M{
+					"namespace": testNs,
+					"dataset":   testDs,
+					"type":      testType,
 				},
 			}),
 		},
 		{
 			name: "split data stream",
 			cfg: mapstr.M{
-				"id":   "myuuid",
-				"type": "montype",
+				"id":   testRootId,
+				"type": testType,
 				"data_stream": mapstr.M{
-					"namespace": "mynamespace",
+					"namespace": testNs,
 				},
 				"streams": []mapstr.M{
 					{
-						"type": "montype",
+						"id":       testStreamId,
+						"origin":   testOrigin,
+						"type":     testType,
+						"schedule": testSched,
 						"data_stream": mapstr.M{
-							"type":    "mytype",
-							"dataset": "mydataset",
+							"type":    testType,
+							"dataset": testDs,
 						},
 					},
 				},
 			},
 			v: lookslike.MustCompile(mapstr.M{
-				"id":   "myuuid",
-				"type": "montype",
+				"id":       testStreamId,
+				"type":     testType,
+				"schedule": testSched,
+				"origin":   testOrigin,
 				"data_stream": mapstr.M{
-					"namespace": "mynamespace",
-					"dataset":   "mydataset",
-					"type":      "mytype",
+					"namespace": testNs,
+					"dataset":   testDs,
+					"type":      testType,
 				},
 			}),
 		},
 		{
 			name: "base is last, not first stream",
 			cfg: mapstr.M{
-				"id": "myuuid",
+				"id": testRootId,
 				"data_stream": mapstr.M{
-					"namespace": "parentnamespace",
+					"namespace": testNs,
 				},
 				"streams": []mapstr.M{
 					{
@@ -107,21 +165,25 @@ func TestUnnestStream(t *testing.T) {
 						},
 					},
 					{
-						"type": "montype",
+						"id":       testStreamId,
+						"type":     testType,
+						"schedule": testSched,
+						"origin":   testOrigin,
 						"data_stream": mapstr.M{
-							"type":    "basetype",
-							"dataset": "basedataset",
+							"type":    testType,
+							"dataset": testDs,
 						},
 					},
 				},
 			},
 			v: lookslike.MustCompile(mapstr.M{
-				"id":   "myuuid",
-				"type": "montype",
+				"id":       testStreamId,
+				"type":     testType,
+				"schedule": testSched,
 				"data_stream": mapstr.M{
-					"namespace": "parentnamespace",
-					"type":      "basetype",
-					"dataset":   "basedataset",
+					"namespace": testNs,
+					"type":      testType,
+					"dataset":   testDs,
 				},
 			}),
 		},

--- a/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
+++ b/x-pack/heartbeat/monitors/browser/synthexec/enrich.go
@@ -23,21 +23,17 @@ import (
 type enricher func(event *beat.Event, se *SynthEvent) error
 
 type streamEnricher struct {
-	je         *journeyEnricher
-	sFields    stdfields.StdMonitorFields
-	checkGroup string
+	je      *journeyEnricher
+	sFields stdfields.StdMonitorFields
 }
 
 func newStreamEnricher(sFields stdfields.StdMonitorFields) *streamEnricher {
-	return &streamEnricher{sFields: sFields, checkGroup: makeUuid()}
+	return &streamEnricher{sFields: sFields}
 }
 
 func (senr *streamEnricher) enrich(event *beat.Event, se *SynthEvent) error {
 	if senr.je == nil || (se != nil && se.Type == JourneyStart) {
 		senr.je = newJourneyEnricher(senr)
-		if senr.je != nil {
-			senr.checkGroup = makeUuid()
-		}
 	}
 
 	return senr.je.enrich(event, se)
@@ -48,6 +44,7 @@ func (senr *streamEnricher) enrich(event *beat.Event, se *SynthEvent) error {
 type journeyEnricher struct {
 	journeyComplete bool
 	journey         *Journey
+	checkGroup      string
 	errorCount      int
 	error           error
 	stepCount       int
@@ -61,6 +58,7 @@ type journeyEnricher struct {
 
 func newJourneyEnricher(senr *streamEnricher) *journeyEnricher {
 	return &journeyEnricher{
+		checkGroup:     makeUuid(),
 		streamEnricher: senr,
 	}
 }
@@ -84,6 +82,7 @@ func (je *journeyEnricher) enrich(event *beat.Event, se *SynthEvent) error {
 		switch se.Type {
 		case JourneyStart:
 			je.error = nil
+			je.checkGroup = makeUuid()
 			je.journey = se.Journey
 			je.start = event.Timestamp
 		case JourneyEnd, CmdStatus:
@@ -115,7 +114,7 @@ func (je *journeyEnricher) enrichSynthEvent(event *beat.Event, se *SynthEvent) e
 	if je.journey != nil {
 		eventext.MergeEventFields(event, mapstr.M{
 			"monitor": mapstr.M{
-				"check_group": je.streamEnricher.checkGroup,
+				"check_group": je.checkGroup,
 				"id":          je.journey.ID,
 				"name":        je.journey.Name,
 			},


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/32224 by using the nested stream ID when stream 'origin' field is present. This distinguishes between monitor management monitors and original fleet integration monitors.

This also cleans up the nests for the unnest code, covering more and making them easier to parse.

## Checklist

No changelog since this is only an internal feature related to monitor management

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Use the following config in a file in `monitors.d`. Run with the below command

`mage build && env ELASTIC_SYNTHETICS_CAPABLE=true ./heartbeat -e`

```yaml
---
- id: root1
  name: 2f629490-fd30-11ec-b3ce-af45fd6132f0-1
  revision: 1
  type: synthetics/http
  use_output: default
  meta:
    package:
      name: synthetics
      version: 0.9.10
  data_stream:
    namespace: default
  streams:
    - id: stream1
      name: Nest Test Root
      type: http
      enabled: true
      data_stream:
        dataset: http
        type: synthetics
      __ui:
        - object Object
      urls: 'https://www.google.com'
      schedule: '@every 3m'
      timeout: 16
      max_redirects: 0
      response.include_headers: null
      response.include_body: on_error
      check.request.method: GET
      processors:
        - add_observer_metadata:
            geo:
              name: Test private location
        - add_fields:
            target: ''
            fields:
              monitor.fleet_managed: true
              config_id: 2f629490-fd30-11ec-b3ce-af45fd6132f0
- id: root2
  name: 2f629490-fd30-11ec-b3ce-af45fd6132f0-1
  revision: 1
  type: synthetics/http
  use_output: default
  meta:
    package:
      name: synthetics
      version: 0.9.10
  data_stream:
    namespace: default
  streams:
    - id: stream2
      name: Nest Test Stream
      type: http
      origin: ui
      enabled: true
      data_stream:
        dataset: http
        type: synthetics
      __ui:
        - object Object
      urls: 'https://www.google.com'
      schedule: '@every 3m'
      timeout: 16
      max_redirects: 0
      response.include_headers: null
      response.include_body: on_error
      check.request.method: GET
      processors:
        - add_observer_metadata:
            geo:
              name: Test private location
        - add_fields:
            target: ''
            fields:
              monitor.fleet_managed: true
              config_id: 2f629490-fd30-11ec-b3ce-af45fd6132f0
```

You should see that the monitor with the `origin` set uses the nested ID in kibana:

<img width="587" alt="image" src="https://user-images.githubusercontent.com/131427/177865363-54a23d1c-ab71-45bd-8fbf-fe482ae6f845.png">

<img width="510" alt="image" src="https://user-images.githubusercontent.com/131427/177865385-0c456b60-acfb-49aa-9e3d-703af253a574.png">


