### PR TITLE
fix: mage installation with go1.18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
           stageStatusCache(id: 'Lint'){
             // test the ./dev-tools/run_with_go_ver used by the Unified Release process
             dir("${BASE_DIR}") {
-              sh "HOME=${WORKSPACE} GO_VERSION=${GO_VERSION} ./dev-tools/run_with_go_ver mage dumpVariables"
+              sh "HOME=${WORKSPACE} GO_VERSION=${GO_VERSION} ./dev-tools/run_with_go_ver make test-mage"
             }
             withBeatsEnv(archive: false, id: "lint") {
               dumpVariables()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
           stageStatusCache(id: 'Lint'){
             // test the ./dev-tools/run_with_go_ver used by the Unified Release process
             dir("${BASE_DIR}") {
-              sh "GO_VERSION=${GO_VERSION} ./dev-tools/run_with_go_ver mage dumpVariables"
+              sh "HOME=${WORKSPACE} GO_VERSION=${GO_VERSION} ./dev-tools/run_with_go_ver mage dumpVariables"
             }
             withBeatsEnv(archive: false, id: "lint") {
               dumpVariables()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,6 +87,10 @@ pipeline {
       steps {
         withGithubNotify(context: "Lint") {
           stageStatusCache(id: 'Lint'){
+            // test the ./dev-tools/run_with_go_ver used by the Unified Release process
+            dir("${BASE_DIR}") {
+              sh "GO_VERSION=${GO_VERSION} ./dev-tools/run_with_go_ver mage dumpVariables"
+            }
             withBeatsEnv(archive: false, id: "lint") {
               dumpVariables()
               whenTrue(env.ONLY_DOCS == 'false') {

--- a/Makefile
+++ b/Makefile
@@ -237,3 +237,7 @@ beats-dashboards: mage update
 build/distributions/dependencies.csv: $(PYTHON)
 	@mkdir -p build/distributions
 	$(PYTHON) dev-tools/dependencies-report --csv $@
+
+## test-mage : Test the mage installation used by the Unified Release process
+test-mage: mage
+	@mage dumpVariables

--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -71,7 +71,7 @@ setup_go_path() {
   export GOPATH="${gopath}"
 
   # Add GOPATH to PATH.
-  export PATH="${GOPATH}/bin:${GOPATH}/go/bin:${PATH}"
+  export PATH="${GOPATH}/bin:${PATH}"
 
   debug "GOPATH=${GOPATH}"
 }

--- a/dev-tools/common.bash
+++ b/dev-tools/common.bash
@@ -71,7 +71,7 @@ setup_go_path() {
   export GOPATH="${gopath}"
 
   # Add GOPATH to PATH.
-  export PATH="${GOPATH}/bin:${PATH}"
+  export PATH="${GOPATH}/bin:${GOPATH}/go/bin:${PATH}"
 
   debug "GOPATH=${GOPATH}"
 }

--- a/dev-tools/make/mage-install.mk
+++ b/dev-tools/make/mage-install.mk
@@ -7,7 +7,7 @@ export MAGE_IMPORT_PATH
 mage:
 ifndef MAGE_PRESENT
 	@echo Installing mage $(MAGE_VERSION).
-	@go get -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
+	@go install -ldflags="-X $(MAGE_IMPORT_PATH)/mage.gitTag=$(MAGE_VERSION)" ${MAGE_IMPORT_PATH}@$(MAGE_VERSION)
 	@-mage -clean
 endif
 	@true


### PR DESCRIPTION
## What does this PR do?

go1.18 changed where the packages are installed when using `go install`
Run the same command in the CI pipeline

## Why is it important?

The UR for 7.17 is broken for the last 5 days.


```
Installing mage v1.13.0.
make[3]: Leaving directory '/var/lib/jenkins/workspace/elastic+unified-release+master+snapshot-beats-7.17/cd/release/release-manager/project-configs/7.17/build/projects/gopath/src/github.com/elastic/beats/libbeat'
bash: mage: command not found
make[3]: [../dev-tools/make/mage-install.mk:11: mage] Error 127 (ignored)
bash: mage: command not found
make[3]: *** [scripts/Makefile:33
```


## Test

```bash
echo  1.17.10 > .go-version
./dev-tools/run_with_go_ver make test-mage 
...

## Variables

GOOS             = darwin
GOARCH           = amd64
GOARM            = 
Platform         = darwin/amd64
BinaryExt        = 
XPackDir         = ../x-pack
```

```bash
echo  1.18.5 > .go-version
./dev-tools/run_with_go_ver make test-mage 
...

## Variables

GOOS             = darwin
GOARCH           = amd64
GOARM            = 
Platform         = darwin/amd64
BinaryExt        = 
XPackDir         = ../x-pack
BeatName         = beats
BeatServiceName  = beats
## Functions

beat_doc_branch              = 7.17
beat_version                 = 7.17.7
commit                       = 0390d5708dec5ef6c7c721af0c29e6a4bc28261d
date                         = 2022-09-14T17:37:17Z
elastic_beats_dir            = /Users/vmartinez/work/src/github.com/elastic/beats
go_version                   = 1.18.5
```

Additionally, I tested on docker, to be the more platform agnostic as possible, see https://github.com/elastic/beats/pull/33083#issuecomment-1247083355

## Issues

Caused by https://github.com/elastic/beats/pull/32693
