### PR TITLE
Update HB k8s template to use <Mi> metric

### DIFF
--- a/deploy/kubernetes/heartbeat-kubernetes.yaml
+++ b/deploy/kubernetes/heartbeat-kubernetes.yaml
@@ -100,7 +100,7 @@ spec:
           runAsUser: 0
         resources:
           limits:
-            memory: 1536mi
+            memory: 1536Mi
           requests:
             # for synthetics, 2 full cores is a good starting point for relatively consistent perform of a single concurrent check
             # For lightweight checks as low as 100m is fine

--- a/deploy/kubernetes/heartbeat/heartbeat-deployment.yaml
+++ b/deploy/kubernetes/heartbeat/heartbeat-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           runAsUser: 0
         resources:
           limits:
-            memory: 1536mi
+            memory: 1536Mi
           requests:
             # for synthetics, 2 full cores is a good starting point for relatively consistent perform of a single concurrent check
             # For lightweight checks as low as 100m is fine


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Updates heartbeat k8s deployment templates to fix memory metric name to <Mi> , instead of <mi>.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

K8S fails to deploy template, unable to process <mi>.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Copy template from `deploy/kubernetes/heartbeat-kubernetes.yaml` and deploy it:
````bash
> kubetctl apply -f heartbeat-kubernetes.yaml
configmap/heartbeat-deployment-config created
deployment.apps/heartbeat created
clusterrolebinding.rbac.authorization.k8s.io/heartbeat created
rolebinding.rbac.authorization.k8s.io/heartbeat created
rolebinding.rbac.authorization.k8s.io/heartbeat-kubeadm-config created
clusterrole.rbac.authorization.k8s.io/heartbeat created
role.rbac.authorization.k8s.io/heartbeat created
role.rbac.authorization.k8s.io/heartbeat-kubeadm-config created
serviceaccount/heartbeat created
````