### PR TITLE
Update Filebeat modules documentation

### DIFF
--- a/filebeat/docs/include/cisco-log-level.asciidoc
+++ b/filebeat/docs/include/cisco-log-level.asciidoc
@@ -1,4 +1,4 @@
-An integer between 1 and 7 that allows to filter messages based on the
+An integer between 1 and 7 that allows filtering messages based on the
 severity level. The different severity levels supported by the Cisco ASA are:
 
 [width="30%",cols="^1,2",options="header"]
@@ -19,6 +19,6 @@ example, `var.log_level: 3` will allow messages of level 1 (Alert), 2 (Critical)
 and 3 (Error). All other messages will be dropped.
 
 NOTE: The filtering is done in the ingest pipeline, if this setting is
-changed, the ingest pipeline need to be reloaded manyally. To reload
+changed, the ingest pipeline need to be reloaded manually. To reload
 the ingest pipeline, set `filebeat.overwrite_pipelines: true` and
-maually <<load-ingest-pipelines>>.
+manually <<load-ingest-pipelines>>.

--- a/filebeat/docs/include/cisco-log-level.asciidoc
+++ b/filebeat/docs/include/cisco-log-level.asciidoc
@@ -1,0 +1,24 @@
+An integer between 1 and 7 that allows to filter messages based on the
+severity level. The different severity levels supported by the Cisco ASA are:
+
+[width="30%",cols="^1,2",options="header"]
+|===========================
+| log_level | severity
+|     1     | Alert
+|     2     | Critical
+|     3     | Error
+|     4     | Warning
+|     5     | Notification
+|     6     | Informational
+|     7     | Debugging
+|===========================
+
+A value of 7 (default) will not filter any messages. A lower value will drop
+any messages with a severity level higher than the specified value. For
+example, `var.log_level: 3` will allow messages of level 1 (Alert), 2 (Critical)
+and 3 (Error). All other messages will be dropped.
+
+NOTE: The filtering is done in the ingest pipeline, if this setting is
+changed, the ingest pipeline need to be reloaded manyally. To reload
+the ingest pipeline, set `filebeat.overwrite_pipelines: true` and
+maually <<load-ingest-pipelines>>.

--- a/filebeat/docs/modules-overview.asciidoc
+++ b/filebeat/docs/modules-overview.asciidoc
@@ -28,7 +28,7 @@ and loads them to the respective {stack} components.
 
 If a module configuration is updated, the {es} ingest pipeline
 definition is not reloaded automatically. To reload the ingest
-pipeline, set `filebeat.overwrite_pipelines: true` and maually
+pipeline, set `filebeat.overwrite_pipelines: true` and manually
 <<load-ingest-pipelines, load the ingest pipelines>>.
 
 [float]

--- a/filebeat/docs/modules-overview.asciidoc
+++ b/filebeat/docs/modules-overview.asciidoc
@@ -26,6 +26,11 @@ log files.
 {beatname_uc} automatically adjusts these configurations based on your environment
 and loads them to the respective {stack} components.
 
+If a module configuration is updated, the {es} ingest pipeline
+definition is not reloaded automatically. To reload the ingest
+pipeline, set `filebeat.overwrite_pipelines: true` and maually
+<<load-ingest-pipelines, load the ingest pipelines>>.
+
 [float]
 === Get started
 

--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -78,25 +78,7 @@ include::../include/var-paths.asciidoc[]
 
 *`var.log_level`*::
 
-An integer between 1 and 7 that allows to filter messages based on the
-severity level. The different severity levels supported by the Cisco ASA are:
-
-[width="30%",cols="^1,2",options="header"]
-|===========================
-| log_level | severity
-|     1     | Alert
-|     2     | Critical
-|     3     | Error
-|     4     | Warning
-|     5     | Notification
-|     6     | Informational
-|     7     | Debugging
-|===========================
-
-A value of 7 (default) will not filter any messages. A lower value will drop
-any messages with a severity level higher than the specified value. For
-example, `var.log_level: 3` will allow messages of level 1 (Alert), 2 (Critical)
-and 3 (Error). All other messages will be dropped.
+include::../include/cisco-log-level.asciidoc[]
 
 *`var.syslog_host`*::
 
@@ -226,25 +208,7 @@ include::../include/var-paths.asciidoc[]
 
 *`var.log_level`*::
 
-An integer between 1 and 7 that allows to filter messages based on the
-severity level. The different severity levels supported by the Cisco ASA are:
-
-[width="30%",cols="^1,2",options="header"]
-|===========================
-| log_level | severity
-|     1     | Alert
-|     2     | Critical
-|     3     | Error
-|     4     | Warning
-|     5     | Notification
-|     6     | Informational
-|     7     | Debugging
-|===========================
-
-A value of 7 (default) will not filter any messages. A lower value will drop
-any messages with a severity level higher than the specified value. For
-example, `var.log_level: 3` will allow messages of level 1 (Alert), 2 (Critical)
-and 3 (Error). All other messages will be dropped.
+include::../include/cisco-log-level.asciidoc[]
 
 *`var.syslog_host`*::
 

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -71,25 +71,7 @@ include::../include/var-paths.asciidoc[]
 
 *`var.log_level`*::
 
-An integer between 1 and 7 that allows to filter messages based on the
-severity level. The different severity levels supported by the Cisco ASA are:
-
-[width="30%",cols="^1,2",options="header"]
-|===========================
-| log_level | severity
-|     1     | Alert
-|     2     | Critical
-|     3     | Error
-|     4     | Warning
-|     5     | Notification
-|     6     | Informational
-|     7     | Debugging
-|===========================
-
-A value of 7 (default) will not filter any messages. A lower value will drop
-any messages with a severity level higher than the specified value. For
-example, `var.log_level: 3` will allow messages of level 1 (Alert), 2 (Critical)
-and 3 (Error). All other messages will be dropped.
+include::../include/cisco-log-level.asciidoc[]
 
 *`var.syslog_host`*::
 
@@ -219,25 +201,7 @@ include::../include/var-paths.asciidoc[]
 
 *`var.log_level`*::
 
-An integer between 1 and 7 that allows to filter messages based on the
-severity level. The different severity levels supported by the Cisco ASA are:
-
-[width="30%",cols="^1,2",options="header"]
-|===========================
-| log_level | severity
-|     1     | Alert
-|     2     | Critical
-|     3     | Error
-|     4     | Warning
-|     5     | Notification
-|     6     | Informational
-|     7     | Debugging
-|===========================
-
-A value of 7 (default) will not filter any messages. A lower value will drop
-any messages with a severity level higher than the specified value. For
-example, `var.log_level: 3` will allow messages of level 1 (Alert), 2 (Critical)
-and 3 (Error). All other messages will be dropped.
+include::../include/cisco-log-level.asciidoc[]
 
 *`var.syslog_host`*::
 


### PR DESCRIPTION
## What does this PR do?

Filebeat module documentation now make it clear that ingest pipelines
are not automatically reloaded automatically.

The Cisco module documentation is also updated making it explicity the
log level filtering is done in the ingest pipeline.

## Why is it important?

It makes the current behaviour more clear

## Checklist


- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~


## How to test this PR locally
1. Clone [bea](https://github.com/elastic/beats) and [docs](https://github.com/elastic/docs) on the same folder
2. Change the directory to `beats/filebeat` (`cd beats/filebeat`)
3. Build the docs: `../../docs/build_docs --verbose --doc ./docs/index.asciidoc --all --rebuild --open`

## Related issues
- Closes #30166

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
