### PR TITLE
action: notify when no bump for the elastic stack snapshots

### DIFF
--- a/.github/workflows/notify-stalled-snapshots.yml
+++ b/.github/workflows/notify-stalled-snapshots.yml
@@ -1,0 +1,54 @@
+---
+name: notify-stalled-snapshots
+
+on:
+  schedule:
+    - cron: '0 20 * * 7'
+
+permissions:
+  contents: read
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    steps:
+      - id: generator
+        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@current
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [filter]
+    strategy:
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: "${{ matrix.branch }}"
+
+      - id: search
+        run: |-
+          if git --no-pager \
+            log --pretty=format: \
+              --name-only \
+              --since="7 days ago" \
+            | grep 'testing/environments/snapshot.yml' ; then
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            echo "found=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - if: ${{ contains(steps.search.outputs.found, 'true') }}
+        name: Report obsoleted branches
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#ingest-notifications"
+          message: "Elastic Stack version for the ${{ matrix.branch }} branch has not been updated for a while ( > 7 days). Review the (<https://github.com/elastic/beats/pulls?q=is%3Apr+is%3Aopen+label%3ATeam%3ABeats-On-Call|open PRs>)"

--- a/.github/workflows/notify-stalled-snapshots.yml
+++ b/.github/workflows/notify-stalled-snapshots.yml
@@ -2,6 +2,7 @@
 name: notify-stalled-snapshots
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 20 * * 7'
 
@@ -50,5 +51,6 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           roleId: ${{ secrets.VAULT_ROLE_ID }}
           secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#ingest-notifications"
+          #channel: "#ingest-notifications"
+          channel: "#observablt-bots"
           message: "Elastic Stack version for the ${{ matrix.branch }} branch has not been updated for a while ( > 7 days). Review the (<https://github.com/elastic/beats/pulls?q=is%3Apr+is%3Aopen+label%3ATeam%3ABeats-On-Call|open PRs>)"

--- a/.github/workflows/notify-stalled-snapshots.yml
+++ b/.github/workflows/notify-stalled-snapshots.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.generator.outputs.matrix }}
     steps:
       - id: generator
-        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@current
+        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@test/support-action-list-stack-snapshots
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -24,6 +24,7 @@ on:
       - check-x-pack-packetbeat
       - check-x-pack-winlogbeat
       - golangci-lint
+      - notify-stalled-snapshots
       - auditbeat
       - filebeat
       - heartbeat


### PR DESCRIPTION
## What does this PR do?

Notify by slack when a particular release branch has not received any bump updates in the last 7 days.

## Why is it important?

It was implemented in the apm-pipeline-library and we are removing all the existing implementations that rely on Jenkins. https://github.com/elastic/apm-pipeline-library/pull/2072

## Issue

Requires https://github.com/elastic/apm-pipeline-library/pull/2070