### PR TITLE
[Metricbeat][Kubernetes] Fix scheduler and proxy dashboard

### DIFF
--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
@@ -918,7 +918,7 @@
                                             "type": "palette"
                                         },
                                         "position": "top",
-                                        "seriesType": "area",
+                                        "seriesType": "line",
                                         "showGridlines": false,
                                         "splitAccessor": "68f1dece-b63b-4a27-9c1f-8068f2f9bedb",
                                         "xAccessor": "34f7328b-5fef-43e7-9350-98256b031a79"
@@ -1128,7 +1128,7 @@
                                             "type": "palette"
                                         },
                                         "position": "top",
-                                        "seriesType": "area",
+                                        "seriesType": "line",
                                         "showGridlines": false,
                                         "splitAccessor": "e7259e4c-0700-48a5-aeff-993fc075bcab",
                                         "xAccessor": "7b8d9b03-439b-4171-8b64-91b8664b4b94"
@@ -1323,7 +1323,7 @@
                                             "type": "palette"
                                         },
                                         "position": "top",
-                                        "seriesType": "area",
+                                        "seriesType": "line",
                                         "showGridlines": false,
                                         "splitAccessor": "73933c6b-b6da-45c6-a190-c501453f658f",
                                         "xAccessor": "3ed7787d-1fbe-487f-a377-9a5e5e6f2571"

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
@@ -2390,7 +2390,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
+            "id": "metricbeat-*",
             "name": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd:metrics_ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd_0_index_pattern",
             "type": "index-pattern"
         },
@@ -2405,7 +2405,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
+            "id": "metricbeat-*",
             "name": "c3fee68f-01c6-49da-a759-2900b1cd15bf:metrics_c3fee68f-01c6-49da-a759-2900b1cd15bf_0_index_pattern",
             "type": "index-pattern"
         },
@@ -2430,7 +2430,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
+            "id": "metricbeat-*",
             "name": "f8313a9d-ab58-448e-b183-75f914caf53f:metrics_f8313a9d-ab58-448e-b183-75f914caf53f_0_index_pattern",
             "type": "index-pattern"
         },

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
@@ -1952,7 +1952,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of differences(sum(kubernetes.controllermanager.client.request.count))",
+                                                    "label": "Part of differences(sum(kubernetes.proxy.client.request.count))",
                                                     "operationType": "differences",
                                                     "references": [
                                                         "eb7e83d0-db8e-4b46-963c-3f2e8f343546"
@@ -1976,13 +1976,13 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of differences(sum(kubernetes.controllermanager.client.request.count))",
+                                                    "label": "Part of differences(sum(kubernetes.proxy.client.request.count))",
                                                     "operationType": "sum",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "kubernetes.controllermanager.client.request.count"
+                                                    "sourceField": "kubernetes.proxy.client.request.count"
                                                 },
                                                 "eb84dd5b-79c5-4928-8636-fcc56d70b7fc": {
                                                     "dataType": "string",
@@ -2010,7 +2010,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 400 and kubernetes.controllermanager.code \u003c 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 400 and kubernetes.proxy.code \u003c 500"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Client errors",
@@ -2036,7 +2036,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 400 and kubernetes.controllermanager.code \u003c 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 400 and kubernetes.proxy.code \u003c 500"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Part of Client errors",
@@ -2052,7 +2052,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 400 and kubernetes.controllermanager.code \u003c 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 400 and kubernetes.proxy.code \u003c 500"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Part of Client errors",
@@ -2176,7 +2176,7 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of differences(sum(kubernetes.controllermanager.client.request.count))",
+                                                    "label": "Part of differences(sum(kubernetes.proxy.client.request.count))",
                                                     "operationType": "differences",
                                                     "references": [
                                                         "e137ff3f-86e1-4be8-9bee-a9f50d5cbec8"
@@ -2188,16 +2188,16 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 400 and kubernetes.controllermanager.code \u003c 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 400 and kubernetes.proxy.code \u003c 500"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Part of differences(sum(kubernetes.controllermanager.client.request.count))",
+                                                    "label": "Part of differences(sum(kubernetes.proxy.client.request.count))",
                                                     "operationType": "sum",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "kubernetes.controllermanager.client.request.count"
+                                                    "sourceField": "kubernetes.proxy.client.request.count"
                                                 },
                                                 "e05814a2-da30-432b-8fbf-bad34214cc4c": {
                                                     "dataType": "string",
@@ -2224,23 +2224,23 @@
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "Part of differences(sum(kubernetes.controllermanager.client.request.count))",
+                                                    "label": "Part of differences(sum(kubernetes.proxy.client.request.count))",
                                                     "operationType": "sum",
                                                     "params": {
                                                         "emptyAsNull": false
                                                     },
                                                     "scale": "ratio",
-                                                    "sourceField": "kubernetes.controllermanager.client.request.count"
+                                                    "sourceField": "kubernetes.proxy.client.request.count"
                                                 },
                                                 "f19c32fc-8086-4c14-a124-747572608ae5": {
                                                     "customLabel": true,
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 400 and kubernetes.controllermanager.code \u003c 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 400 and kubernetes.proxy.code \u003c 500"
                                                     },
                                                     "isBucketed": false,
-                                                    "label": "Part of differences(sum(kubernetes.controllermanager.client.request.count))",
+                                                    "label": "Part of differences(sum(kubernetes.proxy.client.request.count))",
                                                     "operationType": "differences",
                                                     "references": [
                                                         "b842fba2-3cc2-4d13-8cf9-37b66f21b796"
@@ -2252,7 +2252,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 500"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Server errors",
@@ -2278,7 +2278,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 500"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Part of Server errors",
@@ -2294,7 +2294,7 @@
                                                     "dataType": "number",
                                                     "filter": {
                                                         "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.code \u003e= 500"
+                                                        "query": "kubernetes.proxy.code \u003e= 500"
                                                     },
                                                     "isBucketed": false,
                                                     "label": "Part of Server errors",
@@ -2390,7 +2390,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "logs-*",
             "name": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd:metrics_ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd_0_index_pattern",
             "type": "index-pattern"
         },
@@ -2405,7 +2405,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "logs-*",
             "name": "c3fee68f-01c6-49da-a759-2900b1cd15bf:metrics_c3fee68f-01c6-49da-a759-2900b1cd15bf_0_index_pattern",
             "type": "index-pattern"
         },
@@ -2430,7 +2430,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "logs-*",
             "name": "f8313a9d-ab58-448e-b183-75f914caf53f:metrics_f8313a9d-ab58-448e-b183-75f914caf53f_0_index_pattern",
             "type": "index-pattern"
         },

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -1401,7 +1401,7 @@
                                             "type": "palette"
                                         },
                                         "position": "top",
-                                        "seriesType": "area",
+                                        "seriesType": "line",
                                         "showGridlines": false,
                                         "splitAccessor": "68f1dece-b63b-4a27-9c1f-8068f2f9bedb",
                                         "xAccessor": "34f7328b-5fef-43e7-9350-98256b031a79"
@@ -1611,7 +1611,7 @@
                                             "type": "palette"
                                         },
                                         "position": "top",
-                                        "seriesType": "area",
+                                        "seriesType": "line",
                                         "showGridlines": false,
                                         "splitAccessor": "e7259e4c-0700-48a5-aeff-993fc075bcab",
                                         "xAccessor": "7b8d9b03-439b-4171-8b64-91b8664b4b94"
@@ -1826,7 +1826,7 @@
                                             "type": "palette"
                                         },
                                         "position": "top",
-                                        "seriesType": "area",
+                                        "seriesType": "line",
                                         "showGridlines": false,
                                         "splitAccessor": "73933c6b-b6da-45c6-a190-c501453f658f",
                                         "xAccessor": "3ed7787d-1fbe-487f-a377-9a5e5e6f2571"

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -3543,7 +3543,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
+            "id": "metricbeat-*",
             "name": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd:metrics_ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd_0_index_pattern",
             "type": "index-pattern"
         },
@@ -3578,7 +3578,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
+            "id": "metricbeat-*",
             "name": "0599e0ae-2375-4ceb-b12d-2ebec4310cc6:metrics_0599e0ae-2375-4ceb-b12d-2ebec4310cc6_0_index_pattern",
             "type": "index-pattern"
         },
@@ -3623,7 +3623,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
+            "id": "metricbeat-*",
             "name": "c3fee68f-01c6-49da-a759-2900b1cd15bf:metrics_c3fee68f-01c6-49da-a759-2900b1cd15bf_0_index_pattern",
             "type": "index-pattern"
         },
@@ -3653,7 +3653,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "logs-*",
+            "id": "metricbeat-*",
             "name": "f8313a9d-ab58-448e-b183-75f914caf53f:metrics_f8313a9d-ab58-448e-b183-75f914caf53f_0_index_pattern",
             "type": "index-pattern"
         },

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -1117,13 +1117,13 @@
                                                         "orderAgg": {
                                                             "dataType": "number",
                                                             "isBucketed": false,
-                                                            "label": "Sum of kubernetes.controllermanager.workqueue.adds.count",
+                                                            "label": "Sum of kubernetes.scheduler.workqueue.adds.count",
                                                             "operationType": "sum",
                                                             "params": {
                                                                 "emptyAsNull": true
                                                             },
                                                             "scale": "ratio",
-                                                            "sourceField": "kubernetes.controllermanager.workqueue.adds.count"
+                                                            "sourceField": "kubernetes.scheduler.workqueue.adds.count"
                                                         },
                                                         "orderBy": {
                                                             "type": "custom"
@@ -1283,13 +1283,13 @@
                                                         "orderAgg": {
                                                             "dataType": "number",
                                                             "isBucketed": false,
-                                                            "label": "Maximum of kubernetes.controllermanager.workqueue.retries.count",
+                                                            "label": "Maximum of kubernetes.scheduler.workqueue.retries.count",
                                                             "operationType": "max",
                                                             "params": {
                                                                 "emptyAsNull": true
                                                             },
                                                             "scale": "ratio",
-                                                            "sourceField": "kubernetes.controllermanager.workqueue.retries.count"
+                                                            "sourceField": "kubernetes.scheduler.workqueue.retries.count"
                                                         },
                                                         "orderBy": {
                                                             "type": "custom"
@@ -1535,13 +1535,13 @@
                                                         "orderAgg": {
                                                             "dataType": "number",
                                                             "isBucketed": false,
-                                                            "label": "Sum of kubernetes.controllermanager.workqueue.depth.count",
+                                                            "label": "Sum of kubernetes.scheduler.workqueue.depth.count",
                                                             "operationType": "sum",
                                                             "params": {
                                                                 "emptyAsNull": true
                                                             },
                                                             "scale": "ratio",
-                                                            "sourceField": "kubernetes.controllermanager.workqueue.depth.count"
+                                                            "sourceField": "kubernetes.scheduler.workqueue.depth.count"
                                                         },
                                                         "orderBy": {
                                                             "type": "custom"
@@ -1704,13 +1704,13 @@
                                                         "orderAgg": {
                                                             "dataType": "number",
                                                             "isBucketed": false,
-                                                            "label": "Maximum of kubernetes.controllermanager.workqueue.unfinished.sec",
+                                                            "label": "Maximum of kubernetes.scheduler.workqueue.unfinished.sec",
                                                             "operationType": "max",
                                                             "params": {
                                                                 "emptyAsNull": true
                                                             },
                                                             "scale": "ratio",
-                                                            "sourceField": "kubernetes.controllermanager.workqueue.unfinished.sec"
+                                                            "sourceField": "kubernetes.scheduler.workqueue.unfinished.sec"
                                                         },
                                                         "orderBy": {
                                                             "type": "custom"
@@ -3543,7 +3543,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "logs-*",
             "name": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd:metrics_ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd_0_index_pattern",
             "type": "index-pattern"
         },
@@ -3578,7 +3578,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "logs-*",
             "name": "0599e0ae-2375-4ceb-b12d-2ebec4310cc6:metrics_0599e0ae-2375-4ceb-b12d-2ebec4310cc6_0_index_pattern",
             "type": "index-pattern"
         },
@@ -3623,7 +3623,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "logs-*",
             "name": "c3fee68f-01c6-49da-a759-2900b1cd15bf:metrics_c3fee68f-01c6-49da-a759-2900b1cd15bf_0_index_pattern",
             "type": "index-pattern"
         },
@@ -3653,7 +3653,7 @@
             "type": "index-pattern"
         },
         {
-            "id": "metricbeat-*",
+            "id": "logs-*",
             "name": "f8313a9d-ab58-448e-b183-75f914caf53f:metrics_f8313a9d-ab58-448e-b183-75f914caf53f_0_index_pattern",
             "type": "index-pattern"
         },


### PR DESCRIPTION
## What does this PR do?

Regarding https://github.com/elastic/beats/pull/34161, some of the visualizations on Proxy and Scheduler dashboard were using `kubernetes.controllermanager.*` metrics leading to empty visualizations. The only change is switching those metrics to either `kubernetes.scheduler.*` for Scheduler dashboard and to `kubernetes.proxy.*` for Proxy dashboard.

Also updated the remaining area charts to line charts. Example:
![image](https://user-images.githubusercontent.com/113898685/211291757-ec5f2096-8598-4ff7-9295-a2f2346e85ba.png)

A visualization like the one on the right, will be similar to the one on the left in case of a rate change.

## Related issues

- Relates https://github.com/elastic/beats/pull/34161



