### PR TITLE
docs: add example to extract HEX encoded fingerprint from certificate

### DIFF
--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -386,6 +386,14 @@ present in the chain during the handshake, it will be added to the
 `certificate_authorities` list and the handshake will continue
 normaly.
 
+One way to get the fingerprint from a CA certificate is using the
+following command where `ca.crt` is the certificate.
+
+[source]
+------------------------
+openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=" '{print $2}' | sed 's/://g'
+------------------------
+
 
 [discrete]
 [[ssl-server-config]]

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -386,14 +386,14 @@ present in the chain during the handshake, it will be added to the
 `certificate_authorities` list and the handshake will continue
 normaly.
 
-One way to get the fingerprint from a CA certificate is using the
-following command where `ca.crt` is the certificate.
+One way to get the fingerprint from a CA certificate is, on a Unix like
+system, using the following command where `ca.crt` is the
+certificate.
 
 [source]
 ------------------------
 openssl x509 -fingerprint -sha256 -noout -in ./ca.crt | awk --field-separator="=" '{print $2}' | sed 's/://g'
 ------------------------
-
 
 [discrete]
 [[ssl-server-config]]

--- a/libbeat/docs/shared-ssl-config.asciidoc
+++ b/libbeat/docs/shared-ssl-config.asciidoc
@@ -386,8 +386,8 @@ present in the chain during the handshake, it will be added to the
 `certificate_authorities` list and the handshake will continue
 normaly.
 
-One way to get the fingerprint from a CA certificate is, on a Unix like
-system, using the following command where `ca.crt` is the
+To get the fingerprint from a CA certificate on a Unix-like
+system, you can use the following command, where `ca.crt` is the
 certificate.
 
 [source]


### PR DESCRIPTION
## What does this PR do?

This commit adds an example of how to extract the HEX encoded SHA-256 fingerprint from a CA certificate using openssl, awk and sed. Those tools should be available on most Unix-like systems.

## Why is it important?

It helps users to get the HEX encoded SHA-256 fingerprint in the correct format to be used as `ssl.ca_trusted_fingerprint`

## Checklist

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~

## How to test this PR locally

You will need to have Docker installed to build the docs

1. Clone https://github.com/elastic/docs into the same folder as `beats`
2. From the root folder of `beats` run: `../docs/build_docs --doc ./filebeat/docs/index.asciidoc --all --open`
3. A browser window will open, navigate to `http://localhost:8000/guide/configuration-ssl.html#ca_trusted_fingerprint`

~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
>
