### PR TITLE
Enable cgo and fix typecheck linter for github linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -40,6 +40,7 @@ jobs:
       - name: golangci-lint
         env:
           GOOS: ${{ matrix.GOOS }}
+          CGO_ENABLED: 1
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,12 @@ issues:
     - text: "ST1003:"
       linters:
         - stylecheck
+    - text: "undefined"
+      linters:
+        - typecheck
+    - text: "imported but not used"
+      linters:
+        - typecheck
     # From mage we are priting to the console to ourselves
     - path: (.*magefile.go|.*dev-tools/mage/.*)
       linters: forbidigo
@@ -42,7 +48,6 @@ linters:
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
     - structcheck # finds unused struct fields
-    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
     - varcheck # Finds unused global variables and constants
     - asciicheck # simple linter to check that your code does not contain non-ASCII identifiers
     - bodyclose # checks whether HTTP response body is closed successfully


### PR DESCRIPTION
## What does this PR do?

This PR enables CGO in the github actions linter. We need this as right now, with CGO disabled, the `typecheck` sublinter will choke on any imported function or type that's constrained to cgo. This is a source of frequent headaches in the system module, which frequently imports cgo code.

However, there's another problem: if we enable cgo, the `typecheck` linter fails in a different way, particularly it can't seem to handle embedded struct fields or certain kinds of imports. To add insult to injury, we can't actually disable `typecheck`, since it's not actually a linter, and just a frontend for the go compiler that reports any compile errors. However, we have the rest of the CI to deal with compiler-level errors, rendering this unnecessary, even though we can't disable it. As a workaround,  I've added a few filters to remove the errors that usually happen with CGO enabled.


Not sure if this needs a changelog entry? I've tested this on a handful of large files in the beats repo, and it seems to work.