### PR TITLE
Update the port, documentation for vsphere module

### DIFF
--- a/metricbeat/docs/modules/vsphere.asciidoc
+++ b/metricbeat/docs/modules/vsphere.asciidoc
@@ -9,7 +9,8 @@ This file is generated! See scripts/mage/docs_collector.go
 [[metricbeat-module-vsphere]]
 == vSphere module
 
-The vSphere module uses the https://github.com/vmware/govmomi[Govmomi] library to collect metrics from any Vmware SDK URL (ESXi/VCenter). This library is built for and tested against ESXi and vCenter 5.5, 6.0 and 6.5.
+The vSphere module uses the https://github.com/vmware/govmomi[Govmomi] library to collect metrics from any Vmware SDK URL (ESXi/VCenter). 
+This library is built for and tested against ESXi and vCenter 6.5, 6.7 and 7.0.
 
 By default it enables the metricsets `datastore`, `host` and `virtualmachine`.
 
@@ -37,7 +38,7 @@ metricbeat.modules:
   enabled: true
   metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
-  hosts: ["https://localhost/sdk"]
+  hosts: ["https://localhost:8989/sdk"]
 
   username: "user"
   password: "password"

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -951,7 +951,7 @@ metricbeat.modules:
   enabled: true
   metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
-  hosts: ["https://localhost/sdk"]
+  hosts: ["https://localhost:8989/sdk"]
 
   username: "user"
   password: "password"

--- a/metricbeat/module/vsphere/_meta/README.md
+++ b/metricbeat/module/vsphere/_meta/README.md
@@ -15,7 +15,7 @@ export GOPATH=/directory/code
 
 2. Install Govcsim
 ```
-go get -u github.com/vmware/vic/cmd/vcsim
+go get -u github.com/vmware/govmomi/vcsim
 ```
 
 3. Run Govcsim

--- a/metricbeat/module/vsphere/_meta/config.reference.yml
+++ b/metricbeat/module/vsphere/_meta/config.reference.yml
@@ -2,7 +2,7 @@
   enabled: true
   metricsets: ["datastore", "host", "virtualmachine"]
   period: 10s
-  hosts: ["https://localhost/sdk"]
+  hosts: ["https://localhost:8989/sdk"]
 
   username: "user"
   password: "password"

--- a/metricbeat/module/vsphere/_meta/config.yml
+++ b/metricbeat/module/vsphere/_meta/config.yml
@@ -4,7 +4,7 @@
   #  - host
   #  - virtualmachine
   period: 10s
-  hosts: ["https://localhost/sdk"]
+  hosts: ["https://localhost:8989/sdk"]
 
   username: "user"
   password: "password"

--- a/metricbeat/module/vsphere/_meta/docs.asciidoc
+++ b/metricbeat/module/vsphere/_meta/docs.asciidoc
@@ -1,4 +1,5 @@
-The vSphere module uses the https://github.com/vmware/govmomi[Govmomi] library to collect metrics from any Vmware SDK URL (ESXi/VCenter). This library is built for and tested against ESXi and vCenter 5.5, 6.0 and 6.5.
+The vSphere module uses the https://github.com/vmware/govmomi[Govmomi] library to collect metrics from any Vmware SDK URL (ESXi/VCenter). 
+This library is built for and tested against ESXi and vCenter 6.5, 6.7 and 7.0.
 
 By default it enables the metricsets `datastore`, `host` and `virtualmachine`.
 

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -7,7 +7,7 @@
   #  - host
   #  - virtualmachine
   period: 10s
-  hosts: ["https://localhost/sdk"]
+  hosts: ["https://localhost:8989/sdk"]
 
   username: "user"
   password: "password"


### PR DESCRIPTION
- Bug
- Docs

## What does this PR do?

This PR updates the default config file for vsphere and updates the docs. 

## Why is it important?

The current config file usage doesn't retrieve the metrics from vsphere

z/## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/beats/issues/32383
