### PR TITLE
bump go version in go.mod

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -37,6 +37,11 @@ find . -maxdepth 3 -name Dockerfile -print0 |
 ${SED} -E -e "s#(:go-version:) [0-9]+\.[0-9]+\.[0-9]+#\1 ${GO_RELEASE_VERSION}#g" libbeat/docs/version.asciidoc
 git add libbeat/docs/version.asciidoc
 
+GO_MAJOR_VERSION=$(echo ${GO_RELEASE_VERSION} | cut -f1 -d.)
+GO_MINOR_VERSION=$(echo ${GO_RELEASE_VERSION} | cut -f2 -d.)
+${SED} -E -e "s#(go) [0-9]+\.[0-9]+#\1 ${GO_MAJOR_VERSION}\.${GO_MINOR_VERSION}#g" go.mod
+git add go.mod
+
 git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
 git --no-pager log -1
 


### PR DESCRIPTION
## What does this PR do?

Bump the `go` version in `go.mod`, hence https://github.com/elastic/beats/pull/32940/files is not needed anymore

## Why is it important?

One less manual step to be done, so the golang autobump for minor versions will be the one in charge.

There is no need to run any other actions since the PR created with the changes will be validated. Otherwise the `golang` autobump will be much more complex and we wanna leave the logic to the projects that are onboarded to the autobump.

## Test

`.ci/bump-go-release-version.sh 1.19.0` produced

```diff
diff --git a/.go-version b/.go-version
index 8e8b0a9335..815d5ca06d 100644
--- a/.go-version
+++ b/.go-version
@@ -1 +1 @@
-1.18.5
+1.19.0
diff --git a/.golangci.yml b/.golangci.yml
index 763ed2bc2e..6c32807314 100755
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,7 +102,7 @@ linters-settings:
 
   gosimple:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.18.5"
+    go: "1.19.0"
 
   nakedret:
     # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
@@ -122,19 +122,19 @@ linters-settings:
 
   staticcheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.18.5"
+    go: "1.19.0"
     checks: ["all"]
 
   stylecheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.18.5"
+    go: "1.19.0"
     # Disabled:
     # ST1005: error strings should not be capitalized
     checks: ["all", "-ST1005"]
 
   unused:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.18.5"
+    go: "1.19.0"
 
   gosec:
     excludes:
diff --git a/auditbeat/Dockerfile b/auditbeat/Dockerfile
index b0309a6ef5..1ee933ab92 100644
--- a/auditbeat/Dockerfile
+++ b/auditbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 RUN \
     apt-get update \
diff --git a/go.mod b/go.mod
index 3f9c364f95..78659fb72b 100644
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/beats/v7
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/bigquery v1.8.0
diff --git a/heartbeat/Dockerfile b/heartbeat/Dockerfile
index 7873022799..f5735e41fe 100644
--- a/heartbeat/Dockerfile
+++ b/heartbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 RUN \
     apt-get update \
diff --git a/libbeat/docs/version.asciidoc b/libbeat/docs/version.asciidoc
index e11194aa70..a6078a729e 100644
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,6 +1,6 @@
 :stack-version: 8.4.0
 :doc-branch: main
-:go-version: 1.18.5
+:go-version: 1.19.0
 :release-state: unreleased
 :python: 3.7
 :docker: 1.12
diff --git a/metricbeat/Dockerfile b/metricbeat/Dockerfile
index 4eee6b0249..20398dc52b 100644
--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 RUN \
     apt update \
diff --git a/packetbeat/Dockerfile b/packetbeat/Dockerfile
index d24a21f653..eb727a1c32 100644
--- a/packetbeat/Dockerfile
+++ b/packetbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 RUN \
     apt-get update \
diff --git a/x-pack/functionbeat/Dockerfile b/x-pack/functionbeat/Dockerfile
index 27c7d51065..f600ac7db7 100644
--- a/x-pack/functionbeat/Dockerfile
+++ b/x-pack/functionbeat/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5
+FROM golang:1.19.0
 
 RUN \
     apt-get update \
```

