### PR TITLE
Fix loop in filesystemn reporting and debug statement in fsstat

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -92,7 +92,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix logstash cgroup mappings {pull}33131[33131]
 - Remove unused `elasticsearch.node_stats.indices.bulk.avg_time.bytes` mapping {pull}33263[33263]
 - Add tags to events based on parsed identifier. {pull}33472[33472]
-- Fix loop in filesystemn reporting and debug statement in fsstat {pull}33646[33646]
+- Skip over unsupported filesystems in the system.filesystem metricset instead of failing immediately. Fix debug statement in system.fsstat metricset. {pull}33646[33646]
 
 
 *Packetbeat*

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -92,6 +92,8 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix logstash cgroup mappings {pull}33131[33131]
 - Remove unused `elasticsearch.node_stats.indices.bulk.avg_time.bytes` mapping {pull}33263[33263]
 - Add tags to events based on parsed identifier. {pull}33472[33472]
+- Fix loop in filesystemn reporting and debug statement in fsstat {pull}33646[33646]
+
 
 *Packetbeat*
 

--- a/metricbeat/module/system/fsstat/fsstat.go
+++ b/metricbeat/module/system/fsstat/fsstat.go
@@ -84,7 +84,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 			m.Logger().Debugf("error fetching filesystem stats for '%s': %v", fs.Directory, err)
 			continue
 		}
-		m.Logger().Debugf("filesystem: %s total=%d, used=%d, free=%d", fs.Directory, fs.Total, fs.Used.Bytes.ValueOr(0), fs.Free)
+		m.Logger().Debugf("filesystem: %s total=%d, used=%d, free=%d", fs.Directory, fs.Total.ValueOr(0), fs.Used.Bytes.ValueOr(0), fs.Free.ValueOr(0))
 
 		totalFiles += fs.Files.ValueOr(0)
 		totalSize += fs.Total.ValueOr(0)


### PR DESCRIPTION
## What does this PR do?

This fixes two bugs:

- the `system.filesystem` metricset will hard-fail if it encounters a filesystem it can't fetch stats for, instead of merely skipping the given filesystem
- `system.fsstat` had a bad logging statement.

## Why is it important?

These are both bugs.

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
