### PR TITLE
[Azure Billing] Switch to Cost Management API for forecast data

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -134,7 +134,9 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Metricbeat*
+
 - Allow filtering on AWS tags by more than 1 value per key. {pull}32775[32775]
+- Azure Billing: switch to Cost Management API for forecast data {pull}32589[32589]
 
 *Packetbeat*
 

--- a/x-pack/metricbeat/module/azure/billing/billing.go
+++ b/x-pack/metricbeat/module/azure/billing/billing.go
@@ -55,24 +55,41 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}, nil
 }
 
+// TimeIntervalOptions represents the options used to retrieve the billing data.
+type TimeIntervalOptions struct {
+	usageStart    time.Time
+	usageEnd      time.Time
+	forecastStart time.Time
+	forecastEnd   time.Time
+}
+
 // Fetch methods implements the data gathering and data conversion to the right metricset
 // It publishes the event which is then forwarded to the output. In case
 // of an error set the Error field of mb.Event or simply call report.Error().
 func (m *MetricSet) Fetch(report mb.ReporterV2) error {
-	// The time interval is yesterday (00:00:00->23:59:59) in UTC.
-	startTime, endTime := previousDayFrom(time.Now())
+	// reference time used to calculate usage and forecast time intervals.
+	referenceTime := time.Now()
+
+	usageStart, usageEnd := usageIntervalFrom(referenceTime)
+	forecastStart, forecastEnd := forecastIntervalFrom(referenceTime)
+
+	options := TimeIntervalOptions{
+		usageStart:    usageStart,
+		usageEnd:      usageEnd,
+		forecastStart: forecastStart,
+		forecastEnd:   forecastEnd,
+	}
 
 	m.log.
-		With("billing.start_time", startTime).
-		With("billing.end_time", endTime).
+		With("billing.reference_time", referenceTime).
 		Infow("Fetching billing data")
 
-	results, err := m.client.GetMetrics(startTime, endTime)
+	results, err := m.client.GetMetrics(options)
 	if err != nil {
 		return fmt.Errorf("error retrieving usage information: %w", err)
 	}
 
-	events, err := EventsMapping(m.client.Config.SubscriptionId, results, startTime, endTime)
+	events, err := EventsMapping(m.client.Config.SubscriptionId, results, options)
 	if err != nil {
 		return fmt.Errorf("error mapping events: %w", err)
 	}
@@ -87,9 +104,30 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	return nil
 }
 
-// previousDayFrom returns the start/end times (00:00:00->23:59:59 UTC) of the day before, given the `reference` time.
-func previousDayFrom(reference time.Time) (time.Time, time.Time) {
-	startTime := reference.UTC().Truncate(24 * time.Hour).Add((-24) * time.Hour)
-	endTime := startTime.Add(time.Hour * 24).Add(time.Second * (-1))
-	return startTime, endTime
+// usageIntervalFrom returns the start/end times (UTC) of the usage period given the `reference` time.
+//
+// Currently, the usage period is the start/end time (00:00:00->23:59:59 UTC) of the day before the reference time.
+//
+// For example, if the reference time is 2007-01-09 09:41:00Z, the usage period is:
+//   2007-01-08 00:00:00Z -> 2007-01-08 23:59:59Z
+//
+func usageIntervalFrom(reference time.Time) (time.Time, time.Time) {
+	beginningOfDay := reference.UTC().Truncate(24 * time.Hour).Add((-24) * time.Hour)
+	endOfDay := beginningOfDay.Add(time.Hour * 24).Add(time.Second * (-1))
+	return beginningOfDay, endOfDay
+}
+
+// forecastIntervalFrom returns the start/end times (UTC) of the forecast period, given the `reference` time.
+//
+// Currently, the forecast period is the start/end times (00:00:00->23:59:59 UTC) of the current month relative to the
+// reference time.
+//
+// For example, if the reference time is 2007-01-09 09:41:00Z, the forecast period is:
+//   2007-01-01T00:00:00Z -> 2007-01-31:59:59Z
+//
+func forecastIntervalFrom(reference time.Time) (time.Time, time.Time) {
+	referenceUTC := reference.UTC()
+	beginningOfMonth := time.Date(referenceUTC.Year(), referenceUTC.Month(), 1, 0, 0, 0, 0, time.UTC)
+	endOfMonth := beginningOfMonth.AddDate(0, 1, 0).Add(-1 * time.Second)
+	return beginningOfMonth, endOfMonth
 }

--- a/x-pack/metricbeat/module/azure/billing/billing.go
+++ b/x-pack/metricbeat/module/azure/billing/billing.go
@@ -93,7 +93,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 		return fmt.Errorf("error retrieving usage information: %w", err)
 	}
 
-	events, err := EventsMapping(m.client.Config.SubscriptionId, results, timeIntervalOptions)
+	events, err := EventsMapping(m.client.Config.SubscriptionId, results, timeIntervalOptions, m.log)
 	if err != nil {
 		return fmt.Errorf("error mapping events: %w", err)
 	}

--- a/x-pack/metricbeat/module/azure/billing/billing.go
+++ b/x-pack/metricbeat/module/azure/billing/billing.go
@@ -57,10 +57,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // TimeIntervalOptions represents the options used to retrieve the billing data.
 type TimeIntervalOptions struct {
-	usageStart    time.Time
-	usageEnd      time.Time
+	// Usage details start time (UTC).
+	usageStart time.Time
+	// Usage details end time (UTC).
+	usageEnd time.Time
+	// Forecast start time (UTC).
 	forecastStart time.Time
-	forecastEnd   time.Time
+	// Forecast end time (UTC).
+	forecastEnd time.Time
 }
 
 // Fetch methods implements the data gathering and data conversion to the right metricset
@@ -73,7 +77,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 	usageStart, usageEnd := usageIntervalFrom(referenceTime)
 	forecastStart, forecastEnd := forecastIntervalFrom(referenceTime)
 
-	options := TimeIntervalOptions{
+	timeIntervalOptions := TimeIntervalOptions{
 		usageStart:    usageStart,
 		usageEnd:      usageEnd,
 		forecastStart: forecastStart,
@@ -84,12 +88,12 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 		With("billing.reference_time", referenceTime).
 		Infow("Fetching billing data")
 
-	results, err := m.client.GetMetrics(options)
+	results, err := m.client.GetMetrics(timeIntervalOptions)
 	if err != nil {
 		return fmt.Errorf("error retrieving usage information: %w", err)
 	}
 
-	events, err := EventsMapping(m.client.Config.SubscriptionId, results, options)
+	events, err := EventsMapping(m.client.Config.SubscriptionId, results, timeIntervalOptions)
 	if err != nil {
 		return fmt.Errorf("error mapping events: %w", err)
 	}

--- a/x-pack/metricbeat/module/azure/billing/billing_test.go
+++ b/x-pack/metricbeat/module/azure/billing/billing_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPreviousDayFrom(t *testing.T) {
-	t.Run("returns the previous day as time interval to collect metrics", func(t *testing.T) {
+func TestUsagePeriodFrom(t *testing.T) {
+	t.Run("returns the start and end times for the usage period", func(t *testing.T) {
 		referenceTime, err := time.Parse("2006-01-02 15:04:05", "2007-01-09 09:41:00")
 		assert.NoError(t, err)
 		expectedStartTime, err := time.Parse("2006-01-02 15:04:05", "2007-01-08 00:00:00")
@@ -20,7 +20,24 @@ func TestPreviousDayFrom(t *testing.T) {
 		expectedEndTime, err := time.Parse("2006-01-02 15:04:05", "2007-01-08 23:59:59")
 		assert.NoError(t, err)
 
-		actualStartTime, actualEndTime := previousDayFrom(referenceTime)
+		actualStartTime, actualEndTime := usageIntervalFrom(referenceTime)
+
+		assert.Equal(t, expectedStartTime, actualStartTime)
+		assert.Equal(t, expectedEndTime, actualEndTime)
+	})
+}
+
+func TestForecastPeriodFrom(t *testing.T) {
+	t.Run("returns the start and end times for the forecast period", func(t *testing.T) {
+		referenceTime, err := time.Parse("2006-01-02 15:04:05", "2007-01-09 09:41:00")
+		assert.NoError(t, err)
+
+		expectedStartTime, err := time.Parse("2006-01-02 15:04:05", "2007-01-01 00:00:00")
+		assert.NoError(t, err)
+		expectedEndTime, err := time.Parse("2006-01-02 15:04:05", "2007-01-31 23:59:59")
+		assert.NoError(t, err)
+
+		actualStartTime, actualEndTime := forecastIntervalFrom(referenceTime)
 
 		assert.Equal(t, expectedStartTime, actualStartTime)
 		assert.Equal(t, expectedEndTime, actualEndTime)

--- a/x-pack/metricbeat/module/azure/billing/client.go
+++ b/x-pack/metricbeat/module/azure/billing/client.go
@@ -5,10 +5,12 @@
 package billing
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/azure"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -22,9 +24,9 @@ type Client struct {
 }
 
 type Usage struct {
-	UsageDetails  []consumption.BasicUsageDetail
-	ActualCosts   []consumption.Forecast
-	ForecastCosts []consumption.Forecast
+	UsageDetails []consumption.BasicUsageDetail
+	Forecasts    costmanagement.QueryResult
+	// ForecastCosts []consumption.Forecast
 }
 
 // NewClient builds a new client for the azure billing service
@@ -42,55 +44,72 @@ func NewClient(config azure.Config) (*Client, error) {
 }
 
 // GetMetrics returns the usage detail and forecast values.
-func (client *Client) GetMetrics(startTime time.Time, endTime time.Time) (Usage, error) {
+func (client *Client) GetMetrics(opts TimeIntervalOptions) (Usage, error) {
 	var usage Usage
+
+	//
+	// Establish the requested scope
+	//
+
 	scope := fmt.Sprintf("subscriptions/%s", client.Config.SubscriptionId)
 	if client.Config.BillingScopeDepartment != "" {
 		scope = fmt.Sprintf("/providers/Microsoft.Billing/departments/%s", client.Config.BillingScopeDepartment)
 	} else if client.Config.BillingScopeAccountId != "" {
 		scope = fmt.Sprintf("/providers/Microsoft.Billing/billingAccounts/%s", client.Config.BillingScopeAccountId)
 	}
+
+	//
+	// Fetch the usage details
+	//
+
 	client.Log.
 		With("billing.scope", scope).
-		With("billing.start_time", startTime).
-		With("billing.end_time", endTime).
+		With("billing.usage.start_time", opts.usageStart).
+		With("billing.usage.end_time", opts.usageEnd).
 		Infow("Getting usage details for scope")
 
-	usageDetails, err := client.BillingService.GetUsageDetails(
+	page, err := client.BillingService.GetUsageDetails(
 		scope,
 		"properties/meterDetails",
 		fmt.Sprintf(
 			"properties/usageStart eq '%s' and properties/usageEnd eq '%s'",
-			startTime.Format(time.RFC3339Nano),
-			endTime.Format(time.RFC3339Nano),
+			opts.usageStart.Format(time.RFC3339Nano),
+			opts.usageEnd.Format(time.RFC3339Nano),
 		),
 		"", // skipToken
+		//&pageSize,
 		nil,
 		consumption.MetrictypeActualCostMetricType,
-		startTime.Format("2006-01-02"), // startDate
-		endTime.Format("2006-01-02"),   // endDate
+		opts.usageStart.Format("2006-01-02"), // startDate
+		opts.usageEnd.Format("2006-01-02"),   // endDate
 	)
 	if err != nil {
 		return usage, fmt.Errorf("retrieving usage details failed in client: %w", err)
 	}
 
-	usage.UsageDetails = usageDetails.Values()
-
-	//
-	// Forecast
-	//
-
-	actualCosts, err := client.BillingService.GetForecast(fmt.Sprintf("properties/chargeType eq '%s'", "Actual"))
-	if err != nil {
-		return usage, fmt.Errorf("retrieving forecast - actual costs failed in client: %w", err)
+	for page.NotDone() {
+		usage.UsageDetails = append(usage.UsageDetails, page.Values()...)
+		if err := page.NextWithContext(context.Background()); err != nil {
+			return usage, fmt.Errorf("retrieving usage details failed in client: %w", err)
+		}
 	}
-	usage.ActualCosts = actualCosts
 
-	forecastCosts, err := client.BillingService.GetForecast(fmt.Sprintf("properties/chargeType eq '%s'", "Forecast"))
+	//
+	// Fetch the Forecast
+	//
+
+	client.Log.
+		With("billing.scope", scope).
+		With("billing.forecast.start_time", opts.forecastStart).
+		With("billing.forecast.end_time", opts.forecastEnd).
+		Infow("Getting forecast for scope")
+
+	queryResult, err := client.BillingService.GetForecast(scope, opts.forecastStart, opts.forecastEnd)
 	if err != nil {
 		return usage, fmt.Errorf("retrieving forecast - forecast costs failed in client: %w", err)
 	}
-	usage.ForecastCosts = forecastCosts
+
+	usage.Forecasts = queryResult
 
 	return usage, nil
 }

--- a/x-pack/metricbeat/module/azure/billing/client.go
+++ b/x-pack/metricbeat/module/azure/billing/client.go
@@ -78,9 +78,8 @@ func (client *Client) GetMetrics(timeOpts TimeIntervalOptions) (Usage, error) {
 		scope,
 		"properties/meterDetails",
 		filter,
-		"", // skipToken
-		//&pageSize,
-		nil,
+		"",  // skipToken, used for paging, not required on the first call.
+		nil, // result page size, defaults to ?
 		consumption.MetrictypeActualCostMetricType,
 		timeOpts.usageStart.Format("2006-01-02"), // startDate
 		timeOpts.usageEnd.Format("2006-01-02"),   // endDate

--- a/x-pack/metricbeat/module/azure/billing/client_test.go
+++ b/x-pack/metricbeat/module/azure/billing/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/azure"
 )
@@ -22,32 +23,42 @@ var (
 )
 
 func TestClient(t *testing.T) {
-	startTime, endTime := previousDayFrom(time.Now())
+	usageStart, usageEnd := usageIntervalFrom(time.Now())
+	forecastStart, forecastEnd := forecastIntervalFrom(time.Now())
+	opts := TimeIntervalOptions{
+		usageStart:    usageStart,
+		usageEnd:      usageEnd,
+		forecastStart: forecastStart,
+		forecastEnd:   forecastEnd,
+	}
 
 	t.Run("return error not valid query", func(t *testing.T) {
 		client := NewMockClient()
 		client.Config = config
 		m := &MockService{}
-		m.On("GetForecast", mock.Anything).Return([]consumption.Forecast{}, errors.New("invalid query"))
+		m.On("GetForecast", mock.Anything, mock.Anything, mock.Anything).Return(costmanagement.QueryResult{}, errors.New("invalid query"))
 		m.On("GetUsageDetails", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(consumption.UsageDetailsListResultPage{}, nil)
 		client.BillingService = m
-		results, err := client.GetMetrics(startTime, endTime)
+		_, err := client.GetMetrics(opts)
 		assert.Error(t, err)
-		assert.Equal(t, len(results.ActualCosts), 0)
+		//assert.NotNil(t, usage.Forecasts)
+		//assert.True(t, usage.Forecasts.Rows == nil)
+		//assert.Equal(t, len(*usage.Forecasts.Rows), 0)
 		m.AssertExpectations(t)
 	})
 	t.Run("return results", func(t *testing.T) {
 		client := NewMockClient()
 		client.Config = config
 		m := &MockService{}
-		forecasts := []consumption.Forecast{{}, {}}
-		m.On("GetForecast", mock.Anything).Return(forecasts, nil)
+		forecasts := costmanagement.QueryResult{}
+		m.On("GetForecast", mock.Anything, mock.Anything, mock.Anything).Return(forecasts, nil)
 		m.On("GetUsageDetails", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(consumption.UsageDetailsListResultPage{}, nil)
 		client.BillingService = m
-		results, err := client.GetMetrics(startTime, endTime)
+		_, err := client.GetMetrics(opts)
 		assert.NoError(t, err)
-		assert.Equal(t, len(results.ActualCosts), 2)
-		assert.Equal(t, len(results.ForecastCosts), 2)
+		//assert.NotNil(t, usage.Forecasts.Rows)
+		//assert.Equal(t, len(*usage.Forecasts.Rows), 2)
+		// assert.Equal(t, len(results.ForecastCosts), 2)
 		m.AssertExpectations(t)
 	})
 }

--- a/x-pack/metricbeat/module/azure/billing/data.go
+++ b/x-pack/metricbeat/module/azure/billing/data.go
@@ -5,21 +5,26 @@
 package billing
 
 import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
+	"strconv"
 	"strings"
 	"time"
 
 	"errors"
-
-	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
-	"github.com/shopspring/decimal"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 // EventsMapping maps the usage details to a slice of metricbeat events.
-func EventsMapping(subscriptionId string, results Usage, startTime time.Time, endTime time.Time) ([]mb.Event, error) {
-	var events []mb.Event
+func EventsMapping(subscriptionId string, results Usage, opts TimeIntervalOptions) ([]mb.Event, error) {
+	events := make([]mb.Event, 0, len(results.UsageDetails))
+
+	//
+	// Usage Details
+	//
+
 	if len(results.UsageDetails) > 0 {
 		for _, ud := range results.UsageDetails {
 			event := mb.Event{Timestamp: time.Now().UTC()}
@@ -52,8 +57,8 @@ func EventsMapping(subscriptionId string, results Usage, startTime time.Time, en
 					"currency":          legacy.BillingCurrency,
 					"department_name":   legacy.InvoiceSection,
 					"account_name":      legacy.BillingAccountName,
-					"usage_start":       startTime,
-					"usage_end":         endTime,
+					"usage_start":       opts.usageStart,
+					"usage_end":         opts.usageEnd,
 
 					// additional fields
 					"usage_date": legacy.Date, // Date for the usage record.
@@ -77,7 +82,7 @@ func EventsMapping(subscriptionId string, results Usage, startTime time.Time, en
 					"resource": mapstr.M{
 						"name":  getResourceNameFromPath(*modern.InstanceName),
 						"type":  modern.ConsumedService,
-						"group": modern.ResourceGroup,
+						"group": strings.ToLower(*modern.ResourceGroup),
 					},
 				}
 				event.MetricSetFields = mapstr.M{
@@ -88,8 +93,8 @@ func EventsMapping(subscriptionId string, results Usage, startTime time.Time, en
 					"currency":          modern.BillingCurrencyCode,
 					"department_name":   modern.InvoiceSectionName,
 					"account_name":      modern.BillingAccountName,
-					"usage_start":       startTime,
-					"usage_end":         endTime,
+					"usage_start":       opts.usageStart,
+					"usage_end":         opts.usageEnd,
 
 					// additional fields
 					"usage_date": modern.Date, // Date for the usage record.
@@ -114,50 +119,13 @@ func EventsMapping(subscriptionId string, results Usage, startTime time.Time, en
 	//
 	// Forecasts
 	//
-	groupedCosts := make(map[*string][]consumption.Forecast)
 
-	for _, forecast := range results.ForecastCosts {
-		groupedCosts[forecast.UsageDate] = append(groupedCosts[forecast.UsageDate], forecast)
+	forecastsEvents, err := getEventsFromQueryResult(results.Forecasts, subscriptionId)
+	if err != nil {
+		return events, err
 	}
 
-	for _, forecast := range results.ActualCosts {
-		groupedCosts[forecast.UsageDate] = append(groupedCosts[forecast.UsageDate], forecast)
-	}
-
-	for usageDate, items := range groupedCosts {
-		var actualCost *decimal.Decimal
-		var forecastCost *decimal.Decimal
-		for _, item := range items {
-			if item.ChargeType == consumption.ChargeTypeActual {
-				actualCost = item.Charge
-			} else {
-				forecastCost = item.Charge
-			}
-		}
-
-		parsedDate, err := time.Parse("2006-01-02", *usageDate)
-		if err != nil {
-			parsedDate = time.Now().UTC()
-		}
-
-		event := mb.Event{
-			RootFields: mapstr.M{
-				"cloud.provider": "azure",
-			},
-			ModuleFields: mapstr.M{
-				"subscription_id": subscriptionId,
-			},
-			MetricSetFields: mapstr.M{
-				"actual_cost":   actualCost,
-				"forecast_cost": forecastCost,
-				"usage_date":    parsedDate,
-				"currency":      items[0].Currency,
-			},
-			Timestamp: time.Now().UTC(),
-		}
-
-		events = append(events, event)
-	}
+	events = append(events, forecastsEvents...)
 
 	return events, nil
 }
@@ -173,4 +141,116 @@ func getResourceNameFromPath(path string) string {
 	// According to the documentation, `string.Split()` always returns a non-empty slice when the separator is not empty,
 	// so it should be safe to use `len(parts) - 1` to get the last element.
 	return parts[len(parts)-1]
+}
+
+// getEventsFromQueryResult returns the events from the QueryResult obtained Cost Management API.
+//
+// Here's what you'll find in the QueryResult:
+//
+// .Columns:
+// 0: Cost: Number
+// 1: UsageDate: Number
+// 2: CostStatus: String
+// 3: Currency: String
+//
+// .Rows:
+// 0: []interface {}{0.11, 2.0200807e+07, "Actual", "USD"}
+// 1: []interface {}{0.11, 2.0200808e+07, "Forecast", "USD"}
+//
+func getEventsFromQueryResult(result costmanagement.QueryResult, subscriptionID string) ([]mb.Event, error) {
+	// the number of columns expected in the QueryResult supported by this input.
+	expectedColumns := 4
+
+	if result.Columns == nil || len(*result.Columns) != expectedColumns {
+		return []mb.Event{}, fmt.Errorf("unsupported forecasts QueryResult format: %d instead of %d", len(*result.Columns), expectedColumns)
+	}
+
+	if result.Rows == nil {
+		return []mb.Event{}, errors.New("unsupported forecasts QueryResult format: no rows")
+	}
+
+	events := make([]mb.Event, 0, len(*result.Rows))
+	for _, row := range *result.Rows {
+		var cost float64
+		var currency string
+		var costStatus string
+		var usageDate time.Time
+
+		if len(row) != expectedColumns {
+			return events, fmt.Errorf("unsupported forecasts QueryResult.Rows format: %d instead of %d", len(row), expectedColumns)
+		}
+
+		// cost
+		if value, ok := row[0].(float64); !ok {
+			return events, errors.New("unsupported cost format: not float64")
+		} else {
+			cost = value
+		}
+
+		// usage date
+		if value, ok := row[1].(float64); !ok {
+			return events, errors.New("unsupported usage date format: not float64")
+		} else {
+			var err error
+			// The API returns the usage date as a float64 number representing the "YYYYMMDD" value. For example,
+			// the value `float64(20170401)` represents the date "2017-04-01".
+			//
+			// If you print the row using the following statement:
+			//
+			// fmt.Printf("Row: %#v\n", row)
+			//
+			// You will see the following output:
+			//
+			// Row: []interface {}{0.11, 2.0200807e+07, "Actual", "USD"}
+			//
+			// 20170401 (float64) --> "2017-04-01T00:00:00Z" (time.Time)
+			usageDate, err = time.Parse("20060102", strconv.FormatInt(int64(value), 10))
+			if err != nil {
+				return events, errors.New("unsupported usage date format: not valid date")
+			}
+		}
+
+		// cost status (can be "Actual" or "Forecast")
+		if value, ok := row[2].(string); !ok {
+			return events, errors.New("unsupported cost status format: not string")
+		} else {
+			costStatus = value
+		}
+
+		// currency (can be "USD", "EUR", or other currency symbols)
+		if value, ok := row[3].(string); !ok {
+			return events, errors.New("unsupported currency format: not string")
+		} else {
+			currency = value
+		}
+
+		var costFieldName string
+		switch costStatus {
+		case "Actual":
+			costFieldName = "actual_cost"
+		case "Forecast":
+			costFieldName = "forecast_cost"
+		default:
+			return events, errors.New("unsupported cost status: not 'Actual' or 'Forecast'")
+		}
+
+		event := mb.Event{
+			RootFields: mapstr.M{
+				"cloud.provider": "azure",
+			},
+			ModuleFields: mapstr.M{
+				"subscription_id": subscriptionID,
+			},
+			MetricSetFields: mapstr.M{
+				costFieldName: cost,
+				"usage_date":  usageDate,
+				"currency":    currency,
+			},
+			Timestamp: time.Now().UTC(),
+		}
+
+		events = append(events, event)
+	}
+
+	return events, nil
 }

--- a/x-pack/metricbeat/module/azure/billing/data.go
+++ b/x-pack/metricbeat/module/azure/billing/data.go
@@ -6,10 +6,11 @@ package billing
 
 import (
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 
 	"errors"
 
@@ -159,10 +160,10 @@ func getResourceNameFromPath(path string) string {
 //
 func getEventsFromQueryResult(result costmanagement.QueryResult, subscriptionID string) ([]mb.Event, error) {
 	// the number of columns expected in the QueryResult supported by this input.
-	expectedColumns := 4
+	expectedNumberOfColumns := 4
 
-	if result.Columns == nil || len(*result.Columns) != expectedColumns {
-		return []mb.Event{}, fmt.Errorf("unsupported forecasts QueryResult format: %d instead of %d", len(*result.Columns), expectedColumns)
+	if result.Columns == nil || len(*result.Columns) != expectedNumberOfColumns {
+		return []mb.Event{}, fmt.Errorf("unsupported forecasts QueryResult format: %d instead of %d", len(*result.Columns), expectedNumberOfColumns)
 	}
 
 	if result.Rows == nil {
@@ -176,8 +177,8 @@ func getEventsFromQueryResult(result costmanagement.QueryResult, subscriptionID 
 		var costStatus string
 		var usageDate time.Time
 
-		if len(row) != expectedColumns {
-			return events, fmt.Errorf("unsupported forecasts QueryResult.Rows format: %d instead of %d", len(row), expectedColumns)
+		if len(row) != expectedNumberOfColumns {
+			return events, fmt.Errorf("unsupported forecasts QueryResult.Rows format: %d instead of %d", len(row), expectedNumberOfColumns)
 		}
 
 		// cost

--- a/x-pack/metricbeat/module/azure/billing/data_test.go
+++ b/x-pack/metricbeat/module/azure/billing/data_test.go
@@ -8,16 +8,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
 	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
-
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
+// TestEventMapping tests that mapping a QueryResult into a list of events is accurate.
 func TestEventMapping(t *testing.T) {
+	logger := logp.NewLogger("TestEventMapping")
+
 	ID := "ID"
 	kind := "legacy"
 	name := "test"
@@ -86,7 +90,7 @@ func TestEventMapping(t *testing.T) {
 		forecastEnd:   forecastEnd,
 	}
 
-	events, err := EventsMapping("sub", usage, opts)
+	events, err := EventsMapping("sub", usage, opts, logger)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(events))
 
@@ -129,6 +133,95 @@ func TestEventMapping(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestGetEventsFromQueryResult(t *testing.T) {
+	logger := logp.NewLogger("TestGetEventsFromQueryResult")
+	subscriptionID := "sub"
+
+	columns := []costmanagement.QueryColumn{
+		column("Cost", "Number"),
+		column("UsageDate", "Number"),
+		column("CostStatus", "String"),
+		column("Currency", "String"),
+	}
+
+	t.Run("no columns", func(t *testing.T) {
+		queryResult := costmanagement.QueryResult{}
+
+		events, err := getEventsFromQueryResult(queryResult, subscriptionID, logger)
+		assert.Equal(t, []mb.Event{}, events)
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong number of column", func(t *testing.T) {
+		badColumns := []costmanagement.QueryColumn{
+			column("Cost", "Number"),
+			column("UsageDate", "Number"),
+			column("CostStatus", "String"),
+			column("Currency", "String"),
+			column("UnexpectedColumn", "String"),
+		}
+		queryResult := costmanagement.QueryResult{
+			QueryProperties: &costmanagement.QueryProperties{
+				Columns: &badColumns,
+				Rows:    nil,
+			},
+		}
+
+		events, err := getEventsFromQueryResult(queryResult, subscriptionID, logger)
+		assert.Equal(t, []mb.Event{}, events)
+		assert.EqualError(t, err, "unsupported forecasts QueryResult format: got 5 columns instead of 4")
+	})
+
+	t.Run("no rows", func(t *testing.T) {
+		queryResult := costmanagement.QueryResult{
+			QueryProperties: &costmanagement.QueryProperties{
+				Columns: &columns,
+				Rows:    nil,
+			},
+		}
+
+		events, err := getEventsFromQueryResult(queryResult, subscriptionID, logger)
+		assert.Equal(t, []mb.Event{}, events)
+		assert.NoError(t, err)
+	})
+
+	t.Run("wrong number of elements in a row", func(t *testing.T) {
+		rows := [][]interface{}{
+			{float64(1), float64(2), "Actual", "USD", "UnexpectedValue"},
+		}
+		queryResult := costmanagement.QueryResult{
+			QueryProperties: &costmanagement.QueryProperties{
+				Columns: &columns,
+				Rows:    &rows,
+			},
+		}
+
+		events, err := getEventsFromQueryResult(queryResult, subscriptionID, logger)
+		assert.Equal(t, []mb.Event{}, events)
+		assert.NoError(t, err)
+	})
+
+	t.Run("drop rows with a wrong type", func(t *testing.T) {
+		rows := [][]interface{}{
+			{float64(1), float64(20220818), "Actual", "USD"}, // good row, this will be mapped as event
+			{42, float64(20220818), "Actual", "USD"},         // wrong cost type
+			{float64(1), 20220818, "Actual", "USD"},          // wrong usage date type
+			{float64(1), float64(20220818), 42, "USD"},       // wrong cost status type
+			{float64(1), float64(20220818), "Actual", 42},    // wrong currency type
+		}
+		queryResult := costmanagement.QueryResult{
+			QueryProperties: &costmanagement.QueryProperties{
+				Columns: &columns,
+				Rows:    &rows,
+			},
+		}
+
+		events, err := getEventsFromQueryResult(queryResult, subscriptionID, logger)
+		assert.Equal(t, 1, len(events))
+		assert.NoError(t, err)
+	})
 }
 
 func column(name, type_ string) costmanagement.QueryColumn {

--- a/x-pack/metricbeat/module/azure/billing/mock_service.go
+++ b/x-pack/metricbeat/module/azure/billing/mock_service.go
@@ -5,9 +5,12 @@
 package billing
 
 import (
+	"time"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/azure"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -27,10 +30,10 @@ func NewMockClient() *Client {
 	}
 }
 
-// GetForcast is a mock function for the billing service
-func (service *MockService) GetForecast(filter string) ([]consumption.Forecast, error) {
-	args := service.Called(filter)
-	return args.Get(0).([]consumption.Forecast), args.Error(1)
+// GetForecast is a mock function for the billing service
+func (service *MockService) GetForecast(scope string, startTime, endTime time.Time) (costmanagement.QueryResult, error) {
+	args := service.Called(scope, startTime, endTime)
+	return args.Get(0).(costmanagement.QueryResult), args.Error(1)
 }
 
 // GetUsageDetails is a mock function for the billing service

--- a/x-pack/metricbeat/module/azure/billing/service.go
+++ b/x-pack/metricbeat/module/azure/billing/service.go
@@ -6,17 +6,22 @@ package billing
 
 import (
 	"context"
+	"github.com/Azure/go-autorest/autorest/date"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
+	//"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 
 	"github.com/elastic/beats/v7/x-pack/metricbeat/module/azure"
 	"github.com/elastic/elastic-agent-libs/logp"
+
+	"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"
 )
 
 // Service offers access to Azure Usage Details and Forecast data.
 type Service interface {
-	GetForecast(filter string) ([]consumption.Forecast, error)
+	GetForecast(scope string, startTime, endTime time.Time) (costmanagement.QueryResult, error)
 	GetUsageDetails(
 		scope string,
 		expand string,
@@ -31,7 +36,7 @@ type Service interface {
 // UsageService is a thin wrapper to the Usage Details API and the Forecast API from the Azure SDK for Go.
 type UsageService struct {
 	usageDetailsClient *consumption.UsageDetailsClient
-	forecastsClient    *consumption.ForecastsClient
+	forecastClient     *costmanagement.ForecastClient
 	context            context.Context
 	log                *logp.Logger
 }
@@ -46,15 +51,15 @@ func NewService(config azure.Config) (*UsageService, error) {
 		return nil, err
 	}
 
-	forecastsClient := consumption.NewForecastsClientWithBaseURI(config.ResourceManagerEndpoint, config.SubscriptionId)
 	usageDetailsClient := consumption.NewUsageDetailsClientWithBaseURI(config.ResourceManagerEndpoint, config.SubscriptionId)
+	forecastsClient := costmanagement.NewForecastClientWithBaseURI(config.ResourceManagerEndpoint, config.SubscriptionId)
 
-	forecastsClient.Authorizer = authorizer
 	usageDetailsClient.Authorizer = authorizer
+	forecastsClient.Authorizer = authorizer
 
 	service := UsageService{
 		usageDetailsClient: &usageDetailsClient,
-		forecastsClient:    &forecastsClient,
+		forecastClient:     &forecastsClient,
 		context:            context.Background(),
 		log:                logp.NewLogger("azure billing service"),
 	}
@@ -62,33 +67,45 @@ func NewService(config azure.Config) (*UsageService, error) {
 	return &service, nil
 }
 
-// GetForecast fetches the forecast for the given filter.
-func (service *UsageService) GetForecast(filter string) ([]consumption.Forecast, error) {
-	response, err := service.forecastsClient.List(service.context, filter)
-	if err != nil {
-		switch response.StatusCode {
-		case 404:
-			// Forecast API returns 404 when the subscription does not support forecasts.
-			// For example, at the time of writing, forecasts are only available to
-			// enterprises subscriptions:
-			//
-			// "[Forecasts API] Provides operations to get usage forecasts for Enterprise
-			// Subscriptions." [1]
-			//
-			// [1]: https://docs.microsoft.com/en-us/rest/api/consumption/
-			service.log.
-				With("billing.filter", filter).
-				With("billing.subscription_id", service.forecastsClient.SubscriptionID).
-				Warnf(
-					"no forecasts available for subscription; possibly because the subscription is not an enterprise subscription. For details, see: https://docs.microsoft.com/en-us/rest/api/consumption/",
-				)
-			return []consumption.Forecast{}, nil
-		default:
-			return nil, err
-		}
+// GetForecast fetches the forecast for the given scope.
+func (service *UsageService) GetForecast(scope string, startTime, endTime time.Time) (costmanagement.QueryResult, error) {
+	// With this flag, the Forecast API will also return actual usage data
+	// from the first day of the current month.
+	includeActualCost := true
+
+	aggregationName := "Cost"
+
+	forecastDefinition := costmanagement.ForecastDefinition{
+		Dataset: &costmanagement.QueryDataset{
+			Aggregation: map[string]*costmanagement.QueryAggregation{
+				"totalCost": {
+					Function: costmanagement.FunctionTypeSum,
+					Name:     &aggregationName,
+				},
+			},
+			Granularity: costmanagement.GranularityTypeDaily,
+		},
+
+		// Time frame/period of the forecast. Required for MCA accounts.
+		Timeframe: costmanagement.ForecastTimeframeTypeCustom,
+		TimePeriod: &costmanagement.QueryTimePeriod{
+			From: &date.Time{Time: startTime},
+			To:   &date.Time{Time: endTime},
+		},
+
+		Type:              costmanagement.ForecastTypeActualCost,
+		IncludeActualCost: &includeActualCost,
 	}
 
-	return *response.Value, nil
+	// required, but I don't have a value for it yet.
+	filter := ""
+
+	queryResult, err := service.forecastClient.Usage(service.context, scope, forecastDefinition, filter)
+	if err != nil {
+		return costmanagement.QueryResult{}, err
+	}
+
+	return queryResult, nil
 }
 
 // GetUsageDetails fetches the usage details for the given filters.

--- a/x-pack/metricbeat/module/azure/billing/service.go
+++ b/x-pack/metricbeat/module/azure/billing/service.go
@@ -6,8 +6,9 @@ package billing
 
 import (
 	"context"
-	"github.com/Azure/go-autorest/autorest/date"
 	"time"
+
+	"github.com/Azure/go-autorest/autorest/date"
 
 	"github.com/Azure/azure-sdk-for-go/services/consumption/mgmt/2019-10-01/consumption"
 	//"github.com/Azure/azure-sdk-for-go/services/costmanagement/mgmt/2019-11-01/costmanagement"

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2019-06-01/insights"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -49,7 +48,7 @@ func NewClient(config Config) (*Client, error) {
 // the mapMetric function sent in this case will handle the mapping part as different metric and aggregation options work for different metricsets
 func (client *Client) InitResources(fn mapResourceMetrics) error {
 	if len(client.Config.Resources) == 0 {
-		return errors.New("no resource options defined")
+		return fmt.Errorf("no resource options defined")
 	}
 	// check if refresh interval has been set and if it has expired
 	if !client.ResourceConfigurations.Expired() {
@@ -62,11 +61,11 @@ func (client *Client) InitResources(fn mapResourceMetrics) error {
 		// retrieve azure resources information
 		resourceList, err := client.AzureMonitorService.GetResourceDefinitions(resource.Id, resource.Group, resource.Type, resource.Query)
 		if err != nil {
-			err = errors.Wrap(err, "failed to retrieve resources")
+			err = fmt.Errorf("failed to retrieve resources: %w", err)
 			return err
 		}
 		if len(resourceList) == 0 {
-			err = errors.Errorf("failed to retrieve resources: No resources returned using the configuration options resource ID %s, resource group %s, resource type %s, resource query %s",
+			err = fmt.Errorf("failed to retrieve resources: No resources returned using the configuration options resource ID %s, resource group %s, resource type %s, resource query %s",
 				resource.Id, resource.Group, resource.Type, resource.Query)
 			client.Log.Error(err)
 			continue
@@ -126,7 +125,7 @@ func (client *Client) GetMetricValues(metrics []Metric, report mb.ReporterV2) []
 		resp, timegrain, err := client.AzureMonitorService.GetMetricValues(metric.ResourceSubId, metric.Namespace, metric.TimeGrain, timespan, metric.Names,
 			metric.Aggregations, filter)
 		if err != nil {
-			err = errors.Wrapf(err, "error while listing metric values by resource ID %s and namespace  %s", metric.ResourceSubId, metric.Namespace)
+			err = fmt.Errorf("error while listing metric values by resource ID %s and namespace  %s: %w", metric.ResourceSubId, metric.Namespace, err)
 			client.Log.Error(err)
 			report.Error(err)
 		} else {

--- a/x-pack/metricbeat/module/azure/client.go
+++ b/x-pack/metricbeat/module/azure/client.go
@@ -30,7 +30,7 @@ type Client struct {
 // mapResourceMetrics function type will map the configuration options to client metrics (depending on the metricset)
 type mapResourceMetrics func(client *Client, resources []resources.GenericResourceExpanded, resourceConfig ResourceConfig) ([]Metric, error)
 
-// NewClient instantiates the an Azure monitoring client
+// NewClient instantiates the Azure monitoring client
 func NewClient(config Config) (*Client, error) {
 	azureMonitorService, err := NewService(config)
 	if err != nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Switch the fetching of forecast data from the Azure [Consumption API](https://docs.microsoft.com/en-us/rest/api/consumption/) to the [Cost Management API](https://docs.microsoft.com/en-us/rest/api/cost-management/forecast).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The previous forecast endpoint from Consumption API [is no longer maintained](https://github.com/Azure/azure-sdk-for-go/blob/8fb416f409c8e1250e4e397b51a724c268d24c0b/services/consumption/mgmt/2019-10-01/consumption/forecasts.go#L34-L36) and does not support scope.

## Additional information

The Consumption API version of the forecast endpoint was simple: it offered a simple filter with limited options. Instead, the Cost Management API version is a much [richer endpoint with a dozen of options](https://docs.microsoft.com/en-us/rest/api/cost-management/forecast/usage?tabs=HTTP#request-body). The current implementation focuses on offering the same functionality using the new API.

The Azure Portal uses the Cost Management API (version 2021-10-01) to implement the Cost Management > Cost analysis page. We used the Azuire Portal as a reference to build the request for the Forecast data in this module.

This Azure Billing module is using an older version of the Cost Management API: [2019-10-01](https://github.com/Azure/azure-sdk-for-go/tree/main/services/costmanagement/mgmt), it is the latest working [^1] version offered in the official Azure SDK. If we need to jump to a later version, we built a fallback solution: the [github.com/zmoog/azure-sdk-clients](https://github.com/zmoog/azure-sdk-clients/tree/zmoog/costmanagement-2021-10-01/services/costmanagement/mgmt/2021-10-01/costmanagement) repo contains an unofficial Azure SDK client generated from the OpenAPI spec using the same toolchain Microsoft uses.

[^1]: Version [2020-06-01](https://github.com/Azure/azure-sdk-for-go/tree/main/services/costmanagement/mgmt/2020-06-01/costmanagement) does not work for Forecast.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

On Azure:

* Create a new App registration.
* Take note of the "Application (client) ID"; it will be your `CLIENT_ID`.
* Visit App Registrations > App > Certificates & secrets > New client secret.
* Take note of the secret "Value"; it will be your `CLIENT_SECRET`.
* Visit Cost Management + Billing > Access control (IAM) > Add role assignment.
* Select role "Billing account reader" and the name of your app in "Users, groups, or app".

On your local environment:

- Enable the Azure Billing module and use the following configuration:

```yaml
- module: azure
  metricsets:
    - billing
  enabled: true
  period: 24h
  client_id: '<CLIENT_ID>'
  client_secret: '<CLIENT_SECRET>'
  tenant_id: '<TENANT_ID>'
  subscription_id: '<SUBSCRIPTION_ID>'
  refresh_list_interval: 600s
```

- Build and run Metricbeat

```shell
$ cd x-pack/metricbeat
$ mage build 
>> build: Building metricbeat

$ ./metricbeat -e -E cloud.id=<CLOUD_ID> -E cloud.auth=<CLOUD_AUTH> -E output.elasticsearch.allow_older_versions=true
```

You may need to use `output.elasticsearch.allow_older_versions=true` if you built Metricbeat from sources and not using the latest version of ES.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #32033

<!-- Recommended
## Use cases
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
