### PR TITLE
[AWS Cloudwatch] Changed module to call ListMetrics API only once per region

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -203,6 +203,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add support for multiple regions in GCP {pull}32964[32964]
 - Add GCP Redis regions support {pull}33728[33728]
 - Add namespace metadata to all namespaced kubernetes resources. {pull}33763[33763]
+- Changed cloudwatch module to call ListMetrics API only once per region, instead of per AWS namespace {pull}34052[34052]
 
 *Packetbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -203,7 +203,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add support for multiple regions in GCP {pull}32964[32964]
 - Add GCP Redis regions support {pull}33728[33728]
 - Add namespace metadata to all namespaced kubernetes resources. {pull}33763[33763]
-- Changed cloudwatch module to call ListMetrics API only once per region, instead of per AWS namespace {pull}34052[34052]
+- Changed cloudwatch module to call ListMetrics API only once per region, instead of per AWS namespace {pull}34055[34055]
 
 *Packetbeat*
 

--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -297,7 +297,7 @@ GetMetricData max page size: 100, based on https://docs.aws.amazon.com/AmazonClo
 | IAM ListAccountAliases | 1 | Once on startup
 | STS GetCallerIdentity | 1 | Once on startup
 | EC2 DescribeRegions| 1 | Once on startup
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per namespace per collection period
+| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
 | CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per namespace per collection period
 |===
 `billing`, `ebs`, `elb`, `sns`, `usage` and `lambda` are the same as `cloudwatch` metricset.

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -285,7 +285,7 @@ GetMetricData max page size: 100, based on https://docs.aws.amazon.com/AmazonClo
 | IAM ListAccountAliases | 1 | Once on startup
 | STS GetCallerIdentity | 1 | Once on startup
 | EC2 DescribeRegions| 1 | Once on startup
-| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per namespace per collection period
+| CloudWatch ListMetrics | Total number of results / ListMetrics max page size | Per region per collection period
 | CloudWatch GetMetricData | Total number of results / GetMetricData max page size | Per region per namespace per collection period
 |===
 `billing`, `ebs`, `elb`, `sns`, `usage` and `lambda` are the same as `cloudwatch` metricset.

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -197,9 +197,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 			}
 			// filter listMetricsOutput by detailed configuration per each namespace
 			filteredMetricWithStatsTotal := filterListMetricsOutput(listMetricsOutput, namespace, namespaceDetails)
-			for _, filteredMetricDetail := range filteredMetricWithStatsTotal {
-				m.logger.Infof("Filtered namespace for namespace %s: %s", namespace, *filteredMetricDetail.cloudwatchMetric.Namespace)
-			}
+
 			// get resource type filters and tags filters for each namespace
 			resourceTypeTagFilters := constructTagsFilters(namespaceDetails)
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -207,9 +207,6 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 
 			// filter listMetricsOutput by detailed configuration per each namespace
 			filteredMetricWithStatsTotal := filterListMetricsOutput(listMetricsOutput, namespaceDetails)
-			for _, filteredMetricDetail := range filteredMetricWithStatsTotal {
-				m.logger.Infof("Filtered namespace for namespace %s: %s", namespace, *filteredMetricDetail.cloudwatchMetric.Namespace)
-			}
 			// get resource type filters and tags filters for each namespace
 			resourceTypeTagFilters := constructTagsFilters(namespaceDetails)
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -153,6 +153,18 @@ var (
 			tags:               nameTestTag,
 		},
 	}
+	ec2instance1Config = Config{
+		Namespace:  namespace,
+		MetricName: []string{metricName1},
+		Dimensions: []Dimension{
+			{
+				Name:  "InstanceId",
+				Value: instanceID1,
+			},
+		},
+		ResourceType: resourceTypeEC2,
+		Statistic:    []string{"Average"},
+	}
 )
 
 func TestConstructLabel(t *testing.T) {
@@ -402,18 +414,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 		{
 			"test with a specific metric",
 			[]Config{
-				{
-					Namespace:  "AWS/EC2",
-					MetricName: []string{"CPUUtilization"},
-					Dimensions: []Dimension{
-						{
-							Name:  "InstanceId",
-							Value: "i-1",
-						},
-					},
-					ResourceType: "ec2:instance",
-					Statistic:    []string{"Average"},
-				},
+				ec2instance1Config,
 			},
 			nil,
 			expectedListMetricWithDetailEC2,
@@ -422,18 +423,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 		{
 			"test with a specific metric and a namespace",
 			[]Config{
-				{
-					Namespace:  "AWS/EC2",
-					MetricName: []string{"CPUUtilization"},
-					Dimensions: []Dimension{
-						{
-							Name:  "InstanceId",
-							Value: "i-1",
-						},
-					},
-					ResourceType: "ec2:instance",
-					Statistic:    []string{"Average"},
-				},
+				ec2instance1Config,
 				{
 					Namespace: "AWS/S3",
 				},
@@ -445,18 +435,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 		{
 			"test with two specific metrics and a namespace",
 			[]Config{
-				{
-					Namespace:  "AWS/EC2",
-					MetricName: []string{"CPUUtilization"},
-					Dimensions: []Dimension{
-						{
-							Name:  "InstanceId",
-							Value: "i-1",
-						},
-					},
-					Statistic:    []string{"Average"},
-					ResourceType: "ec2:instance",
-				},
+				ec2instance1Config,
 				{
 					Namespace: "AWS/Lambda",
 				},
@@ -589,18 +568,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 				{
 					Namespace: "AWS/Lambda",
 				},
-				{
-					Namespace:  "AWS/EC2",
-					MetricName: []string{"CPUUtilization"},
-					Dimensions: []Dimension{
-						{
-							Name:  "InstanceId",
-							Value: "i-1",
-						},
-					},
-					Statistic:    []string{"Average"},
-					ResourceType: "ec2:instance",
-				},
+				ec2instance1Config,
 				{
 					Namespace:  "AWS/RDS",
 					MetricName: []string{"CommitThroughput"},

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -121,6 +121,24 @@ var (
 			Key:   "name",
 			Value: []string{"test-ec2"},
 		}}
+	nameELBTag = []aws.Tag{
+		{
+			Key:   "name",
+			Value: []string{"test-elb"},
+		},
+	}
+	nameELB1Tag = []aws.Tag{
+		{
+			Key:   "name",
+			Value: []string{"test-elb1"},
+		},
+	}
+	nameELB2Tag = []aws.Tag{
+		{
+			Key:   "name",
+			Value: []string{"test-elb2"},
+		},
+	}
 	elbNamespaceDetail = []namespaceDetail{
 		{
 			resourceTypeFilter: "elasticloadbalancing",
@@ -888,24 +906,10 @@ func TestConstructTagsFilters(t *testing.T) {
 	expectedResourceTypeTagFiltersEC2["ec2:instance"] = nil
 
 	expectedResourceTypeTagFiltersELB := map[string][]aws.Tag{}
-	expectedResourceTypeTagFiltersELB["elasticloadbalancing"] = []aws.Tag{
-		{
-			Key:   "name",
-			Value: []string{"test-elb1"},
-		},
-		{
-			Key:   "name",
-			Value: []string{"test-elb2"},
-		},
-	}
+	expectedResourceTypeTagFiltersELB["elasticloadbalancing"] = append(nameELB1Tag, nameELB2Tag...)
 
 	expectedResourceTypeTagFiltersELBEC2 := map[string][]aws.Tag{}
-	expectedResourceTypeTagFiltersELBEC2["elasticloadbalancing"] = []aws.Tag{
-		{
-			Key:   "name",
-			Value: []string{"test-elb"},
-		},
-	}
+	expectedResourceTypeTagFiltersELBEC2["elasticloadbalancing"] = nameELBTag
 	expectedResourceTypeTagFiltersELBEC2["ec2:instance"] = nameTestEC2Tag
 
 	cases := []struct {
@@ -936,23 +940,13 @@ func TestConstructTagsFilters(t *testing.T) {
 					resourceTypeFilter: "elasticloadbalancing",
 					names:              []string{"BackendConnectionErrors", "HTTPCode_Backend_2XX", "HTTPCode_Backend_3XX"},
 					statistics:         []string{"Sum"},
-					tags: []aws.Tag{
-						{
-							Key:   "name",
-							Value: []string{"test-elb1"},
-						},
-					},
+					tags:               nameELB1Tag,
 				},
 				{
 					resourceTypeFilter: "elasticloadbalancing",
 					names:              []string{"HealthyHostCount", "SurgeQueueLength", "UnHealthyHostCount"},
 					statistics:         []string{"Maximum"},
-					tags: []aws.Tag{
-						{
-							Key:   "name",
-							Value: []string{"test-elb2"},
-						},
-					},
+					tags:               nameELB2Tag,
 				},
 			},
 			expectedResourceTypeTagFiltersELB,
@@ -964,12 +958,7 @@ func TestConstructTagsFilters(t *testing.T) {
 					resourceTypeFilter: "elasticloadbalancing",
 					names:              []string{"BackendConnectionErrors", "HTTPCode_Backend_2XX", "HTTPCode_Backend_3XX"},
 					statistics:         []string{"Sum"},
-					tags: []aws.Tag{
-						{
-							Key:   "name",
-							Value: []string{"test-elb"},
-						},
-					},
+					tags:               nameELBTag,
 				},
 				{
 					resourceTypeFilter: "ec2:instance",

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -111,23 +111,28 @@ var (
 		MetricName: &metricName6,
 		Namespace:  &namespaceMSK,
 	}
-	nameTag = []aws.Tag{
+	nameTestTag = []aws.Tag{
 		{
 			Key:   "name",
 			Value: []string{"test"},
+		}}
+	nameTestEC2Tag = []aws.Tag{
+		{
+			Key:   "name",
+			Value: []string{"test-ec2"},
 		}}
 	elbNamespaceDetail = []namespaceDetail{
 		{
 			resourceTypeFilter: "elasticloadbalancing",
 			names:              []string{"BackendConnectionErrors", "HTTPCode_Backend_2XX", "HTTPCode_Backend_3XX"},
 			statistics:         []string{"Sum"},
-			tags:               nameTag,
+			tags:               nameTestTag,
 		},
 		{
 			resourceTypeFilter: "elasticloadbalancing",
 			names:              []string{"HealthyHostCount", "SurgeQueueLength", "UnHealthyHostCount"},
 			statistics:         []string{"Maximum"},
-			tags:               nameTag,
+			tags:               nameTestTag,
 		},
 	}
 )
@@ -230,8 +235,8 @@ func TestReadCloudwatchConfig(t *testing.T) {
 	}
 
 	resourceTypeFiltersEC2RDSWithTag := map[string][]aws.Tag{}
-	resourceTypeFiltersEC2RDSWithTag["ec2:instance"] = nameTag
-	resourceTypeFiltersEC2RDSWithTag["rds"] = nameTag
+	resourceTypeFiltersEC2RDSWithTag["ec2:instance"] = nameTestTag
+	resourceTypeFiltersEC2RDSWithTag["rds"] = nameTestTag
 	expectedListMetricWithDetailEC2RDSWithTag := listMetricWithDetail{
 		metricsWithStats:    metricsWithStats,
 		resourceTypeFilters: resourceTypeFiltersEC2RDSWithTag,
@@ -290,7 +295,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			resourceTypeFilter: resourceTypeEC2,
 			names:              []string{"CPUUtilization"},
 			statistics:         defaultStatistics,
-			tags:               nameTag,
+			tags:               nameTestTag,
 		},
 	}
 
@@ -300,7 +305,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 	expectedNamespaceDetailELBLambda["AWS/Lambda"] = []namespaceDetail{
 		{
 			statistics: defaultStatistics,
-			tags:       nameTag,
+			tags:       nameTestTag,
 		},
 	}
 	expectedNamespaceDetailELBLambda["AWS/ELB"] = elbNamespaceDetail
@@ -542,7 +547,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 					ResourceType: "elasticloadbalancing",
 				},
 			},
-			nameTag,
+			nameTestTag,
 			listMetricWithDetail{
 				resourceTypeFilters: map[string][]aws.Tag{},
 			},
@@ -595,7 +600,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 					ResourceType: "rds",
 				},
 			},
-			nameTag,
+			nameTestTag,
 			expectedListMetricWithDetailEC2RDSWithTag,
 			expectedNamespaceDetailELBLambda,
 		},
@@ -684,7 +689,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 					ResourceType: "rds",
 				},
 			},
-			nameTag,
+			nameTestTag,
 			expectedListMetricWithDetailEC2sRDSWithTag,
 			map[string][]namespaceDetail{},
 		},
@@ -901,12 +906,7 @@ func TestConstructTagsFilters(t *testing.T) {
 			Value: []string{"test-elb"},
 		},
 	}
-	expectedResourceTypeTagFiltersELBEC2["ec2:instance"] = []aws.Tag{
-		{
-			Key:   "name",
-			Value: []string{"test-ec2"},
-		},
-	}
+	expectedResourceTypeTagFiltersELBEC2["ec2:instance"] = nameTestEC2Tag
 
 	cases := []struct {
 		title                  string
@@ -975,12 +975,7 @@ func TestConstructTagsFilters(t *testing.T) {
 					resourceTypeFilter: "ec2:instance",
 					names:              []string{"CPUUtilization"},
 					statistics:         defaultStatistics,
-					tags: []aws.Tag{
-						{
-							Key:   "name",
-							Value: []string{"test-ec2"},
-						},
-					},
+					tags:               nameTestEC2Tag,
 				},
 			},
 			expectedResourceTypeTagFiltersELBEC2,
@@ -1284,12 +1279,7 @@ func TestCreateEventsWithIdentifier(t *testing.T) {
 		[]string{"Average"},
 	}}
 	resourceTypeTagFilters := map[string][]aws.Tag{}
-	resourceTypeTagFilters["ec2:instance"] = []aws.Tag{
-		{
-			Key:   "name",
-			Value: []string{"test-ec2"},
-		},
-	}
+	resourceTypeTagFilters["ec2:instance"] = nameTestEC2Tag
 	startTime, endTime := aws.GetStartTimeEndTime(time.Now(), m.MetricSet.Period, m.MetricSet.Latency)
 
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
@@ -1408,12 +1398,7 @@ func TestCreateEventsWithTagsFilter(t *testing.T) {
 
 	// Check that the event is created when the tag filter matches
 	resourceTypeTagFilters := map[string][]aws.Tag{}
-	resourceTypeTagFilters["ec2:instance"] = []aws.Tag{
-		{
-			Key:   "name",
-			Value: []string{"test-ec2"},
-		},
-	}
+	resourceTypeTagFilters["ec2:instance"] = nameTestEC2Tag
 
 	startTime, endTime := aws.GetStartTimeEndTime(time.Now(), m.MetricSet.Period, m.MetricSet.Latency)
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -180,36 +180,37 @@ func TestReadCloudwatchConfig(t *testing.T) {
 	resourceTypeFiltersEC2RDS := map[string][]aws.Tag{}
 	resourceTypeFiltersEC2RDS["ec2:instance"] = nil
 	resourceTypeFiltersEC2RDS["rds"] = nil
+	metricsWithStats := []metricsWithStatistics{
+		{
+			cloudwatchtypes.Metric{
+				Dimensions: []cloudwatchtypes.Dimension{{
+					Name:  awssdk.String("InstanceId"),
+					Value: awssdk.String("i-1"),
+				}},
+				MetricName: awssdk.String("CPUUtilization"),
+				Namespace:  awssdk.String("AWS/EC2"),
+			},
+			[]string{"Average"},
+		},
+		{
+			cloudwatchtypes.Metric{
+				Dimensions: []cloudwatchtypes.Dimension{{
+					Name:  awssdk.String("DBClusterIdentifier"),
+					Value: awssdk.String("test1-cluster"),
+				},
+					{
+						Name:  awssdk.String("Role"),
+						Value: awssdk.String("READER"),
+					}},
+				MetricName: awssdk.String("CommitThroughput"),
+				Namespace:  awssdk.String("AWS/RDS"),
+			},
+			[]string{"Average"},
+		},
+	}
 
 	expectedListMetricWithDetailEC2RDS := listMetricWithDetail{
-		metricsWithStats: []metricsWithStatistics{
-			{
-				cloudwatchtypes.Metric{
-					Dimensions: []cloudwatchtypes.Dimension{{
-						Name:  awssdk.String("InstanceId"),
-						Value: awssdk.String("i-1"),
-					}},
-					MetricName: awssdk.String("CPUUtilization"),
-					Namespace:  awssdk.String("AWS/EC2"),
-				},
-				[]string{"Average"},
-			},
-			{
-				cloudwatchtypes.Metric{
-					Dimensions: []cloudwatchtypes.Dimension{{
-						Name:  awssdk.String("DBClusterIdentifier"),
-						Value: awssdk.String("test1-cluster"),
-					},
-						{
-							Name:  awssdk.String("Role"),
-							Value: awssdk.String("READER"),
-						}},
-					MetricName: awssdk.String("CommitThroughput"),
-					Namespace:  awssdk.String("AWS/RDS"),
-				},
-				[]string{"Average"},
-			},
-		},
+		metricsWithStats:    metricsWithStats,
 		resourceTypeFilters: resourceTypeFiltersEC2RDS,
 	}
 
@@ -227,34 +228,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 		},
 	}
 	expectedListMetricWithDetailEC2RDSWithTag := listMetricWithDetail{
-		metricsWithStats: []metricsWithStatistics{
-			{
-				cloudwatchtypes.Metric{
-					Dimensions: []cloudwatchtypes.Dimension{{
-						Name:  awssdk.String("InstanceId"),
-						Value: awssdk.String("i-1"),
-					}},
-					MetricName: awssdk.String("CPUUtilization"),
-					Namespace:  awssdk.String("AWS/EC2"),
-				},
-				[]string{"Average"},
-			},
-			{
-				cloudwatchtypes.Metric{
-					Dimensions: []cloudwatchtypes.Dimension{{
-						Name:  awssdk.String("DBClusterIdentifier"),
-						Value: awssdk.String("test1-cluster"),
-					},
-						{
-							Name:  awssdk.String("Role"),
-							Value: awssdk.String("READER"),
-						}},
-					MetricName: awssdk.String("CommitThroughput"),
-					Namespace:  awssdk.String("AWS/RDS"),
-				},
-				[]string{"Average"},
-			},
-		},
+		metricsWithStats:    metricsWithStats,
 		resourceTypeFilters: resourceTypeFiltersEC2RDSWithTag,
 	}
 
@@ -319,7 +293,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			},
 		},
 	}
-	expectedNamespaceDetailTotal["AWS/ELB"] = []namespaceDetail{
+	elbNamespaceDetail := []namespaceDetail{
 		{
 			resourceTypeFilter: "elasticloadbalancing",
 			names:              []string{"BackendConnectionErrors", "HTTPCode_Backend_2XX", "HTTPCode_Backend_3XX"},
@@ -343,6 +317,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			},
 		},
 	}
+	expectedNamespaceDetailTotal["AWS/ELB"] = elbNamespaceDetail
 
 	expectedNamespaceDetailELBLambda := map[string][]namespaceDetail{}
 	expectedNamespaceDetailELBLambda["AWS/Lambda"] = []namespaceDetail{
@@ -356,30 +331,7 @@ func TestReadCloudwatchConfig(t *testing.T) {
 			},
 		},
 	}
-	expectedNamespaceDetailELBLambda["AWS/ELB"] = []namespaceDetail{
-		{
-			resourceTypeFilter: "elasticloadbalancing",
-			names:              []string{"BackendConnectionErrors", "HTTPCode_Backend_2XX", "HTTPCode_Backend_3XX"},
-			statistics:         []string{"Sum"},
-			tags: []aws.Tag{
-				{
-					Key:   "name",
-					Value: []string{"test"},
-				},
-			},
-		},
-		{
-			resourceTypeFilter: "elasticloadbalancing",
-			names:              []string{"HealthyHostCount", "SurgeQueueLength", "UnHealthyHostCount"},
-			statistics:         []string{"Maximum"},
-			tags: []aws.Tag{
-				{
-					Key:   "name",
-					Value: []string{"test"},
-				},
-			},
-		},
-	}
+	expectedNamespaceDetailELBLambda["AWS/ELB"] = elbNamespaceDetail
 
 	expectedNamespaceWithDetailEC2WithNoMetricName := map[string][]namespaceDetail{}
 	expectedNamespaceWithDetailEC2WithNoMetricName["AWS/EC2"] = []namespaceDetail{

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1111,6 +1111,7 @@ func TestFilterListMetricsOutput(t *testing.T) {
 	cases := []struct {
 		title                        string
 		listMetricsOutput            []cloudwatchtypes.Metric
+		namespace                    string
 		namespaceDetails             []namespaceDetail
 		filteredMetricWithStatsTotal []metricsWithStatistics
 	}{
@@ -1139,6 +1140,7 @@ func TestFilterListMetricsOutput(t *testing.T) {
 					Namespace:  awssdk.String("AWS/EC2"),
 				},
 			},
+			"AWS/EC2",
 			[]namespaceDetail{
 				{
 					resourceTypeFilter: "ec2:instance",
@@ -1190,6 +1192,7 @@ func TestFilterListMetricsOutput(t *testing.T) {
 					Namespace:  awssdk.String("AWS/EC2"),
 				},
 			},
+			"AWS/EC2",
 			[]namespaceDetail{
 				{
 					names:              []string{"CPUUtilization"},
@@ -1214,7 +1217,7 @@ func TestFilterListMetricsOutput(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.title, func(t *testing.T) {
-			output := filterListMetricsOutput(c.listMetricsOutput, c.namespaceDetails)
+			output := filterListMetricsOutput(c.listMetricsOutput, c.namespace, c.namespaceDetails)
 			assert.Equal(t, c.filteredMetricWithStatsTotal, output)
 		})
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR modifies the AWS Cloudwatch module to call ListMetrics API only once per region, instead of once per namespace. Any namespaces that are part of ListMetrics API's response, but not configured to be queried, are removed in code.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

ListMetrics API is billed per number of calls, so reducing the total number of calls lead to cost savings for users of the AWS Cloudwatch module.

References:
- https://github.com/elastic/beats/issues/33134
- https://github.com/elastic/integrations/issues/2913

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #33134
