### PR TITLE
Osquerybeat: support differential query results

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -137,5 +137,6 @@ CHANGELOG*
 /x-pack/metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /x-pack/metricbeat/module/ @elastic/integrations
 /x-pack/metricbeat/module/enterprisesearch @elastic/ent-search-application-backend
+/x-pack/osquerybeat/ @elastic/security-asset-management
 /x-pack/packetbeat/ @elastic/security-external-integrations
 /x-pack/winlogbeat/ @elastic/security-external-integrations

--- a/x-pack/osquerybeat/beater/action_handler.go
+++ b/x-pack/osquerybeat/beater/action_handler.go
@@ -22,7 +22,7 @@ var (
 )
 
 type publisher interface {
-	Publish(index, actionID, responseID string, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{})
+	Publish(index, actionID, responseID string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{})
 }
 
 type queryExecutor interface {
@@ -104,7 +104,7 @@ func (a *actionHandler) executeQuery(ctx context.Context, index string, ac actio
 
 	a.log.Debugf("Completed query in: %v", time.Since(start))
 
-	a.publisher.Publish(index, ac.ID, responseID, hits, ac.ECSMapping, req["data"])
+	a.publisher.Publish(index, ac.ID, responseID, nil, hits, ac.ECSMapping, req["data"])
 
 	return len(hits), nil
 }

--- a/x-pack/osquerybeat/beater/action_handler_test.go
+++ b/x-pack/osquerybeat/beater/action_handler_test.go
@@ -33,15 +33,17 @@ type mockPublisher struct {
 	index      string
 	actionID   string
 	responseID string
+	meta       map[string]interface{}
 	hits       []map[string]interface{}
 	ecsm       ecs.Mapping
 	reqData    interface{}
 }
 
-func (p *mockPublisher) Publish(index, actionID, responseID string, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
+func (p *mockPublisher) Publish(index, actionID, responseID string, meta map[string]interface{}, hits []map[string]interface{}, ecsm ecs.Mapping, reqData interface{}) {
 	p.index = index
 	p.actionID = actionID
 	p.responseID = responseID
+	p.meta = meta
 	p.hits = hits
 	p.ecsm = ecsm
 	p.reqData = reqData

--- a/x-pack/osquerybeat/beater/config_plugin.go
+++ b/x-pack/osquerybeat/beater/config_plugin.go
@@ -217,7 +217,11 @@ func (p *ConfigPlugin) set(inputs []config.InputConfig) (err error) {
 		namespaces[name] = ns
 		queriesCount++
 
-		qi.Snapshot = true
+		// Force snapshot by default
+		if qi.Snapshot == nil {
+			snapshot := true
+			qi.Snapshot = &snapshot
+		}
 		return qi, nil
 	}
 

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -34,7 +34,7 @@ func renderFullConfigJSON(inputs []config.InputConfig) (string, error) {
 				Interval: stream.Interval,
 				Platform: stream.Platform,
 				Version:  stream.Version,
-				Snapshot: true, // enforce snapshot for all queries
+				Snapshot: nil, // enforce snapshot for all queries
 			}
 			pack.Queries[stream.ID] = query
 		}

--- a/x-pack/osquerybeat/beater/config_plugin_test.go
+++ b/x-pack/osquerybeat/beater/config_plugin_test.go
@@ -29,12 +29,13 @@ func renderFullConfigJSON(inputs []config.InputConfig) (string, error) {
 			Queries:   make(map[string]config.Query),
 		}
 		for _, stream := range input.Streams {
+			snapshot := true
 			query := config.Query{
 				Query:    stream.Query,
 				Interval: stream.Interval,
 				Platform: stream.Platform,
 				Version:  stream.Version,
-				Snapshot: nil, // enforce snapshot for all queries
+				Snapshot: &snapshot, // enforce snapshot for all queries
 			}
 			pack.Queries[stream.ID] = query
 		}

--- a/x-pack/osquerybeat/beater/logger_plugin.go
+++ b/x-pack/osquerybeat/beater/logger_plugin.go
@@ -13,13 +13,19 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-type SnapshotResult struct {
+type QueryResult struct {
 	Action       string              `json:"action"`
 	Name         string              `json:"name"`
-	Numeric      string              `json:"numeric"`
+	Numeric      bool                `json:"numeric"`
 	CalendarTime string              `json:"calendarTime"`
 	UnixTime     int64               `json:"unixTime"`
+	Epoch        int64               `json:"epoch"`
+	Counter      int64               `json:"counter"`
 	Hits         []map[string]string `json:"snapshot"`
+	DiffResults  struct {
+		Added   []map[string]string `json:"added"`
+		Removed []map[string]string `json:"removed"`
+	} `json:"diffResults"`
 }
 
 type osqueryLogMessage struct {
@@ -80,14 +86,14 @@ func (m *osqueryLogMessage) Log(typ logger.LogType, log *logp.Logger) {
 	}
 }
 
-type HandleSnapshotResultFunc func(res SnapshotResult)
+type HandleQueryResultFunc func(res QueryResult)
 
 type LoggerPlugin struct {
 	log           *logp.Logger
-	logSnapshotFn HandleSnapshotResultFunc
+	logSnapshotFn HandleQueryResultFunc
 }
 
-func NewLoggerPlugin(log *logp.Logger, logSnapshotFn HandleSnapshotResultFunc) *LoggerPlugin {
+func NewLoggerPlugin(log *logp.Logger, logSnapshotFn HandleQueryResultFunc) *LoggerPlugin {
 	return &LoggerPlugin{
 		log:           log.With("ctx", "logger"),
 		logSnapshotFn: logSnapshotFn,
@@ -95,12 +101,13 @@ func NewLoggerPlugin(log *logp.Logger, logSnapshotFn HandleSnapshotResultFunc) *
 }
 
 func (p *LoggerPlugin) Log(ctx context.Context, typ logger.LogType, logText string) error {
-	if typ == logger.LogTypeSnapshot {
-		var res SnapshotResult
+	if typ == logger.LogTypeSnapshot || typ == logger.LogTypeString {
+		var res QueryResult
 		if err := json.Unmarshal([]byte(logText), &res); err != nil {
 			p.log.Errorf("failed to unmarshal shapshot result: %v", err)
 			return err
 		}
+
 		if p.logSnapshotFn != nil {
 			p.logSnapshotFn(res)
 		}

--- a/x-pack/osquerybeat/beater/logger_plugin_test.go
+++ b/x-pack/osquerybeat/beater/logger_plugin_test.go
@@ -93,7 +93,7 @@ func TestLoggerPlugin_Log(t *testing.T) {
 			name:             "nosnapshot",
 			logQueryResultFn: queryResultFn,
 			logType:          logger.LogTypeString,
-			logMessage:       "",
+			logMessage:       "{}",
 		},
 		{
 			name:             "snapshot invalid",

--- a/x-pack/osquerybeat/beater/logger_plugin_test.go
+++ b/x-pack/osquerybeat/beater/logger_plugin_test.go
@@ -20,37 +20,37 @@ func TestLoggerPlugin_New(t *testing.T) {
 	validLogger := logp.NewLogger("logger_test")
 
 	tests := []struct {
-		name          string
-		log           *logp.Logger
-		logSnapshotFn HandleSnapshotResultFunc
-		shouldPanic   bool
+		name             string
+		log              *logp.Logger
+		logQueryResultFn HandleQueryResultFunc
+		shouldPanic      bool
 	}{
 		{
-			name:          "invalid",
-			log:           nil,
-			logSnapshotFn: nil,
-			shouldPanic:   true,
+			name:             "invalid",
+			log:              nil,
+			logQueryResultFn: nil,
+			shouldPanic:      true,
 		},
 		{
-			name:          "nologfunc",
-			log:           validLogger,
-			logSnapshotFn: nil,
+			name:             "nologfunc",
+			log:              validLogger,
+			logQueryResultFn: nil,
 		},
 		{
-			name:          "nonempty",
-			log:           validLogger,
-			logSnapshotFn: func(res SnapshotResult) {},
+			name:             "nonempty",
+			log:              validLogger,
+			logQueryResultFn: func(res QueryResult) {},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.shouldPanic {
-				testutil.AssertPanic(t, func() { NewLoggerPlugin(tc.log, tc.logSnapshotFn) })
+				testutil.AssertPanic(t, func() { NewLoggerPlugin(tc.log, tc.logQueryResultFn) })
 				return
 			}
 
-			p := NewLoggerPlugin(tc.log, tc.logSnapshotFn)
+			p := NewLoggerPlugin(tc.log, tc.logQueryResultFn)
 			if p == nil {
 				t.Error("expected nil logger pluggin")
 			}
@@ -61,10 +61,10 @@ func TestLoggerPlugin_New(t *testing.T) {
 func TestLoggerPlugin_Log(t *testing.T) {
 	validLogger := logp.NewLogger("logger_test")
 
-	snapshotFn := func(res SnapshotResult) {
+	queryResultFn := func(res QueryResult) {
 	}
 
-	result := SnapshotResult{
+	result := QueryResult{
 		Action: "foo",
 		Name:   "bar",
 		Hits: []map[string]string{
@@ -83,44 +83,44 @@ func TestLoggerPlugin_Log(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		logSnapshotFn HandleSnapshotResultFunc
-		logType       logger.LogType
-		logMessage    string
-		err           string
+		name             string
+		logQueryResultFn HandleQueryResultFunc
+		logType          logger.LogType
+		logMessage       string
+		err              string
 	}{
 		{
-			name:          "nosnapshot",
-			logSnapshotFn: snapshotFn,
-			logType:       logger.LogTypeString,
-			logMessage:    "",
+			name:             "nosnapshot",
+			logQueryResultFn: queryResultFn,
+			logType:          logger.LogTypeString,
+			logMessage:       "",
 		},
 		{
-			name:          "snapshot invalid",
-			logSnapshotFn: snapshotFn,
-			logType:       logger.LogTypeSnapshot,
-			logMessage:    "",
-			err:           "unexpected end of JSON input",
+			name:             "snapshot invalid",
+			logQueryResultFn: queryResultFn,
+			logType:          logger.LogTypeSnapshot,
+			logMessage:       "",
+			err:              "unexpected end of JSON input",
 		},
 		{
-			name:          "snapshot empty",
-			logSnapshotFn: snapshotFn,
-			logType:       logger.LogTypeSnapshot,
-			logMessage:    "{}",
+			name:             "snapshot empty",
+			logQueryResultFn: queryResultFn,
+			logType:          logger.LogTypeSnapshot,
+			logMessage:       "{}",
 		},
 		{
-			name:          "snapshot nonempty",
-			logSnapshotFn: snapshotFn,
-			logType:       logger.LogTypeSnapshot,
-			logMessage:    string(resultbytes),
+			name:             "snapshot nonempty",
+			logQueryResultFn: queryResultFn,
+			logType:          logger.LogTypeSnapshot,
+			logMessage:       string(resultbytes),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var capturedSnapshot *SnapshotResult
-			p := NewLoggerPlugin(validLogger, func(res SnapshotResult) {
-				capturedSnapshot = &res
+			var capturedQueryResult *QueryResult
+			p := NewLoggerPlugin(validLogger, func(res QueryResult) {
+				capturedQueryResult = &res
 			})
 			err := p.Log(context.Background(), tc.logType, tc.logMessage)
 			if err != nil {
@@ -137,7 +137,7 @@ func TestLoggerPlugin_Log(t *testing.T) {
 					t.Errorf("expected error: %v", tc.err)
 				}
 				if tc.logType == logger.LogTypeSnapshot && tc.logMessage == string(resultbytes) {
-					diff := cmp.Diff(capturedSnapshot, &result)
+					diff := cmp.Diff(capturedQueryResult, &result)
 					if diff != "" {
 						t.Error(diff)
 					}

--- a/x-pack/osquerybeat/internal/config/osquery.go
+++ b/x-pack/osquerybeat/internal/config/osquery.go
@@ -19,8 +19,13 @@ type Query struct {
 	// Optional ECS mapping for the query, not rendered into osqueryd configuration
 	ECSMapping map[string]interface{} `config:"ecs_mapping" json:"-"`
 
-	// Enforce true if missing otherwise use the value
-	Snapshot *bool `json:"snapshot,omitempty"`
+	// A boolean to set 'snapshot' mode, default true
+	// This is different from the default osquery behavour where the missing value defaults to false
+	Snapshot *bool `config:"snapshot,omitempty" json:"snapshot,omitempty"`
+
+	// A boolean to determine if "removed" actions should be logged, default true
+	// This is the same as osquery behavour
+	Removed *bool `config:"removed,omitempty" json:"removed,omitempty"`
 }
 
 type Pack struct {

--- a/x-pack/osquerybeat/internal/config/osquery.go
+++ b/x-pack/osquerybeat/internal/config/osquery.go
@@ -20,11 +20,11 @@ type Query struct {
 	ECSMapping map[string]interface{} `config:"ecs_mapping" json:"-"`
 
 	// A boolean to set 'snapshot' mode, default true
-	// This is different from the default osquery behavour where the missing value defaults to false
+	// This is different from the default osquery behavior where the missing value defaults to false
 	Snapshot *bool `config:"snapshot,omitempty" json:"snapshot,omitempty"`
 
 	// A boolean to determine if "removed" actions should be logged, default true
-	// This is the same as osquery behavour
+	// This is the same as osquery behavior
 	Removed *bool `config:"removed,omitempty" json:"removed,omitempty"`
 }
 

--- a/x-pack/osquerybeat/internal/config/osquery.go
+++ b/x-pack/osquerybeat/internal/config/osquery.go
@@ -19,8 +19,8 @@ type Query struct {
 	// Optional ECS mapping for the query, not rendered into osqueryd configuration
 	ECSMapping map[string]interface{} `config:"ecs_mapping" json:"-"`
 
-	// Always enforced as snapshot, can't be changed via configuration
-	Snapshot bool `json:"snapshot"`
+	// Enforce true if missing otherwise use the value
+	Snapshot *bool `json:"snapshot,omitempty"`
 }
 
 type Pack struct {

--- a/x-pack/osquerybeat/internal/osqd/args.go
+++ b/x-pack/osquerybeat/internal/osqd/args.go
@@ -80,6 +80,10 @@ var protectedFlags = Flags{
 	// The delimiter for a full query name that is concatenated as "pack_" + {{pack name}} + "_" + {{query name}} by default
 	"pack_delimiter": "_",
 
+	// This enforces the batch format for differential results
+	// https://osquery.readthedocs.io/en/stable/deployment/logging
+	"logger_event_type": false,
+
 	// Refresh config every 60 seconds
 	// The previous setting was 10 seconds which is unnecessary frequent.
 	// Osquery does not expect that frequent policy/configuration changes

--- a/x-pack/osquerybeat/internal/pub/publisher_test.go
+++ b/x-pack/osquerybeat/internal/pub/publisher_test.go
@@ -21,6 +21,7 @@ func TestHitToEvent(t *testing.T) {
 
 	type params struct {
 		index, eventType, actionID, responseID string
+		meta                                   map[string]interface{}
 		hit                                    map[string]interface{}
 		ecsm                                   ecs.Mapping
 		reqData                                interface{}
@@ -61,7 +62,7 @@ func TestHitToEvent(t *testing.T) {
 
 	for i := 0; i < maxMask; i++ {
 		p := genParams(i)
-		ev := hitToEvent(p.index, p.eventType, p.actionID, p.responseID, p.hit, p.ecsm, p.reqData)
+		ev := hitToEvent(p.index, p.eventType, p.actionID, p.responseID, p.meta, p.hit, p.ecsm, p.reqData)
 
 		if p.index != "" {
 			diff := cmp.Diff(p.index, ev.Meta[events.FieldMetaRawIndex])


### PR DESCRIPTION
## What does this PR do?

Enables support for configurable differential queries. The results documents have a new ```osquery_meta``` property that has additional properties from the query run, the ```type``` of the query snapshot vs diff, and the optional ```action```  that is set to either ```added``` or ```removed```

We will need to update the ```osquery_manager``` intengration package as well in order define the proper mapping for ```osquery_meta```.

If you have suggestions for better naming or the location of this new addition to the document let me know.


## Why is it important?

This capability was asked about by one of our users, that wanted to monitor the new events in particular instead of getting the snapshot results.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

Currently in order to try the differential results (we always force snapshots by default) the user would have to use the advanced section on UI and specify the "snapshot": false, for example
```
{
  "schedule": {
    "processes": {
      "query": "select * from processes",
      "interval": 60,
      "snapshot": false
    }
  }
}
```

<img width="969" alt="Screen Shot 2022-09-12 at 10 14 08 PM" src="https://user-images.githubusercontent.com/872351/189937754-91301411-da3f-4f72-8c5b-a0299fbbb96e.png">


## Screenshots

The resulting documents have the new ```osquery_meta``` property that provides additional information about query result:

<img width="731" alt="Screen Shot 2022-09-13 at 10 14 39 AM" src="https://user-images.githubusercontent.com/872351/189938030-a69dc408-e8d9-4836-8058-9fa778a613c0.png">

<img width="640" alt="Screen Shot 2022-09-13 at 10 16 51 AM" src="https://user-images.githubusercontent.com/872351/189938049-8b6ffc37-862c-44c1-b997-0d429eb65389.png">


<img width="735" alt="Screen Shot 2022-09-13 at 10 24 02 AM" src="https://user-images.githubusercontent.com/872351/189938379-fb2990bf-bab6-41a5-b56c-4d0d533d8db4.png">
