### PR TITLE
Fix make clean (#34134)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ update: notice
 clean: mage
 	@rm -rf build
 	@$(foreach var,$(PROJECTS) $(PROJECTS_XPACK_MAGE),$(MAKE) -C $(var) clean || exit 1;)
-	@$(MAKE) -C generator clean
 	@-mage -clean
 
 ## check : TBD.

--- a/dev-tools/mage/clean.go
+++ b/dev-tools/mage/clean.go
@@ -18,6 +18,11 @@
 package mage
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/magefile/mage/sh"
 )
 
@@ -46,6 +51,12 @@ func Clean(pathLists ...[]string) error {
 		for _, f := range paths {
 			f = MustExpand(f)
 			if err := sh.Rm(f); err != nil {
+				if errors.Is(err, os.ErrPermission) ||
+					strings.Contains(err.Error(), "permission denied") {
+					fmt.Printf("warn: cannot delete %q: %v, proceeding anyway\n",
+						f, err)
+					continue
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
## This is a forwardport of #34134 

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes `make clean`

## Why is it important?

`make clean` was failing, thus not cleaning the project what might lead to an old build of the beats being used when the elastic-agent package process looks for local beats packages.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Run `make clean`, it must succeed

## Related issues

N/A
