### PR TITLE
Osquerybeat: Fix data_stream configuration, enforce the default values used before 8.6.0

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -105,6 +105,9 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Support Oracle-specific connection strings in SQL module {issue}32089[32089] {pull}32293[32293]
 - Remove deprecated metrics from controller manager, scheduler and proxy {pull}34161[34161]
 
+*Osquerybeat*
+
+- Fix data_stream configuration, enforce the default values used before 8.6.0. {pull}34246[34246]
 
 *Packetbeat*
 

--- a/x-pack/osquerybeat/cmd/root.go
+++ b/x-pack/osquerybeat/cmd/root.go
@@ -23,6 +23,7 @@ import (
 
 	_ "github.com/elastic/beats/v7/x-pack/libbeat/include"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/beater"
+	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/config"
 	"github.com/elastic/beats/v7/x-pack/osquerybeat/internal/install"
 )
 
@@ -74,14 +75,30 @@ func genVerifyCmd(_ instance.Settings) *cobra.Command {
 func osquerybeatCfg(rawIn *proto.UnitExpectedConfig, agentInfo *client.AgentInfo) ([]*reload.ConfigWithMeta, error) {
 	// Convert to streams, osquerybeat doesn't use streams
 	streams := make([]*proto.Stream, 1)
+
+	// Enforce the datastream dataset and type because the libbeat call to CreateInputsFromStreams
+	// provides it's own defaults that are breaking the osquery with logstash
+	// The target datastream for the publisher is expected to be logs-osquery_manager.result-<namespace>
+	// while the libebeat management.CreateInputsFromStreams defaults to osquery-generic-default
+	var datastream *proto.DataStream
+	if rawIn.GetDataStream() != nil {
+		// Copy by value and modify dataset and type
+		ds := *rawIn.GetDataStream()
+		ds.Dataset = config.DefaultDataset
+		ds.Type = config.DefaultType
+		datastream = &ds
+	}
+
 	streams[0] = &proto.Stream{
 		Source:     rawIn.GetSource(),
 		Id:         rawIn.GetId(),
-		DataStream: rawIn.GetDataStream(),
+		DataStream: datastream,
 	}
+
 	rawIn.Streams = streams
 
 	procs := defaultProcessors()
+
 	modules, err := management.CreateInputsFromStreams(rawIn, "osquery", agentInfo, procs...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating input list from raw expected config: %w", err)


### PR DESCRIPTION
## What does this PR do?

Fixes the values for the ```data_stream```: ```type``` and```dataset```. 

The 8.6.0 has wrong values set after switching to using the V2 libbeat ```management.CreateInputsFromStreams``` implementation that is inserting the policy processor:
```
  processors:
  - add_fields:
      fields:
        dataset: generic
        namespace: default
        type: osquery
      target: data_stream
```
resulting in these ```data_stream``` properties.
```
"data_stream": {
            "namespace": "default",
            "type": "osquery",
            "dataset": "generic"
},
```

This PR sets the expected default values on the datastream before the configuration transformation takes place thus setting the values back to what it was before 8.6.0:
```
"data_stream": {
            "namespace": "default",
            "type": "logs",
            "dataset": "osquery_manager.result"
},
```

These fields are mapped as the constant_keywords and should never be changed.

## Why is it important?

Fixes the breakage with the Osquery Logstash integration because the logstash sends the data based on the ```data_stream``` "hint", resulting in the output going to ```osquery-generic-default``` instead of ```logs-osquery_manager.result-default```

Also the defect makes 8.6.0 osquery results incompatible with previous releases results documents data. And since the fields are constant, in the mixed agent versions environment or upon upgrade this can cause the issues indexing the osquery results documents.
Resulting in the errors such as:
``` 
[constant_keyword] field [data_stream.type] only accepts values that are equal to the value defined in the mappings [logs], but got [osquery]
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes https://github.com/elastic/beats/issues/34250


## Screenshots

Verified the document ```data_stream``` is set correctly when sending data to elasticsearch output

<img width="652" alt="Screen Shot 2023-01-12 at 12 07 15 PM" src="https://user-images.githubusercontent.com/872351/212147389-1cbebbf9-f4ac-41a5-b9d1-943df427016c.png">

<img width="553" alt="Screen Shot 2023-01-12 at 12 07 22 PM" src="https://user-images.githubusercontent.com/872351/212147420-20c4ff0d-de12-44b3-b632-0db845816977.png">

<img width="1272" alt="Screen Shot 2023-01-12 at 12 07 56 PM" src="https://user-images.githubusercontent.com/872351/212147453-d5d33f0d-0bf7-4cc0-a616-244bfee7637a.png">

<img width="748" alt="Screen Shot 2023-01-12 at 12 08 34 PM" src="https://user-images.githubusercontent.com/872351/212147512-ddb82173-f879-42d7-bcd6-5969692b07ce.png">


Verified the document ```data_stream``` is set correctly when sending data to logstash output

<img width="378" alt="Screen Shot 2023-01-12 at 12 06 01 PM" src="https://user-images.githubusercontent.com/872351/212147719-f2c885c4-d60c-4ab1-9e43-695a57487efb.png">

<img width="557" alt="Screen Shot 2023-01-12 at 12 05 51 PM" src="https://user-images.githubusercontent.com/872351/212147744-28d8c211-c0fa-46aa-abdb-b813f08572a4.png">

<img width="667" alt="Screen Shot 2023-01-12 at 12 04 34 PM" src="https://user-images.githubusercontent.com/872351/212147776-0892210f-38b8-4e4c-9be2-af54ec4a1e80.png">

<img width="1288" alt="Screen Shot 2023-01-12 at 12 03 31 PM" src="https://user-images.githubusercontent.com/872351/212147805-12788282-9f0c-4962-8f48-5602064aecc4.png">

