### PR TITLE
Fix 34597 - Make IBMMQ User property optional

### DIFF
--- a/x-pack/filebeat/module/ibmmq/errorlog/ingest/pipeline.yml
+++ b/x-pack/filebeat/module/ibmmq/errorlog/ingest/pipeline.yml
@@ -28,7 +28,7 @@ processors:
 - grok:
     field: message
     patterns:
-    - 'Process\(%{DATA:process.pid}\) User\(%{WORD:user.name}\) Program\(%{DATA:process.title}\)
+    - 'Process\(%{DATA:process.pid}\) (User\(%{WORD:user.name}\) )?Program\(%{DATA:process.title}\)
       Host\(%{DATA:host.hostname}\) Installation\(%{WORD:ibmmq.errorlog.installation}\)
       VRMF\(%{DATA:service.version}\)( QMgr\(%{DATA:ibmmq.errorlog.qmgr}\))?( Time\(%{TIMESTAMP_ISO8601:log_timestamp}\))?(
       RemoteHost\(%{DATA:destination.address}\))?( ArithInsert1\(%{DATA:ibmmq.errorlog.arithinsert1}\))?(


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
This PR fixes the issue #34597 by making the User property in the header optional


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
In some IBMMQ environments the property User is not written in the output, preventing beats user with IBMMQ appliances to ingest their logs with the out-of-the-box module.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

This PR can be tested locally, by reading a file with a log without the User property, e.g.:

```
----- amqzmgr0.c : 2999 -------------------------------------------------------
04/23/20 15:30:32 - Process(773602.3) Program(amqrmppa)
                    Host(jdawash) Installation(MQAppliance)
                    VRMF(9.2.0.0) QMgr(QM1)
                    Time(2020-04-23T14:30:32.300Z)
                    RemoteHost(192.0.2.10)
                    CommentInsert1(SYSTEM.DEF.SVRCONN)
                    CommentInsert2(wgamsworth(192.0.2.10))
                    CommentInsert3(CLNTUSER(gamsworth) ADDRESS(wgamsworth))
                   
AMQ9777E: Channel was blocked

EXPLANATION:
The inbound channel 'SYSTEM.DEF.SVRCONN' was blocked from address 'wgamsworth
(192.0.2.10)' because the active values of the channel matched a record
configured with USERSRC(NOACCESS). The active values of the channel were
'CLNTUSER(gamsworth) ADDRESS(wgamsworth)'.

ACTION:
Contact the systems administrator, who should examine the channel
authentication records to ensure that the correct settings have been
configured. The ALTER QMGR CHLAUTH switch is used to control whether channel
authentication records are used. The command DISPLAY CHLAUTH can be used to
query the channel authentication records.
```

## Related issues

- Closes #34597 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

