### PR TITLE
ci: fix permissions when reusing workspace to package staging

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -277,8 +277,9 @@ def generateArmStep(beat) {
         }
         // Staging is only needed from branches (main or release branches)
         if (isBranch()) {
-          deleteDir()
-          release('staging')
+          withNewWorkspace() {
+            release('staging')
+          }
         }
       }
     }
@@ -300,19 +301,25 @@ def generateLinuxStep(beat) {
 
         // Staging is only needed from branches (main or release branches)
         if (isBranch()) {
-          // As long as we reuse the same worker to package more than
-          // once, the workspace gets corrupted with some permissions
-          // therefore let's reset the workspace to a new location
-          // in order to reuse the worker and successfully run the package
-          def work = "workspace/${env.JOB_BASE_NAME}-${env.BUILD_NUMBER}-staging"
-          ws(work) {
-            withEnv(["HOME=${env.WORKSPACE}"]) {
-              deleteDir()
-              release('staging')
-            }
+          withNewWorkspace() {
+            release('staging')
           }
         }
       }
+    }
+  }
+}
+
+def withNewWorkspace(Closure body) {
+  // As long as we reuse the same worker to package more than
+  // once, the workspace gets corrupted with some permissions
+  // therefore let's reset the workspace to a new location
+  // in order to reuse the worker and successfully run the package
+  def work = "workspace/${env.JOB_BASE_NAME}-${env.BUILD_NUMBER}-staging"
+  ws(work) {
+    withEnv(["HOME=${env.WORKSPACE}"]) {
+      deleteDir()
+      body()
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Prepare the CI workspace so it can reuse the same worker for packaigng staging artifacts

## Why is it important?

The packaging for `elastic-agent` generates files with different permissions hence it's not possible to delete them and run the packaging again


<img width="1586" alt="image" src="https://user-images.githubusercontent.com/2871786/201310182-5158f8bf-0a61-428a-8b5b-80c4170c163a.png">

<img width="1453" alt="image" src="https://user-images.githubusercontent.com/2871786/201310221-14616047-acda-4fca-950f-4977b08cd310.png">
