### PR TITLE
packaging: use ubuntu-22 for the aarch64 workers

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -261,7 +261,7 @@ def generateSteps() {
 
 def generateArmStep(beat) {
   return {
-    withNode(labels: 'arm') {
+    withNode(labels: 'ubuntu-2204-aarch64') {
       withEnv(["HOME=${env.WORKSPACE}", 'PLATFORMS=linux/arm64','PACKAGES=docker', "BEATS_FOLDER=${beat}"]) {
         withGithubNotify(context: "Packaging Arm ${beat}") {
           deleteDir()


### PR DESCRIPTION
## What does this PR do?

Use ubuntu-22 for the `aarch64` workers

## Why is it important?

Leftover from https://github.com/elastic/beats/pull/34315 and https://github.com/elastic/beats/pull/34383
