### PR TITLE
[Heartbeat] Fix tracking http url parsing error

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -99,6 +99,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 
 *Heartbeat*
 
+- Fix panics when parsing dereferencing invalid parsed url. {pull}34702[34702]
 - Fix broken zip URL monitors. NOTE: Zip URL Monitors will be removed in version 8.7 and replaced with project monitors. {pull}33723[33723]
 - Fix bug where states.duration_ms was incorrect type. {pull}33563[33563]
 - Fix handling of long UDP messages in UDP input. {issue}33836[33836] {pull}33837[33837]

--- a/heartbeat/monitors/active/http/http.go
+++ b/heartbeat/monitors/active/http/http.go
@@ -104,7 +104,7 @@ func create(
 
 	js := make([]jobs.Job, len(config.Hosts))
 	for i, urlStr := range config.Hosts {
-		u, _ := url.Parse(urlStr)
+		u, err := url.Parse(urlStr)
 		if err != nil {
 			return plugin.Plugin{}, err
 		}


### PR DESCRIPTION
## What does this PR do?

Fixes panics when http url is not parseable:
```
"[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x560c665b2eef]"
"goroutine 58 [running]:"
"github.com/elastic/beats/v7/heartbeat/monitors/wrappers.URLFields(0x0)"
"github.com/elastic/beats/v7/heartbeat/monitors/wrappers/util.go:56 +0x2f"
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Configure an http monitor with `urls: [" "]`
