### PR TITLE
Draft: Allow parsing of IPv6 addresses in ingest pipeline

### DIFF
--- a/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/activitylogs/ingest/pipeline.yml
@@ -39,6 +39,7 @@ processors:
 - grok:
     field: azure.activitylogs.callerIpAddress
     patterns:
+      - "%{IPV6:source.ip}"
       - \[%{IPORHOST:source.ip}\]:%{INT:source.port:int}
       - "%{IPORHOST:source.ip}:%{INT:source.port:int}"
       - "%{IPORHOST:source.ip}"

--- a/x-pack/filebeat/module/azure/auditlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/auditlogs/ingest/pipeline.yml
@@ -86,6 +86,7 @@ processors:
 - grok:
     field: azure.auditlogs.callerIpAddress
     patterns:
+      - "%{IPV6:source.ip}"
       - \[%{IPORHOST:source.ip}\]:%{INT:source.port:int}
       - "%{IPORHOST:source.ip}:%{INT:source.port:int}"
       - "%{IPORHOST:source.ip}"

--- a/x-pack/filebeat/module/azure/platformlogs/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/azure/platformlogs/ingest/pipeline.yml
@@ -73,6 +73,7 @@ processors:
 - grok:
     field: azure.platformlogs.callerIpAddress
     patterns:
+      - "%{IPV6:source.ip}"
       - \[%{IPORHOST:source.ip}\]:%{INT:source.port:int}
       - "%{IPORHOST:source.ip}:%{INT:source.port:int}"
       - "%{IPORHOST:source.ip}"


### PR DESCRIPTION
@zmoog: Draft PR for #34277. Will add test cases soon.

- Enhancement

## What does this PR do?

Adds support for parsing IPv6 addresses in the filebeat Azure activitylogs, auditlogs, and platformlogs ingest pipelines.

## Why is it important?

Currently any logs from these Azure log source which have an IPv6 address as the source are not ingested into elasticsearch because the ingest pipeline throws an error when attempting to ingest these logs.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [ ] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

No easy test yet, test cases still need to be added

## Related issues

- Closes #34277 
