### PR TITLE
Correct typo in error message

### DIFF
--- a/libbeat/cmd/instance/locks/lock.go
+++ b/libbeat/cmd/instance/locks/lock.go
@@ -215,7 +215,7 @@ func (lock *Locker) handleFailedCreate() error {
 		// Case: we've gotten a lock file for another process that's already running
 		// This is the "base" lockfile case, which is two beats running from the same directory
 		// This is where we'll catch this particular case on Linux, due to Linux's advisory-style locks.
-		return fmt.Errorf("connot start, data directory belongs to process with pid %d", pf.PID)
+		return fmt.Errorf("cannot start, data directory belongs to process with pid %d", pf.PID)
 	}
 }
 


### PR DESCRIPTION
- Bug

## What does this PR do?

Correct a typo in an error message

`Dec 20 11:48:14 hostname filebeat[107249]: Exiting: cannot obtain lockfile: connot start, data directory belongs to process with pid 1473
`
## Why is it important?

Error messages should be correct

## Checklist



- [X] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~ 
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~ 
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Author's Checklist

n/a

## How to test this PR locally

n/a


