### PR TITLE
ci: enable next minor for daily and weekly automation

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,8 +20,8 @@ pipeline {
   stages {
     stage('Nighly beats builds') {
       steps {
-        runMacosBuilds(quietPeriodFactor: 2000, branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
-        runIronbankBuilds(quietPeriodFactor: 100, branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
+        runMacosBuilds(quietPeriodFactor: 2000, branches: ['main', '8.<next-minor>', '8.<minor>', '8.<next-patch>', '7.<minor>'])
+        runIronbankBuilds(quietPeriodFactor: 100, branches: ['main', '8.<next-minor>', '8.<minor>', '8.<next-patch>', '7.<minor>'])
       }
     }
   }

--- a/.ci/schedule-weekly.groovy
+++ b/.ci/schedule-weekly.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Weekly beats builds for AWS') {
       steps {
-        runBuilds(quietPeriodFactor: 1000, branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'], parameters: [booleanParam(name: 'awsCloudTests', value: true)])
+        runBuilds(quietPeriodFactor: 1000, branches: ['main', '8.<next-minor>', '8.<minor>', '8.<next-patch>', '7.<minor>'], parameters: [booleanParam(name: 'awsCloudTests', value: true)])
       }
     }
     stage('Weekly beats builds for Orka M1') {


### PR DESCRIPTION
## What does this PR do?

Next minor alias was not enabled.

## Why is it important?

`8.5` branch is not enabled for the daily/weekly.
