### PR TITLE
backport: Add 8.7 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -224,3 +224,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.7 branch
+    conditions:
+      - merged
+      - label=backport-v8.7.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.7"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 8.7 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821