### PR TITLE
[elasticsearch] ccr supports enterprise license

### DIFF
--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -18,9 +18,8 @@
 package ccr
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/elastic"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -72,7 +71,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	// the license first.
 	ccrUnavailableMessage, err := m.checkCCRAvailability(info.Version.Number)
 	if err != nil {
-		return errors.Wrap(err, "error determining if CCR is available")
+		return fmt.Errorf("error determining if CCR is available: %w", err)
 	}
 
 	if ccrUnavailableMessage != "" {
@@ -94,7 +93,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *version.V) (message string, err error) {
 	license, err := elasticsearch.GetLicense(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		return "", errors.Wrap(err, "error determining Elasticsearch license")
+		return "", fmt.Errorf("error determining Elasticsearch license: %w", err)
 	}
 
 	if !license.IsOneOf("trial", "platinum", "enterprise") {
@@ -106,7 +105,7 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *version.V)
 
 	xpack, err := elasticsearch.GetXPack(m.HTTP, m.GetServiceURI())
 	if err != nil {
-		return "", errors.Wrap(err, "error determining xpack features")
+		return "", fmt.Errorf("error determining xpack features: %w", err)
 	}
 
 	if !xpack.Features.CCR.Enabled {

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -78,7 +78,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	if ccrUnavailableMessage != "" {
 		if time.Since(m.lastCCRLicenseMessageTimestamp) > 1*time.Minute {
 			m.lastCCRLicenseMessageTimestamp = time.Now()
-			m.Logger().Debug(ccrUnavailableMessage)
+			m.Logger().Warn(ccrUnavailableMessage)
 		}
 		return nil
 	}
@@ -97,8 +97,8 @@ func (m *MetricSet) checkCCRAvailability(currentElasticsearchVersion *version.V)
 		return "", errors.Wrap(err, "error determining Elasticsearch license")
 	}
 
-	if !license.IsOneOf("trial", "platinum") {
-		message = "the CCR feature is available with a platinum Elasticsearch license. " +
+	if !license.IsOneOf("trial", "platinum", "enterprise") {
+		message = "the CCR feature is available with a platinum or enterprise Elasticsearch license. " +
 			"You currently have a " + license.Type + " license. " +
 			"Either upgrade your license or remove the ccr metricset from your Elasticsearch module configuration."
 		return

--- a/metricbeat/module/elasticsearch/ccr/ccr.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr.go
@@ -67,8 +67,6 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		return err
 	}
 
-	// CCR is only available in Trial or Platinum license of Elasticsearch. So we check
-	// the license first.
 	ccrUnavailableMessage, err := m.checkCCRAvailability(info.Version.Number)
 	if err != nil {
 		return fmt.Errorf("error determining if CCR is available: %w", err)


### PR DESCRIPTION
### Summary
We're currently only collecting `ccr` metricset if the ES license is `trial` or `platinum` but the `enterprise` license [is also supported](https://www.elastic.co/subscriptions)

### Testing
- created cloud cluster
- verified local metricbeat was storing ccr documents