### PR TITLE
[Heartbeat] Only use one provider list in k8s configmap example

### DIFF
--- a/deploy/kubernetes/heartbeat-kubernetes.yaml
+++ b/deploy/kubernetes/heartbeat-kubernetes.yaml
@@ -7,8 +7,7 @@ metadata:
     k8s-app: heartbeat
 data:
   heartbeat.yml: |-
-    #heartbeat.autodiscover:
-    #  # Autodiscover pods
+    #heartbeat.autodiscover: # Enable one or more of the providers below
     #  providers:
     #    - type: kubernetes
     #      resource: pod
@@ -16,16 +15,12 @@ data:
     #      node: ${NODE_NAME}
     #      hints.enabled: true
     #
-    #  # Autodiscover services
-    #  providers:
     #    - type: kubernetes
     #      resource: service
     #      scope: cluster
     #      node: ${NODE_NAME}
     #      hints.enabled: true
     #
-    #  # Autodiscover nodes
-    #  providers:
     #    - type: kubernetes
     #      resource: node
     #      node: ${NODE_NAME}

--- a/deploy/kubernetes/heartbeat/heartbeat-configmap.yaml
+++ b/deploy/kubernetes/heartbeat/heartbeat-configmap.yaml
@@ -7,8 +7,7 @@ metadata:
     k8s-app: heartbeat
 data:
   heartbeat.yml: |-
-    #heartbeat.autodiscover:
-    #  # Autodiscover pods
+    #heartbeat.autodiscover: # Enable one or more of the providers below
     #  providers:
     #    - type: kubernetes
     #      resource: pod
@@ -16,16 +15,12 @@ data:
     #      node: ${NODE_NAME}
     #      hints.enabled: true
     #
-    #  # Autodiscover services
-    #  providers:
     #    - type: kubernetes
     #      resource: service
     #      scope: cluster
     #      node: ${NODE_NAME}
     #      hints.enabled: true
     #
-    #  # Autodiscover nodes
-    #  providers:
     #    - type: kubernetes
     #      resource: node
     #      node: ${NODE_NAME}


### PR DESCRIPTION
With our previous example uncommenting multiple providers would break, since our yaml parser just picks the last present `providers` key.
