### PR TITLE
Add stack versions to accepted pytest env vars

### DIFF
--- a/metricbeat/magefile.go
+++ b/metricbeat/magefile.go
@@ -225,7 +225,7 @@ func PythonIntegTest(ctx context.Context) error {
 
 	passThroughEnvVars := append(
 		[]string{"ELASTICSEARCH_VERSION", "KIBANA_VERSION", "BEAT_VERSION"},
-		devtools.ListMatchingEnvVars("PYTEST_")...
+		devtools.ListMatchingEnvVars("PYTEST_")...,
 	)
 	runner, err := devtools.NewDockerIntegrationRunner(passThroughEnvVars...)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Adds support to override the docker images used during metricbeat's `pythonIntegTest`

## Why is it important?

Allows testing metricbeat against unmerged elasticsearch changes.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

From elasticsearch repo:

```
./gradlew buildDockerImage
```

From metricbeat
```
ELASTICSEARCH_VERSION=8.4.0-SNAPSHOT MODULE=elasticsearch mage pythonIntegTest
```

After completion check `docker ps -a` to see that the `docker.elastic.co/integrations-ci/beats-elasticsearch:8.4.0-SNAPSHOT-1` was used.

## Related issues

- Relates https://github.com/elastic/beats/issues/31765

## Use cases

I wanted to test metricbeat in the presence of a new elasticsearch-provided mapping. This seemed to be the only way to do that.