### PR TITLE
Add warning about filestream duplication without unique IDs in documentation

### DIFF
--- a/filebeat/docs/filebeat-options.asciidoc
+++ b/filebeat/docs/filebeat-options.asciidoc
@@ -21,11 +21,13 @@ input type more than once. For example:
 ["source","yaml",subs="attributes"]
 ----
 {beatname_lc}.inputs:
-- type: log
+- type: filestream
+  id: my-filestream-id <1>
   paths:
     - /var/log/system.log
     - /var/log/wifi.log
-- type: log
+- type: filestream
+  id: apache-filestream-id
   paths:
     - "/var/log/apache2/*"
   fields:
@@ -33,14 +35,16 @@ input type more than once. For example:
   fields_under_root: true
 ----
 
+<1> Each filestream input must have a unique ID to allow tracking the state of files.
+
 For the most basic configuration, define a single input with a single path. For
 example:
 
 [source,yaml]
 -------------------------------------------------------------------------------------
 filebeat.inputs:
-- type: log
-  enabled: true
+- type: filestream
+  id: my-filestream-id
   paths:
     - /var/log/*.log
 -------------------------------------------------------------------------------------
@@ -74,7 +78,7 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-httpjson>>
 * <<{beatname_lc}-input-journald>>
 * <<{beatname_lc}-input-kafka>>
-* <<{beatname_lc}-input-log>>
+* <<{beatname_lc}-input-log>> (deprecated in 7.16.0, use <<{beatname_lc}-input-filestream>>)
 * <<{beatname_lc}-input-mqtt>>
 * <<{beatname_lc}-input-netflow>>
 * <<{beatname_lc}-input-o365audit>>
@@ -83,7 +87,6 @@ You can configure {beatname_uc} to use the following inputs:
 * <<{beatname_lc}-input-syslog>>
 * <<{beatname_lc}-input-tcp>>
 * <<{beatname_lc}-input-udp>>
-
 
 include::multiline.asciidoc[]
 

--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -49,7 +49,7 @@ Example configuration:
 ----
 
 WARNING: Each filestream input must have a unique ID. Omitting or changing the filestream ID may cause
-data duplication. Without a unique ID filestream is unable to correctly track the state of files.
+data duplication. Without a unique ID, filestream is unable to correctly track the state of files.
 
 You can apply additional
 <<{beatname_lc}-input-{type}-options,configuration settings>> (such as `fields`,

--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -48,7 +48,7 @@ Example configuration:
     - /var/log/*.log
 ----
 
-WARNING: Each filestream input must have a unique ID. Omitting or changing the input ID may cause
+WARNING: Each filestream input must have a unique ID. Omitting or changing the filestream ID may cause
 data duplication. Without a unique ID filestream is unable to correctly track the state of files.
 
 You can apply additional
@@ -69,7 +69,7 @@ multiple input sections:
     - /var/log/system.log
     - /var/log/wifi.log
 - type: filestream <2>
-  id: bar
+  id: apache-filestream-id
   paths:
     - "/var/log/apache2/*"
   fields:

--- a/filebeat/docs/inputs/input-filestream.asciidoc
+++ b/filebeat/docs/inputs/input-filestream.asciidoc
@@ -48,6 +48,8 @@ Example configuration:
     - /var/log/*.log
 ----
 
+WARNING: Each filestream input must have a unique ID. Omitting or changing the input ID may cause
+data duplication. Without a unique ID filestream is unable to correctly track the state of files.
 
 You can apply additional
 <<{beatname_lc}-input-{type}-options,configuration settings>> (such as `fields`,


### PR DESCRIPTION
I noticed looking at the filebeat documentation that we can improve how we guide users to the filestream input, and also further improve the callouts noting that filestream input IDs are mandatory.

I switched the default filestream example inputs [here](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html) from `log` to `filestream` and also added a note on the `log` input link that it is deprecated.

I also added some more warnings and notes about filestream IDs being required in the first locations users are likely to see a filestream configuration.