### PR TITLE
Disable the EOL Windows 2008 r2 in 7.17 to fix build

### DIFF
--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -74,11 +74,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-8"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-7:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -72,11 +72,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/winlogbeat/Jenkinsfile.yml
+++ b/winlogbeat/Jenkinsfile.yml
@@ -44,11 +44,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-10:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -72,11 +72,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -69,11 +69,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -85,11 +85,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -70,11 +70,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -90,11 +90,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/osquerybeat/Jenkinsfile.yml
+++ b/x-pack/osquerybeat/Jenkinsfile.yml
@@ -58,11 +58,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -73,11 +73,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/winlogbeat/Jenkinsfile.yml
+++ b/x-pack/winlogbeat/Jenkinsfile.yml
@@ -54,11 +54,12 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-10"
         stage: extended_win
-    windows-2008:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-2008-r2"
-        stage: extended_win
+    # EOL: can't install terraform https://github.com/elastic/beats/issues/32327
+    # windows-2008:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-2008-r2"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
Disable windows-2008-r2 builds as they fail setup, example: https://github.com/elastic/beats/issues/32327. We haven't had a successful 7.17 build in weeks.

Windows 2008 R2 is EOL, and is the same underlying OS as Windows 7 which for some reason still works.

Removing it from the build while we work out how to fix the setup issues. Ideally we would remove EOL releases from the support matrix but that can't be done as quickly as removing it from the test targets. Windows 2008 was already disabled for several beats.

It is highly unlikely someone is still using this Windows version and submitting support cases. Product telemetry shows zero Windows 7 users for example.