### PR TITLE
Add `SafeProcessor` wrapper

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -58,6 +58,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix namespacing on self-monitoring {pull}32336[32336]
 - Fix race condition when stopping runners {pull}32433[32433]
 - Fix concurrent map writes when system/process code called from reporter code {pull}32491[32491]
+- Fix panics when a processor is closed twice {pull}34647[34647]
 
 *Auditbeat*
 

--- a/libbeat/processors/registry.go
+++ b/libbeat/processors/registry.go
@@ -54,7 +54,7 @@ var registry = NewNamespace()
 func RegisterPlugin(name string, constructor Constructor) {
 	logp.L().Named(logName).Debugf("Register plugin %s", name)
 
-	err := registry.Register(name, constructor)
+	err := registry.Register(name, SafeWrap(constructor))
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/processors/safe_processor.go
+++ b/libbeat/processors/safe_processor.go
@@ -55,8 +55,8 @@ func (p *SafeProcessor) Close() (err error) {
 // processor of that group which leads to multiple `Close` calls
 // on the same processor.
 //
-// If not use `SafeWrap`, the processor must handle multiple
-// `Close` calls with adding `sync.Once` in its `Close` function.
+// If `SafeWrap` is not used, the processor must handle multiple
+// `Close` calls by using `sync.Once` in its `Close` function.
 // We make it easer for processor developers and take care of it
 // in the processor registry instead.
 func SafeWrap(constructor Constructor) Constructor {

--- a/libbeat/processors/safe_processor.go
+++ b/libbeat/processors/safe_processor.go
@@ -20,9 +20,10 @@ package processors
 import (
 	"sync/atomic"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/pkg/errors"
 )
 
 var ErrClosed = errors.New("attempt to use a closed processor")

--- a/libbeat/processors/safe_processor.go
+++ b/libbeat/processors/safe_processor.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package processors
+
+import (
+	"sync/atomic"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/pkg/errors"
+)
+
+var ErrClosed = errors.New("attempt to use a closed processor")
+
+type SafeProcessor struct {
+	Processor
+	closed uint32
+}
+
+// Run allows to run processor only when `Close` was not called prior
+func (p *SafeProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	if atomic.LoadUint32(&p.closed) == 1 {
+		return nil, ErrClosed
+	}
+	return p.Processor.Run(event)
+}
+
+// Close makes sure the underlying `Close` function is called only once.
+func (p *SafeProcessor) Close() (err error) {
+	if atomic.CompareAndSwapUint32(&p.closed, 0, 1) {
+		return Close(p.Processor)
+	}
+	return nil
+}
+
+// SafeWrap makes sure that the processor handles all the required edge-cases.
+//
+// Each processor might end up in multiple processor groups.
+// Every group has its own `Close` that calls `Close` on each
+// processor of that group which leads to multiple `Close` calls
+// on the same processor.
+//
+// If not use `SafeWrap`, the processor must handle multiple
+// `Close` calls with adding `sync.Once` in its `Close` function.
+// We make it easer for processor developers and take care of it
+// in the processor registry instead.
+func SafeWrap(constructor Constructor) Constructor {
+	return func(config *config.C) (Processor, error) {
+		processor, err := constructor(config)
+		if err != nil {
+			return nil, err
+		}
+		return &SafeProcessor{
+			Processor: processor,
+		}, nil
+	}
+}

--- a/libbeat/processors/safe_processor.go
+++ b/libbeat/processors/safe_processor.go
@@ -18,9 +18,8 @@
 package processors
 
 import (
+	"errors"
 	"sync/atomic"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/config"

--- a/libbeat/processors/safe_processor_test.go
+++ b/libbeat/processors/safe_processor_test.go
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package processors
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/stretchr/testify/require"
+)
+
+type mockProcessor struct {
+	runCount   int
+	closeCount int
+}
+
+func newMockConstructor() (Constructor, *mockProcessor) {
+	p := mockProcessor{}
+	constructor := func(config *config.C) (Processor, error) {
+		return &p, nil
+	}
+	return constructor, &p
+}
+
+func (p *mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	p.runCount++
+	return nil, nil
+}
+
+func (p *mockProcessor) Close() error {
+	p.closeCount++
+	return nil
+}
+func (p *mockProcessor) String() string {
+	return "mock-processor"
+}
+
+func TestSafeProcessor(t *testing.T) {
+	cons, p := newMockConstructor()
+	var (
+		sp  Processor
+		err error
+	)
+	t.Run("creates a wrapped processor", func(t *testing.T) {
+		sw := SafeWrap(cons)
+		sp, err = sw(nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("propagates Run to a processor", func(t *testing.T) {
+		sp.Run(nil)
+		sp.Run(nil)
+		require.Equal(t, 2, p.runCount)
+	})
+
+	t.Run("propagates Close to a processor only once", func(t *testing.T) {
+		Close(sp)
+		Close(sp)
+		require.Equal(t, 1, p.closeCount)
+	})
+
+	t.Run("does not propagate Run when closed", func(t *testing.T) {
+		e, err := sp.Run(nil)
+		require.Nil(t, e)
+		require.ErrorIs(t, err, ErrClosed)
+		require.Equal(t, 2, p.runCount) // still 2 from the previous test case
+	})
+}

--- a/libbeat/processors/safe_processor_test.go
+++ b/libbeat/processors/safe_processor_test.go
@@ -20,10 +20,13 @@ package processors
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/stretchr/testify/require"
 )
+
+var mockEvent = &beat.Event{}
 
 type mockProcessor struct {
 	runCount   int
@@ -40,7 +43,7 @@ func newMockConstructor() (Constructor, *mockProcessor) {
 
 func (p *mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
 	p.runCount++
-	return nil, nil
+	return mockEvent, nil
 }
 
 func (p *mockProcessor) Close() error {
@@ -64,14 +67,24 @@ func TestSafeProcessor(t *testing.T) {
 	})
 
 	t.Run("propagates Run to a processor", func(t *testing.T) {
-		sp.Run(nil)
-		sp.Run(nil)
+		e, err := sp.Run(nil)
+		require.NoError(t, err)
+		require.Equal(t, e, mockEvent)
+
+		e, err = sp.Run(nil)
+		require.NoError(t, err)
+		require.Equal(t, e, mockEvent)
+
 		require.Equal(t, 2, p.runCount)
 	})
 
 	t.Run("propagates Close to a processor only once", func(t *testing.T) {
-		Close(sp)
-		Close(sp)
+		err := Close(sp)
+		require.NoError(t, err)
+
+		err = Close(sp)
+		require.NoError(t, err)
+
 		require.Equal(t, 1, p.closeCount)
 	})
 


### PR DESCRIPTION
## What does this PR do?

Each processor might end up in multiple processor groups. Every group has its own `Close` that calls `Close` on each processor of that group which leads to multiple `Close` calls on the same processor.

If the `SafeProcessor` wrapper was not used,
the processor would have to handle multiple `Close` calls with adding `sync.Once` in its `Close` function.

We make it easer for processor developers and take care of it in the processor registry instead.

## Why is it important?

Our customers could see panics in logs which makes it noisy.

Also, there are reports of higher impact:

* https://github.com/elastic/beats/issues/34219#issuecomment-1440078007
* https://github.com/elastic/integrations/issues/5348#issuecomment-1441400841

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Unfortunately, it's very difficult to reproduce the panic described in the issue, it seems to be a result of some kind of race condition on Beats shutting down.

The change is covered with unit tests and I made sure that a simple processor with the following config still works and there is no regression:

```yaml
filebeat.inputs:
  - type: filestream
    id: my-filestream-id
    enabled: true
    paths:
      - "metadata-panic/logs/log*.ndjson"
    processors:
      - add_fields:
          target: project
          fields:
            name: myproject
            id: 'UNIQUE_VALUE'

path.data: "metadata-panic/data"
logging:
  level: debug
output.console:
  enabled: true
```

and I got this event published:

```json
{
  "@timestamp": "2023-02-23T10:33:22.673Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.8.0"
  },
  "log": {
    "offset": 32170800,
    "file": {
      "path": "metadata-panic/logs/log1.ndjson"
    }
  },
  "message": "{\"data\": \"sample\"}",
  "input": {
    "type": "filestream"
  },
  "project": {
    "name": "myproject",
    "id": "UNIQUE_VALUE"
  },
  "agent": {
    "ephemeral_id": "926e973d-f35b-4f1e-95aa-6b9cf239e21c",
    "id": "2f6fa2ce-1a37-4259-91e8-1df581639d07",
    "name": "MacBook-Pro.localdomain",
    "type": "filebeat",
    "version": "8.8.0"
  },
  "ecs": {
    "version": "8.0.0"
  },
  "host": {
    "name": "MacBook-Pro.localdomain"
  }
}
```

Note

```
"project": {
    "name": "myproject",
    "id": "UNIQUE_VALUE"
  }
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/34219