### PR TITLE
[Filebeat] Treat filebeat.events.active as gauge in monitoring log reporter

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -55,6 +55,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add handling of AAA operations for Cisco ASA module. {issue}32257[32257] {pull}32789[32789]
 - Fix gc.log always shipped even if gc fileset is disabled {issue}30995[30995]
 - Fix handling of empty array in httpjson input. {pull}32001[32001]
+- Fix reporting of `filebeat.events.active` in log events such that the current value is always reported instead of the difference from the last value. {pull}33597[33597]
 
 *Heartbeat*
 - Fix bug affecting let's encrypt and other users of cross-signed certs, where cert expiration was incorrectly calculated. {issue}33215[33215]

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -233,7 +233,7 @@ func (fb *Filebeat) Run(b *beat.Beat) error {
 
 	// count active events for waiting on shutdown
 	wgEvents := &eventCounter{
-		count: monitoring.NewInt(nil, "filebeat.events.active"),
+		count: monitoring.NewInt(nil, "filebeat.events.active"), // Gauge
 		added: monitoring.NewUint(nil, "filebeat.events.added"),
 		done:  monitoring.NewUint(nil, "filebeat.events.done"),
 	}

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -42,6 +42,7 @@ var gauges = map[string]bool{
 	"libbeat.pipeline.clients":           true,
 	"libbeat.config.module.running":      true,
 	"registrar.states.current":           true,
+	"filebeat.events.active":             true,
 	"filebeat.harvester.running":         true,
 	"filebeat.harvester.open_files":      true,
 	"beat.memstats.memory_total":         true,

--- a/libbeat/monitoring/report/log/log.go
+++ b/libbeat/monitoring/report/log/log.go
@@ -249,16 +249,16 @@ func toKeyValuePairs(snaps map[string]monitoring.FlatSnapshot) []interface{} {
 	for name, snap := range snaps {
 		data := make(mapstr.M, snapshotLen(snap))
 		for k, v := range snap.Bools {
-			data.Put(k, v)
+			data.Put(k, v) //nolint:errcheck // All keys within the flat snapshot are unique and are for scalar values.
 		}
 		for k, v := range snap.Floats {
-			data.Put(k, v)
+			data.Put(k, v) //nolint:errcheck // All keys within the flat snapshot are unique and are for scalar values.
 		}
 		for k, v := range snap.Ints {
-			data.Put(k, v)
+			data.Put(k, v) //nolint:errcheck // All keys within the flat snapshot are unique and are for scalar values.
 		}
 		for k, v := range snap.Strings {
-			data.Put(k, v)
+			data.Put(k, v) //nolint:errcheck // All keys within the flat snapshot are unique and are for scalar values.
 		}
 		if len(data) > 0 {
 			args = append(args, logp.Reflect(name, data))

--- a/libbeat/publisher/pipeline/monitoring.go
+++ b/libbeat/publisher/pipeline/monitoring.go
@@ -84,7 +84,7 @@ func newMetricsObserver(metrics *monitoring.Registry) *metricsObserver {
 	return &metricsObserver{
 		metrics: metrics,
 		vars: metricsObserverVars{
-			clients: monitoring.NewUint(reg, "clients"),
+			clients: monitoring.NewUint(reg, "clients"), // Gauge
 
 			events:    monitoring.NewUint(reg, "events.total"),
 			filtered:  monitoring.NewUint(reg, "events.filtered"),
@@ -96,7 +96,7 @@ func newMetricsObserver(metrics *monitoring.Registry) *metricsObserver {
 			queueACKed:     monitoring.NewUint(reg, "queue.acked"),
 			queueMaxEvents: monitoring.NewUint(reg, "queue.max_events"),
 
-			activeEvents: monitoring.NewUint(reg, "events.active"),
+			activeEvents: monitoring.NewUint(reg, "events.active"), // Gauge
 		},
 	}
 }


### PR DESCRIPTION
## What does this PR do?

The monitoring log reporting applies serial differencing to the filebeat.events.active value. But this value is used as a gauge by Filebeat so it can increase and decrease. So by reporting `current - prev` this can result in negative values that are not as useful as knowing the full amount of active events.

This metric is [decremented](https://github.com/elastic/beats/blob/cab8871124af7a6855a482e62a416bbd979fb542/filebeat/beater/channels.go#L101) when an event is ACked.

## Why is it important?

It helps when analyzing logs that contain "Non-zero metrics in the last 30s".

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


