### PR TITLE
Clarify that at least one fileset must be enabled in a filebeat

### DIFF
--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -87,8 +87,9 @@ following command enables the +{modulename}+ module config:
 include::{libbeat-dir}/tab-widgets/enable-modules-widget.asciidoc[]
 --
 
-. In the module config under `modules.d`, enable the desired datasets and
-change the module settings to match your environment. **Datasets are disabled by default.**
+. In the module config under `modules.d`, change the module settings to match
+your environment. You must enable at least one fileset in the module.
+**Filesets are disabled by default.**
 +
 For example, log locations are set based on the OS. If your logs aren't in
 default locations, set the `paths` variable:

--- a/filebeat/docs/include/configuring-intro.asciidoc
+++ b/filebeat/docs/include/configuring-intro.asciidoc
@@ -5,3 +5,6 @@
 You can further refine the behavior of the +{modulename}+ module by specifying
 <<{modulename}-settings,variable settings>> in the
 +modules.d/{modulename}.yml+ file, or overriding settings at the command line.
+
+You must enable at least one fileset in the module.
+**Filesets are disabled by default.**

--- a/libbeat/docs/release-notes/breaking/breaking-8.0.asciidoc
+++ b/libbeat/docs/release-notes/breaking/breaking-8.0.asciidoc
@@ -83,6 +83,16 @@ version of the operating system.
 * MacOS 10.13
 * MacOS 10.14
 
+[discrete]
+==== {filebeat} filesets are disabled by default
+Prior to version 8.0.0, modules had some filesets that were enabled by default.
+This meant that in some cases you could enable a module from the command line
+and run it without modifying the configuration in the `modules.d` directory.
+However this caused problems for some users.
+
+Starting in version 8.0.0, filesets are disabled by default. You must explicitly
+enable the filesets you want {filebeat} to use.
+
 // end::notable-breaking-changes[]
 
 


### PR DESCRIPTION
## What does this PR do?

* Edit the explanation about enabling datasets. Changes the term "dataset" to "fileset" to be consistent with terminology used throughout the Filebeat Reference. If "dataset" is prefered over "fileset," we must change it across all the Filebeat docs.
* Update the wording to match https://github.com/elastic/observability-docs/pull/2053. I'm trying to be explicit here so users know that they must enable at least one fileset.
* Update shared text so that the docs about configuring each module indicate that users must enable at least one module.

Related to https://github.com/elastic/observability-docs/issues/1043.


