### PR TITLE
fixed log naming syntax to not clash with ecs field names

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -56,6 +56,8 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Filebeat*
+- [Azure blob storage] Changed logger field name from `container` to `container_name` so that it does not clash
+   with the ecs field name `container`. {pull}34403[34403]
 - [GCS] Added support for more mime types & introduced offset tracking via cursor state. Also added support for
    automatic splitting at root level, if root level element is an array. {pull}34155[34155]
 - [httpsjon] Improved error handling during pagination with chaining & split processor {pull}34127[34127]

--- a/x-pack/filebeat/input/azureblobstorage/input.go
+++ b/x-pack/filebeat/input/azureblobstorage/input.go
@@ -113,7 +113,7 @@ func (input *azurebsInput) Test(src cursor.Source, ctx v2.TestContext) error {
 func (input *azurebsInput) Run(inputCtx v2.Context, src cursor.Source, cursor cursor.Cursor, publisher cursor.Publisher) error {
 	currentSource := src.(*Source)
 
-	log := inputCtx.Logger.With("account_name", currentSource.AccountName).With("container", currentSource.ContainerName)
+	log := inputCtx.Logger.With("account_name", currentSource.AccountName).With("container_name", currentSource.ContainerName)
 	log.Infof("Running azure blob storage for account: %s", input.config.AccountName)
 
 	var cp *Checkpoint


### PR DESCRIPTION
## Type of change
- Enhancement


## What does this PR do?

updates log field names so that it does not clash with ecs field names.

## Why is it important?

It important that ecs field names are not used as general log field names.

