### PR TITLE
Marshal heartbeat duration as int64,string to prevent int64 -> float conversion

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -86,6 +86,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix handling of long UDP messages in UDP input. {issue}33836[33836] {pull}33837[33837]
 - Fix browser monitor summary reporting as up when monitor is down. {issue}33374[33374] {pull}33819[33819]
 - Fix beat capabilities on Docker image. {pull}33584[33584]
+- Fix serialization of state duration to avoid scientific notation. {pull}34280[34280]
 
 
 *Heartbeat*

--- a/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
+++ b/heartbeat/monitors/wrappers/monitorstate/esloader_test.go
@@ -16,6 +16,7 @@
 // under the License.
 
 //go:build integration
+// +build integration
 
 package monitorstate
 
@@ -126,6 +127,8 @@ func (etc *esTestContext) createTestMonitorStateInES(t *testing.T, s StateStatus
 	}
 
 	initState := newMonitorState(sf, s, 0, true)
+	// Test int64 is un/marshalled correctly
+	initState.DurationMs = 3e9
 	etc.setInitialState(t, sf, initState)
 	return sf
 }

--- a/heartbeat/monitors/wrappers/monitorstate/monitorstate.go
+++ b/heartbeat/monitors/wrappers/monitorstate/monitorstate.go
@@ -60,7 +60,7 @@ type State struct {
 	ID string `json:"id"`
 	// StartedAt is the start time of the state, should be the same for a given state ID
 	StartedAt  time.Time   `json:"started_at"`
-	DurationMs int64       `json:"duration_ms"`
+	DurationMs int64       `json:"duration_ms,string"`
 	Status     StateStatus `json:"status"`
 	Checks     int         `json:"checks"`
 	Up         int         `json:"up"`


### PR DESCRIPTION
## What does this PR do?

Changes marshalling of states duration to string-encoded int64, per recommendation. Fixes #34218.

## Why is it important?

When `duration_ms` gets long enough, it starts being marshalled in **float** format, which is incompatible with int64 type. It then prevents states from being recovered from ES, generating a new one every ~20min.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

