### PR TITLE
ironbank: validate with retry

### DIFF
--- a/.ci/ironbank-validation.groovy
+++ b/.ci/ironbank-validation.groovy
@@ -68,7 +68,13 @@ pipeline {
       steps {
         withMageEnv(){
           dir("${env.BASE_DIR}/${env.BEATS_FOLDER}") {
-            sh(label: 'make validate-ironbank', script: "make -C ironbank validate-ironbank")
+            // Interacts with the docker registry, it might be flaky in some cases, to avoid
+            // the chances of those failures let's retry a few times, though it might somehow
+            // rerun genuine failures, which will take up to 3 times to be reported, but it can
+            // reduce the overhead for flakiness in the infrastructure side.
+            retryWithSleep(retries: 3, seconds: 30, backoff: true) {
+              sh(label: 'make validate-ironbank', script: "make -C ironbank validate-ironbank")
+            }
           }
         }
       }

--- a/x-pack/heartbeat/ironbank/Makefile
+++ b/x-pack/heartbeat/ironbank/Makefile
@@ -38,7 +38,7 @@ download-hardening-manifest-artifacts: setup-yq ## Parse hardening_manifest.yaml
 
 .PHONY: prepare
 prepare: download-hardening-manifest-artifacts ## Download container dependencies.
-	cp ../build/distributions/heartbeat-$(BEAT_VERSION)-linux-x86_64.tar.gz $(LOCATION)/
+	cp -f ../build/distributions/heartbeat-$(BEAT_VERSION)-linux-x86_64.tar.gz $(LOCATION)/
 
 package: ## Package heartbeat for the artifacts consumed by the ironbank docker context.
 	cd ../ ; \


### PR DESCRIPTION
## What does this PR do?

Retry a few times

## Why is it important?

HA for the docker registry is not in place, so this will avoid the overhead to analyse failures related to timeouts or networking with the docker registry.

The downside is related with genuine failures, since they will be retried a few times... although I don't expect any problems since the existing pipeline in  based on a timer so it will not affect anything else

<img width="572" alt="image" src="https://user-images.githubusercontent.com/2871786/191696185-e3dff30c-8f04-4274-bf06-c2745b5ce35e.png">
