### PR TITLE
Add benchmark for beats->protobuf/shipper event conversion

### DIFF
--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -406,6 +407,56 @@ func TestPublish(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expSignals, batch.Signals)
 	})
+}
+
+// BenchmarkToShipperEvent is used to detech performance regression when the conversion function is changed.
+func BenchmarkToShipperEvent(b *testing.B) {
+	ts := time.Date(2022, time.July, 8, 16, 00, 00, 00, time.UTC)
+	str := strings.Repeat("somelongstring", 100)
+
+	// This event causes to go through every code path during the event convertion
+	e := publisher.Event{Content: beat.Event{
+		Timestamp: ts,
+		Meta: mapstr.M{
+			"input_id":  "someinputid",
+			"stream_id": "somestreamid",
+			"data_stream": mapstr.M{
+				"type":      "logs",
+				"namespace": "default",
+				"dataset":   "default",
+			},
+			"number": 42,
+			"string": str,
+			"time":   ts,
+			"bytes":  []byte(str),
+			"list":   []interface{}{str, str, str},
+			"nil":    nil,
+		},
+		Fields: mapstr.M{
+			"inner": mapstr.M{
+				"number": 42,
+				"string": str,
+				"time":   ts,
+				"bytes":  []byte(str),
+				"list":   []interface{}{str, str, str},
+				"nil":    nil,
+			},
+			"number": 42,
+			"string": str,
+			"time":   ts,
+			"bytes":  []byte(str),
+			"list":   []interface{}{str, str, str},
+			"nil":    nil,
+		},
+	}}
+
+	for i := 0; i < b.N; i++ {
+		pe, err := toShipperEvent(e)
+		require.NoError(b, err)
+		bytes, err := proto.Marshal(pe)
+		require.NoError(b, err)
+		require.NotEmpty(b, bytes)
+	}
 }
 
 // runServer mocks the shipper mock server for testing


### PR DESCRIPTION
## What does this PR do?

This is to detect future regressions when a change is made to the
conversion function.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

```
go test -bench=.
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/32081