### PR TITLE
[azure-eventhub input] Switch the run EPH run mode to non-blocking

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -68,6 +68,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Update mito CEL extension library to v0.0.0-20221207004749-2f0f2875e464 {pull}33974[33974]
 - Fix CEL result deserialisation when evaluation fails. {issue}33992[33992] {pull}33996[33996]
 - Fix handling of non-200/non-429 status codes. {issue}33999[33999] {pull}34002[34002]
+- [azure-eventhub input] Switch the run EPH run mode to non-blocking {pull}34075[34075]
 
 *Heartbeat*
 - Fix broken zip URL monitors. NOTE: Zip URL Monitors will be removed in version 8.7 and replaced with project monitors. {pull}33723[33723]

--- a/x-pack/filebeat/input/azureeventhub/eph.go
+++ b/x-pack/filebeat/input/azureeventhub/eph.go
@@ -91,7 +91,9 @@ func (a *azureInput) runWithEPH() error {
 	}
 	a.log.Infof("handler id: %q is registered\n", handlerID)
 
-	// start handling messages from all of the partitions balancing across multiple consumers
+	// Start handling messages from all of the partitions balancing across
+	// multiple consumers.
+	// The processor can be stopped by calling `Close()` on the processor.
 	err = a.processor.StartNonBlocking(a.workerCtx)
 	if err != nil {
 		a.log.Errorw("error starting the processor", "error", err)

--- a/x-pack/filebeat/input/azureeventhub/eph.go
+++ b/x-pack/filebeat/input/azureeventhub/eph.go
@@ -85,7 +85,7 @@ func (a *azureInput) runWithEPH() error {
 	// processor.UnregisterHandler(ctx, handleID)
 
 	// start handling messages from all of the partitions balancing across multiple consumers
-	err = a.processor.Start(a.workerCtx)
+	err = a.processor.StartNonBlocking(a.workerCtx)
 	if err != nil {
 		return err
 	}

--- a/x-pack/filebeat/input/azureeventhub/eph.go
+++ b/x-pack/filebeat/input/azureeventhub/eph.go
@@ -27,7 +27,12 @@ var environments = map[string]azure.Environment{
 	azure.USGovernmentCloud.ResourceManagerEndpoint: azure.USGovernmentCloud,
 }
 
-// runWithEPH will consume ingested events using the Event Processor Host (EPH) https://github.com/Azure/azure-event-hubs-go#event-processor-host, https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-event-processor-host
+// runWithEPH will consume ingested events using the Event Processor Host (EPH).
+//
+// To learn more, check the following resources:
+// - https://github.com/Azure/azure-event-hubs-go#event-processor-host
+// - https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-event-processor-host
+//
 func (a *azureInput) runWithEPH() error {
 	// create a new Azure Storage Leaser / Checkpointer
 	cred, err := azblob.NewSharedKeyCredential(a.config.SAName, a.config.SAKey)
@@ -40,9 +45,12 @@ func (a *azureInput) runWithEPH() error {
 	}
 	leaserCheckpointer, err := storage.NewStorageLeaserCheckpointer(cred, a.config.SAName, a.config.SAContainer, env)
 	if err != nil {
+		a.log.Errorw("error creating storage leaser checkpointer", "error", err)
 		return err
 	}
-	// adding a nil EventProcessorHostOption will break the code, this is why a condition is added and a.processor is assigned
+
+	// adding a nil EventProcessorHostOption will break the code,
+	// this is why a condition is added and a.processor is assigned.
 	if a.config.ConsumerGroup != "" {
 		a.processor, err = eph.NewFromConnectionString(
 			a.workerCtx,
@@ -60,6 +68,7 @@ func (a *azureInput) runWithEPH() error {
 			eph.WithNoBanner())
 	}
 	if err != nil {
+		a.log.Errorw("error creating processor", "error", err)
 		return err
 	}
 
@@ -77,23 +86,23 @@ func (a *azureInput) runWithEPH() error {
 			return onEventErr
 		})
 	if err != nil {
+		a.log.Errorw("error registering handler", "error", err)
 		return err
 	}
-	a.log.Infof("handler id: %q is running\n", handlerID)
-
-	// unregister a handler to stop that handler from receiving events
-	// processor.UnregisterHandler(ctx, handleID)
+	a.log.Infof("handler id: %q is registered\n", handlerID)
 
 	// start handling messages from all of the partitions balancing across multiple consumers
 	err = a.processor.StartNonBlocking(a.workerCtx)
 	if err != nil {
+		a.log.Errorw("error starting the processor", "error", err)
 		return err
 	}
+
 	return nil
 }
 
 func getAzureEnvironment(overrideResManager string) (azure.Environment, error) {
-	// if no overrride is set then the azure public cloud is used
+	// if no override is set then the azure public cloud is used
 	if overrideResManager == "" || overrideResManager == "<no value>" {
 		return azure.PublicCloud, nil
 	}

--- a/x-pack/filebeat/input/azureeventhub/eph_test.go
+++ b/x-pack/filebeat/input/azureeventhub/eph_test.go
@@ -40,7 +40,7 @@ func TestGetAzureEnvironment(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, env, azure.GermanCloud)
 	resMan = "http://management.invalidhybrid.com/"
-	env, err = getAzureEnvironment(resMan)
+	_, err = getAzureEnvironment(resMan)
 	assert.Errorf(t, err, "invalid character 'F' looking for beginning of value")
 	resMan = "<no value>"
 	env, err = getAzureEnvironment(resMan)

--- a/x-pack/filebeat/input/azureeventhub/input.go
+++ b/x-pack/filebeat/input/azureeventhub/input.go
@@ -43,7 +43,6 @@ type azureInput struct {
 	workerCancel context.CancelFunc      // used to signal that the worker should stop.
 	workerOnce   sync.Once               // guarantees that the worker goroutine is only started once.
 	processor    *eph.EventProcessorHost // eph will be assigned if users have enabled the option
-	hub          *eventhub.Hub           // hub will be assigned
 }
 
 const (
@@ -118,39 +117,6 @@ func (a *azureInput) Run() {
 		a.log.Infof("%s input worker has started.", inputName)
 	})
 }
-
-// run will run the input with the non-eph version, this option will be available once a more reliable storage is in place, it is curently using an in-memory storage
-//func (a *azureInput) run() error {
-//	var err error
-//	a.hub, err = eventhub.NewHubFromConnectionString(fmt.Sprintf("%s%s%s", a.config.ConnectionString, eventHubConnector, a.config.EventHubName))
-//	if err != nil {
-//		return err
-//	}
-//	// listen to each partition of the Event Hub
-//	runtimeInfo, err := a.hub.GetRuntimeInformation(a.workerCtx)
-//	if err != nil {
-//		return err
-//	}
-//
-//	for _, partitionID := range runtimeInfo.PartitionIDs {
-//		// Start receiving messages
-//		handler := func(c context.Context, event *eventhub.Event) error {
-//			a.log.Info(string(event.Data))
-//			return a.processEvents(event, partitionID)
-//		}
-//		var err error
-//		// sending a nill ReceiveOption will throw an exception
-//		if a.config.ConsumerGroup != "" {
-//			_, err = a.hub.Receive(a.workerCtx, partitionID, handler, eventhub.ReceiveWithConsumerGroup(a.config.ConsumerGroup))
-//		} else {
-//			_, err = a.hub.Receive(a.workerCtx, partitionID, handler)
-//		}
-//		if err != nil {
-//			return err
-//		}
-//	}
-//	return nil
-//}
 
 // Stop stops `azure-eventhub` input.
 func (a *azureInput) Stop() {

--- a/x-pack/filebeat/input/azureeventhub/input.go
+++ b/x-pack/filebeat/input/azureeventhub/input.go
@@ -94,17 +94,17 @@ func NewInput(
 	return in, nil
 }
 
-// Run starts the `azure-eventhub` input worker then returns.
+// Run starts the `azure-eventhub` input and then returns.
 //
-// Only the first invocation will ever start the worker. All subsequent
+// The first invocation will start an input worker. All subsequent
 // invocations will be no-ops.
 //
-// After we set up and start the worker, it will continue fetching data
-// from the event hub on its own until the input Runner calls
-// the `Stop()` method.
+// The input worker will continue fetching data from the event hub until
+// the input Runner calls the `Stop()` method.
 func (a *azureInput) Run() {
 	// `Run` is invoked periodically by the input Runner. The `sync.Once`
-	// guarantees that we only start the worker once.
+	// guarantees that we only start the worker once during the first
+	// invocation.
 	a.workerOnce.Do(func() {
 		a.log.Infof("%s input worker is starting.", inputName)
 		err := a.runWithEPH()
@@ -119,8 +119,8 @@ func (a *azureInput) Run() {
 // Stop stops `azure-eventhub` input.
 func (a *azureInput) Stop() {
 	if a.processor != nil {
-		// Tells the processor to stop processing events and release all resources,
-		// like scheduler, leaser, checkpointer, and client.
+		// Tells the processor to stop processing events and release all
+		// resources (like scheduler, leaser, checkpointer, and client).
 		err := a.processor.Close(context.Background())
 		if err != nil {
 			a.log.Errorw("error while closing eventhostprocessor", "error", err)

--- a/x-pack/filebeat/input/azureeventhub/input_test.go
+++ b/x-pack/filebeat/input/azureeventhub/input_test.go
@@ -80,9 +80,9 @@ func TestParseMultipleMessages(t *testing.T) {
 		"{\"test\":\"this is 2nd message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}," +
 		"{\"test\":\"this is 3rd message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}]}"
 	msgs := []string{
-		fmt.Sprintf("{\"test\":\"this is some message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}"),
-		fmt.Sprintf("{\"test\":\"this is 2nd message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}"),
-		fmt.Sprintf("{\"test\":\"this is 3rd message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}"),
+		"{\"test\":\"this is some message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}",
+		"{\"test\":\"this is 2nd message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}",
+		"{\"test\":\"this is 3rd message\",\"time\":\"2019-12-17T13:43:44.4946995Z\"}",
 	}
 	input := azureInput{log: logp.NewLogger(fmt.Sprintf("%s test for input", inputName))}
 	messages := input.parseMultipleMessages([]byte(msg))

--- a/x-pack/libbeat/management/generate_test.go
+++ b/x-pack/libbeat/management/generate_test.go
@@ -33,12 +33,7 @@ func TestBareConfig(t *testing.T) {
 		},
 	}
 
-	// First test: this doesn't panic on nil pointer dereference
-	reloadCfg, err := generateBeatConfig(&rawExpected, &client.AgentInfo{ID: "beat-ID", Version: "8.0.0", Snapshot: true})
-	require.NoError(t, err, "error in generateBeatConfig")
-	cfgMap := mapstr.M{}
-	err = reloadCfg[0].Config.Unpack(&cfgMap)
-	require.NoError(t, err, "error in unpack for config %#v", reloadCfg[0].Config)
+	cfgMap := buildConfigMap(t, &rawExpected, &client.AgentInfo{ID: "beat-ID", Version: "8.0.0", Snapshot: true})
 
 	// Actual checks
 	processorFields := map[string]interface{}{
@@ -84,12 +79,7 @@ func TestGlobalProcessInject(t *testing.T) {
 		}),
 	}
 
-	reloadCfg, err := generateBeatConfig(&rawExpected, &client.AgentInfo{ID: "beat-ID", Version: "8.0.0", Snapshot: true})
-	require.NoError(t, err, "error in generateBeatConfig")
-	cfgMap := mapstr.M{}
-	err = reloadCfg[0].Config.Unpack(&cfgMap)
-	require.NoError(t, err, "error in unpack for config %#v", reloadCfg[0].Config)
-
+	cfgMap := buildConfigMap(t, &rawExpected, &client.AgentInfo{ID: "beat-ID", Version: "8.0.0", Snapshot: true})
 	processorFields := map[string]interface{}{
 		"add_fields.fields.stream_id":    "system/metrics-system.filesystem-default-system", // make sure we're not overwiting anything
 		"add_fields.fields.dataset":      "generic",
@@ -138,12 +128,7 @@ func TestMBGenerate(t *testing.T) {
 		},
 	}
 
-	reloadCfg, err := generateBeatConfig(&rawExpected, &client.AgentInfo{ID: "beat-ID", Version: "8.0.0", Snapshot: true})
-	require.NoError(t, err, "error in generateBeatConfig")
-	cfgMap := mapstr.M{}
-	err = reloadCfg[0].Config.Unpack(&cfgMap)
-	require.NoError(t, err, "error in unpack for config %#v", reloadCfg[0].Config)
-
+	cfgMap := buildConfigMap(t, &rawExpected, &client.AgentInfo{ID: "beat-ID", Version: "8.0.0", Snapshot: true})
 	configFields := map[string]interface{}{
 		"drop_event":                  nil,
 		"add_fields.fields.stream_id": "system/metrics-system.filesystem-default-system",
@@ -235,4 +220,13 @@ func findFieldsInProcessors(t *testing.T, configFields map[string]interface{}, c
 		assert.True(t, gotKey, "did not find key for %s", key)
 		assert.True(t, gotVal, "got incorrect key for %s, expected %s, got %s", key, val, errStr)
 	}
+}
+
+func buildConfigMap(t *testing.T, unitRaw *proto.UnitExpectedConfig, agentInfo *client.AgentInfo) mapstr.M {
+	reloadCfg, err := generateBeatConfig(unitRaw, agentInfo)
+	require.NoError(t, err, "error in generateBeatConfig")
+	cfgMap := mapstr.M{}
+	err = reloadCfg[0].Config.Unpack(&cfgMap)
+	require.NoError(t, err, "error in unpack for config %#v", reloadCfg[0].Config)
+	return cfgMap
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Update the `azure-eventhub` input to switch the run mode of the [Event Processor Host (EPH)](https://github.com/Azure/azure-event-hubs-go#event-processor-host) from blocking to non-blocking.

With the changes in the PR, the first call to the input `Start()` method will set up and start the EPH worker in a non-blocking fashion. The EPH worker will continue until the Filebeat calls the `Stop()` method to tear it down for live reloading. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Since 8.3.3, the input Runner [changed its behavior](https://github.com/elastic/beats/commit/2f69f8647780f2225b3bfd9819068f6544fa8415#diff-55d635dc8516b02782b025d565e2191b6e5b559aedc21fd9437610aabaf739fa) during the [live reload](https://github.com/elastic/beats/blob/5fd004137864d356ef5ad33d0e8687e5192e651a/libbeat/cfgfile/list.go#L55):

- `< 8.3.3`: the input Runner stops the old input and starts a new input [without waiting](https://github.com/elastic/beats/blob/v8.3.2/libbeat/cfgfile/list.go#L84-L90) for the stop to complete.
- `>= 8.3.3`: the input Runner stops the old input and [waits for](https://github.com/elastic/beats/blob/5fd004137864d356ef5ad33d0e8687e5192e651a/libbeat/cfgfile/list.go#L84-L96) the `Stop()` method to complete before starting a new one.

Unfortunately, if we run [Start()](https://github.com/Azure/azure-event-hubs-go/blob/0e9e4ef2a1d1218a0eafa928345758ce3d274611/eph/eph.go#L302) with EPH in a blocking mode, the method will not return because it will [continue waiting](https://github.com/Azure/azure-event-hubs-go/blob/0e9e4ef2a1d1218a0eafa928345758ce3d274611/eph/eph.go#L325-L329) for an `os.Signal` that will never come.

If the EPH's `Start()` method does not end, the EPH `sync.WaitGroup` will [continue waiting forever](https://github.com/elastic/beats/blob/5fd004137864d356ef5ad33d0e8687e5192e651a/x-pack/filebeat/input/azureeventhub/input.go#L168).

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


<!-- Recommended
## Author's Checklist
Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

### 1. Enable live reload

Edit the `filebeat.yml` file and update the "Filebeat modules" like this one:

```yaml
# ============================== Filebeat modules ==============================

filebeat.config.modules:
  # Glob pattern for configuration loading
  path: ${path.config}/modules.d/*.yml

  # Set to true to enable config reloading
  # reload.enabled: false
  reload.enabled: true

  # Period on which files under path should be checked for changes
  #reload.period: 10s
  reload.period: 10s

# ======================= Elasticsearch template setting =======================
```

### 2. Enable the azure module

Copy the `azure.yml.disabled` file into `azure.yml`  and set up one of the existing inputs.

For example:

```yaml
  platformlogs:
    enabled: true
    var:
      # adding a new line
      eventhub: "platformlogs"
      consumer_group: "$Default"
      connection_string: "Endpoint=sb://....="
      storage_account: ""
      storage_account_key: ""
      tags:
        - "azure"
        - "whatever4"
```

### 3. Testing

Start Filebeat and make sure the platform logs are created in Elasticsearch.

Make some changes to the `azure.yml`. For example, try to add/remove/change the `tags` and within 10 seconds Filebeat will trigger a [configuration reload](https://github.com/elastic/beats/commit/2f69f8647780f2225b3bfd9819068f6544fa8415#diff-55d635dc8516b02782b025d565e2191b6e5b559aedc21fd9437610aabaf739fa).



## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes elastic/integrations#4743

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

<!-- Recommended
## Logs

Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
