### PR TITLE
Force DEV=0 when cross-compiling to darwin/amd64

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -75,6 +75,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
 - Drop event batch when get HTTP status 413 from Elasticsearch to avoid infinite loop {issue}14350[14350] {pull}29368[29368]
 - Allow to use metricbeat for named mssql instances. {issue}24076[24076] {pull}30859[30859]
+- Setting DEV=true when running `mage build` now correctly generates binaries without optimisations and with debug symbols {pull}31955[31955]
 
 ==== Added
 

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -67,7 +67,7 @@ func DefaultBuildArgs() BuildArgs {
 
 	if DevBuild {
 		// Disable optimizations (-N) and inlining (-l) for debugging.
-		args.ExtraFlags = append(args.ExtraFlags, `-gcflags`, `"all=-N -l"`)
+		args.ExtraFlags = append(args.ExtraFlags, `-gcflags=all=-N -l`)
 	} else {
 		// Strip all debug symbols from binary (does not affect Go stack traces).
 		args.LDFlags = append(args.LDFlags, "-s")

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -311,13 +311,19 @@ func (b GolangCrossBuilder) Build() error {
 		args = append(args, "-v", hostDir+":/go/pkg/mod:ro")
 	}
 
+	if b.Platform == "darwin/amd64" {
+		fmt.Printf(">> %v: Forcing DEV=0 for %s: https://github.com/elastic/golang-crossbuild/issues/217\n", b.Target, b.Platform)
+		args = append(args, "--env", "DEV=0")
+	} else {
+		args = append(args, "--env", fmt.Sprintf("DEV=%v", DevBuild))
+	}
+
 	args = append(args,
 		"--rm",
 		"--env", "GOFLAGS=-mod=readonly",
 		"--env", "MAGEFILE_VERBOSE="+verbose,
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
-		"--env", fmt.Sprintf("DEV=%v", DevBuild),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,


### PR DESCRIPTION
This is a work around for https://github.com/elastic/golang-crossbuild/issues/217 where the package target is broken when setting `DEV=1` with the Go 1.17.11 crossbuild image.

I have also un-reverted the change for https://github.com/elastic/beats/pull/31955 since it was not actually the root cause. It does not cause any issues when tested locally using the Go 1.17.10 image that is known to work.