### PR TITLE
[beats] reduce log noise

### DIFF
--- a/metricbeat/module/beat/stats/stats.go
+++ b/metricbeat/module/beat/stats/stats.go
@@ -47,7 +47,7 @@ var (
 // MetricSet defines all fields of the MetricSet
 type MetricSet struct {
 	*beat.MetricSet
-	lastTimestamp time.Time
+	lastClusterUUIDMessageTimestamp time.Time
 }
 
 // New create a new instance of the MetricSet
@@ -74,9 +74,9 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 	clusterUUID, err := m.getClusterUUID()
 	if err != nil {
 		if err == beat.ErrClusterUUID {
-			if time.Since(m.lastTimestamp) > 1*time.Minute {
-				m.lastTimestamp = time.Now()
-				m.Logger().Warn(beat.ErrClusterUUID)
+			if time.Since(m.lastClusterUUIDMessageTimestamp) > 5*time.Minute {
+				m.lastClusterUUIDMessageTimestamp = time.Now()
+				m.Logger().Debug(beat.ErrClusterUUID)
 			}
 			return nil
 		}

--- a/metricbeat/module/beat/stats/stats.go
+++ b/metricbeat/module/beat/stats/stats.go
@@ -18,9 +18,9 @@
 package stats
 
 import (
+	"errors"
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/metricbeat/mb"
 	"github.com/elastic/beats/v7/metricbeat/mb/parse"
@@ -73,7 +73,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 
 	clusterUUID, err := m.getClusterUUID()
 	if err != nil {
-		if err == beat.ErrClusterUUID {
+		if errors.Is(err, beat.ErrClusterUUID) {
 			if time.Since(m.lastClusterUUIDMessageTimestamp) > 5*time.Minute {
 				m.lastClusterUUIDMessageTimestamp = time.Now()
 				m.Logger().Debug(beat.ErrClusterUUID)
@@ -90,7 +90,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 func (m *MetricSet) getClusterUUID() (string, error) {
 	state, err := beat.GetState(m.MetricSet)
 	if err != nil {
-		return "", errors.Wrap(err, "could not get state information")
+		return "", fmt.Errorf("could not get state information: %w", err)
 	}
 
 	clusterUUID := state.Monitoring.ClusterUUID

--- a/metricbeat/module/beat/stats/stats.go
+++ b/metricbeat/module/beat/stats/stats.go
@@ -76,7 +76,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 		if errors.Is(err, beat.ErrClusterUUID) {
 			if time.Since(m.lastClusterUUIDMessageTimestamp) > 5*time.Minute {
 				m.lastClusterUUIDMessageTimestamp = time.Now()
-				m.Logger().Debug(beat.ErrClusterUUID)
+				m.Logger().Debug(err)
 			}
 			return nil
 		}


### PR DESCRIPTION
### Summary
Related https://github.com/elastic/beats/issues/34217

Reduce log noise when failing to get the cluster uuid from a beats state.
If the issue surfaced by this log is persistent it would already be highlighted by higher severity entries in the logs.