### PR TITLE
[filebeat][httpjson]- improved error handling during pagination with chaining & split processor

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,7 +51,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Filebeat*
-- [httpsjon] Improved error handling during pagination with chaining & split processor {pull}33981[33981]
+- [httpsjon] Improved error handling during pagination with chaining & split processor {pull}34127[34127]
 - [Azure blob storage] Added support for more mime types & introduced offset tracking via cursor state. {pull}33981[33981]
 - Fix EOF on single line not producing any event. {issue}30436[30436] {pull}33568[33568]
 - Fix handling of error in states in direct aws-s3 listing input {issue}33513[33513] {pull}33722[33722]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Filebeat*
+- [httpsjon] Improved error handling during pagination with chaining & split processor {pull}33981[33981]
 - [Azure blob storage] Added support for more mime types & introduced offset tracking via cursor state. {pull}33981[33981]
 - Fix EOF on single line not producing any event. {issue}30436[30436] {pull}33568[33568]
 - Fix handling of error in states in direct aws-s3 listing input {issue}33513[33513] {pull}33722[33722]

--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -667,7 +667,12 @@ func (r *requester) processChainPaginationEvents(stdCtx context.Context, trCtx *
 		n += processAndPublishEvents(chainTrCtx, events, publisher, i < len(r.requestFactories), r.log)
 	}
 
-	defer httpResp.Body.Close()
+	defer func() {
+		if httpResp != nil && httpResp.Body != nil {
+			httpResp.Body.Close()
+		}
+	}()
+
 	return n, nil
 }
 


### PR DESCRIPTION
 ## Type of change
- Bug


## What does this PR do?
Adds a safety check to response.Body.Close to avoid unnecessary panics


## Why is it important?
Improves stability, removing edge-case panics

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ]~~ I have made corresponding changes to the documentation
~~- [ ]~~ I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes #34126 
