### PR TITLE
[Filebeat] gcp-pubsub: Restart Pub/Sub client on errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -58,6 +58,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix counter for number of events published in `httpjson` input. {pull}31993[31993]
 - Fix handling of Checkpoint event for R81. {issue}32380[32380] {pull}32458[32458]
 - Fix a hang on `apt-get update` stage in packaging. {pull}32580[32580]
+- gcp-pubsub input: Restart Pub/Sub client on all errors. {issue}32550[32550]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -58,7 +58,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix counter for number of events published in `httpjson` input. {pull}31993[31993]
 - Fix handling of Checkpoint event for R81. {issue}32380[32380] {pull}32458[32458]
 - Fix a hang on `apt-get update` stage in packaging. {pull}32580[32580]
-- gcp-pubsub input: Restart Pub/Sub client on all errors. {issue}32550[32550]
+- gcp-pubsub input: Restart Pub/Sub client on all errors. {issue}32550[32550] {pull}32712[32712]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/gcppubsub/_meta/Dockerfile
+++ b/x-pack/filebeat/input/gcppubsub/_meta/Dockerfile
@@ -28,6 +28,6 @@ RUN \
 RUN \
     mkdir /data
 
-HEALTHCHECK --interval=1s --retries=90 CMD curl -s -f http://localhost:8432/
+HEALTHCHECK --interval=1s --retries=90 CMD curl -s -f --http2 http://localhost:8432/
 
 CMD gcloud beta emulators pubsub start --data-dir /data --host-port "0.0.0.0:8432"

--- a/x-pack/filebeat/input/gcppubsub/_meta/supported-versions.yml
+++ b/x-pack/filebeat/input/gcppubsub/_meta/supported-versions.yml
@@ -1,2 +1,2 @@
 variants:
-  - SDK_VERSION: 293.0.0-0
+  - SDK_VERSION: 398.0.0-0

--- a/x-pack/filebeat/input/gcppubsub/docker-compose.yml
+++ b/x-pack/filebeat/input/gcppubsub/docker-compose.yml
@@ -2,10 +2,10 @@ version: '2.3'
 
 services:
   googlepubsub:
-    image: docker.elastic.co/integrations-ci/beats-googlepubsub:emulator-${SDK_VERSION:-293.0.0-0}-1
+    image: docker.elastic.co/integrations-ci/beats-googlepubsub:emulator-${SDK_VERSION:-398.0.0-0}-1
     build:
       context: ./_meta
       args:
-        SDK_VERSION: ${SDK_VERSION:-293.0.0-0}
+        SDK_VERSION: ${SDK_VERSION:-398.0.0-0}
     ports:
-      - 8432
+      - '127.0.0.1:8432:8432'

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -14,6 +14,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 
@@ -32,6 +33,9 @@ import (
 const (
 	inputName    = "gcp-pubsub"
 	oldInputName = "google-pubsub"
+
+	// retryInterval is the minimum duration between pub/sub client retries.
+	retryInterval = 30 * time.Second
 )
 
 func init() {
@@ -139,9 +143,28 @@ func (in *pubsubInput) Run() {
 			defer in.log.Info("Pub/Sub input worker has stopped.")
 			defer in.workerWg.Done()
 			defer in.workerCancel()
-			if err := in.run(); err != nil {
-				in.log.Error(err)
-				return
+
+			// Throttle pubsub client restarts.
+			rt := rate.NewLimiter(rate.Every(retryInterval), 1)
+
+			// Watchdog to keep the worker operating after an error.
+			for in.workerCtx.Err() == nil {
+				// Rate limit.
+				if err := rt.Wait(in.workerCtx); err != nil {
+					continue
+				}
+
+				if err := in.run(); err != nil {
+					if in.workerCtx.Err() == nil {
+						in.log.Warnw("Restarting failed Pub/Sub input worker.", "error", err)
+						continue
+					}
+
+					// Log any non-cancellation error before stopping.
+					if !errors.Is(err, context.Canceled) {
+						in.log.Errorw("Pub/Sub input worker failed.", "error", err)
+					}
+				}
 			}
 		}()
 	})


### PR DESCRIPTION
## What does this PR do?

This modifies the gcp-pubsub input in Filebeat to include its own retry loop
rather than being entirely dependent upon the pub/sub client SDK to retry requests.

The input will only exit when the shutdown is triggered by Filebeat. Any errors
generated by the pub/sub client will be logged and then the input will restart the
pub/sub client. It will throttle restarts to once per 30s.

Fixes #32550

## Why is it important?

This improves the reliability of the pub/sub input by handling errors that are not retried by the pub/sub SDK.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Fixes #32550
- Relates https://github.com/elastic/beats/pull/32713 (fixes linter issues)

## Logs

```json
{
  "log.level": "info",
  "@timestamp": "2022-08-16T12:09:40.107-0400",
  "log.logger": "gcp.pubsub",
  "log.origin": {
    "file.name": "gcppubsub/input.go",
    "file.line": 142
  },
  "message": "Pub/Sub input worker has started.",
  "service.name": "filebeat",
  "pubsub_project": "FAKE",
  "pubsub_topic": "foo",
  "pubsub_subscription": {
    "Name": "filebeat",
    "NumGoroutines": 1,
    "MaxOutstandingMessages": 1000,
    "Create": true
  },
  "ecs.version": "1.6.0"
}
{
  "log.level": "warn",
  "@timestamp": "2022-08-16T12:10:40.109-0400",
  "log.logger": "gcp.pubsub",
  "log.origin": {
    "file.name": "gcppubsub/input.go",
    "file.line": 159
  },
  "message": "Restarting failed Pub/Sub input worker.",
  "service.name": "filebeat",
  "pubsub_project": "FAKE",
  "pubsub_topic": "foo",
  "pubsub_subscription": {
    "Name": "filebeat",
    "NumGoroutines": 1,
    "MaxOutstandingMessages": 1000,
    "Create": true
  },
  "error": {
    "message": "failed to subscribe to pub/sub topic: failed to check if subscription exists: context deadline exceeded",
    "stack_trace": "\ngithub.com/elastic/beats/v7/x-pack/filebeat/input/gcppubsub.(*pubsubInput).run\n\tgithub.com/elastic/beats/v7/x-pack/filebeat/input/gcppubsub/input.go:186\ngithub.com/elastic/beats/v7/x-pack/filebeat/input/gcppubsub.(*pubsubInput).Run.func1.1\n\tgithub.com/elastic/beats/v7/x-pack/filebeat/input/gcppubsub/input.go:157\nruntime.goexit\n\truntime/asm_arm64.s:1263"
  },
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2022-08-16T12:11:20.442-0400",
  "log.logger": "gcp.pubsub",
  "log.origin": {
    "file.name": "gcppubsub/input.go",
    "file.line": 169
  },
  "message": "Pub/Sub input worker has stopped.",
  "service.name": "filebeat",
  "pubsub_project": "FAKE",
  "pubsub_topic": "foo",
  "pubsub_subscription": {
    "Name": "filebeat",
    "NumGoroutines": 1,
    "MaxOutstandingMessages": 1000,
    "Create": true
  },
  "ecs.version": "1.6.0"
}
```