### PR TITLE
Add another rule for typecheck linter under cgo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ issues:
     - text: "undefined"
       linters:
         - typecheck
-    - text: "undeclared name"
+    - text: "undeclared name:"
       linters:
         - typecheck
     - text: "imported but not used"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,9 @@ issues:
     - text: "undefined"
       linters:
         - typecheck
+    - text: "undeclared name"
+      linters:
+        - typecheck
     - text: "imported but not used"
       linters:
         - typecheck


### PR DESCRIPTION
## What does this PR do?

This issue was found as part of https://github.com/elastic/beats/pull/31233 , where it looks like they ran into another error condition of `typecheck` that I hadn't before. This adds another rule to hopefully fix that.
