### PR TITLE
[Google Cloud Storage] Add support for alternative_host for system tests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -183,6 +183,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add beta `take over` mode for `filestream` for simple migration from `log` inputs {pull}34292[34292]
 - Add pagination support for Salesforce module. {issue}34057[34057] {pull}34065[34065]
 - Allow users to redact sensitive data from CEL input debug logs. {pull}34302[34302]
+- Added support for HTTP destination override to Google Cloud Storage input. {pull}34413[34413]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/gcs/client.go
+++ b/x-pack/filebeat/input/gcs/client.go
@@ -7,6 +7,7 @@ package gcs
 import (
 	"context"
 	"errors"
+	"net/url"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/option"
@@ -15,6 +16,15 @@ import (
 )
 
 func fetchStorageClient(ctx context.Context, cfg config, log *logp.Logger) (*storage.Client, error) {
+	if cfg.AlternativeHost != "" {
+		var h *url.URL
+		h, err := url.Parse(cfg.AlternativeHost)
+		if err != nil {
+			return nil, err
+		}
+		h.Path = "storage/v1/"
+		return storage.NewClient(ctx, option.WithEndpoint(h.String()), option.WithoutAuthentication())
+	}
 	if cfg.Auth.CredentialsJSON != nil {
 		return storage.NewClient(ctx, option.WithCredentialsJSON([]byte(cfg.Auth.CredentialsJSON.AccountKey)))
 	} else if cfg.Auth.CredentialsFile != nil {

--- a/x-pack/filebeat/input/gcs/config.go
+++ b/x-pack/filebeat/input/gcs/config.go
@@ -27,6 +27,8 @@ type config struct {
 	ParseJSON     *bool          `config:"parse_json,omitempty"`
 	BucketTimeOut *time.Duration `config:"bucket_timeout,omitempty"`
 	Buckets       []bucket       `config:"buckets" validate:"required"`
+	// This field is only used for system test purposes, to override the HTTP endpoint.
+	AlternativeHost string `config:"alternative_host,omitempty"`
 }
 
 // bucket contains the config for each specific object storage bucket in the root account


### PR DESCRIPTION
## What does this PR do?

This adds the `alternative_host` option, which is a field only used for internal testing. By default the input only reaches out to the public cloud GCS API, and this allows us to override this and instead point it to our own emulator running locally for system tests.

## Why is it important?

Required for adding system tests for elastic-agent integration packages.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally

1. Start up the local GCS emulator: `docker run -p 4443:4443 fsouza/fake-gcs-server -host="0.0.0.0" -public-host=localhost -port=4443 -scheme=http`
2. Download stream and run `go build` : `https://github.com/elastic/stream`
3. Create a local file for testing, for example `test.json`, add a JSON object on a single line, like `{ "testmessage" : "success" }`
4. Populate the emulator with the testdata using `stream`: `./stream log --retry=30 --addr=http://localhost:4443 -p gcs --gcs-content-type="application/json" ./test.json`
5. Test `filebeat` with following `filebeat.yml`
```
filebeat.inputs:
- type: gcs
  project_id: testproject
  parse_json: true
  alternative_host: "http://localhost:4443/"
  buckets:
  - name: testbucket
```

The expected result is that a the object is retrieved and that `parse_json` works as expected