### PR TITLE
Remove Kafka worker from reference config.

### DIFF
--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -747,9 +747,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1880,9 +1880,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -893,9 +893,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/libbeat/_meta/config/output-kafka.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-kafka.reference.yml.tmpl
@@ -64,9 +64,6 @@
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1620,9 +1620,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -1248,9 +1248,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -683,9 +683,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -803,9 +803,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -4209,9 +4209,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -893,9 +893,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -2166,9 +2166,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -1248,9 +1248,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -685,9 +685,6 @@ output.elasticsearch:
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
 
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
-
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.
   # Some Beats, such as Filebeat, ignore the max_retries setting and retry until


### PR DESCRIPTION
Follow up from https://github.com/elastic/beats/pull/31978 where the worker documentation was removed but the setting was not removed from the reference configuration file.

Quoting the original reasoning for removing this:

> - Relates #4492: Before this PR, the `worker` setting was used to create multiple `sarama.AsyncProducer`. After it, the `worker` setting only makes [`hosts` entries duplicated](https://github.com/elastic/beats/blob/7102be4e5594f158c2b80ff075246d5eab94bebe/libbeat/outputs/hosts.go#L43-L43) for [calling `sarama.NewAsyncProducer`](https://github.com/elastic/beats/blob/7102be4e5594f158c2b80ff075246d5eab94bebe/libbeat/outputs/kafka/client.go#L123-L123), which does not have any positive effect, but a little overhead for [metadata refresh](https://github.com/Shopify/sarama/blob/30b9203a2d27a1d723a223093753453436084e73/client.go#L891-L891).

