### PR TITLE
Fix EK stack deployment on kubernetes

### DIFF
--- a/metricbeat/module/kubernetes/_meta/test/docs/01_playground/ek_stack.yaml
+++ b/metricbeat/module/kubernetes/_meta/test/docs/01_playground/ek_stack.yaml
@@ -42,6 +42,9 @@ data:
   xpack.security.authc.api_key.enabled: 'true'
   ELASTIC_USERNAME: "elastic"
   ELASTIC_PASSWORD: "changeme"
+  # ELASTIC_SEARCH_* variables are used by kibana to connect to ELASTICSEARCH.
+  ELASTICSEARCH_USERNAME: "kibana_system"
+  ELASTICSEARCH_PASSWORD: "kibanapassword"
 ---
 apiVersion: v1
 kind: Service
@@ -84,12 +87,38 @@ spec:
       labels:
         app: kibana
     spec:
+      initContainers:
+        - image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
+          imagePullPolicy: IfNotPresent
+          name: set-kibana-passwd
+          command:
+          - /bin/bash
+          - -c
+          - |
+            #!/bin/bash
+            set -x
+            retries=0
+            while [[ ! $(curl -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" 'http://elasticsearch:9200/') ]]; do
+                echo "Unable to connect to elastic, retrying in 10 seconds"
+                retries=$(( ${retries} + 1 ))
+                if [[ ${retries} == 10 ]]; then
+                    echo "Unable to connect to elastic. Exiting with code 1"
+                    exit 1
+                fi
+                sleep 10
+            done
+
+            curl -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}" \
+                -XPOST "http://elasticsearch:9200/_security/user/${ELASTICSEARCH_USERNAME}/_password" \
+                -H 'Content-Type: application/json' \
+                -d  "{\"password\": \"${ELASTICSEARCH_PASSWORD}\"}"
+          envFrom:
+            - configMapRef:
+                name: elasticsearch-config
       containers:
         - image: docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT
           imagePullPolicy: IfNotPresent
           name: kibana
-          env:
-          - name: ELASTICSEARCH_USERNAME
-            value: elastic
-          - name: ELASTICSEARCH_PASSWORD
-            value: changeme
+          envFrom:
+            - configMapRef:
+                name: elasticsearch-config


### PR DESCRIPTION
## What does this PR do?
This PR fixes the [EK stack deployment on kubernetes](https://github.com/elastic/beats/blob/main/metricbeat/module/kubernetes/_meta/test/docs/README.md) by changing kibana's username from elastic to kibana_system.

This was broken in https://github.com/elastic/kibana/pull/122722 and it provoked kibana not to start with error:

```
$ k logs -p kibana-76f54554c9-8rsbq
[2022-09-22T10:48:41.271+00:00][INFO ][plugins-service] Plugin "metricsEntities" is disabled.
[2022-09-22T10:48:41.307+00:00][FATAL][root] Error: [config validation of [elasticsearch].username]: value of "elastic" is forbidden. This is a superuser account that cannot write to system indices that Kibana needs to function. Use a service account token instead. Learn more: https://www.elastic.co/guide/en/elasticsearch/reference/8.0/service-accounts.html
    at ensureValidConfiguration (/usr/share/kibana/src/core/server/config/ensure_valid_configuration.js:25:11)
    at Server.preboot (/usr/share/kibana/src/core/server/server.js:160:5)
    at Root.preboot (/usr/share/kibana/src/core/server/root/index.js:48:14)
    at bootstrap (/usr/share/kibana/src/core/server/bootstrap.js:99:9)
    at Command.<anonymous> (/usr/share/kibana/src/cli/serve/serve.js:216:5)

 FATAL  Error: [config validation of [elasticsearch].username]: value of "elastic" is forbidden. This is a superuser account that cannot write to system indices that Kibana needs to function. Use a service account token instead. Learn more: https://www.elastic.co/guide/en/elasticsearch/reference/8.0/service-accounts.html
```

## How to test this PR locally
1- Make sure that you have pulled the latest  docker.elastic.co/kibana/kibana:8.0.0-SNAPSHOT. Most certainly this tag used to point to a different image which used to work before.
2- Follow the instructions of https://github.com/elastic/beats/blob/main/metricbeat/module/kubernetes/_meta/test/docs/README.md.
The only changes are in one file so running `kubectl apply -f metricbeat/module/kubernetes/_meta/test/docs/01_playground/ek_stack.yaml` before and after will show the difference. 

## Related issues
https://github.com/elastic/kibana/issues/123113
https://github.com/elastic/kibana/pull/122722