### PR TITLE
action: use composite updatecli

### DIFF
--- a/.github/workflows/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/bump-elastic-stack-snapshot.yml
@@ -7,8 +7,7 @@ on:
     - cron: '0 15 * * 1-5'
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   filter:
@@ -29,15 +28,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
-
-      - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
-
-      - name: Run Updatecli
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          BRANCH: ${{ matrix.branch }}
-        run: updatecli apply --config ./.ci/bump-elastic-stack-snapshot.yml
-
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/bump-elastic-stack-snapshot.yml

--- a/.github/workflows/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/bump-elastic-stack-snapshot.yml
@@ -34,3 +34,5 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-elastic-stack-snapshot.yml
+        env:
+          BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -6,8 +6,7 @@ on:
     - cron: '0 20 * * 6'
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   bump:
@@ -16,13 +15,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
-
-      - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
-
-      - name: Run Updatecli
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: updatecli apply --config ./.ci/bump-golang.yml
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/bump-golang.yml


### PR DESCRIPTION
### What

Use GitHub composite action

### Why

Reuse code and solve the existing issue with Workflows won't be enabled for PRs created on behalf of `GitHub actions [bot]`, see https://github.com/elastic/ecs-logging-java/pull/200


### Issues

Similar to https://github.com/elastic/ecs-logging-java/pull/201
Requires https://github.com/elastic/apm-pipeline-library/pull/2076
