### PR TITLE
actions: run check for x-pack/packetbeat and packebeat

### DIFF
--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -22,6 +22,7 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     - name: Run check/update
       run: |
-        go get -u github.com/magefile/mage
+        export PATH=$PATH:$(go env GOPATH)/bin
+        go install github.com/magefile/mage@latest
         make -C ${{ env.BEAT_MODULE }} check update
         make check-no-changes

--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -1,0 +1,26 @@
+name: check-packetbeat
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/check-packetbeat.yml'
+      - 'packetbeat/**'
+      - 'x-pack/packetbeat/**'
+
+env:
+  BEAT_MODULE: 'packetbeat'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch Go version from .go-version
+      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Install dependencies
+      run:  go get -u github.com/magefile/mage
+    - name: Run check/update
+      run: make -C ${{ env.BEAT_MODULE }} check update; make check-no-changes

--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Install dependencies
-      run:  go get -u github.com/magefile/mage
     - name: Run check/update
-      run: make -C ${{ env.BEAT_MODULE }} check update; make check-no-changes
+      run: |
+        make -C ${{ env.BEAT_MODULE }} check update
+        make check-no-changes

--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -20,6 +20,8 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
+    - name: Install libpcap-dev
+      run: sudo apt-get install -y libpcap-dev
     - name: Run check/update
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin

--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -22,5 +22,6 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     - name: Run check/update
       run: |
+        go get -u github.com/magefile/mage
         make -C ${{ env.BEAT_MODULE }} check update
         make check-no-changes

--- a/.github/workflows/check-xpack-packetbeat.yml
+++ b/.github/workflows/check-xpack-packetbeat.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/check-xpack-packetbeat.yml'
       - 'x-pack/packetbeat/**'
+      - 'packetbeat/**'
 
 env:
   BEAT_MODULE: 'x-pack/packetbeat'

--- a/.github/workflows/check-xpack-packetbeat.yml
+++ b/.github/workflows/check-xpack-packetbeat.yml
@@ -20,6 +20,8 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
+    - name: Install libpcap-dev
+      run: sudo apt-get install -y libpcap-dev
     - name: Run check/update
       uses: magefile/mage-action@v2
       with:

--- a/.github/workflows/check-xpack-packetbeat.yml
+++ b/.github/workflows/check-xpack-packetbeat.yml
@@ -1,0 +1,25 @@
+name: check-x-pack-packetbeat
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/check-xpack-packetbeat.yml'
+      - 'x-pack/packetbeat/**'
+
+env:
+  BEAT_MODULE: 'x-pack/packetbeat'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch Go version from .go-version
+      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Install dependencies
+      run:  go get -u github.com/magefile/mage
+    - name: Run check/update
+      run: cd ${{ env.BEAT_MODULE }}; mage check; mage update

--- a/.github/workflows/check-xpack-packetbeat.yml
+++ b/.github/workflows/check-xpack-packetbeat.yml
@@ -20,7 +20,8 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Install dependencies
-      run:  go get -u github.com/magefile/mage
     - name: Run check/update
-      run: cd ${{ env.BEAT_MODULE }}; mage check; mage update
+      uses: magefile/mage-action@v2
+      with:
+        args: check update
+        workdir: "${{ env.BEAT_MODULE }}"

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -3,6 +3,8 @@ name: OpenTelemetry Export Trace
 on:
   workflow_run:
     workflows:
+      - check-x-pack-packetbeat
+      - check-packetbeat
       - golangci-lint
       - auditbeat
       - filebeat

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -13,15 +13,6 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    checks:
-        make: |
-          make -C packetbeat check;
-          make -C packetbeat update;
-          make check-no-changes;
-          cd x-pack/packetbeat;
-          mage check;
-          mage update;
-        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -13,15 +13,6 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    checks:
-        mage: |
-          mage check;
-          mage update;
-        make: |
-          make -C packetbeat check;
-          make -C packetbeat update;
-          make check-no-changes;
-        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.


### PR DESCRIPTION
## What does this PR do?

Use GitHub actions to run the `check stage` for `packetbeat` and `x-pack/packetbeat`

What's the `check stage`?
- `make check`
- `make update`
- `make check-no-changes`
- `mage check`
- `mage update`

## Why is it important?

Faster build by running linting/checks outside of the main CI Pipeline.

## Further details

The existing checks in Jenkins are replaced with GitHub checks,  hence the union of these 2 new Github workflows substitutes each former check. Therefore, the same commands will run for the same scenarios.

## Solved Issues

`pcap.h: No such file or directory` 

```
# github.com/google/gopacket/pcap
Error: ../../../../go/pkg/mod/github.com/elastic/gopacket@v1.1.20-0.20211202005954-d412fca7f83a/pcap/pcap_unix.go:[34](https://github.com/elastic/beats/runs/7875203008?check_suite_focus=true#step:5:35):10: fatal error: pcap.h: No such file or directory
   34 | #include <pcap.h>
      |          ^~~~~~~~
compilation terminated.
Error: failed running go vet, please fix the issues reported: running "go vet ./..." failed with exit code 2
make: *** [../libbeat/scripts/Makefile:153: check] Error 1
make: Leaving directory '/home/runner/work/beats/beats/packetbeat'
Error: Process completed with exit code 2.
```

Solved with https://github.com/elastic/beats/pull/32711/commits/a3159072cf3ae39ca48b8ed51c01a101b885a987


## Results

Nearly 10 minutes since they build was triggered in Jenkins and still waiting for workers to be assigned, while the new GitHub checks finished relatively much faster


## Follow ups

If agreed then we can roll out this approach for the remaining beats