### PR TITLE
Fix unchecked stream_id

### DIFF
--- a/x-pack/libbeat/management/generate.go
+++ b/x-pack/libbeat/management/generate.go
@@ -170,8 +170,8 @@ func injectStreamProcessors(expected *proto.UnitExpectedConfig, inputType string
 	// the AST injects input_id at the input level and not the stream level,
 	// for reasons I can't understand, as it just ends up shuffling it around
 	// to individual metricsets anyway, at least on metricbeat
-	if expected.GetId() != "" {
-		inputId := generateAddFieldsProcessor(mapstr.M{"input_id": expected.Id}, "@metadata")
+	if expectedID := expected.GetId(); expectedID != "" {
+		inputId := generateAddFieldsProcessor(mapstr.M{"input_id": expectedID}, "@metadata")
 		processors = append(processors, inputId)
 	}
 
@@ -191,9 +191,10 @@ func injectStreamProcessors(expected *proto.UnitExpectedConfig, inputType string
 	processors = append(processors, event)
 
 	// source stream
-	streamID := streamExpected.GetId()
-	sourceStream := generateAddFieldsProcessor(mapstr.M{"stream_id": streamID}, "@metadata")
-	processors = append(processors, sourceStream)
+	if streamID := streamExpected.GetId(); streamID != "" {
+		sourceStream := generateAddFieldsProcessor(mapstr.M{"stream_id": streamID}, "@metadata")
+		processors = append(processors, sourceStream)
+	}
 
 	// figure out if we have any existing processors
 	currentProcs, ok := stream["processors"]


### PR DESCRIPTION
## What does this PR do?
Closes https://github.com/elastic/beats/issues/33168 By adding a small check to make sure we don't add a blank stream ID.


## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
