### PR TITLE
updatecli: force name of the branch for the bump golang version and update mergify

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -1,5 +1,6 @@
 ---
 name: Bump golang-version to latest version
+pipelineid: 'bump-golang-version'
 
 scms:
   githubConfig:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -81,7 +81,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^update-stack-version
+        - head~=^bump-elastic-stack
         - files~=^testing/environments/snapshot.*\.yml$
     actions:
       delete_head_branch:
@@ -92,7 +92,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^update-go-version
+        - head~=^bump-golang-version
         - files~=^\.go-version$
     actions:
       delete_head_branch:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -81,7 +81,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^bump-elastic-stack
+        - head~=^updatecli_bump-elastic-stack
         - files~=^testing/environments/snapshot.*\.yml$
     actions:
       delete_head_branch:
@@ -92,7 +92,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^bump-golang-version
+        - head~=^updatecli_bump-golang-version
         - files~=^\.go-version$
     actions:
       delete_head_branch:


### PR DESCRIPTION
### What

Set the default branch name for the bump automation in charge of the golang.
Update branch names in the mergify rules

### Why

Help with debugging what's the branch for, otherwise the hash/sha value is not providing much information

Help with the auto-merge/closing old branches done with Mergify