### PR TITLE
[Metricbeat][Kubernetes] Update proxy, scheduler and controller manager dashboards

### DIFF
--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
@@ -7,7 +7,6 @@
             "panelsJSON": "{\"f53d0d21-4502-4dce-8004-017a92104040\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"host.name\",\"title\":\"Host\",\"id\":\"f53d0d21-4502-4dce-8004-017a92104040\",\"selectedOptions\":[],\"enhancements\":{},\"singleSelect\":false}},\"df56c430-83b1-436e-8b9c-fb027aaa29ca\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster\",\"singleSelect\":true,\"id\":\"df56c430-83b1-436e-8b9c-fb027aaa29ca\",\"selectedOptions\":[],\"enhancements\":{}}}}"
         },
         "description": "Kubernetes Controller Manager metrics",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -44,6 +43,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": true,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -66,7 +67,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "### Controller Manager\n\nThis dashboard uses data collected from the metrics endpoint of [kube controller manager](https://kubernetes.io/docs/concepts/overview/components/#kube-controller-manager). Its purpose is to give an overview of what is happening inside it through the controller processes metrics and detect problems that might be happening. \n\n**WARNING**: This dataset **requires access** to the kube controller manager endpoint. Refer [here](https://docs.elastic.co/en/integrations/kubernetes#scheduler-and-controllermanager) to learn how to enable it. In some \"As a Service\" Kubernetes implementations, like GKE or AKS, it is **not possible** to access its metrics.",
+                            "markdown": "### Controller Manager\n\nThis dashboard collects metrics from [kube controller manager](https://kubernetes.io/docs/concepts/overview/components/#kube-controller-manager) endpoint. Its purpose is to give an overview of what is happening inside it through the controller processes metrics and detect problems that might be happening. \n\n**WARNING**: This dataset **requires access** to the kube controller manager endpoint. Refer [here](https://docs.elastic.co/en/integrations/kubernetes#scheduler-and-controllermanager) to learn how to enable it. In some \"As a Service\" Kubernetes implementations, like GKE or AKS, it is **not possible** to access its metrics.",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -83,7 +84,7 @@
                 },
                 "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -167,7 +168,7 @@
                 "panelIndex": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -182,7 +183,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "239b73ac-0fc9-44fd-a7c5-2d0281e6b765": {
                                             "columnOrder": [
@@ -449,9 +450,9 @@
                     "y": 3
                 },
                 "panelIndex": "aef813b5-85d5-46c9-a86a-2e273806d488",
-                "title": "Node collector [Metricbeat Kubernetes]",
+                "title": "Node collector ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -535,7 +536,7 @@
                 "panelIndex": "0599e0ae-2375-4ceb-b12d-2ebec4310cc6",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -555,7 +556,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "76c85206-02c1-4f35-bb0d-c1d4d3ee59d7": {
                                             "columnOrder": [
@@ -743,9 +744,9 @@
                     "y": 13
                 },
                 "panelIndex": "2ba53067-d43d-42eb-ac50-2d941977ce95",
-                "title": "Workqueue additions increase rate [Metricbeat Kubernetes]",
+                "title": "Workqueue additions increase rate ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -765,7 +766,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "77b347b2-91fa-470f-861d-ada0e175cbc4": {
                                             "columnOrder": [
@@ -951,9 +952,9 @@
                     "y": 13
                 },
                 "panelIndex": "1cd3ebab-9630-4253-b9a6-5f921e5cb617",
-                "title": "Workqueue retries increase rate [Metricbeat Kubernetes]",
+                "title": "Workqueue retries increase rate ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -973,7 +974,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "2b80230c-9cc8-444f-b092-1fbc4d764992": {
                                             "columnOrder": [
@@ -1166,9 +1167,9 @@
                     "y": 27
                 },
                 "panelIndex": "3a26dffa-0696-485d-b991-1dbc5092082e",
-                "title": "Workqueue depth variation [Metricbeat Kubernetes]",
+                "title": "Workqueue depth rate",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1188,7 +1189,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a2facaed-7c02-4fb6-9126-5512b8ffd26f": {
                                             "columnOrder": [
@@ -1360,9 +1361,9 @@
                     "y": 27
                 },
                 "panelIndex": "6a8b9a40-11ec-4790-a38d-2d88c5468f12",
-                "title": "Current unfinished work [Metricbeat Kubernetes]",
+                "title": "Current unfinished work ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1446,7 +1447,7 @@
                 "panelIndex": "c3fee68f-01c6-49da-a759-2900b1cd15bf",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1466,7 +1467,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "380c5d66-2e69-4e96-b5fb-ac4e5ab1c807": {
                                             "columnOrder": [
@@ -1777,9 +1778,9 @@
                     "y": 44
                 },
                 "panelIndex": "75255ce8-2d49-4b4f-ac0e-a20fe8f4daec",
-                "title": "Scheduler process data [Metricbeat Kubernetes]",
+                "title": "Controller manager process data ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1792,22 +1793,21 @@
                             },
                             {
                                 "id": "metricbeat-*",
-                                "name": "d9aac793-88e8-4ae5-89e0-2b46dc998789",
+                                "name": "236aa40a-181f-4c61-af17-8df4ecba80d3",
                                 "type": "index-pattern"
                             }
                         ],
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "77da5988-3f03-4e8f-b1e4-39a94d8bec07": {
                                             "columnOrder": [
                                                 "7e1756d9-af1b-4204-a8d4-8c57987216f0",
                                                 "d523e6d2-50f3-4b45-8815-8259df43850c",
                                                 "cf481e4f-b568-4306-8da9-5e3d516ccbea",
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0",
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1"
+                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0"
                                             ],
                                             "columns": {
                                                 "7e1756d9-af1b-4204-a8d4-8c57987216f0": {
@@ -1834,7 +1834,7 @@
                                                 "cf481e4f-b568-4306-8da9-5e3d516ccbea": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "differences(last_value(kubernetes.controllermanager.process.memory.resident.bytes))",
+                                                    "label": "average(kubernetes.controllermanager.process.memory.resident.bytes)",
                                                     "operationType": "formula",
                                                     "params": {
                                                         "format": {
@@ -1843,41 +1843,25 @@
                                                                 "decimals": 1
                                                             }
                                                         },
-                                                        "formula": "differences(last_value(kubernetes.controllermanager.process.memory.resident.bytes))",
+                                                        "formula": "average(kubernetes.controllermanager.process.memory.resident.bytes)",
                                                         "isFormulaBroken": false
                                                     },
-                                                    "references": [
-                                                        "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": "s"
-                                                },
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.controllermanager.process.memory.resident.bytes: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(kubernetes.controllermanager.process.memory.resident.bytes))",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.controllermanager.process.memory.resident.bytes"
-                                                },
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(kubernetes.controllermanager.process.memory.resident.bytes))",
-                                                    "operationType": "differences",
                                                     "references": [
                                                         "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0"
                                                     ],
                                                     "scale": "ratio"
+                                                },
+                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of average(kubernetes.controllermanager.process.memory.resident.bytes)",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.controllermanager.process.memory.resident.bytes"
                                                 },
                                                 "d523e6d2-50f3-4b45-8815-8259df43850c": {
                                                     "dataType": "date",
@@ -1906,7 +1890,7 @@
                                     "meta": {
                                         "alias": null,
                                         "disabled": false,
-                                        "index": "d9aac793-88e8-4ae5-89e0-2b46dc998789",
+                                        "index": "236aa40a-181f-4c61-af17-8df4ecba80d3",
                                         "key": "kubernetes.controllermanager.process.cpu.sec",
                                         "negate": false,
                                         "type": "exists",
@@ -1979,9 +1963,9 @@
                     "y": 44
                 },
                 "panelIndex": "303702e1-ba33-49f2-b337-4cc7d7305606",
-                "title": "Resident memory variation  [Metricbeat Kubernetes]",
+                "title": "Average resident memory  ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2001,7 +1985,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "d3be0fa3-c7a4-49ba-b8cf-ab79f477f332": {
                                             "columnOrder": [
@@ -2205,9 +2189,9 @@
                     "y": 50
                 },
                 "panelIndex": "1604f0de-edd6-456e-8670-ab9b33988abb",
-                "title": "CPU usage increase over time [Metricbeat Kubernetes]",
+                "title": "CPU usage increase over time ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2291,7 +2275,7 @@
                 "panelIndex": "f8313a9d-ab58-448e-b183-75f914caf53f",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2311,7 +2295,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1048fff9-f5a4-446b-8173-e9e22d4b1cff": {
                                             "columnOrder": [
@@ -2483,9 +2467,9 @@
                     "y": 65
                 },
                 "panelIndex": "fd90adaf-517f-4b92-a5b5-c29f7a16663b",
-                "title": "Leader controller manager [Metricbeat Kubernetes]",
+                "title": "Leader controller manager ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2506,7 +2490,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**NOTE**: The default period to fetch the metrics used in **Requests and responses [Metricbeat Kubernetes]** visualization is **10s**. The timestamps from the visualizations were chosen according to that. Otherwise, they might be inaccurate. Adjust them by clicking on the **settings wheel** on the top right of the visualization and go to the **right side menu**. After that, write the custom period value on **Horizontal axis \u003e @timestamp \u003e Minimum interval**.",
+                            "markdown": "**NOTE**: The default period to fetch the metrics used in **Requests and responses counter rate** visualization is **10s**. The timestamps from the visualizations were chosen according to that. Otherwise, they might be inaccurate. Adjust them by clicking on the **settings wheel** on the top right of the visualization and go to the **right side menu**. After that, write the custom period value on **Horizontal axis \u003e @timestamp \u003e Minimum interval**.",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -2523,7 +2507,7 @@
                 },
                 "panelIndex": "83449269-d517-4fe6-9266-9d875070d90d",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2543,7 +2527,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7c7c4b67-a2df-427f-abbd-635e5fa73a9c": {
                                             "columnOrder": [
@@ -2844,9 +2828,9 @@
                     "y": 70
                 },
                 "panelIndex": "91a7ce56-6a49-4b7e-837f-31c184b48c09",
-                "title": "Requests and responses [Metricbeat Kubernetes]",
+                "title": "Requests and responses counter rate",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2861,7 +2845,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f7b7d15b-f8d9-4c06-abf0-7503ae32b8e9": {
                                             "columnOrder": [
@@ -3061,19 +3045,20 @@
                     "y": 71
                 },
                 "panelIndex": "1bd24fa1-319e-4cae-9d45-d821b06a8034",
-                "title": "Average request latency [Metricbeat Kubernetes]",
+                "title": "Average request latency ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             }
         ],
         "timeRestore": false,
-        "title": "[Metricbeat Kubernetes] Controller Manager",
+        "title": "Controller Manager",
         "version": 1
     },
-    "coreMigrationVersion": "8.5.1",
+    "coreMigrationVersion": "8.6.0",
+    "created_at": "2023-01-11T16:15:05.999Z",
     "id": "2ec26ce0-f5f1-11ec-8853-8b596bddf5f9",
     "migrationVersion": {
-        "dashboard": "8.5.0"
+        "dashboard": "8.6.0"
     },
     "references": [
         {
@@ -3158,7 +3143,7 @@
         },
         {
             "id": "metricbeat-*",
-            "name": "303702e1-ba33-49f2-b337-4cc7d7305606:d9aac793-88e8-4ae5-89e0-2b46dc998789",
+            "name": "303702e1-ba33-49f2-b337-4cc7d7305606:236aa40a-181f-4c61-af17-8df4ecba80d3",
             "type": "index-pattern"
         },
         {
@@ -3213,6 +3198,6 @@
         }
     ],
     "type": "dashboard",
-    "updated_at": "2023-01-03T10:21:34.800Z",
-    "version": "WzI2ODYsMV0="
+    "updated_at": "2023-01-11T16:15:05.999Z",
+    "version": "WzM0NTEsMV0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
@@ -450,7 +450,7 @@
                     "y": 3
                 },
                 "panelIndex": "aef813b5-85d5-46c9-a86a-2e273806d488",
-                "title": "Node collector ",
+                "title": "Node collector",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -744,7 +744,7 @@
                     "y": 13
                 },
                 "panelIndex": "2ba53067-d43d-42eb-ac50-2d941977ce95",
-                "title": "Workqueue additions increase rate ",
+                "title": "Workqueue additions increase rate",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -952,7 +952,7 @@
                     "y": 13
                 },
                 "panelIndex": "1cd3ebab-9630-4253-b9a6-5f921e5cb617",
-                "title": "Workqueue retries increase rate ",
+                "title": "Workqueue retries increase rate",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1361,7 +1361,7 @@
                     "y": 27
                 },
                 "panelIndex": "6a8b9a40-11ec-4790-a38d-2d88c5468f12",
-                "title": "Current unfinished work ",
+                "title": "Current unfinished work",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1778,7 +1778,7 @@
                     "y": 44
                 },
                 "panelIndex": "75255ce8-2d49-4b4f-ac0e-a20fe8f4daec",
-                "title": "Controller manager process data ",
+                "title": "Controller manager process data",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1963,7 +1963,7 @@
                     "y": 44
                 },
                 "panelIndex": "303702e1-ba33-49f2-b337-4cc7d7305606",
-                "title": "Average resident memory  ",
+                "title": "Average resident memory",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2189,7 +2189,7 @@
                     "y": 50
                 },
                 "panelIndex": "1604f0de-edd6-456e-8670-ab9b33988abb",
-                "title": "CPU usage increase over time ",
+                "title": "CPU usage increase over time",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2467,7 +2467,7 @@
                     "y": 65
                 },
                 "panelIndex": "fd90adaf-517f-4b92-a5b5-c29f7a16663b",
-                "title": "Leader controller manager ",
+                "title": "Leader controller manager",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -3045,7 +3045,7 @@
                     "y": 71
                 },
                 "panelIndex": "1bd24fa1-319e-4cae-9d45-d821b06a8034",
-                "title": "Average request latency ",
+                "title": "Average request latency",
                 "type": "lens",
                 "version": "8.6.0"
             }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/2ec26ce0-f5f1-11ec-8853-8b596bddf5f9.json
@@ -3051,7 +3051,7 @@
             }
         ],
         "timeRestore": false,
-        "title": "Controller Manager",
+        "title": "[Metricbeat Kubernetes] Controller Manager",
         "version": 1
     },
     "coreMigrationVersion": "8.6.0",

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
@@ -164,7 +164,7 @@
                     "y": 4
                 },
                 "panelIndex": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd",
-                "title": "Proxy ",
+                "title": "Proxy",
                 "type": "visualization",
                 "version": "8.6.0"
             },
@@ -391,7 +391,7 @@
                     "y": 7
                 },
                 "panelIndex": "f74e1a86-4370-4f65-a3b8-d92c9f25ff42",
-                "title": "Average network programming latency ",
+                "title": "Average network programming latency",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -602,7 +602,7 @@
                     "y": 7
                 },
                 "panelIndex": "34de2f11-faf2-49e8-aada-98c2cd5eb266",
-                "title": "Average SyncProxyRules latency ",
+                "title": "Average SyncProxyRules latency",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1019,7 +1019,7 @@
                     "y": 24
                 },
                 "panelIndex": "af47c34c-961a-463c-9d66-ffedcc2eef12",
-                "title": "Proxy process data ",
+                "title": "Proxy process data",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1179,7 +1179,7 @@
                     "y": 24
                 },
                 "panelIndex": "303702e1-ba33-49f2-b337-4cc7d7305606",
-                "title": "Average resident memory  ",
+                "title": "Average resident memory",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1380,7 +1380,7 @@
                     "y": 33
                 },
                 "panelIndex": "1604f0de-edd6-456e-8670-ab9b33988abb",
-                "title": "CPU usage increase over time ",
+                "title": "CPU usage increase over time",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1719,7 +1719,7 @@
                     "y": 52
                 },
                 "panelIndex": "1bd24fa1-319e-4cae-9d45-d821b06a8034",
-                "title": "Average request latency ",
+                "title": "Average request latency",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1902,7 +1902,7 @@
                     "y": 52
                 },
                 "panelIndex": "91a7ce56-6a49-4b7e-837f-31c184b48c09",
-                "title": "Requests counter rate ",
+                "title": "Requests counter rate",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2111,7 +2111,7 @@
                     "y": 66
                 },
                 "panelIndex": "24a2f3ce-a762-4e5f-8794-ff67fc70a41d",
-                "title": "Client error responses counter rate ",
+                "title": "Client error responses counter rate",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2353,7 +2353,7 @@
                     "y": 66
                 },
                 "panelIndex": "e3c408a3-6515-4104-b764-888f39fa6185",
-                "title": "Server error responses counter rate ",
+                "title": "Server error responses counter rate",
                 "type": "lens",
                 "version": "8.6.0"
             }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
@@ -7,7 +7,6 @@
             "panelsJSON": "{\"f53d0d21-4502-4dce-8004-017a92104040\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"host.name\",\"title\":\"Host\",\"id\":\"f53d0d21-4502-4dce-8004-017a92104040\",\"selectedOptions\":[],\"enhancements\":{},\"singleSelect\":false}},\"df56c430-83b1-436e-8b9c-fb027aaa29ca\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster\",\"singleSelect\":true,\"id\":\"df56c430-83b1-436e-8b9c-fb027aaa29ca\",\"selectedOptions\":[],\"enhancements\":{}}}}"
         },
         "description": "Kubernetes Proxy metrics",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -42,6 +41,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": true,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -64,7 +65,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "### Proxy\n\nThis dashboard uses data collected from the metrics endpoint of [kube proxy](https://kubernetes.io/docs/concepts/overview/components/#kube-proxy). Its purpose is to give an overview of what is happening inside it and detect problems that might be happening.",
+                            "markdown": "### Proxy\n\nThis dashboard collects data from [kube proxy](https://kubernetes.io/docs/concepts/overview/components/#kube-proxy) endpoint. Its purpose is to give an overview of what is happening inside it and detect problems that might be happening.",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -81,7 +82,7 @@
                 },
                 "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -165,7 +166,7 @@
                 "panelIndex": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd",
                 "title": "Proxy ",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -180,7 +181,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "5de1942f-e0a5-4ed8-86c0-972d57d62085": {
                                             "columnOrder": [
@@ -390,9 +391,9 @@
                     "y": 7
                 },
                 "panelIndex": "f74e1a86-4370-4f65-a3b8-d92c9f25ff42",
-                "title": "Average network programming latency [Metricbeat Kubernetes]",
+                "title": "Average network programming latency ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -407,7 +408,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0b5eadf5-2a9c-49a2-b862-d317822adfd8": {
                                             "columnOrder": [
@@ -601,9 +602,9 @@
                     "y": 7
                 },
                 "panelIndex": "34de2f11-faf2-49e8-aada-98c2cd5eb266",
-                "title": "Average SyncProxyRules latency [Metricbeat Kubernetes]",
+                "title": "Average SyncProxyRules latency ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -687,7 +688,7 @@
                 "panelIndex": "c3fee68f-01c6-49da-a759-2900b1cd15bf",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -707,7 +708,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "380c5d66-2e69-4e96-b5fb-ac4e5ab1c807": {
                                             "columnOrder": [
@@ -1018,9 +1019,9 @@
                     "y": 24
                 },
                 "panelIndex": "af47c34c-961a-463c-9d66-ffedcc2eef12",
-                "title": "Proxy process data [Metricbeat Kubernetes]",
+                "title": "Proxy process data ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1035,15 +1036,14 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "77da5988-3f03-4e8f-b1e4-39a94d8bec07": {
                                             "columnOrder": [
                                                 "7e1756d9-af1b-4204-a8d4-8c57987216f0",
                                                 "d523e6d2-50f3-4b45-8815-8259df43850c",
                                                 "cf481e4f-b568-4306-8da9-5e3d516ccbea",
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0",
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1"
+                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0"
                                             ],
                                             "columns": {
                                                 "7e1756d9-af1b-4204-a8d4-8c57987216f0": {
@@ -1070,7 +1070,7 @@
                                                 "cf481e4f-b568-4306-8da9-5e3d516ccbea": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "differences(last_value(kubernetes.proxy.process.memory.resident.bytes))",
+                                                    "label": "average(kubernetes.proxy.process.memory.resident.bytes)",
                                                     "operationType": "formula",
                                                     "params": {
                                                         "format": {
@@ -1079,41 +1079,25 @@
                                                                 "decimals": 1
                                                             }
                                                         },
-                                                        "formula": "differences(last_value(kubernetes.proxy.process.memory.resident.bytes))",
+                                                        "formula": "average(kubernetes.proxy.process.memory.resident.bytes)",
                                                         "isFormulaBroken": false
                                                     },
-                                                    "references": [
-                                                        "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": "s"
-                                                },
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.proxy.process.memory.resident.bytes: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(kubernetes.proxy.process.memory.resident.bytes))",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.proxy.process.memory.resident.bytes"
-                                                },
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(kubernetes.proxy.process.memory.resident.bytes))",
-                                                    "operationType": "differences",
                                                     "references": [
                                                         "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0"
                                                     ],
                                                     "scale": "ratio"
+                                                },
+                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of average(kubernetes.proxy.process.memory.resident.bytes)",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.proxy.process.memory.resident.bytes"
                                                 },
                                                 "d523e6d2-50f3-4b45-8815-8259df43850c": {
                                                     "dataType": "date",
@@ -1195,9 +1179,9 @@
                     "y": 24
                 },
                 "panelIndex": "303702e1-ba33-49f2-b337-4cc7d7305606",
-                "title": "Resident memory variation  [Metricbeat Kubernetes]",
+                "title": "Average resident memory  ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1212,7 +1196,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "d3be0fa3-c7a4-49ba-b8cf-ab79f477f332": {
                                             "columnOrder": [
@@ -1396,9 +1380,9 @@
                     "y": 33
                 },
                 "panelIndex": "1604f0de-edd6-456e-8670-ab9b33988abb",
-                "title": "CPU usage increase over time [Metricbeat Kubernetes]",
+                "title": "CPU usage increase over time ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1482,7 +1466,7 @@
                 "panelIndex": "f8313a9d-ab58-448e-b183-75f914caf53f",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1503,7 +1487,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**NOTE**: The default period to fetch the metrics used in **Requests counter rate [Metricbeat Kubernetes], Client error responses counter rate [Metricbeat Kubernetes]** and **Server error responses counter rate [Metricbeat Kubernetes]** visualization is **10s**. The timestamps from the visualizations were chosen according to that. Otherwise, they might be inaccurate. Adjust them by clicking on the **settings wheel** on the top right of the visualization and go to the **right side menu**. After that, write the custom period value on **Horizontal axis \u003e @timestamp \u003e Minimum interval**.",
+                            "markdown": "**NOTE**: The default period to fetch the metrics used in **Requests counter rate , Client error responses counter rate** and **Server error responses counter rate** visualization is **10s**. The timestamps from the visualizations were chosen according to that. Otherwise, they might be inaccurate. Adjust them by clicking on the **settings wheel** on the top right of the visualization and go to the **right side menu**. After that, write the custom period value on **Horizontal axis \u003e @timestamp \u003e Minimum interval**.",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -1520,7 +1504,7 @@
                 },
                 "panelIndex": "6a11dafa-5cd1-49e7-9806-15110738093d",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1535,7 +1519,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f7b7d15b-f8d9-4c06-abf0-7503ae32b8e9": {
                                             "columnOrder": [
@@ -1735,9 +1719,9 @@
                     "y": 52
                 },
                 "panelIndex": "1bd24fa1-319e-4cae-9d45-d821b06a8034",
-                "title": "Average request latency [Metricbeat Kubernetes]",
+                "title": "Average request latency ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1752,7 +1736,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7c7c4b67-a2df-427f-abbd-635e5fa73a9c": {
                                             "columnOrder": [
@@ -1918,9 +1902,9 @@
                     "y": 52
                 },
                 "panelIndex": "91a7ce56-6a49-4b7e-837f-31c184b48c09",
-                "title": "Requests counter rate [Metricbeat Kubernetes]",
+                "title": "Requests counter rate ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1935,7 +1919,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "acbb7181-0ff2-4164-9761-8b2c430d6a68": {
                                             "columnOrder": [
@@ -2127,9 +2111,9 @@
                     "y": 66
                 },
                 "panelIndex": "24a2f3ce-a762-4e5f-8794-ff67fc70a41d",
-                "title": "Client error responses counter rate [Metricbeat Kubernetes]",
+                "title": "Client error responses counter rate ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2144,7 +2128,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "54af7a75-9eab-4746-b959-378d6bbb7cf6": {
                                             "columnOrder": [
@@ -2369,19 +2353,20 @@
                     "y": 66
                 },
                 "panelIndex": "e3c408a3-6515-4104-b764-888f39fa6185",
-                "title": "Server error responses counter rate [Metricbeat Kubernetes]",
+                "title": "Server error responses counter rate ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             }
         ],
         "timeRestore": false,
-        "title": "[Metricbeat Kubernetes] Proxy",
+        "title": " Proxy",
         "version": 1
     },
-    "coreMigrationVersion": "8.5.1",
+    "coreMigrationVersion": "8.6.0",
+    "created_at": "2023-01-11T16:15:13.706Z",
     "id": "5e649d60-9901-11e9-ba57-b7ab4e2d4b58",
     "migrationVersion": {
-        "dashboard": "8.5.0"
+        "dashboard": "8.6.0"
     },
     "references": [
         {
@@ -2466,6 +2451,6 @@
         }
     ],
     "type": "dashboard",
-    "updated_at": "2023-01-03T10:24:03.129Z",
-    "version": "WzI5MTUsMV0="
+    "updated_at": "2023-01-11T16:15:13.706Z",
+    "version": "WzM1MDAsMV0="
 }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/5e649d60-9901-11e9-ba57-b7ab4e2d4b58.json
@@ -2359,7 +2359,7 @@
             }
         ],
         "timeRestore": false,
-        "title": " Proxy",
+        "title": "[Metricbeat Kubernetes] Proxy",
         "version": 1
     },
     "coreMigrationVersion": "8.6.0",

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -337,7 +337,7 @@
                     "y": 3
                 },
                 "panelIndex": "a2b844d8-11e3-4469-af4b-744d33b603ad",
-                "title": "Pending pods ",
+                "title": "Pending pods",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -769,7 +769,7 @@
                     "y": 12
                 },
                 "panelIndex": "181a3fe5-e5b5-472e-98af-ea4aaadc3109",
-                "title": "Average scheduling attempt latency ",
+                "title": "Average scheduling attempt latency",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -933,7 +933,7 @@
                     "y": 12
                 },
                 "panelIndex": "d35d8849-89ba-42b8-8120-c14b087f9690",
-                "title": "Attempts counter rate by result ",
+                "title": "Attempts counter rate by result",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1227,7 +1227,7 @@
                     "y": 29
                 },
                 "panelIndex": "2ba53067-d43d-42eb-ac50-2d941977ce95",
-                "title": "Workqueue additions increase rate ",
+                "title": "Workqueue additions increase rate",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1435,7 +1435,7 @@
                     "y": 29
                 },
                 "panelIndex": "1cd3ebab-9630-4253-b9a6-5f921e5cb617",
-                "title": "Workqueue retries increase rate ",
+                "title": "Workqueue retries increase rate",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -1864,7 +1864,7 @@
                     "y": 43
                 },
                 "panelIndex": "6a8b9a40-11ec-4790-a38d-2d88c5468f12",
-                "title": "Current unfinished work ",
+                "title": "Current unfinished work",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2265,7 +2265,7 @@
                     "y": 60
                 },
                 "panelIndex": "a0716ae8-4157-473d-8eba-8ff6625fed4b",
-                "title": "Scheduler process data ",
+                "title": "Scheduler process data",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2425,7 +2425,7 @@
                     "y": 60
                 },
                 "panelIndex": "303702e1-ba33-49f2-b337-4cc7d7305606",
-                "title": "Average resident memory  ",
+                "title": "Average resident memory",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2651,7 +2651,7 @@
                     "y": 66
                 },
                 "panelIndex": "1604f0de-edd6-456e-8670-ab9b33988abb",
-                "title": "CPU usage increase over time ",
+                "title": "CPU usage increase over time",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -2928,7 +2928,7 @@
                     "y": 81
                 },
                 "panelIndex": "668a51aa-98da-465e-9b09-d49e4f219968",
-                "title": "Leader scheduler ",
+                "title": "Leader scheduler",
                 "type": "lens",
                 "version": "8.6.0"
             },
@@ -3506,7 +3506,7 @@
                     "y": 87
                 },
                 "panelIndex": "1bd24fa1-319e-4cae-9d45-d821b06a8034",
-                "title": "Average request latency ",
+                "title": "Average request latency",
                 "type": "lens",
                 "version": "8.6.0"
             }

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -3512,7 +3512,7 @@
             }
         ],
         "timeRestore": false,
-        "title": " Scheduler",
+        "title": "[Metricbeat Kubernetes] Scheduler",
         "version": 1
     },
     "coreMigrationVersion": "8.6.0",

--- a/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
+++ b/metricbeat/module/kubernetes/_meta/kibana/7/dashboard/f5ab5510-9c94-11e9-94fd-c91206cd5249.json
@@ -7,7 +7,6 @@
             "panelsJSON": "{\"f53d0d21-4502-4dce-8004-017a92104040\":{\"order\":1,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"host.name\",\"title\":\"Host\",\"id\":\"f53d0d21-4502-4dce-8004-017a92104040\",\"selectedOptions\":[],\"enhancements\":{},\"singleSelect\":false}},\"df56c430-83b1-436e-8b9c-fb027aaa29ca\":{\"order\":0,\"width\":\"medium\",\"grow\":true,\"type\":\"optionsListControl\",\"explicitInput\":{\"fieldName\":\"orchestrator.cluster.name\",\"title\":\"Cluster\",\"singleSelect\":true,\"id\":\"df56c430-83b1-436e-8b9c-fb027aaa29ca\",\"selectedOptions\":[],\"enhancements\":{}}}}"
         },
         "description": "Kubernetes Scheduler metrics",
-        "hits": 0,
         "kibanaSavedObjectMeta": {
             "searchSourceJSON": {
                 "filter": [
@@ -42,6 +41,8 @@
         "optionsJSON": {
             "hidePanelTitles": false,
             "syncColors": true,
+            "syncCursor": true,
+            "syncTooltips": false,
             "useMargins": true
         },
         "panelsJSON": [
@@ -64,7 +65,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "### Scheduler\n\nThis dashboard uses data collected from the metrics endpoint of [kube scheduler](https://kubernetes.io/docs/concepts/overview/components/#kube-scheduler). Its purpose is to give an overview of what is happening inside it through this component metrics and detect problems that might be happening. \n\n**WARNING**: This dataset **requires access** to the Kubernetes scheduler endpoint. Refer [here](https://docs.elastic.co/en/integrations/kubernetes#scheduler-and-controllermanager) to learn how to enable it. In some \"As a Service\" Kubernetes implementations, like GKE or AKS, it is **not possible** to access its metrics.",
+                            "markdown": "### Scheduler\n\nThis dashboard collects metrics from [kube scheduler](https://kubernetes.io/docs/concepts/overview/components/#kube-scheduler) endpoint. Its purpose is to give an overview of what is happening inside it through this component metrics and detect problems that might be happening. \n\n**WARNING**: This dataset **requires access** to the Kubernetes scheduler endpoint. Refer [here](https://docs.elastic.co/en/integrations/kubernetes#scheduler-and-controllermanager) to learn how to enable it. In some \"As a Service\" Kubernetes implementations, like GKE or AKS, it is **not possible** to access its metrics.",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -81,7 +82,7 @@
                 },
                 "panelIndex": "c13eb504-6afb-4fa5-8a7d-a75c5fee15b7",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -165,7 +166,7 @@
                 "panelIndex": "ff6afcdf-0de2-47fb-aa9e-72b48f11e0cd",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -203,7 +204,7 @@
                 },
                 "panelIndex": "a47d16df-1a5a-49e1-9a33-dba87c371904",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -218,7 +219,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "0c578d26-c937-4b73-a3a6-e15ebd5854e6": {
                                             "columnOrder": [
@@ -336,9 +337,9 @@
                     "y": 3
                 },
                 "panelIndex": "a2b844d8-11e3-4469-af4b-744d33b603ad",
-                "title": "Pending pods [Metricbeat Kubernetes]",
+                "title": "Pending pods ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -430,7 +431,7 @@
                 },
                 "panelIndex": "d90b0470-44ab-4636-b90b-2b95e79e0577",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -522,7 +523,7 @@
                 "panelIndex": "c6af3313-89c6-493b-8456-a296d3cd78a8",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -542,7 +543,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "c0fe3677-6a5b-4340-8ad0-d8e31b042fe8": {
                                             "columnOrder": [
@@ -768,9 +769,9 @@
                     "y": 12
                 },
                 "panelIndex": "181a3fe5-e5b5-472e-98af-ea4aaadc3109",
-                "title": "Average scheduling attempt latency [Metricbeat Kubernetes]",
+                "title": "Average scheduling attempt latency ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -785,7 +786,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "2b43c72b-5964-4c48-8239-72a42fbe334f": {
                                             "columnOrder": [
@@ -932,9 +933,9 @@
                     "y": 12
                 },
                 "panelIndex": "d35d8849-89ba-42b8-8120-c14b087f9690",
-                "title": "Attempts counter rate per result [Metricbeat Kubernetes]",
+                "title": "Attempts counter rate by result ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1018,7 +1019,7 @@
                 "panelIndex": "0599e0ae-2375-4ceb-b12d-2ebec4310cc6",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1038,7 +1039,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "76c85206-02c1-4f35-bb0d-c1d4d3ee59d7": {
                                             "columnOrder": [
@@ -1226,9 +1227,9 @@
                     "y": 29
                 },
                 "panelIndex": "2ba53067-d43d-42eb-ac50-2d941977ce95",
-                "title": "Workqueue additions increase rate [Metricbeat Kubernetes]",
+                "title": "Workqueue additions increase rate ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1248,7 +1249,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "77b347b2-91fa-470f-861d-ada0e175cbc4": {
                                             "columnOrder": [
@@ -1434,9 +1435,9 @@
                     "y": 29
                 },
                 "panelIndex": "1cd3ebab-9630-4253-b9a6-5f921e5cb617",
-                "title": "Workqueue retries increase rate [Metricbeat Kubernetes]",
+                "title": "Workqueue retries increase rate ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1456,7 +1457,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "2b80230c-9cc8-444f-b092-1fbc4d764992": {
                                             "columnOrder": [
@@ -1649,9 +1650,9 @@
                     "y": 43
                 },
                 "panelIndex": "3a26dffa-0696-485d-b991-1dbc5092082e",
-                "title": "Workqueue depth variation [Metricbeat Kubernetes]",
+                "title": "Workqueue depth rate",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1671,7 +1672,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "a2facaed-7c02-4fb6-9126-5512b8ffd26f": {
                                             "columnOrder": [
@@ -1863,9 +1864,9 @@
                     "y": 43
                 },
                 "panelIndex": "6a8b9a40-11ec-4790-a38d-2d88c5468f12",
-                "title": "Current unfinished work [Metricbeat Kubernetes]",
+                "title": "Current unfinished work ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1949,7 +1950,7 @@
                 "panelIndex": "c3fee68f-01c6-49da-a759-2900b1cd15bf",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -1969,7 +1970,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "380c5d66-2e69-4e96-b5fb-ac4e5ab1c807": {
                                             "columnOrder": [
@@ -2264,9 +2265,9 @@
                     "y": 60
                 },
                 "panelIndex": "a0716ae8-4157-473d-8eba-8ff6625fed4b",
-                "title": "Scheduler process data [Metricbeat Kubernetes]",
+                "title": "Scheduler process data ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2281,15 +2282,14 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "77da5988-3f03-4e8f-b1e4-39a94d8bec07": {
                                             "columnOrder": [
                                                 "7e1756d9-af1b-4204-a8d4-8c57987216f0",
                                                 "d523e6d2-50f3-4b45-8815-8259df43850c",
                                                 "cf481e4f-b568-4306-8da9-5e3d516ccbea",
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0",
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1"
+                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0"
                                             ],
                                             "columns": {
                                                 "7e1756d9-af1b-4204-a8d4-8c57987216f0": {
@@ -2316,7 +2316,7 @@
                                                 "cf481e4f-b568-4306-8da9-5e3d516ccbea": {
                                                     "dataType": "number",
                                                     "isBucketed": false,
-                                                    "label": "differences(last_value(kubernetes.scheduler.process.memory.resident.bytes))",
+                                                    "label": "average(kubernetes.scheduler.process.memory.resident.bytes)",
                                                     "operationType": "formula",
                                                     "params": {
                                                         "format": {
@@ -2325,41 +2325,25 @@
                                                                 "decimals": 1
                                                             }
                                                         },
-                                                        "formula": "differences(last_value(kubernetes.scheduler.process.memory.resident.bytes))",
+                                                        "formula": "average(kubernetes.scheduler.process.memory.resident.bytes)",
                                                         "isFormulaBroken": false
                                                     },
-                                                    "references": [
-                                                        "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1"
-                                                    ],
-                                                    "scale": "ratio",
-                                                    "timeScale": "s"
-                                                },
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "filter": {
-                                                        "language": "kuery",
-                                                        "query": "kubernetes.scheduler.process.memory.resident.bytes: *"
-                                                    },
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(kubernetes.scheduler.process.memory.resident.bytes))",
-                                                    "operationType": "last_value",
-                                                    "params": {
-                                                        "sortField": "@timestamp"
-                                                    },
-                                                    "scale": "ratio",
-                                                    "sourceField": "kubernetes.scheduler.process.memory.resident.bytes"
-                                                },
-                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX1": {
-                                                    "customLabel": true,
-                                                    "dataType": "number",
-                                                    "isBucketed": false,
-                                                    "label": "Part of differences(last_value(kubernetes.scheduler.process.memory.resident.bytes))",
-                                                    "operationType": "differences",
                                                     "references": [
                                                         "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0"
                                                     ],
                                                     "scale": "ratio"
+                                                },
+                                                "cf481e4f-b568-4306-8da9-5e3d516ccbeaX0": {
+                                                    "customLabel": true,
+                                                    "dataType": "number",
+                                                    "isBucketed": false,
+                                                    "label": "Part of average(kubernetes.scheduler.process.memory.resident.bytes)",
+                                                    "operationType": "average",
+                                                    "params": {
+                                                        "emptyAsNull": false
+                                                    },
+                                                    "scale": "ratio",
+                                                    "sourceField": "kubernetes.scheduler.process.memory.resident.bytes"
                                                 },
                                                 "d523e6d2-50f3-4b45-8815-8259df43850c": {
                                                     "dataType": "date",
@@ -2441,9 +2425,9 @@
                     "y": 60
                 },
                 "panelIndex": "303702e1-ba33-49f2-b337-4cc7d7305606",
-                "title": "Resident memory variation  [Metricbeat Kubernetes]",
+                "title": "Average resident memory  ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2463,7 +2447,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "d3be0fa3-c7a4-49ba-b8cf-ab79f477f332": {
                                             "columnOrder": [
@@ -2667,9 +2651,9 @@
                     "y": 66
                 },
                 "panelIndex": "1604f0de-edd6-456e-8670-ab9b33988abb",
-                "title": "CPU usage increase over time [Metricbeat Kubernetes]",
+                "title": "CPU usage increase over time ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2753,7 +2737,7 @@
                 "panelIndex": "f8313a9d-ab58-448e-b183-75f914caf53f",
                 "title": "",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2773,7 +2757,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "1048fff9-f5a4-446b-8173-e9e22d4b1cff": {
                                             "columnOrder": [
@@ -2944,9 +2928,9 @@
                     "y": 81
                 },
                 "panelIndex": "668a51aa-98da-465e-9b09-d49e4f219968",
-                "title": "Leader scheduler [Metricbeat Kubernetes]",
+                "title": "Leader scheduler ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -2967,7 +2951,7 @@
                         "id": "",
                         "params": {
                             "fontSize": 12,
-                            "markdown": "**NOTE**: The default period to fetch the metrics used in **Requests and responses [Metricbeat Kubernetes]** visualization is **10s**. The timestamps from the visualizations were chosen according to that. Otherwise, they might be inaccurate. Adjust them by clicking on the **settings wheel** on the top right of the visualization and go to the **right side menu**. After that, write the custom period value on **Horizontal axis \u003e @timestamp \u003e Minimum interval**.",
+                            "markdown": "**NOTE**: The default period to fetch the metrics used in **Requests and responses counter rate** visualization is **10s**. The timestamps from the visualizations were chosen according to that. Otherwise, they might be inaccurate. Adjust them by clicking on the **settings wheel** on the top right of the visualization and go to the **right side menu**. After that, write the custom period value on **Horizontal axis \u003e @timestamp \u003e Minimum interval**.",
                             "openLinksInNewTab": false
                         },
                         "title": "",
@@ -2984,7 +2968,7 @@
                 },
                 "panelIndex": "e70eea20-8653-4340-b6dd-620090d3cf7a",
                 "type": "visualization",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -3004,7 +2988,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "7c7c4b67-a2df-427f-abbd-635e5fa73a9c": {
                                             "columnOrder": [
@@ -3305,9 +3289,9 @@
                     "y": 86
                 },
                 "panelIndex": "91a7ce56-6a49-4b7e-837f-31c184b48c09",
-                "title": "Requests and responses [Metricbeat Kubernetes]",
+                "title": "Requests and responses counter rate",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             },
             {
                 "embeddableConfig": {
@@ -3322,7 +3306,7 @@
                         "state": {
                             "adHocDataViews": {},
                             "datasourceStates": {
-                                "indexpattern": {
+                                "formBased": {
                                     "layers": {
                                         "f7b7d15b-f8d9-4c06-abf0-7503ae32b8e9": {
                                             "columnOrder": [
@@ -3522,19 +3506,20 @@
                     "y": 87
                 },
                 "panelIndex": "1bd24fa1-319e-4cae-9d45-d821b06a8034",
-                "title": "Average request latency [Metricbeat Kubernetes]",
+                "title": "Average request latency ",
                 "type": "lens",
-                "version": "8.5.1"
+                "version": "8.6.0"
             }
         ],
         "timeRestore": false,
-        "title": "[Metricbeat Kubernetes] Scheduler",
+        "title": " Scheduler",
         "version": 1
     },
-    "coreMigrationVersion": "8.5.1",
+    "coreMigrationVersion": "8.6.0",
+    "created_at": "2023-01-11T16:15:10.039Z",
     "id": "f5ab5510-9c94-11e9-94fd-c91206cd5249",
     "migrationVersion": {
-        "dashboard": "8.5.0"
+        "dashboard": "8.6.0"
     },
     "references": [
         {
@@ -3694,6 +3679,6 @@
         }
     ],
     "type": "dashboard",
-    "updated_at": "2023-01-03T10:20:30.278Z",
-    "version": "WzI2NjYsMV0="
+    "updated_at": "2023-01-11T16:15:10.039Z",
+    "version": "WzM0NzYsMV0="
 }


### PR DESCRIPTION
## What does this PR do?

Following the comments on https://github.com/elastic/integrations/pull/4948, dashboards were updated:

- Visualization for resident memory use now average instead of rate
- `[Metricbeat Kubernetes]` was removed from all titles


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Relates  to https://github.com/elastic/integrations/pull/4948


## Screenshots


![image](https://user-images.githubusercontent.com/113898685/211860697-f355aa5b-e5ab-4cdf-a72b-7977054907e8.png)

