### PR TITLE
golang-crossbuild: fix the issue with the CVE-2022-24765

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -309,6 +309,9 @@ func (b GolangCrossBuilder) Build() error {
 		args = append(args,
 			"--env", "EXEC_UID="+strconv.Itoa(os.Getuid()),
 			"--env", "EXEC_GID="+strconv.Itoa(os.Getgid()),
+			// Force the user/group to match the one from the host
+			// See https://github.com/elastic/golang-crossbuild/issues/232
+			"--user", strconv.Itoa(os.Getuid())+":"+strconv.Itoa(os.Getgid()),
 		)
 	}
 	if versionQualified {

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -309,9 +309,6 @@ func (b GolangCrossBuilder) Build() error {
 		args = append(args,
 			"--env", "EXEC_UID="+strconv.Itoa(os.Getuid()),
 			"--env", "EXEC_GID="+strconv.Itoa(os.Getgid()),
-			// Force the user/group to match the one from the host
-			// See https://github.com/elastic/golang-crossbuild/issues/232
-			"--user", strconv.Itoa(os.Getuid())+":"+strconv.Itoa(os.Getgid()),
 		)
 	}
 	if versionQualified {

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -272,7 +272,7 @@ func (b GolangCrossBuilder) Build() error {
 		return fmt.Errorf("failed to determine repo root and package sub dir: %w", err)
 	}
 
-	mountPoint := filepath.ToSlash(filepath.Join("/go", "src", repoInfo.CanonicalRootImportPath))
+	mountPoint, _ := DockerMountPoint()
 	// use custom dir for build if given, subdir if not:
 	cwd := repoInfo.SubDir
 	if b.InDir != "" {
@@ -344,6 +344,15 @@ func (b GolangCrossBuilder) Build() error {
 	)
 
 	return dockerRun(args...)
+}
+
+func DockerMountPoint() (string, error) {
+	repoInfo, err := GetProjectRepoInfo()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.ToSlash(filepath.Join("/go", "src", repoInfo.CanonicalRootImportPath)), nil
 }
 
 // DockerChown chowns files generated during build. EXEC_UID and EXEC_GID must

--- a/dev-tools/mage/pkgdeps.go
+++ b/dev-tools/mage/pkgdeps.go
@@ -110,6 +110,7 @@ func (i *PackageInstaller) Install(p PlatformDescription) error {
 }
 
 func installDependencies(arch string, pkgs ...string) error {
+	fmt.Printf(">>> installDependencies: Building for %v\n", arch)
 	// See https://github.com/elastic/golang-crossbuild/issues/232
 	mountPoint, err := DockerMountPoint()
 	if err != nil {

--- a/dev-tools/mage/pkgdeps.go
+++ b/dev-tools/mage/pkgdeps.go
@@ -110,6 +110,11 @@ func (i *PackageInstaller) Install(p PlatformDescription) error {
 }
 
 func installDependencies(arch string, pkgs ...string) error {
+	// See https://github.com/elastic/golang-crossbuild/issues/232
+	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", "/go/src/github.com/elastic/beats"); err != nil {
+		return err
+	}
+
 	if arch != "" {
 		err := sh.Run("dpkg", "--add-architecture", arch)
 		if err != nil {

--- a/dev-tools/mage/pkgdeps.go
+++ b/dev-tools/mage/pkgdeps.go
@@ -111,7 +111,12 @@ func (i *PackageInstaller) Install(p PlatformDescription) error {
 
 func installDependencies(arch string, pkgs ...string) error {
 	// See https://github.com/elastic/golang-crossbuild/issues/232
-	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", "/go/src/github.com/elastic/beats"); err != nil {
+	mountPoint, err := DockerMountPoint()
+	if err != nil {
+		return err
+	}
+	// use custom dir for build if given, subdir if not:
+	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", mountPoint); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## What does this PR do?

Fix the issue with the `CVE-2022-24765`, so the workspace is set as safe

## Why is it important?

Otherwise, it will fail with:

```
[2023-01-11T09:58:36.531Z] >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=o64-clang, CXX=o64-clang++, GOARCH=amd64, GOARM=, GOOS=darwin, PLATFORM_ID=darwin-amd64]
[2023-01-11T09:58:36.632Z] fatal: detected dubious ownership in repository at '/go/src/github.com/elastic/beats'
```

## How to test this PR locally


```
cd <your-beats>
PACKAGES="docker" PLATFORMS="linux/arm64" mage package
```

##. Further details

b32084d4aa4bf754061224ffb46f17faf0d85432 didn't work  since the docker container requires the docker use so it can run the `installDependencies` function defined in `dev-tools/mage/pkgdeps.go

So I ended up using the suggestion from https://github.com/elastic/golang-crossbuild/issues/232

## Related issues

- Relates https://github.com/elastic/golang-crossbuild/issues/232

