### PR TITLE
system.auth - sync pipeline with Fleet integration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -109,6 +109,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Extend list of mapped record types in o365 Audit module. {pull}32217[32217]
 - Add references for CRI-O configuration in input-container and in our kubernetes manifests {issue}32149[32149] {pull}32151[32151]
 - httpjson input: Add `replaceAll` helper function to template context. {pull}32365[32365]
+- Optimize grok patterns in system.auth module pipeline. {pull}32360[32360]
 
 *Auditbeat*
 

--- a/filebeat/docs/modules/system.asciidoc
+++ b/filebeat/docs/modules/system.asciidoc
@@ -70,6 +70,13 @@ include::../include/var-paths.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Include `preserve_orginal_event` causes the pipeline to retain the raw
+log in `event.original`. Defaults to `[]`.
+
 include::../include/timezone-support.asciidoc[]
 
 [float]

--- a/filebeat/module/system/_meta/docs.asciidoc
+++ b/filebeat/module/system/_meta/docs.asciidoc
@@ -63,6 +63,13 @@ include::../include/var-paths.asciidoc[]
 
 include::../include/var-paths.asciidoc[]
 
+*`var.tags`*::
+
+A list of tags to include in events. Including `forwarded` indicates that the
+events did not originate on this host and causes `host.name` to not be added to
+events. Include `preserve_orginal_event` causes the pipeline to retain the raw
+log in `event.original`. Defaults to `[]`.
+
 include::../include/timezone-support.asciidoc[]
 
 [float]

--- a/filebeat/module/system/auth/config/auth.yml
+++ b/filebeat/module/system/auth/config/auth.yml
@@ -4,12 +4,14 @@ paths:
  - {{$path}}
 {{ end }}
 exclude_files: [".gz$"]
+
 multiline:
   pattern: "^\\s"
   match: after
+
 processors:
   - add_locale: ~
-  - add_fields:
-      target: ''
-      fields:
-        ecs.version: 1.12.0
+
+tags: {{ .tags | tojson }}
+
+publisher_pipeline.disable_host: {{ inList .tags "forwarded" }}

--- a/filebeat/module/system/auth/ingest/pipeline.yml
+++ b/filebeat/module/system/auth/ingest/pipeline.yml
@@ -1,198 +1,221 @@
-description: Pipeline for parsing system authorisation/secure logs
+---
+description: Pipeline for parsing system authorization and secure logs.
 processors:
-- set:
-    field: event.ingested
-    value: '{{_ingest.timestamp}}'
-- grok:
-    field: message
-    ignore_missing: true
-    pattern_definitions:
-      GREEDYMULTILINE: |-
-        (.|
-        )*
-      TIMESTAMP: (?:%{TIMESTAMP_ISO8601}|%{SYSLOGTIMESTAMP})
-    patterns:
-    - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-      %{DATA:system.auth.ssh.event} %{DATA:system.auth.ssh.method} for (invalid user
-      )?%{DATA:user.name} from %{IPORHOST:source.ip} port %{NUMBER:source.port:long}
-      ssh2(: %{GREEDYDATA:system.auth.ssh.signature})?'
-    - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-      %{DATA:system.auth.ssh.event} user %{DATA:user.name} from %{IPORHOST:source.ip}'
-    - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-      Did not receive identification string from %{IPORHOST:system.auth.ssh.dropped_ip}'
-    - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-      \s*%{DATA:user.name} :( %{DATA:system.auth.sudo.error} ;)? TTY=%{DATA:system.auth.sudo.tty}
-      ; PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}'
-    - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-      new group: name=%{DATA:group.name}, GID=%{NUMBER:group.id}'
-    - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname} %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-      new user: name=%{DATA:user.name}, UID=%{NUMBER:user.id}, GID=%{NUMBER:group.id},
-      home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$'
-    - '%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:
-      %{GREEDYMULTILINE:system.auth.message}'
-- remove:
-    field: message
-- rename:
-    field: system.auth.message
-    target_field: message
-    ignore_missing: true
-    if: ctx?.system?.auth?.message != null && ctx?.system?.auth?.message != ""
-- grok:
-    field: message
-    ignore_missing: true
-    ignore_failure: true
-    patterns:
-    - 'for user \"?%{DATA:_temp.foruser}\"? by \"?%{DATA:_temp.byuser}\"?(?:\(uid=%{NUMBER:_temp.byuid}\))?$'
-    - 'for user \"?%{DATA:_temp.foruser}\"?$'
-    - 'by user \"?%{DATA:_temp.byuser}\"?$'
-    if: ctx?.message != null && ctx?.message != ""
-- rename:
-    field: _temp.byuser
-    target_field: user.name
-    ignore_missing: true
-    ignore_failure: true
-- rename:
-    field: _temp.byuid
-    target_field: user.id
-    ignore_missing: true
-    ignore_failure: true
-- rename:
-    field: _temp.foruser
-    target_field: user.name
-    ignore_missing: true
-    ignore_failure: true
-    if: ctx?.user?.name == null || ctx?.user?.name == ""
-- rename:
-    field: _temp.foruser
-    target_field: user.effective.name
-    ignore_missing: true
-    ignore_failure: true
-    if: ctx?.user?.name != null
-- convert:
-    field: system.auth.sudo.user
-    target_field: user.effective.name
-    type: string
-    ignore_failure: true
-    if: ctx?.system?.auth?.sudo?.user != null
-- set:
-    field: source.ip
-    value: '{{system.auth.ssh.dropped_ip}}'
-    ignore_empty_value: true
-- date:
-    if: ctx.event.timezone == null
-    field: system.auth.timestamp
-    target_field: '@timestamp'
-    formats:
-    - MMM  d HH:mm:ss
-    - MMM dd HH:mm:ss
-    - ISO8601
-    on_failure:
-    - append:
-        field: error.message
-        value: '{{ _ingest.on_failure_message }}'
-- date:
-    if: ctx.event.timezone != null
-    field: system.auth.timestamp
-    target_field: '@timestamp'
-    formats:
-    - MMM  d HH:mm:ss
-    - MMM dd HH:mm:ss
-    - ISO8601
-    timezone: '{{ event.timezone }}'
-    on_failure:
-    - append:
-        field: error.message
-        value: '{{ _ingest.on_failure_message }}'
-- remove:
-    field: system.auth.timestamp
-- geoip:
-    field: source.ip
-    target_field: source.geo
-    ignore_failure: true
-- geoip:
-    database_file: GeoLite2-ASN.mmdb
-    field: source.ip
-    target_field: source.as
-    properties:
-    - asn
-    - organization_name
-    ignore_missing: true
-- rename:
-    field: source.as.asn
-    target_field: source.as.number
-    ignore_missing: true
-- rename:
-    field: source.as.organization_name
-    target_field: source.as.organization.name
-    ignore_missing: true
-- set:
-    field: event.kind
-    value: event
-- script:
-    lang: painless
-    ignore_failure: true
-    source: >-
-      if (ctx.system.auth.ssh.event == "Accepted") {
-        ctx.event.type = ["authentication_success", "info"];
-        ctx.event.category = ["authentication","session"];
-        ctx.event.action = "ssh_login";
-        ctx.event.outcome = "success";
-      } else if (ctx.system.auth.ssh.event == "Invalid" || ctx.system.auth.ssh.event == "Failed") {
-        ctx.event.type = ["authentication_failure", "info"];
-        ctx.event.category = ["authentication"];
-        ctx.event.action = "ssh_login";
-        ctx.event.outcome = "failure";
-      }
-
-- append:
-    field: event.category
-    value: iam
-    if: "ctx?.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)"
-- set:
-    field: event.outcome
-    value: success
-    if: "ctx?.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)"
-- append:
-    field: event.type
-    value: user
-    if: "ctx?.process?.name != null && ['useradd', 'userdel', 'usermod'].contains(ctx.process.name)"
-- append:
-    field: event.type
-    value: group
-    if: "ctx?.process?.name != null && ['groupadd', 'groupdel', 'groupmod'].contains(ctx.process.name)"
-- append:
-    field: event.type
-    value: creation
-    if: "ctx?.process?.name != null && ['useradd', 'groupadd'].contains(ctx.process.name)"
-- append:
-    field: event.type
-    value: deletion
-    if: "ctx?.process?.name != null && ['userdel', 'groupdel'].contains(ctx.process.name)"
-- append:
-    field: event.type
-    value: change
-    if: "ctx?.process?.name != null && ['usermod', 'groupmod'].contains(ctx.process.name)"
-- append:
-    field: related.user
-    value: "{{user.name}}"
-    allow_duplicates: false
-    if: "ctx?.user?.name != null && ctx.user?.name != ''"
-- append:
-    field: related.user
-    value: "{{user.effective.name}}"
-    allow_duplicates: false
-    if: "ctx?.user?.effective?.name != null && ctx.user?.effective?.name != ''"
-- append:
-    field: related.ip
-    value: "{{source.ip}}"
-    allow_duplicates: false
-    if: "ctx?.source?.ip != null && ctx.source?.ip != ''"
-- append:
-    field: related.hosts
-    value: "{{host.hostname}}"
-    allow_duplicates: false
-    if: "ctx.host?.hostname != null && ctx.host?.hostname != ''"
+  - set:
+      field: event.ingested
+      copy_from: _ingest.timestamp
+  - set:
+      if: ctx.message != null
+      copy_from: message
+      field: event.original
+      override: false
+  - remove:
+      field: message
+      ignore_missing: true
+  - grok:
+      description: Grok the message header.
+      tag: grok-message-header
+      field: event.original
+      pattern_definitions:
+        GREEDYMULTILINE: |-
+          (.|
+          )*
+        TIMESTAMP: (?:%{TIMESTAMP_ISO8601}|%{SYSLOGTIMESTAMP})
+      patterns:
+        - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:%{SPACE}+%{GREEDYMULTILINE:_temp.message}$'
+  - grok:
+      description: Grok specific auth messages.
+      tag: grok-specific-messages
+      field: _temp.message
+      ignore_missing: true
+      patterns:
+        - '^%{DATA:system.auth.ssh.event} %{DATA:system.auth.ssh.method} for (invalid user)?%{DATA:user.name} from %{IPORHOST:source.ip} port %{NUMBER:source.port:long} ssh2(: %{GREEDYDATA:system.auth.ssh.signature})?'
+        - '^%{DATA:system.auth.ssh.event} user %{DATA:user.name} from %{IPORHOST:source.ip}'
+        - '^Did not receive identification string from %{IPORHOST:system.auth.ssh.dropped_ip}'
+        - '^%{DATA:user.name} :( %{DATA:system.auth.sudo.error} ;)? TTY=%{DATA:system.auth.sudo.tty} ; PWD=%{DATA:system.auth.sudo.pwd} ; USER=%{DATA:system.auth.sudo.user} ; COMMAND=%{GREEDYDATA:system.auth.sudo.command}'
+        - '^new group: name=%{DATA:group.name}, GID=%{NUMBER:group.id}'
+        - '^new user: name=%{DATA:user.name}, UID=%{NUMBER:user.id}, GID=%{NUMBER:group.id}, home=%{DATA:system.auth.useradd.home}, shell=%{DATA:system.auth.useradd.shell}$'
+      on_failure:
+        - rename:
+            description: Leave the unmatched content in message.
+            field: _temp.message
+            target_field: message
+  - remove:
+      field: _temp
+  - grok:
+      description: Grok usernames from PAM messages.
+      tag: grok-pam-users
+      field: message
+      ignore_missing: true
+      ignore_failure: true
+      patterns:
+        - 'for user \"?%{DATA:_temp.foruser}\"? by \"?%{DATA:_temp.byuser}\"?(?:\(uid=%{NUMBER:_temp.byuid}\))?$'
+        - 'for user \"?%{DATA:_temp.foruser}\"?$'
+        - 'by user \"?%{DATA:_temp.byuser}\"?$'
+      if: ctx.message != null && ctx.message != ""
+  - rename:
+      field: _temp.byuser
+      target_field: user.name
+      ignore_missing: true
+      ignore_failure: true
+  - rename:
+      field: _temp.byuid
+      target_field: user.id
+      ignore_missing: true
+      ignore_failure: true
+  - rename:
+      field: _temp.foruser
+      target_field: user.name
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.user?.name == null || ctx.user?.name == ""
+  - rename:
+      field: _temp.foruser
+      target_field: user.effective.name
+      ignore_missing: true
+      ignore_failure: true
+      if: ctx.user?.name != null
+  - remove:
+      field: _temp
+      ignore_missing: true
+  - convert:
+      field: system.auth.sudo.user
+      target_field: user.effective.name
+      type: string
+      ignore_failure: true
+      if: ctx.system?.auth?.sudo?.user != null
+  - convert:
+      field: system.auth.ssh.dropped_ip
+      target_field: source.ip
+      type: ip
+      ignore_missing: true
+      on_failure:
+        - remove:
+            field: system.auth.ssh.dropped_ip
+  - date:
+      if: ctx.event?.timezone == null
+      field: system.auth.timestamp
+      target_field: '@timestamp'
+      formats:
+        - MMM  d HH:mm:ss
+        - MMM dd HH:mm:ss
+        - ISO8601
+      on_failure:
+        - append:
+            field: error.message
+            value: '{{{ _ingest.on_failure_message }}}'
+  - date:
+      if: ctx.event?.timezone != null
+      field: system.auth.timestamp
+      target_field: '@timestamp'
+      formats:
+        - MMM  d HH:mm:ss
+        - MMM dd HH:mm:ss
+        - ISO8601
+      timezone: '{{{ event.timezone }}}'
+      on_failure:
+        - append:
+            field: error.message
+            value: '{{{ _ingest.on_failure_message }}}'
+  - remove:
+      field: system.auth.timestamp
+  - geoip:
+      field: source.ip
+      target_field: source.geo
+      ignore_missing: true
+  - geoip:
+      database_file: GeoLite2-ASN.mmdb
+      field: source.ip
+      target_field: source.as
+      properties:
+        - asn
+        - organization_name
+      ignore_missing: true
+  - rename:
+      field: source.as.asn
+      target_field: source.as.number
+      ignore_missing: true
+  - rename:
+      field: source.as.organization_name
+      target_field: source.as.organization.name
+      ignore_missing: true
+  - set:
+      field: event.kind
+      value: event
+  - script:
+      description: Add event.category/action/output to SSH events.
+      tag: script-categorize-ssh-event
+      if: ctx.system?.auth?.ssh?.event != null
+      lang: painless
+      source: >-
+        if (ctx.system.auth.ssh.event == "Accepted") {
+          ctx.event.type = ["info"];
+          ctx.event.category = ["authentication", "session"];
+          ctx.event.action = "ssh_login";
+          ctx.event.outcome = "success";
+        } else if (ctx.system.auth.ssh.event == "Invalid" || ctx.system.auth.ssh.event == "Failed") {
+          ctx.event.type = ["info"];
+          ctx.event.category = ["authentication"];
+          ctx.event.action = "ssh_login";
+          ctx.event.outcome = "failure";
+        }
+  - append:
+      field: event.category
+      value: iam
+      if: ctx.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)
+  - set:
+      field: event.outcome
+      value: success
+      if: ctx.process?.name != null && ['groupadd', 'groupdel', 'groupmod', 'useradd', 'userdel', 'usermod'].contains(ctx.process.name)
+  - append:
+      field: event.type
+      value: user
+      if: ctx.process?.name != null && ['useradd', 'userdel', 'usermod'].contains(ctx.process.name)
+  - append:
+      field: event.type
+      value: group
+      if: ctx.process?.name != null && ['groupadd', 'groupdel', 'groupmod'].contains(ctx.process.name)
+  - append:
+      field: event.type
+      value: creation
+      if: ctx.process?.name != null && ['useradd', 'groupadd'].contains(ctx.process.name)
+  - append:
+      field: event.type
+      value: deletion
+      if: ctx.process?.name != null && ['userdel', 'groupdel'].contains(ctx.process.name)
+  - append:
+      field: event.type
+      value: change
+      if: ctx.process?.name != null && ['usermod', 'groupmod'].contains(ctx.process.name)
+  - append:
+      field: related.user
+      value: "{{{ user.name }}}"
+      allow_duplicates: false
+      if: ctx.user?.name != null && ctx.user?.name != ''
+  - append:
+      field: related.user
+      value: "{{{ user.effective.name }}}"
+      allow_duplicates: false
+      if: ctx.user?.effective?.name != null && ctx.user?.effective?.name != ''
+  - append:
+      field: related.ip
+      value: "{{{ source.ip }}}"
+      allow_duplicates: false
+      if: ctx.source?.ip != null && ctx.source?.ip != ''
+  - append:
+      field: related.hosts
+      value: "{{{ host.hostname }}}"
+      allow_duplicates: false
+      if: ctx.host?.hostname != null && ctx.host?.hostname != ''
+  - set:
+      field: ecs.version
+      value: 8.0.0
+  - remove:
+      field: event.original
+      if: "ctx?.tags == null || !(ctx.tags.contains('preserve_original_event'))"
+      ignore_failure: true
+      ignore_missing: true
 on_failure:
-- set:
-    field: error.message
-    value: '{{ _ingest.on_failure_message }}'
+  - set:
+      field: error.message
+      value: '{{{ _ingest.on_failure_message }}}'

--- a/filebeat/module/system/auth/ingest/pipeline.yml
+++ b/filebeat/module/system/auth/ingest/pipeline.yml
@@ -4,13 +4,10 @@ processors:
   - set:
       field: event.ingested
       copy_from: _ingest.timestamp
-  - set:
-      if: ctx.message != null
-      copy_from: message
-      field: event.original
-      override: false
-  - remove:
+  - rename:
+      if: ctx.event?.original == null
       field: message
+      target_field: event.original
       ignore_missing: true
   - grok:
       description: Grok the message header.

--- a/filebeat/module/system/auth/ingest/pipeline.yml
+++ b/filebeat/module/system/auth/ingest/pipeline.yml
@@ -17,9 +17,7 @@ processors:
       tag: grok-message-header
       field: event.original
       pattern_definitions:
-        GREEDYMULTILINE: |-
-          (.|
-          )*
+        GREEDYMULTILINE: '(.|\n)*'
         TIMESTAMP: (?:%{TIMESTAMP_ISO8601}|%{SYSLOGTIMESTAMP})
       patterns:
         - '^%{TIMESTAMP:system.auth.timestamp} %{SYSLOGHOST:host.hostname}? %{DATA:process.name}(?:\[%{POSINT:process.pid:long}\])?:%{SPACE}+%{GREEDYMULTILINE:_temp.message}$'

--- a/filebeat/module/system/auth/manifest.yml
+++ b/filebeat/module/system/auth/manifest.yml
@@ -10,6 +10,8 @@ var:
       # ssh logs to files
       - /var/log/secure.log*
     os.windows: []
+  - name: tags
+    default: []
 
 ingest_pipeline: ingest/pipeline.yml
 input: config/auth.yml

--- a/filebeat/module/system/auth/test/auth-ubuntu1204.log-expected.json
+++ b/filebeat/module/system/auth/test/auth-ubuntu1204.log-expected.json
@@ -1381,7 +1381,7 @@
         "host.hostname": "precise32",
         "input.type": "log",
         "log.offset": 11099,
-        "message": " vagrant : (command continued) '/etc/metricbeat/metricbeat.yml)",
+        "message": "vagrant : (command continued) '/etc/metricbeat/metricbeat.yml)",
         "process.name": "sudo",
         "related.hosts": [
             "precise32"

--- a/filebeat/module/system/auth/test/secure-rhel7.log-expected.json
+++ b/filebeat/module/system/auth/test/secure-rhel7.log-expected.json
@@ -10,7 +10,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -72,7 +71,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -134,7 +132,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -264,7 +261,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -326,7 +322,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -388,7 +383,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -450,7 +444,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -512,7 +505,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -680,7 +672,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -742,7 +733,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -808,7 +798,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -870,7 +859,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -936,7 +924,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -998,7 +985,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1077,7 +1063,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1139,7 +1124,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1269,7 +1253,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1331,7 +1314,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1393,7 +1375,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1455,7 +1436,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1517,7 +1497,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1647,7 +1626,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1709,7 +1687,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1771,7 +1748,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1833,7 +1809,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -1895,7 +1870,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2025,7 +1999,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2091,7 +2064,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2157,7 +2129,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2274,7 +2245,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2336,7 +2306,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2398,7 +2367,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2460,7 +2428,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2522,7 +2489,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -2652,7 +2618,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",

--- a/filebeat/module/system/auth/test/test.log-expected.json
+++ b/filebeat/module/system/auth/test/test.log-expected.json
@@ -11,7 +11,6 @@
         "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_success",
             "info"
         ],
         "fileset.name": "auth",
@@ -49,7 +48,6 @@
         "event.outcome": "success",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_success",
             "info"
         ],
         "fileset.name": "auth",
@@ -85,7 +83,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",
@@ -119,7 +116,6 @@
         "event.outcome": "failure",
         "event.timezone": "-02:00",
         "event.type": [
-            "authentication_failure",
             "info"
         ],
         "fileset.name": "auth",


### PR DESCRIPTION
## What does this PR do?

Sync the pipeline for the system.auth dataset with the Fleet integration
from https://github.com/elastic/integrations/pull/3705.

This removes the event.type authentication_failed and authentication_success
values which are not allowed as per ECS. You can use event.category: authentication
and event.outcome: success/failure to query instead.

## Why is it important?

This should make the pipeline more efficient and it aligns the event.type field to ECS.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues


- Relates [#123](https://github.com/elastic/integrations/pull/3705)
