### PR TITLE
[DOCS] Add banner to encourage Functionbeat users to move to ESF

### DIFF
--- a/x-pack/functionbeat/docs/page_header.html
+++ b/x-pack/functionbeat/docs/page_header.html
@@ -1,0 +1,3 @@
+Functionbeat will reach End of Support on October 18, 2023. You should consider
+moving your deployments to the more versatile and efficient Elastic Serverless
+Forwarder.


### PR DESCRIPTION
## What does this PR do?

Adds banner to encourage users to use the Elastic Serverless Forwarder instead of Functionbeat.

## Why is it important?

Starting in 8.5, Functionbeat is deprecated. Users should prepare for the migration to Elastic Serverless Forwarder now.

## Checklist

- [x] My code follows the style guidelines of this project

## Related issues

- Closes https://github.com/elastic/observability-docs/issues/2225

## Screenshots

![image](https://user-images.githubusercontent.com/14206422/194971687-fd37e223-80db-4801-a775-bf5157465149.png)
