### PR TITLE
action: use forked version to support otelServiceName

### DIFF
--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -24,9 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Export Workflow Trace
-        uses: inception-health/otel-export-trace-action@latest
+        uses: v1v/otel-export-trace-action@v2
         with:
           otlpEndpoint: "${{ secrets.APM_SERVER }}"
           otlpHeaders: "Authorization=Bearer ${{ secrets.APM_TOKEN }}"
+          otelServiceName: ${{ github.repository }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           runId: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## What does this PR do?

The existing workflow does not support to set the name of the service, so I'll change it to use the open PR https://github.com/inception-health/otel-export-trace-action/pull/13

```suggestion
        uses: v1v/otel-export-trace-action@v2
```

## Why is it important?

Help to use the service for the trace matching the github repository, so it will help to categorise easier with more semantic

Additionally, we don't need to wait for the upstream action to implement the new features or support the ones we need in our end.