### PR TITLE
add `enable-all-filesets` flag to setup command

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -115,6 +115,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Improve performance of disk queue by coalescing writes. {pull}31935[31935]
 - Update `elastic/go-structform` from `v0.0.9` to `v0.0.10` to reduce memory usage. {pull}32536[32536]
+- Added `--enable-all-filesets` to the `setup` command. {issue}30916[30916] {pull}33114[33114]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -115,7 +115,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Improve performance of disk queue by coalescing writes. {pull}31935[31935]
 - Update `elastic/go-structform` from `v0.0.9` to `v0.0.10` to reduce memory usage. {pull}32536[32536]
-- Added `--enable-all-filesets` to the `setup` command. {issue}30916[30916] {pull}33114[33114]
+- Added `--enable-all-filesets` to the `setup` command to simplify loading all ingest pipelines. {issue}30916[30916] {pull}33114[33114]
 
 *Auditbeat*
 

--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -69,7 +69,7 @@ func NewLogHints(cfg *conf.C) (autodiscover.Builder, error) {
 		return nil, fmt.Errorf("unable to unpack hints config due to error: %w", err)
 	}
 
-	moduleRegistry, err := fileset.NewModuleRegistry(nil, beat.Info{}, false)
+	moduleRegistry, err := fileset.NewModuleRegistry(nil, beat.Info{}, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -179,7 +179,7 @@ func (fb *Filebeat) setupPipelineLoaderCallback(b *beat.Beat) error {
 			if enableAllFilesets {
 				//All module configs need to be loaded to enable all the filesets
 				//contained in the modules.  The default glob just loads the enabled
-				//ones.  Swithching the glob pattern from *.yml to * achieves this.
+				//ones.  Switching the glob pattern from *.yml to * achieves this.
 				origPath, _ := fb.config.ConfigModules.String("path", -1)
 				newPath := strings.TrimSuffix(origPath, ".yml")
 				_ = fb.config.ConfigModules.SetString("path", -1, newPath)

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -177,6 +177,9 @@ func (fb *Filebeat) setupPipelineLoaderCallback(b *beat.Beat) error {
 		modulesFactory := fileset.NewSetupFactory(b.Info, pipelineLoaderFactory, enableAllFilesets)
 		if fb.config.ConfigModules.Enabled() {
 			if enableAllFilesets {
+				//All module configs need to be loaded to enable all the filesets
+				//contained in the modules.  The default glob just loads the enabled
+				//ones.  Swithching the glob pattern from *.yml to * achieves this.
 				origPath, _ := fb.config.ConfigModules.String("path", -1)
 				newPath := strings.TrimSuffix(origPath, ".yml")
 				_ = fb.config.ConfigModules.SetString("path", -1, newPath)

--- a/filebeat/docs/howto/load-ingest-pipelines.asciidoc
+++ b/filebeat/docs/howto/load-ingest-pipelines.asciidoc
@@ -4,11 +4,45 @@
 The ingest pipelines used to parse log lines are set up automatically the first
 time you run {beatname_uc}, assuming the {es} output is enabled. If you're sending
 events to {ls} you need to load the ingest pipelines manually. To do this, run the
-`setup` command with the `--pipelines` option specified. If you used the
-<<modules-command,`modules`>> command to enable modules in the `modules.d`
-directory, also specify the `--modules` flag. For example, the following command
-loads the ingest pipelines used by all filesets enabled in the system, nginx,
-and mysql modules:
+`setup` command with the `--pipelines` option specified.  You also need to enable
+the modules and filesets, this can be accomplished one of two ways.
+
+First you can use the `--modules` option to enable the module, and the
+`-M` option to enable the fileset.  For example, the following command
+loads the access pipeline from the nginx module.
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} setup --pipelines --modules nginx -M "nginx.access.enabled=true"
+----
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup --pipelines --modules nginx -M "nginx.access.enabled=true"
+----
+
+*linux:*
+
+["source","sh",subs="attributes"]
+----
+./{beatname_lc} setup --pipelines --modules nginx -M "nginx.access.enabled=true"
+----
+
+*win:*
+
+["source","sh",subs="attributes"]
+----
+PS > .{backslash}{beatname_lc}.exe setup --pipelines --modules nginx -M "nginx.access.enabled=true"
+----
+
+The second option is to use the `--enable-all-filesets` option to
+enable all the modules and all the filesets so all of the ingest
+pipelines are loaded.  For example, the following command loads all
+the ingest pipelines.
 
 //TODO: Replace with the platform tab widget.
 
@@ -16,28 +50,28 @@ and mysql modules:
 
 ["source","sh",subs="attributes"]
 ----
-{beatname_lc} setup --pipelines --modules system,nginx,mysql
+{beatname_lc} setup --pipelines --enable-all-filesets
 ----
 
 *mac:*
 
 ["source","sh",subs="attributes"]
 ----
-./{beatname_lc} setup --pipelines --modules system,nginx,mysql
+./{beatname_lc} setup --pipelines --enable-all-filesets
 ----
 
 *linux:*
 
 ["source","sh",subs="attributes"]
 ----
-./{beatname_lc} setup --pipelines --modules system,nginx,mysql
+./{beatname_lc} setup --pipelines --enable-all-filesets
 ----
 
 *win:*
 
 ["source","sh",subs="attributes"]
 ----
-PS > .{backslash}{beatname_lc}.exe setup --pipelines --modules system,nginx,mysql
+PS > .{backslash}{beatname_lc}.exe setup --pipelines --enable-all-filesets
 ----
 
 TIP: If you're loading ingest pipelines manually because you want to send events

--- a/filebeat/fileset/factory.go
+++ b/filebeat/fileset/factory.go
@@ -129,7 +129,7 @@ func (f *Factory) CheckConfig(c *conf.C) error {
 // createRegistry starts a registry for a set of filesets, it returns the registry and
 // its input configurations
 func (f *Factory) createRegistry(c *conf.C) (*ModuleRegistry, []*conf.C, error) {
-	m, err := NewModuleRegistry([]*conf.C{c}, f.beatInfo, false)
+	m, err := NewModuleRegistry([]*conf.C{c}, f.beatInfo, false, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/filebeat/fileset/modules.go
+++ b/filebeat/fileset/modules.go
@@ -59,6 +59,8 @@ func newModuleRegistry(modulesPath string,
 	}
 
 	for _, mcfg := range moduleConfigs {
+		// an empty ModuleConfig can reach this so we only force enable a
+		// config if the Module name is set and Enabled pointer is valid.
 		if enableAllFilesets && mcfg.Module != "" && mcfg.Enabled != nil {
 			*mcfg.Enabled = true
 		}
@@ -85,6 +87,8 @@ func newModuleRegistry(modulesPath string,
 				return nil, fmt.Errorf("error applying overrides on fileset %s/%s: %w", mcfg.Module, filesetName, err)
 			}
 
+			// ModuleConfig can have empty Filesets so we only force
+			// enable if the Enabled pointer is valid
 			if enableAllFilesets && fcfg.Enabled != nil {
 				*fcfg.Enabled = true
 			}

--- a/filebeat/fileset/modules_integration_test.go
+++ b/filebeat/fileset/modules_integration_test.go
@@ -115,7 +115,7 @@ func TestSetupNginx(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("5.2.0"))
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("5.2.0"), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestLoadMultiplePipelines(t *testing.T) {
 		{"foo", &enabled, filesetConfigs},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"))
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +239,7 @@ func TestLoadMultiplePipelinesWithRollback(t *testing.T) {
 		{"foo", &enabled, filesetConfigs},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"))
+	reg, err := newModuleRegistry(modulesPath, configs, nil, makeTestInfo("6.6.0"), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/filebeat/fileset/modules_test.go
+++ b/filebeat/fileset/modules_test.go
@@ -82,7 +82,7 @@ func TestNewModuleRegistry(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"})
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"}, false)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -149,7 +149,7 @@ func TestNewModuleRegistryConfig(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"})
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"}, false)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 
@@ -175,7 +175,7 @@ func TestMovedModule(t *testing.T) {
 		},
 	}
 
-	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"})
+	reg, err := newModuleRegistry(modulesPath, configs, nil, beat.Info{Version: "5.2.0"}, false)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 }
@@ -446,7 +446,7 @@ func TestMissingModuleFolder(t *testing.T) {
 		load(t, map[string]interface{}{"module": "nginx"}),
 	}
 
-	reg, err := NewModuleRegistry(configs, beat.Info{Version: "5.2.0"}, true)
+	reg, err := NewModuleRegistry(configs, beat.Info{Version: "5.2.0"}, true, false)
 	require.NoError(t, err)
 	assert.NotNil(t, reg)
 

--- a/filebeat/fileset/setup.go
+++ b/filebeat/fileset/setup.go
@@ -29,20 +29,22 @@ type SetupFactory struct {
 	beatInfo              beat.Info
 	pipelineLoaderFactory PipelineLoaderFactory
 	overwritePipelines    bool
+	enableAllFilesets     bool
 }
 
 // NewSetupFactory creates a SetupFactory
-func NewSetupFactory(beatInfo beat.Info, pipelineLoaderFactory PipelineLoaderFactory) *SetupFactory {
+func NewSetupFactory(beatInfo beat.Info, pipelineLoaderFactory PipelineLoaderFactory, enableAllFilesets bool) *SetupFactory {
 	return &SetupFactory{
 		beatInfo:              beatInfo,
 		pipelineLoaderFactory: pipelineLoaderFactory,
 		overwritePipelines:    true,
+		enableAllFilesets:     enableAllFilesets,
 	}
 }
 
 // Create creates a new SetupCfgRunner to setup module configuration.
 func (sf *SetupFactory) Create(_ beat.PipelineConnector, c *conf.C) (cfgfile.Runner, error) {
-	m, err := NewModuleRegistry([]*conf.C{c}, sf.beatInfo, false)
+	m, err := NewModuleRegistry([]*conf.C{c}, sf.beatInfo, false, sf.enableAllFilesets)
 	if err != nil {
 		return nil, err
 	}

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -549,7 +549,8 @@ type SetupSettings struct {
 	//Deprecated: use IndexManagementKey instead
 	Template bool
 	//Deprecated: use IndexManagementKey instead
-	ILMPolicy bool
+	ILMPolicy         bool
+	EnableAllFilesets bool
 }
 
 // Setup registers ES index template, kibana dashboards, ml jobs and pipelines.
@@ -614,12 +615,16 @@ func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) er
 		}
 
 		if setup.Pipeline && b.OverwritePipelinesCallback != nil {
+			if setup.EnableAllFilesets {
+				if err := b.Beat.BeatConfig.SetBool("config.modules.enable_all_filesets", -1, true); err != nil {
+					return fmt.Errorf("error setting enable_all_filesets config option %w", err)
+				}
+			}
 			esConfig := b.Config.Output.Config()
 			err = b.OverwritePipelinesCallback(esConfig)
 			if err != nil {
 				return err
 			}
-
 			fmt.Println("Loaded Ingest pipelines")
 		}
 

--- a/libbeat/cmd/setup.go
+++ b/libbeat/cmd/setup.go
@@ -34,6 +34,8 @@ const (
 	PipelineKey = "pipelines"
 	//IndexManagementKey used for loading all components related to ES index management in setup cmd
 	IndexManagementKey = "index-management"
+	//EnableAllFilesetsKey enables all modules and filesets regardless of config
+	EnableAllFilesetsKey = "enable-all-filesets"
 )
 
 func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Command {
@@ -55,9 +57,10 @@ func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Co
 			}
 
 			var registeredFlags = map[string]bool{
-				DashboardKey:       false,
-				PipelineKey:        false,
-				IndexManagementKey: false,
+				DashboardKey:         false,
+				PipelineKey:          false,
+				IndexManagementKey:   false,
+				EnableAllFilesetsKey: false,
 			}
 			var setupAll = true
 
@@ -88,6 +91,8 @@ func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Co
 						s.Pipeline = true
 					case IndexManagementKey:
 						s.IndexManagement = true
+					case EnableAllFilesetsKey:
+						s.EnableAllFilesets = true
 					}
 				}
 			}
@@ -102,6 +107,7 @@ func genSetupCmd(settings instance.Settings, beatCreator beat.Creator) *cobra.Co
 	setup.Flags().Bool(PipelineKey, false, "Setup Ingest pipelines")
 	setup.Flags().Bool(IndexManagementKey, false,
 		"Setup all components related to Elasticsearch index management, including template, ilm policy and rollover alias")
+	setup.Flags().Bool("enable-all-filesets", false, "Behave as if all modules and filesets had been enabled")
 
 	return &setup
 }

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -836,8 +836,11 @@ enabled modules in the +{beatname_lc}.yml+ file. If you used the
 directory, also specify the `--modules` flag.
 
 *`--enable-all-filesets`*::
-Enables all modules and filesets.  This is useful with `--pipelines` if
-you want to load all ingest pipelines.
+Enables all modules and filesets. This is useful with `--pipelines`
+if you want to load all ingest pipelines. Without this option you
+would have to list every module with the <<modules-command,`modules`>>
+command and enable every fileset within the module with a `-M` option,
+to load all of the ingest pipelines.
 
 endif::[]
 

--- a/libbeat/docs/command-reference.asciidoc
+++ b/libbeat/docs/command-reference.asciidoc
@@ -834,6 +834,11 @@ Sets up ingest pipelines for configured filesets. {beatname_uc} looks for
 enabled modules in the +{beatname_lc}.yml+ file. If you used the
 <<modules-command,`modules`>> command to enable modules in the `modules.d`
 directory, also specify the `--modules` flag.
+
+*`--enable-all-filesets`*::
+Enables all modules and filesets.  This is useful with `--pipelines` if
+you want to load all ingest pipelines.
+
 endif::[]
 
 *`--index-management`*::


### PR DESCRIPTION
## What does this PR do?

Add a new flag `--enable-all-filesets` to the `setup` command.  This
results in all modules and filesets being enabled.  

## Why is it important?

This is useful when used with the `--pipelines` flag to enable loading
of all ingest pipelines.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Configure the output
2. Run setup without any modules enabled (no pipelines loaded)

``` bash
.\filebeat -e setup --pipelines

```

3. Run setup with new flag and no modules enabled (all pipelines loaded)

``` bash
.\filebeat -e setup --pipelines --enable-all-filesets
```

## Related issues

- Closes #30916

## Use cases

Useful if you want to load all ingest pipelines without having to
configuring all the modules and filesets.