### PR TITLE
backport: Add 8.4 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -188,6 +188,19 @@ pull_request_rules:
   - name: backport patches to 8.4 branch
     conditions:
       - merged
+      - label=backport-v8.5.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.4"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.4 branch
+    conditions:
+      - merged
       - label=backport-v8.4.0
     actions:
       backport:


### PR DESCRIPTION
Merge as soon as 8.4 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821