### PR TITLE
action: avoid failing fast

### DIFF
--- a/.github/workflows/notify-stalled-snapshots.yml
+++ b/.github/workflows/notify-stalled-snapshots.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [filter]
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this PR do?

Bump automation should run independently for each active release branch