### PR TITLE
Fix missing comment in filebeat.reference.yml

### DIFF
--- a/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
+++ b/filebeat/_meta/config/filebeat.inputs.reference.yml.tmpl
@@ -339,7 +339,7 @@ filebeat.inputs:
 
   #parsers:
     #- include_message.patterns:
-      - ["WARN", "ERR"]
+      #- ["WARN", "ERR"]
 
   #### Multiline options
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -746,7 +746,7 @@ filebeat.inputs:
 
   #parsers:
     #- include_message.patterns:
-      - ["WARN", "ERR"]
+      #- ["WARN", "ERR"]
 
   #### Multiline options
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -2910,7 +2910,7 @@ filebeat.inputs:
 
   #parsers:
     #- include_message.patterns:
-      - ["WARN", "ERR"]
+      #- ["WARN", "ERR"]
 
   #### Multiline options
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Current config is not valid as it contains example values which aren't commented out.
Results in error: `Exiting: error loading config file: yaml: line xxx: did not find expected key`

## Why is it important?

Reference `filebeat.yml` isn't valid YAML

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~