### PR TITLE
Use non-deprecated docker image for testing jolokia

### DIFF
--- a/metricbeat/module/jolokia/_meta/Dockerfile
+++ b/metricbeat/module/jolokia/_meta/Dockerfile
@@ -1,5 +1,5 @@
 # Tomcat is started to fetch Jolokia metrics from it
-FROM java:8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 ENV TOMCAT_VERSION 7.0.86
 ENV TC apache-tomcat-${TOMCAT_VERSION}


### PR DESCRIPTION
## What does this PR do?

Fixes the jolokia docker image to use the non-deprecated openjdk version

## Why is it important?

Fixes some of the recurrent failures for the last few days related to the `goIntegTest` that are using a non-existing docker image
