### PR TITLE
[Heartbeat] Deprecate zip_url / local monitors

### DIFF
--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -41,6 +41,8 @@ Contains information on how to run synthetic tests.
 [[monitor-source-inline]]
 ===== `inline`
 
+NOTE: While `inline` browser monitors are still supported, we highly encourage trying project monitors instead. See the https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html[Elastic synthetics docs].
+
 Runs the Synthetic test scripts that are defined inline in the configuration.
 See {observability-guide}/synthetics-create-test.html[Synthetics syntax] for
 more information.
@@ -58,7 +60,9 @@ the inline journeys.
 
 [float]
 [[monitor-source-zipurl]]
-===== `Zip URL`
+===== `Zip URL` (Deprecated)
+
+NOTE: Zip URL monitors are now deprecated! Please use project monitors instead. See the https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html[Elastic synthetics docs].
 
 Remote zip endpoint configuration allows users to specify the location
 of a synthetics test project ZIP file.
@@ -96,7 +100,9 @@ Example configuration:
 
 [float]
 [[monitor-source-local]]
-===== `Local directory`
+===== `Local directory` (Deprecated)
+
+NOTE: Local browser monitors are now deprecated! Please use project monitors instead. See the https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html[Elastic synthetics docs].
 
 Local directory where the synthetic test files are located.
 

--- a/x-pack/heartbeat/monitors/browser/source/local.go
+++ b/x-pack/heartbeat/monitors/browser/source/local.go
@@ -34,6 +34,7 @@ func ErrInvalidPath(path string) error {
 }
 
 func (l *LocalSource) Validate() error {
+	logp.L().Warn("local browser monitors are now deprecated! Please use project monitors instead. See the Elastic synthetics docs at https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html")
 	if l.OrigPath == "" {
 		return ErrNoPath
 	}

--- a/x-pack/heartbeat/monitors/browser/source/zipurl.go
+++ b/x-pack/heartbeat/monitors/browser/source/zipurl.go
@@ -43,6 +43,7 @@ type ZipURLSource struct {
 var ErrNoEtag = fmt.Errorf("no ETag header in zip file response. Heartbeat requires an etag to efficiently cache downloaded code")
 
 func (z *ZipURLSource) Validate() (err error) {
+	logp.L().Warn("Zip URL browser monitors are now deprecated! Please use project monitors instead. See the Elastic synthetics docs at https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html")
 	if z.httpClient == nil {
 		z.httpClient, _ = z.Transport.Client()
 	}


### PR DESCRIPTION
Partial work toward: https://github.com/elastic/synthetics-dev/issues/124

This deprecates these options emitting a warning log and via docs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
