### PR TITLE
[Metricbeat][Kubernetes] Move common code from state_* metricsets to a new file

### DIFF
--- a/metricbeat/helper/kubernetes/ktest/ktest.go
+++ b/metricbeat/helper/kubernetes/ktest/ktest.go
@@ -1,0 +1,75 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ktest
+
+import (
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
+	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
+)
+
+// GetTestCases Build test cases from the files and returns them
+func GetTestCases(files []string) ptest.TestCases {
+	var cases ptest.TestCases
+	for i := 0; i < len(files); i++ {
+		cases = append(cases,
+			struct {
+				MetricsFile  string
+				ExpectedFile string
+			}{
+				MetricsFile:  files[i],
+				ExpectedFile: files[i][1:] + ".expected",
+			},
+		)
+	}
+	return cases
+}
+
+// TestStateMetricsFamily
+// This function reads the metric files and checks if the resource fetched metrics exist in it.
+// It only checks the family metric, because if the metric doesn't have any data, we don't have a way
+// to know the labels from the file.
+// The test fails if the metric does not exist in any of the files.
+// A warning is printed if the metric is not present in all of them.
+// Nothing happens, otherwise.
+func TestStateMetricsFamily(t *testing.T, files []string, mapping *p.MetricsMapping) {
+	metricsFiles := map[string][]string{}
+	for i := 0; i < len(files); i++ {
+		content, err := ioutil.ReadFile(files[i])
+		if err != nil {
+			t.Fatalf("Unknown file %s.", files[i])
+		}
+		text := string(content)
+		for metric, _ := range mapping.Metrics {
+			if !strings.Contains(text, "# TYPE "+metric+" ") {
+				metricsFiles[metric] = append(metricsFiles[metric], files[i])
+			}
+		}
+	}
+	for metric, filesList := range metricsFiles {
+		if len(filesList) != len(files) {
+			t.Logf("Warning: metric %s is not present in all files.", metric)
+		} else {
+			t.Errorf("Unknown metric: %s", metric)
+		}
+	}
+
+}

--- a/metricbeat/helper/kubernetes/state_metricset.go
+++ b/metricbeat/helper/kubernetes/state_metricset.go
@@ -1,0 +1,112 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elastic/beats/v7/metricbeat/helper/prometheus"
+	"github.com/elastic/beats/v7/metricbeat/mb"
+	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
+)
+
+const prefix = "state_"
+
+var mappings = map[string]*prometheus.MetricsMapping{}
+
+// Init registers the MetricSet with the central registry.
+// The New method will be called after the setup of the module and before starting to fetch data
+func Init(name string, mapping *prometheus.MetricsMapping) {
+	name = prefix + name
+	mappings[name] = mapping
+	mb.Registry.MustAddMetricSet("kubernetes", name, New, mb.WithHostParser(prometheus.HostParser))
+}
+
+// MetricSet type defines all fields of the MetricSet
+// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
+// additional entries. These variables can be used to persist data or configuration between
+// multiple fetch calls.
+type MetricSet struct {
+	mb.BaseMetricSet
+	prometheusClient   prometheus.Prometheus
+	prometheusMappings *prometheus.MetricsMapping
+	mod                k8smod.Module
+	enricher           util.Enricher
+}
+
+func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
+	prometheusClient, err := prometheus.NewPrometheusClient(base)
+	if err != nil {
+		return nil, err
+	}
+	mod, ok := base.Module().(k8smod.Module)
+	if !ok {
+		return nil, fmt.Errorf("must be child of kubernetes module")
+	}
+
+	mapping := mappings[base.Name()]
+	var ms = MetricSet{
+		BaseMetricSet:      base,
+		prometheusClient:   prometheusClient,
+		prometheusMappings: mapping,
+		enricher:           util.NewResourceMetadataEnricher(base, strings.ReplaceAll(base.Name(), prefix, ""), mod.GetMetricsRepo(), false),
+		mod:                mod,
+	}
+	return &ms, nil
+}
+
+// Fetch methods implements the data gathering and data conversion to the right
+// format. It publishes the event which is then forwarded to the output. In case
+// of an error set the Error field of mb.Event or simply call report.Error().
+func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
+	m.enricher.Start()
+
+	families, err := m.mod.GetStateMetricsFamilies(m.prometheusClient)
+	if err != nil {
+		m.Logger().Error(err)
+		reporter.Error(err)
+		return
+	}
+	events, err := m.prometheusClient.ProcessMetrics(families, m.prometheusMappings)
+	if err != nil {
+		m.Logger().Error(err)
+		reporter.Error(err)
+		return
+	}
+
+	m.enricher.Enrich(events)
+	for _, event := range events {
+		e, err := util.CreateEvent(event, "kubernetes."+strings.ReplaceAll(m.BaseMetricSet.Name(), "state_", ""))
+		if err != nil {
+			m.Logger().Error(err)
+		}
+
+		if reported := reporter.Event(e); !reported {
+			m.Logger().Debug("error trying to emit event")
+			return
+		}
+	}
+}
+
+// Close stops this metricset
+func (m *MetricSet) Close() error {
+	m.enricher.Stop()
+	return nil
+}

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
@@ -20,6 +20,7 @@ package state_cronjob
 import (
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
 var mapping = &p.MetricsMapping{
@@ -40,8 +41,7 @@ var mapping = &p.MetricsMapping{
 	},
 }
 
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_cronjob",
-		NewCronJobMetricSet,
-		mb.WithHostParser(p.HostParser))
+	sm.Init(util.CronJobResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
@@ -18,6 +18,7 @@
 package state_cronjob
 
 import (
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob.go
@@ -18,116 +18,30 @@
 package state_cronjob
 
 import (
-	"fmt"
-
-	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
-
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 )
+
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_cronjob_info":                           p.InfoMetric(),
+		"kube_cronjob_created":                        p.Metric("created.sec"),
+		"kube_cronjob_status_active":                  p.Metric("active.count"),
+		"kube_cronjob_status_last_schedule_time":      p.Metric("last_schedule.sec"),
+		"kube_cronjob_next_schedule_time":             p.Metric("next_schedule.sec"),
+		"kube_cronjob_spec_suspend":                   p.BooleanMetric("is_suspended"),
+		"kube_cronjob_spec_starting_deadline_seconds": p.Metric("deadline.sec"),
+	},
+	Labels: map[string]p.LabelMap{
+		"cronjob":            p.KeyLabel("name"),
+		"namespace":          p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+		"schedule":           p.KeyLabel("schedule"),
+		"concurrency_policy": p.KeyLabel("concurrency"),
+	},
+}
 
 func init() {
 	mb.Registry.MustAddMetricSet("kubernetes", "state_cronjob",
 		NewCronJobMetricSet,
 		mb.WithHostParser(p.HostParser))
-}
-
-// CronJobMetricSet uses a prometheus based MetricSet that looks for
-// mb.ModuleDataKey prefixed fields and puts then at the module level
-//
-// Copying the code from other kube state metrics, this should be improved to
-// avoid all these ugly tricks
-type CronJobMetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	mapping    *p.MetricsMapping
-	mod        k8smod.Module
-	enricher   util.Enricher
-}
-
-// NewCronJobMetricSet returns a prometheus based metricset for CronJobs
-func NewCronJobMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-
-	ms := CronJobMetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		mod:           mod,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.CronJob{}, mod.GetMetricsRepo(), false),
-		mapping: &p.MetricsMapping{
-			Metrics: map[string]p.MetricMap{
-				"kube_cronjob_info":                           p.InfoMetric(),
-				"kube_cronjob_created":                        p.Metric("created.sec"),
-				"kube_cronjob_status_active":                  p.Metric("active.count"),
-				"kube_cronjob_status_last_schedule_time":      p.Metric("last_schedule.sec"),
-				"kube_cronjob_next_schedule_time":             p.Metric("next_schedule.sec"),
-				"kube_cronjob_spec_suspend":                   p.BooleanMetric("is_suspended"),
-				"kube_cronjob_spec_starting_deadline_seconds": p.Metric("deadline.sec"),
-			},
-			Labels: map[string]p.LabelMap{
-				"cronjob":            p.KeyLabel("name"),
-				"namespace":          p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-				"schedule":           p.KeyLabel("schedule"),
-				"concurrency_policy": p.KeyLabel("concurrency"),
-			},
-		},
-	}
-
-	return &ms, nil
-}
-
-// Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
-// module rooted fields at the event that gets reported
-//
-// Copied from other kube state metrics.
-func (m *CronJobMetricSet) Fetch(reporter mb.ReporterV2) {
-	if m.enricher != nil {
-		m.enricher.Start()
-	}
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, m.mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	if m.enricher != nil {
-		m.enricher.Enrich(events)
-	}
-	for _, event := range events {
-		e, err := util.CreateEvent(event, "kubernetes.cronjob")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *CronJobMetricSet) Close() error {
-	if m.enricher != nil {
-		m.enricher.Stop()
-	}
-	return nil
 }

--- a/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
+++ b/metricbeat/module/kubernetes/state_daemonset/state_daemonset.go
@@ -18,119 +18,28 @@
 package state_daemonset
 
 import (
-	"fmt"
-
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
-const (
-	defaultScheme = "http"
-	defaultPath   = "/metrics"
-)
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_daemonset_metadata_generation":             p.InfoMetric(),
+		"kube_daemonset_status_number_available":         p.Metric("replicas.available"),
+		"kube_daemonset_status_desired_number_scheduled": p.Metric("replicas.desired"),
+		"kube_daemonset_status_number_ready":             p.Metric("replicas.ready"),
+		"kube_daemonset_status_number_unavailable":       p.Metric("replicas.unavailable"),
+	},
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		DefaultPath:   defaultPath,
-	}.Build()
+	Labels: map[string]p.LabelMap{
+		"daemonset": p.KeyLabel("name"),
+		"namespace": p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+	},
+}
 
-	mapping = &p.MetricsMapping{
-		Metrics: map[string]p.MetricMap{
-			"kube_daemonset_metadata_generation":             p.InfoMetric(),
-			"kube_daemonset_status_number_available":         p.Metric("replicas.available"),
-			"kube_daemonset_status_desired_number_scheduled": p.Metric("replicas.desired"),
-			"kube_daemonset_status_number_ready":             p.Metric("replicas.ready"),
-			"kube_daemonset_status_number_unavailable":       p.Metric("replicas.unavailable"),
-		},
-
-		Labels: map[string]p.LabelMap{
-			"daemonset": p.KeyLabel("name"),
-			"namespace": p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-		},
-	}
-)
-
-// init registers the MetricSet with the central registry.
-// The New method will be called after the setup of the module and before starting to fetch data
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_daemonset", New,
-		mb.WithHostParser(hostParser),
-	)
-}
-
-// MetricSet type defines all fields of the MetricSet
-// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
-// additional entries. These variables can be used to persist data or configuration between
-// multiple fetch calls.
-type MetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// New create a new instance of the MetricSet
-// Part of new is also setting up the configuration by processing additional
-// configuration entries if needed.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.DaemonSet{}, mod.GetMetricsRepo(), false),
-		mod:           mod,
-	}, nil
-}
-
-// Fetch methods implements the data gathering and data conversion to the right
-// format. It publishes the event which is then forwarded to the output. In case
-// of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.daemonset")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-
-}
-
-// Close stops this metricset
-func (m *MetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.DaemonSetResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment.go
@@ -18,120 +18,29 @@
 package state_deployment
 
 import (
-	"fmt"
-
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
-const (
-	defaultScheme = "http"
-	defaultPath   = "/metrics"
-)
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_deployment_metadata_generation":         p.InfoMetric(),
+		"kube_deployment_status_replicas_updated":     p.Metric("replicas.updated"),
+		"kube_deployment_status_replicas_unavailable": p.Metric("replicas.unavailable"),
+		"kube_deployment_status_replicas_available":   p.Metric("replicas.available"),
+		"kube_deployment_spec_replicas":               p.Metric("replicas.desired"),
+		"kube_deployment_spec_paused":                 p.BooleanMetric("paused"),
+	},
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		DefaultPath:   defaultPath,
-	}.Build()
+	Labels: map[string]p.LabelMap{
+		"deployment": p.KeyLabel("name"),
+		"namespace":  p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+	},
+}
 
-	mapping = &p.MetricsMapping{
-		Metrics: map[string]p.MetricMap{
-			"kube_deployment_metadata_generation":         p.InfoMetric(),
-			"kube_deployment_status_replicas_updated":     p.Metric("replicas.updated"),
-			"kube_deployment_status_replicas_unavailable": p.Metric("replicas.unavailable"),
-			"kube_deployment_status_replicas_available":   p.Metric("replicas.available"),
-			"kube_deployment_spec_replicas":               p.Metric("replicas.desired"),
-			"kube_deployment_spec_paused":                 p.BooleanMetric("paused"),
-		},
-
-		Labels: map[string]p.LabelMap{
-			"deployment": p.KeyLabel("name"),
-			"namespace":  p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-		},
-	}
-)
-
-// init registers the MetricSet with the central registry.
-// The New method will be called after the setup of the module and before starting to fetch data
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_deployment", New,
-		mb.WithHostParser(hostParser),
-	)
-}
-
-// MetricSet type defines all fields of the MetricSet
-// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
-// additional entries. These variables can be used to persist data or configuration between
-// multiple fetch calls.
-type MetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// New create a new instance of the MetricSet
-// Part of new is also setting up the configuration by processing additional
-// configuration entries if needed.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Deployment{}, mod.GetMetricsRepo(), false),
-		mod:           mod,
-	}, nil
-}
-
-// Fetch methods implements the data gathering and data conversion to the right
-// format. It publishes the event which is then forwarded to the output. In case
-// of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.deployment")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *MetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.DeploymentResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_job/state_job.go
+++ b/metricbeat/module/kubernetes/state_job/state_job.go
@@ -18,137 +18,47 @@
 package state_job
 
 import (
-	"fmt"
-
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
-const (
-	defaultScheme = "http"
-	defaultPath   = "/metrics"
-)
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		// Make everything in "kube_job_owner" available for use in the Labels section, below.
+		"kube_job_owner": p.InfoMetric(),
+		// These fields are mapped 1:1 from their KSM metrics.
+		"kube_job_status_active":    p.Metric("pods.active"),
+		"kube_job_status_failed":    p.Metric("pods.failed"),
+		"kube_job_status_succeeded": p.Metric("pods.succeeded"),
+		"kube_job_spec_completions": p.Metric("completions.desired"),
+		// completions observed?
+		"kube_job_spec_parallelism":       p.Metric("parallelism.desired"),
+		"kube_job_created":                p.Metric("time.created", p.OpUnixTimestampValue()),
+		"kube_job_status_completion_time": p.Metric("time.completed", p.OpUnixTimestampValue()),
+		// These fields will be set to "true", "false", or "unknown" based on input that looks
+		// like this:
+		//
+		// kube_job_complete{namespace="default",job_name="timer-27074308",condition="true"} 1
+		// kube_job_complete{namespace="default",job_name="timer-27074308",condition="false"} 0
+		// kube_job_complete{namespace="default",job_name="timer-27074308",condition="unknown"} 0
+		"kube_job_complete": p.LabelMetric("status.complete", "condition", p.OpLowercaseValue()),
+		"kube_job_failed":   p.LabelMetric("status.failed", "condition", p.OpLowercaseValue()),
+	},
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		DefaultPath:   defaultPath,
-	}.Build()
+	Labels: map[string]p.LabelMap{
+		// Jobs are uniquely identified by the combination of name and namespace.
+		"job_name":  p.KeyLabel("name"),
+		"namespace": p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+		// Add owner information provided by the "kube_job_owner" InfoMetric.
+		"owner_kind":          p.Label("owner.kind"),
+		"owner_name":          p.Label("owner.name"),
+		"owner_is_controller": p.Label("owner.is_controller"),
+	},
+}
 
-	mapping = &p.MetricsMapping{
-		Metrics: map[string]p.MetricMap{
-			// Make everything in "kube_job_owner" available for use in the Labels section, below.
-			"kube_job_owner": p.InfoMetric(),
-			// These fields are mapped are mapped 1:1 from their KSM metrics.
-			"kube_job_status_active":    p.Metric("pods.active"),
-			"kube_job_status_failed":    p.Metric("pods.failed"),
-			"kube_job_status_succeeded": p.Metric("pods.succeeded"),
-			"kube_job_spec_completions": p.Metric("completions.desired"),
-			// completions observed?
-			"kube_job_spec_parallelism":       p.Metric("parallelism.desired"),
-			"kube_job_created":                p.Metric("time.created", p.OpUnixTimestampValue()),
-			"kube_job_status_completion_time": p.Metric("time.completed", p.OpUnixTimestampValue()),
-			// These fields will be set to "true", "false", or "unknown" based on input that looks
-			// like this:
-			//
-			// kube_job_complete{namespace="default",job_name="timer-27074308",condition="true"} 1
-			// kube_job_complete{namespace="default",job_name="timer-27074308",condition="false"} 0
-			// kube_job_complete{namespace="default",job_name="timer-27074308",condition="unknown"} 0
-			"kube_job_complete": p.LabelMetric("status.complete", "condition", p.OpLowercaseValue()),
-			"kube_job_failed":   p.LabelMetric("status.failed", "condition", p.OpLowercaseValue()),
-		},
-
-		Labels: map[string]p.LabelMap{
-			// Jobs are uniquely identified by the combination of name and namespace.
-			"job_name":  p.KeyLabel("name"),
-			"namespace": p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-			// Add owner information provided by the "kube_job_owner" InfoMetric.
-			"owner_kind":          p.Label("owner.kind"),
-			"owner_name":          p.Label("owner.name"),
-			"owner_is_controller": p.Label("owner.is_controller"),
-		},
-	}
-)
-
-// init registers the MetricSet with the central registry.
-// The New method will be called after the setup of the module and before starting to fetch data
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_job", New,
-		mb.WithHostParser(hostParser),
-	)
-}
-
-// MetricSet type defines all fields of the MetricSet
-// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
-// additional entries. These variables can be used to persist data or configuration between
-// multiple fetch calls.
-type MetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// New create a new instance of the MetricSet
-// Part of new is also setting up the configuration by processing additional
-// configuration entries if needed.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Job{}, mod.GetMetricsRepo(), false),
-		mod:           mod,
-	}, nil
-}
-
-// Fetch methods implements the data gathering and data conversion to the right
-// format. It publishes the event which is then forwarded to the output. In case
-// of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.job")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *MetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.JobResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_node/state_node.go
+++ b/metricbeat/module/kubernetes/state_node/state_node.go
@@ -18,143 +18,52 @@
 package state_node
 
 import (
-	"fmt"
-
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
-	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
-const (
-	defaultScheme = "http"
-	defaultPath   = "/metrics"
-)
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_node_info":                            p.InfoMetric(),
+		"kube_node_status_allocatable_pods":         p.Metric("pod.allocatable.total"),
+		"kube_node_status_capacity_pods":            p.Metric("pod.capacity.total"),
+		"kube_node_status_capacity_memory_bytes":    p.Metric("memory.capacity.bytes"),
+		"kube_node_status_allocatable_memory_bytes": p.Metric("memory.allocatable.bytes"),
+		"kube_node_status_capacity_cpu_cores":       p.Metric("cpu.capacity.cores"),
+		"kube_node_status_allocatable_cpu_cores":    p.Metric("cpu.allocatable.cores"),
+		"kube_node_status_capacity": p.Metric("", p.OpFilterMap(
+			"resource", map[string]string{
+				"pods":   "pod.capacity.total",
+				"cpu":    "cpu.capacity.cores",
+				"memory": "memory.capacity.bytes",
+			},
+		)),
+		"kube_node_status_allocatable": p.Metric("", p.OpFilterMap(
+			"resource", map[string]string{
+				"pods":   "pod.allocatable.total",
+				"cpu":    "cpu.allocatable.cores",
+				"memory": "memory.allocatable.bytes",
+			},
+		)),
+		"kube_node_spec_unschedulable": p.BooleanMetric("status.unschedulable"),
+		"kube_node_status_ready":       p.LabelMetric("status.ready", "condition"),
+		"kube_node_status_condition": p.LabelMetric("status", "status", p.OpFilterMap(
+			"condition", map[string]string{
+				"Ready":          "ready",
+				"MemoryPressure": "memory_pressure",
+				"DiskPressure":   "disk_pressure",
+				"OutOfDisk":      "out_of_disk",
+				"PIDPressure":    "pid_pressure",
+			},
+		)),
+	},
+	Labels: map[string]p.LabelMap{
+		"node": p.KeyLabel("name"),
+	},
+}
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		DefaultPath:   defaultPath,
-	}.Build()
-
-	mapping = &p.MetricsMapping{
-		Metrics: map[string]p.MetricMap{
-			"kube_node_info":                            p.InfoMetric(),
-			"kube_node_status_allocatable_pods":         p.Metric("pod.allocatable.total"),
-			"kube_node_status_capacity_pods":            p.Metric("pod.capacity.total"),
-			"kube_node_status_capacity_memory_bytes":    p.Metric("memory.capacity.bytes"),
-			"kube_node_status_allocatable_memory_bytes": p.Metric("memory.allocatable.bytes"),
-			"kube_node_status_capacity_cpu_cores":       p.Metric("cpu.capacity.cores"),
-			"kube_node_status_allocatable_cpu_cores":    p.Metric("cpu.allocatable.cores"),
-			"kube_node_status_capacity": p.Metric("", p.OpFilterMap(
-				"resource", map[string]string{
-					"pods":   "pod.capacity.total",
-					"cpu":    "cpu.capacity.cores",
-					"memory": "memory.capacity.bytes",
-				},
-			)),
-			"kube_node_status_allocatable": p.Metric("", p.OpFilterMap(
-				"resource", map[string]string{
-					"pods":   "pod.allocatable.total",
-					"cpu":    "cpu.allocatable.cores",
-					"memory": "memory.allocatable.bytes",
-				},
-			)),
-			"kube_node_spec_unschedulable": p.BooleanMetric("status.unschedulable"),
-			"kube_node_status_ready":       p.LabelMetric("status.ready", "condition"),
-			"kube_node_status_condition": p.LabelMetric("status", "status", p.OpFilterMap(
-				"condition", map[string]string{
-					"Ready":          "ready",
-					"MemoryPressure": "memory_pressure",
-					"DiskPressure":   "disk_pressure",
-					"OutOfDisk":      "out_of_disk",
-					"PIDPressure":    "pid_pressure",
-				},
-			)),
-		},
-		Labels: map[string]p.LabelMap{
-			"node": p.KeyLabel("name"),
-		},
-	}
-)
-
-// init registers the MetricSet with the central registry.
-// The New method will be called after the setup of the module and before starting to fetch data
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_node", New,
-		mb.WithHostParser(hostParser),
-	)
-}
-
-// MetricSet type defines all fields of the MetricSet
-// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
-// additional entries. These variables can be used to persist data or configuration between
-// multiple fetch calls.
-type MetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// New create a new instance of the MetricSet
-// Part of new is also setting up the configuration by processing additional
-// configuration entries if needed.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Node{}, mod.GetMetricsRepo(), false),
-		mod:           mod,
-	}, nil
-}
-
-// Fetch methods implements the data gathering and data conversion to the right
-// format. It publishes the event which is then forwarded to the output. In case
-// of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.node")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *MetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.NodeResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume.go
@@ -18,103 +18,32 @@
 package state_persistentvolume
 
 import (
-	"fmt"
-
-	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_persistentvolume_capacity_bytes": p.Metric("capacity.bytes"),
+		"kube_persistentvolume_status_phase":   p.LabelMetric("phase", "phase"),
+		"kube_persistentvolume_labels": p.ExtendedInfoMetric(
+			p.Configuration{
+				StoreNonMappedLabels:     true,
+				NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
+				MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
+			}),
+		"kube_persistentvolume_info": p.InfoMetric(),
+	},
+	Labels: map[string]p.LabelMap{
+		"persistentvolume": p.KeyLabel("name"),
+		"storageclass":     p.Label("storage_class"),
+	},
+}
+
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_persistentvolume",
-		NewPersistentVolumeMetricSet,
-		mb.WithHostParser(p.HostParser))
-}
-
-// PersistentVolumeMetricSet is a prometheus based MetricSet that looks for
-// mb.ModuleDataKey prefixed fields and puts then at the module level
-type PersistentVolumeMetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	mapping    *p.MetricsMapping
-	mod        k8smod.Module
-	enricher   util.Enricher
-}
-
-// NewPersistentVolumeMetricSet returns a prometheus based metricset for Persistent Volumes
-func NewPersistentVolumeMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &PersistentVolumeMetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		mod:           mod,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.PersistentVolume{}, mod.GetMetricsRepo(), false),
-		mapping: &p.MetricsMapping{
-			Metrics: map[string]p.MetricMap{
-				"kube_persistentvolume_capacity_bytes": p.Metric("capacity.bytes"),
-				"kube_persistentvolume_status_phase":   p.LabelMetric("phase", "phase"),
-				"kube_persistentvolume_labels": p.ExtendedInfoMetric(
-					p.Configuration{
-						StoreNonMappedLabels:     true,
-						NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
-						MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
-					}),
-				"kube_persistentvolume_info": p.InfoMetric(),
-			},
-			Labels: map[string]p.LabelMap{
-				"persistentvolume": p.KeyLabel("name"),
-				"storageclass":     p.Label("storage_class"),
-			},
-		},
-	}, nil
-}
-
-// Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
-// module rooted fields at the event that gets reported
-func (m *PersistentVolumeMetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, m.mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.persistentvolume")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-
-}
-
-// Close stops this metricset
-func (m *PersistentVolumeMetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.PersistentVolumeResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim.go
@@ -18,107 +18,36 @@
 package state_persistentvolumeclaim
 
 import (
-	"fmt"
-
-	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
 )
 
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+
+		"kube_persistentvolumeclaim_access_mode": p.LabelMetric("access_mode", "access_mode"),
+		"kube_persistentvolumeclaim_info":        p.InfoMetric(),
+		"kube_persistentvolumeclaim_labels": p.ExtendedInfoMetric(
+			p.Configuration{
+				StoreNonMappedLabels:     true,
+				NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
+				MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
+			}),
+		"kube_persistentvolumeclaim_resource_requests_storage_bytes": p.Metric("request_storage.bytes"),
+		"kube_persistentvolumeclaim_status_phase":                    p.LabelMetric("phase", "phase"),
+	},
+	Labels: map[string]p.LabelMap{
+		"namespace":             p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+		"persistentvolumeclaim": p.KeyLabel("name"),
+		"storageclass":          p.Label("storage_class"),
+		"volumename":            p.Label("volume_name"),
+	},
+}
+
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_persistentvolumeclaim",
-		NewpersistentvolumeclaimMetricSet,
-		mb.WithHostParser(p.HostParser))
-}
-
-// persistentvolumeclaimMetricSet is a prometheus based MetricSet that looks for
-// mb.ModuleDataKey prefixed fields and puts then at the module level
-type persistentvolumeclaimMetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	mapping    *p.MetricsMapping
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// NewpersistentvolumeclaimMetricSet returns a prometheus based metricset for Persistent Volumes
-func NewpersistentvolumeclaimMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &persistentvolumeclaimMetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		mod:           mod,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.PersistentVolumeClaim{}, mod.GetMetricsRepo(), false),
-		mapping: &p.MetricsMapping{
-			Metrics: map[string]p.MetricMap{
-
-				"kube_persistentvolumeclaim_access_mode": p.LabelMetric("access_mode", "access_mode"),
-				"kube_persistentvolumeclaim_info":        p.InfoMetric(),
-				"kube_persistentvolumeclaim_labels": p.ExtendedInfoMetric(
-					p.Configuration{
-						StoreNonMappedLabels:     true,
-						NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
-						MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
-					}),
-				"kube_persistentvolumeclaim_resource_requests_storage_bytes": p.Metric("request_storage.bytes"),
-				"kube_persistentvolumeclaim_status_phase":                    p.LabelMetric("phase", "phase"),
-			},
-			Labels: map[string]p.LabelMap{
-				"namespace":             p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-				"persistentvolumeclaim": p.KeyLabel("name"),
-				"storageclass":          p.Label("storage_class"),
-				"volumename":            p.Label("volume_name"),
-			},
-		},
-	}, nil
-}
-
-// Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
-// module rooted fields at the event that gets reported
-func (m *persistentvolumeclaimMetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, m.mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.persistentvolumeclaim")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-
-}
-
-// Close stops this metricset
-func (m *persistentvolumeclaimMetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.PersistentVolumeClaimResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_pod/state_pod.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod.go
@@ -18,122 +18,31 @@
 package state_pod
 
 import (
-	"fmt"
-
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
-const (
-	defaultScheme = "http"
-	defaultPath   = "/metrics"
-)
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_pod_info":             p.InfoMetric(),
+		"kube_pod_status_phase":     p.LabelMetric("status.phase", "phase", p.OpLowercaseValue()),
+		"kube_pod_status_ready":     p.LabelMetric("status.ready", "condition", p.OpLowercaseValue()),
+		"kube_pod_status_scheduled": p.LabelMetric("status.scheduled", "condition", p.OpLowercaseValue()),
+	},
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		DefaultPath:   defaultPath,
-	}.Build()
+	Labels: map[string]p.LabelMap{
+		"pod":       p.KeyLabel("name"),
+		"namespace": p.KeyLabel(mb.ModuleDataKey + ".namespace"),
 
-	mapping = &p.MetricsMapping{
-		Metrics: map[string]p.MetricMap{
-			"kube_pod_info":             p.InfoMetric(),
-			"kube_pod_status_phase":     p.LabelMetric("status.phase", "phase", p.OpLowercaseValue()),
-			"kube_pod_status_ready":     p.LabelMetric("status.ready", "condition", p.OpLowercaseValue()),
-			"kube_pod_status_scheduled": p.LabelMetric("status.scheduled", "condition", p.OpLowercaseValue()),
-		},
+		"node":    p.Label(mb.ModuleDataKey + ".node.name"),
+		"pod_ip":  p.Label("ip"),
+		"host_ip": p.Label("host_ip"),
+	},
+}
 
-		Labels: map[string]p.LabelMap{
-			"pod":       p.KeyLabel("name"),
-			"namespace": p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-
-			"node":    p.Label(mb.ModuleDataKey + ".node.name"),
-			"pod_ip":  p.Label("ip"),
-			"host_ip": p.Label("host_ip"),
-		},
-	}
-)
-
-// init registers the MetricSet with the central registry.
-// The New method will be called after the setup of the module and before starting to fetch data
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_pod", New,
-		mb.WithHostParser(hostParser),
-	)
-}
-
-// MetricSet type defines all fields of the MetricSet
-// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
-// additional entries. These variables can be used to persist data or configuration between
-// multiple fetch calls.
-type MetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// New create a new instance of the MetricSet
-// Part of new is also setting up the configuration by processing additional
-// configuration entries if needed.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.Pod{}, mod.GetMetricsRepo(), false),
-		mod:           mod,
-	}, nil
-}
-
-// Fetch methods implements the data gathering and data conversion to the right
-// format. It publishes the event which is then forwarded to the output. In case
-// of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.pod")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *MetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.PodResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset.go
@@ -18,119 +18,29 @@
 package state_replicaset
 
 import (
-	"fmt"
-
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
-const (
-	defaultScheme = "http"
-	defaultPath   = "/metrics"
-)
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_replicaset_metadata_generation":           p.InfoMetric(),
+		"kube_replicaset_status_fully_labeled_replicas": p.Metric("replicas.labeled"),
+		"kube_replicaset_status_observed_generation":    p.Metric("replicas.observed"),
+		"kube_replicaset_status_ready_replicas":         p.Metric("replicas.ready"),
+		"kube_replicaset_spec_replicas":                 p.Metric("replicas.desired"),
+		"kube_replicaset_status_replicas":               p.Metric("replicas.available"),
+	},
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		DefaultPath:   defaultPath,
-	}.Build()
+	Labels: map[string]p.LabelMap{
+		"replicaset": p.KeyLabel("name"),
+		"namespace":  p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+	},
+}
 
-	mapping = &p.MetricsMapping{
-		Metrics: map[string]p.MetricMap{
-			"kube_replicaset_metadata_generation":           p.InfoMetric(),
-			"kube_replicaset_status_fully_labeled_replicas": p.Metric("replicas.labeled"),
-			"kube_replicaset_status_observed_generation":    p.Metric("replicas.observed"),
-			"kube_replicaset_status_ready_replicas":         p.Metric("replicas.ready"),
-			"kube_replicaset_spec_replicas":                 p.Metric("replicas.desired"),
-			"kube_replicaset_status_replicas":               p.Metric("replicas.available"),
-		},
-
-		Labels: map[string]p.LabelMap{
-			"replicaset": p.KeyLabel("name"),
-			"namespace":  p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-		},
-	}
-)
-
-// init registers the MetricSet with the central registry.
-// The New method will be called after the setup of the module and before starting to fetch data
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_replicaset", New,
-		mb.WithHostParser(hostParser),
-	)
-}
-
-// MetricSet type defines all fields of the MetricSet
-// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
-// additional entries. These variables can be used to persist data or configuration between
-// multiple fetch calls.
-type MetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// New create a new instance of the MetricSet
-// Part of new is also setting up the configuration by processing additional
-// configuration entries if needed.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.ReplicaSet{}, mod.GetMetricsRepo(), false),
-		mod:           mod,
-	}, nil
-}
-
-// Fetch methods implements the data gathering and data conversion to the right
-// format. It publishes the event which is then forwarded to the output. In case
-// of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.replicaset")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *MetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.ReplicaSetResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_service/state_service.go
+++ b/metricbeat/module/kubernetes/state_service/state_service.go
@@ -18,114 +18,41 @@
 package state_service
 
 import (
-	"fmt"
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_service_info": p.InfoMetric(),
+		"kube_service_labels": p.ExtendedInfoMetric(
+			p.Configuration{
+				StoreNonMappedLabels:     true,
+				NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
+				MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
+			}),
+		"kube_service_created":                      p.Metric("created", p.OpUnixTimestampValue()),
+		"kube_service_spec_type":                    p.InfoMetric(),
+		"kube_service_spec_external_ip":             p.InfoMetric(),
+		"kube_service_status_load_balancer_ingress": p.InfoMetric(),
+	},
+	Labels: map[string]p.LabelMap{
+		"namespace":        p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+		"service":          p.KeyLabel("name"),
+		"cluster_ip":       p.Label("cluster_ip"),
+		"external_name":    p.Label("external_name"),
+		"external_ip":      p.Label("external_ip"),
+		"load_balancer_ip": p.Label("load_balancer_ip"),
+		"type":             p.Label("type"),
+		"ip":               p.Label("ingress_ip"),
+		"hostname":         p.Label("ingress_hostname"),
+	},
+}
+
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_service",
-		NewServiceMetricSet,
-		mb.WithHostParser(p.HostParser))
-}
-
-// ServiceMetricSet is a prometheus based MetricSet that looks for
-// mb.ModuleDataKey prefixed fields and puts then at the module level
-//
-// Copying the code from other kube state metrics, this should be improved to
-// avoid all these ugly tricks
-type ServiceMetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	mapping    *p.MetricsMapping
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// NewServiceMetricSet returns a prometheus based metricset for Services
-func NewServiceMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &ServiceMetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		mod:           mod,
-		mapping: &p.MetricsMapping{
-			Metrics: map[string]p.MetricMap{
-				"kube_service_info": p.InfoMetric(),
-				"kube_service_labels": p.ExtendedInfoMetric(
-					p.Configuration{
-						StoreNonMappedLabels:     true,
-						NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
-						MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
-					}),
-				"kube_service_created":                      p.Metric("created", p.OpUnixTimestampValue()),
-				"kube_service_spec_type":                    p.InfoMetric(),
-				"kube_service_spec_external_ip":             p.InfoMetric(),
-				"kube_service_status_load_balancer_ingress": p.InfoMetric(),
-			},
-			Labels: map[string]p.LabelMap{
-				"namespace":        p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-				"service":          p.KeyLabel("name"),
-				"cluster_ip":       p.Label("cluster_ip"),
-				"external_name":    p.Label("external_name"),
-				"external_ip":      p.Label("external_ip"),
-				"load_balancer_ip": p.Label("load_balancer_ip"),
-				"type":             p.Label("type"),
-				"ip":               p.Label("ingress_ip"),
-				"hostname":         p.Label("ingress_hostname"),
-			},
-		},
-		enricher: util.NewResourceMetadataEnricher(base, &kubernetes.Service{}, mod.GetMetricsRepo(), false),
-	}, nil
-}
-
-// Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
-// module rooted fields at the event that gets reported
-func (m *ServiceMetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, m.mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.service")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *ServiceMetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.ServiceResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_statefulset/state_statefulset.go
+++ b/metricbeat/module/kubernetes/state_statefulset/state_statefulset.go
@@ -18,119 +18,29 @@
 package state_statefulset
 
 import (
-	"fmt"
-
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	"github.com/elastic/beats/v7/metricbeat/mb/parse"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
-const (
-	defaultScheme = "http"
-	defaultPath   = "/metrics"
-)
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_statefulset_created":                    p.Metric("created"),
+		"kube_statefulset_metadata_generation":        p.Metric("generation.desired"),
+		"kube_statefulset_status_observed_generation": p.Metric("generation.observed"),
+		"kube_statefulset_replicas":                   p.Metric("replicas.desired"),
+		"kube_statefulset_status_replicas":            p.Metric("replicas.observed"),
+		"kube_statefulset_status_replicas_ready":      p.Metric("replicas.ready"),
+	},
 
-var (
-	hostParser = parse.URLHostParserBuilder{
-		DefaultScheme: defaultScheme,
-		DefaultPath:   defaultPath,
-	}.Build()
+	Labels: map[string]p.LabelMap{
+		"statefulset": p.KeyLabel("name"),
+		"namespace":   p.KeyLabel(mb.ModuleDataKey + ".namespace"),
+	},
+}
 
-	mapping = &p.MetricsMapping{
-		Metrics: map[string]p.MetricMap{
-			"kube_statefulset_created":                    p.Metric("created"),
-			"kube_statefulset_metadata_generation":        p.Metric("generation.desired"),
-			"kube_statefulset_status_observed_generation": p.Metric("generation.observed"),
-			"kube_statefulset_replicas":                   p.Metric("replicas.desired"),
-			"kube_statefulset_status_replicas":            p.Metric("replicas.observed"),
-			"kube_statefulset_status_replicas_ready":      p.Metric("replicas.ready"),
-		},
-
-		Labels: map[string]p.LabelMap{
-			"statefulset": p.KeyLabel("name"),
-			"namespace":   p.KeyLabel(mb.ModuleDataKey + ".namespace"),
-		},
-	}
-)
-
-// init registers the MetricSet with the central registry.
-// The New method will be called after the setup of the module and before starting to fetch data
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_statefulset", New,
-		mb.WithHostParser(hostParser),
-	)
-}
-
-// MetricSet type defines all fields of the MetricSet
-// As a minimum it must inherit the mb.BaseMetricSet fields, but can be extended with
-// additional entries. These variables can be used to persist data or configuration between
-// multiple fetch calls.
-type MetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	enricher   util.Enricher
-	mod        k8smod.Module
-}
-
-// New create a new instance of the MetricSet
-// Part of new is also setting up the configuration by processing additional
-// configuration entries if needed.
-func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &MetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.StatefulSet{}, mod.GetMetricsRepo(), false),
-		mod:           mod,
-	}, nil
-}
-
-// Fetch methods implements the data gathering and data conversion to the right
-// format. It publishes the event which is then forwarded to the output. In case
-// of an error set the Error field of mb.Event or simply call report.Error().
-func (m *MetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.statefulset")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *MetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.StatefulSetResource, mapping)
 }

--- a/metricbeat/module/kubernetes/state_storageclass/state_storageclass.go
+++ b/metricbeat/module/kubernetes/state_storageclass/state_storageclass.go
@@ -18,105 +18,35 @@
 package state_storageclass
 
 import (
-	"fmt"
+	sm "github.com/elastic/beats/v7/metricbeat/helper/kubernetes"
 
 	p "github.com/elastic/beats/v7/metricbeat/helper/prometheus"
 	"github.com/elastic/beats/v7/metricbeat/mb"
-	k8smod "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 	"github.com/elastic/beats/v7/metricbeat/module/kubernetes/util"
-	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
 )
 
+var mapping = &p.MetricsMapping{
+	Metrics: map[string]p.MetricMap{
+		"kube_storageclass_info": p.InfoMetric(),
+		"kube_storageclass_labels": p.ExtendedInfoMetric(
+			p.Configuration{
+				StoreNonMappedLabels:     true,
+				NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
+				MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
+			}),
+		"kube_storageclass_created": p.Metric("created", p.OpUnixTimestampValue()),
+	},
+	Labels: map[string]p.LabelMap{
+		"storageclass":        p.KeyLabel("name"),
+		"provisioner":         p.Label("provisioner"),
+		"reclaimPolicy":       p.Label("reclaim_policy"),
+		"reclaim_policy":      p.Label("reclaim_policy"),
+		"volumeBindingMode":   p.Label("volume_binding_mode"),
+		"volume_binding_mode": p.Label("volume_binding_mode"),
+	},
+}
+
+// Register metricset
 func init() {
-	mb.Registry.MustAddMetricSet("kubernetes", "state_storageclass",
-		NewStorageClassMetricSet,
-		mb.WithHostParser(p.HostParser))
-}
-
-// StorageClassMetricSet is a prometheus based MetricSet that fetches
-// and reports kube-state-metrics storage class metrics
-type StorageClassMetricSet struct {
-	mb.BaseMetricSet
-	prometheus p.Prometheus
-	mapping    *p.MetricsMapping
-	mod        k8smod.Module
-	enricher   util.Enricher
-}
-
-// NewStorageClassMetricSet returns a prometheus based metricset for Storage classes
-func NewStorageClassMetricSet(base mb.BaseMetricSet) (mb.MetricSet, error) {
-	prometheus, err := p.NewPrometheusClient(base)
-	if err != nil {
-		return nil, err
-	}
-	mod, ok := base.Module().(k8smod.Module)
-	if !ok {
-		return nil, fmt.Errorf("must be child of kubernetes module")
-	}
-	return &StorageClassMetricSet{
-		BaseMetricSet: base,
-		prometheus:    prometheus,
-		mod:           mod,
-		enricher:      util.NewResourceMetadataEnricher(base, &kubernetes.StorageClass{}, mod.GetMetricsRepo(), false),
-		mapping: &p.MetricsMapping{
-			Metrics: map[string]p.MetricMap{
-				"kube_storageclass_info": p.InfoMetric(),
-				"kube_storageclass_labels": p.ExtendedInfoMetric(
-					p.Configuration{
-						StoreNonMappedLabels:     true,
-						NonMappedLabelsPlacement: mb.ModuleDataKey + ".labels",
-						MetricProcessingOptions:  []p.MetricOption{p.OpLabelKeyPrefixRemover("label_")},
-					}),
-				"kube_storageclass_created": p.Metric("created", p.OpUnixTimestampValue()),
-			},
-			Labels: map[string]p.LabelMap{
-				"storageclass":        p.KeyLabel("name"),
-				"provisioner":         p.Label("provisioner"),
-				"reclaimPolicy":       p.Label("reclaim_policy"),
-				"reclaim_policy":      p.Label("reclaim_policy"),
-				"volumeBindingMode":   p.Label("volume_binding_mode"),
-				"volume_binding_mode": p.Label("volume_binding_mode"),
-			},
-		},
-	}, nil
-}
-
-// Fetch prometheus metrics and treats those prefixed by mb.ModuleDataKey as
-// module rooted fields at the event that gets reported
-func (m *StorageClassMetricSet) Fetch(reporter mb.ReporterV2) {
-	m.enricher.Start()
-
-	families, err := m.mod.GetStateMetricsFamilies(m.prometheus)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-	events, err := m.prometheus.ProcessMetrics(families, m.mapping)
-	if err != nil {
-		m.Logger().Error(err)
-		reporter.Error(err)
-		return
-	}
-
-	m.enricher.Enrich(events)
-
-	for _, event := range events {
-
-		e, err := util.CreateEvent(event, "kubernetes.storageclass")
-		if err != nil {
-			m.Logger().Error(err)
-		}
-
-		if reported := reporter.Event(e); !reported {
-			m.Logger().Debug("error trying to emit event")
-			return
-		}
-	}
-}
-
-// Close stops this metricset
-func (m *StorageClassMetricSet) Close() error {
-	m.enricher.Stop()
-	return nil
+	sm.Init(util.StorageClassResource, mapping)
 }

--- a/metricbeat/module/kubernetes/util/kubernetes.go
+++ b/metricbeat/module/kubernetes/util/kubernetes.go
@@ -78,10 +78,56 @@ type enricher struct {
 
 const selector = "kubernetes"
 
+const (
+	PodResource                   = "pod"
+	ServiceResource               = "service"
+	DeploymentResource            = "deployment"
+	ReplicaSetResource            = "replicaset"
+	StatefulSetResource           = "statefulset"
+	DaemonSetResource             = "daemonset"
+	JobResource                   = "job"
+	NodeResource                  = "node"
+	CronJobResource               = "cronjob"
+	PersistentVolumeResource      = "persistentvolume"
+	PersistentVolumeClaimResource = "persistentvolumeclaim"
+	StorageClassResource          = "storageclass"
+)
+
+func getResource(resourceName string) kubernetes.Resource {
+	switch resourceName {
+	case PodResource:
+		return &kubernetes.Pod{}
+	case ServiceResource:
+		return &kubernetes.Service{}
+	case DeploymentResource:
+		return &kubernetes.Deployment{}
+	case ReplicaSetResource:
+		return &kubernetes.ReplicaSet{}
+	case StatefulSetResource:
+		return &kubernetes.StatefulSet{}
+	case DaemonSetResource:
+		return &kubernetes.DaemonSet{}
+	case JobResource:
+		return &kubernetes.Job{}
+	case CronJobResource:
+		return &kubernetes.CronJob{}
+	case PersistentVolumeResource:
+		return &kubernetes.PersistentVolume{}
+	case PersistentVolumeClaimResource:
+		return &kubernetes.PersistentVolumeClaim{}
+	case StorageClassResource:
+		return &kubernetes.StorageClass{}
+	case NodeResource:
+		return &kubernetes.Node{}
+	default:
+		return nil
+	}
+}
+
 // NewResourceMetadataEnricher returns an Enricher configured for kubernetes resource events
 func NewResourceMetadataEnricher(
 	base mb.BaseMetricSet,
-	res kubernetes.Resource,
+	resourceName string,
 	metricsRepo *MetricsRepo,
 	nodeScope bool) Enricher {
 
@@ -91,6 +137,10 @@ func NewResourceMetadataEnricher(
 		return &nilEnricher{}
 	}
 
+	res := getResource(resourceName)
+	if res == nil {
+		return &nilEnricher{}
+	}
 	watcher, nodeWatcher, namespaceWatcher := getResourceMetadataWatchers(config, res, nodeScope)
 
 	if watcher == nil {
@@ -138,30 +188,30 @@ func NewResourceMetadataEnricher(
 				nodeStore, _ := metricsRepo.AddNodeStore(nodeName)
 				nodeStore.SetNodeMetrics(metrics)
 
-				m[id] = metaGen.Generate("node", r)
+				m[id] = metaGen.Generate(NodeResource, r)
 
 			case *kubernetes.Deployment:
-				m[id] = metaGen.Generate("deployment", r)
+				m[id] = metaGen.Generate(DeploymentResource, r)
 			case *kubernetes.Job:
-				m[id] = metaGen.Generate("job", r)
+				m[id] = metaGen.Generate(JobResource, r)
 			case *kubernetes.CronJob:
-				m[id] = metaGen.Generate("cronjob", r)
+				m[id] = metaGen.Generate(CronJobResource, r)
 			case *kubernetes.Service:
 				m[id] = serviceMetaGen.Generate(r)
 			case *kubernetes.StatefulSet:
-				m[id] = metaGen.Generate("statefulset", r)
+				m[id] = metaGen.Generate(StatefulSetResource, r)
 			case *kubernetes.Namespace:
 				m[id] = metaGen.Generate("namespace", r)
 			case *kubernetes.ReplicaSet:
-				m[id] = metaGen.Generate("replicaset", r)
+				m[id] = metaGen.Generate(ReplicaSetResource, r)
 			case *kubernetes.DaemonSet:
-				m[id] = metaGen.Generate("daemonset", r)
+				m[id] = metaGen.Generate(DaemonSetResource, r)
 			case *kubernetes.PersistentVolume:
-				m[id] = metaGen.Generate("persistentvolume", r)
+				m[id] = metaGen.Generate(PersistentVolumeResource, r)
 			case *kubernetes.PersistentVolumeClaim:
-				m[id] = metaGen.Generate("persistentvolumeclaim", r)
+				m[id] = metaGen.Generate(PersistentVolumeClaimResource, r)
 			case *kubernetes.StorageClass:
-				m[id] = metaGen.Generate("storageclass", r)
+				m[id] = metaGen.Generate(StorageClassResource, r)
 			default:
 				m[id] = metaGen.Generate(r.GetObjectKind().GroupVersionKind().Kind, r)
 			}


### PR DESCRIPTION
## What does this PR do?
Move common code from state_* metricsets to a new file.

## Why is it important?
The functions being used are the same, and making one change would imply changing all the others. Moving them to one file reduces maintenance. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates to [#123](https://github.com/elastic/beats/pull/34399)


