### PR TITLE
Fix errors for non-synth capable instances

### DIFF
--- a/heartbeat/ecserr/ecserr.go
+++ b/heartbeat/ecserr/ecserr.go
@@ -120,3 +120,11 @@ func NewCouldNotConnectErr(host, port string, err error) *ECSErr {
 		fmt.Sprintf("Could not connect to '%s:%s' with error: %s", host, port, err),
 	)
 }
+
+func NewNotSyntheticsCapableError() *ECSErr {
+	return NewECSErr(
+		TYPE_IO,
+		"AGENT_NOT_BROWSER_CAPABLE",
+		"browser monitors cannot be created outside the official elastic docker image",
+	)
+}

--- a/heartbeat/monitors/wrappers/wrappers.go
+++ b/heartbeat/monitors/wrappers/wrappers.go
@@ -229,7 +229,7 @@ func addMonitorStatus(summaryOnly bool) jobs.JobWrapper {
 			if summaryOnly {
 				hasSummary, _ := event.Fields.HasKey("summary.up")
 				if !hasSummary {
-					return cont, nil
+					return cont, err
 				}
 			}
 

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -720,16 +720,16 @@ func TestProjectBrowserJob(t *testing.T) {
 
 func TestECSErrors(t *testing.T) {
 	ecse := ecserr.NewBadCmdStatusErr(123, "mycommand")
-	wrappedEcsErr := fmt.Errorf("wrapped: %w", ecse)
-	expectedEcsErr := ecserr.NewECSErr(
+	wrappedECSErr := fmt.Errorf("wrapped: %w", ecse)
+	expectedECSErr := ecserr.NewECSErr(
 		ecse.Type,
 		ecse.Code,
-		wrappedEcsErr.Error(),
+		wrappedECSErr.Error(),
 	)
 
-	j := WrapCommon([]jobs.Job{makeProjectBrowserJob(t, "http://example.net", true, wrappedEcsErr, projectMonitorValues)}, testBrowserMonFields, nil)
+	j := WrapCommon([]jobs.Job{makeProjectBrowserJob(t, "http://example.net", true, wrappedECSErr, projectMonitorValues)}, testBrowserMonFields, nil)
 	event := &beat.Event{}
 	_, err := j[0](event)
 	require.NoError(t, err)
-	require.Equal(t, event.Fields["error"], expectedEcsErr)
+	require.Equal(t, expectedECSErr, event.Fields["error"])
 }

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -719,6 +719,12 @@ func TestProjectBrowserJob(t *testing.T) {
 }
 
 func TestECSErrors(t *testing.T) {
+	// key is test name, value is whether to test a summary event or not
+	testCases := map[string]bool{
+		"on summary event":     true,
+		"on non-summary event": false,
+	}
+
 	ecse := ecserr.NewBadCmdStatusErr(123, "mycommand")
 	wrappedECSErr := fmt.Errorf("wrapped: %w", ecse)
 	expectedECSErr := ecserr.NewECSErr(
@@ -727,9 +733,13 @@ func TestECSErrors(t *testing.T) {
 		wrappedECSErr.Error(),
 	)
 
-	j := WrapCommon([]jobs.Job{makeProjectBrowserJob(t, "http://example.net", true, wrappedECSErr, projectMonitorValues)}, testBrowserMonFields, nil)
-	event := &beat.Event{}
-	_, err := j[0](event)
-	require.NoError(t, err)
-	require.Equal(t, expectedECSErr, event.Fields["error"])
+	for name, makeSummaryEvent := range testCases {
+		t.Run(name, func(t *testing.T) {
+			j := WrapCommon([]jobs.Job{makeProjectBrowserJob(t, "http://example.net", makeSummaryEvent, wrappedECSErr, projectMonitorValues)}, testBrowserMonFields, nil)
+			event := &beat.Event{}
+			_, err := j[0](event)
+			require.NoError(t, err)
+			require.Equal(t, expectedECSErr, event.Fields["error"])
+		})
+	}
 }

--- a/x-pack/heartbeat/monitors/browser/browser.go
+++ b/x-pack/heartbeat/monitors/browser/browser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 
+	"github.com/elastic/beats/v7/heartbeat/ecserr"
 	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 )
 
@@ -24,14 +25,12 @@ func init() {
 
 var showExperimentalOnce = sync.Once{}
 
-var ErrNotSyntheticsCapableError = fmt.Errorf("synthetic monitors cannot be created outside the official elastic docker image")
-
 func create(name string, cfg *config.C) (p plugin.Plugin, err error) {
 	// We don't want users running synthetics in environments that don't have the required GUI libraries etc, so we check
 	// this flag. When we're ready to support the many possible configurations of systems outside the docker environment
 	// we can remove this check.
 	if os.Getenv("ELASTIC_SYNTHETICS_CAPABLE") != "true" {
-		return plugin.Plugin{}, ErrNotSyntheticsCapableError
+		return plugin.Plugin{}, ecserr.NewNotSyntheticsCapableError()
 	}
 
 	showExperimentalOnce.Do(func() {


### PR DESCRIPTION
Fixes https://github.com/elastic/beats/issues/32694  by making sure we use the lightweight wrapper code always when monitors cannot be initialized.

This also fixes an unrelated bug, where errors attached to non-summary events would not be indexed.

![image](https://user-images.githubusercontent.com/131427/195201946-2c94d0e1-1452-4474-ad6f-f9fd15407360.png)


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Create an inline monitor with a non-docker heartbeat, sending the results to ES. Kibana should show the error in the screenshot.