### PR TITLE
fix: Tag filters only allow single values per key

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,6 +80,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - in module/windows/perfmon, changed collection method of the second counter value required to create a displayable value {pull}32305[32305]
 - Fix and improve AWS metric period calculation to avoid zero-length intervals {pull}32724[32724]
+- Allow filtering on AWS tags by more than 1 value per key. {pull}32775[32775]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -80,7 +80,6 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - in module/windows/perfmon, changed collection method of the second counter value required to create a displayable value {pull}32305[32305]
 - Fix and improve AWS metric period calculation to avoid zero-length intervals {pull}32724[32724]
-- Allow filtering on AWS tags by more than 1 value per key. {pull}32775[32775]
 
 *Packetbeat*
 
@@ -132,7 +131,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Metricbeat*
-
+- Allow filtering on AWS tags by more than 1 value per key. {pull}32775[32775]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -66,7 +66,8 @@ The tags to filter against. If tags are given in config, then only
 collect metrics from resources that have tag key and tag value matches the filter.
 For example, if tags parameter is given as `Organization=Engineering` under
 `AWS/ELB` namespace, then only collect metrics from ELBs with tag name equals to
-`Organization` and tag value equals to `Engineering`.
+`Organization` and tag value equals to `Engineering`. In order to filter for different
+values for the same key, add the values to the value array (see example)
 
 Note: tag filtering only works for metricsets with `resource_type` specified in the 
 metricset-specific configuration.
@@ -81,7 +82,7 @@ metricset-specific configuration.
     - ec2
   tags_filter:
     - key: "Organization"
-      value: "Engineering"
+      value: ["Engineering", "Product"]
 ----
 
 * *fips_enabled*

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -54,7 +54,8 @@ The tags to filter against. If tags are given in config, then only
 collect metrics from resources that have tag key and tag value matches the filter.
 For example, if tags parameter is given as `Organization=Engineering` under
 `AWS/ELB` namespace, then only collect metrics from ELBs with tag name equals to
-`Organization` and tag value equals to `Engineering`.
+`Organization` and tag value equals to `Engineering`. In order to filter for different
+values for the same key, add the values to the value array (see example)
 
 Note: tag filtering only works for metricsets with `resource_type` specified in the 
 metricset-specific configuration.
@@ -69,7 +70,7 @@ metricset-specific configuration.
     - ec2
   tags_filter:
     - key: "Organization"
-      value: "Engineering"
+      value: ["Engineering", "Product"]
 ----
 
 * *fips_enabled*

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -52,8 +52,8 @@ type MetricSet struct {
 
 // Tag holds a configuration specific for ec2 and cloudwatch metricset.
 type Tag struct {
-	Key   string `config:"key"`
-	Value string `config:"value"`
+	Key   string   `config:"key"`
+	Value []string `config:"value"`
 }
 
 // ModuleName is the name of this module.
@@ -248,7 +248,12 @@ func CheckTagFiltersExist(tagsFilter []Tag, tags interface{}) bool {
 	}
 
 	for _, tagFilter := range tagsFilter {
-		if exists, idx := StringInSlice(tagFilter.Key, tagKeys); !exists || tagValues[idx] != tagFilter.Value {
+		if exists, idx := StringInSlice(tagFilter.Key, tagKeys); exists {
+			valueExists, _ := StringInSlice(tagValues[idx], tagFilter.Value)
+			if !valueExists {
+				return false
+			}
+		} else {
 			return false
 		}
 	}

--- a/x-pack/metricbeat/module/aws/aws_test.go
+++ b/x-pack/metricbeat/module/aws/aws_test.go
@@ -78,6 +78,7 @@ var (
 	tagValue2 = "foobar"
 	tagKey3   = "Organization"
 	tagValue3 = "Engineering"
+	tagValue4 = "Product"
 )
 
 func TestCheckTagFiltersExist(t *testing.T) {
@@ -92,11 +93,11 @@ func TestCheckTagFiltersExist(t *testing.T) {
 			[]Tag{
 				{
 					Key:   "Name",
-					Value: "ECS Instance",
+					Value: []string{"ECS Instance"},
 				},
 				{
 					Key:   "Organization",
-					Value: "Engineering",
+					Value: []string{"Engineering"},
 				},
 			},
 			[]ec2types.Tag{
@@ -120,11 +121,11 @@ func TestCheckTagFiltersExist(t *testing.T) {
 			[]Tag{
 				{
 					Key:   "Name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 				{
 					Key:   "Organization",
-					Value: "Engineering",
+					Value: []string{"Engineering"},
 				},
 			},
 			[]resourcegroupstaggingapitypes.Tag{
@@ -148,7 +149,7 @@ func TestCheckTagFiltersExist(t *testing.T) {
 			[]Tag{
 				{
 					Key:   "Name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 			[]resourcegroupstaggingapitypes.Tag{
@@ -166,6 +167,26 @@ func TestCheckTagFiltersExist(t *testing.T) {
 				},
 			},
 			false,
+		},
+		{
+			"more than one value per key of tagFilters is included in resourcegroupstaggingapi tags",
+			[]Tag{
+				{
+					Key:   "Organization",
+					Value: []string{"Product", "Engineering"},
+				},
+			},
+			[]resourcegroupstaggingapitypes.Tag{
+				{
+					Key:   awssdk.String(tagKey3),
+					Value: awssdk.String(tagValue3),
+				},
+				{
+					Key:   awssdk.String(tagKey3),
+					Value: awssdk.String(tagValue4),
+				},
+			},
+			true,
 		},
 	}
 	for _, c := range cases {

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -216,13 +216,13 @@ func TestReadCloudwatchConfig(t *testing.T) {
 	resourceTypeFiltersEC2RDSWithTag["ec2:instance"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "test",
+			Value: []string{"test"},
 		},
 	}
 	resourceTypeFiltersEC2RDSWithTag["rds"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "test",
+			Value: []string{"test"},
 		},
 	}
 	expectedListMetricWithDetailEC2RDSWithTag := listMetricWithDetail{
@@ -313,7 +313,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			tags: []aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 		},
@@ -326,7 +326,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			tags: []aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 		},
@@ -337,7 +337,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			tags: []aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 		},
@@ -350,7 +350,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			tags: []aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 		},
@@ -363,7 +363,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			tags: []aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 		},
@@ -374,7 +374,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			tags: []aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 		},
@@ -641,7 +641,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			[]aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 			listMetricWithDetail{
@@ -699,7 +699,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			[]aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 			expectedListMetricWithDetailEC2RDSWithTag,
@@ -793,7 +793,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			[]aws.Tag{
 				{
 					Key:   "name",
-					Value: "test",
+					Value: []string{"test"},
 				},
 			},
 			expectedListMetricWithDetailEC2sRDSWithTag,
@@ -997,11 +997,11 @@ func TestConstructTagsFilters(t *testing.T) {
 	expectedResourceTypeTagFiltersELB["elasticloadbalancing"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "test-elb1",
+			Value: []string{"test-elb1"},
 		},
 		{
 			Key:   "name",
-			Value: "test-elb2",
+			Value: []string{"test-elb2"},
 		},
 	}
 
@@ -1009,13 +1009,13 @@ func TestConstructTagsFilters(t *testing.T) {
 	expectedResourceTypeTagFiltersELBEC2["elasticloadbalancing"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "test-elb",
+			Value: []string{"test-elb"},
 		},
 	}
 	expectedResourceTypeTagFiltersELBEC2["ec2:instance"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "test-ec2",
+			Value: []string{"test-ec2"},
 		},
 	}
 
@@ -1050,7 +1050,7 @@ func TestConstructTagsFilters(t *testing.T) {
 					tags: []aws.Tag{
 						{
 							Key:   "name",
-							Value: "test-elb1",
+							Value: []string{"test-elb1"},
 						},
 					},
 				},
@@ -1061,7 +1061,7 @@ func TestConstructTagsFilters(t *testing.T) {
 					tags: []aws.Tag{
 						{
 							Key:   "name",
-							Value: "test-elb2",
+							Value: []string{"test-elb2"},
 						},
 					},
 				},
@@ -1078,7 +1078,7 @@ func TestConstructTagsFilters(t *testing.T) {
 					tags: []aws.Tag{
 						{
 							Key:   "name",
-							Value: "test-elb",
+							Value: []string{"test-elb"},
 						},
 					},
 				},
@@ -1089,7 +1089,7 @@ func TestConstructTagsFilters(t *testing.T) {
 					tags: []aws.Tag{
 						{
 							Key:   "name",
-							Value: "test-ec2",
+							Value: []string{"test-ec2"},
 						},
 					},
 				},
@@ -1389,7 +1389,7 @@ func TestCreateEventsWithIdentifier(t *testing.T) {
 	resourceTypeTagFilters["ec2:instance"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "test-ec2",
+			Value: []string{"test-ec2"},
 		},
 	}
 	startTime, endTime := aws.GetStartTimeEndTime(time.Now(), m.MetricSet.Period, m.MetricSet.Latency)
@@ -1474,7 +1474,7 @@ func TestCreateEventsWithTagsFilter(t *testing.T) {
 	resourceTypeTagFilters["ec2:instance"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "test-ec2",
+			Value: []string{"test-ec2"},
 		},
 	}
 
@@ -1487,7 +1487,7 @@ func TestCreateEventsWithTagsFilter(t *testing.T) {
 	resourceTypeTagFilters["ec2:instance"] = []aws.Tag{
 		{
 			Key:   "name",
-			Value: "foo",
+			Value: []string{"foo"},
 		},
 	}
 

--- a/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/ec2/_meta/docs.asciidoc
@@ -62,10 +62,10 @@ image::./images/metricbeat-aws-ec2-overview.png[]
   session_token: '<session_token>'
   tags_filter:
     - key: "Organization"
-      value: "Engineering"
+      value: ["Engineering", "Product"]
 ----
 
 `tags_filter` can be specified to only collect metrics with certain tag keys/values.
 For example, with the configuration example above, ec2 metricset will only collect
 metrics from EC2 instances that have tag key equals "Organization" and tag value
-equals to "Engineering".
+equals to "Engineering" or "Product".


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

When filtering tags from the AWS Metricbeat module, it is not possible to specify more than one value associated to a particular key. This PR allows for that.

## Why is it important?

A practical example of this would be filtering for more than one development environment (among others) on a single instance of Metricbeat.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Try loading the following AWS module config into Metricbeat:
```
aws.yml: |-
    - module: aws
      period: 1m
      regions: us-east-2
      metricsets:
        - cloudwatch
      metrics:
        - namespace: AWS/ApiGateway
          resource_type: apigateway
        - namespace: AWS/Lambda
          resource_type: lambda
      tags_filter:
        - key: "amwell:environment-name"
          value: "dev-next"
        - key: "amwell:environment-name"
          value: "stg01"
```
