### PR TITLE
mergify: backport policy

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -129,6 +129,23 @@ pull_request_rules:
         - files~=^\.mergify\.yml$
     actions:
       delete_head_branch:
+  - name: notify the backport policy
+    conditions:
+      - -label~=^backport
+      - base=main
+      - -merged
+      - -closed
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label.
+          If this is a bug or security fix, could you label this PR @{{author}}? 🙏.
+          For such, you'll need to label your PR with:
+          * The upcoming major version of the Elastic Stack
+          * The upcoming minor version of the Elastic Stack (if you're not pushing a breaking change)
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `backport-v8./d.0` is the label to automatically backport to the `8./d` branch. `/d` is the digit
   - name: notify the backport has not been merged yet
     conditions:
       - -merged

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -141,15 +141,6 @@ pull_request_rules:
       comment:
         message: |
           This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
-  - name: remove-backport label
-    conditions:
-      - label~=backport-v
-      - -merged
-      - -closed
-    actions:
-      label:
-        remove:
-          - backport-skip
   - name: backport patches to 7.17 branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

Add a specific message so the backport policy is public available.

## Why is it important?

https://github.com/elastic/beats/pull/31104 remove the backport notification by default, but the backport policy is not explained and therefore https://github.com/elastic/beats/pull/32689 was created as a consequence.

Thanks @gsantoro for pointing about this



