### PR TITLE
release: DRA for 7.17 is not available

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -120,6 +120,7 @@ pipeline {
           when {
             allOf {
               expression { return env.IS_BRANCH_AVAILABLE == "true" }
+              // DRA is not supported in 7.17 yet
               not { branch '7.17' }
             }
           }
@@ -143,7 +144,8 @@ pipeline {
               // minor version is created, therefore old release branches won't be able
               // to use the release manager as their definition is removed.
               expression { return env.IS_BRANCH_AVAILABLE == "true" }
-              not { branch 'main' }
+              // DRA is not supported in 7.17 yet
+              not { branch '7.17' }
             }
           }
           steps {


### PR DESCRIPTION
## What does this PR do?

Disable DRA for `7.17`

## Why is it important?

The packaging pipeline with DRA should support 8.2+ 
