### PR TITLE
[Filebeat] Fix input metrics not being unregistered for aws-s3, aws-cloudwatch, lumberjack

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -71,6 +71,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix how to handle IPv6 addresses in the fileset `nginx/ingress_controller` for Filebeat. {pull}32989[32989]
 - Fix handling of Cisco 302020 messages in ASA and FTD modules. {pull}33089[33089]
 - Fix requestID parsing in AWS cloudtrail fileset. {pull}33143[33143]
+- Fix input metrics not being unregistered when an input closes. This led to panics when configuration was reloaded for the aws-s3, aws-cloudwatch, and lumberjack inputs. {pull}33259[33259]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/awscloudwatch/metrics.go
+++ b/x-pack/filebeat/input/awscloudwatch/metrics.go
@@ -29,7 +29,7 @@ func newInputMetrics(parent *monitoring.Registry, id string) *inputMetrics {
 	monitoring.NewString(reg, "id").Set(id)
 	out := &inputMetrics{
 		id:                           id,
-		parent:                       reg,
+		parent:                       parent,
 		logEventsReceivedTotal:       monitoring.NewUint(reg, "log_events_received_total"),
 		logGroupsTotal:               monitoring.NewUint(reg, "log_groups_total"),
 		cloudwatchEventsCreatedTotal: monitoring.NewUint(reg, "cloudwatch_events_created_total"),

--- a/x-pack/filebeat/input/awss3/metrics.go
+++ b/x-pack/filebeat/input/awss3/metrics.go
@@ -48,7 +48,7 @@ func newInputMetrics(parent *monitoring.Registry, id string) *inputMetrics {
 	monitoring.NewString(reg, "id").Set(id)
 	out := &inputMetrics{
 		id:                                  id,
-		parent:                              reg,
+		parent:                              parent,
 		sqsMessagesReceivedTotal:            monitoring.NewUint(reg, "sqs_messages_received_total"),
 		sqsVisibilityTimeoutExtensionsTotal: monitoring.NewUint(reg, "sqs_visibility_timeout_extensions_total"),
 		sqsMessagesInflight:                 monitoring.NewUint(reg, "sqs_messages_inflight_gauge"),

--- a/x-pack/filebeat/input/awss3/metrics_test.go
+++ b/x-pack/filebeat/input/awss3/metrics_test.go
@@ -20,7 +20,7 @@ func TestInputMetricsClose(t *testing.T) {
 	metrics := newInputMetrics(reg, "aws-s3-aws.cloudfront_logs-8b312b5f-9f99-492c-b035-3dff354a1f01")
 	metrics.Close()
 
-	reg.Do(monitoring.Full, func(s string, i interface{}) {
+	reg.Do(monitoring.Full, func(s string, _ interface{}) {
 		t.Errorf("registry should be empty, but found %v", s)
 	})
 }

--- a/x-pack/filebeat/input/awss3/metrics_test.go
+++ b/x-pack/filebeat/input/awss3/metrics_test.go
@@ -1,0 +1,26 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package awss3
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+// TestInputMetricsClose asserts that metrics registered by this input are
+// removed after Close() is called. This is important because an input with
+// the same ID could be re-registered, and that ID cannot exist in the
+// monitoring registry.
+func TestInputMetricsClose(t *testing.T) {
+	reg := monitoring.NewRegistry()
+
+	metrics := newInputMetrics(reg, "aws-s3-aws.cloudfront_logs-8b312b5f-9f99-492c-b035-3dff354a1f01")
+	metrics.Close()
+
+	reg.Do(monitoring.Full, func(s string, i interface{}) {
+		t.Errorf("registry should be empty, but found %v", s)
+	})
+}

--- a/x-pack/filebeat/input/lumberjack/metrics.go
+++ b/x-pack/filebeat/input/lumberjack/metrics.go
@@ -33,7 +33,7 @@ func newInputMetrics(parent *monitoring.Registry, id string) *inputMetrics {
 	monitoring.NewString(reg, "id").Set(id)
 	out := &inputMetrics{
 		id:                    id,
-		parent:                reg,
+		parent:                parent,
 		bindAddress:           monitoring.NewString(reg, "bind_address"),
 		batchesReceivedTotal:  monitoring.NewUint(reg, "batches_received_total"),
 		batchesACKedTotal:     monitoring.NewUint(reg, "batches_acked_total"),


### PR DESCRIPTION
## What does this PR do?

Filebeat inputs for aws-s3, aws-cloudwatch, and lumberjack register metrics in the "dataset" namespace. They use the ID of the Filebeat input as a key in the monitoring registry. The monitoring registry will panic if you attempt to register an ID that already exists in the registry.

The aws-s3 input was observed to panic under Agent when configuration was modified. The root cause was that input's metrics were not unregistered when the input closed. This was due to a bug where the metrics were removed from the wrong monitoring registry instance. A test was added to aws-s3 to verify the fix and similar code was found and fixed in aws-cloudwatch and lumberjack.

This observed panic from Filebeat 8.4.2 under Agent was:

```
panic: name cloudfront_logs-decbb626-7967-4188-b39e-f7b20ff88f42 already used

goroutine 2248 [running]:
github.com/elastic/elastic-agent-libs/monitoring.panicErr({0x55687ad39c80, 0xc000bf8440})
	/go/pkg/mod/github.com/elastic/elastic-agent-libs@v0.2.11/monitoring/registry.go:257 +0x65
github.com/elastic/elastic-agent-libs/monitoring.(*Registry).Add(0xc0004adf40, {0xc000946fc0, 0x3f}, {0x55687ad3d360, 0xc000bfa100}, 0x1)
	/go/pkg/mod/github.com/elastic/elastic-agent-libs@v0.2.11/monitoring/registry.go:155 +0x11f
github.com/elastic/elastic-agent-libs/monitoring.(*Registry).NewRegistry(0xc0004adf40, {0xc000946fc0, 0x3f}, {0x0, 0x0, 0x0})
	/go/pkg/mod/github.com/elastic/elastic-agent-libs@v0.2.11/monitoring/registry.go:94 +0x1ed
github.com/elastic/beats/v7/x-pack/filebeat/input/awss3.newInputMetrics(0xc0004adf40, {0xc000946fc0, 0x3f})
	/go/src/github.com/elastic/beats/x-pack/filebeat/input/awss3/metrics.go:46 +0x6e
github.com/elastic/beats/v7/x-pack/filebeat/input/awss3.(*s3Input).createSQSReceiver(0xc0003f4300, {0xc001dbb410, {0xc000946fc0, 0x3f}, {{0x556879d7f3ee, 0x8}, {0x556879d7f3ee, 0x8}, {0x556879d77900, 0x5}, ...}, ...}, ...)
	/go/src/github.com/elastic/beats/x-pack/filebeat/input/awss3/input.go:185 +0x817
github.com/elastic/beats/v7/x-pack/filebeat/input/awss3.(*s3Input).Run(0xc0003f4300, {0xc001dbb410, {0xc000946fc0, 0x3f}, {{0x556879d7f3ee, 0x8}, {0x556879d7f3ee, 0x8}, {0x556879d77900, 0x5}, ...}, ...}, ...)
	/go/src/github.com/elastic/beats/x-pack/filebeat/input/awss3/input.go:130 +0xbf8
github.com/elastic/beats/v7/filebeat/input/v2/compat.(*runner).Start.func1()
	/go/src/github.com/elastic/beats/filebeat/input/v2/compat/compat.go:114 +0x2b5
created by github.com/elastic/beats/v7/filebeat/input/v2/compat.(*runner).Start
	/go/src/github.com/elastic/beats/filebeat/input/v2/compat/compat.go:111 +0x113
```

For context, the input metrics I'm referencing are the ones mentioned [here](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-aws-s3.html#_metrics). Under Agent you can view them with `curl --unix /usr/share/elastic-agent/state/data/tmp/default/filebeat/filebeat.sock "http://f/dataset?pretty"`.

## Why is it important?

Config reloads (and Agent policy changes) lead to Filebeat panics.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

