### PR TITLE
Fix race condition when reloading configuration

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Expand fields in `decode_json_fields` if target is set. {issue}31712[31712] {pull}32010[32010]
 - Fix OS name reported by add_host_metadata on Windows 11. {issue}30833[30833] {pull}32259[32259]
 - Fix race condition when reloading runners {pull}32309[32309]
+- Fix race condition when stopping runners {pull}32433[32433]
 
 *Auditbeat*
 

--- a/libbeat/autodiscover/autodiscover_test.go
+++ b/libbeat/autodiscover/autodiscover_test.go
@@ -533,7 +533,7 @@ func TestAutodiscoverWithMutlipleEntries(t *testing.T) {
 	wait(t, func() bool { return len(adapter.Runners()) == 3 })
 	runners = adapter.Runners()
 	// Ensure the first config is the same as before
-	fmt.Println(runners)
+	t.Log(runners)
 	assert.Equal(t, len(runners), 3)
 	assert.Equal(t, len(autodiscover.configs["mock:foo"]), 2)
 	check(t, runners, conf.MustNewConfigFrom(map[string]interface{}{"a": "b"}), true, false)
@@ -571,6 +571,7 @@ func TestAutodiscoverWithMutlipleEntries(t *testing.T) {
 }
 
 func wait(t *testing.T, test func() bool) {
+	t.Helper()
 	sleep := 20 * time.Millisecond
 	ready := test()
 	for !ready && sleep < 10*time.Second {
@@ -585,6 +586,7 @@ func wait(t *testing.T, test func() bool) {
 }
 
 func check(t *testing.T, runners []*mockRunner, expected *conf.C, started, stopped bool) {
+	t.Helper()
 	for _, r := range runners {
 		if reflect.DeepEqual(expected, r.config) {
 			ok1 := assert.Equal(t, started, r.started)

--- a/libbeat/cfgfile/list.go
+++ b/libbeat/cfgfile/list.go
@@ -87,11 +87,11 @@ func (r *RunnerList) Reload(configs []*reload.ConfigWithMeta) error {
 		wg.Add(1)
 		r.logger.Debugf("Stopping runner: %s", runner)
 		delete(r.runners, hash)
-		go func() {
+		go func(runner Runner) {
 			defer wg.Done()
 			runner.Stop()
 			r.logger.Debugf("Runner: '%s' has stopped", runner)
-		}()
+		}(runner)
 		moduleStops.Add(1)
 	}
 


### PR DESCRIPTION
## What does this PR do?

This commit fixes the race condition introduced by
f3d1010029d436807c9cc90234c79e724cfe3f39 that aimed to fix some race
conditions.

A test has its logging updated to use t.Log, so it only logs when
verbosity is on and test line issuing the log is also shown.

Some t.Helper() calls are also added.

## Why is it important?

It fixes a bug

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [x] I have made corresponding changes to the documentation~~
~~- [x] I have made corresponding change to the default configuration files~~
~~- [x] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally
`TestAutodiscoverWithMutlipleEntries` from `libbeat/autodiscover/autodiscover_test.go` fails intermittently if the bug is not fixed. A set of 5 consecutive runs always triggered the bug for me. So to verify the fix, just run that test a few times:
```
cd libbeat/autodiscover/
go test -run="TestAutodiscoverWithMutlipleEntries" -count 100
```

100 runs takes about 10s on my machine. All tests must pass.

## Related issues
- Fixes https://github.com/elastic/beats/issues/32337
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~