### PR TITLE
Osquerybeat: Fix the logging  with the wrong logger

### DIFF
--- a/x-pack/osquerybeat/internal/osqdcli/client.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"golang.org/x/sync/semaphore"
-	"gotest.tools/gotestsum/log"
 
 	"github.com/osquery/osquery-go"
 	genosquery "github.com/osquery/osquery-go/gen/osquery"
@@ -132,7 +131,7 @@ func (c *Client) reconnect(ctx context.Context) error {
 	return r.Run(ctx, func(ctx context.Context) error {
 		cli, err := osquery.NewClient(c.socketPath, c.timeout)
 		if err != nil {
-			log.Errorf("failed to connect: %v", err)
+			r.log.Errorf("failed to connect: %v", err)
 			return err
 		}
 		c.cli = cli

--- a/x-pack/osquerybeat/internal/osqdcli/client.go
+++ b/x-pack/osquerybeat/internal/osqdcli/client.go
@@ -131,7 +131,7 @@ func (c *Client) reconnect(ctx context.Context) error {
 	return r.Run(ctx, func(ctx context.Context) error {
 		cli, err := osquery.NewClient(c.socketPath, c.timeout)
 		if err != nil {
-			r.log.Errorf("failed to connect: %v", err)
+			r.log.Warnf("failed to connect, reconnect might be attempted, err: %v", err)
 			return err
 		}
 		c.cli = cli


### PR DESCRIPTION
## What does this PR do?

Fixes the typo that was causing the osquerybeat to use the wrong logger that was logging into stderr output.

## Why is it important?

Fixes the wrong logging

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas

