### PR TITLE
[Httpjson Input] Adding client side rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ require (
 	golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde
 	golang.org/x/sys v0.2.0
 	golang.org/x/text v0.4.0
-	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
+	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.1.12
 	google.golang.org/api v0.94.0
 	google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf

--- a/go.sum
+++ b/go.sum
@@ -2281,6 +2281,8 @@ golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20220609170525-579cf78fd858 h1:Dpdu/EMxGMFgq0CeYMh4fazTD2vtlZRYE7wyynxJb9U=
 golang.org/x/time v0.0.0-20220609170525-579cf78fd858/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-httpjson.asciidoc
@@ -508,6 +508,19 @@ The maximum number of redirects to follow for a request. Default: `10`.
 
 [[request-rate-limit]]
 [float]
+==== `request.rate_limit.client_limit.interval`
+
+Client side rate limit options, when the API endpoint does not provide rate limit options.
+This value is used together with `request.rate_limit.client_limit.requests` to configure
+how many requests are allowed to be sent, per interval (in seconds)
+
+[float]
+==== `request.rate_limit.client_limit.requests`
+Client side rate limit options, when the API endpoint does not provide rate limit options.
+This value is used together with `request.rate_limit.client_limit.interval` to configure
+how many requests are allowed to be sent, per interval (in seconds)
+
+[float]
 ==== `request.rate_limit.limit`
 
 The value of the response that specifies the total limit. It is defined with a Go template value.

--- a/x-pack/filebeat/input/httpjson/config_request.go
+++ b/x-pack/filebeat/input/httpjson/config_request.go
@@ -60,16 +60,26 @@ func (c retryConfig) getWaitMax() time.Duration {
 }
 
 type rateLimitConfig struct {
-	Limit      *valueTpl `config:"limit"`
-	Reset      *valueTpl `config:"reset"`
-	Remaining  *valueTpl `config:"remaining"`
-	EarlyLimit *float64  `config:"early_limit"`
+	Limit        *valueTpl      `config:"limit"`
+	Reset        *valueTpl      `config:"reset"`
+	Remaining    *valueTpl      `config:"remaining"`
+	EarlyLimit   *float64       `config:"early_limit"`
+	ClientLimits *clientLimiter `config:"client_limit"`
+}
+
+type clientLimiter struct {
+	Interval float64 `config:"interval"`
+	Requests int     `config:"requests"`
 }
 
 func (c rateLimitConfig) Validate() error {
 	switch {
 	case c.EarlyLimit != nil && *c.EarlyLimit < 0:
 		return errors.New("early_limit must be greater than or equal to 0")
+	case c.ClientLimits.Interval > 0 && c.ClientLimits.Requests == 0:
+		return errors.New("client_limit.requests must be higher than 0 when client_limit.interval is set to higher than 0")
+	case c.ClientLimits.Interval == 0 && c.ClientLimits.Requests > 0:
+		return errors.New("client_limit.interval must be higher than 0 when client_limit.requests is set to higher than 0")
 	}
 	return nil
 }

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -1398,6 +1398,14 @@ func dateCursorHandler() http.HandlerFunc {
 	}
 }
 
+func clientLimitHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"@timestamp":"2002-10-02T15:00:02Z","foo":"bar"}`))
+	}
+}
+
 func paginationHandler() http.HandlerFunc {
 	var count int
 	return func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What does this PR do?

This PR adds the possibility to configure a client side rate limiting option, configuration is X requests per Y interval.

## Why is it important?

Certain cloud vendors require rate limiting for their API's but do not provide the necessary reponse headers, so we have to implement some sort of client side rate limiting option.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


