### PR TITLE
ironbank: change packetbeat name in the hardening_manifest.yaml

### DIFF
--- a/dev-tools/packaging/templates/ironbank/packetbeat/hardening_manifest.yaml
+++ b/dev-tools/packaging/templates/ironbank/packetbeat/hardening_manifest.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 
 # The repository name in registry1, excluding /ironbank/
-name: "elastic/beats/7.x/packetbeat"
+name: "elastic/beats/packetbeat"
 
 # List of tags to push for the repository in registry1
 # The most specific version should be the first tag and will be shown


### PR DESCRIPTION
## What does this PR do?

Change the name for `packetbeat` in the ironbank context to reflect the current branch

## Why is it important?

`7.x` is not supported in main or 8.x branches