### PR TITLE
correct a wrong field name in filebeats event.yml config

### DIFF
--- a/x-pack/filebeat/module/fortinet/firewall/ingest/event.yml
+++ b/x-pack/filebeat/module/fortinet/firewall/ingest/event.yml
@@ -106,7 +106,7 @@ processors:
     field: fortinet.firewall.dst_host
     target_field: destination.domain
     ignore_missing: true
-    if: "ctx.destination?.address == null"
+    if: "ctx.destination?.domain == null"
 - convert:
     field: fortinet.firewall.sentbyte
     target_field: source.bytes


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
-->

## What does this PR do?

this PR corrects a wrong field name in event.yml config for beats

## Why is it important?

without this correction, filebeats will send the wrong output to elasticsearch when the type of the log entry is `event`

in [this](https://github.com/elastic/beats/blob/10466529eed80994e6c3563a42e34985835c2f87/x-pack/filebeat/module/fortinet/firewall/ingest/event.yml#L100) line, the `rename` processor tests if `destination.address` null, if yes it renames `fortinet.firewall.dst_host` to it, and in [this](https://github.com/elastic/beats/blob/10466529eed80994e6c3563a42e34985835c2f87/x-pack/filebeat/module/fortinet/firewall/ingest/event.yml#L105), the processor (mistakenly) tests if `destination.address` is null again, then renames `fortinet.firewall.dst_host` to `destination.domain`. it should test if `destination.domain` is null instead of `ctx.destination.address`

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~[ ] My code follows the style guidelines of this project~
- ~[ ] I have commented my code, particularly in hard-to-understand areas~
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have made corresponding change to the default configuration files~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

in the case where the change needs to be tested, one has to setup filebeats parse fortinet logs that are of type `event`