### PR TITLE
Add do.Once protection to beater interface

### DIFF
--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/v7/filebeat/channel"
@@ -67,6 +68,7 @@ type Filebeat struct {
 	moduleRegistry *fileset.ModuleRegistry
 	pluginFactory  PluginFactory
 	done           chan struct{}
+	stopOnce       sync.Once // wraps the Stop() method
 	pipeline       beat.PipelineConnector
 }
 
@@ -431,7 +433,7 @@ func (fb *Filebeat) Stop() {
 	logp.Info("Stopping filebeat")
 
 	// Stop Filebeat
-	close(fb.done)
+	fb.stopOnce.Do(func() { close(fb.done) })
 }
 
 // Create a new pipeline loader (es client) factory

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -20,6 +20,7 @@ package beater
 import (
 	"errors"
 	"fmt"
+	"sync"
 
 	"syscall"
 	"time"
@@ -45,7 +46,8 @@ import (
 
 // Heartbeat represents the root datastructure of this beat.
 type Heartbeat struct {
-	done chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
 	// config is used for iterating over elements of the config.
 	config             config.Config
 	scheduler          *scheduler.Scheduler
@@ -257,7 +259,7 @@ func (bt *Heartbeat) makeAutodiscover(b *beat.Beat) (*autodiscover.Autodiscover,
 
 // Stop stops the beat.
 func (bt *Heartbeat) Stop() {
-	close(bt.done)
+	bt.stopOnce.Do(func() { close(bt.done) })
 }
 
 func makeStatesClient(cfg *conf.C, replace func(monitorstate.StateLoader), runFrom *config.LocationWithID) error {

--- a/metricbeat/beater/metricbeat.go
+++ b/metricbeat/beater/metricbeat.go
@@ -45,6 +45,7 @@ import (
 // Metricbeat implements the Beater interface for metricbeat.
 type Metricbeat struct {
 	done         chan struct{}   // Channel used to initiate shutdown.
+	stopOnce     sync.Once       // wraps the Stop() method
 	runners      []module.Runner // Active list of module runners.
 	config       Config
 	autodiscover *autodiscover.Autodiscover
@@ -272,7 +273,8 @@ func (bt *Metricbeat) Run(b *beat.Beat) error {
 // Stop should only be called a single time. Calling it more than once may
 // result in undefined behavior.
 func (bt *Metricbeat) Stop() {
-	close(bt.done)
+	bt.stopOnce.Do(func() { close(bt.done) })
+
 }
 
 // Modules return a list of all configured modules.

--- a/packetbeat/beater/packetbeat.go
+++ b/packetbeat/beater/packetbeat.go
@@ -19,6 +19,7 @@ package beater
 
 import (
 	"flag"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -77,9 +78,10 @@ func initialConfig() config.Config {
 
 // Beater object. Contains all objects needed to run the beat
 type packetbeat struct {
-	config  *conf.C
-	factory *processorFactory
-	done    chan struct{}
+	config   *conf.C
+	factory  *processorFactory
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // New returns a new Packetbeat beat.Beater.
@@ -186,5 +188,5 @@ func (pb *packetbeat) runManaged(b *beat.Beat, factory *processorFactory) error 
 // Called by the Beat stop function
 func (pb *packetbeat) Stop() {
 	logp.Info("Packetbeat send stop signal")
-	close(pb.done)
+	pb.stopOnce.Do(func() { close(pb.done) })
 }


### PR DESCRIPTION
## What does this PR do?

This is a fix for https://github.com/elastic/beats/issues/32608, which in turn I'm hoping might fix some of the issues with the pidfile fix here: https://github.com/elastic/beats/issues/31670#issuecomment-1320001998

This wraps the beater `Stop()` call used by the beats in a `once.Do()` statement in order to prevent a "close of closed channel" panic. This appears to happening under agent, presumably due to a SIGINT handler calling `Stop()` at the same time another component is shutting down and _also_ trying to call `Stop()`.  There's no added changes for auditbeat, since it just imports the metricbeat beater interface.

I've tested this by prodding elastic-agent with a `restart` command, can't get the panic again.

## Why is it important?

We don't want beats to randomly panic.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
