### PR TITLE
Fix debug mode for dev-tools/kubernetes

### DIFF
--- a/dev-tools/kubernetes/Tiltfile
+++ b/dev-tools/kubernetes/Tiltfile
@@ -10,7 +10,7 @@ def compile(
     flags = ""
     suffix = ""
     if mode == "debug":
-        flags = '-gcflags "-N -l"'
+        flags = '-gcflags=all="-N -l"'
         suffix = "-debugger"
     build_cmd = "CGO_ENABLED=0 GOOS=linux GOARCH={} go build {} -o build/{}{} ../../{}".format(
         arch, flags, beat, suffix, beat)
@@ -61,10 +61,12 @@ def build(
         suffix = "-debugger"
         docker_entrypoint = [
             "dlv",
-            "--headless=true",
+            "--headless",
             "--listen=:56268",
             "--api-version=2",
             "--log",
+            "--log-output",
+            "debugger",
             "exec",
             "/usr/share/{}/{}{}".format(beat, beat, suffix),
             "--"

--- a/dev-tools/kubernetes/Tiltfile
+++ b/dev-tools/kubernetes/Tiltfile
@@ -127,11 +127,12 @@ def k8s_expose(
 # `arch`: `amd64` to build go binary for amd64 architecture, `arm64` to build go binary for arm64 (aka M1 Apple chip) architecture
 # `k8s_env`: `kind` to run against a Kind cluster with no docker repo, `gcp` to use a docker repo on GCP
 # `k8s_cluster`: `single` to use a single node k8s cluster, `multi` to use a k8s with more than 1 node.
-#       if running on a multi-node cluster we expect to have at least 2 workers and a control plane node.
-#       A Beat in debugger mode will run on a node with a Taint `debugger=yes:NoSchedule`, while 1 Beat per node will run on all the other worker nodes.
+#       if running on a multi-node cluster we expect to have at least 2 workers and a control plane node. One of the workers (eg. worker1)
+#       should have a taint and a label (for node affinity) to make sure that only the debugger runs on that node. You need to run the following commands:
+#         kubectl taint nodes worker1 debugger=ok:NoSchedule
+#         kubectl label nodes worker1 debugger=ok
 #       More info on Taints and Tolerations at https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/.
-#       You can add a taint with the following command:
-#           `kubectl taint nodes <node_name> debugger=yes:NoSchedule`
+#       More on node affinity at https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity.
 def beat(
         beat="metricbeat",
         mode="run",

--- a/dev-tools/kubernetes/filebeat/Dockerfile.debug
+++ b/dev-tools/kubernetes/filebeat/Dockerfile.debug
@@ -17,5 +17,5 @@ WORKDIR /usr/share/filebeat
 COPY --from=builder /go/bin/dlv /go/bin/dlv
 COPY --from=builder /usr/share/filebeat/filebeat-debugger /usr/share/filebeat/filebeat-debugger
 
-ENTRYPOINT ["dlv", "--headless=true", "--listen=:56268", "--api-version=2", "--log", "exec", /usr/share/filebeat/filebeat-debugger", "--"]
+ENTRYPOINT ["dlv", "--headless", "--listen=:56268", "--api-version=2", "--log",  "--log-output", "debugger", "exec", "/usr/share/filebeat/filebeat-debugger", "--"]
 CMD [ "-e" ]

--- a/dev-tools/kubernetes/filebeat/manifest.debug.yaml
+++ b/dev-tools/kubernetes/filebeat/manifest.debug.yaml
@@ -99,8 +99,9 @@ spec:
           # If using Red Hat OpenShift uncomment this:
           #privileged: true
         resources:
-          limits:
-            memory: 200Mi
+          ## on debugger image cause pod to crash since we use > 350MB of memory
+          # limits:
+          #   memory: 200Mi
           requests:
             cpu: 100m
             memory: 100Mi

--- a/dev-tools/kubernetes/metricbeat/Dockerfile.debug
+++ b/dev-tools/kubernetes/metricbeat/Dockerfile.debug
@@ -17,5 +17,5 @@ WORKDIR /usr/share/metricbeat
 COPY --from=builder /go/bin/dlv /go/bin/dlv
 COPY --from=builder /usr/share/metricbeat/metricbeat-debugger /usr/share/metricbeat/metricbeat-debugger
 
-ENTRYPOINT ["dlv", "--headless=true", "--listen=:56268", "--api-version=2", "--log", "exec", "/usr/share/metricbeat/metricbeat-debugger", "--"]
+ENTRYPOINT ["dlv", "--headless", "--listen=:56268", "--api-version=2", "--log",  "--log-output", "debugger", "exec", "/usr/share/metricbeat/metricbeat-debugger", "--"]
 CMD [ "-e" ]

--- a/dev-tools/kubernetes/metricbeat/manifest.debug.multi.yaml
+++ b/dev-tools/kubernetes/metricbeat/manifest.debug.multi.yaml
@@ -2,6 +2,35 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: metricbeat-debugger-config
+  namespace: kube-system
+  labels:
+    k8s-app: metricbeat
+data:
+  metricbeat.yml: |-
+      metricbeat.config.modules:
+        # Mounted `modules` configmap:
+        path: ${path.config}/modules.d/*.yml
+        # Reload module configs as they change:
+        reload.enabled: false
+
+      # processors:
+      #   - add_cloud_metadata:
+
+      cloud.id: ${ELASTIC_CLOUD_ID}
+      cloud.auth: ${ELASTIC_CLOUD_AUTH}
+
+      output.elasticsearch:
+        hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
+        protocol: https
+        ssl.verification_mode: "none"
+        username: ${ELASTICSEARCH_USERNAME}
+        password: ${ELASTICSEARCH_PASSWORD}
+        allow_older_versions: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: metricbeat-daemonset-config
   namespace: kube-system
   labels:
@@ -9,7 +38,7 @@ metadata:
 data:
   metricbeat.yml: |-
     metricbeat.config.modules:
-      # Mounted `metricbeat-daemonset-modules` configmap:
+      # Mounted `metricbeat-modules` configmap:
       path: ${path.config}/modules.d/*.yml
       # Reload module configs as they change:
       reload.enabled: false
@@ -79,7 +108,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: metricbeat-daemonset-modules
+  name: metricbeat-modules
   namespace: kube-system
   labels:
     k8s-app: metricbeat
@@ -184,12 +213,12 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        # resources:
+        #   limits:
+        #     memory: 200Mi
+        #   requests:
+        #     cpu: 100m
+        #     memory: 100Mi
         volumeMounts:
         - name: config
           mountPath: /etc/metricbeat.yml
@@ -220,7 +249,7 @@ spec:
       - name: modules
         configMap:
           defaultMode: 0640
-          name: metricbeat-daemonset-modules
+          name: metricbeat-modules
       - name: data
         hostPath:
           # When metricbeat runs as non-root user, this directory needs to be writable by group (g+w)
@@ -249,6 +278,15 @@ spec:
       terminationGracePeriodSeconds: 30
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: debugger
+                operator: In
+                values:
+                - ok
       tolerations:
         - key: "debugger"
           operator: "Exists"
@@ -284,12 +322,12 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
-        resources:
-          limits:
-            memory: 200Mi
-          requests:
-            cpu: 100m
-            memory: 100Mi
+        # resources:
+        #   limits:
+        #     memory: 200Mi
+        #   requests:
+        #     cpu: 100m
+        #     memory: 100Mi
         volumeMounts:
         - name: config
           mountPath: /etc/metricbeat.yml
@@ -316,11 +354,11 @@ spec:
       - name: config
         configMap:
           defaultMode: 0640
-          name: metricbeat-daemonset-config
+          name: metricbeat-debugger-config
       - name: modules
         configMap:
           defaultMode: 0640
-          name: metricbeat-daemonset-modules
+          name: metricbeat-modules
       - name: data
         hostPath:
           # When metricbeat runs as non-root user, this directory needs to be writable by group (g+w)

--- a/dev-tools/kubernetes/metricbeat/manifest.debug.multi.yaml
+++ b/dev-tools/kubernetes/metricbeat/manifest.debug.multi.yaml
@@ -2,35 +2,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: metricbeat-debugger-config
-  namespace: kube-system
-  labels:
-    k8s-app: metricbeat
-data:
-  metricbeat.yml: |-
-      metricbeat.config.modules:
-        # Mounted `modules` configmap:
-        path: ${path.config}/modules.d/*.yml
-        # Reload module configs as they change:
-        reload.enabled: false
-
-      # processors:
-      #   - add_cloud_metadata:
-
-      cloud.id: ${ELASTIC_CLOUD_ID}
-      cloud.auth: ${ELASTIC_CLOUD_AUTH}
-
-      output.elasticsearch:
-        hosts: ['${ELASTICSEARCH_HOST:elasticsearch}:${ELASTICSEARCH_PORT:9200}']
-        protocol: https
-        ssl.verification_mode: "none"
-        username: ${ELASTICSEARCH_USERNAME}
-        password: ${ELASTICSEARCH_PASSWORD}
-        allow_older_versions: true
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: metricbeat-daemonset-config
   namespace: kube-system
   labels:
@@ -38,7 +9,7 @@ metadata:
 data:
   metricbeat.yml: |-
     metricbeat.config.modules:
-      # Mounted `metricbeat-modules` configmap:
+      # Mounted `metricbeat-daemonset-modules` configmap:
       path: ${path.config}/modules.d/*.yml
       # Reload module configs as they change:
       reload.enabled: false
@@ -108,7 +79,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: metricbeat-modules
+  name: metricbeat-daemonset-modules
   namespace: kube-system
   labels:
     k8s-app: metricbeat
@@ -213,12 +184,12 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
-        # resources:
-        #   limits:
-        #     memory: 200Mi
-        #   requests:
-        #     cpu: 100m
-        #     memory: 100Mi
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - name: config
           mountPath: /etc/metricbeat.yml
@@ -249,7 +220,7 @@ spec:
       - name: modules
         configMap:
           defaultMode: 0640
-          name: metricbeat-modules
+          name: metricbeat-daemonset-modules
       - name: data
         hostPath:
           # When metricbeat runs as non-root user, this directory needs to be writable by group (g+w)
@@ -322,12 +293,13 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           runAsUser: 0
-        # resources:
-        #   limits:
-        #     memory: 200Mi
-        #   requests:
-        #     cpu: 100m
-        #     memory: 100Mi
+        resources:
+          ## on debugger image cause pod to crash since we use > 350MB of memory
+          # limits:
+          #   memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
         volumeMounts:
         - name: config
           mountPath: /etc/metricbeat.yml
@@ -354,11 +326,11 @@ spec:
       - name: config
         configMap:
           defaultMode: 0640
-          name: metricbeat-debugger-config
+          name: metricbeat-daemonset-config
       - name: modules
         configMap:
           defaultMode: 0640
-          name: metricbeat-modules
+          name: metricbeat-daemonset-modules
       - name: data
         hostPath:
           # When metricbeat runs as non-root user, this directory needs to be writable by group (g+w)

--- a/dev-tools/kubernetes/metricbeat/manifest.debug.yaml
+++ b/dev-tools/kubernetes/metricbeat/manifest.debug.yaml
@@ -189,8 +189,9 @@ spec:
         securityContext:
           runAsUser: 0
         resources:
-          limits:
-            memory: 200Mi
+          ## on debugger image cause pod to crash since we use > 350MB of memory
+          # limits:
+          #   memory: 200Mi
           requests:
             cpu: 100m
             memory: 100Mi


### PR DESCRIPTION
## What does this PR do?

Remove memory limits on the pod metricbeat-debugger that caused the pod to crash. Also uses pod affinity to schedule the debugger on a specific node

## Why is it important?

We want to run multiple Metricbeat instances in normal run mode (oner per worker node), plus having a node that run a Metricbeat instance in debugger mode.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

## Author's Checklist

- [ ] start Tilt to start a Metricbeat instance with remote debugger enabled on a single node in a multi-node k8s cluster

## How to test this PR locally

1. Run elastic stack locally with elastic-package stack up
2. Create a multinode Kind cluster with at least 2 worker nodes
3. Run `kubectl taint nodes <node_name> debugger=yes:NoSchedule` on one of the nodes
4. run `kubectl label nodes <name of node1> debugger=ok` 
5. From the folder dev-tools/kubernetes run tilt up to deploy Metricbeat in a multi node k8s cluster
6. Connect from your IDE to the remote debugger
7. Observer N metricbeat instances in Elastic correctly running and keep debugging Metricbeat
## Related issues

- Relates https://github.com/elastic/beats/pull/32607