### PR TITLE
fix race condition when stopping inputs filestream ID bookkeeper

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Expand fields in `decode_json_fields` if target is set. {issue}31712[31712] {pull}32010[32010]
 - Fix OS name reported by add_host_metadata on Windows 11. {issue}30833[30833] {pull}32259[32259]
+- Fix race condition when reloading runners {pull}32309[32309]
 
 *Auditbeat*
 
@@ -49,6 +50,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix Cisco AMP rate limit and pagination. {pull}32030[32030]
 - Fix wrong state ID in states registry for awss3 s3 direct input. {pull}32164[32164]
 - cisco/asa: fix handling of user names when there are Security Group Tags present. {issue}32009[32009] {pull}32196[32196]
+- Fix race conditions when reloading input V2 and filestream input {pull}32309[32309]
 
 *Heartbeat*
 

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -81,6 +81,10 @@ func (inp *managedInput) Run(
 
 	inp.prospector.Run(ctx, sourceStore, hg)
 
+	// Notify the manager the input  has stopped, currently that is used to
+	// keep track of duplicated IDs
+	inp.manager.StopInput(inp.userID)
+
 	return nil
 }
 

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -71,6 +71,7 @@ type InputManager struct {
 	store      *store
 	ackUpdater *updateWriter
 	ackCH      *updateChan
+	idsMux     sync.Mutex
 	ids        map[string]struct{}
 }
 
@@ -176,12 +177,14 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 			" duplication, please add an ID and restart Filebeat")
 	}
 
+	cim.idsMux.Lock()
 	if _, exists := cim.ids[settings.ID]; exists {
 		cim.Logger.Errorf("filestream input with ID '%s' already exists, this "+
 			"will lead to data duplication, please use a different ID", settings.ID)
 	}
 
 	cim.ids[settings.ID] = struct{}{}
+	cim.idsMux.Unlock()
 
 	prospector, harvester, err := cim.Configure(config)
 	if err != nil {
@@ -224,6 +227,15 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 		cleanTimeout:     settings.CleanTimeout,
 		harvesterLimit:   settings.HarvesterLimit,
 	}, nil
+}
+
+// StopInput peforms all necessary clean up when an input finishes.
+func (cim *InputManager) StopInput(id string) {
+	cim.idsMux.Lock()
+	if _, exists := cim.ids[id]; exists {
+		delete(cim.ids, id)
+	}
+	cim.idsMux.Unlock()
 }
 
 func (cim *InputManager) getRetainedStore() *store {

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -232,9 +232,7 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 // StopInput peforms all necessary clean up when an input finishes.
 func (cim *InputManager) StopInput(id string) {
 	cim.idsMux.Lock()
-	if _, exists := cim.ids[id]; exists {
-		delete(cim.ids, id)
-	}
+	delete(cim.ids, id)
 	cim.idsMux.Unlock()
 }
 

--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -104,11 +104,13 @@ func (f *factory) Create(
 func (r *runner) String() string { return r.input.Name() }
 
 func (r *runner) Start() {
+	r.wg.Add(1)
 	log := r.log
 	name := r.input.Name()
 
 	go func() {
-		log.Infof("Input %v starting", name)
+		defer r.wg.Done()
+		log.Infof("Input '%s' - '%s' starting", name, r.id)
 		err := r.input.Run(
 			v2.Context{
 				ID:          r.id,
@@ -119,9 +121,9 @@ func (r *runner) Start() {
 			r.connector,
 		)
 		if err != nil {
-			log.Errorf("Input '%v' failed with: %+v", name, err)
+			log.Errorf("Input '%s' - '%s' failed with: %+v", name, r.id, err)
 		} else {
-			log.Infof("Input '%v' stopped", name)
+			log.Infof("Input '%s' - '%s' stopped (goroutine)", name, r.id)
 		}
 	}()
 }
@@ -129,7 +131,7 @@ func (r *runner) Start() {
 func (r *runner) Stop() {
 	r.sig.Cancel()
 	r.wg.Wait()
-	r.log.Infof("Input '%v' stopped", r.input.Name())
+	r.log.Infof("Input '%s' - '%s' stopped (runner)", r.input.Name(), r.id)
 }
 
 func configID(config *conf.C) (string, error) {

--- a/filebeat/input/v2/compat/compat.go
+++ b/filebeat/input/v2/compat/compat.go
@@ -110,7 +110,7 @@ func (r *runner) Start() {
 
 	go func() {
 		defer r.wg.Done()
-		log.Infof("Input '%s' - '%s' starting", name, r.id)
+		log.Infof("Input '%s' starting", name)
 		err := r.input.Run(
 			v2.Context{
 				ID:          r.id,
@@ -121,9 +121,9 @@ func (r *runner) Start() {
 			r.connector,
 		)
 		if err != nil {
-			log.Errorf("Input '%s' - '%s' failed with: %+v", name, r.id, err)
+			log.Errorf("Input '%s' failed with: %+v", name, err)
 		} else {
-			log.Infof("Input '%s' - '%s' stopped (goroutine)", name, r.id)
+			log.Infof("Input '%s' stopped (goroutine)", name)
 		}
 	}()
 }
@@ -131,7 +131,7 @@ func (r *runner) Start() {
 func (r *runner) Stop() {
 	r.sig.Cancel()
 	r.wg.Wait()
-	r.log.Infof("Input '%s' - '%s' stopped (runner)", r.input.Name(), r.id)
+	r.log.Infof("Input '%s' stopped (runner)", r.input.Name())
 }
 
 func configID(config *conf.C) (string, error) {

--- a/filebeat/tests/system/test_reload_inputs.py
+++ b/filebeat/tests/system/test_reload_inputs.py
@@ -281,11 +281,6 @@ class Test(BaseTest):
         with open(self.working_dir + "/configs/input.yml", 'w') as f:
             f.write(inputConfigTemplate.format(self.working_dir + "/logs/test.log"))
 
-        # Make sure error shows up in log file
-        self.wait_until(
-            lambda: self.log_contains("Can only start an input when all related states are finished"),
-            max_timeout=15)
-
         # Wait until old runner is stopped
         self.wait_until(
             lambda: self.log_contains("Stopping runner:"),

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -81,13 +81,22 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 
 	r.logger.Debugf("Start list: %d, Stop list: %d", len(startList), len(stopList))
 
+	wg := sync.WaitGroup{}
 	// Stop removed runners
 	for hash, runner := range stopList {
+		wg.Add(1)
 		r.logger.Debugf("Stopping runner: %s", runner)
 		delete(r.runners, hash)
-		runner.Stop()
+		go func() {
+			defer wg.Done()
+			runner.Stop()
+			r.logger.Debugf("Runner: '%s' has stopped", runner)
+		}()
 		moduleStops.Add(1)
 	}
+
+	// Wait for all runners to stop before starting new ones
+	wg.Wait()
 
 	// Start new runners
 	for hash, config := range startList {

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -85,7 +85,7 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 	for hash, runner := range stopList {
 		r.logger.Debugf("Stopping runner: %s", runner)
 		delete(r.runners, hash)
-		go runner.Stop()
+		runner.Stop()
 		moduleStops.Add(1)
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes three race conditions:
1. When reloading inputs the Reload method would not wait for the
runner to stop before starting a new input.
2. The runner's Start method was not incrementing the WaitGroup, hence
Stop would finish before the runner had stopped.
3. The input manager that keeps track of filestream input IDs did not
syncronise access to the IDs map, allowing for some race conditions
when issuing the log error about possible data duplucation.

Some log messages have been modified to contain more details like the
filestream ID.

## Why is it important?

It fixes some bugs.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
~~## How to test this PR locally~~
## Related issues

- Relates https://github.com/elastic/beats/issues/31512
- Relates https://github.com/elastic/integrations/pull/3672

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
