### PR TITLE
[Google Cloud Storage] Remove event kind from input

### DIFF
--- a/x-pack/filebeat/input/gcs/job.go
+++ b/x-pack/filebeat/input/gcs/job.go
@@ -102,9 +102,6 @@ func (j *job) do(ctx context.Context, id string) {
 		err := fmt.Errorf("job with jobId %s encountered an error: content-type %s not supported", id, j.object.ContentType)
 		fields = mapstr.M{
 			"message": err.Error(),
-			"event": mapstr.M{
-				"kind": "publish_error",
-			},
 		}
 		event := beat.Event{
 			Timestamp: time.Now(),
@@ -318,11 +315,6 @@ func (j *job) createEvent(message []byte, data []mapstr.M, offset int64) beat.Ev
 				Provider string `json:"provider"`
 			}{
 				Provider: "google cloud",
-			},
-			"event": struct {
-				Kind string `json:"kind"`
-			}{
-				Kind: "publish_data",
 			},
 		},
 	}


### PR DESCRIPTION
## What does this PR do?

Similar to https://github.com/elastic/beats/pull/34439, we remove the hardcoded event.kind, as it does not follow the ECS field definition, and should be set based on the event itself

## Why is it important?

Required for system tests to pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally

Just run any system test with --generate and see if the resulting output does not have event.kind

## Related issues

- Relates #34439
