### PR TITLE
[Manual backport][Heartbeat] Fix hint generator test

### DIFF
--- a/heartbeat/autodiscover/builder/hints/monitors_test.go
+++ b/heartbeat/autodiscover/builder/hints/monitors_test.go
@@ -18,6 +18,7 @@
 package hints
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,7 +97,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type":     "http",
 				"schedule": "@every 5s",
-				"hosts":    []interface{}{"1.2.3.4:8888", "1.2.3.4:9090"},
+				"hosts":    []string{"1.2.3.4:8888", "1.2.3.4:9090"},
 			},
 		},
 		{
@@ -137,7 +138,7 @@ func TestGenerateHints(t *testing.T) {
 			len: 1,
 			result: common.MapStr{
 				"type":     "http",
-				"hosts":    []interface{}{"1.2.3.4:9090"},
+				"hosts":    []string{"1.2.3.4:9090"},
 				"schedule": "@every 5s",
 				"processors": []interface{}{
 					map[string]interface{}{
@@ -170,7 +171,7 @@ func TestGenerateHints(t *testing.T) {
 			result: common.MapStr{
 				"type":     "http",
 				"schedule": "@every 5s",
-				"hosts":    []interface{}{"1.2.3.4:8888", "1.2.3.4:9090"},
+				"hosts":    []string{"1.2.3.4:8888", "1.2.3.4:9090"},
 			},
 		},
 		{
@@ -208,6 +209,17 @@ func TestGenerateHints(t *testing.T) {
 			config := common.MapStr{}
 			err := cfgs[0].Unpack(&config)
 			assert.Nil(t, err, test.message)
+
+			// Autodiscover can return configs with different sort orders here, which is irrelevant
+			// To make tests pass consistently we sort the host list
+			hostStrs := []string{}
+			if hostsSlice, ok := config["hosts"].([]interface{}); ok && len(hostsSlice) > 0 {
+				for _, hi := range hostsSlice {
+					hostStrs = append(hostStrs, hi.(string))
+				}
+				sort.Strings(hostStrs)
+				config["hosts"] = hostStrs
+			}
 
 			assert.Equal(t, test.result, config, test.message)
 		}


### PR DESCRIPTION
## What does this PR do?

Manual backport of hint autodiscovery tests flakiness here: https://github.com/elastic/beats/pull/34307

## Why is it important?

With [#34759](https://github.com/elastic/beats/pull/34307/files#diff-a051d69f4bebe8212813e94b6996485b5ad67726d9b63d1cc339e97633faa89eL99), same test flakiness (which was fixed later on 8.X) has been introduced into 7.17, this manual backport addresses that.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


