### PR TITLE
packetbeat/protos/{tcp,udp}: prevent metric namespace collision

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -196,7 +196,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Bump Windows Npcap version to v1.71. {issue}33164[33164] {pull}33172[33172]
 - Add fragmented IPv4 packet reassembly. {issue}33012[33012] {pull}33296[33296]
 - Reduce logging level for ENOENT to WARN when mapping sockets to processes. {issue}33793[33793] {pull}[]
-- Add metrics for TCP and UDP packet processing. {pull}33833[33833]
+- Add metrics for TCP and UDP packet processing. {pull}33833[33833] {pull}34353[34353]
 
 *Packetbeat*
 

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -294,44 +294,45 @@ func TestTCSeqPayload(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Logf("Test (%v): %v", i, test.name)
-
-		gap := 0
-		var state []byte
-		tcp, err := NewTCP(protocols{
-			tcp: map[protos.Protocol]protos.TCPPlugin{
-				httpProtocol: &TestProtocol{
-					Ports: []int{ServerPort},
-					gap:   makeCountGaps(nil, &gap),
-					parse: makeCollectPayload(&state, true),
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gap := 0
+			var state []byte
+			tcp, err := NewTCP(protocols{
+				tcp: map[protos.Protocol]protos.TCPPlugin{
+					httpProtocol: &TestProtocol{
+						Ports: []int{ServerPort},
+						gap:   makeCountGaps(nil, &gap),
+						parse: makeCollectPayload(&state, true),
+					},
 				},
-			},
-		}, "", "")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		addr := common.NewIPPortTuple(4,
-			net.ParseIP(ServerIP), ServerPort,
-			net.ParseIP(ClientIP), uint16(rand.Intn(65535)))
-
-		for _, segment := range test.segments {
-			hdr := &layers.TCP{Seq: segment.seq}
-			pkt := &protos.Packet{
-				Ts:      time.Now(),
-				Tuple:   addr,
-				Payload: segment.payload,
+			}, "test", "test")
+			if err != nil {
+				t.Fatal(err)
 			}
-			tcp.Process(nil, hdr, pkt)
-		}
+			defer tcp.metrics.close()
 
-		assert.Equal(t, test.expectedGaps, gap)
-		if len(test.expectedState) != len(state) {
-			assert.Equal(t, len(test.expectedState), len(state))
-			continue
-		}
-		assert.Equal(t, test.expectedState, state)
+			addr := common.NewIPPortTuple(4,
+				net.ParseIP(ServerIP), ServerPort,
+				net.ParseIP(ClientIP), uint16(rand.Intn(65535)))
+
+			for _, segment := range test.segments {
+				hdr := &layers.TCP{Seq: segment.seq}
+				pkt := &protos.Packet{
+					Ts:      time.Now(),
+					Tuple:   addr,
+					Payload: segment.payload,
+				}
+				tcp.Process(nil, hdr, pkt)
+			}
+
+			assert.Equal(t, test.expectedGaps, gap)
+			if len(test.expectedState) != len(state) {
+				assert.Equal(t, len(test.expectedState), len(state))
+				return
+			}
+			assert.Equal(t, test.expectedState, state)
+		})
 	}
 }
 

--- a/packetbeat/protos/udp/udp_test.go
+++ b/packetbeat/protos/udp/udp_test.go
@@ -111,7 +111,7 @@ func testSetup(t *testing.T) *TestStruct {
 	plugin := &TestProtocol{Ports: []int{PORT}}
 	protocols.udp[PROTO] = plugin
 
-	udp, err := NewUDP(protocols, "", "")
+	udp, err := NewUDP(protocols, "test", "test")
 	if err != nil {
 		t.Error("Error creating UDP handler: ", err)
 	}
@@ -206,6 +206,7 @@ func Test_buildPortsMap_portOverlapError(t *testing.T) {
 // packet's source port.
 func Test_decideProtocol_bySrcPort(t *testing.T) {
 	test := testSetup(t)
+	defer test.udp.metrics.close()
 	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("192.168.0.1"), PORT,
 		net.ParseIP("10.0.0.1"), 34898)
@@ -216,6 +217,7 @@ func Test_decideProtocol_bySrcPort(t *testing.T) {
 // packet's destination port.
 func Test_decideProtocol_byDstPort(t *testing.T) {
 	test := testSetup(t)
+	defer test.udp.metrics.close()
 	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("10.0.0.1"), 34898,
 		net.ParseIP("192.168.0.1"), PORT)
@@ -226,6 +228,7 @@ func Test_decideProtocol_byDstPort(t *testing.T) {
 // which it does not have a plugin.
 func TestProcess_unknownProtocol(t *testing.T) {
 	test := testSetup(t)
+	defer test.udp.metrics.close()
 	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("10.0.0.1"), 34898,
 		net.ParseIP("192.168.0.1"), PORT+1)
@@ -235,6 +238,7 @@ func TestProcess_unknownProtocol(t *testing.T) {
 // Verify that Process ignores empty packets.
 func TestProcess_emptyPayload(t *testing.T) {
 	test := testSetup(t)
+	defer test.udp.metrics.close()
 	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("192.168.0.1"), PORT,
 		net.ParseIP("10.0.0.1"), 34898)
@@ -247,6 +251,7 @@ func TestProcess_emptyPayload(t *testing.T) {
 // ProcessUdp on it.
 func TestProcess_nonEmptyPayload(t *testing.T) {
 	test := testSetup(t)
+	defer test.udp.metrics.close()
 	tuple := common.NewIPPortTuple(4,
 		net.ParseIP("192.168.0.1"), PORT,
 		net.ParseIP("10.0.0.1"), 34898)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Metrics are registered in a namspace derived solely from the id parameter of inputmon.NewInputRegistry, while packetbeat does not provide per-proto IDs. This means that when more that one sniffer is active on the same NIC there will be a namespace collision. To prevent this, construct an ID from the packetbeat ID, the proto and the list of ports that are being sniffed in a canonical syntax, and the NIC's name.

Also make the testing of metric namespace collision more rigorous within the packages themselves, leaving a relaxed testing mode for external packages.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently registering multiple sniffers will cause packetbeat to panic.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes elastic/cloud-on-k8s#6346

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
