### PR TITLE
ci: remove e2e-testing in the main pipeline for elastic-agent

### DIFF
--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -93,7 +93,7 @@ stages:
     packaging-linux:
         packaging-linux: "mage package"
         e2e:
-            enabled: true
+            enabled: false
             testMatrixFile: '.ci/.e2e-tests-for-elastic-agent.yaml'
         stage: packaging
         when:


### PR DESCRIPTION
## What does this PR do?

Remove e2e-testing from the main pipeline

## Why is it important?

e2e-testing requires more components to be built such as metricbeat, hence the packaging with `e2e-testing` for the `x-pack/elastic-agent` won't work since it requires metricbeat to be packaged.