### PR TITLE
[elasticsearch] add isXpack branch in enrich metricset

### DIFF
--- a/metricbeat/module/elasticsearch/enrich/data.go
+++ b/metricbeat/module/elasticsearch/enrich/data.go
@@ -82,8 +82,8 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		event := mb.Event{}
 
 		event.ModuleFields = mapstr.M{}
-		event.ModuleFields.Put("cluster.name", info.ClusterName)
-		event.ModuleFields.Put("cluster.id", info.ClusterID)
+		_, _ = event.ModuleFields.Put("cluster.name", info.ClusterName)
+		_, _ = event.ModuleFields.Put("cluster.id", info.ClusterID)
 
 		fields, err := schema.Apply(stat)
 		if err != nil {
@@ -96,8 +96,8 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 			errs = append(errs, errors.Wrap(err, "failure retrieving node ID from Elasticsearch Enrich Stats API response"))
 		}
 
-		event.ModuleFields.Put("node.id", nodeID)
-		fields.Delete("node_id")
+		_, _ = event.ModuleFields.Put("node.id", nodeID)
+		_ = fields.Delete("node_id")
 
 		event.MetricSetFields = fields
 
@@ -113,8 +113,8 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		event := mb.Event{}
 
 		event.ModuleFields = mapstr.M{}
-		event.ModuleFields.Put("cluster.name", info.ClusterName)
-		event.ModuleFields.Put("cluster.id", info.ClusterID)
+		_, _ = event.ModuleFields.Put("cluster.name", info.ClusterName)
+		_, _ = event.ModuleFields.Put("cluster.id", info.ClusterID)
 		event.MetricSetFields = mapstr.M{}
 
 		policyName, ok := policy["name"]

--- a/metricbeat/module/elasticsearch/enrich/data.go
+++ b/metricbeat/module/elasticsearch/enrich/data.go
@@ -121,7 +121,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		policyName, ok := policy["name"]
 		if !ok {
 			// No name found for policy. Ignore because all policies require a name
-			errs = append(errs, fmt.Errorf("found an 'executing policy' without a name. Omitting."))
+			errs = append(errs, errors.New("found an 'executing policy' without a name. Omitting."))
 			continue
 		}
 

--- a/metricbeat/module/elasticsearch/enrich/data.go
+++ b/metricbeat/module/elasticsearch/enrich/data.go
@@ -19,12 +19,13 @@ package enrich
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
 	"github.com/joeshaw/multierror"
-	"github.com/pkg/errors"
 
 	s "github.com/elastic/beats/v7/libbeat/common/schema"
 	c "github.com/elastic/beats/v7/libbeat/common/schema/mapstriface"
@@ -73,7 +74,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 	var data response
 	err := json.Unmarshal(content, &data)
 	if err != nil {
-		return errors.Wrap(err, "failure parsing Elasticsearch Enrich Stats API response")
+		return fmt.Errorf("failure parsing Elasticsearch Enrich Stats API response: %w", err)
 	}
 
 	var errs multierror.Errors
@@ -87,13 +88,13 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 
 		fields, err := schema.Apply(stat)
 		if err != nil {
-			errs = append(errs, errors.Wrap(err, "failure applying enrich coordinator stats schema"))
+			errs = append(errs, fmt.Errorf("failure applying enrich coordinator stats schema: %w", err))
 			continue
 		}
 
 		nodeID, err := fields.GetValue("node_id")
 		if err != nil {
-			errs = append(errs, errors.Wrap(err, "failure retrieving node ID from Elasticsearch Enrich Stats API response"))
+			errs = append(errs, fmt.Errorf("failure retrieving node ID from Elasticsearch Enrich Stats API response: %w", err))
 		}
 
 		_, _ = event.ModuleFields.Put("node.id", nodeID)
@@ -120,7 +121,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 		policyName, ok := policy["name"]
 		if !ok {
 			// No name found for policy. Ignore because all policies require a name
-			errs = append(errs, errors.New("found an 'executing policy' without a name. Omitting."))
+			errs = append(errs, fmt.Errorf("found an 'executing policy' without a name. Omitting."))
 			continue
 		}
 
@@ -139,7 +140,7 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 
 		fields, err := task.Apply(taskMapstr)
 		if err != nil {
-			errs = append(errs, errors.Wrap(err, "failure applying enrich coordinator stats schema"))
+			errs = append(errs, fmt.Errorf("failure applying enrich coordinator stats schema: %w", err))
 			continue
 		}
 

--- a/metricbeat/module/elasticsearch/enrich/data.go
+++ b/metricbeat/module/elasticsearch/enrich/data.go
@@ -101,8 +101,10 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 
 		event.MetricSetFields = fields
 
-		index := elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
-		event.Index = index
+		if isXpack {
+			index := elastic.MakeXPackMonitoringIndexName(elastic.Elasticsearch)
+			event.Index = index
+		}
 
 		r.Event(event)
 	}

--- a/metricbeat/module/elasticsearch/enrich/data.go
+++ b/metricbeat/module/elasticsearch/enrich/data.go
@@ -144,8 +144,8 @@ func eventsMapping(r mb.ReporterV2, info elasticsearch.Info, content []byte, isX
 			continue
 		}
 
-		event.MetricSetFields.Put("executing_policy.name", policyName)
-		event.MetricSetFields.Put("executing_policy.task", fields)
+		_, _ = event.MetricSetFields.Put("executing_policy.name", policyName)
+		_, _ = event.MetricSetFields.Put("executing_policy.task", fields)
 
 		// xpack.enabled in config using standalone metricbeat writes to `.monitoring` instead of `metricbeat-*`
 		// When using Agent, the index name is overwritten anyways.


### PR DESCRIPTION
### Summary

A subset of documents from the `elasticsearch.enrich` metricset did not respect the `xpack.enabled` flag and are currently routed to `.monitoring-es-8-mb` data stream regardless of the setting value. We should only overwrite the indice destination when the setting is true. (see [example](https://github.com/elastic/beats/blob/main/metricbeat/module/elasticsearch/node_stats/data.go#L409))

Fixes https://github.com/elastic/kibana/issues/140039

### Testing
- Start metricbeat with elasticsearch module and enrich metricset enabled
  ```
  metricbeat.modules:
    - module: elasticsearch
      period: 10s
      hosts: [ "https://localhost:9200" ]
      username: "elastic"
      password: "changeme"
      ssl.verification_mode: none
      metricsets:
        - enrich
  ```
- Verify that documents are routed to `metricbeat-*` when `xpack.enabled: false` and `.monitoring-es-8-mb` when `xpack.enabled: true`