### PR TITLE
Preallocate memory to reduce GC load

### DIFF
--- a/libbeat/template/load_integration_test.go
+++ b/libbeat/template/load_integration_test.go
@@ -370,7 +370,7 @@ func TestESLoader_Load(t *testing.T) {
 					require.NoError(t, err)
 					p, ok := val.(map[string]interface{})
 					require.True(t, ok)
-					var properties []string
+					properties := make([]string, 0, len(p))
 					for k := range p {
 						properties = append(properties, k)
 					}

--- a/x-pack/filebeat/input/httpjson/transform_registry.go
+++ b/x-pack/filebeat/input/httpjson/transform_registry.go
@@ -52,7 +52,7 @@ func (reg registry) String() string {
 
 	var str string
 	for namespace, m := range reg.namespaces {
-		var names []string
+		names := make([]string, 0, len(m))
 		for k := range m {
 			names = append(names, k)
 		}


### PR DESCRIPTION
## What does this PR do?

Preallocating memory reduces the load Go needs to handle and track allocated memory regions. This also reduces GC load.

## Why is it important?

While Go takes care of memory operations, like allocating, resizing and freeing, it is a good style to let Go know in advance the final required size to reduce the load of these operations. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~


