### PR TITLE
document how decode_xml_wineventlog maps fields

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -116,6 +116,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - httpjson input: Add `replaceAll` helper function to template context. {pull}32365[32365]
 - Optimize grok patterns in system.auth module pipeline. {pull}32360[32360]
 - Checkpoint module: add authentication operation outcome enrichment. {issue}32230[32230] {pull}32431[32431]
+- add documentation for decode_xml_wineventlog processor field mappings.  {pull}32456[32456]
 
 *Auditbeat*
 

--- a/libbeat/processors/decode_xml_wineventlog/docs/decode_xml_wineventlog.asciidoc
+++ b/libbeat/processors/decode_xml_wineventlog/docs/decode_xml_wineventlog.asciidoc
@@ -108,3 +108,58 @@ Will produce the following output:
 -------------------------------------------------------------------------------
 
 See <<conditions>> for a list of supported conditions.
+
+The field mappings are as follows:
+
+[cols="<m,<m,<d",options="header",]
+|========================================================
+| Event Field | Source XML Element | Notes
+| winlog.channel | <Event><System><Channel> |
+| winlog.event_id | <Event><System><EventID> |
+| winlog.provider_name | <Event><System><Provider> | `Name` attribute
+| winlog.record_id | <Event><System><EventRecordID> |
+| winlog.task | <Event><System><Task> |
+| winlog.computer_name | <Event><System><Computer> |
+| winlog.keywords | <Event><RenderingInfo><Keywords> | list of each `Keyword`
+| winlog.opcodes | <Event><RenderingInfo><Opcode> |
+| winlog.provider_guid | <Event><System><Provider> | `Guid` attribute
+| winlog.version | <Event><System><Version> |
+| winlog.time_created | <Event><System><TimeCreated> | `SystemTime` attribute
+| winlog.outcome | <Event><System><Keywords> | "success" if bit 0x20000000000000 is set, "failure" if 0x10000000000000 is set
+| winlog.level | <Event><System><Level> | converted to lowercase
+| winlog.message | <Event><RenderingInfo><Message> | line endings removed
+| winlog.user.identifier | <Event><System><Security><UserID> |
+| winlog.user.domain | <Event><System><Security><Domain> |
+| winlog.user.name | <Event><System><Security><Name> |
+| winlog.user.type | <Event><System><Security><Type> | converted from integer to String
+| winlog.event_data | <Event><EventData> | map where `Name` attribute in Data element is key, and value is the value of the Data element
+| winlog.user_data | <Event><UserData> | map where `Name` attribute in Data element is key, and value is the value of the Data element
+| winlog.activity_id | <Event><System><Correlation><ActivityID> |
+| winlog.related_activity_id | <Event><System><Correlation><RelatedActivityID> |
+| winlog.kernel_time | <Event><System><Execution><KernelTime> |
+| winlog.process.pid | <Event><System><Execution><ProcessID> |
+| winlog.process.thread.id | <Event><System><Execution><ThreadID> |
+| winlog.processor_id | <Event><System><Execution><ProcessorID> |
+| winlog.processor_time | <Event><System><Execution><ProcessorTime> |
+| winlog.session_id | <Event><System><Execution><SessionID> |
+| winlog.user_time | <Event><System><Execution><UserTime> |
+| winlog.error.code | <Event><ProcessingErrorData><ErrorCode> |
+|========================================================
+
+
+If `map_ecs_fields` is enabled then the following field mappings are also performed:
+
+[cols="<m,<m,<d",options="header",]
+|========================================================
+| Event Field | Source XML or other field | Notes
+| event.code | winlog.event_id |
+| event.kind | "event" |
+| event.provider | <Event><System><Provider> | `Name` attribute
+| event.action | <Event><RenderingInfo><Task> |
+| event.host.name | <Event><System><Computer> |
+| event.outcome | winlog.outcome |
+| log.level | winlog.level |
+| message | winlog.message |
+| error.code | winlog.error.code |
+| error.message | winlog.error.message |
+|========================================================


### PR DESCRIPTION
## What does this PR do?

Documents the field mappings for the `decode_xml_wineventlog` processor.

## Why is it important?

Needed so users will know what fields will be populated so they can filter on them in Conditionals or Logstash.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Screenshots
<img width="781" alt="Screen Shot 2022-07-21 at 14 57 41" src="https://user-images.githubusercontent.com/57081003/180309554-18b2c5af-ea7b-4f2b-96ee-fcfc988e25b4.png">

<img width="781" alt="Screen Shot 2022-07-21 at 14 58 14" src="https://user-images.githubusercontent.com/57081003/180309579-dd73b632-2c75-43c7-980f-ff677772b964.png">

