### PR TITLE
[automation] update elastic stack version for testing 8.5.0-7c74e950

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-f8c98e5d-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-7c74e950-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -31,7 +31,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.5.0-f8c98e5d-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.5.0-7c74e950-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -44,7 +44,7 @@ services:
       - 5055:5055
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.0-f8c98e5d-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.0-7c74e950-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 17 Oct 2022 00:17:28 GMT, release_branch:8.5, prefix:, end_time:Mon, 17 Oct 2022 05:59:35 GMT, manifest_version:2.1.0, version:8.5.0-SNAPSHOT, branch:8.5, build_id:8.5.0-7c74e950, build_duration_seconds:20527]