### PR TITLE
Disable seccomp filter for osquerybeat

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2022 Elasticsearch BV
+Copyright 2014-2023 Elasticsearch BV
 
 This product includes software developed by The Apache Software 
 Foundation (http://www.apache.org/).

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -428,8 +428,12 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		}
 	}
 
-	if err := seccomp.LoadFilter(b.Config.Seccomp); err != nil {
-		return err
+	// Do not load seccomp for osquerybeat, it was disabled before V2 in the configuration file
+	// https://github.com/elastic/beats/blob/7cf873fd340172c33f294500ccfec948afd7a47c/x-pack/osquerybeat/osquerybeat.yml#L16
+	if b.Info.Beat != "osquerybeat" {
+		if err := seccomp.LoadFilter(b.Config.Seccomp); err != nil {
+			return err
+		}
 	}
 
 	beater, err := b.createBeater(bt)
@@ -552,7 +556,7 @@ func (b *Beat) TestConfig(settings Settings, bt beat.Creator) error {
 	}())
 }
 
-//SetupSettings holds settings necessary for beat setup
+// SetupSettings holds settings necessary for beat setup
 type SetupSettings struct {
 	Dashboard       bool
 	Pipeline        bool
@@ -565,6 +569,7 @@ type SetupSettings struct {
 }
 
 // Setup registers ES index template, kibana dashboards, ml jobs and pipelines.
+//
 //nolint:forbidigo // required to give feedback to user
 func (b *Beat) Setup(settings Settings, bt beat.Creator, setup SetupSettings) error {
 	return handleError(func() error {


### PR DESCRIPTION
## What does this PR do?

Disables seccomp filter for osquerybeat. 
It was disabled before V2 with osquerybeat.yml config
https://github.com/elastic/beats/blob/7cf873fd340172c33f294500ccfec948afd7a47c/x-pack/osquerybeat/osquerybeat.yml#L16

There is probably a better place for this, but this works for this release deadline.
Somebody more familiar with that area of the agent feel free to chime in. We can move it later in 8.7.0.

## Why is it important?

Osquerybeat fails to run without this change with error:
```
"Exiting: fork/exec /usr/share/elastic-agent/data/elastic-agent-362d2b/components/osqueryd: operation not permitted"
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Screenshots

Osquery works with this change

<img width="1265" alt="Screen Shot 2023-01-03 at 5 41 39 PM" src="https://user-images.githubusercontent.com/872351/210454695-8e5c31f3-675c-41e8-8ca4-a95659ec1c15.png">


