### PR TITLE
packetbeat/sniffer: allow multiple interface devices to be followed

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -148,6 +148,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Packetbeat*
 
 - Add option to allow sniffer to change device when default route changes. {issue}31905[31905] {pull}32681[32681]
+- Add option to allow sniffing multiple interface devices. {issue}31905[31905] {pull}32933[32933]
 
 *Functionbeat*
 

--- a/packetbeat/_meta/config/beat.yml.tmpl
+++ b/packetbeat/_meta/config/beat.yml.tmpl
@@ -12,7 +12,19 @@
 # Select the network interface to sniff the data. On Linux, you can use the
 # "any" keyword to sniff on all connected interfaces. On all platforms, you
 # can use "default_route", "default_route_ipv4" or "default_route_ipv6"
-# to sniff on the device carrying the default route.
+# to sniff on the device carrying the default route. If you wish to sniff
+# on multiple network interfaces you may specify an array of distinct interfaces
+# as a YAML array with each device's configuration specified individually.
+# Each device may only appear once in the array of interfaces.
+#
+# packetbeat.interfaces:
+# - device: en0
+#   internal_networks:
+#   - private
+# - device: en1
+#   internal_networks:
+#   - private
+#
 packetbeat.interfaces.device: {{ call .device .GOOS }}
 
 # Specify the amount of time between polling for changes in the default

--- a/packetbeat/packetbeat.yml
+++ b/packetbeat/packetbeat.yml
@@ -12,7 +12,19 @@
 # Select the network interface to sniff the data. On Linux, you can use the
 # "any" keyword to sniff on all connected interfaces. On all platforms, you
 # can use "default_route", "default_route_ipv4" or "default_route_ipv6"
-# to sniff on the device carrying the default route.
+# to sniff on the device carrying the default route. If you wish to sniff
+# on multiple network interfaces you may specify an array of distinct interfaces
+# as a YAML array with each device's configuration specified individually.
+# Each device may only appear once in the array of interfaces.
+#
+# packetbeat.interfaces:
+# - device: en0
+#   internal_networks:
+#   - private
+# - device: en1
+#   internal_networks:
+#   - private
+#
 packetbeat.interfaces.device: any
 
 # Specify the amount of time between polling for changes in the default

--- a/x-pack/packetbeat/packetbeat.yml
+++ b/x-pack/packetbeat/packetbeat.yml
@@ -12,7 +12,19 @@
 # Select the network interface to sniff the data. On Linux, you can use the
 # "any" keyword to sniff on all connected interfaces. On all platforms, you
 # can use "default_route", "default_route_ipv4" or "default_route_ipv6"
-# to sniff on the device carrying the default route.
+# to sniff on the device carrying the default route. If you wish to sniff
+# on multiple network interfaces you may specify an array of distinct interfaces
+# as a YAML array with each device's configuration specified individually.
+# Each device may only appear once in the array of interfaces.
+#
+# packetbeat.interfaces:
+# - device: en0
+#   internal_networks:
+#   - private
+# - device: en1
+#   internal_networks:
+#   - private
+#
 packetbeat.interfaces.device: any
 
 # Specify the amount of time between polling for changes in the default


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This runs multiple sniffers for each Sniffer, each handling default route
polling as needed independently. All sniffers terminate if any
individual terminates.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This allows multiple network devices to be followed.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #31905

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
