### PR TITLE
Remove extra s3 input registration from x-pack/filebeat default inputs.

### DIFF
--- a/x-pack/filebeat/input/default-inputs/inputs.go
+++ b/x-pack/filebeat/input/default-inputs/inputs.go
@@ -32,7 +32,6 @@ func xpackInputs(info beat.Info, log *logp.Logger, store beater.StateStore) []v2
 		httpjson.Plugin(log, store),
 		o365audit.Plugin(log, store),
 		awss3.Plugin(store),
-		awss3.Plugin(store),
 		awscloudwatch.Plugin(store),
 	}
 }


### PR DESCRIPTION
This is currently breaking the 7.17 build with filebeat refusing to start for some tests.

This appears to have been introduced in https://github.com/elastic/beats/commit/d593a21503aa3e1dafb0c5a01d3991065db2b22a, I suspect a bad conflict resolution during the backport.

It seems filebeat deadlocks when it tries to panic and report the error in this case, hiding the cause of the issue:

https://github.com/elastic/beats/blob/cad3c7f951e55221712b96a2b32461c09c426e27/filebeat/beater/filebeat.go#L288-L290

I'll open a separate issue for that problem if I can't find the root cause.