### PR TITLE
[Packetbeat] Fix for race condition in ProcessWatcher

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,7 +41,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
-
+- Fixed a race condition in Packetbeat that could cause crashes or instability {pull}34514[34514]
 - Fix Windows service install/uninstall when Win32_Service returns error, add logic to wait until the Windows Service is stopped before proceeding. {pull}33322[33322]
 - Support for multiline zookeeper logs {issue}2496[2496]
 - Allow `clock_nanosleep` in the default seccomp profiles for amd64 and 386. Newer versions of glibc (e.g. 2.31) require it. {issue}33792[33792]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,7 +41,6 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
-- Fixed a race condition in Packetbeat that could cause crashes or instability {pull}34514[34514]
 - Fix Windows service install/uninstall when Win32_Service returns error, add logic to wait until the Windows Service is stopped before proceeding. {pull}33322[33322]
 - Support for multiline zookeeper logs {issue}2496[2496]
 - Allow `clock_nanosleep` in the default seccomp profiles for amd64 and 386. Newer versions of glibc (e.g. 2.31) require it. {issue}33792[33792]
@@ -135,6 +134,8 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 
 *Packetbeat*
+
+- Fixed a race condition in Packetbeat that could cause crashes or instability {pull}34514[34514]
 
 
 *Winlogbeat*

--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -135,7 +135,7 @@ func (p *processorFactory) Create(pipeline beat.PipelineConnector, cfg *conf.C) 
 		return nil, err
 	}
 
-	watcher := procs.ProcessesWatcher{}
+	watcher := &procs.ProcessesWatcher{}
 	// Enable the process watcher only if capturing live traffic
 	if config.Interfaces[0].File == "" {
 		err = watcher.Init(config.Procs)
@@ -167,7 +167,7 @@ func (p *processorFactory) Create(pipeline beat.PipelineConnector, cfg *conf.C) 
 
 // setupFlows returns a *flows.Flows that will publish to the provided pipeline,
 // configured with cfg and process enrichment via the provided watcher.
-func setupFlows(pipeline beat.Pipeline, watcher procs.ProcessesWatcher, cfg config.Config) (*flows.Flows, error) {
+func setupFlows(pipeline beat.Pipeline, watcher *procs.ProcessesWatcher, cfg config.Config) (*flows.Flows, error) {
 	if !cfg.Flows.IsEnabled() {
 		return nil, nil
 	}

--- a/packetbeat/flows/flows.go
+++ b/packetbeat/flows/flows.go
@@ -45,7 +45,7 @@ type Flows struct {
 
 // NewFlows returns a Flows publishing to pub after enrichment by the given
 // process watcher. Publication timeout and period are specified by config.
-func NewFlows(pub Reporter, watcher procs.ProcessesWatcher, config *config.Flows) (*Flows, error) {
+func NewFlows(pub Reporter, watcher *procs.ProcessesWatcher, config *config.Flows) (*Flows, error) {
 	duration := func(s string, d time.Duration) (time.Duration, error) {
 		if s == "" {
 			return d, nil

--- a/packetbeat/flows/flows_test.go
+++ b/packetbeat/flows/flows_test.go
@@ -52,7 +52,7 @@ func TestFlowsCounting(t *testing.T) {
 	port1 := []byte{0, 1}
 	port2 := []byte{0, 2}
 
-	module, err := NewFlows(nil, procs.ProcessesWatcher{}, &config.Flows{})
+	module, err := NewFlows(nil, &procs.ProcessesWatcher{}, &config.Flows{})
 	assert.NoError(t, err)
 
 	uint1, err := module.NewUint("uint1")

--- a/packetbeat/flows/flows_test.go
+++ b/packetbeat/flows/flows_test.go
@@ -72,6 +72,7 @@ func TestFlowsCounting(t *testing.T) {
 
 	processor := &flowsProcessor{
 		table:    module.table,
+		watcher:  &procs.ProcessesWatcher{},
 		counters: module.counterReg,
 		timeout:  20 * time.Millisecond,
 	}

--- a/packetbeat/flows/worker.go
+++ b/packetbeat/flows/worker.go
@@ -127,7 +127,7 @@ func (w *worker) periodically(tick time.Duration, fn func() error) {
 // reporting will be done at flow lifetime end.
 // Flows are published via the pub Reporter after being enriched with process information
 // by watcher.
-func newFlowsWorker(pub Reporter, watcher procs.ProcessesWatcher, table *flowMetaTable, counters *counterReg, timeout, period time.Duration) (*worker, error) {
+func newFlowsWorker(pub Reporter, watcher *procs.ProcessesWatcher, table *flowMetaTable, counters *counterReg, timeout, period time.Duration) (*worker, error) {
 	if timeout < time.Second {
 		return nil, ErrInvalidTimeout
 	}
@@ -222,7 +222,7 @@ func makeWorker(processor *flowsProcessor, tick time.Duration, timeout, period i
 
 type flowsProcessor struct {
 	spool    spool
-	watcher  procs.ProcessesWatcher
+	watcher  *procs.ProcessesWatcher
 	table    *flowMetaTable
 	counters *counterReg
 	timeout  time.Duration
@@ -287,7 +287,7 @@ func (fw *flowsProcessor) report(w *worker, ts time.Time, flow *biFlow, isOver b
 	fw.spool.publish(event)
 }
 
-func createEvent(watcher procs.ProcessesWatcher, ts time.Time, f *biFlow, isOver bool, intNames, uintNames, floatNames []string) beat.Event {
+func createEvent(watcher *procs.ProcessesWatcher, ts time.Time, f *biFlow, isOver bool, intNames, uintNames, floatNames []string) beat.Event {
 	timestamp := ts
 
 	event := mapstr.M{

--- a/packetbeat/flows/worker_test.go
+++ b/packetbeat/flows/worker_test.go
@@ -65,7 +65,7 @@ func TestCreateEvent(t *testing.T) {
 	}
 	bif.stats[0] = &flowStats{uintFlags: []uint8{1, 1}, uints: []uint64{10, 1}}
 	bif.stats[1] = &flowStats{uintFlags: []uint8{1, 1}, uints: []uint64{460, 2}}
-	event := createEvent(procs.ProcessesWatcher{}, time.Now(), bif, true, nil, []string{"bytes", "packets"}, nil)
+	event := createEvent(&procs.ProcessesWatcher{}, time.Now(), bif, true, nil, []string{"bytes", "packets"}, nil)
 
 	// Validate the contents of the event.
 	validate := lookslike.MustCompile(map[string]interface{}{

--- a/packetbeat/procs/procs.go
+++ b/packetbeat/procs/procs.go
@@ -20,6 +20,7 @@ package procs
 import (
 	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -40,6 +41,7 @@ var (
 
 // ProcessWatcher implements process enrichment for network traffic.
 type ProcessesWatcher struct {
+	mu           sync.Mutex
 	portProcMap  map[applayer.Transport]map[endpoint]portProcMapping
 	localAddrs   []net.IP         // localAddrs lists IP addresses that are to be treated as local.
 	processCache map[int]*process // processCache is a time-expiration cache of process details keyed on PID.
@@ -186,7 +188,9 @@ func (proc *ProcessesWatcher) findProc(address net.IP, port uint16, transport ap
 	// dependency code panics in normal operation.
 	defer logp.Recover("FindProc exception")
 
+	proc.mu.Lock()
 	procMap, ok := proc.portProcMap[transport]
+	proc.mu.Unlock()
 	if !ok {
 		return nil
 	}
@@ -254,6 +258,8 @@ func (proc *ProcessesWatcher) expireProcessCache() {
 }
 
 func (proc *ProcessesWatcher) updateMappingEntry(transport applayer.Transport, e endpoint, pid int) {
+	proc.mu.Lock()
+	defer proc.mu.Unlock()
 	prev, ok := proc.portProcMap[transport][e]
 	if ok && prev.pid == pid {
 		// This port->pid mapping already exists

--- a/packetbeat/protos/amqp/amqp.go
+++ b/packetbeat/protos/amqp/amqp.go
@@ -50,7 +50,7 @@ type amqpPlugin struct {
 	transactions              *common.Cache
 	transactionTimeout        time.Duration
 	results                   protos.Reporter
-	watcher                   procs.ProcessesWatcher
+	watcher                   *procs.ProcessesWatcher
 
 	// map containing functions associated with different method numbers
 	methodMap map[codeClass]map[codeMethod]amqpMethod
@@ -68,7 +68,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &amqpPlugin{}
@@ -85,7 +85,7 @@ func New(
 	return p, nil
 }
 
-func (amqp *amqpPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *amqpConfig) error {
+func (amqp *amqpPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *amqpConfig) error {
 	amqp.initMethodMap()
 	amqp.setFromConfig(config)
 

--- a/packetbeat/protos/amqp/amqp_test.go
+++ b/packetbeat/protos/amqp/amqp_test.go
@@ -47,7 +47,7 @@ func amqpModForTests() (*eventStore, *amqpPlugin) {
 	var amqp amqpPlugin
 	results := &eventStore{}
 	config := defaultConfig
-	amqp.init(results.publish, procs.ProcessesWatcher{}, &config)
+	amqp.init(results.publish, &procs.ProcessesWatcher{}, &config)
 	return results, &amqp
 }
 

--- a/packetbeat/protos/cassandra/cassandra.go
+++ b/packetbeat/protos/cassandra/cassandra.go
@@ -36,7 +36,7 @@ type cassandra struct {
 	ports        protos.PortsConfig
 	parserConfig parserConfig
 	transConfig  transactionConfig
-	watcher      procs.ProcessesWatcher
+	watcher      *procs.ProcessesWatcher
 	pub          transPub
 }
 
@@ -61,7 +61,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &cassandra{}
@@ -78,7 +78,7 @@ func New(
 	return p, nil
 }
 
-func (cassandra *cassandra) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *cassandraConfig) error {
+func (cassandra *cassandra) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *cassandraConfig) error {
 	if err := cassandra.setFromConfig(config); err != nil {
 		return err
 	}

--- a/packetbeat/protos/cassandra/trans.go
+++ b/packetbeat/protos/cassandra/trans.go
@@ -34,7 +34,7 @@ type transactions struct {
 
 	onTransaction transactionHandler
 
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 }
 
 type transactionConfig struct {
@@ -48,7 +48,7 @@ type messageList struct {
 	head, tail *message
 }
 
-func (trans *transactions) init(c *transactionConfig, watcher procs.ProcessesWatcher, cb transactionHandler) {
+func (trans *transactions) init(c *transactionConfig, watcher *procs.ProcessesWatcher, cb transactionHandler) {
 	trans.config = c
 	trans.watcher = watcher
 	trans.onTransaction = cb

--- a/packetbeat/protos/dhcpv4/dhcpv4.go
+++ b/packetbeat/protos/dhcpv4/dhcpv4.go
@@ -50,13 +50,13 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	return newPlugin(testMode, results, watcher, cfg)
 }
 
-func newPlugin(testMode bool, results protos.Reporter, watcher procs.ProcessesWatcher, cfg *conf.C) (*dhcpv4Plugin, error) {
+func newPlugin(testMode bool, results protos.Reporter, watcher *procs.ProcessesWatcher, cfg *conf.C) (*dhcpv4Plugin, error) {
 	config := defaultConfig
 
 	if !testMode {
@@ -76,7 +76,7 @@ func newPlugin(testMode bool, results protos.Reporter, watcher procs.ProcessesWa
 type dhcpv4Plugin struct {
 	dhcpv4Config
 	report  protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 	log     *logp.Logger
 }
 

--- a/packetbeat/protos/dhcpv4/dhcpv4_test.go
+++ b/packetbeat/protos/dhcpv4/dhcpv4_test.go
@@ -83,7 +83,7 @@ var (
 
 func TestParseDHCPRequest(t *testing.T) {
 	_ = logp.TestingSetup()
-	p, err := newPlugin(true, nil, procs.ProcessesWatcher{}, nil)
+	p, err := newPlugin(true, nil, &procs.ProcessesWatcher{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestParseDHCPRequest(t *testing.T) {
 }
 
 func TestParseDHCPACK(t *testing.T) {
-	p, err := newPlugin(true, nil, procs.ProcessesWatcher{}, nil)
+	p, err := newPlugin(true, nil, &procs.ProcessesWatcher{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/packetbeat/protos/dns/dns.go
+++ b/packetbeat/protos/dns/dns.go
@@ -58,7 +58,7 @@ type dnsPlugin struct {
 	transactionTimeout time.Duration
 
 	results protos.Reporter // Channel where results are pushed.
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 
 	logger *logp.Logger
 }
@@ -219,7 +219,7 @@ func init() {
 	protos.Register("dns", New)
 }
 
-func New(testMode bool, results protos.Reporter, watcher procs.ProcessesWatcher, cfg *conf.C) (protos.Plugin, error) {
+func New(testMode bool, results protos.Reporter, watcher *procs.ProcessesWatcher, cfg *conf.C) (protos.Plugin, error) {
 	p := &dnsPlugin{logger: logp.NewLogger("dns")}
 	config := defaultConfig
 	if !testMode {
@@ -234,7 +234,7 @@ func New(testMode bool, results protos.Reporter, watcher procs.ProcessesWatcher,
 	return p, nil
 }
 
-func (dns *dnsPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *dnsConfig) error {
+func (dns *dnsPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *dnsConfig) error {
 	dns.setFromConfig(config)
 	dns.transactions = common.NewCacheWithRemovalListener(
 		dns.transactionTimeout,

--- a/packetbeat/protos/dns/dns_test.go
+++ b/packetbeat/protos/dns/dns_test.go
@@ -115,7 +115,7 @@ func newDNS(store *eventStore, verbose bool) *dnsPlugin {
 		"send_request":        true,
 		"send_response":       true,
 	})
-	dns, err := New(false, callback, procs.ProcessesWatcher{}, cfg)
+	dns, err := New(false, callback, &procs.ProcessesWatcher{}, cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -186,25 +186,26 @@ func mapValueHelper(t testing.TB, m mapstr.M, keys []string) interface{} {
 // The validation provided my this method should only be used on results
 // published where the response packet was "sent".
 // The following fields are validated by this method:
-//     type (must be dns)
-//     src (ip and port)
-//     dst (ip and port)
-//     query
-//     resource
-//     method
-//     dns.id
-//     dns.op_code
-//     dns.flags
-//     dns.response_code
-//     dns.question.class
-//     dns.question.type
-//     dns.question.name
-//     dns.answers_count
-//     dns.answers.data
-//     dns.authorities_count
-//     dns.authorities
-//     dns.additionals_count
-//     dns.additionals
+//
+//	type (must be dns)
+//	src (ip and port)
+//	dst (ip and port)
+//	query
+//	resource
+//	method
+//	dns.id
+//	dns.op_code
+//	dns.flags
+//	dns.response_code
+//	dns.question.class
+//	dns.question.type
+//	dns.question.name
+//	dns.answers_count
+//	dns.answers.data
+//	dns.authorities_count
+//	dns.authorities
+//	dns.additionals_count
+//	dns.additionals
 func assertMapStrData(t testing.TB, m mapstr.M, q dnsTestMessage) {
 	t.Helper()
 

--- a/packetbeat/protos/http/http.go
+++ b/packetbeat/protos/http/http.go
@@ -102,7 +102,7 @@ type httpPlugin struct {
 	transactionTimeout time.Duration
 
 	results protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 }
 
 var (
@@ -117,7 +117,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &httpPlugin{}
@@ -135,7 +135,7 @@ func New(
 }
 
 // Init initializes the HTTP protocol analyser.
-func (http *httpPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *httpConfig) error {
+func (http *httpPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *httpConfig) error {
 	http.setFromConfig(config)
 
 	isDebug = logp.IsDebug("http")

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -88,7 +88,7 @@ func httpModForTests(store *eventStore) *httpPlugin {
 		callback = store.publish
 	}
 
-	http, err := New(false, callback, procs.ProcessesWatcher{}, conf.NewConfig())
+	http, err := New(false, callback, &procs.ProcessesWatcher{}, conf.NewConfig())
 	if err != nil {
 		panic(err)
 	}

--- a/packetbeat/protos/icmp/icmp.go
+++ b/packetbeat/protos/icmp/icmp.go
@@ -48,7 +48,7 @@ type icmpPlugin struct {
 	transactionTimeout time.Duration
 
 	results protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 }
 
 type ICMPv4Processor interface {
@@ -78,7 +78,7 @@ var (
 	duplicateRequests  = monitoring.NewInt(nil, "icmp.duplicate_requests")
 )
 
-func New(testMode bool, results protos.Reporter, watcher procs.ProcessesWatcher, cfg *conf.C) (*icmpPlugin, error) {
+func New(testMode bool, results protos.Reporter, watcher *procs.ProcessesWatcher, cfg *conf.C) (*icmpPlugin, error) {
 	p := &icmpPlugin{}
 	config := defaultConfig
 	if !testMode {
@@ -93,7 +93,7 @@ func New(testMode bool, results protos.Reporter, watcher procs.ProcessesWatcher,
 	return p, nil
 }
 
-func (icmp *icmpPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *icmpConfig) error {
+func (icmp *icmpPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *icmpConfig) error {
 	icmp.setFromConfig(config)
 
 	var err error

--- a/packetbeat/protos/icmp/icmp_test.go
+++ b/packetbeat/protos/icmp/icmp_test.go
@@ -62,7 +62,7 @@ func TestIcmpDirection(t *testing.T) {
 func BenchmarkIcmpProcessICMPv4(b *testing.B) {
 	logp.TestingSetup(logp.WithSelectors("icmp", "icmpdetailed"))
 
-	icmp, err := New(true, func(beat.Event) {}, procs.ProcessesWatcher{}, conf.NewConfig())
+	icmp, err := New(true, func(beat.Event) {}, &procs.ProcessesWatcher{}, conf.NewConfig())
 	if err != nil {
 		b.Error("Failed to create ICMP processor")
 		return

--- a/packetbeat/protos/memcache/memcache.go
+++ b/packetbeat/protos/memcache/memcache.go
@@ -41,7 +41,7 @@ import (
 type memcache struct {
 	ports   protos.PortsConfig
 	results protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 	config  parserConfig
 
 	udpMemcache
@@ -135,7 +135,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &memcache{}
@@ -153,7 +153,7 @@ func New(
 }
 
 // Called to initialize the Plugin
-func (mc *memcache) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *memcacheConfig) error {
+func (mc *memcache) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *memcacheConfig) error {
 	debug("init memcache plugin")
 
 	mc.handler = mc

--- a/packetbeat/protos/memcache/memcache_test.go
+++ b/packetbeat/protos/memcache/memcache_test.go
@@ -39,7 +39,7 @@ type memcacheTest struct {
 func newMemcacheTest(config memcacheConfig) *memcacheTest {
 	mct := &memcacheTest{}
 	mc := &memcache{}
-	mc.init(nil, procs.ProcessesWatcher{}, &config)
+	mc.init(nil, &procs.ProcessesWatcher{}, &config)
 	mc.handler = mct
 	mct.mc = mc
 	return mct

--- a/packetbeat/protos/mongodb/mongodb.go
+++ b/packetbeat/protos/mongodb/mongodb.go
@@ -49,7 +49,7 @@ type mongodbPlugin struct {
 	transactionTimeout time.Duration
 
 	results protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 }
 
 type transactionKey struct {
@@ -66,7 +66,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &mongodbPlugin{}
@@ -83,7 +83,7 @@ func New(
 	return p, nil
 }
 
-func (mongodb *mongodbPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *mongodbConfig) error {
+func (mongodb *mongodbPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *mongodbConfig) error {
 	debugf("Init a MongoDB protocol parser")
 	mongodb.setFromConfig(config)
 

--- a/packetbeat/protos/mongodb/mongodb_test.go
+++ b/packetbeat/protos/mongodb/mongodb_test.go
@@ -49,7 +49,7 @@ func mongodbModForTests() (*eventStore, *mongodbPlugin) {
 	var mongodb mongodbPlugin
 	results := &eventStore{}
 	config := defaultConfig
-	mongodb.init(results.publish, procs.ProcessesWatcher{}, &config)
+	mongodb.init(results.publish, &procs.ProcessesWatcher{}, &config)
 	return results, &mongodb
 }
 

--- a/packetbeat/protos/mysql/mysql.go
+++ b/packetbeat/protos/mysql/mysql.go
@@ -157,7 +157,7 @@ type mysqlPlugin struct {
 	prepareStatementTimeout time.Duration
 
 	results protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 
 	// function pointer for mocking
 	handleMysql func(mysql *mysqlPlugin, m *mysqlMessage, tcp *common.TCPTuple,
@@ -171,7 +171,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &mysqlPlugin{}
@@ -188,7 +188,7 @@ func New(
 	return p, nil
 }
 
-func (mysql *mysqlPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *mysqlConfig) error {
+func (mysql *mysqlPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *mysqlConfig) error {
 	mysql.setFromConfig(config)
 
 	mysql.transactions = common.NewCache(

--- a/packetbeat/protos/mysql/mysql_test.go
+++ b/packetbeat/protos/mysql/mysql_test.go
@@ -59,7 +59,7 @@ func mysqlModForTests(store *eventStore) *mysqlPlugin {
 	var mysql mysqlPlugin
 	config := defaultConfig
 	config.Ports = []int{serverPort}
-	mysql.init(callback, procs.ProcessesWatcher{}, &config)
+	mysql.init(callback, &procs.ProcessesWatcher{}, &config)
 	return &mysql
 }
 

--- a/packetbeat/protos/nfs/rpc.go
+++ b/packetbeat/protos/nfs/rpc.go
@@ -72,7 +72,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	_ procs.ProcessesWatcher,
+	_ *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &rpc{}

--- a/packetbeat/protos/pgsql/pgsql.go
+++ b/packetbeat/protos/pgsql/pgsql.go
@@ -51,7 +51,7 @@ type pgsqlPlugin struct {
 	transactionTimeout time.Duration
 
 	results protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 
 	// function pointer for mocking
 	handlePgsql func(pgsql *pgsqlPlugin, m *pgsqlMessage, tcp *common.TCPTuple,
@@ -139,7 +139,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &pgsqlPlugin{}
@@ -156,7 +156,7 @@ func New(
 	return p, nil
 }
 
-func (pgsql *pgsqlPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *pgsqlConfig) error {
+func (pgsql *pgsqlPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *pgsqlConfig) error {
 	pgsql.setFromConfig(config)
 
 	pgsql.log = logp.NewLogger("pgsql")

--- a/packetbeat/protos/pgsql/pgsql_test.go
+++ b/packetbeat/protos/pgsql/pgsql_test.go
@@ -55,7 +55,7 @@ func pgsqlModForTests(store *eventStore) *pgsqlPlugin {
 
 	var pgsql pgsqlPlugin
 	config := defaultConfig
-	pgsql.init(callback, procs.ProcessesWatcher{}, &config)
+	pgsql.init(callback, &procs.ProcessesWatcher{}, &config)
 	return &pgsql
 }
 

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -113,7 +113,7 @@ type reporterFactory interface {
 func (s ProtocolsStruct) Init(
 	testMode bool,
 	pub reporterFactory,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	configs map[string]*conf.C,
 	listConfigs []*conf.C,
 ) error {
@@ -150,7 +150,7 @@ func (s ProtocolsStruct) Init(
 func (s ProtocolsStruct) configureProtocol(
 	testMode bool,
 	pub reporterFactory,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	name string,
 	config *conf.C,
 ) error {

--- a/packetbeat/protos/redis/redis.go
+++ b/packetbeat/protos/redis/redis.go
@@ -56,7 +56,7 @@ type redisPlugin struct {
 	transactionTimeout time.Duration
 	queueConfig        MessageQueueConfig
 
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 	results protos.Reporter
 }
 
@@ -77,7 +77,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &redisPlugin{}
@@ -94,7 +94,7 @@ func New(
 	return p, nil
 }
 
-func (redis *redisPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *redisConfig) error {
+func (redis *redisPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *redisConfig) error {
 	redis.setFromConfig(config)
 
 	redis.results = results

--- a/packetbeat/protos/registry.go
+++ b/packetbeat/protos/registry.go
@@ -30,7 +30,7 @@ import (
 type ProtocolPlugin func(
 	testMode bool,
 	results Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (Plugin, error)
 

--- a/packetbeat/protos/sip/plugin.go
+++ b/packetbeat/protos/sip/plugin.go
@@ -56,13 +56,13 @@ type connectionData struct {
 type plugin struct {
 	cfg     *config
 	results protos.Reporter
-	watcher procs.ProcessesWatcher
+	watcher *procs.ProcessesWatcher
 }
 
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	cfgwarn.Beta("packetbeat SIP protocol is used")
@@ -89,7 +89,7 @@ func New(
 }
 
 // Init initializes the HTTP protocol analyser.
-func (p *plugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *config) {
+func (p *plugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *config) {
 	p.results = results
 	p.watcher = watcher
 	p.cfg = config

--- a/packetbeat/protos/sip/plugin_test.go
+++ b/packetbeat/protos/sip/plugin_test.go
@@ -116,7 +116,7 @@ func TestParseUDP(t *testing.T) {
 		gotEvent = &evt
 	}
 	const data = "INVITE sip:test@10.0.2.15:5060 SIP/2.0\r\nVia: SIP/2.0/UDP 10.0.2.20:5060;branch=z9hG4bK-2187-1-0\r\nFrom: \"DVI4/8000\" <sip:sipp@10.0.2.20:5060>;tag=1\r\nTo: test <sip:test@10.0.2.15:5060>\r\nCall-ID: 1-2187@10.0.2.20\r\nCSeq: 1 INVITE\r\nContact: sip:sipp@10.0.2.20:5060\r\nMax-Forwards: 70\r\nContent-Type: application/sdp\r\nContent-Length:   123\r\n\r\nv=0\r\no=- 42 42 IN IP4 10.0.2.20\r\ns=-\r\nc=IN IP4 10.0.2.20\r\nt=0 0\r\nm=audio 6000 RTP/AVP 5\r\na=rtpmap:5 DVI4/8000\r\na=recvonly\r\n"
-	p, _ := New(true, reporter, procs.ProcessesWatcher{}, nil)
+	p, _ := New(true, reporter, &procs.ProcessesWatcher{}, nil)
 	plugin := p.(*plugin)
 	plugin.ParseUDP(&protos.Packet{
 		Ts:      time.Now(),

--- a/packetbeat/protos/tcp/tcp_test.go
+++ b/packetbeat/protos/tcp/tcp_test.go
@@ -46,7 +46,7 @@ const (
 var httpProtocol, mysqlProtocol, redisProtocol protos.Protocol
 
 func init() {
-	new := func(_ bool, _ protos.Reporter, _ procs.ProcessesWatcher, _ *conf.C) (protos.Plugin, error) {
+	new := func(_ bool, _ protos.Reporter, _ *procs.ProcessesWatcher, _ *conf.C) (protos.Plugin, error) {
 		return &TestProtocol{}, nil
 	}
 

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -59,7 +59,7 @@ type thriftPlugin struct {
 
 	publishQueue chan *thriftTransaction
 	results      protos.Reporter
-	watcher      procs.ProcessesWatcher
+	watcher      *procs.ProcessesWatcher
 	idl          *thriftIdl
 }
 
@@ -185,7 +185,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &thriftPlugin{}
@@ -205,7 +205,7 @@ func New(
 func (thrift *thriftPlugin) init(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	config *thriftConfig,
 ) error {
 	thrift.InitDefaults()

--- a/packetbeat/protos/thrift/thrift.go
+++ b/packetbeat/protos/thrift/thrift.go
@@ -220,6 +220,7 @@ func (thrift *thriftPlugin) init(
 		protos.DefaultTransactionHashSize)
 	thrift.transactions.StartJanitor(thrift.transactionTimeout)
 
+	thrift.watcher = &procs.ProcessesWatcher{}
 	if !testMode {
 		thrift.publishQueue = make(chan *thriftTransaction, 1000)
 		thrift.results = results

--- a/packetbeat/protos/thrift/thrift_test.go
+++ b/packetbeat/protos/thrift/thrift_test.go
@@ -34,7 +34,7 @@ import (
 func thriftForTests() *thriftPlugin {
 	t := &thriftPlugin{}
 	config := defaultConfig
-	t.init(true, nil, procs.ProcessesWatcher{}, &config)
+	t.init(true, nil, &procs.ProcessesWatcher{}, &config)
 	return t
 }
 

--- a/packetbeat/protos/tls/tls.go
+++ b/packetbeat/protos/tls/tls.go
@@ -61,7 +61,7 @@ type tlsPlugin struct {
 	fingerprints           []*FingerprintAlgorithm
 	transactionTimeout     time.Duration
 	results                protos.Reporter
-	watcher                procs.ProcessesWatcher
+	watcher                *procs.ProcessesWatcher
 }
 
 var (
@@ -80,7 +80,7 @@ func init() {
 func New(
 	testMode bool,
 	results protos.Reporter,
-	watcher procs.ProcessesWatcher,
+	watcher *procs.ProcessesWatcher,
 	cfg *conf.C,
 ) (protos.Plugin, error) {
 	p := &tlsPlugin{}
@@ -97,7 +97,7 @@ func New(
 	return p, nil
 }
 
-func (plugin *tlsPlugin) init(results protos.Reporter, watcher procs.ProcessesWatcher, config *tlsConfig) error {
+func (plugin *tlsPlugin) init(results protos.Reporter, watcher *procs.ProcessesWatcher, config *tlsConfig) error {
 	if err := plugin.setFromConfig(config); err != nil {
 		return err
 	}

--- a/packetbeat/protos/tls/tls_test.go
+++ b/packetbeat/protos/tls/tls_test.go
@@ -71,7 +71,7 @@ func testInit() (*eventStore, *tlsPlugin) {
 	logp.TestingSetup(logp.WithSelectors("tls", "tlsdetailed"))
 
 	results := &eventStore{}
-	tls, err := New(true, results.publish, procs.ProcessesWatcher{}, nil)
+	tls, err := New(true, results.publish, &procs.ProcessesWatcher{}, nil)
 	if err != nil {
 		return nil, nil
 	}

--- a/packetbeat/sniffer/decoders.go
+++ b/packetbeat/sniffer/decoders.go
@@ -38,7 +38,7 @@ type Decoders func(_ layers.LinkType, device string) (decoders *decoder.Decoder,
 
 // DecodersFor returns a source of Decoders using the provided configuration
 // components. The id string is expected to be the ID of the beat.
-func DecodersFor(id string, publisher *publish.TransactionPublisher, protocols *protos.ProtocolsStruct, watcher procs.ProcessesWatcher, flows *flows.Flows, cfg config.Config) Decoders {
+func DecodersFor(id string, publisher *publish.TransactionPublisher, protocols *protos.ProtocolsStruct, watcher *procs.ProcessesWatcher, flows *flows.Flows, cfg config.Config) Decoders {
 	return func(dl layers.LinkType, device string) (*decoder.Decoder, func(), error) {
 		var icmp4 icmp.ICMPv4Processor
 		var icmp6 icmp.ICMPv6Processor


### PR DESCRIPTION
## Type of change
- Bug


## What does this PR do?
There was a race condition for the ProcessWatcher part of packetbeat, where multiple threads would try to update the same value without any mutex locking.

## Why is it important?

This fix this will remove unwanted behavior in certain usecases, which caused packetbeat to panic & exit.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [] I have commented my code, particularly in hard-to-understand areas~~
~~- [] I have made corresponding changes to the documentation~~
~~- [] I have made corresponding change to the default configuration files~~
~~- [] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

- Superseds #34498
