### PR TITLE
Add persistence acknowledgement support for shipper

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10069,11 +10069,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-l
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/elastic-agent-shipper-client
-Version: v0.2.0
+Version: v0.4.0
 Licence type (autodetected): Elastic
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-shipper-client@v0.2.0/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-shipper-client@v0.4.0/LICENSE.txt:
 
 Elastic License 2.0
 

--- a/go.mod
+++ b/go.mod
@@ -203,7 +203,7 @@ require (
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/elastic-agent-autodiscover v0.2.1
 	github.com/elastic/elastic-agent-libs v0.2.11
-	github.com/elastic/elastic-agent-shipper-client v0.2.0
+	github.com/elastic/elastic-agent-shipper-client v0.4.0
 	github.com/elastic/elastic-agent-system-metrics v0.4.4
 	github.com/elastic/go-elasticsearch/v8 v8.2.0
 	github.com/pierrec/lz4/v4 v4.1.15

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/elastic/elastic-agent-libs v0.2.5/go.mod h1:chO3rtcLyGlKi9S0iGVZhYCzD
 github.com/elastic/elastic-agent-libs v0.2.7/go.mod h1:chO3rtcLyGlKi9S0iGVZhYCzDfdDsAQYBc+ui588AFE=
 github.com/elastic/elastic-agent-libs v0.2.11 h1:ZeYn35Kxt+IdtMPmE01TaDeaahCg/z7MkGPVWUo6Lp4=
 github.com/elastic/elastic-agent-libs v0.2.11/go.mod h1:chO3rtcLyGlKi9S0iGVZhYCzDfdDsAQYBc+ui588AFE=
-github.com/elastic/elastic-agent-shipper-client v0.2.0 h1:p+5ep48YCOe+3nICeWmiLwQV11yDLad2n4NunI66Shg=
-github.com/elastic/elastic-agent-shipper-client v0.2.0/go.mod h1:OyI2W+Mv3JxlkEF3OeT7K0dbuxvwew8ke2Cf4HpLa9Q=
+github.com/elastic/elastic-agent-shipper-client v0.4.0 h1:nsTJF9oo4RHLl+zxFUZqNHaE86C6Ba5aImfegcEf6Sk=
+github.com/elastic/elastic-agent-shipper-client v0.4.0/go.mod h1:OyI2W+Mv3JxlkEF3OeT7K0dbuxvwew8ke2Cf4HpLa9Q=
 github.com/elastic/elastic-agent-system-metrics v0.4.4 h1:Br3S+TlBhijrLysOvbHscFhgQ00X/trDT5VEnOau0E0=
 github.com/elastic/elastic-agent-system-metrics v0.4.4/go.mod h1:tF/f9Off38nfzTZHIVQ++FkXrDm9keFhFpJ+3pQ00iI=
 github.com/elastic/elastic-transport-go/v8 v8.1.0 h1:NeqEz1ty4RQz+TVbUrpSU7pZ48XkzGWQj02k5koahIE=

--- a/libbeat/outputs/shipper/api/shipper_mock.go
+++ b/libbeat/outputs/shipper/api/shipper_mock.go
@@ -58,9 +58,6 @@ func (p *ProducerMock) PublishEvents(ctx context.Context, r *messages.PublishReq
 	}
 
 	resp.AcceptedIndex = uint64(len(p.Q))
-	if resp.AcceptedIndex > 0 {
-		resp.PersistedIndex = resp.AcceptedIndex - 1 // so we trigger the use of `PersistedIndex`
-	}
 
 	return resp, nil
 }

--- a/libbeat/outputs/shipper/config.go
+++ b/libbeat/outputs/shipper/config.go
@@ -39,7 +39,10 @@ type Config struct {
 	MaxRetries int `config:"max_retries" validate:"min=-1,nonzero"`
 	// BulkMaxSize max amount of events in a single batch
 	BulkMaxSize int `config:"bulk_max_size"`
-	// AckPollingInterval is an interval for polling the shipper server for persistence acknowledgement
+	// AckPollingInterval is an interval for polling the shipper server for persistence acknowledgement.
+	// The default/minimum 5 ms polling interval means we could publish at most 1000 ms / 5 ms = 200 batches/sec.
+	// With the default `bulk_max_size` of 50 events this would limit
+	// the default throughput per worker to 200 * 50 = 10000 events/sec.
 	AckPollingInterval time.Duration `config:"ack_polling_interval" validate:"min=5ms"`
 	// Backoff strategy for the shipper output
 	Backoff backoffConfig `config:"backoff"`

--- a/libbeat/outputs/shipper/config.go
+++ b/libbeat/outputs/shipper/config.go
@@ -34,21 +34,24 @@ type Config struct {
 	// TLS/SSL configurationf or secure connection
 	TLS *tlscommon.Config `config:"ssl"`
 	// Timeout of a single batch publishing request
-	Timeout time.Duration `config:"timeout"             validate:"min=1"`
+	Timeout time.Duration `config:"timeout" validate:"min=1"`
 	// MaxRetries is how many times the same batch is attempted to be sent
-	MaxRetries int `config:"max_retries"         validate:"min=-1,nonzero"`
+	MaxRetries int `config:"max_retries" validate:"min=-1,nonzero"`
 	// BulkMaxSize max amount of events in a single batch
 	BulkMaxSize int `config:"bulk_max_size"`
+	// AckPollingInterval is an interval for polling the shipper server for persistence acknowledgement
+	AckPollingInterval time.Duration `config:"ack_polling_interval" validate:"min=5ms"`
 	// Backoff strategy for the shipper output
 	Backoff backoffConfig `config:"backoff"`
 }
 
 func defaultConfig() Config {
 	return Config{
-		TLS:         nil,
-		Timeout:     30 * time.Second,
-		MaxRetries:  3,
-		BulkMaxSize: 50,
+		TLS:                nil,
+		Timeout:            30 * time.Second,
+		MaxRetries:         3,
+		BulkMaxSize:        50,
+		AckPollingInterval: 5 * time.Millisecond,
 		Backoff: backoffConfig{
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,

--- a/libbeat/outputs/shipper/shipper.go
+++ b/libbeat/outputs/shipper/shipper.go
@@ -177,7 +177,7 @@ func (c *shipper) Publish(ctx context.Context, batch publisher.Batch) error {
 		Events: convertedEvents,
 	})
 
-	if status.Code(err) != codes.OK || publishReply == nil {
+	if status.Code(err) != codes.OK {
 		batch.Cancelled()         // does not decrease the TTL
 		st.Cancelled(len(events)) // we cancel the whole batch not just non-dropped events
 		return fmt.Errorf("failed to publish the batch to the shipper, none of the %d events were accepted: %w", len(convertedEvents), err)

--- a/libbeat/outputs/shipper/shipper.go
+++ b/libbeat/outputs/shipper/shipper.go
@@ -208,9 +208,7 @@ func (c *shipper) Publish(ctx context.Context, batch publisher.Batch) error {
 		if indexReply.GetUuid() != c.serverID {
 			batch.Cancelled()
 			st.Cancelled(len(events))
-			err := fmt.Errorf("acknowledgement failed due to a connection to a different server %s, expected %s", indexReply.Uuid, c.serverID)
-			c.serverID = indexReply.GetUuid()
-			return err
+			return fmt.Errorf("acknowledgement failed due to a connection to a different server %s, expected %s", indexReply.Uuid, c.serverID)
 		}
 
 		if indexReply.PersistedIndex >= publishReply.AcceptedIndex {

--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -386,7 +386,7 @@ func TestPublish(t *testing.T) {
 		require.Equal(t, expSignals, batch.Signals)
 	})
 
-	t.Run("cancel the batch when a differnet server responds", func(t *testing.T) {
+	t.Run("cancel the batch when a different server responds", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 

--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -419,9 +419,12 @@ func TestPublish(t *testing.T) {
 		batch = outest.NewBatch(events...)
 		err = client.Publish(ctx, batch)
 		require.Error(t, err)
-		// the mock server does not validate incoming IDs on `Publish`, so the error should come from
-		// the acknowledgement request
-		require.Contains(t, err.Error(), "acknowledgement failed due to a connection to a different server")
+
+		require.Eventually(t, func() bool {
+			// the mock server does not validate incoming IDs on `Publish`, so the error should come from
+			// the acknowledgement request
+			return strings.Contains(err.Error(), "acknowledgement failed due to a connection to a different server")
+		}, 100*time.Millisecond, 10*time.Millisecond)
 	})
 
 }

--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -305,21 +305,11 @@ func TestPublish(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			group, err := makeShipper(
-				nil,
-				beat.Info{Beat: "libbeat", IndexPrefix: "testbeat"},
-				outputs.NewNilObserver(),
-				cfg,
-			)
-			require.NoError(t, err)
-			require.Len(t, group.Clients, 1)
+			client := createShipperClient(t, cfg)
 
 			batch := outest.NewBatch(tc.events...)
 
-			err = group.Clients[0].(outputs.Connectable).Connect()
-			require.NoError(t, err)
-
-			err = group.Clients[0].Publish(ctx, batch)
+			err = client.Publish(ctx, batch)
 			if tc.expError != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expError)
@@ -348,19 +338,7 @@ func TestPublish(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		group, err := makeShipper(
-			nil,
-			beat.Info{Beat: "libbeat", IndexPrefix: "testbeat"},
-			outputs.NewNilObserver(),
-			cfg,
-		)
-		require.NoError(t, err)
-		require.Len(t, group.Clients, 1)
-
-		client := group.Clients[0].(outputs.NetworkClient)
-
-		err = client.Connect()
-		require.NoError(t, err)
+		client := createShipperClient(t, cfg)
 
 		// Should successfully publish with the server running
 		batch := outest.NewBatch(events...)
@@ -407,6 +385,45 @@ func TestPublish(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, expSignals, batch.Signals)
 	})
+
+	t.Run("cancel the batch when a differnet server responds", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		addr, stop := runServer(t, 5, nil, "localhost:0")
+		defer stop()
+
+		cfg, err := config.NewConfigFrom(map[string]interface{}{
+			"server":  addr,
+			"timeout": 5, // 5 sec
+			"backoff": map[string]interface{}{
+				"init": "10ms",
+				"max":  "5s",
+			},
+		})
+		require.NoError(t, err)
+
+		client := createShipperClient(t, cfg)
+
+		// Should successfully publish without an ID change
+		batch := outest.NewBatch(events...)
+		err = client.Publish(ctx, batch)
+		require.NoError(t, err)
+
+		// Replace the server (would change the ID)
+		stop()
+
+		_, stop = runServer(t, 5, nil, addr)
+		defer stop()
+
+		batch = outest.NewBatch(events...)
+		err = client.Publish(ctx, batch)
+		require.Error(t, err)
+		// the mock server does not validate incoming IDs on `Publish`, so the error should come from
+		// the acknowledgement request
+		require.Contains(t, err.Error(), "acknowledgement failed due to a connection to a different server")
+	})
+
 }
 
 // BenchmarkToShipperEvent is used to detect performance regression when the conversion function is changed.
@@ -483,6 +500,24 @@ func runServer(t *testing.T, qSize int, err error, listenAddr string) (actualAdd
 	}
 
 	return actualAddr, stop
+}
+
+func createShipperClient(t *testing.T, cfg *config.C) outputs.NetworkClient {
+	group, err := makeShipper(
+		nil,
+		beat.Info{Beat: "libbeat", IndexPrefix: "testbeat"},
+		outputs.NewNilObserver(),
+		cfg,
+	)
+	require.NoError(t, err)
+	require.Len(t, group.Clients, 1)
+
+	client := group.Clients[0].(outputs.NetworkClient)
+
+	err = client.Connect()
+	require.NoError(t, err)
+
+	return client
 }
 
 func protoStruct(t *testing.T, values map[string]interface{}) *messages.Struct {


### PR DESCRIPTION
## What does this PR do?

Now the shipper output is able to receive acknowledgement of the
persisted events from the shipper server.

Also, added the UUID verification in case the client is reconnected to
a different server.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To avoid data loss.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #32329 
