### PR TITLE
Add lock path when returning ErrAlreadyLocked

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -11,7 +11,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Affecting all Beats*
 
 * Upgrade to Go 1.18. Certificates signed with SHA-1 are now rejected. See the Go 1.18 https://tip.golang.org/doc/go1.18#sha1[release notes] for details. {pull}32493[32493]
-* Add lock path when returning ErrAlreadyLocked. {pull}32980[32980]
+* Add lock file path to the error when the data path is already locked. {pull}32980[32980]
 
 - Fix namespacing on self-monitoring {pull}32336[32336]
 - Fix formatting of hardware addresses populated by the add-host-metadata processor. {issue}32264[32264] {pull}32265[32265]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -11,7 +11,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Affecting all Beats*
 
 * Upgrade to Go 1.18. Certificates signed with SHA-1 are now rejected. See the Go 1.18 https://tip.golang.org/doc/go1.18#sha1[release notes] for details. {pull}32493[32493]
-* Add lock path when returning ErrAlreadyLocked. {pull}[32980]
+* Add lock path when returning ErrAlreadyLocked. {pull}32980[32980]
 
 - Fix namespacing on self-monitoring {pull}32336[32336]
 - Fix formatting of hardware addresses populated by the add-host-metadata processor. {issue}32264[32264] {pull}32265[32265]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -11,7 +11,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Affecting all Beats*
 
 * Upgrade to Go 1.18. Certificates signed with SHA-1 are now rejected. See the Go 1.18 https://tip.golang.org/doc/go1.18#sha1[release notes] for details. {pull}32493[32493]
-
+* Add lock path when returning ErrAlreadyLocked. {pull}[32980]
 
 - Fix namespacing on self-monitoring {pull}32336[32336]
 - Fix formatting of hardware addresses populated by the add-host-metadata processor. {issue}32264[32264] {pull}32265[32265]

--- a/libbeat/cmd/instance/locker.go
+++ b/libbeat/cmd/instance/locker.go
@@ -18,6 +18,7 @@
 package instance
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/gofrs/flock"
@@ -54,7 +55,7 @@ func (l *locker) lock() error {
 	}
 
 	if !isLocked {
-		return ErrAlreadyLocked
+		return fmt.Errorf("data path %s: %w", l.fl.Path(), ErrAlreadyLocked)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

When returning the error `data path already locked by another beat`, add the path to the lock file to the error message

## Why is it important?

This error is likely due a miss configuration due to a user change, or some inconsistent state. Either way, without deep knowledge about the beats internal it isn't trivial to determine "what" is locking the beat, and where the lock is. Hopefully, by adding the lock file path to the error message, a regular user, not a beats developer, will be able to fully understand the error, and eventually fix it.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Ensure a lock file is present when starting the beat. 
It can be done by running 2 beats sharing the same `data.path`, or just stopping the beat or elastic-agent, if run under the Elastic Agent, creating the lock file, and starting the beat/elastic-agent again.

for a regular filebeat, the lock file is on `Elastic/Agent/data/elastic-agent-*/run/default/filebeat--8.x.y/filebeat.lock`


## Use cases

Investigating why a beat does not start or an Elastic Agent is unhealthy due to `Exiting: data path already locked by another beat. Please make sure that multiple beats are not sharing the same data path (path.data).`

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
