### PR TITLE
Revert "Update .mergify.yml with missing 8.1.0 backport"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -163,32 +163,6 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.0 branch
-    conditions:
-      - merged
-      - label=backport-v8.0.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.0"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.1 branch
-    conditions:
-      - merged
-      - label=backport-v8.1.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.1"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.2 branch
     conditions:
       - merged


### PR DESCRIPTION
Reverts elastic/beats#32689

Non active branches should not have automated backports, so if it's required to backport any PRs, then it should be done manually or through the Mergify command, https://docs.mergify.com/commands/#backport

This was agreed sometime ago, when accidentally PRs were backported to old branches and those PRs were new features.