### PR TITLE
Adding filenames from the zip to the response for httpjson

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -181,6 +181,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add metrics for UDP packet processing. {pull}33870[33870]
 - Convert UDP input to v2 input. {pull}33930[33930]
 - Improve collection of risk information from Okta debug data. {issue}33677[33677] {pull}34030[34030]
+- Adding filename details from zip to response for httpjson {issue}33952[33952] {pull}34044[34044]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/httpjson/encoding.go
+++ b/x-pack/filebeat/input/httpjson/encoding.go
@@ -210,8 +210,7 @@ func decodeAsZip(p []byte, dst *response) error {
 	}
 
 	dst.body = results
-	//nolint:errorlint // Bad linter!
-	if dst.header == nil {
+	if dst.header == nil { //nolint:errorlint // golangci-lint-action #624
 		dst.header = http.Header{}
 	}
 	dst.header["X-Zip-Files"] = names

--- a/x-pack/filebeat/input/httpjson/encoding.go
+++ b/x-pack/filebeat/input/httpjson/encoding.go
@@ -210,7 +210,8 @@ func decodeAsZip(p []byte, dst *response) error {
 	}
 
 	dst.body = results
-	if dst.header == nil {
+	if dst.header == nil { //nolint:errorlint // Bad linter!
+		// https://github.com/golangci/golangci-lint-action/issues/624
 		dst.header = http.Header{}
 	}
 	dst.header["X-Zip-Files"] = names

--- a/x-pack/filebeat/input/httpjson/encoding.go
+++ b/x-pack/filebeat/input/httpjson/encoding.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -188,11 +189,13 @@ func decodeAsZip(p []byte, dst *response) error {
 		return err
 	}
 
+	names := make([]string, 0, len(r.File))
 	for _, f := range r.File {
 		rc, err := f.Open()
 		if err != nil {
 			return err
 		}
+		names = append(names, f.Name)
 
 		dec := json.NewDecoder(rc)
 		for dec.More() {
@@ -207,6 +210,10 @@ func decodeAsZip(p []byte, dst *response) error {
 	}
 
 	dst.body = results
+	if dst.header == nil {
+		dst.header = http.Header{}
+	}
+	dst.header["X-Zip-Files"] = names
 
 	return nil
 }

--- a/x-pack/filebeat/input/httpjson/encoding.go
+++ b/x-pack/filebeat/input/httpjson/encoding.go
@@ -210,8 +210,8 @@ func decodeAsZip(p []byte, dst *response) error {
 	}
 
 	dst.body = results
-	if dst.header == nil { //nolint:errorlint // Bad linter!
-		// https://github.com/golangci/golangci-lint-action/issues/624
+	//nolint:errorlint // Bad linter!
+	if dst.header == nil {
 		dst.header = http.Header{}
 	}
 	dst.header["X-Zip-Files"] = names

--- a/x-pack/filebeat/input/httpjson/encoding_test.go
+++ b/x-pack/filebeat/input/httpjson/encoding_test.go
@@ -18,7 +18,7 @@ import (
 func TestDecodeZip(t *testing.T) {
 	buf := new(bytes.Buffer)
 	w := zip.NewWriter(buf)
-	var files = []struct {
+	files := []struct {
 		Name, Body string
 	}{
 		{
@@ -57,6 +57,8 @@ func TestDecodeZip(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, string(j))
+
+	assert.Equal(t, []string{"a.json", "b.ndjson", "c.ndjson"}, resp.header["X-Zip-Files"])
 }
 
 func TestDecodeNdjson(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

The httpjson input will report filenames for application/zip events in the response.

## Why is it important?

We have a [bug](https://github.com/elastic/integrations/issues/4764) for an integration that utilizes the filename to determine a `log_type` field as the field is in the name.  For example, `filename="delivery_20160705162902600.log"` -> `log_type: delivery`. When utilizing `compress: true`, the filename is instead a random guid and so the `log_type` can't be derived, example `filename="8578FCFC-A305-4D9A-99CB-F4D5ECEFE297.zip"`. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [X] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist
- [ ]

## How to test this PR locally

## Related issues

Closes https://github.com/elastic/beats/issues/33952

## Use cases

## Screenshots

## Logs
