### PR TITLE
[+DOC] Filebeat output Kafka workers

### DIFF
--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -238,6 +238,12 @@ metadata for the configured topics. The default is false.
 
 *`retry.backoff`*:: Waiting time between retries during leader elections. Default is 250ms.
 
+===== `workers`
+
+The number of workers per configured host publishing events to Kafka. This is best used with 
+load balancing mode enabled. Example: If you have 2 hosts and 3 workers, in total 
+6 workers are started (3 for each host).
+
 ===== `max_retries`
 
 ifdef::ignores_max_retries[]


### PR DESCRIPTION
👋 Howdy! 

## What does this PR do?
I believe [this default config](https://github.com/elastic/beats/blob/master/filebeat/filebeat.reference.yml#L1789) demonstrates that the Kafka output should have a `worker` config. I've copied the text over from the [Logstash doc](https://www.elastic.co/guide/en/beats/filebeat/current/logstash-output.html#_worker_2). Will you confirm? 🙏🏼


## Why is it important?
Documents key setting for throughput performance gains.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

## How to test this PR locally

## Related issues

## Use cases

## Screenshots

## Logs
