### PR TITLE
Add test for logs and sqs with FIPS enabled for CreateServiceName

### DIFF
--- a/x-pack/libbeat/common/aws/credentials_test.go
+++ b/x-pack/libbeat/common/aws/credentials_test.go
@@ -156,6 +156,34 @@ func TestCreateServiceName(t *testing.T) {
 			"us-east-1",
 			"ec2-fips",
 		},
+		{
+			"SQS - fips - us-gov-east-1",
+			"sqs",
+			true,
+			"us-gov-east-1",
+			"sqs",
+		},
+		{
+			"SQS - fips - us-east-1",
+			"sqs",
+			true,
+			"us-east-1",
+			"sqs-fips",
+		},
+		{
+			"logs - fips - us-gov-east-1",
+			"logs",
+			true,
+			"us-gov-east-1",
+			"logs",
+		},
+		{
+			"logs - fips - us-east-1",
+			"logs",
+			true,
+			"us-east-1",
+			"logs-fips",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Just experimenting logs and sqs with FIPS enabled for `CreateServiceName` function. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

