### PR TITLE
[Azure blob storage] removing wrong event.kind from input

### DIFF
--- a/x-pack/filebeat/input/azureblobstorage/job.go
+++ b/x-pack/filebeat/input/azureblobstorage/job.go
@@ -80,9 +80,6 @@ func (j *job) do(ctx context.Context, id string) {
 		err := fmt.Errorf("job with jobId %s encountered an error: content-type %s not supported", id, *j.blob.Properties.ContentType)
 		fields = mapstr.M{
 			"message": err.Error(),
-			"event": mapstr.M{
-				"kind": "publish_error",
-			},
 		}
 		event := beat.Event{
 			Timestamp: time.Now(),
@@ -227,9 +224,6 @@ func (j *job) createEvent(message string, offset int64) beat.Event {
 			},
 			"cloud": mapstr.M{
 				"provider": "azure",
-			},
-			"event": mapstr.M{
-				"kind": "publish_data",
 			},
 		},
 	}


### PR DESCRIPTION
## What does this PR do?

Event.kind was set to wrong values (not conforming with ECS), and should really be set in ingest pipelines based on the output of the actual event.

## Why is it important?

Required for the input to respect ECS, and to pass system tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist


## How to test this PR locally

Just run any system test with `--generate` and see if the resulting output does not have event.kind