### PR TITLE
Enable TLS by default in shipper output

### DIFF
--- a/libbeat/outputs/shipper/config.go
+++ b/libbeat/outputs/shipper/config.go
@@ -53,6 +53,7 @@ type Config struct {
 func defaultConfig() Config {
 	enabled := true
 	return Config{
+		// agent will expect that TLS is enabled by default, will disable explicitly
 		TLS: &tlscommon.Config{
 			Enabled: &enabled,
 		},

--- a/libbeat/outputs/shipper/config.go
+++ b/libbeat/outputs/shipper/config.go
@@ -28,6 +28,7 @@ type backoffConfig struct {
 	Max  time.Duration `config:"max" validate:"nonzero"`
 }
 
+// Config manages configuration for the shipper output
 type Config struct {
 	// Server address in the format of host:port, e.g. `localhost:50051`
 	Server string `config:"server"`
@@ -50,8 +51,11 @@ type Config struct {
 }
 
 func defaultConfig() Config {
+	enabled := true
 	return Config{
-		TLS:                nil,
+		TLS: &tlscommon.Config{
+			Enabled: &enabled,
+		},
 		Timeout:            30 * time.Second,
 		MaxRetries:         3,
 		BulkMaxSize:        50,

--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -224,6 +224,7 @@ func TestConvertMapStr(t *testing.T) {
 				require.Nil(t, converted)
 				return
 			}
+			require.NoError(t, err)
 			requireEqualProto(t, tc.exp, converted)
 		})
 	}
@@ -305,6 +306,9 @@ func TestPublish(t *testing.T) {
 
 			cfg, err := config.NewConfigFrom(map[string]interface{}{
 				"server": addr,
+				"ssl": map[string]interface{}{
+					"enabled": false,
+				},
 			})
 			require.NoError(t, err)
 
@@ -338,7 +342,10 @@ func TestPublish(t *testing.T) {
 		defer stop()
 
 		cfg, err := config.NewConfigFrom(map[string]interface{}{
-			"server":  addr,
+			"server": addr,
+			"ssl": map[string]interface{}{
+				"enabled": false,
+			},
 			"timeout": 5, // 5 sec
 			"backoff": map[string]interface{}{
 				"init": "10ms",
@@ -383,6 +390,9 @@ func TestPublish(t *testing.T) {
 		defer stop()
 
 		cfg, err := config.NewConfigFrom(map[string]interface{}{
+			"ssl": map[string]interface{}{
+				"enabled": false,
+			},
 			"server":  addr,
 			"timeout": 5, // 5 sec
 			"backoff": map[string]interface{}{

--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -45,6 +45,29 @@ import (
 	"github.com/elastic/elastic-agent-shipper-client/pkg/proto/messages"
 )
 
+func TestShipperConfig(t *testing.T) {
+	input := mapstr.M{
+		"ssl": mapstr.M{
+			"enabled": false,
+		},
+		"timeout": time.Second * 10,
+		"backoff": mapstr.M{
+			"init": time.Second,
+		},
+	}
+	cfg, err := config.NewConfigFrom(input)
+	require.NoError(t, err)
+
+	shipperSettings := defaultConfig()
+	err = cfg.Unpack(&shipperSettings)
+	require.NoError(t, err)
+
+	require.Equal(t, false, *shipperSettings.TLS.Enabled)
+	require.Equal(t, 3, shipperSettings.MaxRetries)
+	require.Equal(t, time.Second*10, shipperSettings.Timeout)
+	require.Equal(t, time.Second, shipperSettings.Backoff.Init)
+}
+
 func TestToShipperEvent(t *testing.T) {
 	wrong := struct{}{}
 	ts := time.Now().Truncate(time.Second)


### PR DESCRIPTION
## What does this PR do?

closes https://github.com/elastic/beats/issues/34321

This changes the default config for the shipper output so TLS is enabled by default, which is what elastic-agent and shipper expect.

## How to test:

- follow the setup instructions here: https://github.com/elastic/elastic-agent-shipper/pull/185
- If setup correctly, the shipper will _not_ be able to connect, as there's still missing pieces in the shipper's TLS. You can verify that the issue is at the TLS level by adding the following to the `shipper.spec.yml` and looking in the logs:
```
      env:
        - name: GRPC_GO_LOG_VERBOSITY_LEVEL
          value: 99
        - name: GRPC_GO_LOG_SEVERITY_LEVEL
          value: info
        - name: GRPC_TRACE
          value: all
```
