### PR TITLE
[Metricbeat] Add time_throttled in ES node_stats metricset (#143337)

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -230,6 +230,9 @@ var (
 						"times_throttled": s.Object{
 							"count": c.Int("number_of_times_throttled"),
 						},
+						"time_throttled": s.Object{
+							"ns": c.Int("time_throttled_nanos"),
+						},
 					}),
 				}),
 				"memory": c.Dict("memory", s.Schema{


### PR DESCRIPTION
Fixes [#143337](https://github.com/elastic/kibana/issues/143337)

### Summary

The field `elasticsearch.node.stats.os.cgroup.cpu.stat.time_throttled.ns` (aliased under `node_stats.os.cgroup.cpu.stat.time_throttled_nanos`) was not being reported in the `node_stats` metricset of the Elasticsearch module. 

This is due to it not being part of the schema that is used to copy data from the `_nodes/stats` API response to the Metricbeat event.

### How to test
Get the changes: `git fetch git@github.com:miltonhultgren/beats.git 143337-missing-cpu-quota-data:143337-missing-cpu-quota-data && git switch 143337-missing-cpu-quota-data`

I suggest running two single-node Elasticsearch clusters, one that is monitored with Metricbeat and one that is the monitoring cluster which Kibana connects to. 

For the "monitoring" cluster just set it up within Kibana (`yarn es` and `yarn start`).

For the "production" cluster, we'll need to run in a container with limits set, I found [this guide ](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) helpful, here is a summary of the steps:

Start Elasticsearch:
```
docker network create elastic
docker run --name es01 --net elastic -p 9201:9200 -p 9301:9300 -it --cpu-period 1000 --cpu-quota 1000 docker.elastic.co/elasticsearch/elasticsearch:8.4.3
```

Once it's started, you'll see the password for the `elastic` user in the output. 
We'll also need to copy the CA certificate to use HTTPS.

Inside the Metricbeat folder:
```
docker cp es01:/usr/share/elasticsearch/config/certs/http_ca.crt .
```

Put this into your `metricbeat.yml`:
```
metricbeat.modules:
  - module: elasticsearch
    xpack.enabled: true
    period: 10s
    hosts:
      - "https://localhost:9201"
    username: "elastic"
    password: "<<PASSWORD>>"
    ssl.verification_mode: "none"
    ssl.certificate_authorities:
      - ./http_ca.crt

output.elasticsearch:
  hosts: [ "localhost:9200" ]
  username: "elastic"
  password: "changeme"
```

Start Metricbeat (after running `mage build`) and confirm in Kibana that:

1. In Discover, the documents being shipped include the field `elasticsearch.node.stats.os.cgroup.cpu.stat.time_throttled.ns`
<img width="2575" alt="Screenshot 2022-10-14 at 17 13 24" src="https://user-images.githubusercontent.com/2564140/195881523-9eabcac1-274a-4044-9d2a-e386e261c07e.png">

2. In Stack Monitoring's Elasticsearch Nodes list, the CPU usage and CPU throttling columns do not show "N/A"
<img width="2876" alt="Screenshot 2022-10-14 at 17 13 36" src="https://user-images.githubusercontent.com/2564140/195881529-fba26173-c5ee-4355-8c7a-0c50f6ba2d6b.png">


### Follow up steps
Similar to the work done in https://github.com/elastic/beats/pull/33214, we should likely go through **every** metricset in **every** module we own to make sure all documented fields are actually present.