### PR TITLE
libbeat/metric/system/cgroup/cgv2: explicitly convert Stat_t.Rdev to uint64

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -61,6 +61,7 @@ The list below covers the major changes between 7.0.0-rc2 and master only.
 - Remove `event.dataset` (ECS) annotion from `libbeat.logp`. {issue}27404[27404]
 - Errors should be thrown as errors. Metricsets inside Metricbeat will now throw errors as the `error` log level. {pull}27804[27804]
 - Avoid panicking in `add_fields` processor when input event.Fields is a nil map. {pull}28219[28219]
+- Fix type mismatch in libbeat/metric/system/cgroup/cgv2 when building on mips platforms. {pull}34658[34658]
 
 ==== Added
 

--- a/libbeat/metric/system/cgroup/cgv2/io_helper_linux.go
+++ b/libbeat/metric/system/cgroup/cgv2/io_helper_linux.go
@@ -49,7 +49,7 @@ func fetchDeviceName(major, minor uint64) (bool, string, error) {
 		if !ok {
 			return nil
 		}
-		devID := infoT.Rdev
+		devID := uint64(infoT.Rdev) // On GOARCH=mips* syscall.Stat_t.Rdev is uint32, so make explicit conversion.
 		// do some bitmapping to extract the major and minor device values
 		// The odd duplicated logic here is to deal with 32 and 64 bit values.
 		// see bits/sysmacros.h

--- a/libbeat/metric/system/cgroup/cgv2/io_helper_linux.go
+++ b/libbeat/metric/system/cgroup/cgv2/io_helper_linux.go
@@ -34,7 +34,7 @@ func fetchDeviceName(major, minor uint64) (bool, string, error) {
 	// iterate over /dev/ and pull major and minor values
 	found := false
 	var devName string
-	walkFunc := func(path string, d fs.DirEntry, err error) error {
+	walkFunc := func(path string, d fs.DirEntry, _ error) error {
 		if d.IsDir() && path != "/dev/" {
 			return fs.SkipDir
 		}
@@ -49,7 +49,7 @@ func fetchDeviceName(major, minor uint64) (bool, string, error) {
 		if !ok {
 			return nil
 		}
-		devID := uint64(infoT.Rdev) // On GOARCH=mips* syscall.Stat_t.Rdev is uint32, so make explicit conversion.
+		devID := uint64(infoT.Rdev) //nolint:unconvert // On GOARCH=mips* syscall.Stat_t.Rdev is uint32, so make explicit conversion.
 		// do some bitmapping to extract the major and minor device values
 		// The odd duplicated logic here is to deal with 32 and 64 bit values.
 		// see bits/sysmacros.h


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

On mips family platforms this field is uint32, so convert to uint64 in all cases.

This is a minimal replay of elastic/elastic-agent-system-metrics#71 to allow 7.17 branch beats to build on mips family platforms.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Currently will not build.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
