### PR TITLE
Fix terraform cleanup error

### DIFF
--- a/.ci/scripts/terraform-cleanup.sh
+++ b/.ci/scripts/terraform-cleanup.sh
@@ -7,6 +7,7 @@ DIRECTORY=${1:-.}
 FAILED=0
 for tfstate in $(find $DIRECTORY -name terraform.tfstate); do
   cd $(dirname $tfstate)
+  terraform init
   if ! terraform destroy -auto-approve; then
     FAILED=1
   fi


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

I'm seeing this terraform clean up error in 2 different PRs:
https://github.com/elastic/beats/pull/33105 and https://github.com/elastic/beats/pull/33143

```
[2022-09-28T17:52:04.645Z] + .ci/scripts/terraform-cleanup.sh x-pack/filebeat
[2022-09-28T17:52:04.645Z] + DIRECTORY=x-pack/filebeat
[2022-09-28T17:52:04.645Z] + FAILED=0
[2022-09-28T17:52:04.645Z] ++ find x-pack/filebeat -name terraform.tfstate
[2022-09-28T17:52:04.747Z] + for tfstate in $(find $DIRECTORY -name terraform.tfstate)
[2022-09-28T17:52:04.747Z] ++ dirname x-pack/filebeat/input/awss3/_meta/terraform/terraform.tfstate
[2022-09-28T17:52:04.747Z] + cd x-pack/filebeat/input/awss3/_meta/terraform
[2022-09-28T17:52:04.747Z] + terraform destroy -auto-approve
[2022-09-28T17:52:05.550Z] [31m╷[0m[0m
[2022-09-28T17:52:05.550Z] [31m│[0m [0m[1m[31mError: [0m[0m[1mCould not load plugin[0m
[2022-09-28T17:52:05.550Z] [31m│[0m [0m
[2022-09-28T17:52:05.550Z] [31m│[0m [0m[0m
[2022-09-28T17:52:05.550Z] [31m│[0m [0mPlugin reinitialization required. Please run "terraform init".
[2022-09-28T17:52:05.550Z] [31m│[0m [0m
[2022-09-28T17:52:05.550Z] [31m│[0m [0mPlugins are external binaries that Terraform uses to access and manipulate
[2022-09-28T17:52:05.550Z] [31m│[0m [0mresources. The configuration provided requires plugins which can't be
[2022-09-28T17:52:05.550Z] [31m│[0m [0mlocated,
[2022-09-28T17:52:05.550Z] [31m│[0m [0mdon't satisfy the version constraints, or are otherwise incompatible.
[2022-09-28T17:52:05.550Z] [31m│[0m [0m
[2022-09-28T17:52:05.550Z] [31m│[0m [0mTerraform automatically discovers provider requirements from your
[2022-09-28T17:52:05.550Z] [31m│[0m [0mconfiguration, including providers used in child modules. To see the
[2022-09-28T17:52:05.550Z] [31m│[0m [0mrequirements and constraints, run "terraform providers".
[2022-09-28T17:52:05.551Z] [31m│[0m [0m
[2022-09-28T17:52:05.551Z] [31m│[0m [0m3 problems:
[2022-09-28T17:52:05.551Z] [31m│[0m [0m
[2022-09-28T17:52:05.551Z] [31m│[0m [0m- failed to instantiate provider "registry.terraform.io/hashicorp/aws" to
[2022-09-28T17:52:05.551Z] [31m│[0m [0mobtain schema: the cached package for registry.terraform.io/hashicorp/aws
[2022-09-28T17:52:05.551Z] [31m│[0m [0m3.52.0 (in .terraform/providers) does not match any of the checksums
[2022-09-28T17:52:05.551Z] [31m│[0m [0mrecorded in the dependency lock file
[2022-09-28T17:52:05.551Z] [31m│[0m [0m- failed to instantiate provider "registry.terraform.io/hashicorp/local" to
[2022-09-28T17:52:05.551Z] [31m│[0m [0mobtain schema: the cached package for registry.terraform.io/hashicorp/local
[2022-09-28T17:52:05.551Z] [31m│[0m [0m2.1.0 (in .terraform/providers) does not match any of the checksums
[2022-09-28T17:52:05.551Z] [31m│[0m [0mrecorded in the dependency lock file
[2022-09-28T17:52:05.551Z] [31m│[0m [0m- failed to instantiate provider "registry.terraform.io/hashicorp/random"
[2022-09-28T17:52:05.551Z] [31m│[0m [0mto obtain schema: the cached package for
[2022-09-28T17:52:05.551Z] [31m│[0m [0mregistry.terraform.io/hashicorp/random 3.1.0 (in .terraform/providers) does
[2022-09-28T17:52:05.551Z] [31m│[0m [0mnot match any of the checksums recorded in the dependency lock file
[2022-09-28T17:52:05.551Z] [31m│[0m [0m
[2022-09-28T17:52:05.551Z] [31m╵[0m[0m
[2022-09-28T17:52:05.551Z] + FAILED=1
[2022-09-28T17:52:05.551Z] + cd -
[2022-09-28T17:52:05.551Z] /var/lib/jenkins/workspace/PR-33143-3-ee38bf65-a63d-4871-be8a-7d2e58e71adc/src/github.com/elastic/beats
[2022-09-28T17:52:05.551Z] + exit 1
script returned exit code 1
```
I added this change into my [PR](https://github.com/elastic/beats/pull/33105) and CI passed. Since I don't know when my PR will get merged, I would like to get this line of change out into its own PR so I can unblock other PRs from failing CI.

