### PR TITLE
[7.17] backport: Add beats directory into git safe dirs

### DIFF
--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -122,6 +122,15 @@ func GolangCrossBuild(params BuildArgs) error {
 
 	defer DockerChown(filepath.Join(params.OutputDir, params.Name+binaryExtension(GOOS)))
 	defer DockerChown(filepath.Join(params.OutputDir))
+
+	mountPoint, err := ElasticBeatsDir()
+	if err != nil {
+		return err
+	}
+	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", mountPoint); err != nil {
+		return err
+	}
+
 	return Build(params)
 }
 


### PR DESCRIPTION
Backport of https://github.com/elastic/elastic-agent/pull/2093

## What does this PR do?

Fix the issue with the `CVE-2022-24765`, so the workspace is set as safe

## Why is it important?

Otherwise, it will fail with:

```
[2023-01-11T09:58:36.531Z] >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=o64-clang, CXX=o64-clang++, GOARCH=amd64, GOARM=, GOOS=darwin, PLATFORM_ID=darwin-amd64]
[2023-01-11T09:58:36.632Z] fatal: detected dubious ownership in repository at '/go/src/github.com/elastic/beats'
```

