### PR TITLE
docs: Add Kibana endpoint config to non-ES outputs

### DIFF
--- a/libbeat/outputs/console/docs/console.asciidoc
+++ b/libbeat/outputs/console/docs/console.asciidoc
@@ -7,7 +7,7 @@
 
 The Console output writes events in JSON format to stdout.
 
-WARNING: The Console output should be used only for debugging issues as it can produce a large amount of logging data. 
+WARNING: The Console output should be used only for debugging issues as it can produce a large amount of logging data.
 
 To use this output, edit the {beatname_uc} configuration file to disable the {es}
 output by commenting it out, and enable the console output by adding `output.console`.
@@ -19,6 +19,13 @@ Example configuration:
 output.console:
   pretty: true
 ------------------------------------------------------------------------------
+
+ifdef::apm-server[]
+[float]
+==== Configure the {kib} output
+
+include::../../../../shared-kibana-endpoint.asciidoc[tag=shared-kibana-config]
+endif::[]
 
 ==== Configuration options
 

--- a/libbeat/outputs/fileout/docs/fileout.asciidoc
+++ b/libbeat/outputs/fileout/docs/fileout.asciidoc
@@ -25,6 +25,13 @@ output.file:
   #rotate_on_startup: true
 ------------------------------------------------------------------------------
 
+ifdef::apm-server[]
+[float]
+==== Configure the {kib} output
+
+include::../../../../shared-kibana-endpoint.asciidoc[tag=shared-kibana-config]
+endif::[]
+
 ==== Configuration options
 
 You can specify the following `output.file` options in the +{beatname_lc}.yml+ config file:

--- a/libbeat/outputs/kafka/docs/kafka.asciidoc
+++ b/libbeat/outputs/kafka/docs/kafka.asciidoc
@@ -33,6 +33,13 @@ output.kafka:
 
 NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be dropped. To avoid this problem, make sure {beatname_uc} does not generate events bigger than <<kafka-max_message_bytes,`max_message_bytes`>>.
 
+ifdef::apm-server[]
+[float]
+==== Configure the {kib} output
+
+include::../../../../shared-kibana-endpoint.asciidoc[tag=shared-kibana-config]
+endif::[]
+
 [[kafka-compatibility]]
 ==== Compatibility
 

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -46,6 +46,13 @@ some extra setup. For more information, see
 {logstash-ref}/filebeat-modules.html[Working with {beatname_uc} modules].
 endif::[]
 
+ifdef::apm-server[]
+[float]
+==== Configure the {kib} output
+
+include::../../../../shared-kibana-endpoint.asciidoc[tag=shared-kibana-config]
+endif::[]
+
 // end::shared-logstash-config[]
 
 ==== Accessing metadata fields

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -24,6 +24,13 @@ output.redis:
   timeout: 5
 ------------------------------------------------------------------------------
 
+ifdef::apm-server[]
+[float]
+==== Configure the {kib} output
+
+include::../../../../shared-kibana-endpoint.asciidoc[tag=shared-kibana-config]
+endif::[]
+
 ==== Compatibility
 
 This output is expected to work with all Redis versions between 3.2.4 and 5.0.8. Other versions might work as well,


### PR DESCRIPTION
### Summary

**This PR only impacts the APM Server documentation.**

This PR adds a section on configuring the Kibana endpoint to all non-elasticsearch output configuration documentation.

### Related

Do not merge before https://github.com/elastic/apm-server/pull/10248.