### PR TITLE
Fix changelog after a bad backport

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -44,31 +44,9 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Filebeat*
-- [GCS] Added support for more mime types & introduced offset tracking via cursor state. Also added support for 
-   automatic splitting at root level, if root level element is an array. {pull}34155[34155]
-- [httpsjon] Improved error handling during pagination with chaining & split processor {pull}34127[34127]
-- [Azure blob storage] Added support for more mime types & introduced offset tracking via cursor state. {pull}33981[33981]
-- Fix EOF on single line not producing any event. {issue}30436[30436] {pull}33568[33568]
-- Fix handling of error in states in direct aws-s3 listing input {issue}33513[33513] {pull}33722[33722]
-- Fix `httpjson` input page number initialization and documentation. {pull}33400[33400]
-- Add handling of AAA operations for Cisco ASA module. {issue}32257[32257] {pull}32789[32789]
-- Fix gc.log always shipped even if gc fileset is disabled {issue}30995[30995]
-- Fix handling of empty array in httpjson input. {pull}32001[32001]
-- Fix reporting of `filebeat.events.active` in log events such that the current value is always reported instead of the difference from the last value. {pull}33597[33597]
-- Fix splitting array of strings/arrays in httpjson input {issue}30345[30345] {pull}33609[33609]
-- Fix Google workspace pagination and document ID generation. {pull}33666[33666]
-- Fix PANW handling of messages with event.original already set. {issue}33829[33829] {pull}33830[33830]
-- Rename identity as identity_name when the value is a string in Azure Platform Logs. {pull}33654[33654]
-- Fix 'requires pointer' error while getting cursor metadata. {pull}33956[33956]
-- Fix input cancellation handling when HTTP client does not support contexts. {issue}33962[33962] {pull}33968[33968]
-- Update mito CEL extension library to v0.0.0-20221207004749-2f0f2875e464 {pull}33974[33974]
-- Fix CEL result deserialisation when evaluation fails. {issue}33992[33992] {pull}33996[33996]
-- Fix handling of non-200/non-429 status codes. {issue}33999[33999] {pull}34002[34002]
-- [azure-eventhub input] Switch the run EPH run mode to non-blocking {pull}34075[34075]
 - [google_workspace] Fix pagination and cursor value update. {pull}34274[34274]
 - Fix handling of quoted values in auditd module. {issue}22587[22587] {pull}34069[34069]
 - The `close.on_state_change.inactive` default value is now set to 5 minutes, matching the documentation.
-
 
 *Heartbeat*
 
@@ -130,6 +108,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add cloudflare R2 to provider list in AWS S3 input. {pull}32620[32620]
 - Add support for single string containing multiple relation-types in getRFC5988Link. {pull}32811[32811]
 - Allow user configuration of keep-alive behaviour for HTTPJSON and CEL inputs. {issue}33951[33951] {pull}34014[34014]
+- [GCS] Added support for more mime types & introduced offset tracking via cursor state. Also added support for automatic splitting at root level, if root level element is an array. {pull}34155[34155]
 
 *Auditbeat*
 


### PR DESCRIPTION
The changelog had extra entries which were not supposed to be added by https://github.com/elastic/beats/pull/34338

Also, the section was wrong, it's `Added` not `Fixed`.
