### PR TITLE
Auditbeat socket: Do not run socket allocation tests under Windows

### DIFF
--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build (linux && 386) || (linux && amd64)
+// +build linux,386 linux,amd64
+
 package helper
 
 import "time"

--- a/x-pack/auditbeat/module/system/socket/helper/linkedlist_test.go
+++ b/x-pack/auditbeat/module/system/socket/helper/linkedlist_test.go
@@ -2,6 +2,9 @@
 // or more contributor license agreements. Licensed under the Elastic License;
 // you may not use this file except in compliance with the Elastic License.
 
+//go:build (linux && 386) || (linux && amd64)
+// +build linux,386 linux,amd64
+
 package helper
 
 import (


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Sets Go's build flags in Auditbeat's system/socket dataset linked-list test so that it only runs under Linux (as the rest of the dataset).

## Why is it important?

The linkedlist zero-allocation checks are failing under Win10 & Win11 because one allocation is being reported.

## Related issues


- Closes #32483