### PR TITLE
Heartbeat support options for lightweight checks

### DIFF
--- a/heartbeat/docs/monitors/monitor-http.asciidoc
+++ b/heartbeat/docs/monitors/monitor-http.asciidoc
@@ -133,8 +133,8 @@ Example configuration:
 
 Under `check.request`, specify these options:
 
-*`method`*:: The HTTP method to use. Valid values are `"HEAD"`, `"GET"` and
-`"POST"`.
+*`method`*:: The HTTP method to use. Valid values are `"HEAD"`, `"GET"`, `"POST"` and
+`"OPTIONS"`.
 *`headers`*:: A dictionary of additional HTTP headers to send. By default heartbeat
 will set the 'User-Agent' header to identify itself.
 *`body`*:: Optional request body content.

--- a/heartbeat/monitors/active/http/config.go
+++ b/heartbeat/monitors/active/http/config.go
@@ -141,7 +141,7 @@ func (r *responseConfig) Validate() error {
 // Validate validates of the requestParameters object is valid or not
 func (r *requestParameters) Validate() error {
 	switch strings.ToUpper(r.Method) {
-	case "HEAD", "GET", "POST":
+	case "HEAD", "GET", "POST", "OPTIONS":
 	default:
 		return fmt.Errorf("HTTP method '%v' not supported", r.Method)
 	}

--- a/heartbeat/tests/system/config/heartbeat.yml.j2
+++ b/heartbeat/tests/system/config/heartbeat.yml.j2
@@ -33,6 +33,9 @@ heartbeat.monitors:
     {% endfor %}
   {% endif -%}
 
+  {%- if monitor.check_request_method is defined %}
+  check.request.method: {{monitor.check_request_method}}
+  {% endif -%}
 
   {%- if monitor.check_response_json is defined %}
   check.response.json:

--- a/heartbeat/tests/system/heartbeat.py
+++ b/heartbeat/tests/system/heartbeat.py
@@ -26,7 +26,20 @@ class BaseTest(TestCase):
 
                 self.wfile.write(bytes(content, "utf-8"))
 
+        # set up a HTTPHandler that supports OPTIONS method as well
+        class HTTPHandlerEnabledOPTIONS(HTTPHandler):
+            def do_OPTIONS(self):
+                self.send_response(status_code)
+                self.send_header('Access-Control-Allow-Credentials', 'true')
+                self.send_header('Access-Control-Allow-Origin', '*')
+                self.send_header('Access-Control-Allow-Methods', 'HEAD, GET, POST, OPTIONS')
+                self.end_headers()
+
+        # initialize http server based on if it needs to support OPTIONS method
         server = http.server.HTTPServer(('localhost', 0), HTTPHandler)
+        # setup enable_options_method as False if it's not set
+        if kwargs.get("enable_options_method", False):
+            server = http.server.HTTPServer(('localhost', 0), HTTPHandlerEnabledOPTIONS)
 
         thread = threading.Thread(target=server.serve_forever)
         thread.start()

--- a/libbeat/docs/tab-widgets/spinup-stack.asciidoc
+++ b/libbeat/docs/tab-widgets/spinup-stack.asciidoc
@@ -5,5 +5,5 @@ available on AWS, GCP, and Azure. {ess-trial}[Try it out for free].
 // end::cloud[]
 
 // tag::self-managed[]
-See {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
+To install and run {es} and {kib}, see {stack-ref}/installing-elastic-stack.html[Installing the {stack}].
 // end::self-managed[]

--- a/libbeat/docs/tab-widgets/spinup-stack.asciidoc
+++ b/libbeat/docs/tab-widgets/spinup-stack.asciidoc
@@ -5,5 +5,5 @@ available on AWS, GCP, and Azure. {ess-trial}[Try it out for free].
 // end::cloud[]
 
 // tag::self-managed[]
-To install and run {es} and {kib}, see {stack-ref}/installing-elastic-stack.html[Installing the {stack}].
+See {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
 // end::self-managed[]


### PR DESCRIPTION
## What does this PR do?

According to this issue:
https://github.com/elastic/beats/issues/32457
We're looking for a way to support url check with OPTIONS method.

## Why is it important?
With this change, heartbeat could do the url check with OPTIONS without any more response message.

## Checklist
- [*] My code follows the style guidelines of this project
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [] I have made corresponding change to the default configuration files
- [*] I have added tests that prove my fix is effective or that my feature works
- [] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
```
# go to heartbeat dir, something like `beats/heartbeat`
mage update
mage pythonUnitTest 
# heartbeat/tests/system/test_monitor.py::Test::test_http_check_with_options_method_#num were my unittest
```

## Related issues
https://github.com/elastic/beats/issues/32457

## Use cases
```
new options for check url.check:
check.request.method: OPTIONS
```

full example is
```
heartbeat.monitors:
- type: http
  schedule: '@every 1s'
  hosts:
    - 'localhost:64572'
    
  check.request.method: OPTIONS
```
