### PR TITLE
packetbeat/decoder: reset multilayer decoding layers for each sniffed packet

### DIFF
--- a/packetbeat/decoder/decoder.go
+++ b/packetbeat/decoder/decoder.go
@@ -172,7 +172,6 @@ func (d *Decoder) OnPacket(data []byte, ci *gopacket.CaptureInfo) {
 	packet := protos.Packet{Ts: ci.Timestamp}
 
 	debugf("decode packet data")
-	processed := false
 
 	if d.flowID != nil {
 		d.flowID.Reset(d.flowIDBufferBacking[:0])
@@ -195,7 +194,7 @@ func (d *Decoder) OnPacket(data []byte, ci *gopacket.CaptureInfo) {
 		nextType := current.NextLayerType()
 		data = current.LayerPayload()
 
-		processed, err = d.process(&packet, currentType)
+		processed, err := d.process(&packet, currentType)
 		if err != nil {
 			logp.Info("Error processing packet: %v", err)
 			break

--- a/packetbeat/decoder/decoder.go
+++ b/packetbeat/decoder/decoder.go
@@ -182,6 +182,9 @@ func (d *Decoder) OnPacket(data []byte, ci *gopacket.CaptureInfo) {
 		defer d.flows.Unlock()
 	}
 
+	d.stD1Q.i = 0
+	d.stIP4.i = 0
+	d.stIP6.i = 0
 	for len(data) > 0 {
 		err := current.DecodeFromBytes(data, d)
 		if err != nil {


### PR DESCRIPTION
The current logic for multilayer use means that sucessive packets in the stream
from the sniffer can end up as parts of the multilayer although they are not
related layers. The documentation for the type says it is provided to allow
"switching between multiple layers to remember outer layer results", but
successive packet in the sniffer stream do not have this relationship.

For #33012