### PR TITLE
x-pack/filebeat/input/httpjson: fix handling of null or empty arrays during split

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -92,6 +92,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Filebeat*
 
+- Fix handling of null or empty arrays during split with keep parent option. {pull}34322[34322]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -159,6 +159,66 @@ func TestInput(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name:        "Test split on null field with ignore_empty_value keeping parent",
+			setupServer: newTestServer(httptest.NewServer),
+			baseConfig: map[string]interface{}{
+				"interval":       1,
+				"request.method": http.MethodGet,
+				"response.split": map[string]interface{}{
+					"target":             "body.response.empty",
+					"ignore_empty_value": true,
+					"keep_parent":        true,
+				},
+			},
+			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":null}}`),
+			expected: []string{`{"response":{"empty":null}}`},
+		},
+		{
+			name:        "Test split on empty array with ignore_empty_value keeping parent",
+			setupServer: newTestServer(httptest.NewServer),
+			baseConfig: map[string]interface{}{
+				"interval":       1,
+				"request.method": http.MethodGet,
+				"response.split": map[string]interface{}{
+					"target":             "body.response.empty",
+					"ignore_empty_value": true,
+					"keep_parent":        true,
+				},
+			},
+			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
+			expected: []string{`{"response":{"empty":[]}}`},
+		},
+		{
+			name:        "Test split on null field at root with ignore_empty_value keeping parent",
+			setupServer: newTestServer(httptest.NewServer),
+			baseConfig: map[string]interface{}{
+				"interval":       1,
+				"request.method": http.MethodGet,
+				"response.split": map[string]interface{}{
+					"target":             "body.response",
+					"ignore_empty_value": true,
+					"keep_parent":        true,
+				},
+			},
+			handler:  defaultHandler(http.MethodGet, "", `{"response":null,"other":"data"}`),
+			expected: []string{`{"other":"data","response":null}`},
+		},
+		{
+			name:        "Test split on empty array at root with ignore_empty_value keeping parent",
+			setupServer: newTestServer(httptest.NewServer),
+			baseConfig: map[string]interface{}{
+				"interval":       1,
+				"request.method": http.MethodGet,
+				"response.split": map[string]interface{}{
+					"target":             "body.response",
+					"ignore_empty_value": true,
+					"keep_parent":        true,
+				},
+			},
+			handler:  defaultHandler(http.MethodGet, "", `{"response":[],"other":"data"}`),
+			expected: []string{`{"other":"data","response":[]}`},
+		},
+		{
 			name:        "Test nested split",
 			setupServer: newTestServer(httptest.NewServer),
 			baseConfig: map[string]interface{}{

--- a/x-pack/filebeat/input/httpjson/split.go
+++ b/x-pack/filebeat/input/httpjson/split.go
@@ -112,9 +112,16 @@ func (s *split) split(ctx *transformContext, root mapstr.M, ch chan<- maybeMsg) 
 			if s.child != nil {
 				return s.child.split(ctx, root, ch)
 			}
+			if s.keepParent {
+				ch <- maybeMsg{msg: root}
+			}
 			return nil
 		}
 		if s.isRoot {
+			if s.keepParent {
+				ch <- maybeMsg{msg: root}
+				return errEmptyField
+			}
 			return errEmptyRootField
 		}
 		ch <- maybeMsg{msg: root}
@@ -132,6 +139,9 @@ func (s *split) split(ctx *transformContext, root mapstr.M, ch chan<- maybeMsg) 
 			if s.ignoreEmptyValue {
 				if s.child != nil {
 					return s.child.split(ctx, root, ch)
+				}
+				if s.keepParent {
+					ch <- maybeMsg{msg: root}
 				}
 				return nil
 			}
@@ -161,6 +171,9 @@ func (s *split) split(ctx *transformContext, root mapstr.M, ch chan<- maybeMsg) 
 			if s.ignoreEmptyValue {
 				if s.child != nil {
 					return s.child.split(ctx, root, ch)
+				}
+				if s.keepParent {
+					ch <- maybeMsg{msg: root}
 				}
 				return nil
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This allows documents to be retained when a split would be empty, if `keep_parent` and `ignore_empty_value` are true.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently splits will drop these split documents.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
