### PR TITLE
Fix sample config in log rotation docs

### DIFF
--- a/filebeat/docs/filebeat-log-rotation.asciidoc
+++ b/filebeat/docs/filebeat-log-rotation.asciidoc
@@ -70,8 +70,8 @@ sure it does not miss any events.
 [source,yaml]
 -----------------------------------------------------
 filebeat.inputs:
-- type: log
-  enabled: false
+- type: filestream
+  id: my-server-filestream-id
   paths:
   - /var/log/my-server/my-server.log*
 -----------------------------------------------------


### PR DESCRIPTION
Troubleshooting guide for logs rotation contains a sample configuration with `enabled: false`. I guess this configuration shouldn't be disabled. Enable it, and migrate it from `log` input to `filestream`.

These are the sample configurations in https://www.elastic.co/guide/en/beats/filebeat/8.4/file-log-rotation.html#log-rotate-example