### PR TITLE
action: checks for x-pack/functionbeat

### DIFF
--- a/.github/workflows/check-xpack-functionbeat.yml
+++ b/.github/workflows/check-xpack-functionbeat.yml
@@ -1,0 +1,27 @@
+name: check-x-pack-functionbeat
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/check-xpack-functionbeat.yml'
+      - 'x-pack/functionbeat/**'
+      - 'functionbeat/**'
+
+env:
+  BEAT_MODULE: 'x-pack/functionbeat'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch Go version from .go-version
+      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Run check/update
+      uses: magefile/mage-action@v2
+      with:
+        args: check update
+        workdir: "${{ env.BEAT_MODULE }}"

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -3,6 +3,7 @@ name: OpenTelemetry Export Trace
 on:
   workflow_run:
     workflows:
+      - check-x-pack-functionbeat
       - check-x-pack-packetbeat
       - check-packetbeat
       - golangci-lint

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -13,12 +13,6 @@ when:
     tags: true                 ## for all the tags
 platform: "immutable && ubuntu-18" ## default label for all the stages
 stages:
-    checks:
-        make: |
-          make -C x-pack/functionbeat check;
-          make -C x-pack/functionbeat update;
-          make check-no-changes;
-        stage: checks
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.


### PR DESCRIPTION
## What does this PR do?

Use GitHub actions to run the `check stage` for `x-pack/functionbeat`

What's the `check stage`?
- `mage check`
- `mage update`

## Why is it important?

Faster builds by running linting/checks outside of the main CI Pipeline.

## Errors


## Further details

The existing checks in Jenkins are replaced with GitHub checks,  hence the union of these 2 new Github workflows substitutes each former check. Therefore, the same commands will run for the same scenarios.

## Results

Nearly 10 minutes since they build was triggered in Jenkins and still waiting for workers to be assigned, while the new GitHub checks finished relatively much faster

## Related issues

Similar to https://github.com/elastic/beats/pull/32711
