### PR TITLE
Add custom JSON unmarshaller to logstash node_stats

### DIFF
--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -30,8 +30,6 @@ import (
 
 	"github.com/elastic/beats/v7/metricbeat/module/logstash"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
@@ -189,7 +187,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 	var nodeStats NodeStats
 	err := json.Unmarshal(content, &nodeStats)
 	if err != nil {
-		return errors.Wrap(err, "could not parse node stats response")
+		return fmt.Errorf("could not parse node stats response: %s", err)
 	}
 
 	timestamp := common.Time(time.Now())
@@ -250,14 +248,14 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 			ModuleFields: mapstr.M{},
 		}
 
-		event.ModuleFields.Put("node.stats", logstashStats)
-		event.RootFields.Put("service.id", nodeStats.ID)
-		event.RootFields.Put("service.hostname", nodeStats.Host)
-		event.RootFields.Put("service.version", nodeStats.Version)
+		_, _ = event.ModuleFields.Put("node.stats", logstashStats)
+		_, _ = event.RootFields.Put("service.id", nodeStats.ID)
+		_, _ = event.RootFields.Put("service.hostname", nodeStats.Host)
+		_, _ = event.RootFields.Put("service.version", nodeStats.Version)
 
 		if clusterUUID != "" {
-			event.ModuleFields.Put("cluster.id", clusterUUID)
-			event.ModuleFields.Put("elasticsearch.cluster.id", clusterUUID)
+			_, _ = event.ModuleFields.Put("cluster.id", clusterUUID)
+			_, _ = event.ModuleFields.Put("elasticsearch.cluster.id", clusterUUID)
 		}
 
 		// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`
@@ -274,8 +272,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 }
 
 func makeClusterToPipelinesMap(pipelines []PipelineStats, overrideClusterUUID string) map[string][]PipelineStats {
-	var clusterToPipelinesMap map[string][]PipelineStats
-	clusterToPipelinesMap = make(map[string][]PipelineStats)
+	clusterToPipelinesMap := make(map[string][]PipelineStats)
 
 	if overrideClusterUUID != "" {
 		clusterToPipelinesMap[overrideClusterUUID] = pipelines

--- a/metricbeat/module/logstash/node_stats/data.go
+++ b/metricbeat/module/logstash/node_stats/data.go
@@ -187,7 +187,7 @@ func eventMapping(r mb.ReporterV2, content []byte, isXpack bool, logger *logp.Lo
 	var nodeStats NodeStats
 	err := json.Unmarshal(content, &nodeStats)
 	if err != nil {
-		return fmt.Errorf("could not parse node stats response: %s", err)
+		return fmt.Errorf("could not parse node stats response: %w", err)
 	}
 
 	timestamp := common.Time(time.Now())

--- a/metricbeat/module/logstash/node_stats/data_test.go
+++ b/metricbeat/module/logstash/node_stats/data_test.go
@@ -111,13 +111,15 @@ func TestData(t *testing.T) {
 		}
 
 		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
-		w.Write(input)
+		_, err := w.Write(input)
+		require.NoError(t, err)
 	}))
 
 	mux.Handle("/_node/stats", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			input, _ := ioutil.ReadFile("./_meta/test/node_stats.710.json")
-			w.Write(input)
+			_, err := w.Write(input)
+			require.NoError(t, err)
 		}))
 
 	server := httptest.NewServer(mux)


### PR DESCRIPTION
## What does this PR do?
This is a revision/follow-up to  #32599

From the original PR: 

This fixes rather odd bug that would happen the logstash module we receive a large integer value, handle it as a float, and then re-encode the json event as an integer or a float depending on the number of digits in the resulting number. This resulted in some mapping errors as fields would sometimes be floats, and sometimes be integers when received by logstash on the other end of metricbeat.

## Why is it important?

By default, if you pass an `interface{}` value to the go JSON unmarshaller, it'll treat any number as a float.
On the other end, Beat's JSON marshaller has some logic such that `if typeof(value) == float && number_of_digits(value) > x; then format_as_scientific_notation()` so that that floats that are sufficiently large like `12345678.0` will become `"1.2345678e7"` or whatever, which is breaking something ES when it tries to read it as a `long` type specified by the mapping, which I assume wouldn't happen if the float was rendered as `"12345678.0"`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
