### PR TITLE
packetbeat/sniffer: fix shutdown logic

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -97,6 +97,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 *Packetbeat*
 
 - Fix panic on memcache transaction with no request or response. {issue}33852[33852] {pull}33853[33853]
+- Fix termination logic. {pull}33979[33979]
 
 *Winlogbeat*
 

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -44,13 +44,13 @@ import (
 // to a Worker.
 type Sniffer struct {
 	sniffers []sniffer
+	cancel   func()
 }
 
 type sniffer struct {
 	config config.InterfaceConfig
 
-	state atomic.Int32  // store snifferState
-	done  chan struct{} // done is required to wire state into a select.
+	state atomic.Int32 // store snifferState
 
 	// device is the first active device after calling New.
 	// It is not updated by default route polling.
@@ -184,16 +184,17 @@ func validateAfPacketConfig(cfg *config.InterfaceConfig) error {
 // Run opens the sniffing device and processes packets being read from that device.
 // Worker instances are instantiated as needed.
 func (s *Sniffer) Run() error {
-	g, ctx := errgroup.WithContext(context.Background())
-	for _, c := range s.sniffers {
-		c := c
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	g, ctx := errgroup.WithContext(ctx)
+	for i := range s.sniffers {
+		c := &s.sniffers[i]
 		g.Go(func() error {
 			var (
 				defaultRoute chan string
 				refresh      chan struct{}
 			)
 			if c.followDefault {
-				c.done = make(chan struct{})
 				defaultRoute = make(chan string)
 				refresh = make(chan struct{}, 1)
 				go c.pollDefaultRoute(ctx, defaultRoute, refresh)
@@ -208,8 +209,8 @@ func (s *Sniffer) Run() error {
 }
 
 // pollDefaultRoute repeatedly polls the default route's device at intervals
-// specified in config.PollDefaultRoute. The poller is terminated by closing
-// done and the device chan can be read for changes in the default route.
+// specified in config.PollDefaultRoute. The poller is terminated by cancelling
+// the context and the device chan can be read for changes in the default route.
 // Changes in default route will put the Sniffer into the inactive state to
 // trigger a new sniffer connection. Termination of the sniffer is not under
 // the control of the poller.
@@ -232,11 +233,6 @@ func (s *sniffer) pollDefaultRoute(ctx context.Context, device chan<- string, re
 				logp.Debug("sniffer", "requested new default route")
 				current = s.poll(current, device)
 			case <-ctx.Done():
-				logp.Info("polling cancelled")
-				close(device)
-				tick.Stop()
-				return
-			case <-s.done:
 				logp.Info("closing default route poller")
 				close(device)
 				tick.Stop()
@@ -459,11 +455,14 @@ func (s *sniffer) open(device string) (snifferHandle, error) {
 // Stop marks a sniffer as stopped. The Run method will return once the stop
 // signal has been given.
 func (s *Sniffer) Stop() {
+	logp.Debug("sniffer", "sending stop to all sniffers")
 	for _, c := range s.sniffers {
+		logp.Debug("sniffer", "sending closing to %s", c.config.Device)
 		c.state.Store(snifferClosing)
-		if c.done != nil {
-			close(c.done)
-		}
+	}
+	if s.cancel != nil {
+		logp.Debug("sniffer", "cancelling sniffers")
+		s.cancel()
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This simplifies the shutdown logic and ensures that blocking calls all receive the signal to terminate when the Sniffer Stop method has been called.

Previously, the sniffer done chan was not shared, meaning that it was not closed and would not have had any effect if it were. The context that was being passed around was not a cancellation context and so never had a chance to terminate sniffHandle.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The current behaviour does not allow correct termination of the beat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works — manually tested
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Recommend careful review of the dataflow for shutdown through `*sniffer.state` and the `ctx` parameter.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For https://github.com/elastic/beats/issues/33962#issuecomment-1339963007

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
