### PR TITLE
actions: use v3 and mage install

### DIFF
--- a/.github/workflows/check-default.yml
+++ b/.github/workflows/check-default.yml
@@ -16,14 +16,13 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Run check-default
       run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        go install github.com/magefile/mage@latest
+        go install github.com/magefile/mage
         make check-default

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -16,10 +16,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Install libpcap-dev
@@ -30,6 +30,5 @@ jobs:
       run: sudo apt-get install -y librpm-dev
     - name: Run check
       run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        go install github.com/magefile/mage@latest
+        go install github.com/magefile/mage
         make check

--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -14,17 +14,16 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update
       run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        go install github.com/magefile/mage@latest
+        go install github.com/magefile/mage
         make -C ${{ env.BEAT_MODULE }} check update
         make check-no-changes

--- a/.github/workflows/check-xpack-packetbeat.yml
+++ b/.github/workflows/check-xpack-packetbeat.yml
@@ -14,10 +14,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Install libpcap-dev

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -42,12 +42,12 @@ jobs:
         echo Changed GOPATH to ${{ env.MACOS_GOPATH }}
         echo "GOPATH="${{ env.MACOS_GOPATH }} >> $GITHUB_ENV
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ github.event.inputs.go_version }}
     - name: Install dependencies
-      run:  go get -u github.com/magefile/mage
-    - uses: actions/checkout@v2
+      run:  go install github.com/magefile/mage
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
         ref: ${{ env.GITHUB_REF }}


### PR DESCRIPTION

## What does this PR do?

Use v3 versions and use mage version from go.sum

## Why is it important?

Already reported in some other actions, this is just an update.
