### PR TITLE
[Bug] winlogbeat/sys/wineventlog: fix publisherHandle close.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -110,6 +110,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix fatal invalid memory write on Windows 11. {issue}32469[32469] {pull}32519[32519]
 - Fix handling of event formatting when no metadata is available on Windows 11. {issue}32468[32468] {pull}32519[32519]
 - Reduce severity of message salvage failure logging. {pull}32697[32697]
+- Fix publish handle leak. {pull}33328[33328]
 
 *Functionbeat*
 

--- a/winlogbeat/sys/wineventlog/wineventlog_windows.go
+++ b/winlogbeat/sys/wineventlog/wineventlog_windows.go
@@ -227,16 +227,16 @@ func RenderEvent(
 		return err
 	}
 
-	var publisherHandle uintptr
+	var publisherHandle EvtHandle
 	if pubHandleProvider != nil {
 		messageFiles := pubHandleProvider(providerName)
 		if messageFiles.Err == nil {
 			// There is only ever a single handle when using the Windows Event
 			// Log API.
-			publisherHandle = messageFiles.Handles[0].Handle
+			publisherHandle = EvtHandle(messageFiles.Handles[0].Handle)
 		}
 	}
-
+	defer _EvtClose(publisherHandle) //nolint:errcheck // This is just a resource release.
 	// Only a single string is returned when rendering XML.
 	err = FormatEventString(EvtFormatMessageXml,
 		eventHandle, providerName, EvtHandle(publisherHandle), lang, renderBuf, out)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Fix the defer close `ph` of `FormatEventString`.
<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
When `ph` is not 0/null, it will not be closed. In some cases, it will lead data origin uninstall failed.
Detailed info: https://discuss.elastic.co/t/winlogbeat-may-leak-publisherhandle-and-lead-to-failure-of-sysmon-uninstalling/316246
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.