### PR TITLE
Enforce "yes" when install debian packages in packaging

### DIFF
--- a/dev-tools/mage/pkgdeps.go
+++ b/dev-tools/mage/pkgdeps.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/magefile/mage/sh"
-	"github.com/pkg/errors"
 )
 
 type PackageInstaller struct {
@@ -114,7 +113,7 @@ func installDependencies(arch string, pkgs ...string) error {
 	if arch != "" {
 		err := sh.Run("dpkg", "--add-architecture", arch)
 		if err != nil {
-			return errors.Wrap(err, "error while adding architecture")
+			return fmt.Errorf("error while adding architecture: %w", err)
 		}
 	}
 
@@ -122,7 +121,7 @@ func installDependencies(arch string, pkgs ...string) error {
 		return err
 	}
 
-	params := append([]string{"install", "-y",
+	params := append([]string{"install", "-y", "--force-yes",
 		"--no-install-recommends",
 
 		// Journalbeat is built with old versions of Debian that don't update


### PR DESCRIPTION
Older versions of Debian have expired GPG keys. In this case `-y` is not enough and `apt-get` requires an additional `--force-yes`.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Why is it important?

Packaging jobs fail on 7.17 due to this flag missing https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fpackaging/detail/PR-33843/4/pipeline/150/

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files`
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~