### PR TITLE
x-pack/filebeat/input/httpjson: test and document empty split behaviour

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -157,6 +157,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add support for single string containing multiple relation-types in getRFC5988Link. {pull}32811[32811]
 - Fix handling of invalid UserIP and LocalIP values. {pull}32896[32896]
 - Allow http_endpoint instances to share ports. {issue}32578[32578] {pull}33377[33377]
+- Improve httpjson documentation for split processor. {pull}33473[33473]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -633,6 +633,7 @@ filebeat.inputs:
 ==== `response.split`
 
 Split operation to apply to the response once it is received. A split can convert a map, array, or string into multiple events.
+If the split target is empty the parent document will be kept. If documents with empty splits should be dropped, the `ignore_empty_value` option should be set to `true`.
 
 [float]
 ==== `response.split[].target`

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -38,7 +38,7 @@ func TestInput(t *testing.T) {
 				"interval":       1,
 				"request.method": http.MethodGet,
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
 		{
@@ -49,7 +49,7 @@ func TestInput(t *testing.T) {
 				"request.method":                http.MethodGet,
 				"request.ssl.verification_mode": "none",
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
 		{
@@ -85,7 +85,7 @@ func TestInput(t *testing.T) {
 					"test": "abc",
 				},
 			},
-			handler:  defaultHandler(http.MethodPost, `{"test":"abc"}`),
+			handler:  defaultHandler(http.MethodPost, `{"test":"abc"}`, ""),
 			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
 		{
@@ -95,7 +95,7 @@ func TestInput(t *testing.T) {
 				"interval":       "100ms",
 				"request.method": http.MethodPost,
 			},
-			handler: defaultHandler(http.MethodPost, ""),
+			handler: defaultHandler(http.MethodPost, "", ""),
 			expected: []string{
 				`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`,
 				`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`,
@@ -111,7 +111,7 @@ func TestInput(t *testing.T) {
 					"target": "body.hello",
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{`{"world":"moon"}`, `{"space":[{"cake":"pumpkin"}]}`},
 		},
 		{
@@ -125,11 +125,38 @@ func TestInput(t *testing.T) {
 					"keep_parent": true,
 				},
 			},
-			handler: defaultHandler(http.MethodGet, ""),
+			handler: defaultHandler(http.MethodGet, "", ""),
 			expected: []string{
 				`{"hello":{"world":"moon"}}`,
 				`{"hello":{"space":[{"cake":"pumpkin"}]}}`,
 			},
+		},
+		{
+			name:        "Test split on empty array without ignore_empty_value",
+			setupServer: newTestServer(httptest.NewServer),
+			baseConfig: map[string]interface{}{
+				"interval":       1,
+				"request.method": http.MethodGet,
+				"response.split": map[string]interface{}{
+					"target": "body.response.empty",
+				},
+			},
+			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
+			expected: []string{`{"response":{"empty":[]}}`},
+		},
+		{
+			name:        "Test split on empty array with ignore_empty_value",
+			setupServer: newTestServer(httptest.NewServer),
+			baseConfig: map[string]interface{}{
+				"interval":       1,
+				"request.method": http.MethodGet,
+				"response.split": map[string]interface{}{
+					"target":             "body.response.empty",
+					"ignore_empty_value": true,
+				},
+			},
+			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
+			expected: nil,
 		},
 		{
 			name:        "Test nested split",
@@ -145,7 +172,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler: defaultHandler(http.MethodGet, ""),
+			handler: defaultHandler(http.MethodGet, "", ""),
 			expected: []string{
 				`{"world":"moon"}`,
 				`{"space":{"cake":"pumpkin"}}`,
@@ -161,7 +188,7 @@ func TestInput(t *testing.T) {
 					"target": "body.unknown",
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{},
 		},
 		{
@@ -366,7 +393,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodPost, `{"bar":"foo","url":{"path":"/test-path"}}`),
+			handler:  defaultHandler(http.MethodPost, `{"bar":"foo","url":{"path":"/test-path"}}`, ""),
 			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
 		{
@@ -399,7 +426,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
 		{
@@ -417,7 +444,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
 		{
@@ -457,7 +484,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
 		{
@@ -532,7 +559,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, ""),
+			handler:  defaultHandler(http.MethodGet, "", ""),
 			expected: []string{`{"world":"moon"}`, `{"space":[{"cake":"pumpkin"}]}`},
 		},
 		{
@@ -554,7 +581,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler: defaultHandler(http.MethodGet, ""),
+			handler: defaultHandler(http.MethodGet, "", ""),
 			expected: []string{
 				`{"hello":{"world":"moon"}}`,
 				`{"hello":{"space":[{"cake":"pumpkin"}]}}`,
@@ -585,7 +612,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler: defaultHandler(http.MethodGet, ""),
+			handler: defaultHandler(http.MethodGet, "", ""),
 			expected: []string{
 				`{"world":"moon"}`,
 				`{"space":{"cake":"pumpkin"}}`,
@@ -615,7 +642,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler: defaultHandler(http.MethodGet, ""),
+			handler: defaultHandler(http.MethodGet, "", ""),
 			expected: []string{
 				`{"hello":{"world":"moon"}}`,
 				`{"space":{"cake":"pumpkin"}}`,
@@ -661,7 +688,7 @@ func TestInput(t *testing.T) {
 					},
 				},
 			},
-			handler: defaultHandler(http.MethodGet, ""),
+			handler: defaultHandler(http.MethodGet, "", ""),
 			expected: []string{
 				`{"hello":{"world":"moon"}}`,
 				`{"space":{"cake":"pumpkin"}}`,
@@ -699,6 +726,11 @@ func TestInput(t *testing.T) {
 			t.Cleanup(func() { _ = timeout.Stop() })
 
 			if len(tc.expected) == 0 {
+				select {
+				case <-timeout.C:
+				case got := <-chanClient.Channel:
+					t.Errorf("unexpected event: %v", got)
+				}
 				cancel()
 				assert.NoError(t, g.Wait())
 				return
@@ -794,10 +826,12 @@ func newV2Context() (v2.Context, func()) {
 	}, cancel
 }
 
-func defaultHandler(expectedMethod, expectedBody string) http.HandlerFunc {
+func defaultHandler(expectedMethod, expectedBody, msg string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("content-type", "application/json")
-		msg := `{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`
+		if msg == "" {
+			msg = `{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`
+		}
 		switch {
 		case r.Method != expectedMethod:
 			w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds documentation explaining the expected behaviour when an httpjson split processor is invoked on an empty value and adds tests to ensure this behaviour is retained.

Testing changes allow local specification of response bodies and add testing of extra unexpected events when no-event is expected from a test.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The current documentation does not explain the expected behaviour.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
