### PR TITLE
mergify remove 8.2 backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -143,6 +143,7 @@ pull_request_rules:
           For such, you'll need to label your PR with:
           * The upcoming major version of the Elastic Stack
           * The upcoming minor version of the Elastic Stack (if you're not pushing a breaking change)
+
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
           * `backport-v8./d.0` is the label to automatically backport to the `8./d` branch. `/d` is the digit

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -172,19 +172,6 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: backport patches to 8.2 branch
-    conditions:
-      - merged
-      - label=backport-v8.2.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.2"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
   - name: backport patches to 8.3 branch
     conditions:
       - merged


### PR DESCRIPTION
## What does this PR do?

Remove support for automated backports to `8.2` using GitHub labels. It's still possible to use `@mergifyio backport 8.2` if needed

## Why is it important?

avoid accident backports