### PR TITLE
[Heartbeat] Limit browser jobs to 2 by default

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -21,6 +21,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Heartbeat*
 - Browser monitors (beta) no write to the `synthetics-*` index prefix. {pull}32064[32064]
 - Setting a custom index for a given monitor is now deprecated. Streams are preferred. {pull}32064[32064]
+- Browserc monitors now default to a max concurrency of two. {pull}32564[32564]
 
 
 *Metricbeat*

--- a/heartbeat/config/config.go
+++ b/heartbeat/config/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	ConfigMonitors *conf.C              `config:"config.monitors"`
 	Scheduler      Scheduler            `config:"scheduler"`
 	Autodiscover   *autodiscover.Config `config:"autodiscover"`
-	Jobs           map[string]JobLimit  `config:"jobs"`
+	Jobs           map[string]*JobLimit `config:"jobs"`
 }
 
 type JobLimit struct {
@@ -47,7 +47,7 @@ type Scheduler struct {
 
 // DefaultConfig is the canonical instantiation of Config.
 var DefaultConfig = Config{
-	Jobs: map[string]JobLimit{
+	Jobs: map[string]*JobLimit{
 		"browser": {
 			Limit: 2,
 		},

--- a/heartbeat/config/config.go
+++ b/heartbeat/config/config.go
@@ -46,4 +46,10 @@ type Scheduler struct {
 }
 
 // DefaultConfig is the canonical instantiation of Config.
-var DefaultConfig = Config{}
+var DefaultConfig = Config{
+	Jobs: map[string]JobLimit{
+		"browser": {
+			Limit: 2,
+		},
+	},
+}

--- a/heartbeat/scheduler/schedjob_test.go
+++ b/heartbeat/scheduler/schedjob_test.go
@@ -99,7 +99,7 @@ func TestSchedJobRun(t *testing.T) {
 
 // testRecursiveForkingJob tests that a schedJob that splits into multiple parallel pieces executes without error
 func TestRecursiveForkingJob(t *testing.T) {
-	s := Create(1000, monitoring.NewRegistry(), tarawaTime(), map[string]config.JobLimit{
+	s := Create(1000, monitoring.NewRegistry(), tarawaTime(), map[string]*config.JobLimit{
 		"atype": {Limit: 1},
 	}, false)
 	ran := batomic.NewInt(0)

--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -76,6 +76,7 @@ func getJobLimitSem(jobLimitByType map[string]config.JobLimit) map[string]*semap
 	jobLimitSem := map[string]*semaphore.Weighted{}
 	for jobType, jobLimit := range jobLimitByType {
 		if jobLimit.Limit > 0 {
+			logp.L().Info("limiting to %d concurrent jobs for '%s' type", jobLimit, jobType)
 			jobLimitSem[jobType] = semaphore.NewWeighted(jobLimit.Limit)
 		}
 	}

--- a/heartbeat/scheduler/scheduler.go
+++ b/heartbeat/scheduler/scheduler.go
@@ -72,11 +72,11 @@ type Schedule interface {
 	RunOnInit() bool
 }
 
-func getJobLimitSem(jobLimitByType map[string]config.JobLimit) map[string]*semaphore.Weighted {
+func getJobLimitSem(jobLimitByType map[string]*config.JobLimit) map[string]*semaphore.Weighted {
 	jobLimitSem := map[string]*semaphore.Weighted{}
 	for jobType, jobLimit := range jobLimitByType {
 		if jobLimit.Limit > 0 {
-			logp.L().Info("limiting to %d concurrent jobs for '%s' type", jobLimit, jobType)
+			logp.L().Infof("limiting to %d concurrent jobs for '%s' type", jobLimit.Limit, jobType)
 			jobLimitSem[jobType] = semaphore.NewWeighted(jobLimit.Limit)
 		}
 	}
@@ -84,7 +84,7 @@ func getJobLimitSem(jobLimitByType map[string]config.JobLimit) map[string]*semap
 }
 
 // NewWithLocation creates a new Scheduler using the given runAt zone.
-func Create(limit int64, registry *monitoring.Registry, location *time.Location, jobLimitByType map[string]config.JobLimit, runOnce bool) *Scheduler {
+func Create(limit int64, registry *monitoring.Registry, location *time.Location, jobLimitByType map[string]*config.JobLimit, runOnce bool) *Scheduler {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	if limit < 1 {

--- a/heartbeat/scheduler/scheduler_test.go
+++ b/heartbeat/scheduler/scheduler_test.go
@@ -245,10 +245,10 @@ func TestSchedTaskLimits(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var jobConfigByType = map[string]config.JobLimit{}
+			var jobConfigByType = map[string]*config.JobLimit{}
 			jobType := "http"
 			if tt.limit > 0 {
-				jobConfigByType = map[string]config.JobLimit{
+				jobConfigByType = map[string]*config.JobLimit{
 					jobType: {Limit: tt.limit},
 				}
 			}


### PR DESCRIPTION
Fixes #32082 by limiting browser jobs to 2. Users can still override this with the global `heartbeat.jobs.browser.limit: 42`.

This also fixes a previously unknown bug, where changing the `heartbeat.jobs.*.limit` values would cause heartbeat to crash with a panic. This appears to be a bug in`go-ucfg`. The workaround this PR adds is moving from `map[string]JobLimit` to `map[string]*JobLimit`, which doesn't trigger the same reflection issues.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

The new log message should help confirm this works. It's kind of hard to test perfectly otherwise, but we don't need to add new tests for the job limit system.