### PR TITLE
[Heartbeat] Fix enabled flag usage in case of streams

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -83,6 +83,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix handling of empty array in httpjson input. {pull}32001[32001]
 
 *Heartbeat*
+- Fix broken disable feature for kibana configured monitors. {pull}33293[33293]
 
 
 *Metricbeat*

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -115,13 +115,13 @@ func (NoopRunner) Stop() {
 
 // Create makes a new Runner for a new monitor with the given Config.
 func (f *RunnerFactory) Create(p beat.Pipeline, c *conf.C) (cfgfile.Runner, error) {
-	if !c.Enabled() {
-		return NoopRunner{}, nil
-	}
-
 	c, err := stdfields.UnnestStream(c)
 	if err != nil {
 		return nil, err
+	}
+
+	if !c.Enabled() {
+		return NoopRunner{}, nil
 	}
 
 	configEditor, err := newCommonPublishConfigs(f.info, f.beatLocation, c)

--- a/heartbeat/monitors/factory_test.go
+++ b/heartbeat/monitors/factory_test.go
@@ -207,24 +207,38 @@ func TestPreProcessors(t *testing.T) {
 }
 
 func TestDisabledMonitor(t *testing.T) {
-	confMap := map[string]interface{}{
-		"type":    "test",
-		"enabled": "false",
+	testConfigs := []map[string]interface{}{
+		{
+			"type":     "test",
+			"enabled":  "false",
+			"schedule": "@every 10s",
+		},
+		{
+			"streams": []map[string]interface{}{
+				{
+					"type":     "test",
+					"enabled":  "false",
+					"schedule": "@every 10s",
+				},
+			},
+		},
 	}
 
-	conf, err := config.NewConfigFrom(confMap)
-	require.NoError(t, err)
+	for _, confMap := range testConfigs {
+		conf, err := config.NewConfigFrom(confMap)
+		require.NoError(t, err)
 
-	reg, built, closed := mockPluginsReg()
-	f, sched, fClose := makeMockFactory(reg)
-	defer fClose()
-	defer sched.Stop()
-	runner, err := f.Create(&MockPipeline{}, conf)
-	require.NoError(t, err)
-	require.IsType(t, runner, NoopRunner{})
+		reg, built, closed := mockPluginsReg()
+		f, sched, fClose := makeMockFactory(reg)
+		defer fClose()
+		defer sched.Stop()
+		runner, err := f.Create(&MockPipeline{}, conf)
+		require.NoError(t, err)
+		require.IsType(t, NoopRunner{}, runner)
 
-	require.Equal(t, 0, built.Load())
-	require.Equal(t, 0, closed.Load())
+		require.Equal(t, 0, built.Load())
+		require.Equal(t, 0, closed.Load())
+	}
 }
 
 func TestDuplicateMonitorIDs(t *testing.T) {


### PR DESCRIPTION
Fixes usage of Enabled incase of data streams !!


Fix https://github.com/elastic/beats/issues/33270

Example to test

  ```
- id: >-
      synthetics/browser-synthetics-e1a84561-a0df-49a1-b61f-0c09e0e4f25f-elastic-agent-managed-ep-default
    name: My first monitor-Test private location-default
    revision: 3
    type: synthetics/browser
    use_output: default
    meta:
      package:
        name: synthetics
        version: 0.11.0
    data_stream:
      namespace: default
    package_policy_id: e1a84561-a0df-49a1-b61f-0c09e0e4f25f-elastic-agent-managed-ep-default
    streams:
      - id: >-
          synthetics/browser-browser.screenshot-e1a84561-a0df-49a1-b61f-0c09e0e4f25f-elastic-agent-managed-ep-default
        data_stream:
          dataset: browser.screenshot
          type: synthetics
        processors:
          - add_observer_metadata:
              geo:
                name: Fleet managed
          - add_fields:
              fields:
                monitor.fleet_managed: true
              target: ''
      - id: e1a84561-a0df-49a1-b61f-0c09e0e4f25f
        name: My first monitor
        type: browser
        enabled: false
        data_stream:
          dataset: browser
          type: synthetics
        schedule: '@every 1m'
        throttling: 5d/3u/20l
        source.inline.script: |-
          step('Go to https://www.google.com', async () => {
            await page.goto('https://www.google.com');
          });
        origin: ui
        __ui:
          script_source:
            file_name: ''
            is_generated_script: false
          is_tls_enabled: true
          is_zip_url_tls_enabled: false
        processors:
          - add_observer_metadata:
              geo:
                name: Test private location
          - add_fields:
              fields:
                config_id: e1a84561-a0df-49a1-b61f-0c09e0e4f25f
                monitor.fleet_managed: true
              target: ''
        timeout: null
        screenshots: 'on'
      - id: >-
          synthetics/browser-browser.network-e1a84561-a0df-49a1-b61f-0c09e0e4f25f-elastic-agent-managed-ep-default
        data_stream:
          dataset: browser.network
          type: synthetics
        processors:
          - add_observer_metadata:
              geo:
                name: Fleet managed
          - add_fields:
              fields:
                monitor.fleet_managed: true
              target: ''
```