### PR TITLE
action: avoid fail fast for bump-elastic-stack-snapshot

### DIFF
--- a/.github/workflows/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/bump-elastic-stack-snapshot.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [filter]
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this PR do?

Run each branch independent

## Why is it important?

Otherwise if a snapshot is not ready for any release branch, as today with `8.7` then the bump won't work