### PR TITLE
packetbeat/sniffer: remove unused error return on Sniffer.Stop

### DIFF
--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -79,7 +79,7 @@ func (p *processor) Start() {
 }
 
 func (p *processor) Stop() {
-	p.sniffer.Stop() //nolint:errcheck // *sniffer.Sniffer.Stop() never returns a non-nil error.
+	p.sniffer.Stop()
 	if p.flows != nil {
 		p.flows.Stop()
 	}

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -229,11 +229,8 @@ func (s *Sniffer) open() (snifferHandle, error) {
 
 // Stop marks a sniffer as stopped. The Run method will return once the stop
 // signal has been given.
-func (s *Sniffer) Stop() error {
-	// FIXME: Remove error from signature it is never used
-	// and *Sniffer does not need it to satisfy an interface.
+func (s *Sniffer) Stop() {
 	s.state.Store(snifferClosing)
-	return nil
 }
 
 func validateConfig(filter string, cfg *config.InterfacesConfig) error {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This removes an unnecessary alway-nil error return on the `Sniffer.Stop` method. The method is not needed to satisfy an interface.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The code is not needed and adds complexity to the code base.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~ **Not user-facing**

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #32654

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
