### PR TITLE
Add processing of event ID's 5140 and 5145 to mirror Elastic Agent's …

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,7 +33,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Corrects issue with security events with source IP of "LOCAL" or "Unknown" failing to ingest {issue}19627[19627] {pull}34295[34295]
 - Added processing for Windows Event ID's 4797, 5379, 5380, 5381, and 5382 for the Security Ingest Pipeline {issue}34293[34293] {pull}34294[34294]
-- Added processing for Windows Event ID's 4040 and 4045 for the Security Ingest Pipeline {pull}34352[34352]
+- Added processing for Windows Event ID's 5140 and 5145 for the Security Ingest Pipeline {pull}34352[34352]
 
 *Functionbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -33,6 +33,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 - Corrects issue with security events with source IP of "LOCAL" or "Unknown" failing to ingest {issue}19627[19627] {pull}34295[34295]
 - Added processing for Windows Event ID's 4797, 5379, 5380, 5381, and 5382 for the Security Ingest Pipeline {issue}34293[34293] {pull}34294[34294]
+- Added processing for Windows Event ID's 4040 and 4045 for the Security Ingest Pipeline {pull}34352[34352]
 
 *Functionbeat*
 

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -3485,7 +3485,7 @@ processors:
         ctx.event?.code != null &&
         ["5140", "5145"].contains(ctx.event.code) &&
         ctx.winlog?.event_data?.ShareLocalPath != null &&
-        ctx.winlog?.event_data?.ShareLocalPath != ""
+        ctx.winlog.event_data.ShareLocalPath != ""
   - set:
       field: file.target_path
       value: "{{winlog.event_data.ShareName}}\\{{file.name}}"

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -3503,6 +3503,7 @@ processors:
         def extIdx = ctx.file.name.lastIndexOf(".");
         if (extIdx > -1) {
             ctx.file.extension = ctx.file.name.substring(extIdx+1);
+        }
   - convert:
       field: winlog.record_id
       type: string

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -3465,7 +3465,7 @@ processors:
         ctx.event?.code != null &&
         ["5140", "5145"].contains(ctx.event.code) &&
         ctx.winlog?.event_data?.RelativeTargetName != null &&
-        ctx.winlog?.event_data?.RelativeTargetName != ""
+        ctx.winlog.event_data.RelativeTargetName != ""
   - set:
       field: file.directory
       copy_from: winlog.event_data.ShareLocalPath

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -3493,7 +3493,7 @@ processors:
         ctx.event?.code != null &&
         ["5140", "5145"].contains(ctx.event.code) &&
         ctx.winlog?.event_data?.ShareName != null &&
-        ctx.winlog?.event_data?.ShareName != "" &&
+        ctx.winlog.event_data.ShareName != "" &&
         ctx.file?.name != null
   - script:
       description: Adds file information.

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -3473,7 +3473,7 @@ processors:
         ctx.event?.code != null &&
         ["5140", "5145"].contains(ctx.event.code) &&
         ctx.winlog?.event_data?.ShareLocalPath != null &&
-        ctx.winlog?.event_data?.ShareLocalPath != ""
+        ctx.winlog.event_data.ShareLocalPath != ""
   - set:
       field: file.path
       value: "{{file.directory}}\\{{file.name}}"

--- a/x-pack/winlogbeat/module/security/ingest/security.yml
+++ b/x-pack/winlogbeat/module/security/ingest/security.yml
@@ -750,6 +750,22 @@ processors:
           type:
             - end
           action: windows-firewall-driver-error
+        "5140":
+          category:
+            - network
+            - file
+          type:
+            - info
+            - access
+          action: network-share-object-accessed
+        "5145":
+          category:
+            - network
+            - file
+          type:
+            - info
+            - access
+          action: network-share-object-access-checked
         "5379":
           category:
             - iam
@@ -2644,7 +2660,7 @@ processors:
               "4750", "4751", "4752", "4753", "4754", "4755", "4756", "4757",
               "4758", "4759", "4760", "4761", "4762", "4763", "4764", "4767",
               "4781", "4798", "4799", "4817", "4904", "4905", "4907", "4912",
-              "4648", "4797", "5379", "5380", "5381", "5382"].contains(ctx.event.code)) {
+              "4648", "4797", "5140", "5145", "5379", "5380", "5381", "5382"].contains(ctx.event.code)) {
           return;
         }
         if (ctx?.winlog?.event_data?.SubjectUserSid != null) {
@@ -2831,7 +2847,7 @@ processors:
               "4749", "4750", "4751", "4752", "4753", "4754", "4755", "4756",
               "4757", "4758", "4759", "4760", "4761", "4762", "4763", "4764",
               "4767", "4768", "4769", "4770", "4771", "4798", "4799", "4817",
-              "4904", "4905", "4907", "4912"].contains(ctx.event.code)) {
+              "4904", "4905", "4907", "4912", "5140", "5145"].contains(ctx.event.code)) {
           return;
         }
         if (ctx?.winlog?.event_data?.ProcessId != null) {
@@ -3442,6 +3458,51 @@ processors:
           splitSidList(ctx.winlog.event_data.SidList, params, ctx);
         }
 
+  - set:
+      field: file.name
+      copy_from: winlog.event_data.RelativeTargetName
+      if: |-
+        ctx.event?.code != null &&
+        ["5140", "5145"].contains(ctx.event.code) &&
+        ctx.winlog?.event_data?.RelativeTargetName != null &&
+        ctx.winlog?.event_data?.RelativeTargetName != ""
+  - set:
+      field: file.directory
+      copy_from: winlog.event_data.ShareLocalPath
+      if: |-
+        ctx.event?.code != null &&
+        ["5140", "5145"].contains(ctx.event.code) &&
+        ctx.winlog?.event_data?.ShareLocalPath != null &&
+        ctx.winlog?.event_data?.ShareLocalPath != ""
+  - set:
+      field: file.path
+      value: "{{file.directory}}\\{{file.name}}"
+      if: ctx.file?.name != null && ctx.file?.directory != null
+  - set:
+      field: file.directory
+      copy_from: winlog.event_data.ShareLocalPath
+      if: |-
+        ctx.event?.code != null &&
+        ["5140", "5145"].contains(ctx.event.code) &&
+        ctx.winlog?.event_data?.ShareLocalPath != null &&
+        ctx.winlog?.event_data?.ShareLocalPath != ""
+  - set:
+      field: file.target_path
+      value: "{{winlog.event_data.ShareName}}\\{{file.name}}"
+      if: |-
+        ctx.event?.code != null &&
+        ["5140", "5145"].contains(ctx.event.code) &&
+        ctx.winlog?.event_data?.ShareName != null &&
+        ctx.winlog?.event_data?.ShareName != "" &&
+        ctx.file?.name != null
+  - script:
+      description: Adds file information.
+      lang: painless
+      if: ctx.file?.name != null
+      source: |-
+        def extIdx = ctx.file.name.lastIndexOf(".");
+        if (extIdx > -1) {
+            ctx.file.extension = ctx.file.name.substring(extIdx+1);
   - convert:
       field: winlog.record_id
       type: string


### PR DESCRIPTION
## Type of change

- Enhancement

## What does this PR do?

While creating [#5085](https://github.com/elastic/integrations/pull/5085), I realized Elastic Agent includes parsing for two additional event ID's not included in the Winlogbeat Security Ingest Pipeline. This PR adds event parsing to the Security Ingest Pipeline for Winlogbeat for Event ID's 4040 and 4045.

## Why is it important?

This PR will create a 1:1 match of event ID coverage between Winlogbeat's Security module and Elastic Agent's `system` Integration for Windows Security events.

## Checklist

- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #34294 
