### PR TITLE
Fix docker provider add_fields processors

### DIFF
--- a/x-pack/elastic-agent/CHANGELOG.next.asciidoc
+++ b/x-pack/elastic-agent/CHANGELOG.next.asciidoc
@@ -96,6 +96,7 @@
 - Allow ':' characters in dynamic variables. {pull}32407[32407]
 - Allow the - char to appear as part of variable names in eql expressions. {pull}32350[32350]
 - Allow the / char to appear as part of variable names in eql expressions. {pull}32528{32528}
+- Fix add_fields processor on Docker provider {pull}33269{33269}
 
 ==== New features
 

--- a/x-pack/elastic-agent/pkg/composable/providers/docker/docker.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/docker/docker.go
@@ -145,7 +145,7 @@ func generateData(event bus.Event) (*dockerContainerData, error) {
 						"image":  container.Image,
 						"labels": processorLabelMap,
 					},
-					"to": "container",
+					"target": "container",
 				},
 			},
 		},

--- a/x-pack/elastic-agent/pkg/composable/providers/docker/docker_test.go
+++ b/x-pack/elastic-agent/pkg/composable/providers/docker/docker_test.go
@@ -53,7 +53,7 @@ func TestGenerateData(t *testing.T) {
 						"co_elastic_logs/disable": "true",
 					},
 				},
-				"to": "container",
+				"target": "container",
 			},
 		},
 	}


### PR DESCRIPTION
This is a backport PR for: https://github.com/elastic/elastic-agent/pull/1420

## What does this PR do?
The Docker provider was using a wrong key when defining the `add_fields` processor, this causes Filebeat not to start the input and stay on a unhealthy state. This processor seems to be defined every time a variable like `${docker}` is used on a input configuration.

This commit fixes it.

## Why is it important?
It fixes a bug on Docker auto discovery provider

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist
 - [x] Decide about backports (7.17?)
 - [x] Backport to 7.17.x (PR on Beats repo)

## How to test this PR locally
1. Make sure you have Docker installed and running
1. Deploy Elastic Stack
1. Start a container that will generate logs (e.g: `docker run --rm --name flog -d mingrammer/flog /bin/flog -s1 -d1 -l -f rfc3164`).
2. Create a standalone Elastic-Agent policy [using Kibana as suggested in the documentation](https://www.elastic.co/guide/en/fleet/current/create-standalone-agent-policy.html#create-standalone-agent-policy).
3. On this policy add the "Custom Logs Integration" configuring the path as `/var/lib/docker/containers/${docker.container.id}/*-json.log`.
4. Download the policy (e.g: `/tmp/elastic-agent.yml`), adjust the Elasticsearch credentials as needed.
5. Start the Elastic-Agent with log debug (running as root is usually required to read `/var/lib/docker/*)`:
   ```
   sudo elastic-agent  -e -d "*"
   ```
6. You should see logs on Kibana

## Related issues
- Fixes https://github.com/elastic/beats/issues/29030

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
