### PR TITLE
golang-crossbuild: Fix a vulnerability CVE-2022-24765

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -334,7 +334,7 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
 		// See https://github.com/elastic/golang-crossbuild/issues/232
-		"--env", fmt.Sprintf("GIT_CEILING_DIRECTORIES=%v", workDir),
+		"--env", fmt.Sprintf("GIT_CEILING_DIRECTORIES=%v", mountPoint),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -334,7 +334,7 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
 		// See https://github.com/elastic/golang-crossbuild/issues/232
-		//"--env", fmt.Sprintf("GIT_CEILING_DIRECTORIES=%v", workDir),
+		"--env", fmt.Sprintf("GIT_CEILING_DIRECTORIES=%v", workDir),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -333,6 +333,8 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", "MAGEFILE_VERBOSE="+verbose,
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
+		// See https://github.com/elastic/golang-crossbuild/issues/232
+		//"--env", fmt.Sprintf("GIT_CEILING_DIRECTORIES=%v", workDir),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -334,7 +334,7 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
 		// See https://github.com/elastic/golang-crossbuild/issues/232
-		"--env", fmt.Sprintf("GIT_CEILING_DIRECTORIES=%v", mountPoint),
+		"--env", "GIT_CEILING_DIRECTORIES=/"),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -334,7 +334,7 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
 		// See https://github.com/elastic/golang-crossbuild/issues/232
-		"--env", "GIT_CEILING_DIRECTORIES=\/"),
+		"--env", "GIT_CEILING_DIRECTORIES=/",
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,

--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -334,7 +334,7 @@ func (b GolangCrossBuilder) Build() error {
 		"--env", "MAGEFILE_TIMEOUT="+EnvOr("MAGEFILE_TIMEOUT", ""),
 		"--env", fmt.Sprintf("SNAPSHOT=%v", Snapshot),
 		// See https://github.com/elastic/golang-crossbuild/issues/232
-		"--env", "GIT_CEILING_DIRECTORIES=/"),
+		"--env", "GIT_CEILING_DIRECTORIES=\/"),
 		"-v", repoInfo.RootDir+":"+mountPoint,
 		"-w", workDir,
 		image,


### PR DESCRIPTION
## What does this PR do?

The [announcement for CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/) recommends setting GIT_CEILING_DIRECTORIES to prevent out-of-bounds config access.

## Why is it important?

Otherwise, it will fail with:

```
[2023-01-11T09:58:36.531Z] >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=o64-clang, CXX=o64-clang++, GOARCH=amd64, GOARM=, GOOS=darwin, PLATFORM_ID=darwin-amd64]
[2023-01-11T09:58:36.632Z] fatal: detected dubious ownership in repository at '/go/src/github.com/elastic/beats'
```

## How to test this PR locally

```
cd <your-beats>
PACKAGES="docker" PLATFORMS="linux/arm64" mage package
```


## Related issues

- Relates https://github.com/elastic/golang-crossbuild/issues/232
- Duplicates https://github.com/elastic/beats/pull/34241

