### PR TITLE
[Azure Blob Storage] Allowing empty content encoding headers for system tests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,7 +81,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - [azure-eventhub input] Switch the run EPH run mode to non-blocking {pull}34075[34075]
 - [google_workspace] Fix pagination and cursor value update. {pull}34274[34274]
 - Fix handling of quoted values in auditd module. {issue}22587[22587] {pull}34069[34069]
-- Fixing system tests not returning expected content encoding for azure blob storage input. {issue}22587[22587] {pull}34069[34069]
+- Fixing system tests not returning expected content encoding for azure blob storage input. {pull}34412[34412]
 
 *Heartbeat*
 - Fix broken zip URL monitors. NOTE: Zip URL Monitors will be removed in version 8.7 and replaced with project monitors. {pull}33723[33723]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -81,6 +81,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - [azure-eventhub input] Switch the run EPH run mode to non-blocking {pull}34075[34075]
 - [google_workspace] Fix pagination and cursor value update. {pull}34274[34274]
 - Fix handling of quoted values in auditd module. {issue}22587[22587] {pull}34069[34069]
+- Fixing system tests not returning expected content encoding for azure blob storage input. {issue}22587[22587] {pull}34069[34069]
 
 *Heartbeat*
 - Fix broken zip URL monitors. NOTE: Zip URL Monitors will be removed in version 8.7 and replaced with project monitors. {pull}33723[33723]

--- a/x-pack/filebeat/input/azureblobstorage/job.go
+++ b/x-pack/filebeat/input/azureblobstorage/job.go
@@ -66,9 +66,8 @@ func azureObjectHash(src *Source, blob *azblob.BlobItemInternal) string {
 
 func (j *job) do(ctx context.Context, id string) {
 	var fields mapstr.M
-
 	if allowedContentTypes[*j.blob.Properties.ContentType] {
-		if *j.blob.Properties.ContentType == gzType || *j.blob.Properties.ContentEncoding == encodingGzip {
+		if *j.blob.Properties.ContentType == gzType || (j.blob.Properties.ContentEncoding != nil && *j.blob.Properties.ContentEncoding == encodingGzip) {
 			j.isCompressed = true
 		}
 		err := j.processAndPublishData(ctx, id)


### PR DESCRIPTION
## What does this PR do?

Adding a failsafe for when content encoding headers might be nil, especially for system tests.

## Why is it important?

Required for Agent integration package system tests

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

### Testing instructions

When creating system tests for elastic-package, we use the Azure Blob Storage emulator: https://hub.docker.com/_/microsoft-azure-storage-azurite

Unfortunately the emulator itself does not return a `ContentEncoding` header, while the Cloud API will always ensure at least a default `octet-stream` is added if value is nil, we need to add the possibility for the Encoding Header to not be present to be able to continue the system tests.

Steps to reproduce:
1. Start up the emulator: `docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite-blob --blobHost 0.0.0.0`
2. Download stream and run `go build` : `https://github.com/elastic/stream`
3. Create a local file for testing, for example `test.json`, add a JSON object on a single line, like `{ "testmessage" : "success" }`
4. Populate the emulator with the testdata using `stream`: `./stream log --retry=30 --addr=localhost -p azureblobstorage --azure-blob-storage-port=10000 --azure-blob-storage-container=azure-container1 ./test.json`
5. Configure the filebeat input to test against the emulator **The password is a public key, not pasted by mistake:**
```
filebeat.inputs:
- type: azure-blob-storage
  id: my-azureblobstorage-id
  enabled: true
  storage_url: http://localhost:10000/devstoreaccount1/
  account_name: devstoreaccount1
  auth.shared_credentials.account_key: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
  max_workers: 10
  poll: true
  poll_interval: 20s
  containers:
  - name: azure-container1
    max_workers: 1
    poll: true
    poll_interval: 20s
```

Before this PR, when we run filebeat with `./filebeat -e` it will result in a panic:
```
panic: runtime error: invalid memory address or nil pointer dereference","component"
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x561c9cc3ac49]
```
However with this PR, the test will pass.