### PR TITLE
Change heartbeat config formatting

### DIFF
--- a/x-pack/heartbeat/cmd/root.go
+++ b/x-pack/heartbeat/cmd/root.go
@@ -22,14 +22,8 @@ var RootCmd *cmd.BeatsRootCmd
 
 // heartbeatCfg is a callback registered via SetTransform that returns a Elastic Agent client.Unit
 // configuration generated from a raw Elastic Agent config
-func heartbeatCfg(rawIn *proto.UnitExpectedConfig, agentInfo *client.AgentInfo) ([]*reload.ConfigWithMeta, error) {
-	//grab and properly format the input streams
-	inputStreams, err := management.CreateInputsFromStreams(rawIn, "synthetics", agentInfo)
-	if err != nil {
-		return nil, fmt.Errorf("error generating new stream config: %w", err)
-	}
-
-	configList, err := management.CreateReloadConfigFromInputs(inputStreams)
+func heartbeatCfg(rawIn *proto.UnitExpectedConfig, _ *client.AgentInfo) ([]*reload.ConfigWithMeta, error) {
+	configList, err := management.CreateReloadConfigFromInputs([]map[string]interface{}{rawIn.GetSource().AsMap()})
 	if err != nil {
 		return nil, fmt.Errorf("error creating reloader config: %w", err)
 	}


### PR DESCRIPTION
## What does this PR do?
Part of the fixes for https://github.com/elastic/elastic-agent/issues/1931 , although this might be the final component. 

This PR mostly bypasses all the config transformations for heartbeat, as the the heartbeat launcher will handle beat config itself (see `monitors/factory.go`),  and the default transformations were breaking heartbeat's own built-in config handling.  This PR is basically what was proposed here: https://github.com/elastic/elastic-agent/issues/1931#issuecomment-1351833489

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
