### PR TITLE
Add workaround for expried GPG keys for auditbeat packaging

### DIFF
--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -223,6 +223,11 @@ func installDependencies(arch string, pkgs ...string) error {
 		return err
 	}
 
-	args := append([]string{"install", "-y", "--no-install-recommends"}, pkgs...)
+	// Due to the expired GPG keys in the old Debian version we must use `--force-yes` additionally to `-y`.
+	args := append([]string{
+		"install", "-y", "--force-yes",
+		"--allow-unauthenticated",
+		"--no-install-recommends",
+	}, pkgs...)
 	return sh.Run("apt-get", args...)
 }


### PR DESCRIPTION
It's using Debian Wheezy which has expired GPG keys, we need additional flags in order to package auditbeat now.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
So, the packaging job would not fail like this one https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fpackaging/detail/PR-33843/10/pipeline/141/