### PR TITLE
Fix issues with bare fields in expected config

### DIFF
--- a/x-pack/libbeat/management/generate.go
+++ b/x-pack/libbeat/management/generate.go
@@ -68,7 +68,11 @@ func (r *TransformRegister) Transform(cfg *proto.UnitExpectedConfig, agentInfo *
 // that can later be formatted into the reloader's ConfigWithMetaData and sent to an indvidual beat/
 // This also performs the basic task of inserting module-level add_field processors into the inputs/modules.
 func CreateInputsFromStreams(raw *proto.UnitExpectedConfig, inputType string, agentInfo *client.AgentInfo) ([]map[string]interface{}, error) {
-	inputs := make([]map[string]interface{}, len(raw.Streams))
+	// should this be an error?
+	if raw.GetStreams() == nil {
+		return []map[string]interface{}{}, nil
+	}
+	inputs := make([]map[string]interface{}, len(raw.GetStreams()))
 
 	for iter, stream := range raw.GetStreams() {
 		streamSource := raw.GetStreams()[iter].GetSource().AsMap()
@@ -271,6 +275,9 @@ func groupByOutputs(outCfg *proto.UnitExpectedConfig) (*reload.ConfigWithMeta, e
 	// I don't think we can get the `Headers()` data reported by the AgentInfo()
 	sourceMap := outCfg.GetSource().AsMap()
 	outputType := outCfg.GetType() //nolint:typecheck // this is used, linter just doesn't seem to see it
+	if outputType == "" {
+		return nil, fmt.Errorf("output config does not have a configured type field")
+	}
 	formattedOut := mapstr.M{
 		outputType: sourceMap,
 	}

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -334,6 +334,7 @@ func (cm *BeatV2Manager) handleOutputReload(unit *client.Unit) {
 	_, _, rawConfig := unit.Expected()
 	if rawConfig == nil {
 		cm.logger.Warnf("got output update with no config, ignoring")
+		return
 	}
 	cm.logger.Debugf("Got Output unit config '%s'", rawConfig.GetId())
 
@@ -366,6 +367,7 @@ func (cm *BeatV2Manager) handleInputReload(unit *client.Unit) {
 	_, _, rawConfig := unit.Expected()
 	if rawConfig == nil {
 		cm.logger.Warnf("got input update with no config, ignoring")
+		return
 	}
 	cm.setMainUnitValue(unit)
 	cm.logger.Debugf("Got Input unit config %s", rawConfig.GetId())

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -333,7 +333,7 @@ func (cm *BeatV2Manager) handleUnitReload(unit *client.Unit) {
 func (cm *BeatV2Manager) handleOutputReload(unit *client.Unit) {
 	_, _, rawConfig := unit.Expected()
 	if rawConfig == nil {
-		cm.logger.Warnf("got output update with no config, ignoring")
+		cm.logger.Infof("got output update with no config, ignoring")
 		return
 	}
 	cm.logger.Debugf("Got Output unit config '%s'", rawConfig.GetId())
@@ -370,7 +370,7 @@ func (cm *BeatV2Manager) handleInputReload(unit *client.Unit) {
 		return
 	}
 	cm.setMainUnitValue(unit)
-	cm.logger.Debugf("Got Input unit config %s", rawConfig.GetId())
+	cm.logger.Infof("Got Input unit config %s", rawConfig.GetId())
 
 	// Find the V2 inputs we need to reload
 	// The reloader provides list and non-list types, but all the beats register as lists,

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -212,7 +212,7 @@ func (cm *BeatV2Manager) setMainUnitValue(unit *client.Unit) {
 	cm.unitsMut.Lock()
 	defer cm.unitsMut.Unlock()
 	if cm.mainUnit == "" {
-		cm.logger.Debugf("Set main input unit to ID %s", unit.ID)
+		cm.logger.Debugf("Set main input unit to ID %s", unit.ID())
 		cm.mainUnit = unit.ID()
 	}
 }
@@ -332,7 +332,10 @@ func (cm *BeatV2Manager) handleUnitReload(unit *client.Unit) {
 // Handle the updated config for an output unit
 func (cm *BeatV2Manager) handleOutputReload(unit *client.Unit) {
 	_, _, rawConfig := unit.Expected()
-	cm.logger.Debugf("Got Output unit config %s", rawConfig.GetId())
+	if rawConfig == nil {
+		cm.logger.Warnf("got output update with no config, ignoring")
+	}
+	cm.logger.Debugf("Got Output unit config '%s'", rawConfig.GetId())
 
 	reloadConfig, err := groupByOutputs(rawConfig)
 	if err != nil {
@@ -361,6 +364,9 @@ func (cm *BeatV2Manager) handleOutputReload(unit *client.Unit) {
 // handle the updated config for an input unit
 func (cm *BeatV2Manager) handleInputReload(unit *client.Unit) {
 	_, _, rawConfig := unit.Expected()
+	if rawConfig == nil {
+		cm.logger.Warnf("got input update with no config, ignoring")
+	}
 	cm.setMainUnitValue(unit)
 	cm.logger.Debugf("Got Input unit config %s", rawConfig.GetId())
 


### PR DESCRIPTION
## What does this PR do?

This is part of https://github.com/elastic/elastic-agent/issues/1800 

This makes config parsing a little more defensive in some spots, including erroring out if we get a output config with no `type` field set.

## Why is it important?

This can produce some ugly and hard to understand error messages.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
