### PR TITLE
Fix aws cloudwatch event identifiers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -58,7 +58,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Filebeat*
-- [Auditbeat System Package] Added support for Apple Silicon chips. {pull}34433[34433] 
+- [Auditbeat System Package] Added support for Apple Silicon chips. {pull}34433[34433]
 - [Azure blob storage] Changed logger field name from `container` to `container_name` so that it does not clash
    with the ecs field name `container`. {pull}34403[34403]
 - [GCS] Added support for more mime types & introduced offset tracking via cursor state. Also added support for
@@ -127,6 +127,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Add tags to events based on parsed identifier. {pull}33472[33472]
 - Support Oracle-specific connection strings in SQL module {issue}32089[32089] {pull}32293[32293]
 - Remove deprecated metrics from controller manager, scheduler and proxy {pull}34161[34161]
+- Fix metrics split through different events and metadata not matching for aws cloudwatch. {pull}34483[34483]
 
 
 *Osquerybeat*

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -478,7 +478,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 			for valI, metricDataResultValue := range metricDataResult.Values {
 				if len(labels) != 5 {
 					// when there is no identifier value in label, use region+accountID+label+index instead
-					identifier := regionName + m.AccountID + *metricDataResult.Label + fmt.Sprint("-", valI)
+					identifier := regionName + m.AccountID + labels[namespaceIdx] + fmt.Sprint("-", valI)
 					if _, ok := events[identifier]; !ok {
 						events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID, metricDataResult.Timestamps[valI])
 					}
@@ -486,7 +486,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 					continue
 				}
 
-				identifierValue := *metricDataResult.Label + fmt.Sprint("-", valI)
+				identifierValue := labels[identifierValueIdx] + fmt.Sprint("-", valI)
 				if _, ok := events[identifierValue]; !ok {
 					events[identifierValue] = aws.InitEvent(regionName, m.AccountName, m.AccountID, metricDataResult.Timestamps[valI])
 				}
@@ -534,7 +534,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 					}
 
 					// when there is no identifier value in label, use region+accountID+labels instead
-					identifier := regionName + m.AccountID + *output.Label + fmt.Sprint("-", valI)
+					identifier := regionName + m.AccountID + labels[namespaceIdx] + fmt.Sprint("-", valI)
 					if _, ok := events[identifier]; !ok {
 						events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID, output.Timestamps[valI])
 					}
@@ -543,7 +543,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 				}
 
 				identifierValue := labels[identifierValueIdx]
-				uniqueIdentifierValue := *output.Label + fmt.Sprint("-", valI)
+				uniqueIdentifierValue := identifierValue + fmt.Sprint("-", valI)
 
 				// add tags to event based on identifierValue
 				// Check if identifier includes dimensionSeparator (comma in this case),

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch.go
@@ -477,7 +477,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 			labels := strings.Split(*metricDataResult.Label, labelSeparator)
 			for valI, metricDataResultValue := range metricDataResult.Values {
 				if len(labels) != 5 {
-					// when there is no identifier value in label, use region+accountID+label+index instead
+					// when there is no identifier value in label, use region+accountID+namespace+index instead
 					identifier := regionName + m.AccountID + labels[namespaceIdx] + fmt.Sprint("-", valI)
 					if _, ok := events[identifier]; !ok {
 						events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID, metricDataResult.Timestamps[valI])
@@ -533,7 +533,7 @@ func (m *MetricSet) createEvents(svcCloudwatch cloudwatch.GetMetricDataAPIClient
 						continue
 					}
 
-					// when there is no identifier value in label, use region+accountID+labels instead
+					// when there is no identifier value in label, use region+accountID+namespace+index instead
 					identifier := regionName + m.AccountID + labels[namespaceIdx] + fmt.Sprint("-", valI)
 					if _, ok := events[identifier]; !ok {
 						events[identifier] = aws.InitEvent(regionName, m.AccountName, m.AccountID, output.Timestamps[valI])

--- a/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/cloudwatch_test.go
@@ -1241,13 +1241,13 @@ func TestCreateEventsWithIdentifier(t *testing.T) {
 
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(events))
+	assert.Equal(t, 1, len(events))
 
-	metricValue, err := events[label1+"-0"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
+	metricValue, err := events["i-1-0"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
 	assert.NoError(t, err)
 	assert.Equal(t, value1, metricValue)
 
-	dimension, err := events[label2+"-0"].RootFields.GetValue("aws.dimensions.InstanceId")
+	dimension, err := events["i-1-0"].RootFields.GetValue("aws.dimensions.InstanceId")
 	assert.NoError(t, err)
 	assert.Equal(t, instanceID1, dimension)
 }
@@ -1283,12 +1283,12 @@ func TestCreateEventsWithoutIdentifier(t *testing.T) {
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
 	assert.NoError(t, err)
 
-	expectedID := regionName + accountID
-	metricValue, err := events[expectedID+label3+"-0"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
+	expectedID := regionName + accountID + namespace
+	metricValue, err := events[expectedID+"-0"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
 	assert.NoError(t, err)
 	assert.Equal(t, value1, metricValue)
 
-	dimension, err := events[expectedID+label4+"-0"].RootFields.GetValue("aws.ec2.metrics.DiskReadOps.avg")
+	dimension, err := events[expectedID+"-0"].RootFields.GetValue("aws.ec2.metrics.DiskReadOps.avg")
 	assert.NoError(t, err)
 	assert.Equal(t, value2, dimension)
 }
@@ -1319,19 +1319,19 @@ func TestCreateEventsWithDataGranularity(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectedID := regionName + accountID
-	metricValue, err := events[expectedID+label3+"-0"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
+	metricValue, err := events[expectedID+namespace+"-0"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
 	assert.NoError(t, err)
-	metricValue1, err := events[expectedID+label3+"-1"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
+	metricValue1, err := events[expectedID+namespace+"-1"].RootFields.GetValue("aws.ec2.metrics.CPUUtilization.avg")
 	assert.NoError(t, err)
-	metricValue2, err := events[expectedID+label4+"-0"].RootFields.GetValue("aws.ec2.metrics.DiskReadOps.avg")
+	metricValue2, err := events[expectedID+namespace+"-0"].RootFields.GetValue("aws.ec2.metrics.DiskReadOps.avg")
 	assert.NoError(t, err)
-	metricValue3, err := events[expectedID+label4+"-1"].RootFields.GetValue("aws.ec2.metrics.DiskReadOps.avg")
+	metricValue3, err := events[expectedID+namespace+"-1"].RootFields.GetValue("aws.ec2.metrics.DiskReadOps.avg")
 	assert.NoError(t, err)
 	assert.Equal(t, value1, metricValue)
 	assert.Equal(t, value1, metricValue1)
 	assert.Equal(t, value2, metricValue2)
 	assert.Equal(t, value2, metricValue3)
-	assert.Equal(t, 4, len(events))
+	assert.Equal(t, 2, len(events))
 }
 
 func TestCreateEventsWithTagsFilter(t *testing.T) {
@@ -1360,7 +1360,7 @@ func TestCreateEventsWithTagsFilter(t *testing.T) {
 	startTime, endTime := aws.GetStartTimeEndTime(time.Now(), m.MetricSet.Period, m.MetricSet.Latency)
 	events, err := m.createEvents(mockCloudwatchSvc, mockTaggingSvc, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(events))
+	assert.Equal(t, 1, len(events))
 
 	// Specify a tag filter that does not match the tag for i-1
 	resourceTypeTagFilters["ec2:instance"] = []aws.Tag{
@@ -1522,8 +1522,7 @@ func TestCreateEventsTimestamp(t *testing.T) {
 	resGroupTaggingClientMock := &MockResourceGroupsTaggingClient{}
 	events, err := m.createEvents(cloudwatchMock, resGroupTaggingClientMock, listMetricWithStatsTotal, resourceTypeTagFilters, regionName, startTime, endTime)
 	assert.NoError(t, err)
-	assert.Equal(t, timestamp, events[regionName+accountID+label3+"-0"].Timestamp)
-	assert.Equal(t, timestamp, events[regionName+accountID+label4+"-0"].Timestamp)
+	assert.Equal(t, timestamp, events[regionName+accountID+namespace+"-0"].Timestamp)
 }
 
 func TestGetStartTimeEndTime(t *testing.T) {

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/ec2/ec2.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/ec2/ec2.go
@@ -37,7 +37,9 @@ func AddMetadata(regionName string, awsConfig awssdk.Config, fips_enabled bool, 
 	monitoringStates := map[string]string{}
 	for instanceID, output := range instancesOutputs {
 		for eventIdentifier := range events {
-			if !strings.HasPrefix(eventIdentifier, instanceID) {
+			eventIdentifierComponents := strings.Split(eventIdentifier, "-")
+			potentialInstanceID := strings.Join(eventIdentifierComponents[0:len(eventIdentifierComponents)-1], "-")
+			if instanceID != potentialInstanceID {
 				continue
 			}
 

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/rds/rds.go
@@ -7,6 +7,7 @@ package rds
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 
@@ -43,37 +44,41 @@ func AddMetadata(regionName string, awsConfig awssdk.Config, fips_enabled bool, 
 		}
 	}
 
-	for identifier, output := range dbDetailsMap {
-		if _, ok := events[identifier]; !ok {
-			continue
-		}
+	for dbInstanceIdentifier, output := range dbDetailsMap {
+		for eventIdentifier := range events {
+			eventIdentifierComponents := strings.Split(eventIdentifier, "-")
+			potentialDBInstanceIdentifier := strings.Join(eventIdentifierComponents[0:len(eventIdentifierComponents)-1], "-")
+			if dbInstanceIdentifier != potentialDBInstanceIdentifier {
+				continue
+			}
 
-		if output.DBInstanceArn != nil {
-			_, _ = events[identifier].RootFields.Put(metadataPrefix+"arn", *output.DBInstanceArn)
-		}
+			if output.DBInstanceArn != nil {
+				_, _ = events[eventIdentifier].RootFields.Put(metadataPrefix+"arn", *output.DBInstanceArn)
+			}
 
-		if output.DBInstanceStatus != nil {
-			_, _ = events[identifier].RootFields.Put(metadataPrefix+"status", *output.DBInstanceStatus)
-		}
+			if output.DBInstanceStatus != nil {
+				_, _ = events[eventIdentifier].RootFields.Put(metadataPrefix+"status", *output.DBInstanceStatus)
+			}
 
-		if output.DBInstanceIdentifier != nil {
-			_, _ = events[identifier].RootFields.Put(metadataPrefix+"identifier", *output.DBInstanceIdentifier)
-		}
+			if output.DBInstanceIdentifier != nil {
+				_, _ = events[eventIdentifier].RootFields.Put(metadataPrefix+"identifier", *output.DBInstanceIdentifier)
+			}
 
-		if output.DBClusterIdentifier != nil {
-			_, _ = events[identifier].RootFields.Put(metadataPrefix+"db_cluster_identifier", *output.DBClusterIdentifier)
-		}
+			if output.DBClusterIdentifier != nil {
+				_, _ = events[eventIdentifier].RootFields.Put(metadataPrefix+"db_cluster_identifier", *output.DBClusterIdentifier)
+			}
 
-		if output.DBInstanceClass != nil {
-			_, _ = events[identifier].RootFields.Put(metadataPrefix+"class", *output.DBInstanceClass)
-		}
+			if output.DBInstanceClass != nil {
+				_, _ = events[eventIdentifier].RootFields.Put(metadataPrefix+"class", *output.DBInstanceClass)
+			}
 
-		if output.Engine != nil {
-			_, _ = events[identifier].RootFields.Put(metadataPrefix+"engine_name", *output.Engine)
-		}
+			if output.Engine != nil {
+				_, _ = events[eventIdentifier].RootFields.Put(metadataPrefix+"engine_name", *output.Engine)
+			}
 
-		if output.AvailabilityZone != nil {
-			_, _ = events[identifier].RootFields.Put("cloud.availability_zone", *output.AvailabilityZone)
+			if output.AvailabilityZone != nil {
+				_, _ = events[eventIdentifier].RootFields.Put("cloud.availability_zone", *output.AvailabilityZone)
+			}
 		}
 	}
 	return events, nil

--- a/x-pack/metricbeat/module/aws/cloudwatch/metadata/sqs/sqs.go
+++ b/x-pack/metricbeat/module/aws/cloudwatch/metadata/sqs/sqs.go
@@ -38,10 +38,15 @@ func AddMetadata(regionName string, awsConfig awssdk.Config, fips_enabled bool, 
 	for _, queueURL := range queueURLs {
 		queueURLParsed := strings.Split(queueURL, "/")
 		queueName := queueURLParsed[len(queueURLParsed)-1]
-		if _, ok := events[queueName]; !ok {
-			continue
+		for eventIdentifier := range events {
+			eventIdentifierComponents := strings.Split(eventIdentifier, "-")
+			potentialQueueName := strings.Join(eventIdentifierComponents[0:len(eventIdentifierComponents)-1], "-")
+			if queueName != potentialQueueName {
+				continue
+			}
+
+			_, _ = events[eventIdentifier].RootFields.Put(metadataPrefix+".name", queueName)
 		}
-		_, _ = events[queueName].RootFields.Put(metadataPrefix+".name", queueName)
 	}
 	return events, nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->
Bug
## What does this PR do?
https://github.com/elastic/beats/pull/33166 introduced support for granularity in cloudwatch metrics API calls.
we collect events identified by an ID: different metrics are merged in a single event according to the ID of the event
the mentioned PR refactored the way the ID was generated, introducing a bug that prevented different metrics to be merged in a single event.
changing the event ID also prevented the ec2 add metadata to match the metadata of an instance to a given event, losing the enrichment of an event with such metadata
we fix the ID generation, still suffixing it with the dimension of the given granularity, so that we are able to merge different metrics on the same event
we refactored the ID matching logic in the ec2 add metadata to ignore the granularity dimension suffix

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
