### PR TITLE
[elasticsearch] Collect node roles as part of node_stats metricset

### DIFF
--- a/metricbeat/module/elasticsearch/node_stats/data.go
+++ b/metricbeat/module/elasticsearch/node_stats/data.go
@@ -367,11 +367,14 @@ func eventsMapping(r mb.ReporterV2, m elasticsearch.MetricSetAPI, info elasticse
 			continue
 		}
 
+		roles := node["roles"]
+
 		event.ModuleFields = mapstr.M{
 			"node": mapstr.M{
 				"id":       nodeID,
 				"mlockall": mlockall,
 				"master":   isMaster,
+				"roles":    roles,
 			},
 			"cluster": mapstr.M{
 				"name": info.ClusterName,


### PR DESCRIPTION
Related issue: https://github.com/elastic/kibana/issues/151818

In order to display the roles of each node in the SM UI, we need to extend the collection to also collect the role data. This is exposed by the same endpoint the node_stats metricset is pulling from and the mappings were already added when the ingest metricset was added so we're only extending the event with the roles data.

Related PR: https://github.com/elastic/kibana/pull/152127