### PR TITLE
libbeat/processors/util: make mac address rendering conform to ECS

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -11,6 +11,8 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Affecting all Beats*
 
 
+- Fix namespacing on self-monitoring {pull}32336[32336]
+- Fix formatting of hardware addresses populated by the add-host-metadata processor. {issue}32264[32264] {pull}32265[32265]
 
 *Auditbeat*
 

--- a/libbeat/processors/util/netinfo.go
+++ b/libbeat/processors/util/netinfo.go
@@ -41,10 +41,8 @@ func GetNetInfo() (ipList []string, hwList []string, err error) {
 			continue
 		}
 
-		hw := i.HardwareAddr.String()
-		// Skip empty hardware addresses
-		if hw != "" {
-			hwList = append(hwList, hw)
+		if len(i.HardwareAddr) != 0 {
+			hwList = append(hwList, formatHardwareAddr(i.HardwareAddr))
 		}
 
 		addrs, err := i.Addrs()
@@ -65,6 +63,19 @@ func GetNetInfo() (ipList []string, hwList []string, err error) {
 	}
 
 	return ipList, unique(hwList), errs.Err()
+}
+
+// formatHardwareAddr formats hardware addresses according to the ECS spec.
+func formatHardwareAddr(addr net.HardwareAddr) string {
+	buf := make([]byte, 0, len(addr)*3-1)
+	for _, b := range addr {
+		if len(buf) != 0 {
+			buf = append(buf, '-')
+		}
+		const hexDigit = "0123456789ABCDEF"
+		buf = append(buf, hexDigit[b>>4], hexDigit[b&0xf])
+	}
+	return string(buf)
 }
 
 // unique returns addrs lexically sorted and with repeated elements

--- a/libbeat/processors/util/netinfo_test.go
+++ b/libbeat/processors/util/netinfo_test.go
@@ -18,13 +18,16 @@
 package util
 
 import (
+	"net"
 	"reflect"
+	"regexp"
 	"sort"
+	"strings"
 	"testing"
 )
 
 func TestUnique(t *testing.T) {
-	var tests = [][]string{
+	tests := [][]string{
 		{},
 		{"a"},
 		{"a", "a"},
@@ -51,6 +54,34 @@ func TestUnique(t *testing.T) {
 
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("unexpected result for test %d: got:%q want:%q", i, got, want)
+		}
+	}
+}
+
+func TestFormatHardwareAddr(t *testing.T) {
+	tests := []string{
+		"00:00:5e:00:53:01",
+		"02:00:5e:10:00:00:00:01",
+		"00:00:00:00:fe:80:00:00:00:00:00:00:02:00:5e:10:00:00:00:01",
+		"00-00-5e-00-53-01",
+		"02-00-5e-10-00-00-00-01",
+		"00-00-00-00-fe-80-00-00-00-00-00-00-02-00-5e-10-00-00-00-01",
+		"0000.5e00.5301",
+		"0200.5e10.0000.0001",
+		"0000.0000.fe80.0000.0000.0000.0200.5e10.0000.0001",
+	}
+
+	spec := regexp.MustCompile(`[0-9A-F]{2}(?:[0-9A-F]{2})*`)
+	for _, test := range tests {
+		addr, err := net.ParseMAC(test)
+		if err != nil {
+			t.Errorf("failed to parse test case %q", test)
+			continue
+		}
+		got := formatHardwareAddr(addr)
+		want := strings.ToUpper(strings.ReplaceAll(addr.String(), ":", "-"))
+		if got != want || !spec.MatchString(got) {
+			t.Errorf("unexpected format for %q: got:%q want:%q", test, got, want)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This alters the syntax of hardware addresses to match the syntax that is [specified in ECS](https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-mac).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently it does not match the spec and this leaks out to integrations and modules in ways that are irritating to fix in ingest pipelines.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #32264 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
