### PR TITLE
[docs] Reset edit URL properly at the each topic

### DIFF
--- a/filebeat/docs/modules/activemq.asciidoc
+++ b/filebeat/docs/modules/activemq.asciidoc
@@ -88,4 +88,4 @@ image::./images/filebeat-activemq-audit-events.png[]
 For a description of each field in the module, see the
 <<exported-fields-activemq,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/apache.asciidoc
+++ b/filebeat/docs/modules/apache.asciidoc
@@ -104,4 +104,4 @@ image::./images/kibana-apache.png[]
 For a description of each field in the module, see the
 <<exported-fields-apache,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/auditd.asciidoc
+++ b/filebeat/docs/modules/auditd.asciidoc
@@ -88,4 +88,4 @@ image::./images/kibana-audit-auditd.png[]
 For a description of each field in the module, see the
 <<exported-fields-auditd,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/aws.asciidoc
+++ b/filebeat/docs/modules/aws.asciidoc
@@ -334,4 +334,4 @@ include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
 For a description of each field in the module, see the
 <<exported-fields-aws,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/awsfargate.asciidoc
+++ b/filebeat/docs/modules/awsfargate.asciidoc
@@ -139,4 +139,4 @@ include::{libbeat-xpack-dir}/docs/aws-credentials-config.asciidoc[]
 For a description of each field in the module, see the
 <<exported-fields-awsfargate,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/azure.asciidoc
+++ b/filebeat/docs/modules/azure.asciidoc
@@ -138,4 +138,4 @@ image::./images/filebeat-azure-overview.png[]
 For a description of each field in the module, see the
 <<exported-fields-azure,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/barracuda.asciidoc
+++ b/filebeat/docs/modules/barracuda.asciidoc
@@ -126,4 +126,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-barracuda,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/bluecoat.asciidoc
+++ b/filebeat/docs/modules/bluecoat.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-bluecoat,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/cef.asciidoc
+++ b/filebeat/docs/modules/cef.asciidoc
@@ -168,4 +168,4 @@ Check Point CEF extensions are mapped as follows:
 For a description of each field in the module, see the
 <<exported-fields-cef,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/checkpoint.asciidoc
+++ b/filebeat/docs/modules/checkpoint.asciidoc
@@ -195,4 +195,4 @@ Check Point Syslog extensions are mapped as follows to ECS:
 For a description of each field in the module, see the
 <<exported-fields-checkpoint,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -552,4 +552,4 @@ image::./images/kibana-cisco-asa.png[]
 For a description of each field in the module, see the
 <<exported-fields-cisco,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/coredns.asciidoc
+++ b/filebeat/docs/modules/coredns.asciidoc
@@ -64,4 +64,4 @@ image::./images/kibana-coredns.jpg[]
 For a description of each field in the module, see the
 <<exported-fields-coredns,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/crowdstrike.asciidoc
+++ b/filebeat/docs/modules/crowdstrike.asciidoc
@@ -77,4 +77,4 @@ And for all over event CrowdStrike Falcon event types, go to Host -> Events.
 For a description of each field in the module, see the
 <<exported-fields-crowdstrike,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/cyberarkpas.asciidoc
+++ b/filebeat/docs/modules/cyberarkpas.asciidoc
@@ -187,4 +187,4 @@ image::./images/filebeat-cyberarkpas-overview.png[]
 For a description of each field in the module, see the
 <<exported-fields-cyberarkpas,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/cylance.asciidoc
+++ b/filebeat/docs/modules/cylance.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-cylance,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/elasticsearch.asciidoc
+++ b/filebeat/docs/modules/elasticsearch.asciidoc
@@ -138,4 +138,4 @@ include::../include/timezone-support.asciidoc[]
 For a description of each field in the module, see the
 <<exported-fields-elasticsearch,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/envoyproxy.asciidoc
+++ b/filebeat/docs/modules/envoyproxy.asciidoc
@@ -37,4 +37,4 @@ image::./images/kibana-envoyproxy.jpg[]
 For a description of each field in the module, see the
 <<exported-fields-envoyproxy,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/f5.asciidoc
+++ b/filebeat/docs/modules/f5.asciidoc
@@ -130,4 +130,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-f5,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -322,4 +322,4 @@ This is a list of FortiOS fields that are mapped to ECS.
 For a description of each field in the module, see the
 <<exported-fields-fortinet,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/gcp.asciidoc
+++ b/filebeat/docs/modules/gcp.asciidoc
@@ -175,4 +175,4 @@ field. Defaults to `false`, meaning the original message is not saved.
 For a description of each field in the module, see the
 <<exported-fields-gcp,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/google_workspace.asciidoc
+++ b/filebeat/docs/modules/google_workspace.asciidoc
@@ -144,4 +144,4 @@ These are the common ones to all filesets.
 For a description of each field in the module, see the
 <<exported-fields-google_workspace,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/haproxy.asciidoc
+++ b/filebeat/docs/modules/haproxy.asciidoc
@@ -75,4 +75,4 @@ image::./images/kibana-haproxy-overview.png[]
 For a description of each field in the module, see the
 <<exported-fields-haproxy,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/ibmmq.asciidoc
+++ b/filebeat/docs/modules/ibmmq.asciidoc
@@ -63,4 +63,4 @@ image::./images/filebeat-ibmmq.png[]
 For a description of each field in the module, see the
 <<exported-fields-ibmmq,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/icinga.asciidoc
+++ b/filebeat/docs/modules/icinga.asciidoc
@@ -96,4 +96,4 @@ image::./images/kibana-icinga-main.png[]
 For a description of each field in the module, see the
 <<exported-fields-icinga,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/iis.asciidoc
+++ b/filebeat/docs/modules/iis.asciidoc
@@ -89,4 +89,4 @@ image::./images/kibana-iis.png[]
 For a description of each field in the module, see the
 <<exported-fields-iis,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/imperva.asciidoc
+++ b/filebeat/docs/modules/imperva.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-imperva,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/infoblox.asciidoc
+++ b/filebeat/docs/modules/infoblox.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-infoblox,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/iptables.asciidoc
+++ b/filebeat/docs/modules/iptables.asciidoc
@@ -100,4 +100,4 @@ image::./images/kibana-iptables-ubiquiti.png[]
 For a description of each field in the module, see the
 <<exported-fields-iptables,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/juniper.asciidoc
+++ b/filebeat/docs/modules/juniper.asciidoc
@@ -239,4 +239,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-juniper,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/kafka.asciidoc
+++ b/filebeat/docs/modules/kafka.asciidoc
@@ -98,4 +98,4 @@ image::./images/filebeat-kafka-logs-overview.png[]
 For a description of each field in the module, see the
 <<exported-fields-kafka,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/kibana.asciidoc
+++ b/filebeat/docs/modules/kibana.asciidoc
@@ -53,4 +53,4 @@ include::../include/var-paths.asciidoc[]
 For a description of each field in the module, see the
 <<exported-fields-kibana,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/logstash.asciidoc
+++ b/filebeat/docs/modules/logstash.asciidoc
@@ -107,4 +107,4 @@ the JSON object starts on a new line, the fileset may not parse the multiline pl
 For a description of each field in the module, see the
 <<exported-fields-logstash,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/microsoft.asciidoc
+++ b/filebeat/docs/modules/microsoft.asciidoc
@@ -278,4 +278,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-microsoft,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/misp.asciidoc
+++ b/filebeat/docs/modules/misp.asciidoc
@@ -45,4 +45,4 @@ image::./images/kibana-misp.png[]
 For a description of each field in the module, see the
 <<exported-fields-misp,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/mongodb.asciidoc
+++ b/filebeat/docs/modules/mongodb.asciidoc
@@ -78,4 +78,4 @@ image::./images/filebeat-mongodb-overview.png[]
 For a description of each field in the module, see the
 <<exported-fields-mongodb,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/mssql.asciidoc
+++ b/filebeat/docs/modules/mssql.asciidoc
@@ -65,4 +65,4 @@ include::../include/timezone-support.asciidoc[]
 For a description of each field in the module, see the
 <<exported-fields-mssql,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/mysql.asciidoc
+++ b/filebeat/docs/modules/mysql.asciidoc
@@ -90,4 +90,4 @@ image::./images/kibana-mysql.png[]
 For a description of each field in the module, see the
 <<exported-fields-mysql,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/mysqlenterprise.asciidoc
+++ b/filebeat/docs/modules/mysqlenterprise.asciidoc
@@ -82,4 +82,4 @@ MySQL Enterprise Audit fields are mapped to ECS in the following way:
 For a description of each field in the module, see the
 <<exported-fields-mysqlenterprise,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/nats.asciidoc
+++ b/filebeat/docs/modules/nats.asciidoc
@@ -56,4 +56,4 @@ image::./images/filebeat_nats_dashboard.png[]
 For a description of each field in the module, see the
 <<exported-fields-nats,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/netflow.asciidoc
+++ b/filebeat/docs/modules/netflow.asciidoc
@@ -102,4 +102,4 @@ events. Defaults to `[forwarded]`.
 For a description of each field in the module, see the
 <<exported-fields-netflow,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/netscout.asciidoc
+++ b/filebeat/docs/modules/netscout.asciidoc
@@ -79,4 +79,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-netscout,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/nginx.asciidoc
+++ b/filebeat/docs/modules/nginx.asciidoc
@@ -113,4 +113,4 @@ image::./images/kibana-nginx.png[]
 For a description of each field in the module, see the
 <<exported-fields-nginx,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/o365.asciidoc
+++ b/filebeat/docs/modules/o365.asciidoc
@@ -231,4 +231,4 @@ image::./images/filebeat-o365-audit.png[]
 For a description of each field in the module, see the
 <<exported-fields-o365,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/okta.asciidoc
+++ b/filebeat/docs/modules/okta.asciidoc
@@ -136,4 +136,4 @@ image::./images/filebeat-okta-dashboard.png[]
 For a description of each field in the module, see the
 <<exported-fields-okta,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/oracle.asciidoc
+++ b/filebeat/docs/modules/oracle.asciidoc
@@ -78,4 +78,4 @@ Oracle Database fields are mapped to the current ECS Fields:
 For a description of each field in the module, see the
 <<exported-fields-oracle,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/osquery.asciidoc
+++ b/filebeat/docs/modules/osquery.asciidoc
@@ -93,4 +93,4 @@ image::./images/kibana-osquery-compatibility.png[]
 For a description of each field in the module, see the
 <<exported-fields-osquery,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/panw.asciidoc
+++ b/filebeat/docs/modules/panw.asciidoc
@@ -194,4 +194,4 @@ image::./images/filebeat-panw-threat.png[]
 For a description of each field in the module, see the
 <<exported-fields-panw,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/pensando.asciidoc
+++ b/filebeat/docs/modules/pensando.asciidoc
@@ -65,4 +65,4 @@ image::./images/filebeat-pensando-dfw.png[]
 For a description of each field in the module, see the
 <<exported-fields-pensando,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/postgresql.asciidoc
+++ b/filebeat/docs/modules/postgresql.asciidoc
@@ -166,4 +166,4 @@ image::./images/filebeat-postgresql-slowlog-overview.png[]
 For a description of each field in the module, see the
 <<exported-fields-postgresql,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/proofpoint.asciidoc
+++ b/filebeat/docs/modules/proofpoint.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-proofpoint,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/rabbitmq.asciidoc
+++ b/filebeat/docs/modules/rabbitmq.asciidoc
@@ -71,4 +71,4 @@ include::../include/timezone-support.asciidoc[]
 For a description of each field in the module, see the
 <<exported-fields-rabbitmq,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/radware.asciidoc
+++ b/filebeat/docs/modules/radware.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-radware,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/redis.asciidoc
+++ b/filebeat/docs/modules/redis.asciidoc
@@ -115,4 +115,4 @@ image::./images/kibana-redis.png[]
 For a description of each field in the module, see the
 <<exported-fields-redis,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/salesforce.asciidoc
+++ b/filebeat/docs/modules/salesforce.asciidoc
@@ -319,4 +319,4 @@ image::./images/filebeat-salesforce-logout-dashboard.png[]
 For a description of each field in the module, see the
 <<exported-fields-salesforce,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/santa.asciidoc
+++ b/filebeat/docs/modules/santa.asciidoc
@@ -73,4 +73,4 @@ image::./images/kibana-santa-log-overview.png[]
 For a description of each field in the module, see the
 <<exported-fields-santa,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/snort.asciidoc
+++ b/filebeat/docs/modules/snort.asciidoc
@@ -83,4 +83,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-snort,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/snyk.asciidoc
+++ b/filebeat/docs/modules/snyk.asciidoc
@@ -244,4 +244,4 @@ This is a list of Snyk Vulnerability fields that are mapped to ECS.
 For a description of each field in the module, see the
 <<exported-fields-snyk,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/sonicwall.asciidoc
+++ b/filebeat/docs/modules/sonicwall.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-sonicwall,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/sophos.asciidoc
+++ b/filebeat/docs/modules/sophos.asciidoc
@@ -203,4 +203,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-sophos,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/squid.asciidoc
+++ b/filebeat/docs/modules/squid.asciidoc
@@ -81,4 +81,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-squid,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/suricata.asciidoc
+++ b/filebeat/docs/modules/suricata.asciidoc
@@ -89,4 +89,4 @@ image::./images/filebeat-suricata-alerts.png[]
 For a description of each field in the module, see the
 <<exported-fields-suricata,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -93,4 +93,4 @@ image::./images/kibana-system.png[]
 For a description of each field in the module, see the
 <<exported-fields-system,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/threatintel.asciidoc
+++ b/filebeat/docs/modules/threatintel.asciidoc
@@ -686,4 +686,4 @@ Overview of the information provided by the ThreatQuotient feed.
 For a description of each field in the module, see the
 <<exported-fields-threatintel,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/tomcat.asciidoc
+++ b/filebeat/docs/modules/tomcat.asciidoc
@@ -85,4 +85,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-tomcat,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/traefik.asciidoc
+++ b/filebeat/docs/modules/traefik.asciidoc
@@ -75,4 +75,4 @@ image::./images/kibana-traefik.png[]
 For a description of each field in the module, see the
 <<exported-fields-traefik,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/zeek.asciidoc
+++ b/filebeat/docs/modules/zeek.asciidoc
@@ -800,4 +800,4 @@ image::./images/kibana-zeek.png[]
 For a description of each field in the module, see the
 <<exported-fields-zeek,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/zookeeper.asciidoc
+++ b/filebeat/docs/modules/zookeeper.asciidoc
@@ -88,4 +88,4 @@ include::../include/timezone-support.asciidoc[]
 For a description of each field in the module, see the
 <<exported-fields-zookeeper,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/zoom.asciidoc
+++ b/filebeat/docs/modules/zoom.asciidoc
@@ -70,4 +70,4 @@ Configuration options for SSL parameters like the SSL certificate and CA to use 
 For a description of each field in the module, see the
 <<exported-fields-zoom,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/docs/modules/zscaler.asciidoc
+++ b/filebeat/docs/modules/zscaler.asciidoc
@@ -87,4 +87,4 @@ will be found under `rsa.raw`. The default is false.
 For a description of each field in the module, see the
 <<exported-fields-zscaler,exported fields>> section.
 
-edit_url!:
+:edit_url!:

--- a/filebeat/scripts/docs_collector.py
+++ b/filebeat/scripts/docs_collector.py
@@ -65,7 +65,7 @@ For a description of each field in the module, see the
 
 """
 
-        module_file += "edit_url!:"
+        module_file += ":edit_url!:"
 
         # Write module docs
         docs_path = os.path.join(os.path.abspath("docs"), "modules", module + ".asciidoc")


### PR DESCRIPTION
Looks like an earlier change to set the Edit URL properly for generated Filebeat module docs had a missing colon.
