### PR TITLE
packetbeat: allow user to prevent Npcap installation on Windows

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -218,8 +218,9 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add option to allow sniffing multiple interface devices. {issue}31905[31905] {pull}32933[32933]
 - Bump Windows Npcap version to v1.71. {issue}33164[33164] {pull}33172[33172]
 - Add fragmented IPv4 packet reassembly. {issue}33012[33012] {pull}33296[33296]
-- Reduce logging level for ENOENT to WARN when mapping sockets to processes. {issue}33793[33793] {pull}[]
+- Reduce logging level for ENOENT to WARN when mapping sockets to processes. {issue}33793[33793] {pull}33854[33854]
 - Add metrics for TCP and UDP packet processing. {pull}33833[33833] {pull}34353[34353]
+- Allow user to prevent Npcap library installation on Windows. {issue}34420[34420] {pull}34428[34428]
 
 *Packetbeat*
 

--- a/packetbeat/_meta/config/beat.reference.yml.tmpl
+++ b/packetbeat/_meta/config/beat.reference.yml.tmpl
@@ -59,6 +59,8 @@ packetbeat.interfaces.internal_networks:
 # can stay enabled even after beat is shut down.
 #packetbeat.interfaces.auto_promisc_mode: true
 
+{{- template "windows_npcap.yml.tmpl" .}}
+
 {{header "Flows"}}
 
 packetbeat.flows:

--- a/packetbeat/_meta/config/beat.yml.tmpl
+++ b/packetbeat/_meta/config/beat.yml.tmpl
@@ -42,6 +42,8 @@ packetbeat.interfaces.poll_default_route: 1m
 packetbeat.interfaces.internal_networks:
   - private
 
+{{- template "windows_npcap.yml.tmpl" .}}
+
 {{header "Flows"}}
 
 # Set `enabled: false` or comment out all options to disable flows reporting.

--- a/packetbeat/_meta/config/windows_npcap.yml.tmpl
+++ b/packetbeat/_meta/config/windows_npcap.yml.tmpl
@@ -1,0 +1,13 @@
+{{if and (eq .BeatLicense "Elastic License") (eq .GOOS "windows")}}
+
+{{header "Windows Npcap installation settings"}}
+
+# Windows Npcap installation options. These options specify how the Npcap packet
+# capture library for Windows should be obtained and installed.
+#
+#packetbeat.npcap:
+#  # If a specific local version of Npcap is required, installation by packetbeat
+#  # can be blocked by setting never_install to true. No action is taken if this
+#  # option is set to true.
+#  never_install: false
+{{- end -}}

--- a/packetbeat/beater/install_npcap.go
+++ b/packetbeat/beater/install_npcap.go
@@ -54,10 +54,22 @@ func installNpcap(b *beat.Beat) error {
 		return nil
 	}
 
+	log := logp.NewLogger("npcap_install")
+
+	var cfg struct {
+		NeverInstall bool `config:"npcap.never_install"`
+	}
+	err := b.BeatConfig.Unpack(&cfg)
+	if err != nil {
+		return fmt.Errorf("failed to unpack npcap config: %w", err)
+	}
+	if cfg.NeverInstall {
+		log.Warn("npcap installation/upgrade disabled by user")
+		return nil
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), installTimeout)
 	defer cancel()
-
-	log := logp.NewLogger("npcap_install")
 
 	if npcap.Installer == nil {
 		return nil

--- a/packetbeat/docs/packetbeat-options.asciidoc
+++ b/packetbeat/docs/packetbeat-options.asciidoc
@@ -54,6 +54,19 @@ packetbeat.interfaces.type: af_packet
 packetbeat.interfaces.buffer_size_mb: 100
 ------------------------------------------------------------------------------
 
+[float]
+=== Windows Npcap installation options
+
+On Windows {beatname} requires an Npcap DLL installation. This is provided by {beatname}
+for users of the Elastic Licenced version. In some cases users may wish to use
+their own installed version. In order to do this the `packetbeat.npcap.never_install`
+option can be used. Setting this option to `true` will not attempt to install the
+bundled Npcap library on start-up.
+
+[source,yaml]
+------------------------------------------------------------------------------
+packetbeat.npcap.never_install: true
+------------------------------------------------------------------------------
 
 [float]
 === Sniffing configuration options


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Allow user to prevent Npcap installation on Windows.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Some users depend on software that uses Npcap pinned to other versions.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Test locally on a windows machine with no npcap installed, and running with `.\packetbeat -e -d '*'` (binary must have been built with npcap installer asset in place) with the following packetbeat.yml.
```
packetbeat.interfaces.device: default_route

packetbeat.npcap:
  never_install: true

packetbeat.interfaces.poll_default_route: 1m

packetbeat.interfaces.internal_networks:
  - private

packetbeat.flows:
  timeout: 30s
  period: 10s

packetbeat.protocols:
- type: icmp
  # Enable ICMPv4 and ICMPv6 monitoring. The default is true.
  enabled: true

output.file:
  path: "./"
  filename: packetbeat-test
```

You will see the following two lines in the output
```
{"log.level":"warn","@timestamp":"2023-01-30T23:11:39.642-0800","log.logger":"npcap_install","log.origin":{"file.name":"beater/install_npcap.go","file.line":67},"message":"npcap installation/upgrade disabled by user","service.name":"packetbeat","ecs.version":"1.6.0"}
{"log.level":"warn","@timestamp":"2023-01-30T23:11:39.642-0800","log.logger":"npcap","log.origin":{"file.name":"beater/install_npcap.go","file.line":47},"message":"no version available for npcap","service.name":"packetbeat","ecs.version":"1.6.0"}
```
and then will shortly after packetbeat will terminate with
```
{"log.level":"error","@timestamp":"2023-01-30T23:11:39.673-0800","log.origin":{"file.name":"instance/beat.go","file.line":1070},"message":"Exiting: failed to get device list: couldn't load wpcap.dll","service.name":"packetbeat","ecs.version":"1.6.0"}
Exiting: failed to get device list: couldn't load wpcap.dll
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #34420 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
