### PR TITLE
actions: report test result as opentelemetry traces

### DIFF
--- a/.github/workflows/macos-auditbeat.yml
+++ b/.github/workflows/macos-auditbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-auditbeat.yml
+++ b/.github/workflows/macos-auditbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-filebeat.yml
+++ b/.github/workflows/macos-filebeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-filebeat.yml
+++ b/.github/workflows/macos-filebeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-heartbeat.yml
+++ b/.github/workflows/macos-heartbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-heartbeat.yml
+++ b/.github/workflows/macos-heartbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-metricbeat.yml
+++ b/.github/workflows/macos-metricbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-metricbeat.yml
+++ b/.github/workflows/macos-metricbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && echo "See https://github.com/elastic/beats/issues/29038"
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-packetbeat.yml
+++ b/.github/workflows/macos-packetbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-packetbeat.yml
+++ b/.github/workflows/macos-packetbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-auditbeat.yml
+++ b/.github/workflows/macos-xpack-auditbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-auditbeat.yml
+++ b/.github/workflows/macos-xpack-auditbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-filebeat.yml
+++ b/.github/workflows/macos-xpack-filebeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-filebeat.yml
+++ b/.github/workflows/macos-xpack-filebeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-functionbeat.yml
+++ b/.github/workflows/macos-xpack-functionbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-functionbeat.yml
+++ b/.github/workflows/macos-xpack-functionbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-heartbeat.yml
+++ b/.github/workflows/macos-xpack-heartbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-heartbeat.yml
+++ b/.github/workflows/macos-xpack-heartbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-metricbeat.yml
+++ b/.github/workflows/macos-xpack-metricbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-metricbeat.yml
+++ b/.github/workflows/macos-xpack-metricbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-osquerybeat.yml
+++ b/.github/workflows/macos-xpack-osquerybeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-osquerybeat.yml
+++ b/.github/workflows/macos-xpack-osquerybeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-packetbeat.yml
+++ b/.github/workflows/macos-xpack-packetbeat.yml
@@ -29,3 +29,12 @@ jobs:
       run: cd ${{ env.BEAT_MODULE }} && mage build
     - name: Run test
       run: cd ${{ env.BEAT_MODULE }} && mage unitTest
+    - uses: v1v/otel-upload-test-artifact-action@v2
+      if: always()
+      continue-on-error: true
+      with:
+        jobName: "macos"
+        stepName: "Run test"
+        path: "test_output/*.junit.xml"
+        type: "junit"
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos-xpack-packetbeat.yml
+++ b/.github/workflows/macos-xpack-packetbeat.yml
@@ -35,6 +35,6 @@ jobs:
       with:
         jobName: "macos"
         stepName: "Run test"
-        path: "test_output/*.junit.xml"
+        path: "${{ env.BEAT_MODULE }}/build/TEST*.xml"
         type: "junit"
         githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Report test results as opentelemetry traces.

## Why

This is the last part after merging https://github.com/elastic/beats/pull/32256


## What do we have so far?

<img width="1483" alt="image" src="https://user-images.githubusercontent.com/2871786/177965040-f5ac8b47-60b4-42df-8533-4966eef9da73.png">


With this proposal there will be as many spans as executed tests under the `Run test` span

<img width="1487" alt="image" src="https://user-images.githubusercontent.com/2871786/178003873-bfcf1e0c-8058-40aa-9e49-ec16a13026e6.png">
