### PR TITLE
ci: disable windows-10/windows-11 for x-pack/auditbeat

### DIFF
--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -72,17 +72,17 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended_win
-    // See https://github.com/elastic/beats/issues/32499
-    // windows-11:
-    //     mage: "mage build unitTest"
-    //     platforms:             ## override default labels in this specific stage.
-    //         - "windows-11"
-    //     stage: extended_win
-    // windows-10:
-    //     mage: "mage build unitTest"
-    //     platforms:             ## override default labels in this specific stage.
-    //         - "windows-10"
-    //     stage: extended_win
+    # See https://github.com/elastic/beats/issues/32499
+    # windows-11:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-11"
+    #     stage: extended_win
+    # windows-10:
+    #     mage: "mage build unitTest"
+    #     platforms:             ## override default labels in this specific stage.
+    #         - "windows-10"
+    #     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -72,16 +72,17 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended_win
-    windows-11:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-11"
-        stage: extended_win
-    windows-10:
-        mage: "mage build unitTest"
-        platforms:             ## override default labels in this specific stage.
-            - "windows-10"
-        stage: extended_win
+    // See https://github.com/elastic/beats/issues/32499
+    // windows-11:
+    //     mage: "mage build unitTest"
+    //     platforms:             ## override default labels in this specific stage.
+    //         - "windows-11"
+    //     stage: extended_win
+    // windows-10:
+    //     mage: "mage build unitTest"
+    //     platforms:             ## override default labels in this specific stage.
+    //         - "windows-10"
+    //     stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

As long as there are test failures for windows-10 and windows-11 in the x-pack/auditbeat then let's disable to use them

## Why is it important?

Temporary fix until the team fixes the real issue with the windows-10/windows-11


## Issue

Test failure tracked https://github.com/elastic/beats/issues/32499