### PR TITLE
[Packetbeat] Fixes race condition in ProcessWatcher

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -134,6 +134,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Packetbeat*
 
+- Fixing a race condition in Packetbeat that could cause crashes or instability {pull}34498[34498]
 
 *Winlogbeat*
 

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -20,6 +20,7 @@ package procs
 import (
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -40,6 +41,7 @@ var (
 
 // ProcessWatcher implements process enrichment for network traffic.
 type ProcessesWatcher struct {
+	mu           sync.Mutex
 	portProcMap  map[applayer.Transport]map[endpoint]portProcMapping
 	localAddrs   []net.IP         // localAddrs lists IP addresses that are to be treated as local.
 	processCache map[int]*process // processCache is a time-expiration cache of process details keyed on PID.
@@ -186,7 +188,9 @@ func (proc *ProcessesWatcher) findProc(address net.IP, port uint16, transport ap
 	// dependency code panics in normal operation.
 	defer logp.Recover("FindProc exception")
 
+	proc.mu.Lock()
 	procMap, ok := proc.portProcMap[transport]
+	proc.mu.Unlock()
 	if !ok {
 		return nil
 	}
@@ -254,6 +258,8 @@ func (proc *ProcessesWatcher) expireProcessCache() {
 }
 
 func (proc *ProcessesWatcher) updateMappingEntry(transport applayer.Transport, e endpoint, pid int) {
+	proc.mu.Lock()
+	defer proc.mu.Unlock()
 	prev, ok := proc.portProcMap[transport][e]
 	if ok && prev.pid == pid {
 		// This port->pid mapping already exists


### PR DESCRIPTION
## What does this PR do?

There was a race condition for the ProcessWatcher part of packetbeat, where multiple threads would try to update the same value without any mutex locking.

## Why is it important?

Without the fix it will result in unwanted behavior in certain usecases, creating a panic and exiting.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


