### PR TITLE
Revert "ci: disable windows-10/windows-11 for x-pack/auditbeat (#32500)"

### DIFF
--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -72,17 +72,16 @@ stages:
         platforms:             ## override default labels in this specific stage.
             - "windows-2012-r2"
         stage: extended_win
-    # See https://github.com/elastic/beats/issues/32499
-    # windows-11:
-    #     mage: "mage build unitTest"
-    #     platforms:             ## override default labels in this specific stage.
-    #         - "windows-11"
-    #     stage: extended_win
-    # windows-10:
-    #     mage: "mage build unitTest"
-    #     platforms:             ## override default labels in this specific stage.
-    #         - "windows-10"
-    #     stage: extended_win
+    windows-11:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-11"
+        stage: extended_win
+    windows-10:
+        mage: "mage build unitTest"
+        platforms:             ## override default labels in this specific stage.
+            - "windows-10"
+        stage: extended_win
     windows-8:
         mage: "mage build unitTest"
         platforms:             ## override default labels in this specific stage.


### PR DESCRIPTION
## What does this PR do?

This reverts commit 95238c88c2f06bddcc65d70411c9cdba6b72f58e (#32500).

## Why is it important?

It's not necessary to disable win10/11 for x-pack/auditbeat as the underlying issue was fixed in #32501.
