### PR TITLE
Update .mergify.yml with missing 8.1.0 backport

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -163,6 +163,19 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.1 branch
+    conditions:
+      - merged
+      - label=backport-v8.1.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.1"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.2 branch
     conditions:
       - merged

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -163,6 +163,19 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.0 branch
+    conditions:
+      - merged
+      - label=backport-v8.0.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.0"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.1 branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

Add support to mergify to create 8.0.0 and 8.1.0 PRs 

## Why is it important?

PRs for backport for versions 8.0.0 and 8.1.0 are not created automaically

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] check that .mergify config is valid and it is able to create PRs for 8.0.0 and 8.1.0

