### PR TITLE
[Heartbeat] Better loading / reloading of state tracker

### DIFF
--- a/heartbeat/config/config.go
+++ b/heartbeat/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Autodiscover   *autodiscover.Config `config:"autodiscover"`
 	Jobs           map[string]*JobLimit `config:"jobs"`
 	RunFrom        *LocationWithID      `config:"run_from"`
+	States         *conf.C              `config:"states"` // only enabled / disabled for now
 }
 
 type JobLimit struct {

--- a/heartbeat/monitors/wrappers/monitorstate/tracker.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker.go
@@ -104,3 +104,16 @@ func (t *Tracker) getCurrentState(sf stdfields.StdMonitorFields) (state *State) 
 func NilStateLoader(_ stdfields.StdMonitorFields) (*State, error) {
 	return nil, nil
 }
+
+func AtomicStateLoader(inner StateLoader) (sl StateLoader, replace func(StateLoader)) {
+	mtx := &sync.Mutex{}
+	return func(currentSL stdfields.StdMonitorFields) (*State, error) {
+			mtx.Lock()
+			defer mtx.Unlock()
+			return inner(currentSL)
+		}, func(sl StateLoader) {
+			mtx.Lock()
+			defer mtx.Unlock()
+			inner = sl
+		}
+}


### PR DESCRIPTION
Fixes loading / reloading of monitor state tracker to:

1. Only occur either in the context of elastic agent (e.g. managed mode) OR if `heartbeat.states.enabled: true` 
2. Reload the ES config on agent updates of the config file

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
