### PR TITLE
ci: rename stage for DRA staging

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -132,7 +132,7 @@ pipeline {
             }
           }
         }
-        stage('DRA Staging') {
+        stage('DRA Release Staging') {
           options { skipDefaultCheckout() }
           when {
             allOf {


### PR DESCRIPTION
## What does this PR do?

Cosmetic change in the name of the stage in the `packaging` pipeline

## Why is it important?

Add more context about the scope of the stage, since it will be skipped for the `main` branch

## Issue

similar to https://github.com/elastic/fleet-server/pull/1840