### PR TITLE
[DOCS] Remove hard coded links to master branch

### DIFF
--- a/libbeat/docs/newbeat.asciidoc
+++ b/libbeat/docs/newbeat.asciidoc
@@ -1,4 +1,4 @@
 [[new-beat]]
 == Developer Guide: Creating a New Beat
 
-See the https://www.elastic.co/guide/en/beats/devguide/master/index.html[Beats Developer Guide] for the latest information about creating a new beat.
+See the {beats-devguide}/index.html[Beats Developer Guide] for the latest information about creating a new beat.


### PR DESCRIPTION
Related to [#3357](https://github.com/elastic/beats/issues/33577)

## What does this PR do?

Fixes links in preparation for switching branch name to main.