### PR TITLE
added mac m1 support for auditbeat system/package

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -56,7 +56,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Filebeat*
-
+- [Auditbeat System Package] Added support for Apple Silicon chips. {pull}34433[34433] 
 - [Azure blob storage] Changed logger field name from `container` to `container_name` so that it does not clash
    with the ecs field name `container`. {pull}34403[34403]
 - [GCS] Added support for more mime types & introduced offset tracking via cursor state. Also added support for

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -525,6 +525,7 @@ func (ms *MetricSet) getPackages() (packages []*Package, err error) {
 		}
 		ms.log.Debugf("Homebrew packages: %v", len(homebrewPackages))
 		packages = append(packages, homebrewPackages...)
+		break
 	}
 
 	if !foundPackageManager && !ms.suppressNoPackageWarnings {

--- a/x-pack/auditbeat/module/system/package/package.go
+++ b/x-pack/auditbeat/module/system/package/package.go
@@ -12,8 +12,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -49,7 +51,7 @@ const (
 var (
 	rpmPath            = "/var/lib/rpm"
 	dpkgPath           = "/var/lib/dpkg"
-	homebrewCellarPath = "/usr/local/Cellar"
+	homebrewCellarPath = []string{"/usr/local/Cellar", "/opt/homebrew/Cellar"}
 )
 
 type eventAction uint8
@@ -508,11 +510,17 @@ func (ms *MetricSet) getPackages() (packages []*Package, err error) {
 		return nil, fmt.Errorf("error opening %v: %w", dpkgPath, err)
 	}
 
-	_, err = os.Stat(homebrewCellarPath)
+	updatedCellarPath := homebrewCellarPath[0]
+	_, err = os.Stat(homebrewCellarPath[0])
+	if err != nil && errors.Is(err, fs.ErrNotExist) && len(homebrewCellarPath) == 2 {
+		_, err = os.Stat(homebrewCellarPath[1])
+		updatedCellarPath = homebrewCellarPath[1]
+	}
+
 	if err == nil {
 		foundPackageManager = true
 
-		homebrewPackages, err := listBrewPackages()
+		homebrewPackages, err := listBrewPackages(updatedCellarPath)
 		if err != nil {
 			return nil, fmt.Errorf("error getting Homebrew packages: %w", err)
 		}
@@ -520,12 +528,12 @@ func (ms *MetricSet) getPackages() (packages []*Package, err error) {
 
 		packages = append(packages, homebrewPackages...)
 	} else if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("error opening %v: %w", homebrewCellarPath, err)
+		return nil, fmt.Errorf("error opening %v: %w", updatedCellarPath, err)
 	}
 
 	if !foundPackageManager && !ms.suppressNoPackageWarnings {
 		ms.log.Warnf("No supported package managers found. None of %v, %v, %v exist.",
-			rpmPath, dpkgPath, homebrewCellarPath)
+			rpmPath, dpkgPath, updatedCellarPath)
 
 		// Only warn once at the start of Auditbeat.
 		ms.suppressNoPackageWarnings = true

--- a/x-pack/auditbeat/module/system/package/package_homebrew.go
+++ b/x-pack/auditbeat/module/system/package/package_homebrew.go
@@ -27,8 +27,8 @@ type InstallReceipt struct {
 	Source InstallReceiptSource
 }
 
-func listBrewPackages(updatedCellarPath string) ([]*Package, error) {
-	packageDirs, err := ioutil.ReadDir(updatedCellarPath)
+func listBrewPackages(brewCellarPath string) ([]*Package, error) {
+	packageDirs, err := ioutil.ReadDir(brewCellarPath)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func listBrewPackages(updatedCellarPath string) ([]*Package, error) {
 		if !packageDir.IsDir() {
 			continue
 		}
-		pkgPath := path.Join(updatedCellarPath, packageDir.Name())
+		pkgPath := path.Join(brewCellarPath, packageDir.Name())
 		versions, err := ioutil.ReadDir(pkgPath)
 		if err != nil {
 			return nil, fmt.Errorf("error reading directory: %s: %w", pkgPath, err)
@@ -57,7 +57,7 @@ func listBrewPackages(updatedCellarPath string) ([]*Package, error) {
 
 			// Read formula
 			var formulaPath string
-			installReceiptPath := path.Join(updatedCellarPath, pkg.Name, pkg.Version, "INSTALL_RECEIPT.json")
+			installReceiptPath := path.Join(brewCellarPath, pkg.Name, pkg.Version, "INSTALL_RECEIPT.json")
 			contents, err := ioutil.ReadFile(installReceiptPath)
 			if err != nil {
 				pkg.error = fmt.Errorf("error reading %v: %w", installReceiptPath, err)
@@ -73,7 +73,7 @@ func listBrewPackages(updatedCellarPath string) ([]*Package, error) {
 
 			if formulaPath == "" {
 				// Fallback to /usr/local/Cellar/{pkg.Name}/{pkg.Version}/.brew/{pkg.Name}.rb
-				formulaPath = path.Join(updatedCellarPath, pkg.Name, pkg.Version, ".brew", pkg.Name+".rb")
+				formulaPath = path.Join(brewCellarPath, pkg.Name, pkg.Version, ".brew", pkg.Name+".rb")
 			}
 
 			file, err := os.Open(formulaPath)

--- a/x-pack/auditbeat/module/system/package/package_homebrew.go
+++ b/x-pack/auditbeat/module/system/package/package_homebrew.go
@@ -27,8 +27,8 @@ type InstallReceipt struct {
 	Source InstallReceiptSource
 }
 
-func listBrewPackages() ([]*Package, error) {
-	packageDirs, err := ioutil.ReadDir(homebrewCellarPath)
+func listBrewPackages(updatedCellarPath string) ([]*Package, error) {
+	packageDirs, err := ioutil.ReadDir(updatedCellarPath)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func listBrewPackages() ([]*Package, error) {
 		if !packageDir.IsDir() {
 			continue
 		}
-		pkgPath := path.Join(homebrewCellarPath, packageDir.Name())
+		pkgPath := path.Join(updatedCellarPath, packageDir.Name())
 		versions, err := ioutil.ReadDir(pkgPath)
 		if err != nil {
 			return nil, fmt.Errorf("error reading directory: %s: %w", pkgPath, err)
@@ -57,7 +57,7 @@ func listBrewPackages() ([]*Package, error) {
 
 			// Read formula
 			var formulaPath string
-			installReceiptPath := path.Join(homebrewCellarPath, pkg.Name, pkg.Version, "INSTALL_RECEIPT.json")
+			installReceiptPath := path.Join(updatedCellarPath, pkg.Name, pkg.Version, "INSTALL_RECEIPT.json")
 			contents, err := ioutil.ReadFile(installReceiptPath)
 			if err != nil {
 				pkg.error = fmt.Errorf("error reading %v: %w", installReceiptPath, err)
@@ -73,7 +73,7 @@ func listBrewPackages() ([]*Package, error) {
 
 			if formulaPath == "" {
 				// Fallback to /usr/local/Cellar/{pkg.Name}/{pkg.Version}/.brew/{pkg.Name}.rb
-				formulaPath = path.Join(homebrewCellarPath, pkg.Name, pkg.Version, ".brew", pkg.Name+".rb")
+				formulaPath = path.Join(updatedCellarPath, pkg.Name, pkg.Version, ".brew", pkg.Name+".rb")
 			}
 
 			file, err := os.Open(formulaPath)

--- a/x-pack/auditbeat/module/system/package/package_homebrew_test.go
+++ b/x-pack/auditbeat/module/system/package/package_homebrew_test.go
@@ -27,10 +27,10 @@ func TestHomebrew(t *testing.T) {
 	defer func() {
 		homebrewCellarPath = oldPath
 	}()
-	homebrewCellarPath = "testdata/homebrew/"
+	homebrewCellarPath = []string{"testdata/homebrew/"}
 
 	// Test just listBrewPackages()
-	packages, err := listBrewPackages()
+	packages, err := listBrewPackages(homebrewCellarPath[0])
 	assert.NoError(t, err)
 	if assert.Len(t, packages, 1) {
 		pkg := packages[0]
@@ -85,10 +85,10 @@ func TestHomebrewNotExist(t *testing.T) {
 	defer func() {
 		homebrewCellarPath = oldPath
 	}()
-	homebrewCellarPath = "/does/not/exist"
+	homebrewCellarPath = []string{"/does/not/exist"}
 
 	// Test just listBrewPackages()
-	packages, err := listBrewPackages()
+	packages, err := listBrewPackages(homebrewCellarPath[0])
 	if assert.Error(t, err) {
 		assert.True(t, os.IsNotExist(err), "Unexpected error %v", err)
 	}

--- a/x-pack/auditbeat/module/system/package/package_homebrew_test.go
+++ b/x-pack/auditbeat/module/system/package/package_homebrew_test.go
@@ -30,7 +30,7 @@ func TestHomebrew(t *testing.T) {
 	homebrewCellarPath = []string{"testdata/homebrew/"}
 
 	// Test just listBrewPackages()
-	packages, err := listBrewPackages(homebrewCellarPath[0])
+	packages, err := listBrewPackages("testdata/homebrew/")
 	assert.NoError(t, err)
 	if assert.Len(t, packages, 1) {
 		pkg := packages[0]
@@ -88,7 +88,7 @@ func TestHomebrewNotExist(t *testing.T) {
 	homebrewCellarPath = []string{"/does/not/exist"}
 
 	// Test just listBrewPackages()
-	packages, err := listBrewPackages(homebrewCellarPath[0])
+	packages, err := listBrewPackages("/does/not/exist")
 	if assert.Error(t, err) {
 		assert.True(t, os.IsNotExist(err), "Unexpected error %v", err)
 	}

--- a/x-pack/auditbeat/module/system/package/package_test.go
+++ b/x-pack/auditbeat/module/system/package/package_test.go
@@ -66,7 +66,7 @@ func TestDpkg(t *testing.T) {
 		homebrewCellarPath = brewPathOld
 	}()
 	rpmPath = "/does/not/exist"
-	homebrewCellarPath = "/does/not/exist"
+	homebrewCellarPath = []string{"/does/not/exist"}
 
 	var err error
 	dpkgPath, err = filepath.Abs("testdata/dpkg/")
@@ -125,7 +125,7 @@ func TestDpkgInstalledSize(t *testing.T) {
 		homebrewCellarPath = brewPathOld
 	}()
 	rpmPath = "/does/not/exist"
-	homebrewCellarPath = "/does/not/exist"
+	homebrewCellarPath = []string{"/does/not/exist"}
 
 	var err error
 	dpkgPath, err = filepath.Abs("testdata/dpkg-size/")


### PR DESCRIPTION
## Type of change
- Enhancement

## What does this PR do?
Adds support for detecting homebrew packages on macs with apple silicon chips.

## Why is it important?
Previously packages were not being detected on macs with m1 chips.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues
- Closes #34043 
- Relates  #33765 
