### PR TITLE
Fix Elasticsearch callbacks not being registered when run under the V2 agent

### DIFF
--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -900,7 +900,7 @@ func (b *Beat) loadDashboards(ctx context.Context, force bool) error {
 // to is at least on the same version as the Beat.
 // If the check is disabled or the output is not Elasticsearch, nothing happens.
 func (b *Beat) checkElasticsearchVersion() {
-	if !isElasticsearchOutput(b.Config.Output.Name()) || b.isConnectionToOlderVersionAllowed() {
+	if b.isConnectionToOlderVersionAllowed() {
 		return
 	}
 
@@ -931,7 +931,7 @@ func (b *Beat) isConnectionToOlderVersionAllowed() bool {
 // policy as a callback with the elasticsearch output. It is important the
 // registration happens before the publisher is created.
 func (b *Beat) registerESIndexManagement() error {
-	if !isElasticsearchOutput(b.Config.Output.Name()) || !b.IdxSupporter.Enabled() {
+	if !b.IdxSupporter.Enabled() {
 		return nil
 	}
 
@@ -978,10 +978,8 @@ func (b *Beat) createOutput(stats outputs.Observer, cfg config.Namespace) (outpu
 }
 
 func (b *Beat) registerClusterUUIDFetching() {
-	if isElasticsearchOutput(b.Config.Output.Name()) {
-		callback := b.clusterUUIDFetchingCallback()
-		_, _ = elasticsearch.RegisterConnectCallback(callback)
-	}
+	callback := b.clusterUUIDFetchingCallback()
+	_, _ = elasticsearch.RegisterConnectCallback(callback)
 }
 
 // Build and return a callback to fetch the Elasticsearch cluster_uuid for monitoring


### PR DESCRIPTION
Remove the check for a configured Elasticsearch output when setting up global Elasticsearch connection callbacks.

When a Beat is started under the V2 agent, it no longer has or reads the default configuration file that configures an Elasticsearch output on localhost. In V2 the initial output configuration is sent sometime after startup via the control protocol. Now the output configuration name is `""` at startup, so the global "OnConnect" Elasticsearch callbacks never get registered. One of those callbacks fetches the cluster UUID which is required and expected of the Metricbeat beat monitoring module used by agent. 

Since the callbacks here are just added to a global map of functions to invoke when connecting to Elasticsearch, there is actually no reason to guard them with a check for an Elasticsearch output. These changes simply bypass that check that to restore beat metrics collection under agent, by ensuring the cluster UUID can be collected.

I looked for other similar uses of b.Config access that assume a configuration file is available immediately when the Beat, and while there are a few they don't seem like they apply to running under agent. The Beats historically were able to assume they were loading a configuration file from disk, which doesn't apply anymore.

Resolves https://github.com/elastic/elastic-agent/issues/1860
