### PR TITLE
changed "elastic" to "username" in docker run

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -112,7 +112,7 @@ using this syntax:
 [source,shell]
 --------------------------------------------
 -E cloud.id=<Cloud ID from Elasticsearch Service> \
--E cloud.auth=elastic:<elastic password>
+-E cloud.auth=username:<elastic password>
 --------------------------------------------
 
 endif::apm-server[]


### PR DESCRIPTION
As a new user it was a bit confusing to me and I spent sometime for this run command.

<!-- Type of change
- Docs
-->

## What does this PR do?

Changed the word "elastic" to "username" in the docker run command given in the document.

## Why is it important?
It is quite confusing for a new user to read this document and try running the docker run command. 

## Checklist

No checks are required as it is just a change in a doc.

