### PR TITLE
packetbeat: add option to allow sniffer to change device when default route changes

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -129,6 +129,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Packetbeat*
 
+- Add option to allow sniffer to change device when default route changes. {issue}31905[31905] {pull}32681[32681]
 
 *Functionbeat*
 

--- a/packetbeat/_meta/config/beat.yml.tmpl
+++ b/packetbeat/_meta/config/beat.yml.tmpl
@@ -15,6 +15,11 @@
 # to sniff on the device carrying the default route.
 packetbeat.interfaces.device: {{ call .device .GOOS }}
 
+# Specify the amount of time between polling for changes in the default
+# route. This option is only used when one of the default route devices
+# is specified.
+packetbeat.interfaces.poll_default_route: 1m
+
 # The network CIDR blocks that are considered "internal" networks for
 # the purpose of network perimeter boundary classification. The valid
 # values for internal_networks are the same as those that can be used

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -58,7 +58,7 @@ var cmdLineArgs = flags{
 	loop:       flag.Int("l", 1, "Loop file. 0 - loop forever"),
 	oneAtAtime: flag.Bool("O", false, "Read packets one at a time (press Enter)"),
 	topSpeed:   flag.Bool("t", false, "Read packets as fast as possible, without sleeping"),
-	dumpfile:   flag.String("dump", "", "Write all captured packets to this libpcap file"),
+	dumpfile:   flag.String("dump", "", "Write all captured packets to libpcap files with this prefix - a timestamp and pcap extension are added"),
 }
 
 func initialConfig() config.Config {

--- a/packetbeat/config/config.go
+++ b/packetbeat/config/config.go
@@ -43,6 +43,9 @@ func (c Config) FromStatic(cfg *conf.C) (Config, error) {
 	if err != nil {
 		return c, err
 	}
+	if 0 < c.Interfaces.PollDefaultRoute && c.Interfaces.PollDefaultRoute < time.Second {
+		c.Interfaces.PollDefaultRoute = time.Second
+	}
 	return c, nil
 }
 
@@ -76,17 +79,18 @@ func (c Config) ICMP() (*conf.C, error) {
 }
 
 type InterfacesConfig struct {
-	Device                string   `config:"device"`
-	Type                  string   `config:"type"`
-	File                  string   `config:"file"`
-	WithVlans             bool     `config:"with_vlans"`
-	BpfFilter             string   `config:"bpf_filter"`
-	Snaplen               int      `config:"snaplen"`
-	BufferSizeMb          int      `config:"buffer_size_mb"`
-	EnableAutoPromiscMode bool     `config:"auto_promisc_mode"`
-	InternalNetworks      []string `config:"internal_networks"`
+	Device                string        `config:"device"`
+	PollDefaultRoute      time.Duration `config:"poll_default_route"`
+	Type                  string        `config:"type"`
+	File                  string        `config:"file"`
+	WithVlans             bool          `config:"with_vlans"`
+	BpfFilter             string        `config:"bpf_filter"`
+	Snaplen               int           `config:"snaplen"`
+	BufferSizeMb          int           `config:"buffer_size_mb"`
+	EnableAutoPromiscMode bool          `config:"auto_promisc_mode"`
+	InternalNetworks      []string      `config:"internal_networks"`
 	TopSpeed              bool
-	Dumpfile              string
+	Dumpfile              string // Dumpfile is the basename of pcap dumpfiles. The file names will have a creation time stamp and .pcap extension appended.
 	OneAtATime            bool
 	Loop                  int
 }

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -15,6 +15,11 @@
 # to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
+# Specify the amount of time between polling for changes in the default
+# route. This option is only used when one of the default route devices
+# is specified.
+packetbeat.interfaces.poll_default_route: 1m
+
 # The network CIDR blocks that are considered "internal" networks for
 # the purpose of network perimeter boundary classification. The valid
 # values for internal_networks are the same as those that can be used

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -245,7 +245,7 @@ func (s *Sniffer) sniffDynamic(defaultRoute <-chan string, refresh chan<- struct
 }
 
 // sniffOneDynamic handles sniffing a single device that may change link type.
-// If the the link type associated with the device differs from the last link
+// If the link type associated with the device differs from the last link
 // type or dec is nil, a new decoder is returned. The link type associated
 // with the device is returned.
 func (s *Sniffer) sniffOneDynamic(device string, last layers.LinkType, dec *decoder.Decoder, refresh chan<- struct{}) (layers.LinkType, *decoder.Decoder, error) {

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/google/gopacket"
@@ -33,6 +34,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/beats/v7/packetbeat/config"
+	"github.com/elastic/beats/v7/packetbeat/decoder"
 )
 
 // Sniffer provides packet sniffing capabilities, forwarding packets read
@@ -40,7 +42,12 @@ import (
 type Sniffer struct {
 	config config.InterfacesConfig
 
-	state atomic.Int32 // store snifferState
+	state atomic.Int32  // store snifferState
+	done  chan struct{} // done is required to wire state into a select.
+
+	// device is the first active device after calling New.
+	// It is not updated by default route polling.
+	device string
 
 	// filter is the bpf filter program used by the sniffer.
 	filter string
@@ -95,7 +102,7 @@ func New(testMode bool, filter string, decoders Decoders, interfaces config.Inte
 				return nil, err
 			}
 		} else {
-			s.config.Device = name
+			s.device = name
 			if name == "any" && !deviceAnySupported {
 				return nil, fmt.Errorf("any interface is not supported on %s", runtime.GOOS)
 			}
@@ -110,7 +117,7 @@ func New(testMode bool, filter string, decoders Decoders, interfaces config.Inte
 			if t := s.config.Type; t == "autodetect" || t == "" {
 				s.config.Type = "pcap"
 			}
-			logp.Debug("sniffer", "Sniffer type: %s device: %s", s.config.Type, s.config.Device)
+			logp.Debug("sniffer", "Sniffer type: %s device: %s", s.config.Type, s.device)
 		}
 	}
 
@@ -125,15 +132,124 @@ func New(testMode bool, filter string, decoders Decoders, interfaces config.Inte
 // Run opens the sniffing device and processes packets being read from that device.
 // Worker instances are instantiated as needed.
 func (s *Sniffer) Run() error {
-	handle, err := s.open()
+	var defaultRoute chan string
+	if s.config.PollDefaultRoute > 0 && strings.HasPrefix(s.config.Device, "default_route") {
+		s.done = make(chan struct{})
+		defaultRoute = make(chan string)
+		go s.pollDefaultRoute(defaultRoute)
+	}
+	if defaultRoute == nil {
+		return s.sniffStatic(s.device)
+	}
+	return s.sniffDynamic(defaultRoute)
+}
+
+// pollDefaultRoute repeatedly polls the default route's device at intervals
+// specified in config.PollDefaultRoute. The poller is terminated by closing
+// done and the device chan can be read for changes in the default route.
+// Changes in default route will put the Sniffer into the inactive state to
+// trigger a new sniffer connection. Termination of the sniffer is not under
+// the control of the poller.
+func (s *Sniffer) pollDefaultRoute(device chan string) {
+	go func() {
+		logp.Info("starting default route poller")
+
+		// Prime the channel.
+		current := s.device
+		device <- current
+
+		tick := time.NewTicker(s.config.PollDefaultRoute)
+		for {
+			select {
+			case <-tick.C:
+				logp.Debug("sniffer", "polling default route")
+				dev, err := resolveDeviceName(s.config.Device)
+				if err != nil {
+					logp.Warn("sniffer failed to poll default route device: %v", err)
+					continue
+				}
+				if dev != current {
+					logp.Info("sniffer changing default route device: %s -> %s", current, dev)
+					current = dev
+					s.state.Store(snifferInactive) // Mark current device as stale. ¯\_(ツ)_/¯
+					device <- current              // Pass the new device name.
+				}
+			case <-s.done:
+				logp.Info("closing default route poller")
+				close(device)
+				tick.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// sniffStatic performs the sniffing work on a single static interface.
+func (s *Sniffer) sniffStatic(device string) error {
+	handle, err := s.open(device)
 	if err != nil {
 		return fmt.Errorf("failed to start sniffer: %w", err)
 	}
 	defer handle.Close()
 
+	dec, err := s.decoders(handle.LinkType())
+	if err != nil {
+		return err
+	}
+
+	return s.sniffHandle(handle, dec)
+}
+
+// sniffDynamic performs sniffing work on a stream of dynamic interfaces from
+// defaultRoute decoders are retained between successive interfaces if they are
+// the same link type.
+func (s *Sniffer) sniffDynamic(defaultRoute <-chan string) error {
+	var (
+		last    layers.LinkType
+		decoder *decoder.Decoder
+	)
+	for device := range defaultRoute {
+		var err error
+		last, decoder, err = s.sniffOneDynamic(device, last, decoder)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sniffOneDynamic handles sniffing a single device that may change link type.
+// If the the link type associated with the device differs from the last link
+// type or dec is nil, a new decoder is returned. The link type associated
+// with the device is returned.
+func (s *Sniffer) sniffOneDynamic(device string, last layers.LinkType, dec *decoder.Decoder) (layers.LinkType, *decoder.Decoder, error) {
+	handle, err := s.open(device)
+	if err != nil {
+		return last, dec, fmt.Errorf("failed to start sniffer: %w", err)
+	}
+	defer handle.Close()
+
+	linkType := handle.LinkType()
+	if dec == nil || linkType != last {
+		logp.Info("changing link type: %d -> %d", last, linkType)
+		dec, err = s.decoders(linkType)
+		if err != nil {
+			return linkType, dec, err
+		}
+	}
+
+	err = s.sniffHandle(handle, dec)
+	return linkType, dec, err
+}
+
+// sniff performs the sniffing work and writing dump files if requested.
+func (s *Sniffer) sniffHandle(handle snifferHandle, dec *decoder.Decoder) error {
 	var w *pcapgo.Writer
 	if s.config.Dumpfile != "" {
-		f, err := os.Create(s.config.Dumpfile)
+		const timeSuffixFormat = "20060102150405"
+		filename := fmt.Sprintf("%s-%s.pcap", s.config.Dumpfile, time.Now().Format(timeSuffixFormat))
+		logp.Info("creating new dump file %s", filename)
+		f, err := os.Create(filename)
 		if err != nil {
 			return err
 		}
@@ -144,11 +260,6 @@ func (s *Sniffer) Run() error {
 		if err != nil {
 			return fmt.Errorf("failed to write dump file header to %s: %w", s.config.Dumpfile, err)
 		}
-	}
-
-	decoder, err := s.decoders(handle.LinkType())
-	if err != nil {
-		return err
 	}
 
 	// Mark inactive sniffer as active. In case of the sniffer/packetbeat closing
@@ -168,7 +279,12 @@ func (s *Sniffer) Run() error {
 
 		data, ci, err := handle.ReadPacketData()
 		if err == pcap.NextErrorTimeoutExpired || isAfpacketErrTimeout(err) { //nolint:errorlint // pcap.NextErrorTimeoutExpired is not wrapped.
-			logp.Debug("sniffer", "timedout")
+			logp.Debug("sniffer", "timed out")
+
+			// TODO: Consider a communication back to the default route
+			// poller to request a new device in this case, probably
+			// after a number of timeouts rather than on the first
+			// occasion.
 			continue
 		}
 
@@ -197,22 +313,22 @@ func (s *Sniffer) Run() error {
 		}
 
 		logp.Debug("sniffer", "Packet number: %d", packets)
-		decoder.OnPacket(data, &ci)
+		dec.OnPacket(data, &ci)
 	}
 
 	return nil
 }
 
-func (s *Sniffer) open() (snifferHandle, error) {
+func (s *Sniffer) open(device string) (snifferHandle, error) {
 	if s.config.File != "" {
 		return newFileHandler(s.config.File, s.config.TopSpeed, s.config.Loop)
 	}
 
 	switch s.config.Type {
 	case "pcap":
-		return openPcap(s.filter, &s.config)
+		return openPcap(device, s.filter, &s.config)
 	case "af_packet":
-		return openAFPacket(s.filter, &s.config)
+		return openAFPacket(device, s.filter, &s.config)
 	default:
 		return nil, fmt.Errorf("unknown sniffer type: %s", s.config.Type)
 	}
@@ -222,6 +338,9 @@ func (s *Sniffer) open() (snifferHandle, error) {
 // signal has been given.
 func (s *Sniffer) Stop() {
 	s.state.Store(snifferClosing)
+	if s.done != nil {
+		close(s.done)
+	}
 }
 
 func validateConfig(filter string, cfg *config.InterfacesConfig) error {
@@ -258,10 +377,10 @@ func validatePcapFilter(expr string) error {
 	return err
 }
 
-func openPcap(filter string, cfg *config.InterfacesConfig) (snifferHandle, error) {
+func openPcap(device, filter string, cfg *config.InterfacesConfig) (snifferHandle, error) {
 	snaplen := int32(cfg.Snaplen)
 	timeout := 500 * time.Millisecond
-	h, err := pcap.OpenLive(cfg.Device, snaplen, true, timeout)
+	h, err := pcap.OpenLive(device, snaplen, true, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -275,14 +394,14 @@ func openPcap(filter string, cfg *config.InterfacesConfig) (snifferHandle, error
 	return h, nil
 }
 
-func openAFPacket(filter string, cfg *config.InterfacesConfig) (snifferHandle, error) {
+func openAFPacket(device, filter string, cfg *config.InterfacesConfig) (snifferHandle, error) {
 	szFrame, szBlock, numBlocks, err := afpacketComputeSize(cfg.BufferSizeMb, cfg.Snaplen, os.Getpagesize())
 	if err != nil {
 		return nil, err
 	}
 
 	timeout := 500 * time.Millisecond
-	h, err := newAfpacketHandle(cfg.Device, szFrame, szBlock, numBlocks, timeout, cfg.EnableAutoPromiscMode)
+	h, err := newAfpacketHandle(device, szFrame, szBlock, numBlocks, timeout, cfg.EnableAutoPromiscMode)
 	if err != nil {
 		return nil, err
 	}

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -166,6 +166,7 @@ func (s *Sniffer) pollDefaultRoute(device chan<- string, refresh <-chan struct{}
 		// Prime the channel.
 		current := s.device
 		device <- current
+		defaultRouteMetric.Set(current)
 
 		tick := time.NewTicker(s.config.PollDefaultRoute)
 		for {
@@ -206,6 +207,7 @@ func (s *Sniffer) poll(old string, device chan<- string) (current string) {
 		logp.Info("sniffer changing default route device: %s -> %s", old, current)
 		s.state.Store(snifferInactive) // Mark current device as stale. ¯\_(ツ)_/¯
 		device <- current              // Pass the new device name.
+		defaultRouteMetric.Set(current)
 	}
 	return current
 }

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -15,6 +15,11 @@
 # to sniff on the device carrying the default route.
 packetbeat.interfaces.device: any
 
+# Specify the amount of time between polling for changes in the default
+# route. This option is only used when one of the default route devices
+# is specified.
+packetbeat.interfaces.poll_default_route: 1m
+
 # The network CIDR blocks that are considered "internal" networks for
 # the purpose of network perimeter boundary classification. The valid
 # values for internal_networks are the same as those that can be used


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Rather than attempting to append new sniffer device data to an established dump,
file, dump files are rolled when a new device is used. The alternative would
require keeping a track of link type and *pcapgo.Writer between calls to sniff
to ensure that the dump file is not truncated and that the header is
appropriately written.

If the user needs to have a single pcap file for the session, they can be merged
using either wireshark or mergecap.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This makes packetbeat more useful on non-linux platforms that do not allow sniffing on the "any" device.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Make the following change and run packetbeat locally with `packetbeat run -e`.

```diff
diff --git a/packetbeat/packetbeat.yml b/packetbeat/packetbeat.yml
index ace50f29d3..18d30247ce 100644
--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -13,12 +13,13 @@
 # "any" keyword to sniff on all connected interfaces. On all platforms, you
 # can use "default_route", "default_route_ipv4" or "default_route_ipv6"
 # to sniff on the device carrying the default route.
-packetbeat.interfaces.device: any
+packetbeat.interfaces.device: default_route
 
 # Specify the amount of time between polling for changes in the default
 # route. This option is only used when one of the default route devices
 # is specified.
-packetbeat.interfaces.poll_default_route: 1m
+packetbeat.interfaces.poll_default_route: 20s
+packetbeat.interfaces.dumpfile: dump
 
 # The network CIDR blocks that are considered "internal" networks for
 # the purpose of network perimeter boundary classification. The valid
```

You should see a set of files in the form `dump-<timestamp>.pcap`. Opening these with wireshark should show you the network activity on the default route. Changing network interface should not stop capture, though there may be interruptions up to 20s long.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #31905

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
