### PR TITLE
packetbeat/protos/memcache: don't panic when a transaction is empty

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Packetbeat*
 
+- Fix panic on memcache transaction with no request or response. {issue}33852[33852] {pull}33853[33853]
 
 *Winlogbeat*
 

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -198,6 +198,9 @@ func (mc *memcache) GetPorts() []int {
 }
 
 func (mc *memcache) finishTransaction(t *transaction) error {
+	if t == nil {
+		return nil
+	}
 	mc.handler.onTransaction(t)
 	return nil
 }

--- a/packetbeat/protos/memcache/plugin_udp.go
+++ b/packetbeat/protos/memcache/plugin_udp.go
@@ -144,6 +144,7 @@ func (mc *memcache) ParseUDP(pkt *protos.Packet) {
 	}
 	if !done {
 		trans.timer = time.AfterFunc(mc.udpConfig.transTimeout, func() {
+			defer logp.Recover("ParseMemcache(UDP) panic during forward")
 			debug("transaction timeout -> forward")
 			mc.onUDPTrans(trans)
 			mc.udpExpTrans.push(trans)
@@ -261,6 +262,9 @@ func (c *udpConnection) killTransaction(t *udpTransaction) {
 }
 
 func (lst *udpExpTransList) push(t *udpTransaction) {
+	if t == nil {
+		return
+	}
 	lst.Lock()
 	defer lst.Unlock()
 	t.next = lst.head


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

When a *transaction is constructed from a UDP stream, but has no request and no response, onTransaction is handed a nil *transaction, resulting in a panic in Event when the *transaction.Notes field is accessed. The panic is not recovered by ParseUDP's recover because the panic happens in a separate goroutine. So be more careful with pointer dereferencing in this path and put a separate recover in the time.AfterFunc-called closure.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The panic causes loss of packetbeat service in some situations.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #33852

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
