### PR TITLE
Fix links to integrations documentation

### DIFF
--- a/filebeat/docs/modules/activemq.asciidoc
+++ b/filebeat/docs/modules/activemq.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == ActiveMQ module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This module parses Apache ActiveMQ logs. It supports application and audit logs.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -12,7 +12,13 @@ This file is generated! See scripts/docs_collector.py
 
 == Cisco module
 
+//temporarily override modulename to create working link
+:modulename: cisco_asa
+
 include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: cisco
 
 This is a module for Cisco network device's logs and Cisco Umbrella. It includes the following
 filesets for receiving logs over syslog or read from a file:

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Elasticsearch module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the elasticsearch module.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/docs/modules/kibana.asciidoc
+++ b/filebeat/docs/modules/kibana.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Kibana module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the Kibana module.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -10,6 +10,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Logstash module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ modules parse logstash regular logs and the slow log, it will support the plain text format
 and the JSON format.
 

--- a/filebeat/docs/modules/microsoft.asciidoc
+++ b/filebeat/docs/modules/microsoft.asciidoc
@@ -12,7 +12,13 @@ This file is generated! See scripts/docs_collector.py
 
 == Microsoft module
 
+//temporarily override modulename to create working link
+:modulename: m365_defender
+
 include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: microsoft
 
 This is a module for ingesting data from the different Microsoft Products. Currently supports these filesets:
 

--- a/filebeat/docs/modules/oracle.asciidoc
+++ b/filebeat/docs/modules/oracle.asciidoc
@@ -13,6 +13,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Oracle module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting Audit Trail logs from Oracle Databases.
 
 The module expects an *.aud audit file that is generated from Oracle Databases by default. If this has been disabled then please see the https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/introduction-to-auditing.html#GUID-8D96829C-9151-4FA4-BED9-831D088F12FF[Oracle Database Audit Trail Documentation].

--- a/filebeat/docs/modules/snort.asciidoc
+++ b/filebeat/docs/modules/snort.asciidoc
@@ -14,6 +14,10 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 This is a module for receiving Snort/Sourcefire logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/filebeat/docs/modules/threatintel.asciidoc
+++ b/filebeat/docs/modules/threatintel.asciidoc
@@ -12,6 +12,14 @@ This file is generated! See scripts/docs_collector.py
 
 == Threat Intel module
 
+//temporarily override modulename to create working link
+:modulename: ti_abusech
+
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: threatintel
+
 This module ingests data from a collection of different threat intelligence
 sources. The ingested data is meant to be used with
 https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-indicator-rule[Indicator

--- a/filebeat/docs/modules/zscaler.asciidoc
+++ b/filebeat/docs/modules/zscaler.asciidoc
@@ -14,7 +14,13 @@ This file is generated! See scripts/docs_collector.py
 
 experimental[]
 
+//temporarily override modulename to create working link
+:modulename: zscaler_zia
+
 include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: zscaler
 
 This is a module for receiving Zscaler NSS logs over Syslog or a file.
 

--- a/filebeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/filebeat/module/elasticsearch/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Elasticsearch module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the elasticsearch module.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/module/kibana/_meta/docs.asciidoc
+++ b/filebeat/module/kibana/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Kibana module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is the Kibana module.
 
 include::../include/what-happens.asciidoc[]

--- a/filebeat/module/logstash/_meta/docs.asciidoc
+++ b/filebeat/module/logstash/_meta/docs.asciidoc
@@ -3,6 +3,8 @@
 
 == Logstash module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 The +{modulename}+ modules parse logstash regular logs and the slow log, it will support the plain text format
 and the JSON format.
 

--- a/libbeat/docs/shared/integration-link.asciidoc
+++ b/libbeat/docs/shared/integration-link.asciidoc
@@ -6,10 +6,10 @@ https://docs.elastic.co/en/integrations/{modulename}[Elastic Integrations docume
 [%collapsible]
 .Learn more
 ====
-{agent} is a single, unified agent that you can deploy to hosts or containers to
-collect data and send it to the {stack}. {agent} uses integrations to connect
-your data to the {stack}. Behind the scenes, {agent} runs the {beats} shippers
-required for your configuration. Refer to the documentation for a detailed
+{agent} is a single, unified way to add monitoring for logs, metrics, and
+other types of data to a host. It can also protect hosts from security threats,
+query data from operating systems, forward data from remote services or
+hardware, and more. Refer to the documentation for a detailed
 {fleet-guide}/beats-agent-comparison.html[comparison of {beats} and {agent}]. 
 
 ====

--- a/metricbeat/docs/modules/activemq.asciidoc
+++ b/metricbeat/docs/modules/activemq.asciidoc
@@ -10,6 +10,10 @@ This file is generated! See scripts/mage/docs_collector.go
 [role="xpack"]
 == ActiveMQ module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 This module periodically fetches JMX metrics from Apache ActiveMQ.
 
 [float]

--- a/metricbeat/docs/modules/cockroachdb.asciidoc
+++ b/metricbeat/docs/modules/cockroachdb.asciidoc
@@ -12,6 +12,10 @@ This file is generated! See scripts/mage/docs_collector.go
 
 beta[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 This module periodically fetches metrics from CockroachDB.
 
 [float]

--- a/metricbeat/docs/modules/elasticsearch.asciidoc
+++ b/metricbeat/docs/modules/elasticsearch.asciidoc
@@ -9,6 +9,10 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-elasticsearch]]
 == Elasticsearch module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 The `elasticsearch` module collects metrics about {es}.
 
 [float]

--- a/metricbeat/docs/modules/kibana.asciidoc
+++ b/metricbeat/docs/modules/kibana.asciidoc
@@ -9,6 +9,10 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-kibana]]
 == Kibana module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 The `kibana` module collects metrics about {kib}.
 
 [float]

--- a/metricbeat/docs/modules/logstash.asciidoc
+++ b/metricbeat/docs/modules/logstash.asciidoc
@@ -9,6 +9,10 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-logstash]]
 == Logstash module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 The `logstash` module collects metrics about {ls}.
 
 [float]

--- a/metricbeat/module/elasticsearch/_meta/docs.asciidoc
+++ b/metricbeat/module/elasticsearch/_meta/docs.asciidoc
@@ -1,3 +1,7 @@
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 The `elasticsearch` module collects metrics about {es}.
 
 [float]

--- a/metricbeat/module/kibana/_meta/docs.asciidoc
+++ b/metricbeat/module/kibana/_meta/docs.asciidoc
@@ -1,3 +1,7 @@
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 The `kibana` module collects metrics about {kib}.
 
 [float]

--- a/metricbeat/module/logstash/_meta/docs.asciidoc
+++ b/metricbeat/module/logstash/_meta/docs.asciidoc
@@ -1,3 +1,7 @@
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 The `logstash` module collects metrics about {ls}.
 
 [float]

--- a/x-pack/filebeat/module/activemq/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/activemq/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == ActiveMQ module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This module parses Apache ActiveMQ logs. It supports application and audit logs.
 
 include::../include/what-happens.asciidoc[]

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -5,7 +5,13 @@
 
 == Cisco module
 
+//temporarily override modulename to create working link
+:modulename: cisco_asa
+
 include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: cisco
 
 This is a module for Cisco network device's logs and Cisco Umbrella. It includes the following
 filesets for receiving logs over syslog or read from a file:

--- a/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
@@ -5,7 +5,13 @@
 
 == Microsoft module
 
+//temporarily override modulename to create working link
+:modulename: m365_defender
+
 include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: microsoft
 
 This is a module for ingesting data from the different Microsoft Products. Currently supports these filesets:
 

--- a/x-pack/filebeat/module/oracle/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/oracle/_meta/docs.asciidoc
@@ -6,6 +6,8 @@
 
 == Oracle module
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
 This is a module for ingesting Audit Trail logs from Oracle Databases.
 
 The module expects an *.aud audit file that is generated from Oracle Databases by default. If this has been disabled then please see the https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/introduction-to-auditing.html#GUID-8D96829C-9151-4FA4-BED9-831D088F12FF[Oracle Database Audit Trail Documentation].

--- a/x-pack/filebeat/module/snort/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/snort/_meta/docs.asciidoc
@@ -7,6 +7,10 @@
 
 experimental[]
 
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 This is a module for receiving Snort/Sourcefire logs over Syslog or a file.
 
 include::../include/gs-link.asciidoc[]

--- a/x-pack/filebeat/module/threatintel/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/threatintel/_meta/docs.asciidoc
@@ -5,6 +5,14 @@
 
 == Threat Intel module
 
+//temporarily override modulename to create working link
+:modulename: ti_abusech
+
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: threatintel
+
 This module ingests data from a collection of different threat intelligence
 sources. The ingested data is meant to be used with
 https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-indicator-rule[Indicator

--- a/x-pack/filebeat/module/zscaler/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zscaler/_meta/docs.asciidoc
@@ -7,7 +7,13 @@
 
 experimental[]
 
+//temporarily override modulename to create working link
+:modulename: zscaler_zia
+
 include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+//reset modulename
+:modulename: zscaler
 
 This is a module for receiving Zscaler NSS logs over Syslog or a file.
 

--- a/x-pack/metricbeat/module/activemq/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/activemq/_meta/docs.asciidoc
@@ -1,3 +1,7 @@
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 This module periodically fetches JMX metrics from Apache ActiveMQ.
 
 [float]

--- a/x-pack/metricbeat/module/cockroachdb/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/cockroachdb/_meta/docs.asciidoc
@@ -1,3 +1,7 @@
+include::{libbeat-dir}/shared/integration-link.asciidoc[]
+
+:modulename!:
+
 This module periodically fetches metrics from CockroachDB.
 
 [float]


### PR DESCRIPTION
Closes #31618 

## What does this PR do?

- Adds links from module docs to related integration.
- Fixes links that were broken because there was no page that matched the module name. 
- Modifies Elastic Agent description for https://github.com/elastic/observability-docs/issues/1908

## Why is it important?

Users need to know if there is an Elastic Agent integration available they can use instead of Beats.

## Checklist

- [x] My code follows the style guidelines of this project
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

