### PR TITLE
Fix list formatting problem

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -73,6 +73,7 @@ https://github.com/elastic/beats/compare/v8.6.0\...v8.6.1[View commits]
 - Fix unnecessarily restarting every time a new configuration was received from the Elastic Agent. {pull}34346[34346]
 
 *Filebeat*
+
 - [google_workspace] Fix pagination and cursor value update. {pull}34274[34274]
 - Fix handling of quoted values in auditd module. {issue}22587[22587] {pull}34069[34069]
 - The `close.on_state_change.inactive` default value is now set to 5 minutes, matching the documentation.


### PR DESCRIPTION
Follow-up to https://github.com/elastic/beats/pull/34612. Fixes list formatting problem.


@fearful-symmetry  An empty line is required between text and a bulleted list. Is there a bug in the changelog tool? Also can you update the release checklist to remind folks to preview the changelog to make sure it looks right in HTML?

BTW, when/how do you get the latest 8.x changes into main? I know that backporting changelogs is fraught with problems (hence the need for fragments and the changelog tool). Do you just update main manually from time to time? (I don't think it's super important because no one should be looking at main, but it is confusing to folks who haven't worked on Beats release notes before.)

UPDATED: I see now that forward porting the release notes is in the release checklist for 8.6.2 but has not been completed yet.