### PR TITLE
[Heartbeat] Update copy in info message to be less confusing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -22,6 +22,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Browser monitors (beta) no write to the `synthetics-*` index prefix. {pull}32064[32064]
 - Setting a custom index for a given monitor is now deprecated. Streams are preferred. {pull}32064[32064]
 - Browserc monitors now default to a max concurrency of two. {pull}32564[32564]
+- Change disabled monitor log message copy to avoid term `plugin`. {pull}32581[32581]
 
 
 *Metricbeat*

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -35,7 +35,7 @@ import (
 )
 
 // ErrMonitorDisabled is returned when the monitor plugin is marked as disabled.
-var ErrMonitorDisabled = fmt.Errorf("monitor not loaded, disabled with enabled: false")
+var ErrMonitorDisabled = fmt.Errorf("monitor not loaded because its 'enabled' key was set to false")
 
 const (
 	MON_INIT = iota

--- a/heartbeat/monitors/monitor.go
+++ b/heartbeat/monitors/monitor.go
@@ -35,7 +35,7 @@ import (
 )
 
 // ErrMonitorDisabled is returned when the monitor plugin is marked as disabled.
-var ErrMonitorDisabled = fmt.Errorf("monitor not loaded, plugin is disabled")
+var ErrMonitorDisabled = fmt.Errorf("monitor not loaded, disabled with enabled: false")
 
 const (
 	MON_INIT = iota


### PR DESCRIPTION
## What does this PR do?

Resolves #32424.

Changes the copy in an `info`-level message to avoid the term `plugin`, and instead name the config key that caused the monitor to be skipped.

## Why is it important?

The existing copy utilizes a term that is only internally used in Heartbeat. Plugin in this context does not appear in user-facing documentation or functionality.

## Checklist



- [x] My code follows the style guidelines of this project
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

To test this change, start Heartbeat with a disabled monitor with `enabled: false` in `heartbeat.yml`, and observe that the updated message appears in the log.

## Related issues


## Use cases

Using Heartbeat with a disabled monitor.

## Screenshots

## Logs

```
{"log.level":"info","@timestamp":"2022-08-02T15:59:50.242-0400","log.origin":{"file.name":"beater/heartbeat.go","file.line":148},"message":"skipping disabled monitor: monitor 'My Monitor' with id 'my-monitor' skipped: monitor not loaded, disabled with enabled: false","service.name":"heartbeat","ecs.version":"1.6.0"}
```