### PR TITLE
[7.17] Add missing WaitTimeoutError definition

### DIFF
--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -30,11 +30,13 @@ REGEXP_TYPE = type(re.compile("t"))
 class TimeoutError(Exception):
     pass
 
+
 class WaitTimeoutError(Exception):
     """
     WaitTimeoutError is raised by the wait_until function if the `until` logic passes its timeout.
     """
     pass
+
 
 class Proc(object):
     """

--- a/libbeat/tests/system/beat/beat.py
+++ b/libbeat/tests/system/beat/beat.py
@@ -30,6 +30,11 @@ REGEXP_TYPE = type(re.compile("t"))
 class TimeoutError(Exception):
     pass
 
+class WaitTimeoutError(Exception):
+    """
+    WaitTimeoutError is raised by the wait_until function if the `until` logic passes its timeout.
+    """
+    pass
 
 class Proc(object):
     """


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to add the missing `WaitTimeoutError` class definition in beat.py.

