### PR TITLE
Remove beta flag for Enterprise Search metricbeat module

### DIFF
--- a/metricbeat/docs/modules/enterprisesearch.asciidoc
+++ b/metricbeat/docs/modules/enterprisesearch.asciidoc
@@ -8,8 +8,6 @@ This file is generated! See scripts/mage/docs_collector.go
 [role="xpack"]
 == Enterprise Search module
 
-beta[]
-
 This module periodically fetches metrics and health information from Elastic Enterprise Search instances using HTTP APIs.
 
 [float]


### PR DESCRIPTION
We've been using this module internally for Stack monitoring since 8.2. I think we can remove the beta flag.

cc @aznick @carlosdelest @ioanatia

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
