### PR TITLE
[Filebeat] gcp-pubsub: Remove github.com/pkg/errors

### DIFF
--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -215,7 +215,7 @@ func makeEvent(topicID string, msg *pubsub.Message) beat.Event {
 	event.SetID(id)
 
 	if len(msg.Attributes) > 0 {
-		event.PutValue("labels", msg.Attributes)
+		event.Fields["labels"] = msg.Attributes
 	}
 
 	return event

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"github.com/pkg/errors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 
@@ -37,12 +37,12 @@ const (
 func init() {
 	err := input.Register(inputName, NewInput)
 	if err != nil {
-		panic(errors.Wrapf(err, "failed to register %v input", inputName))
+		panic(fmt.Errorf("failed to register %v input: %w", inputName, err))
 	}
 
 	err = input.Register(oldInputName, NewInput)
 	if err != nil {
-		panic(errors.Wrapf(err, "failed to register %v input", oldInputName))
+		panic(fmt.Errorf("failed to register %v input: %w", oldInputName, err))
 	}
 }
 
@@ -160,7 +160,7 @@ func (in *pubsubInput) run() error {
 	// Setup our subscription to the topic.
 	sub, err := in.getOrCreateSubscription(ctx, client)
 	if err != nil {
-		return errors.Wrap(err, "failed to subscribe to pub/sub topic")
+		return fmt.Errorf("failed to subscribe to pub/sub topic: %w", err)
 	}
 	sub.ReceiveSettings.NumGoroutines = in.Subscription.NumGoroutines
 	sub.ReceiveSettings.MaxOutstandingMessages = in.Subscription.MaxOutstandingMessages
@@ -226,7 +226,7 @@ func (in *pubsubInput) getOrCreateSubscription(ctx context.Context, client *pubs
 
 	exists, err := sub.Exists(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to check if subscription exists")
+		return nil, fmt.Errorf("failed to check if subscription exists: %w", err)
 	}
 	if exists {
 		return sub, nil
@@ -238,7 +238,7 @@ func (in *pubsubInput) getOrCreateSubscription(ctx context.Context, client *pubs
 			Topic: client.Topic(in.Topic),
 		})
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create subscription")
+			return nil, fmt.Errorf("failed to create subscription: %w", err)
 		}
 		in.log.Debug("Created new subscription.")
 		return sub, nil

--- a/x-pack/filebeat/input/gcppubsub/input.go
+++ b/x-pack/filebeat/input/gcppubsub/input.go
@@ -16,6 +16,7 @@ import (
 	"cloud.google.com/go/pubsub"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
 	"github.com/elastic/beats/v7/filebeat/input"
@@ -251,8 +252,8 @@ func (in *pubsubInput) newPubsubClient(ctx context.Context) (*pubsub.Client, err
 	opts := []option.ClientOption{option.WithUserAgent(useragent.UserAgent("Filebeat", version.GetDefaultVersion(), version.Commit(), version.BuildTime().String()))}
 
 	if in.AlternativeHost != "" {
-		// this will be typically set because we want to point the input to a testing pubsub emulator
-		conn, err := grpc.Dial(in.AlternativeHost, grpc.WithInsecure())
+		// This will be typically set because we want to point the input to a testing pubsub emulator.
+		conn, err := grpc.Dial(in.AlternativeHost, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, fmt.Errorf("cannot connect to alternative host %q: %w", in.AlternativeHost, err)
 		}


### PR DESCRIPTION
## What does this PR do?

Remove github.com/pkg/errors from gcp-pubsub.  Use stdlib instead.

Also fixes two other linter issues.

```
  Error: Error return value of `event.PutValue` is not checked (errcheck)
  Error: SA1019: grpc.WithInsecure is deprecated: use WithTransportCredentials and insecure.NewCredentials() instead. Will be supported throughout 1.x.  (staticcheck)
```

## Why is it important?

The package is no longer maintained.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

