### PR TITLE
actions: use go-version-file: .go-version

### DIFF
--- a/.github/workflows/check-audtibeat.yml
+++ b/.github/workflows/check-audtibeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-default.yml
+++ b/.github/workflows/check-default.yml
@@ -17,11 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check-default
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-dev-tools.yml
+++ b/.github/workflows/check-dev-tools.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -17,11 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Install libsystemd-dev

--- a/.github/workflows/check-filebeat.yml
+++ b/.github/workflows/check-filebeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install libsystemd-dev
       run: sudo apt-get install -y libsystemd-dev
     - name: Run check/update

--- a/.github/workflows/check-heartbeat.yml
+++ b/.github/workflows/check-heartbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-libbeat.yml
+++ b/.github/workflows/check-libbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update

--- a/.github/workflows/check-metricbeat.yml
+++ b/.github/workflows/check-metricbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update

--- a/.github/workflows/check-winlogbeat.yml
+++ b/.github/workflows/check-winlogbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-xpack-auditbeat.yml
+++ b/.github/workflows/check-xpack-auditbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install librpm-dev
       run: sudo apt-get install -y librpm-dev
     - name: Run check/update

--- a/.github/workflows/check-xpack-dockerlogbeat.yml
+++ b/.github/workflows/check-xpack-dockerlogbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-xpack-filebeat.yml
+++ b/.github/workflows/check-xpack-filebeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update

--- a/.github/workflows/check-xpack-functionbeat.yml
+++ b/.github/workflows/check-xpack-functionbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-xpack-heartbeat.yml
+++ b/.github/workflows/check-xpack-heartbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-xpack-libbeat.yml
+++ b/.github/workflows/check-xpack-libbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-xpack-metricbeat.yml
+++ b/.github/workflows/check-xpack-metricbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-xpack-osquerybeat.yml
+++ b/.github/workflows/check-xpack-osquerybeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       run: |
         go install github.com/magefile/mage

--- a/.github/workflows/check-xpack-packetbeat.yml
+++ b/.github/workflows/check-xpack-packetbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update

--- a/.github/workflows/check-xpack-winlogbeat.yml
+++ b/.github/workflows/check-xpack-winlogbeat.yml
@@ -15,11 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - name: Run check/update
       uses: magefile/mage-action@v2
       with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,14 +28,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      # Uses Go version from the repository.
-      - name: Read .go-version file
-        id: goversion
-        run: echo "::set-output name=version::$(cat .go-version)"
-
       - uses: actions/setup-go@v3
         with:
-          go-version: "${{ steps.goversion.outputs.version }}"
+          go-version-file: .go-version
 
       - name: golangci-lint
         env:

--- a/.github/workflows/macos-auditbeat.yml
+++ b/.github/workflows/macos-auditbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-filebeat.yml
+++ b/.github/workflows/macos-filebeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-heartbeat.yml
+++ b/.github/workflows/macos-heartbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-metricbeat.yml
+++ b/.github/workflows/macos-metricbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-packetbeat.yml
+++ b/.github/workflows/macos-packetbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-xpack-auditbeat.yml
+++ b/.github/workflows/macos-xpack-auditbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-xpack-filebeat.yml
+++ b/.github/workflows/macos-xpack-filebeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-xpack-functionbeat.yml
+++ b/.github/workflows/macos-xpack-functionbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-xpack-heartbeat.yml
+++ b/.github/workflows/macos-xpack-heartbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-xpack-metricbeat.yml
+++ b/.github/workflows/macos-xpack-metricbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-xpack-osquerybeat.yml
+++ b/.github/workflows/macos-xpack-osquerybeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'

--- a/.github/workflows/macos-xpack-packetbeat.yml
+++ b/.github/workflows/macos-xpack-packetbeat.yml
@@ -18,11 +18,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
     - uses: actions/setup-python@v4
       with:
         python-version: '3.9'


### PR DESCRIPTION
 ## What does this PR do?

Use the `setup-go` action with the `go-version-file` input so it reads the file `.go-version`

## Why is it important?

Avoid the logic to read and create env variables and use the undocumented `.go-version-file` 

See https://github.com/actions/setup-go/pull/295