### PR TITLE
[Heartbeat] Update node to v18.12.0 in container image

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -162,6 +162,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Heartbeat*
 
 - Add new states field for internal use by new synthetics app. {pull}30632[30632]
+- Upgrade node to 18.12.0
 
 *Metricbeat*
 

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -122,7 +122,7 @@ RUN echo \
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
 ENV SUITES_DIR={{ $beatHome }}/suites
-ENV NODE_VERSION=16.15.0
+ENV NODE_VERSION=18.12.0
 ENV PATH="$NODE_PATH/node/bin:$PATH"
 # Install the latest version of @elastic/synthetics forcefully ignoring the previously
 # cached node_modules, heartbeat then calls the global executable to run test suites


### PR DESCRIPTION
This puts us on to the latest LTS release of node. I like to just modify [run.sh](https://github.com/elastic/synthetics-dev/tree/main/heartbeat-testing/run-current) from here.
