### PR TITLE
packaging: staging artifacts with DEV=false

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -394,8 +394,10 @@ def prepareE2ETestForPackage(String beat){
 
 def release(type){
   withBeatsEnv(type){
+    // As agreed DEV=false for staging otherwise DEV=true
+    // this should avoid releasing binaries with the debug symbols and disabled most build optimizations.
     withEnv([
-      "DEV=true"
+      "DEV=${!type.equals('staging')}"
     ]) {
       dockerLogin(secret: "${DOCKERELASTIC_SECRET}", registry: "${DOCKER_REGISTRY}")
       dir("${env.BEATS_FOLDER}") {

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Affecting all Beats*
 
+- Re-enable build optimizations to reduce binary size and improve performance. {pull}33620[33620]
 - Fix namespacing for agent self-monitoring, CPU no longer reports as zero. {pull}32336[32336]
 - Fix namespacing on self-monitoring {pull}32336[32336]
 - Expand fields in `decode_json_fields` if target is set. {issue}31712[31712] {pull}32010[32010]


### PR DESCRIPTION
## What does this PR do?

reduce the size of the Beats and Agent release artifacts, possible significantly. It should also lead to a small increase in efficiency.

## Why

Setting DEV=true includes debug symbols in the released binary and disabled most build optimizations. Unrequired for releases
