### PR TITLE
ci: enable synthetics tests for heartbeats

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -356,6 +356,13 @@ def withTools(Map args = [:], Closure body) {
     withGCP() {
       body()
     }
+  } else if (args.get('nodejs', false)) {
+    withNodeJSEnv() {
+      withEnv(["ELASTIC_SYNTHETICS_CAPABLE=true"]) {
+        cmd(label: "Install @elastic/synthetics", script: "npm i -g @elastic/synthetics")
+        body()
+      }
+    }
   } else {
     body()
   }
@@ -588,10 +595,11 @@ def targetWithoutNode(Map args = [:]) {
   def dockerArch = args.get('dockerArch', 'amd64')
   def enableRetry = args.get('enableRetry', false)
   def withGCP = args.get('withGCP', false)
+  def withNodejs = args.get('withNodejs', false)
   withGithubNotify(context: "${context}") {
     withBeatsEnv(archive: true, withModule: withModule, directory: directory, id: args.id) {
       dumpVariables()
-      withTools(k8s: installK8s, gcp: withGCP) {
+      withTools(k8s: installK8s, gcp: withGCP, nodejs: withNodejs) {
         // make commands use -C <folder> while mage commands require the dir(folder)
         // let's support this scenario with the location variable.
         dir(isMage ? directory : '') {
@@ -1088,6 +1096,7 @@ class RunCommand extends co.elastic.beats.BeatsFunction {
       def installK8s = args.content.get('installK8s', false)
       def withAWS = args.content.get('withAWS', false)
       def withGCP = args.content.get('withGCP', false)
+      def withNodejs = args.content.get('withNodejs', false)
       //
       // What's the retry policy for fighting the flakiness:
       //   1) Lint/Packaging/Cloud/k8sTest stages don't retry, since their failures are normally legitim
@@ -1118,6 +1127,7 @@ class RunCommand extends co.elastic.beats.BeatsFunction {
                      withModule: withModule,
                      isMage: true,
                      withGCP: withGCP,
+                     withNodejs: withNodejs,
                      id: args.id,
                      enableRetry: enableRetry)
       }

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -37,6 +37,7 @@ stages:
         stage: extended
     unitTest:
         mage: "mage build unitTest"
+        withNodejs: true
         stage: mandatory
     goIntegTest:
         mage: "mage goIntegTest"

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -37,7 +37,6 @@ stages:
         stage: extended
     unitTest:
         mage: "mage build unitTest"
-        withNodejs: true
         stage: mandatory
     goIntegTest:
         mage: "mage goIntegTest"

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -27,6 +27,7 @@ stages:
         stage: mandatory
     goIntegTest:
         mage: "mage goIntegTest"
+        withNodejs: true
         stage: mandatory
     macos:
         mage: "mage build unitTest"

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -23,6 +23,7 @@ stages:
         stage: checks
     unitTest:
         mage: "mage build unitTest"
+        withNodejs: true
         stage: mandatory
     goIntegTest:
         mage: "mage goIntegTest"


### PR DESCRIPTION
## What

So, we'd want our CI boxes that run the unit tests for `x-pack/heartbeat` to:

1. Have node available
2. Have `npm i -g @elastic/synthetics` installed
3. Have the `ELASTIC_SYNTHETICS_CAPABLE` flag set to `true` to signal that it can run these tests.


## Why

With https://github.com/elastic/beats/pull/32542 we now have improved testing of browser based monitors in heartbeat. We don't, however, have a good way to run these tests using the actual synthetics node package. Heartbeat fork/execs the `elastic-synthetics` binary provided by `npm i -g @elastic/synthetics` to run browser monitors. 

### Test

The [first build](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-32710/1/) ran the below steps:
<img width="1766" alt="image" src="https://user-images.githubusercontent.com/2871786/185071840-390df00f-3601-4408-9aeb-f3730b59f7be.png">

#### `heartbeat`

**NOTE**: As requested it will not run on `heartbeat` but `x-pack/heartbeat` only.

This [log](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-32710/1/execution/node/18293/log/) is the one with the `npm i -g @elastic/synthetics` execution and this [other log](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-32710/1/execution/node/18446/log/) is the one with the traces for running `mage build unitTest` for the `hearbeat`

#### `x-pack/heartbeat`  when `mage unitTest`

<img width="1746" alt="image" src="https://user-images.githubusercontent.com/2871786/185072676-7490a303-75fb-4800-9d40-6ee1f3e11bd7.png"> 

This [log](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-32710/1/execution/node/18572/log/)  is the one with the traces for running `mage build unitTest` for the `x-pack/hearbeat`, @andrewvc , can you please verify if that's the expected behaviour?

#### `x-pack/heartbeat` when `mage goIntegTest`

<img width="1755" alt="image" src="https://user-images.githubusercontent.com/2871786/185383445-ed6fca61-444e-4200-af0f-cbd672a7dcdc.png">
