### PR TITLE
[automation] update elastic stack version for testing 7.17.6-02b91d00

### DIFF
--- a/testing/environments/snapshot-oss.yml
+++ b/testing/environments/snapshot-oss.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.17.6-74b6df3e-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.17.6-02b91d00-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -17,7 +17,7 @@ services:
     - "indices.id_field_data.enabled=true"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash-oss:7.17.6-74b6df3e-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash-oss:7.17.6-02b91d00-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -27,7 +27,7 @@ services:
     - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana-oss:7.17.6-74b6df3e-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana-oss:7.17.6-02b91d00-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600

--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6-74b6df3e-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6-02b91d00-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -22,7 +22,7 @@ services:
     - "ingest.geoip.downloader.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.17.6-74b6df3e-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.17.6-02b91d00-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -32,7 +32,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.6-74b6df3e-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.6-02b91d00-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600

--- a/x-pack/elastic-agent/pkg/artifact/download/http/downloader_test.go
+++ b/x-pack/elastic-agent/pkg/artifact/download/http/downloader_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -28,10 +27,8 @@ import (
 func TestDownloadBodyError(t *testing.T) {
 	// This tests the scenario where the download encounters a network error
 	// part way through the download, while copying the response body.
-	// Skipped on Windows where it frequently but not always fails.
-	if runtime.GOOS == "windows" {
-		t.Skip("Flaky test: https://github.com/elastic/beats/issues/31996")
-	}
+	// Skipped as it frequently but not always fails.
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/31996")
 
 	type connKey struct{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 2 Aug 2022 15:16:53 GMT, release_branch:7.17, prefix:, end_time:Tue, 2 Aug 2022 20:05:56 GMT, manifest_version:2.1.0, version:7.17.6-SNAPSHOT, branch:7.17, build_id:7.17.6-02b91d00, build_duration_seconds:17343]