### PR TITLE
ci: fix google bucket location

### DIFF
--- a/.ci/beats-tester.groovy
+++ b/.ci/beats-tester.groovy
@@ -69,8 +69,7 @@ pipeline {
           when { changeRequest() }
           steps {
             runBeatsTesterJob(version: "${env.VERSION}-SNAPSHOT",
-                              apm: "https://storage.googleapis.com/apm-ci-artifacts/jobs/pull-requests/pr-${env.CHANGE_ID}",
-                              beats: "https://storage.googleapis.com/beats-ci-artifacts/pull-requests/pr-${env.CHANGE_ID}")
+                              beats: "https://storage.googleapis.com/beats-ci-artifacts/beats/pull-requests/pr-${env.CHANGE_ID}")
           }
         }
         stage('Build release branch') {
@@ -106,7 +105,7 @@ def runBeatsTesterJob(Map args = [:]) {
     def props = readProperties(file: 'beats-tester.properties')
     apm = props.get('APM_URL_BASE', '')
     beats = props.get('BEATS_URL_BASE', '')
-    version = props.get('VERSION', '8.0.0-SNAPSHOT')
+    version = props.get('VERSION', '8.7.0-SNAPSHOT')
   }
   if (apm?.trim() || beats?.trim()) {
     build(job: env.BEATS_TESTER_JOB, propagate: false, wait: false,

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -162,7 +162,7 @@ pipeline {
                     text: """\
                     ## To be consumed by the beats-tester pipeline
                     COMMIT=${env.GIT_BASE_COMMIT}
-                    BEATS_URL_BASE=https://storage.googleapis.com/${env.JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}
+                    BEATS_URL_BASE=https://storage.googleapis.com/${env.JOB_GCS_BUCKET}/${env.REPO}/commits/${env.GIT_BASE_COMMIT}
                     VERSION=${env.BEAT_VERSION}-SNAPSHOT""".stripIndent()) // stripIdent() requires '''/
           archiveArtifacts artifacts: 'beats-tester.properties'
         }


### PR DESCRIPTION
## What does this PR do?

Configure where the snapshots are stored since there is a nested folder with the project name.

<img width="403" alt="image" src="https://user-images.githubusercontent.com/2871786/216282986-5353c77a-6d8e-4d06-b2e4-9a94a8a0509c.png">

<img width="394" alt="image" src="https://user-images.githubusercontent.com/2871786/216283041-b5676e8c-7f61-4f9c-a003-5caf904562d3.png">


### Why

The new folder layout was not reflected in this project.

### Issue

Originally implemented in https://github.com/elastic/apm-pipeline-library/pull/1549