### PR TITLE
x-pack/filebeat/input/cel: add support for http+{unix,npipe} schemes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,6 +76,7 @@ CHANGELOG*
 /x-pack/filebeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
 /x-pack/filebeat/input/awscloudwatch/ @elastic/obs-cloud-monitoring
 /x-pack/filebeat/input/awss3/ @elastic/obs-cloud-monitoring
+/x-pack/filebeat/input/cel/ @elastic/security-external-integrations
 /x-pack/filebeat/input/gcppubsub/ @elastic/security-external-integrations
 /x-pack/filebeat/input/http_endpoint/ @elastic/security-external-integrations
 /x-pack/filebeat/input/httpjson/ @elastic/security-external-integrations

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -163,7 +163,8 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Modified `aws-s3` input to reduce mutex contention when multiple SQS message are being processed concurrently. {pull}33658[33658]
 - Disable "event normalization" processing for the aws-s3 input to reduce allocations. {pull}33673[33673]
 - Add Common Expression Language input. {pull}31233[31233]
-- Add support for http+unix and http+npipe schemes. {issue}33571[33571] {pull}33610[33610]
+- Add support for http+unix and http+npipe schemes in httpjson input. {issue}33571[33571] {pull}33610[33610]
+- Add support for http+unix and http+npipe schemes in cel input. {issue}33571[33571] {pull}33712[33712]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-cel.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-cel.asciidoc
@@ -425,6 +425,9 @@ with `auth.oauth2.google.jwt_file` or `auth.oauth2.google.jwt_json`.
 
 The URL of the HTTP API. Required.
 
+The API endpoint may be accessed via unix socket and Windows named pipes by adding  `+unix` or `+npipe`
+to the URL scheme, for example, `http+unix:///var/socket/`.
+
 [float]
 ==== `resource.timeout`
 

--- a/x-pack/filebeat/input/cel/transport_other.go
+++ b/x-pack/filebeat/input/cel/transport_other.go
@@ -1,0 +1,21 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build !windows
+
+package cel
+
+import (
+	"errors"
+	"net"
+)
+
+// npipeDialer implements transport.Dialer.
+type npipeDialer struct {
+	path string
+}
+
+func (npipeDialer) Dial(_, _ string) (net.Conn, error) {
+	return nil, errors.New("named pipe only available on windows")
+}

--- a/x-pack/filebeat/input/cel/transport_windows.go
+++ b/x-pack/filebeat/input/cel/transport_windows.go
@@ -1,0 +1,23 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+//go:build windows
+
+package cel
+
+import (
+	"net"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// npipeDialer implements transport.Dialer to a constant named pipe path.
+type npipeDialer struct {
+	path string
+}
+
+func (d npipeDialer) Dial(_, _ string) (net.Conn, error) {
+	return winio.DialPipe(`\\.\pipe`+filepath.FromSlash(d.path), nil)
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds support for requests to endpoints over Unix sockets and Windows named pipes using the `https?+(unix|npipe)` schemes. No testing at this stage since cel test infrastructure assumes a TCP transport.

It also marks the cel input as owned by SEI to avoid troubling agent-data-plane in the future.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

From #33571

> This would be used connect to internal services that are only exposed locally. Services like [Beats HTTP monitoring endpoint](https://www.elastic.co/guide/en/beats/filebeat/current/http-endpoint.html) and Docker have APIs that listen on unix sockets. It would be useful if httpjson (and any future inputs that also monitor arbitrary HTTP services) could monitor data from these local APIs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Query inclusion in 8.6 backport for 8.6.1.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #33571

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
