### PR TITLE
heartbeat docfix

### DIFF
--- a/heartbeat/docs/monitors/monitor-common-options.asciidoc
+++ b/heartbeat/docs/monitors/monitor-common-options.asciidoc
@@ -145,6 +145,7 @@ processors in your config.
 
 [float]
 [[monitor-data-stream]]
+==== `data_stream`
 
 Contains options pertaining to data stream naming, following the conventions followed by [Fleet Data Streams](https://www.elastic.co/guide/en/fleet/current/data-streams.html). By default Heartbeat will
 write to a datastream named `heartbeat-VERSION` except in the case of `browser` monitors, which will

--- a/heartbeat/docs/monitors/monitor-common-options.asciidoc
+++ b/heartbeat/docs/monitors/monitor-common-options.asciidoc
@@ -147,7 +147,7 @@ processors in your config.
 [[monitor-data-stream]]
 ==== `data_stream`
 
-Contains options pertaining to data stream naming, following the conventions followed by [Fleet Data Streams](https://www.elastic.co/guide/en/fleet/current/data-streams.html). By default Heartbeat will
+Contains options pertaining to data stream naming, following the conventions followed by {fleet-guide}/data-streams.html[Fleet Data Streams]. By default Heartbeat will
 write to a datastream named `heartbeat-VERSION` except in the case of `browser` monitors, which will
 always follow the Fleet convention of `type-dataset-namespace`, where the type is always synthetics
 unless overriden.


### PR DESCRIPTION
Fix the rendering of the documentation page where data_stream link is empty thus not displayed

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Docs
-->

## What does this PR do?

Attempt to fix missing link in the heartbeat doc rendering

## Why is it important?

Clarity of the page

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Screenshots
before: 
<img width="874" alt="image" src="https://user-images.githubusercontent.com/2949987/187445617-a1fa3eff-ce44-48a3-96da-1e886e117868.png">

after:
<img width="874" alt="image" src="https://user-images.githubusercontent.com/2949987/187446116-a3a7ffdd-75a6-4764-8679-b547c7ae7952.png">

