### PR TITLE
Add support for excluded paths in packaging

### DIFF
--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/blakesmith/ar"
 	rpm "github.com/cavaliercoder/go-rpm"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -186,8 +187,6 @@ func checkZip(t *testing.T, file string) {
 }
 
 const (
-	npcapSettings   = "Windows Npcap installation settings"
-	npcapGrant      = `Insecure.Com LLC \(“The Nmap Project”\) has granted Elasticsearch`
 	npcapLicense    = `Dependency : Npcap \(https://nmap.org/npcap/\)`
 	libpcapLicense  = `Dependency : Libpcap \(http://www.tcpdump.org/\)`
 	winpcapLicense  = `Dependency : Winpcap \(https://www.winpcap.org/\)`
@@ -603,7 +602,7 @@ func readDeb(debFile string, dataBuffer *bytes.Buffer) (*packageFile, error) {
 	for {
 		header, err := arReader.Next()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err
@@ -654,7 +653,7 @@ func readTarContents(tarName string, data io.Reader) (*packageFile, error) {
 	for {
 		header, err := tarReader.Next()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err
@@ -733,7 +732,7 @@ func readDocker(dockerFile string) (*packageFile, *dockerInfo, error) {
 	for {
 		header, err := tarReader.Next()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, nil, err

--- a/dev-tools/packaging/package_test.go
+++ b/dev-tools/packaging/package_test.go
@@ -37,9 +37,10 @@ import (
 	"strings"
 	"testing"
 
+	"errors"
+
 	"github.com/blakesmith/ar"
 	rpm "github.com/cavaliercoder/go-rpm"
-	"github.com/pkg/errors"
 )
 
 const (


### PR DESCRIPTION
## What does this PR do?
Adds support for excluded paths when testing the packaging.

## Why is it important?

After an update in heartbeat we have have a path like `usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/templates/lightweight/heartbeat.yml` which matches the `configFilePattern` which causes a permission check which the file does not satisfy. It has nothing to do with the actual heartbeat configuration file.

See the failure here https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fpackaging/detail/PR-33843/4/pipeline/150/

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->



<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->



<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~