### PR TITLE
Run apt-get update before running apt-get install in GitHub actions

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -20,6 +20,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: .go-version
+    - name: Update package lists
+      run: sudo apt-get update
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Install libsystemd-dev

--- a/.github/workflows/check-filebeat.yml
+++ b/.github/workflows/check-filebeat.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: .go-version
+    - name: Update package lists
+      run: sudo apt-get update
     - name: Install libsystemd-dev
       run: sudo apt-get install -y libsystemd-dev
     - name: Run check/update

--- a/.github/workflows/check-libbeat.yml
+++ b/.github/workflows/check-libbeat.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: .go-version
+    - name: Update package lists
+      run: sudo apt-get update
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update

--- a/.github/workflows/check-packetbeat.yml
+++ b/.github/workflows/check-packetbeat.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: .go-version
+    - name: Update package lists
+      run: sudo apt-get update
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update

--- a/.github/workflows/check-xpack-auditbeat.yml
+++ b/.github/workflows/check-xpack-auditbeat.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: .go-version
+    - name: Update package lists
+      run: sudo apt-get update
     - name: Install librpm-dev
       run: sudo apt-get install -y librpm-dev
     - name: Run check/update

--- a/.github/workflows/check-xpack-filebeat.yml
+++ b/.github/workflows/check-xpack-filebeat.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: .go-version
+    - name: Update package lists
+      run: sudo apt-get update
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update

--- a/.github/workflows/check-xpack-packetbeat.yml
+++ b/.github/workflows/check-xpack-packetbeat.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version-file: .go-version
+    - name: Update package lists
+      run: sudo apt-get update
     - name: Install libpcap-dev
       run: sudo apt-get install -y libpcap-dev
     - name: Run check/update


### PR DESCRIPTION
Run apt-get update before running apt-get install in GitHub actions to ensure the package lists for mirrors are always up to date.

Attempt to fix https://github.com/elastic/beats/actions/runs/4363453232/jobs/7630072199

```
The following NEW packages will be installed:
  libsystemd-dev
0 upgraded, 1 newly installed, 0 to remove and 13 not upgraded.
Need to get 306 kB of archives.
After this operation, [11](https://github.com/elastic/beats/actions/runs/4363453232/jobs/7630072199#step:4:12)94 kB of additional disk space will be used.
Err:1 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsystemd-dev amd64 249.11-0ubuntu3.6
  404  Not Found [IP: 40.81.[13](https://github.com/elastic/beats/actions/runs/4363453232/jobs/7630072199#step:4:14).82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/s/systemd/libsystemd-dev_249.11-0ubuntu3.6_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```