### PR TITLE
Add option to disable pod events enrichment with deployment name

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/beats/compare/v7.0.0-alpha2...master[Check the HEAD d
 
 - Add extra protection on gRPC server start process to avoid trying to start a nil server.
 - `add_fields` processor is now able to set metadata in events. {pull}30092[30092]
+- Allows disable pod events enrichment with deployment name {pull}28521[28521] {pull}34097[34097]
 
 *Auditbeat*
 

--- a/libbeat/common/kubernetes/metadata/config.go
+++ b/libbeat/common/kubernetes/metadata/config.go
@@ -35,8 +35,9 @@ type Config struct {
 
 // AddResourceMetadataConfig allows adding config for enriching additional resources
 type AddResourceMetadataConfig struct {
-	Node      *common.Config `config:"node"`
-	Namespace *common.Config `config:"namespace"`
+	Node       *common.Config `config:"node"`
+	Namespace  *common.Config `config:"namespace"`
+	Deployment bool           `config:"deployment"`
 }
 
 // InitDefaults initializes the defaults for the config.
@@ -56,7 +57,8 @@ func GetDefaultResourceMetadataConfig() *AddResourceMetadataConfig {
 	metaConfig.InitDefaults()
 	metaCfg, _ := common.NewConfigFrom(&metaConfig)
 	return &AddResourceMetadataConfig{
-		Node:      metaCfg,
-		Namespace: metaCfg,
+		Node:       metaCfg,
+		Namespace:  metaCfg,
+		Deployment: true,
 	}
 }

--- a/libbeat/common/kubernetes/metadata/pod.go
+++ b/libbeat/common/kubernetes/metadata/pod.go
@@ -91,11 +91,13 @@ func (p *pod) GenerateK8s(obj kubernetes.Resource, opts ...FieldOptions) common.
 	out := p.resource.GenerateK8s("pod", obj, opts...)
 
 	// check if Pod is handled by a ReplicaSet which is controlled by a Deployment
-	rsName, _ := out.GetValue("replicaset.name")
-	if rsName, ok := rsName.(string); ok {
-		dep := p.getRSDeployment(rsName, po.GetNamespace())
-		if dep != "" {
-			_, _ = out.Put("deployment.name", dep)
+	if p.addResourceMetadata.Deployment {
+		rsName, _ := out.GetValue("replicaset.name")
+		if rsName, ok := rsName.(string); ok {
+			dep := p.getRSDeployment(rsName, po.GetNamespace())
+			if dep != "" {
+				_, _ = out.Put("deployment.name", dep)
+			}
 		}
 	}
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -244,7 +244,8 @@ endif::[]
  `add_resource_metadata` can be done for `node` or `namespace`. By default all labels will be included
   while annotations are not added by default. This settings are useful when labels' and annotations'
   storing requires special handling to avoid overloading the storage output. The enrichment of `node` or `namespace` metadata
-  can be individually disabled by setting `enabled: false`.
+  can be individually disabled by setting `enabled: false`. If resource is `pod` and it is created from a `deployment`, by default
+  the deployment name is added, this can be disabled by set to `false`.
   Example:
 
 ["source","yaml",subs="attributes"]
@@ -255,6 +256,7 @@ endif::[]
         node:
           include_labels: ["nodelabel2"]
           include_annotations: ["nodeannotation1"]
+        deployment: false
 -------------------------------------------------------------------------------------
 
 `unique`:: (Optional) Defaults to `false`. Marking an autodiscover provider as unique results into

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -245,7 +245,7 @@ endif::[]
   while annotations are not added by default. This settings are useful when labels' and annotations'
   storing requires special handling to avoid overloading the storage output. The enrichment of `node` or `namespace` metadata
   can be individually disabled by setting `enabled: false`. If resource is `pod` and it is created from a `deployment`, by default
-  the deployment name is added, this can be disabled by set to `false`.
+  the deployment name is added, this can be disabled by setting `deployment: false`.
   Example:
 
 ["source","yaml",subs="attributes"]


### PR DESCRIPTION
## What does this PR do?
This is a "backport" of https://github.com/elastic/beats/pull/28521 so as to support disabling of Deployment metadata enrichment in Pod events. 

This will allow us to disable the enrichment that in large clusters can cost a lot and push the k8s API server.

@gizas @tetianakravchenko what do you think?