### PR TITLE
Adding support for v1.25.0 k8s

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     TERRAFORM_VERSION = "0.13.7"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
     KIND_VERSION = 'v0.14.0'
-    K8S_VERSION = 'v1.24.0'
+    K8S_VERSION = 'v1.25.0'
   }
   options {
     timeout(time: 6, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     TERRAFORM_VERSION = "0.13.7"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
     KIND_VERSION = 'v0.14.0'
-    K8S_VERSION = 'v1.25.0'
+    K8S_VERSION = 'v1.25.0-beta.0'
   }
   options {
     timeout(time: 6, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     TERRAFORM_VERSION = "0.13.7"
     XPACK_MODULE_PATTERN = '^x-pack\\/[a-z0-9]+beat\\/module\\/([^\\/]+)\\/.*'
     KIND_VERSION = 'v0.14.0'
-    K8S_VERSION = 'v1.25.0-beta.0'
+    K8S_VERSION = 'v1.25.0'
   }
   options {
     timeout(time: 6, unit: 'HOURS')

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: checks
     k8sTest:
-        k8sTest: "v1.25.0-beta.0,v1.24.3,v1.23.6,v1.22.9"
+        k8sTest: "v1.25.0,v1.24.3,v1.23.6,v1.22.9"
         stage: mandatory

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: checks
     k8sTest:
-        k8sTest: "v1.24.0,v1.23.6,v1.22.9,v1.21.12"
+        k8sTest: "v1.25.0,v1.24.3,v1.23.9,v1.22.12"
         stage: mandatory

--- a/deploy/kubernetes/Jenkinsfile.yml
+++ b/deploy/kubernetes/Jenkinsfile.yml
@@ -18,5 +18,5 @@ stages:
             make check-no-changes;
         stage: checks
     k8sTest:
-        k8sTest: "v1.25.0,v1.24.3,v1.23.9,v1.22.12"
+        k8sTest: "v1.25.0-beta.0,v1.24.3,v1.23.6,v1.22.9"
         stage: mandatory

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -157,7 +157,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.22.x, 1.23.x, 1.24.x, 1.25.x 
+1.22.x, 1.23.x, 1.24.x, 1.25.x
 
 [float]
 === Dashboard

--- a/metricbeat/docs/modules/kubernetes.asciidoc
+++ b/metricbeat/docs/modules/kubernetes.asciidoc
@@ -157,7 +157,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.21.x, 1.22.x, 1.23.x, 1.24.x
+1.22.x, 1.23.x, 1.24.x, 1.25.x 
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/_meta/docs.asciidoc
+++ b/metricbeat/module/kubernetes/_meta/docs.asciidoc
@@ -146,7 +146,7 @@ roleRef:
 === Compatibility
 
 The Kubernetes module is tested with the following versions of Kubernetes:
-1.21.x, 1.22.x, 1.23.x, 1.24.x
+1.22.x, 1.23.x, 1.24.x, 1.25.x
 
 [float]
 === Dashboard

--- a/metricbeat/module/kubernetes/kubernetes.yml
+++ b/metricbeat/module/kubernetes/kubernetes.yml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.8.0
+        image: quay.io/coreos/kube-state-metrics:v2.6.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/metricbeat/module/kubernetes/kubernetes.yml
+++ b/metricbeat/module/kubernetes/kubernetes.yml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v2.6.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## What does this PR do?

Adds the new version of v1.25.0 in the list of the supported/tested versions.

Part of https://github.com/elastic/observability-dev/issues/2195