### PR TITLE
Make `Host info` IPs valid

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -53,6 +53,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Log errors from the Elastic Agent V2 client errors channel. Avoids blocking when error occurs communicating with the Elastic Agent. {pull}34392[34392]
 - Only log publish event messages in trace log level under elastic-agent. {pull}34391[34391]
 - Fix issue where updating a single Elastic Agent configuration unit results in other units being turned off. {pull}34504[34504]
+- Fix dropped events when monitor a beat under the agent and send its `Host info` log entry. {pull}34599[34599]
 
 *Auditbeat*
 

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -156,7 +156,8 @@ func TestMetaJsonWithTimestamp(t *testing.T) {
 		panic(err)
 	}
 	assert.False(t, firstStart.Equal(secondBeat.Info.FirstStart), "Before meta.json is loaded, first start must be different")
-	secondBeat.loadMeta(metaPath)
+	err = secondBeat.loadMeta(metaPath)
+	require.NoError(t, err)
 
 	assert.Equal(t, nil, err, "Unable to load meta file properly")
 	assert.True(t, firstStart.Equal(secondBeat.Info.FirstStart), "Cannot load first start")

--- a/libbeat/cmd/instance/beat_test.go
+++ b/libbeat/cmd/instance/beat_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewInstance(t *testing.T) {
@@ -159,4 +160,66 @@ func TestMetaJsonWithTimestamp(t *testing.T) {
 
 	assert.Equal(t, nil, err, "Unable to load meta file properly")
 	assert.True(t, firstStart.Equal(secondBeat.Info.FirstStart), "Cannot load first start")
+}
+
+func TestSanitizeIPs(t *testing.T) {
+	cases := []struct {
+		name        string
+		ips         []string
+		expectedIPs []string
+	}{
+		{
+			name: "does not change valid IPs",
+			ips: []string{
+				"127.0.0.1",
+				"::1",
+				"fe80::1",
+				"fe80::6ca6:cdff:fe6a:4f59",
+				"192.168.1.101",
+			},
+			expectedIPs: []string{
+				"127.0.0.1",
+				"::1",
+				"fe80::1",
+				"fe80::6ca6:cdff:fe6a:4f59",
+				"192.168.1.101",
+			},
+		},
+		{
+			name: "cuts the masks",
+			ips: []string{
+				"127.0.0.1/8",
+				"::1/128",
+				"fe80::1/64",
+				"fe80::6ca6:cdff:fe6a:4f59/64",
+				"192.168.1.101/24",
+			},
+			expectedIPs: []string{
+				"127.0.0.1",
+				"::1",
+				"fe80::1",
+				"fe80::6ca6:cdff:fe6a:4f59",
+				"192.168.1.101",
+			},
+		},
+		{
+			name: "excludes invalid IPs",
+			ips: []string{
+				"",
+				"fe80::6ca6:cdff:fe6a:4f59",
+				"invalid",
+				"192.168.1.101",
+			},
+			expectedIPs: []string{
+				"fe80::6ca6:cdff:fe6a:4f59",
+				"192.168.1.101",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expectedIPs, sanitizeIPs(tc.ips))
+		})
+	}
 }


### PR DESCRIPTION
## What does this PR do?

The `Host info` log entry is ingested to Elasticsearch by the monitoring toolkit when running under Elastic Agent.

The monitoring events are ingested into a data
stream created out of the `logs` index template which is partially defined by the `data-streams-mappings` component template.

The `data-streams-mappings` component template defines auto-mapping for every field named `ip` to have the `ip` field type which does not tolerate having a netmask as the IP address suffix.

This results in dropping events created out of this `Host info` log entry.

This is to trim the netmasks and make sure that IP addresses we're sending are valid, so the event is not dropped.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. **Before this change**, when you started Filebeat you would see this log entry:

```json
{
  "log.level": "info",
  "@timestamp": "2023-02-15T17:37:43.440+0100",
  "log.logger": "beat",
  "log.origin": {
    "file.name": "instance/beat.go",
    "file.line": 1111
  },
  "message": "Host info",
  "service.name": "filebeat",
  "system_info": {
    "host": {
      "architecture": "arm64",
      "boot_time": "2023-02-15T09:41:32.755854+01:00",
      "name": "MacBook-Pro.localdomain",
      "ip": [
        "127.0.0.1/8",
        "::1/128",
        "fe80::1/64",
        "fe80::6ca6:cdff:fe6a:4f59/64",
        "fe80::6ca6:cdff:fe6a:4f5b/64",
        "fe80::6ca6:cdff:fe6a:4f5a/64",
        "fe80::f84d:89ff:fe67:b0b1/64",
        "fe80::482:d6be:4cde:4ccd/64",
        "192.168.1.101/24",
        "fe80::8017:14ff:fe08:e5e/64",
        "fe80::8017:14ff:fe08:e5e/64",
        "fe80::c30f:d2ef:351:a20d/64",
        "fe80::2e15:fa5c:f61c:fcc0/64",
        "fe80::ce81:b1c:bd2c:69e/64"
      ],
      "kernel_version": "22.3.0",
      "mac": [
        "<redacted>"
      ],
      "os": {
        "type": "macos",
        "family": "darwin",
        "platform": "darwin",
        "name": "macOS",
        "version": "13.2.1",
        "major": 13,
        "minor": 2,
        "patch": 1,
        "build": "22D68"
      },
      "timezone": "CET",
      "timezone_offset_sec": 3600,
      "id": "470010DB-B6F8-5334-976D-DCEA8564B4D6"
    },
    "ecs.version": "1.6.0"
  }
}
```

2. Go to dev tools in Kibana and create a data stream (the name must match `logs-*-*`):

```
PUT /_data_stream/logs-test-index
```

You should see:

```json
{
  "acknowledged": true
}
```

Try to index the old log entry into this data stream:

```
POST logs-test-index/_doc/
{
  "log.level": "info",
  "@timestamp": "2023-02-15T17:37:43.440+0100",
  "log.logger": "beat",
  "log.origin": {
    "file.name": "instance/beat.go",
    "file.line": 1111
  },
  "message": "Host info",
  "service.name": "filebeat",
  "system_info": {
    "host": {
      "architecture": "arm64",
      "boot_time": "2023-02-15T09:41:32.755854+01:00",
      "name": "MacBook-Pro.localdomain",
      "ip": [
        "127.0.0.1/8",
        "::1/128",
        "fe80::1/64",
        "fe80::6ca6:cdff:fe6a:4f59/64",
        "fe80::6ca6:cdff:fe6a:4f5b/64",
        "fe80::6ca6:cdff:fe6a:4f5a/64",
        "fe80::f84d:89ff:fe67:b0b1/64",
        "fe80::482:d6be:4cde:4ccd/64",
        "192.168.1.101/24",
        "fe80::8017:14ff:fe08:e5e/64",
        "fe80::8017:14ff:fe08:e5e/64",
        "fe80::c30f:d2ef:351:a20d/64",
        "fe80::2e15:fa5c:f61c:fcc0/64",
        "fe80::ce81:b1c:bd2c:69e/64"
      ],
      "kernel_version": "22.3.0",
      "mac": [
        "<redacted>"
      ],
      "os": {
        "type": "macos",
        "family": "darwin",
        "platform": "darwin",
        "name": "macOS",
        "version": "13.2.1",
        "major": 13,
        "minor": 2,
        "patch": 1,
        "build": "22D68"
      },
      "timezone": "CET",
      "timezone_offset_sec": 3600,
      "id": "470010DB-B6F8-5334-976D-DCEA8564B4D6"
    },
    "ecs.version": "1.6.0"
  }
}
```

You'll see the validation error:

```json
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "failed to parse field [system_info.host.ip] of type [ip] in document with id 'ibqOWYYBVYNFIhQVfonp'. Preview of field's value: '127.0.0.1/8'"
      }
    ],
    "type": "mapper_parsing_exception",
    "reason": "failed to parse field [system_info.host.ip] of type [ip] in document with id 'ibqOWYYBVYNFIhQVfonp'. Preview of field's value: '127.0.0.1/8'",
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "'127.0.0.1/8' is not an IP string literal."
    }
  },
  "status": 400
}
```

3. Run the fixed version **after the change** and you'll see the new log entry format (note no IP masks):

```json
{
  "log.level": "info",
  "@timestamp": "2023-02-16T10:31:32.322+0100",
  "log.logger": "beat",
  "log.origin": {
    "file.name": "instance/beat.go",
    "file.line": 1114
  },
  "message": "Host info",
  "service.name": "filebeat",
  "system_info": {
    "host": {
      "architecture": "arm64",
      "boot_time": "2023-02-15T09:41:32.759526+01:00",
      "name": "MacBook-Pro.localdomain",
      "ip": [
        "127.0.0.1",
        "::1",
        "fe80::1",
        "fe80::6ca6:cdff:fe6a:4f59",
        "fe80::6ca6:cdff:fe6a:4f5b",
        "fe80::6ca6:cdff:fe6a:4f5a",
        "fe80::f84d:89ff:fe67:b0b1",
        "fe80::482:d6be:4cde:4ccd",
        "192.168.1.101",
        "fe80::84b:d9ff:fe65:c27",
        "fe80::84b:d9ff:fe65:c27",
        "fe80::c30f:d2ef:351:a20d",
        "fe80::2e15:fa5c:f61c:fcc0",
        "fe80::ce81:b1c:bd2c:69e"
      ],
      "kernel_version": "22.3.0",
      "mac": [
        "<redacted>"
      ],
      "os": {
        "type": "macos",
        "family": "darwin",
        "platform": "darwin",
        "name": "macOS",
        "version": "13.2.1",
        "major": 13,
        "minor": 2,
        "patch": 1,
        "build": "22D68"
      },
      "timezone": "CET",
      "timezone_offset_sec": 3600,
      "id": "470010DB-B6F8-5334-976D-DCEA8564B4D6"
    },
    "ecs.version": "1.6.0"
  }
}
```

4. Try to index this document into the data stream:

```
POST logs-test-index/_doc/
{
  "log.level": "info",
  "@timestamp": "2023-02-16T10:31:32.322+0100",
  "log.logger": "beat",
  "log.origin": {
    "file.name": "instance/beat.go",
    "file.line": 1114
  },
  "message": "Host info",
  "service.name": "filebeat",
  "system_info": {
    "host": {
      "architecture": "arm64",
      "boot_time": "2023-02-15T09:41:32.759526+01:00",
      "name": "MacBook-Pro.localdomain",
      "ip": [
        "127.0.0.1",
        "::1",
        "fe80::1",
        "fe80::6ca6:cdff:fe6a:4f59",
        "fe80::6ca6:cdff:fe6a:4f5b",
        "fe80::6ca6:cdff:fe6a:4f5a",
        "fe80::f84d:89ff:fe67:b0b1",
        "fe80::482:d6be:4cde:4ccd",
        "192.168.1.101",
        "fe80::84b:d9ff:fe65:c27",
        "fe80::84b:d9ff:fe65:c27",
        "fe80::c30f:d2ef:351:a20d",
        "fe80::2e15:fa5c:f61c:fcc0",
        "fe80::ce81:b1c:bd2c:69e"
      ],
      "kernel_version": "22.3.0",
      "mac": [
        "<redacted>"
      ],
      "os": {
        "type": "macos",
        "family": "darwin",
        "platform": "darwin",
        "name": "macOS",
        "version": "13.2.1",
        "major": 13,
        "minor": 2,
        "patch": 1,
        "build": "22D68"
      },
      "timezone": "CET",
      "timezone_offset_sec": 3600,
      "id": "470010DB-B6F8-5334-976D-DCEA8564B4D6"
    },
    "ecs.version": "1.6.0"
  }
}
```

You'll see the success message:

```json
{
  "_index": ".ds-logs-test-index-2023.02.16-000001",
  "_id": "jLqTWYYBVYNFIhQVEIkV",
  "_version": 1,
  "result": "created",
  "_shards": {
    "total": 2,
    "successful": 1,
    "failed": 0
  },
  "_seq_no": 0,
  "_primary_term": 1
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/2131