### PR TITLE
Validate Source IP "LOCAL" or "Unknown" in Windows Security Logs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -111,6 +111,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Winlogbeat*
 
+- in /module/security/ingest/security.yml, added corrections for Source IP values "LOCAL" or "Unknown"
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -2349,7 +2349,12 @@ processors:
 
         //ClientAddress to source.ip and related.ip
         if (ctx?.winlog?.event_data?.ClientAddress != null &&
-            ctx.winlog.event_data.ClientAddress != "-") {
+            ctx.winlog.event_data.ClientAddress != "-" &&
+            ctx.winlog.event_data.ClientAddress != "Unknown") {
+          // Correct invalid IP address "LOCAL"
+          if (ctx?.winlog?.event_data?.ClientAddress == "LOCAL") {
+            ctx.winlog.event_data.ClientAddress="127.0.0.1";
+          }
           if (ctx?.source == null) {
             HashMap hm = new HashMap();
             ctx.put("source", hm);

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -616,6 +616,13 @@ processors:
             - user
             - change
           action: renamed-user-account
+        "4797":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: query-existence-of-blank-password
         "4798":
           category:
             - iam
@@ -743,6 +750,34 @@ processors:
           type:
             - end
           action: windows-firewall-driver-error
+        "5379":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: credential-manager-credentials-were-read
+        "5380":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: vault-credential-find
+        "5381":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: vault-credentials-were-read
+        "5382":
+          category:
+            - iam
+          type:
+            - user
+            - info
+          action: vault-credentials-were-read
       source: |-
         if (ctx?.event?.code == null || params.get(ctx.event.code) == null) {
           return;


### PR DESCRIPTION
## What does this PR do?

Some security events contain a source IP address of "LOCAL" or "Unknown" which are not valid IP addresses. This PR will correct the processing of events containing one of those values. 

Please see cancelled [#34252](https://github.com/elastic/beats/pull/34252). 

## Why is it important?

This bug causes mapping exceptions and prevents these events from being ingested. 

## Checklist

- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

-fixes #19627