### PR TITLE
Run linter across some files that Will deal with the V2 agent update

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/filebeat/channel"
 	cfg "github.com/elastic/beats/v7/filebeat/config"
 	"github.com/elastic/beats/v7/filebeat/fileset"
@@ -47,8 +45,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 	"github.com/elastic/go-concert/unison"
-
-	_ "github.com/elastic/beats/v7/filebeat/include"
 
 	// Add filebeat level processors
 	_ "github.com/elastic/beats/v7/filebeat/processor/add_kubernetes_metadata"
@@ -91,7 +87,7 @@ func New(plugins PluginFactory) beat.Creator {
 func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Beater, error) {
 	config := cfg.DefaultConfig
 	if err := rawConfig.Unpack(&config); err != nil {
-		return nil, fmt.Errorf("Error reading config file: %v", err)
+		return nil, fmt.Errorf("Error reading config file: %w", err)
 	}
 
 	if err := cfgwarn.CheckRemoved6xSettings(
@@ -130,7 +126,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 
 	if !config.ConfigInput.Enabled() && !config.ConfigModules.Enabled() && !haveEnabledInputs && config.Autodiscover == nil && !b.Manager.Enabled() {
 		if !b.InSetupCmd {
-			return nil, errors.New("no modules or inputs enabled and configuration reloading disabled. What files do you want me to watch?")
+			return nil, fmt.Errorf("no modules or inputs enabled and configuration reloading disabled. What files do you want me to watch?")
 		}
 
 		// in the `setup` command, log this only as a warning
@@ -138,7 +134,7 @@ func newBeater(b *beat.Beat, plugins PluginFactory, rawConfig *conf.C) (beat.Bea
 	}
 
 	if *once && config.ConfigInput.Enabled() && config.ConfigModules.Enabled() {
-		return nil, errors.New("input configs and -once cannot be used together")
+		return nil, fmt.Errorf("input configs and -once cannot be used together")
 	}
 
 	if config.IsInputEnabled("stdin") && len(enabledInputs) > 1 {
@@ -291,7 +287,9 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	}
 
 	var inputTaskGroup unison.TaskGroup
-	defer inputTaskGroup.Stop()
+	defer func() {
+		_ = inputTaskGroup.Stop()
+	}()
 	if err := v2InputLoader.Init(&inputTaskGroup, v2.ModeRun); err != nil {
 		logp.Err("Failed to initialize the input managers: %v", err)
 		return err
@@ -316,7 +314,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	// Start the registrar
 	err = registrar.Start()
 	if err != nil {
-		return fmt.Errorf("Could not start registrar: %v", err)
+		return fmt.Errorf("Could not start registrar: %w", err)
 	}
 
 	// Stopping registrar will write last state
@@ -340,7 +338,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 	err = crawler.Start(fb.pipeline, config.ConfigInput, config.ConfigModules)
 	if err != nil {
 		crawler.Stop()
-		return fmt.Errorf("Failed to start crawler: %+v", err)
+		return fmt.Errorf("Failed to start crawler: %w", err)
 	}
 
 	// If run once, add crawler completion check as alternative to done signal
@@ -433,7 +431,7 @@ func newPipelineLoaderFactory(esConfig *conf.C) fileset.PipelineLoaderFactory {
 	pipelineLoaderFactory := func() (fileset.PipelineLoader, error) {
 		esClient, err := eslegclient.NewConnectedClient(esConfig, "Filebeat")
 		if err != nil {
-			return nil, errors.Wrap(err, "Error creating Elasticsearch client")
+			return nil, fmt.Errorf("Error creating Elasticsearch client: %w", err)
 		}
 		return esClient, nil
 	}

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -18,9 +18,8 @@
 package reload
 
 import (
+	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -72,11 +71,11 @@ func (r *Registry) Register(name string, obj Reloadable) error {
 	defer r.Unlock()
 
 	if obj == nil {
-		return errors.New("got a nil object")
+		return fmt.Errorf("got a nil object")
 	}
 
 	if r.nameTaken(name) {
-		return errors.Errorf("%s configuration list is already registered", name)
+		return fmt.Errorf("%s configuration list is already registered", name)
 	}
 
 	r.confs[name] = obj
@@ -89,11 +88,11 @@ func (r *Registry) RegisterList(name string, list ReloadableList) error {
 	defer r.Unlock()
 
 	if list == nil {
-		return errors.New("got a nil object")
+		return fmt.Errorf("got a nil object")
 	}
 
 	if r.nameTaken(name) {
-		return errors.Errorf("%s configuration is already registered", name)
+		return fmt.Errorf("%s configuration is already registered", name)
 	}
 
 	r.confsLists[name] = list

--- a/libbeat/common/reload/reload_test.go
+++ b/libbeat/common/reload/reload_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type reloadable struct{}
@@ -33,7 +34,8 @@ func TestRegisterReloadable(t *testing.T) {
 	obj := reloadable{}
 	r := NewRegistry()
 
-	r.Register("my.reloadable", obj)
+	err := r.Register("my.reloadable", obj)
+	require.NoError(t, err)
 
 	assert.Equal(t, obj, r.GetReloadable("my.reloadable"))
 }
@@ -42,7 +44,8 @@ func TestRegisterReloadableList(t *testing.T) {
 	objl := reloadableList{}
 	r := NewRegistry()
 
-	r.RegisterList("my.reloadable", objl)
+	err := r.RegisterList("my.reloadable", objl)
+	require.NoError(t, err)
 
 	assert.Equal(t, objl, r.GetReloadableList("my.reloadable"))
 }

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -18,9 +18,8 @@
 package beater
 
 import (
+	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/autodiscover"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -131,7 +130,7 @@ func DefaultTestModulesCreator() beat.Creator {
 func newMetricbeat(b *beat.Beat, c *conf.C, options ...Option) (*Metricbeat, error) {
 	config := defaultConfig
 	if err := c.Unpack(&config); err != nil {
-		return nil, errors.Wrap(err, "error reading configuration file")
+		return nil, fmt.Errorf("error reading configuration file: %w", err)
 	}
 
 	dynamicCfgEnabled := config.ConfigModules.Enabled() || config.Autodiscover != nil || b.Manager.Enabled()


### PR DESCRIPTION
## What does this PR do?

This change is related to https://github.com/elastic/beats/pull/32673

That PR is already fairly large, so this is an attempt to break it up by just doing the "make linter happy" changes in a separate PR, and then rebase the V2 support PR.


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
