### PR TITLE
Add ulimit setting to debian containers in mage build

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Fix counter for number of events published in `httpjson` input. {pull}31993[31993]
 - Fix handling of Checkpoint event for R81. {issue}32380[32380] {pull}32458[32458]
+- Fix a hang on `apt-get update` stage in packaging. {pull}32580[32580]
 
 *Heartbeat*
 

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -296,6 +296,15 @@ func (b GolangCrossBuilder) Build() error {
 		verbose = "true"
 	}
 	var args []string
+	// There's a bug on certain debian versions:
+	// https://discuss.linuxcontainers.org/t/debian-jessie-containers-have-extremely-low-performance/1272
+	// basically, apt-get has a bug where will try to iterate through every possible FD as set by the NOFILE ulimit.
+	// On certain docker installs, docker will set the ulimit to a value > 10^9, which means apt-get will take >1 hour.
+	// This runs across all possible debian platforms, since there's no real harm in it.
+	if strings.Contains(b.Platform, "debian") {
+		args = append(args, "--ulimit", "nofile=262144:262144")
+	}
+
 	if runtime.GOOS != "windows" {
 		args = append(args,
 			"--env", "EXEC_UID="+strconv.Itoa(os.Getuid()),


### PR DESCRIPTION
## What does this PR do?

After a considerable amount of googling and `strace` yesterday, I learned that there's a bug in certain older versions of `apt-get` in debian, where it'll try to iterate through all possible FDs as set by internal linux system limits. This results in some amusing `strace` output:
```
fcntl(337334262, F_SETFD, FD_CLOEXEC)    = -1 EBADF (Bad file descriptor)
```
This only happens on certain docker installs where the docker daemon won't set the `NOFILE` ulimit in its containers. 

This fix just adds a `ulimit` flag to the docker invocation when needed.

## Why is it important?

On systems that hit this bug, `mage package` on filebeat can take up to an hour, purely due to the `apt-get update` operation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
