### PR TITLE
[Filebeat] aws-s3 - Disable event normalization processing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -157,6 +157,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Improve httpjson documentation for split processor. {pull}33473[33473]
 - Added separation of transform context object inside httpjson. Introduced new clause `.parent_last_response.*` {pull}33499[33499]
 - Cloud Foundry input uses server-side filtering when retrieving logs. {pull}33456[33456]
+- Disable "event normalization" processing for the aws-s3 input to reduce allocations. {pull}33673[33673]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -112,6 +112,11 @@ func (in *s3Input) Run(inputContext v2.Context, pipeline beat.Pipeline) error {
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
 		CloseRef:   inputContext.Cancelation,
 		ACKHandler: awscommon.NewEventACKHandler(),
+		Processing: beat.ProcessingConfig{
+			// This input only produces events with basic types so normalization
+			// is not required.
+			EventNormalization: boolPtr(false),
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create pipeline client: %w", err)
@@ -368,3 +373,6 @@ func getProviderFromDomain(endpoint string, ProviderOverride string) string {
 	}
 	return "unknown"
 }
+
+// boolPtr returns a pointer to b.
+func boolPtr(b bool) *bool { return &b }


### PR DESCRIPTION
## What does this PR do?

Disable event normalization for the aws-s3 input to reduce allocations when processing events. The input only produces basic types in its events. Either it puts a string into the `message` field or it decodes json into a map[string]interface with encoding/json. Both of those should be fine for the downstream processors and outputs.

Relates #33657

## Why is it important?

It makes Filebeat more efficient.

## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues


- Relates #33657

## Screenshots

<img width="763" alt="Screen Shot 2022-11-13 at 11 18 45" src="https://user-images.githubusercontent.com/4565752/201532281-d24c601d-fd02-4fd0-b707-4ad95fa17846.png">