### PR TITLE
Validate Source IP "LOCAL" or "Unknown" in Windows Security Logs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Winlogbeat*
 
+- Corrects issue with security events with source IP of "LOCAL" or "Unknown" failing to ingest
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -2349,7 +2349,12 @@ processors:
 
         //ClientAddress to source.ip and related.ip
         if (ctx?.winlog?.event_data?.ClientAddress != null &&
-            ctx.winlog.event_data.ClientAddress != "-") {
+            ctx.winlog.event_data.ClientAddress != "-" &&
+            ctx.winlog.event_data.ClientAddress != "Unknown") {
+          // Correct invalid IP address "LOCAL"
+          if (ctx?.winlog?.event_data?.ClientAddress == "LOCAL") {
+            ctx.winlog.event_data.ClientAddress="127.0.0.1";
+          }
           if (ctx?.source == null) {
             HashMap hm = new HashMap();
             ctx.put("source", hm);

--- a/x-pack/winlogbeat/module/security/test/testdata/collection/4778.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/collection/4778.evtx.golden.json
@@ -1,0 +1,212 @@
+[
+  {
+    "event": {
+      "code": "4778",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "LOCAL",
+        "ClientName": "Unknown",
+        "LogonID": "0x5c7c095",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 4484
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 6540868,
+      "time_created": "2023-01-17T21:35:22.347697Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4778",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "LOCAL",
+        "ClientName": "Unknown",
+        "LogonID": "0x2d7650",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 9240
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 6533066,
+      "time_created": "2023-01-17T14:30:22.2097094Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4778",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "LOCAL",
+        "ClientName": "Unknown",
+        "LogonID": "0x2d7650",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 20588
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 6529837,
+      "time_created": "2023-01-17T12:16:32.6562756Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4778",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "LOCAL",
+        "ClientName": "Unknown",
+        "LogonID": "0x2d7650",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 1560
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 6528511,
+      "time_created": "2023-01-17T11:38:09.0384455Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4778",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "LOCAL",
+        "ClientName": "Unknown",
+        "LogonID": "0x32b6a80",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 1560
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 6524523,
+      "time_created": "2023-01-17T05:15:18.8083596Z"
+    }
+  }
+]

--- a/x-pack/winlogbeat/module/security/test/testdata/collection/4779.evtx.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/collection/4779.evtx.golden.json
@@ -1,0 +1,212 @@
+[
+  {
+    "event": {
+      "code": "4779",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0x4c636b9",
+        "SessionName": "rdp-sxs220817450#18"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 9584
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 3480043,
+      "time_created": "2023-01-17T22:37:25.1926737Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4779",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0x3fc8b36",
+        "SessionName": "rdp-sxs220817450#12"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 7788
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 3479302,
+      "time_created": "2023-01-17T22:09:56.3562679Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4779",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0xe03a99",
+        "SessionName": "rdp-sxs220817450#16"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 4660
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 3479095,
+      "time_created": "2023-01-17T21:55:25.3931099Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4779",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0xe03a99",
+        "SessionName": "rdp-sxs220817450#15"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 4660
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 3479032,
+      "time_created": "2023-01-17T21:54:30.3134111Z"
+    }
+  },
+  {
+    "event": {
+      "code": "4779",
+      "kind": "event",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing"
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0xe03a99",
+        "SessionName": "rdp-sxs220817450#3"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 7328
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": 3478947,
+      "time_created": "2023-01-17T21:53:19.6235931Z"
+    }
+  }
+]

--- a/x-pack/winlogbeat/module/security/test/testdata/ingest/4778.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/ingest/4778.golden.json
@@ -1,0 +1,372 @@
+[
+  {
+    "@timestamp": "2023-01-17T21:35:22.347Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-reconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4778",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "start"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "ip": [
+        "127.0.0.1"
+      ],
+      "user": [
+        "user1"
+      ]
+    },
+    "source": {
+      "domain": "Unknown",
+      "ip": "127.0.0.1"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "user1"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "127.0.0.1",
+        "ClientName": "Unknown",
+        "LogonID": "0x5c7c095",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0x5c7c095"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 4484
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "6540868",
+      "time_created": "2023-01-17T21:35:22.347697Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T14:30:22.209Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-reconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4778",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "start"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "ip": [
+        "127.0.0.1"
+      ],
+      "user": [
+        "user1"
+      ]
+    },
+    "source": {
+      "domain": "Unknown",
+      "ip": "127.0.0.1"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "user1"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "127.0.0.1",
+        "ClientName": "Unknown",
+        "LogonID": "0x2d7650",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0x2d7650"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 9240
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "6533066",
+      "time_created": "2023-01-17T14:30:22.2097094Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T12:16:32.656Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-reconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4778",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "start"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "ip": [
+        "127.0.0.1"
+      ],
+      "user": [
+        "user1"
+      ]
+    },
+    "source": {
+      "domain": "Unknown",
+      "ip": "127.0.0.1"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "user1"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "127.0.0.1",
+        "ClientName": "Unknown",
+        "LogonID": "0x2d7650",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0x2d7650"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 20588
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "6529837",
+      "time_created": "2023-01-17T12:16:32.6562756Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T11:38:09.038Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-reconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4778",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "start"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "ip": [
+        "127.0.0.1"
+      ],
+      "user": [
+        "user1"
+      ]
+    },
+    "source": {
+      "domain": "Unknown",
+      "ip": "127.0.0.1"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "user1"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "127.0.0.1",
+        "ClientName": "Unknown",
+        "LogonID": "0x2d7650",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0x2d7650"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 1560
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "6528511",
+      "time_created": "2023-01-17T11:38:09.0384455Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T05:15:18.808Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-reconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4778",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "start"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "ip": [
+        "127.0.0.1"
+      ],
+      "user": [
+        "user1"
+      ]
+    },
+    "source": {
+      "domain": "Unknown",
+      "ip": "127.0.0.1"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "user1"
+    },
+    "winlog": {
+      "activity_id": "{7261ec5d-29d2-0001-bdec-6172d229d901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "user1",
+        "ClientAddress": "127.0.0.1",
+        "ClientName": "Unknown",
+        "LogonID": "0x32b6a80",
+        "SessionName": "Console"
+      },
+      "event_id": "4778",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0x32b6a80"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 320,
+        "thread": {
+          "id": 1560
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "6524523",
+      "time_created": "2023-01-17T05:15:18.8083596Z"
+    }
+  }
+]

--- a/x-pack/winlogbeat/module/security/test/testdata/ingest/4779.golden.json
+++ b/x-pack/winlogbeat/module/security/test/testdata/ingest/4779.golden.json
@@ -1,0 +1,352 @@
+[
+  {
+    "@timestamp": "2023-01-17T22:37:25.192Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-disconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4779",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "end"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "user": [
+        "USER1"
+      ]
+    },
+    "source": {
+      "domain": "DESKTOP"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "USER1"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0x4c636b9",
+        "SessionName": "rdp-sxs220817450#18"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0x4c636b9"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 9584
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "3480043",
+      "time_created": "2023-01-17T22:37:25.1926737Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T22:09:56.356Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-disconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4779",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "end"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "user": [
+        "USER1"
+      ]
+    },
+    "source": {
+      "domain": "DESKTOP"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "USER1"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0x3fc8b36",
+        "SessionName": "rdp-sxs220817450#12"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0x3fc8b36"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 7788
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "3479302",
+      "time_created": "2023-01-17T22:09:56.3562679Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T21:55:25.393Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-disconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4779",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "end"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "user": [
+        "USER1"
+      ]
+    },
+    "source": {
+      "domain": "DESKTOP"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "USER1"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0xe03a99",
+        "SessionName": "rdp-sxs220817450#16"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0xe03a99"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 4660
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "3479095",
+      "time_created": "2023-01-17T21:55:25.3931099Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T21:54:30.313Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-disconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4779",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "end"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "user": [
+        "USER1"
+      ]
+    },
+    "source": {
+      "domain": "DESKTOP"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "USER1"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0xe03a99",
+        "SessionName": "rdp-sxs220817450#15"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0xe03a99"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 4660
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "3479032",
+      "time_created": "2023-01-17T21:54:30.3134111Z"
+    }
+  },
+  {
+    "@timestamp": "2023-01-17T21:53:19.623Z",
+    "ecs": {
+      "version": "1.12.0"
+    },
+    "event": {
+      "action": "session-disconnected",
+      "category": [
+        "authentication",
+        "session"
+      ],
+      "code": "4779",
+      "kind": "event",
+      "module": "security",
+      "outcome": "success",
+      "provider": "Microsoft-Windows-Security-Auditing",
+      "type": [
+        "end"
+      ]
+    },
+    "host": {
+      "name": "COMPUTER1.contoso.com"
+    },
+    "log": {
+      "level": "information"
+    },
+    "related": {
+      "user": [
+        "USER1"
+      ]
+    },
+    "source": {
+      "domain": "DESKTOP"
+    },
+    "user": {
+      "domain": "CONTOSO",
+      "name": "USER1"
+    },
+    "winlog": {
+      "activity_id": "{01f78c75-2270-0002-52ab-626e802ad901}",
+      "channel": "Security",
+      "computer_name": "COMPUTER1.contoso.com",
+      "event_data": {
+        "AccountDomain": "CONTOSO",
+        "AccountName": "USER1",
+        "ClientAddress": "Unknown",
+        "ClientName": "DESKTOP",
+        "LogonID": "0xe03a99",
+        "SessionName": "rdp-sxs220817450#3"
+      },
+      "event_id": "4779",
+      "keywords": [
+        "Audit Success"
+      ],
+      "logon": {
+        "id": "0xe03a99"
+      },
+      "opcode": "Info",
+      "process": {
+        "pid": 932,
+        "thread": {
+          "id": 7328
+        }
+      },
+      "provider_guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+      "provider_name": "Microsoft-Windows-Security-Auditing",
+      "record_id": "3478947",
+      "time_created": "2023-01-17T21:53:19.6235931Z"
+    }
+  }
+]


### PR DESCRIPTION
## What does this PR do?

Some security events contain a source IP address of "LOCAL" or "Unknown" which are not valid IP addresses. This PR will correct the processing of events containing one of those values. 

## Why is it important?

This bug causes mapping exceptions and prevents these events from being ingested. 

## Checklist

- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

-fixes #19627