### PR TITLE
ignore matching event port with hints port

### DIFF
--- a/heartbeat/autodiscover/builder/hints/monitors.go
+++ b/heartbeat/autodiscover/builder/hints/monitors.go
@@ -140,16 +140,17 @@ func (hb *heartbeatHints) getHostsWithPort(hints mapstr.M, port int) []string {
 	// Only pick hosts that have ${data.port} or the port on current event. This will make
 	// sure that incorrect meta mapping doesn't happen
 	for _, h := range thosts {
-		if strings.Contains(h, "data.port") || strings.Contains(h, fmt.Sprintf(":%d", port)) ||
-			// Use the event that has no port config if there is a ${data.host}:9090 like input
-			(port == 0 && strings.Contains(h, "data.host")) {
-			result = append(result, h)
-		} else if port == 0 && !strings.Contains(h, ":") {
-			// For ICMP like use cases allow only host to be passed if there is no port
-			result = append(result, h)
-		} else {
-			hb.logger.Warn("unable to frame a host from input host: %s", h)
-		}
+		// if strings.Contains(h, "data.port") || strings.Contains(h, fmt.Sprintf(":%d", port)) ||
+		// 	// Use the event that has no port config if there is a ${data.host}:9090 like input
+		// 	(port == 0 && strings.Contains(h, "data.host")) {
+		// 	result = append(result, h)
+		// } else if port == 0 && !strings.Contains(h, ":") {
+		// 	// For ICMP like use cases allow only host to be passed if there is no port
+		// 	result = append(result, h)
+		// } else {
+		// 	hb.logger.Warn("unable to frame a host from input host: %s", h)
+		// }
+		result = append(result, h)
 	}
 
 	if len(thosts) > 0 && len(result) == 0 {

--- a/heartbeat/autodiscover/builder/hints/monitors.go
+++ b/heartbeat/autodiscover/builder/hints/monitors.go
@@ -19,7 +19,7 @@ package hints
 
 import (
 	"fmt"
-	"strings"
+	// "strings"
 
 	"github.com/elastic/go-ucfg"
 


### PR DESCRIPTION
## What does this PR do?

Ignore matching event port with hints in order to fix a bug that adds extra Uptime monitors without URL that are always down. The side effect is that when using autodiscover with a service with multiple exposed ports and multiple hints this change can add the same monitor multiple times. This code is only rerun when a service is redeployed and it has no visual side effect in Kibana.

## Why is it important?

Avoid adding extra monitors without URLs that are always down. This was raised by an SDH

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ]

## How to test this PR locally

Sample svc to test this PR is provided at https://github.com/elastic/beats/issues/34214

## Related issues

- Closes #34214

