### PR TITLE
Add concrete types to logstash

### DIFF
--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -58,7 +58,7 @@ type MetricSet struct {
 }
 
 type Graph struct {
-	Vertices []map[string]interface{} `json:"vertices"`
+	Vertices []Vertex                 `json:"vertices"`
 	Edges    []map[string]interface{} `json:"edges"`
 }
 
@@ -78,6 +78,24 @@ type PipelineState struct {
 	Representation *GraphContainer `json:"representation"`
 	BatchSize      int             `json:"batch_size"`
 	Workers        int             `json:"workers"`
+}
+
+// Vertex represents a vertex in node_stats
+type Vertex struct {
+	ID                        string `json:"id"`
+	PipelineEphemeralID       string `json:"pipeline_ephemeral_id"`
+	ClusterUUID               string `json:"cluster_uuid"`
+	EventsOut                 int64  `json:"events_out"`
+	EventsIn                  int64  `json:"events_in"`
+	DurationInMillis          int64  `json:"duration_in_millis"`
+	QueuePushDurationInMillis int64  `json:"queue_push_duration_in_millis"`
+}
+
+type Queue struct {
+	Type                string `json:"type,omitempty"`
+	EventsCount         int64  `json:"events_count"`
+	QueueSizeInBytes    int64  `json:"queue_size_in_bytes"`
+	MaxQueueSizeInBytes int64  `json:"max_queue_size_in_bytes"`
 }
 
 // NewMetricSet creates a metricset that can be used to build other metricsets
@@ -154,17 +172,8 @@ func (m *MetricSet) CheckPipelineGraphAPIsAvailable() error {
 // GetVertexClusterUUID returns the correct cluster UUID value for the given Elasticsearch
 // vertex from a Logstash pipeline. If the vertex has no cluster UUID associated with it,
 // the given override cluster UUID is returned.
-func GetVertexClusterUUID(vertex map[string]interface{}, overrideClusterUUID string) string {
-	c, ok := vertex["cluster_uuid"]
-	if !ok {
-		return overrideClusterUUID
-	}
-
-	clusterUUID, ok := c.(string)
-	if !ok {
-		return overrideClusterUUID
-	}
-
+func GetVertexClusterUUID(vertex Vertex, overrideClusterUUID string) string {
+	clusterUUID := vertex.ClusterUUID
 	if clusterUUID == "" {
 		return overrideClusterUUID
 	}

--- a/metricbeat/module/logstash/logstash.go
+++ b/metricbeat/module/logstash/logstash.go
@@ -22,8 +22,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -127,7 +125,7 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 func GetPipelines(m *MetricSet) ([]PipelineState, string, error) {
 	content, err := fetchPath(m.HTTP, "_node/pipelines", "graph=true")
 	if err != nil {
-		return nil, "", errors.Wrap(err, "could not fetch node pipelines")
+		return nil, "", fmt.Errorf("could not fetch node pipelines: %w", err)
 	}
 
 	pipelinesResponse := struct {
@@ -139,7 +137,7 @@ func GetPipelines(m *MetricSet) ([]PipelineState, string, error) {
 
 	err = json.Unmarshal(content, &pipelinesResponse)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "could not parse node pipelines response")
+		return nil, "", fmt.Errorf("could not parse node pipelines response: %w", err)
 	}
 
 	var pipelines []PipelineState

--- a/metricbeat/module/logstash/logstash_test.go
+++ b/metricbeat/module/logstash/logstash_test.go
@@ -32,20 +32,20 @@ import (
 
 func TestGetVertexClusterUUID(t *testing.T) {
 	tests := map[string]struct {
-		vertex              map[string]interface{}
+		vertex              logstash.Vertex
 		overrideClusterUUID string
 		expectedClusterUUID string
 	}{
 		"vertex_and_override": {
-			map[string]interface{}{
-				"cluster_uuid": "v",
+			logstash.Vertex{
+				ClusterUUID: "v",
 			},
 			"o",
 			"v",
 		},
 		"vertex_only": {
-			vertex: map[string]interface{}{
-				"cluster_uuid": "v",
+			vertex: logstash.Vertex{
+				ClusterUUID: "v",
 			},
 			expectedClusterUUID: "v",
 		},

--- a/metricbeat/module/logstash/node/data.go
+++ b/metricbeat/module/logstash/node/data.go
@@ -44,14 +44,14 @@ var (
 
 func commonFieldsMapping(event *mb.Event, fields mapstr.M) error {
 	event.RootFields = mapstr.M{}
-	event.RootFields.Put("service.name", logstash.ModuleName)
+	_, _ = event.RootFields.Put("service.name", logstash.ModuleName)
 
 	// Set service ID
 	serviceID, err := fields.GetValue("id")
 	if err != nil {
 		return elastic.MakeErrorForMissingField("id", elastic.Logstash)
 	}
-	event.RootFields.Put("service.id", serviceID)
+	_, _ = event.RootFields.Put("service.id", serviceID)
 	_ = fields.Delete("id")
 
 	// Set service hostname
@@ -59,7 +59,7 @@ func commonFieldsMapping(event *mb.Event, fields mapstr.M) error {
 	if err != nil {
 		return elastic.MakeErrorForMissingField("host", elastic.Logstash)
 	}
-	event.RootFields.Put("service.hostname", host)
+	_, _ = event.RootFields.Put("service.hostname", host)
 	_ = fields.Delete("host")
 
 	// Set service version
@@ -121,8 +121,8 @@ func eventMapping(r mb.ReporterV2, content []byte, pipelines []logstash.Pipeline
 			}
 
 			if clusterUUID != "" {
-				event.ModuleFields.Put("cluster.id", clusterUUID)
-				event.ModuleFields.Put("elasticsearch.cluster.id", clusterUUID)
+				_, _ = event.ModuleFields.Put("cluster.id", clusterUUID)
+				_, _ = event.ModuleFields.Put("elasticsearch.cluster.id", clusterUUID)
 			}
 
 			event.ID = pipeline.EphemeralID

--- a/metricbeat/module/logstash/node/data.go
+++ b/metricbeat/module/logstash/node/data.go
@@ -67,7 +67,7 @@ func commonFieldsMapping(event *mb.Event, fields mapstr.M) error {
 	if err != nil {
 		return elastic.MakeErrorForMissingField("version", elastic.Logstash)
 	}
-	event.RootFields.Put("service.version", version)
+	_, _ = event.RootFields.Put("service.version", version)
 	_ = fields.Delete("version")
 
 	// Set PID

--- a/metricbeat/module/logstash/node/data.go
+++ b/metricbeat/module/logstash/node/data.go
@@ -188,13 +188,9 @@ func getUserDefinedPipelines(pipelines []logstash.PipelineState) []logstash.Pipe
 	return userDefinedPipelines
 }
 
+// TODO: make test for this
 func removeClusterUUIDsFromPipeline(pipeline logstash.PipelineState) {
-	for _, vertex := range pipeline.Graph.Graph.Vertices {
-		_, exists := vertex["cluster_uuid"]
-		if !exists {
-			continue
-		}
-
-		delete(vertex, "cluster_uuid")
+	for iter := range pipeline.Graph.Graph.Vertices {
+		pipeline.Graph.Graph.Vertices[iter].ClusterUUID = ""
 	}
 }

--- a/metricbeat/module/logstash/node/data.go
+++ b/metricbeat/module/logstash/node/data.go
@@ -188,7 +188,6 @@ func getUserDefinedPipelines(pipelines []logstash.PipelineState) []logstash.Pipe
 	return userDefinedPipelines
 }
 
-// TODO: make test for this
 func removeClusterUUIDsFromPipeline(pipeline logstash.PipelineState) {
 	for iter := range pipeline.Graph.Graph.Vertices {
 		pipeline.Graph.Graph.Vertices[iter].ClusterUUID = ""

--- a/metricbeat/module/logstash/node/data.go
+++ b/metricbeat/module/logstash/node/data.go
@@ -75,7 +75,7 @@ func commonFieldsMapping(event *mb.Event, fields mapstr.M) error {
 	if err != nil {
 		return elastic.MakeErrorForMissingField("jvm.pid", elastic.Logstash)
 	}
-	event.RootFields.Put("process.pid", pid)
+	_, _ = event.RootFields.Put("process.pid", pid)
 	_ = fields.Delete("jvm.pid")
 
 	return nil

--- a/metricbeat/module/logstash/node/data_test.go
+++ b/metricbeat/module/logstash/node/data_test.go
@@ -64,15 +64,15 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []logstash.Vertex{
 								{
-									"id": "vertex_1",
+									ID: "vertex_1",
 								},
 								{
-									"id": "vertex_2",
+									ID: "vertex_2",
 								},
 								{
-									"id": "vertex_3",
+									ID: "vertex_3",
 								},
 							},
 						},
@@ -86,15 +86,15 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []logstash.Vertex{
 									{
-										"id": "vertex_1",
+										ID: "vertex_1",
 									},
 									{
-										"id": "vertex_2",
+										ID: "vertex_2",
 									},
 									{
-										"id": "vertex_3",
+										ID: "vertex_3",
 									},
 								},
 							},
@@ -109,16 +109,16 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []logstash.Vertex{
 								{
-									"id":           "vertex_1",
-									"cluster_uuid": "es_1",
+									ID:          "vertex_1",
+									ClusterUUID: "es_1",
 								},
 								{
-									"id": "vertex_2",
+									ID: "vertex_2",
 								},
 								{
-									"id": "vertex_3",
+									ID: "vertex_3",
 								},
 							},
 						},
@@ -132,16 +132,16 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []logstash.Vertex{
 									{
-										"id":           "vertex_1",
-										"cluster_uuid": "es_1",
+										ID:          "vertex_1",
+										ClusterUUID: "es_1",
 									},
 									{
-										"id": "vertex_2",
+										ID: "vertex_2",
 									},
 									{
-										"id": "vertex_3",
+										ID: "vertex_3",
 									},
 								},
 							},
@@ -156,16 +156,16 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_1",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []logstash.Vertex{
 								{
-									"id":           "vertex_1_1",
-									"cluster_uuid": "es_1",
+									ID:          "vertex_1_1",
+									ClusterUUID: "es_1",
 								},
 								{
-									"id": "vertex_1_2",
+									ID: "vertex_1_2",
 								},
 								{
-									"id": "vertex_1_3",
+									ID: "vertex_1_3",
 								},
 							},
 						},
@@ -175,15 +175,15 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_2",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []logstash.Vertex{
 								{
-									"id": "vertex_2_1",
+									ID: "vertex_2_1",
 								},
 								{
-									"id": "vertex_2_2",
+									ID: "vertex_2_2",
 								},
 								{
-									"id": "vertex_2_3",
+									ID: "vertex_2_3",
 								},
 							},
 						},
@@ -197,16 +197,16 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_1",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []logstash.Vertex{
 									{
-										"id":           "vertex_1_1",
-										"cluster_uuid": "es_1",
+										ID:          "vertex_1_1",
+										ClusterUUID: "es_1",
 									},
 									{
-										"id": "vertex_1_2",
+										ID: "vertex_1_2",
 									},
 									{
-										"id": "vertex_1_3",
+										ID: "vertex_1_3",
 									},
 								},
 							},
@@ -216,15 +216,15 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_2",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []logstash.Vertex{
 									{
-										"id": "vertex_2_1",
+										ID: "vertex_2_1",
 									},
 									{
-										"id": "vertex_2_2",
+										ID: "vertex_2_2",
 									},
 									{
-										"id": "vertex_2_3",
+										ID: "vertex_2_3",
 									},
 								},
 							},
@@ -239,17 +239,17 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_1",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []logstash.Vertex{
 								{
-									"id":           "vertex_1_1",
-									"cluster_uuid": "es_1",
+									ID:          "vertex_1_1",
+									ClusterUUID: "es_1",
 								},
 								{
-									"id":           "vertex_1_2",
-									"cluster_uuid": "es_2",
+									ID:          "vertex_1_2",
+									ClusterUUID: "es_2",
 								},
 								{
-									"id": "vertex_1_3",
+									ID: "vertex_1_3",
 								},
 							},
 						},
@@ -259,15 +259,15 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 					ID: "test_pipeline_2",
 					Graph: &logstash.GraphContainer{
 						Graph: &logstash.Graph{
-							Vertices: []map[string]interface{}{
+							Vertices: []logstash.Vertex{
 								{
-									"id": "vertex_2_1",
+									ID: "vertex_2_1",
 								},
 								{
-									"id": "vertex_2_2",
+									ID: "vertex_2_2",
 								},
 								{
-									"id": "vertex_2_3",
+									ID: "vertex_2_3",
 								},
 							},
 						},
@@ -281,17 +281,17 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_1",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []logstash.Vertex{
 									{
-										"id":           "vertex_1_1",
-										"cluster_uuid": "es_1",
+										ID:          "vertex_1_1",
+										ClusterUUID: "es_1",
 									},
 									{
-										"id":           "vertex_1_2",
-										"cluster_uuid": "es_2",
+										ID:          "vertex_1_2",
+										ClusterUUID: "es_2",
 									},
 									{
-										"id": "vertex_1_3",
+										ID: "vertex_1_3",
 									},
 								},
 							},
@@ -303,17 +303,17 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_1",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []logstash.Vertex{
 									{
-										"id":           "vertex_1_1",
-										"cluster_uuid": "es_1",
+										ID:          "vertex_1_1",
+										ClusterUUID: "es_1",
 									},
 									{
-										"id":           "vertex_1_2",
-										"cluster_uuid": "es_2",
+										ID:          "vertex_1_2",
+										ClusterUUID: "es_2",
 									},
 									{
-										"id": "vertex_1_3",
+										ID: "vertex_1_3",
 									},
 								},
 							},
@@ -325,15 +325,15 @@ func TestMakeClusterToPipelinesMap(t *testing.T) {
 						ID: "test_pipeline_2",
 						Graph: &logstash.GraphContainer{
 							Graph: &logstash.Graph{
-								Vertices: []map[string]interface{}{
+								Vertices: []logstash.Vertex{
 									{
-										"id": "vertex_2_1",
+										ID: "vertex_2_1",
 									},
 									{
-										"id": "vertex_2_2",
+										ID: "vertex_2_2",
 									},
 									{
-										"id": "vertex_2_3",
+										ID: "vertex_2_3",
 									},
 								},
 							},

--- a/metricbeat/module/logstash/node_stats/_meta/test/node_stats.710.json
+++ b/metricbeat/module/logstash/node_stats/_meta/test/node_stats.710.json
@@ -1,197 +1,207 @@
 {
-    "host" : "logstash",
-    "version" : "7.10.0",
-    "http_address" : "0.0.0.0:9600",
-    "id" : "84539cd1-193c-4439-8432-5a160911f135",
-    "name" : "logstash",
-    "ephemeral_id" : "9c6737de-dde2-4926-bee3-9ccc0ed1d2a6",
-    "status" : "green",
-    "snapshot" : false,
-    "pipeline" : {
-      "workers" : 8,
-      "batch_size" : 125,
-      "batch_delay" : 50
+  "host": "logstash",
+  "version": "7.10.0",
+  "http_address": "0.0.0.0:9600",
+  "id": "84539cd1-193c-4439-8432-5a160911f135",
+  "name": "logstash",
+  "ephemeral_id": "9c6737de-dde2-4926-bee3-9ccc0ed1d2a6",
+  "status": "green",
+  "snapshot": false,
+  "pipeline": {
+    "workers": 8,
+    "batch_size": 125,
+    "batch_delay": 50
+  },
+  "jvm": {
+    "threads": {
+      "count": 35,
+      "peak_count": 35
     },
-    "jvm" : {
-      "threads" : {
-        "count" : 35,
-        "peak_count" : 35
-      },
-      "mem" : {
-        "heap_used_percent" : 13,
-        "heap_committed_in_bytes" : 1037959168,
-        "heap_max_in_bytes" : 1037959168,
-        "heap_used_in_bytes" : 144995280,
-        "non_heap_used_in_bytes" : 148041864,
-        "non_heap_committed_in_bytes" : 172560384,
-        "pools" : {
-          "survivor" : {
-            "committed_in_bytes" : 35782656,
-            "used_in_bytes" : 23405920,
-            "peak_max_in_bytes" : 35782656,
-            "peak_used_in_bytes" : 35782656,
-            "max_in_bytes" : 35782656
-          },
-          "young" : {
-            "committed_in_bytes" : 286326784,
-            "used_in_bytes" : 16565808,
-            "peak_max_in_bytes" : 286326784,
-            "peak_used_in_bytes" : 286326784,
-            "max_in_bytes" : 286326784
-          },
-          "old" : {
-            "committed_in_bytes" : 715849728,
-            "used_in_bytes" : 105023552,
-            "peak_max_in_bytes" : 715849728,
-            "peak_used_in_bytes" : 105023552,
-            "max_in_bytes" : 715849728
-          }
-        }
-      },
-      "gc" : {
-        "collectors" : {
-          "young" : {
-            "collection_time_in_millis" : 335,
-            "collection_count" : 7
-          },
-          "old" : {
-            "collection_time_in_millis" : 374,
-            "collection_count" : 2
-          }
-        }
-      },
-      "uptime_in_millis" : 17006
-    },
-    "process" : {
-      "open_file_descriptors" : 140,
-      "peak_open_file_descriptors" : 140,
-      "max_file_descriptors" : 1048576,
-      "mem" : {
-        "total_virtual_in_bytes" : 6392164352
-      },
-      "cpu" : {
-        "total_in_millis" : 58710,
-        "percent" : 23,
-        "load_average" : {
-          "1m" : 0.87,
-          "5m" : 0.22,
-          "15m" : 0.13
+    "mem": {
+      "heap_used_percent": 13,
+      "heap_committed_in_bytes": 1037959168,
+      "heap_max_in_bytes": 1037959168,
+      "heap_used_in_bytes": 144995280,
+      "non_heap_used_in_bytes": 148041864,
+      "non_heap_committed_in_bytes": 172560384,
+      "pools": {
+        "survivor": {
+          "committed_in_bytes": 35782656,
+          "used_in_bytes": 23405920,
+          "peak_max_in_bytes": 35782656,
+          "peak_used_in_bytes": 35782656,
+          "max_in_bytes": 35782656
+        },
+        "young": {
+          "committed_in_bytes": 286326784,
+          "used_in_bytes": 16565808,
+          "peak_max_in_bytes": 286326784,
+          "peak_used_in_bytes": 286326784,
+          "max_in_bytes": 286326784
+        },
+        "old": {
+          "committed_in_bytes": 715849728,
+          "used_in_bytes": 105023552,
+          "peak_max_in_bytes": 715849728,
+          "peak_used_in_bytes": 105023552,
+          "max_in_bytes": 715849728
         }
       }
     },
-    "events" : {
-      "in" : 0,
-      "filtered" : 0,
-      "out" : 0,
-      "duration_in_millis" : 0,
-      "queue_push_duration_in_millis" : 0
-    },
-    "pipelines" : {
-      "main" : {
-        "events" : {
-          "filtered" : 0,
-          "duration_in_millis" : 0,
-          "out" : 0,
-          "queue_push_duration_in_millis" : 0,
-          "in" : 0
+    "gc": {
+      "collectors": {
+        "young": {
+          "collection_time_in_millis": 335,
+          "collection_count": 7
         },
-        "plugins" : {
-          "inputs" : [ {
-            "id" : "0710cad67e8f47667bc7612580d5b91f691dd8262a4187d9eca8cf87229d04aa",
-            "name" : "beats",
-            "events" : {
-              "out" : 0,
-              "queue_push_duration_in_millis" : 0
-            }
-          } ],
-          "codecs" : [ {
-            "id" : "plain_be1a2b95-edff-4dc2-94b5-b902f11bfb07",
-            "encode" : {
-              "duration_in_millis" : 0,
-              "writes_in" : 0
-            },
-            "name" : "plain",
-            "decode" : {
-              "duration_in_millis" : 0,
-              "writes_in" : 0,
-              "out" : 0
-            }
-          }, {
-            "id" : "rubydebug_93993219-1a2d-493c-a63c-341a0a5c86ac",
-            "encode" : {
-              "duration_in_millis" : 9,
-              "writes_in" : 0
-            },
-            "name" : "rubydebug",
-            "decode" : {
-              "duration_in_millis" : 0,
-              "writes_in" : 0,
-              "out" : 0
-            }
-          } ],
-          "filters" : [ ],
-          "outputs" : [ {
-            "id" : "f4944472678ac54e7343c1a49748c402b0bafd76ebab7fe2f3930269e0e5097b",
-            "name" : "stdout",
-            "events" : {
-              "duration_in_millis" : 20,
-              "out" : 0,
-              "in" : 0
-            }
-          } ]
-        },
-        "reloads" : {
-          "last_success_timestamp" : null,
-          "last_failure_timestamp" : null,
-          "last_error" : null,
-          "successes" : 0,
-          "failures" : 0
-        },
-        "queue" : {
-          "type" : "memory",
-          "events_count" : 0,
-          "queue_size_in_bytes" : 0,
-          "max_queue_size_in_bytes" : 0
-        },
-        "hash" : "1e3da6bfb66bd25bbb98769a5dcdc16c06f98a333675d3b71cccad117e103b99",
-        "ephemeral_id" : "793497fe-de31-4b3a-bfbd-0b77eb7a2d9b",
-        "vertices" : [ {
-          "id" : "0710cad67e8f47667bc7612580d5b91f691dd8262a4187d9eca8cf87229d04aa",
-          "pipeline_ephemeral_id" : "793497fe-de31-4b3a-bfbd-0b77eb7a2d9b",
-          "events_out" : 0,
-          "queue_push_duration_in_millis" : 0
-        }, {
-          "id" : "f4944472678ac54e7343c1a49748c402b0bafd76ebab7fe2f3930269e0e5097b",
-          "pipeline_ephemeral_id" : "793497fe-de31-4b3a-bfbd-0b77eb7a2d9b",
-          "duration_in_millis" : 20,
-          "events_out" : 0,
-          "events_in" : 0
-        } ]
-      }
-    },
-    "reloads" : {
-      "successes" : 0,
-      "failures" : 0
-    },
-    "os" : {
-      "cgroup" : {
-        "cpuacct" : {
-          "control_group" : "/",
-          "usage_nanos" : 58485023221
-        },
-        "cpu" : {
-          "cfs_quota_micros" : -1,
-          "cfs_period_micros" : 100000,
-          "control_group" : "/",
-          "stat" : {
-            "number_of_elapsed_periods" : 0,
-            "number_of_times_throttled" : 0,
-            "time_throttled_nanos" : 0
-          }
+        "old": {
+          "collection_time_in_millis": 374,
+          "collection_count": 2
         }
       }
     },
-    "queue" : {
-      "events_count" : 0
+    "uptime_in_millis": 17006
+  },
+  "process": {
+    "open_file_descriptors": 140,
+    "peak_open_file_descriptors": 140,
+    "max_file_descriptors": 1048576,
+    "mem": {
+      "total_virtual_in_bytes": 6392164352
+    },
+    "cpu": {
+      "total_in_millis": 58710,
+      "percent": 23,
+      "load_average": {
+        "1m": 0.87,
+        "5m": 0.22,
+        "15m": 0.13
+      }
     }
+  },
+  "events": {
+    "in": 0,
+    "filtered": 0,
+    "out": 0,
+    "duration_in_millis": 0,
+    "queue_push_duration_in_millis": 0
+  },
+  "pipelines": {
+    "main": {
+      "events": {
+        "filtered": 0,
+        "duration_in_millis": 5,
+        "out": 0,
+        "queue_push_duration_in_millis": 0,
+        "in": 0
+      },
+      "plugins": {
+        "inputs": [
+          {
+            "id": "0710cad67e8f47667bc7612580d5b91f691dd8262a4187d9eca8cf87229d04aa",
+            "name": "beats",
+            "events": {
+              "out": 0,
+              "queue_push_duration_in_millis": 0
+            }
+          }
+        ],
+        "codecs": [
+          {
+            "id": "plain_be1a2b95-edff-4dc2-94b5-b902f11bfb07",
+            "encode": {
+              "duration_in_millis": 0,
+              "writes_in": 0
+            },
+            "name": "plain",
+            "decode": {
+              "duration_in_millis": 0,
+              "writes_in": 0,
+              "out": 0
+            }
+          },
+          {
+            "id": "rubydebug_93993219-1a2d-493c-a63c-341a0a5c86ac",
+            "encode": {
+              "duration_in_millis": 9,
+              "writes_in": 0
+            },
+            "name": "rubydebug",
+            "decode": {
+              "duration_in_millis": 0,
+              "writes_in": 0,
+              "out": 0
+            }
+          }
+        ],
+        "filters": [],
+        "outputs": [
+          {
+            "id": "f4944472678ac54e7343c1a49748c402b0bafd76ebab7fe2f3930269e0e5097b",
+            "name": "stdout",
+            "events": {
+              "duration_in_millis": 20,
+              "out": 0,
+              "in": 0
+            }
+          }
+        ]
+      },
+      "reloads": {
+        "last_success_timestamp": null,
+        "last_failure_timestamp": null,
+        "last_error": null,
+        "successes": 0,
+        "failures": 0
+      },
+      "queue": {
+        "type": "memory",
+        "events_count": 100,
+        "queue_size_in_bytes": 0,
+        "max_queue_size_in_bytes": 0
+      },
+      "hash": "1e3da6bfb66bd25bbb98769a5dcdc16c06f98a333675d3b71cccad117e103b99",
+      "ephemeral_id": "793497fe-de31-4b3a-bfbd-0b77eb7a2d9b",
+      "vertices": [
+        {
+          "id": "0710cad67e8f47667bc7612580d5b91f691dd8262a4187d9eca8cf87229d04aa",
+          "pipeline_ephemeral_id": "793497fe-de31-4b3a-bfbd-0b77eb7a2d9b",
+          "events_out": 0,
+          "queue_push_duration_in_millis": 2
+        },
+        {
+          "id": "f4944472678ac54e7343c1a49748c402b0bafd76ebab7fe2f3930269e0e5097b",
+          "pipeline_ephemeral_id": "793497fe-de31-4b3a-bfbd-0b77eb7a2d9b",
+          "duration_in_millis": 20,
+          "events_out": 0,
+          "events_in": 0
+        }
+      ]
+    }
+  },
+  "reloads": {
+    "successes": 0,
+    "failures": 0
+  },
+  "os": {
+    "cgroup": {
+      "cpuacct": {
+        "control_group": "/",
+        "usage_nanos": 58485023221
+      },
+      "cpu": {
+        "cfs_quota_micros": -1,
+        "cfs_period_micros": 100000,
+        "control_group": "/",
+        "stat": {
+          "number_of_elapsed_periods": 0,
+          "number_of_times_throttled": 0,
+          "time_throttled_nanos": 0
+        }
+      }
+    }
+  },
+  "queue": {
+    "events_count": 0
   }
+}

--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -236,8 +236,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 }
 
 func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID string) map[string][]PipelineStats {
-	var clusterToPipelinesMap map[string][]PipelineStats
-	clusterToPipelinesMap = make(map[string][]PipelineStats)
+	clusterToPipelinesMap := make(map[string][]PipelineStats)
 
 	if overrideClusterUUID != "" {
 		clusterToPipelinesMap[overrideClusterUUID] = pipelines

--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -138,14 +138,15 @@ type LogstashStats struct {
 }
 
 // PipelineStats represents the stats of a Logstash pipeline
+// fields here aren't all documented, see https://github.com/elastic/logstash/issues/14381
 type PipelineStats struct {
-	ID          string                   `json:"id"`
-	Hash        string                   `json:"hash"`
-	EphemeralID string                   `json:"ephemeral_id"`
-	Events      map[string]interface{}   `json:"events"`
-	Reloads     reloads                  `json:"reloads"`
-	Queue       map[string]interface{}   `json:"queue"`
-	Vertices    []map[string]interface{} `json:"vertices"`
+	ID          string            `json:"id"`
+	Hash        string            `json:"hash"`
+	EphemeralID string            `json:"ephemeral_id"`
+	Events      map[string]int64  `json:"events"`
+	Reloads     reloads           `json:"reloads"`
+	Queue       logstash.Queue    `json:"queue"`
+	Vertices    []logstash.Vertex `json:"vertices"`
 }
 
 func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Logger) error {
@@ -185,7 +186,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 	pipelineDocumentsShouldContainHash := !StatsVersion.LessThan(PipelineDocumentsContainHashVersion)
 
 	for pipelineID, pipeline := range nodeStats.Pipelines {
-		if pipelineDocumentsShouldContainHash && (pipeline.Hash == "" || pipeline.Vertices == nil) {
+		if pipelineDocumentsShouldContainHash && (pipeline.Hash == "" || pipeline.Vertices == nil || len(pipeline.Vertices) == 0) {
 			logger.Warn(fmt.Sprintf("Pipeline document was discarded due to missing properties. This can happen when the Logstash node stats API is polled before the pipeline setup has completed. Pipeline ID: %s", pipelineID))
 		} else {
 			pipeline.ID = pipelineID

--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -29,8 +29,6 @@ import (
 
 	"github.com/elastic/beats/v7/metricbeat/module/logstash"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
@@ -153,7 +151,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 	var nodeStats NodeStats
 	err := json.Unmarshal(content, &nodeStats)
 	if err != nil {
-		return errors.Wrap(err, "could not parse node stats response")
+		return fmt.Errorf("could not parse node stats response: %w", err)
 	}
 
 	timestamp := common.Time(time.Now())
@@ -214,14 +212,14 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 			ModuleFields: mapstr.M{},
 		}
 
-		event.ModuleFields.Put("node.stats", logstashStats)
-		event.RootFields.Put("service.id", nodeStats.ID)
-		event.RootFields.Put("service.hostname", nodeStats.Host)
-		event.RootFields.Put("service.version", nodeStats.Version)
+		_, _ = event.ModuleFields.Put("node.stats", logstashStats)
+		_, _ = event.RootFields.Put("service.id", nodeStats.ID)
+		_, _ = event.RootFields.Put("service.hostname", nodeStats.Host)
+		_, _ = event.RootFields.Put("service.version", nodeStats.Version)
 
 		if clusterUUID != "" {
-			event.ModuleFields.Put("cluster.id", clusterUUID)
-			event.ModuleFields.Put("elasticsearch.cluster.id", clusterUUID)
+			_, _ = event.ModuleFields.Put("cluster.id", clusterUUID)
+			_, _ = event.ModuleFields.Put("elasticsearch.cluster.id", clusterUUID)
 		}
 
 		// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`

--- a/metricbeat/module/logstash/node_stats/data_test.go
+++ b/metricbeat/module/logstash/node_stats/data_test.go
@@ -110,13 +110,15 @@ func TestData(t *testing.T) {
 		}
 
 		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
-		w.Write(input)
+		_, err := w.Write(input)
+		require.NoError(t, err, "error writing file in / for TestData")
 	}))
 
 	mux.Handle("/_node/stats", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			input, _ := ioutil.ReadFile("./_meta/test/node_stats.710.json")
-			w.Write(input)
+			_, err := w.Write(input)
+			require.NoError(t, err, "error writing file in /_node/stats for TestData")
 		}))
 
 	server := httptest.NewServer(mux)


### PR DESCRIPTION
## What does this PR do?

This fixes rather odd bug that would happen the logstash module we receive a large integer value, handle it as a float, and then re-encode the json event as an integer or a float depending on the number of digits in the resulting number. This resulted in some mapping errors as fields would sometimes be floats, and sometimes be integers when received by logstash on the other end of metricbeat.

However, this ended up being a much more complex change than I anticipated, and I'd really like someone with some amount of logstash experience to go over this and make sure what I'm doing is correct. I'm particularly worried that some of these fields have changed across logstash versions in a way I don't know about. @mashhurs has done some work to document these fields, hence the review tag.

## Why is it important?

This would result in mapping errors in cases where the logstash module events was being sent to logstash, and then finally to elasticsearch.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
