### PR TITLE
x-pack/filebeat/input/{cel,httpjson}: make transport keep-alives configurable

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -183,6 +183,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Convert UDP input to v2 input. {pull}33930[33930]
 - Improve collection of risk information from Okta debug data. {issue}33677[33677] {pull}34030[34030]
 - Adding filename details from zip to response for httpjson {issue}33952[33952] {pull}34044[34044]
+- Allow user configuration of keep-alive behaviour for HTTPJSON and CEL inputs. {issue}33951[33951] {pull}34014[34014]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-cel.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-cel.asciidoc
@@ -435,6 +435,26 @@ CAs are used for HTTPS connections. See <<configuration-ssl>> for more
 information.
 
 [float]
+==== `resource.keep_alive.disable`
+
+This specifies whether to disable keep-alives for HTTP end-points. Default: `true`.
+
+[float]
+==== `resource.keep_alive.max_idle_connections`
+
+The maximum number of idle connections across all hosts. Zero means no limit. Default: `0`.
+
+[float]
+==== `resource.keep_alive.max_idle_connections_per_host`
+
+The maximum idle connections to keep per-host. If zero, defaults to two. Default: `0`.
+
+[float]
+==== `resource.keep_alive.idle_connection_timeout`
+
+The maximum amount of time an idle connection will remain idle before closing itself. Zero means no limit. Default: `0s`.
+
+[float]
 ==== `resource.retry.max_attempts`
 
 The maximum number of retries for the HTTP client. Default: `5`.

--- a/x-pack/filebeat/docs/inputs/input-cel.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-cel.asciidoc
@@ -452,7 +452,7 @@ The maximum idle connections to keep per-host. If zero, defaults to two. Default
 [float]
 ==== `resource.keep_alive.idle_connection_timeout`
 
-The maximum amount of time an idle connection will remain idle before closing itself. Zero means no limit. Default: `0s`.
+The maximum amount of time an idle connection will remain idle before closing itself. Valid time units are `ns`, `us`, `ms`, `s`, `m`, `h`. Zero means no limit. Default: `0s`.
 
 [float]
 ==== `resource.retry.max_attempts`

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -474,7 +474,7 @@ The maximum idle connections to keep per-host. If zero, defaults to two. Default
 [float]
 ==== `request.keep_alive.idle_connection_timeout`
 
-The maximum amount of time an idle connection will remain idle before closing itself. Zero means no limit. Default: `0s`.
+The maximum amount of time an idle connection will remain idle before closing itself. Valid time units are `ns`, `us`, `ms`, `s`, `m`, `h`. Zero means no limit. Default: `0s`.
 
 [float]
 ==== `request.retry.max_attempts`

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -457,6 +457,26 @@ filebeat.inputs:
 ----
 
 [float]
+==== `request.keep_alive.disable`
+
+This specifies whether to disable keep-alives for HTTP end-points. Default: `true`.
+
+[float]
+==== `request.keep_alive.max_idle_connections`
+
+The maximum number of idle connections across all hosts. Zero means no limit. Default: `0`.
+
+[float]
+==== `request.keep_alive.max_idle_connections_per_host`
+
+The maximum idle connections to keep per-host. If zero, defaults to two. Default: `0`.
+
+[float]
+==== `request.keep_alive.idle_connection_timeout`
+
+The maximum amount of time an idle connection will remain idle before closing itself. Zero means no limit. Default: `0s`.
+
+[float]
 ==== `request.retry.max_attempts`
 
 The maximum number of retries for the HTTP client. Default: `5`.

--- a/x-pack/filebeat/input/cel/config.go
+++ b/x-pack/filebeat/input/cel/config.go
@@ -143,6 +143,38 @@ func (c rateLimitConfig) Validate() error {
 	return nil
 }
 
+type keepAlive struct {
+	Disable             *bool         `config:"disable"`
+	MaxIdleConns        int           `config:"max_idle_connections"`
+	MaxIdleConnsPerHost int           `config:"max_idle_connections_per_host"` // If zero, http.DefaultMaxIdleConnsPerHost is the value used by http.Transport.
+	IdleConnTimeout     time.Duration `config:"idle_connection_timeout"`
+}
+
+func (c keepAlive) Validate() error {
+	if c.Disable == nil || *c.Disable {
+		return nil
+	}
+	if c.MaxIdleConns < 0 {
+		return errors.New("max_idle_connections must not be negative")
+	}
+	if c.MaxIdleConnsPerHost < 0 {
+		return errors.New("max_idle_connections_per_host must not be negative")
+	}
+	if c.IdleConnTimeout < 0 {
+		return errors.New("idle_connection_timeout must not be negative")
+	}
+	return nil
+}
+
+func (c keepAlive) settings() httpcommon.WithKeepaliveSettings {
+	return httpcommon.WithKeepaliveSettings{
+		Disable:             c.Disable == nil || *c.Disable,
+		MaxIdleConns:        c.MaxIdleConns,
+		MaxIdleConnsPerHost: c.MaxIdleConnsPerHost,
+		IdleConnTimeout:     c.IdleConnTimeout,
+	}
+}
+
 type ResourceConfig struct {
 	URL                    *urlConfig       `config:"url" validate:"required"`
 	Retry                  retryConfig      `config:"retry"`
@@ -150,6 +182,7 @@ type ResourceConfig struct {
 	RedirectHeadersBanList []string         `config:"redirect.headers_ban_list"`
 	RedirectMaxRedirects   int              `config:"redirect.max_redirects"`
 	RateLimit              *rateLimitConfig `config:"rate_limit"`
+	KeepAlive              keepAlive        `config:"keep_alive"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`
 

--- a/x-pack/filebeat/input/httpjson/config_request.go
+++ b/x-pack/filebeat/input/httpjson/config_request.go
@@ -74,6 +74,38 @@ func (c rateLimitConfig) Validate() error {
 	return nil
 }
 
+type keepAlive struct {
+	Disable             *bool         `config:"disable"`
+	MaxIdleConns        int           `config:"max_idle_connections"`
+	MaxIdleConnsPerHost int           `config:"max_idle_connections_per_host"` // If zero, http.DefaultMaxIdleConnsPerHost is the value used by http.Transport.
+	IdleConnTimeout     time.Duration `config:"idle_connection_timeout"`
+}
+
+func (c keepAlive) Validate() error {
+	if c.Disable == nil || *c.Disable {
+		return nil
+	}
+	if c.MaxIdleConns < 0 {
+		return errors.New("max_idle_connections must not be negative")
+	}
+	if c.MaxIdleConnsPerHost < 0 {
+		return errors.New("max_idle_connections_per_host must not be negative")
+	}
+	if c.IdleConnTimeout < 0 {
+		return errors.New("idle_connection_timeout must not be negative")
+	}
+	return nil
+}
+
+func (c keepAlive) settings() httpcommon.WithKeepaliveSettings {
+	return httpcommon.WithKeepaliveSettings{
+		Disable:             c.Disable == nil || *c.Disable,
+		MaxIdleConns:        c.MaxIdleConns,
+		MaxIdleConnsPerHost: c.MaxIdleConnsPerHost,
+		IdleConnTimeout:     c.IdleConnTimeout,
+	}
+}
+
 type urlConfig struct {
 	*url.URL
 }
@@ -99,6 +131,7 @@ type requestConfig struct {
 	RedirectHeadersBanList []string         `config:"redirect.headers_ban_list"`
 	RedirectMaxRedirects   int              `config:"redirect.max_redirects"`
 	RateLimit              *rateLimitConfig `config:"rate_limit"`
+	KeepAlive              keepAlive        `config:"keep_alive"`
 	Transforms             transformsConfig `config:"transforms"`
 
 	Transport httpcommon.HTTPTransportSettings `config:",inline"`

--- a/x-pack/filebeat/input/httpjson/request_chain_helper.go
+++ b/x-pack/filebeat/input/httpjson/request_chain_helper.go
@@ -32,7 +32,7 @@ const (
 
 func newChainHTTPClient(ctx context.Context, authCfg *authConfig, requestCfg *requestConfig, log *logp.Logger, p ...*Policy) (*httpClient, error) {
 	// Make retryable HTTP client
-	netHTTPClient, err := requestCfg.Transport.Client(clientOptions(requestCfg.URL.URL)...)
+	netHTTPClient, err := requestCfg.Transport.Client(clientOptions(requestCfg.URL.URL, requestCfg.KeepAlive.settings())...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This makes it possible for users to configure idle connection keep-alive behaviour. The behaviour defaults to the old behaviour, but exposes the full set of httpcommon.WithKeepaliveSettings configuration options.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Keep-alive behaviour can have a performance and API-limit impact in some cases.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #33951

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
