### PR TITLE
Docs: Use user level for HAProxy socket

### DIFF
--- a/metricbeat/docs/modules/haproxy.asciidoc
+++ b/metricbeat/docs/modules/haproxy.asciidoc
@@ -49,7 +49,7 @@ To enable stats reporting via a UNIX socket, add the following line to the
 
 [source,shell]
 ----
- stats socket /path/to/haproxy.sock mode 660 level admin
+ stats socket /path/to/haproxy.sock mode 660 level user
 ----
 
 [float]

--- a/metricbeat/module/haproxy/_meta/docs.asciidoc
+++ b/metricbeat/module/haproxy/_meta/docs.asciidoc
@@ -38,7 +38,7 @@ To enable stats reporting via a UNIX socket, add the following line to the
 
 [source,shell]
 ----
- stats socket /path/to/haproxy.sock mode 660 level admin
+ stats socket /path/to/haproxy.sock mode 660 level user
 ----
 
 [float]


### PR DESCRIPTION
## What does this PR do?

Use user level for HAProxy socket.

## Why is it important?

According to the [documentation](https://www.elastic.co/guide/en/beats/devguide/current/beats-contributing.html), the metric sets `info` and `stat` are used. Both `show info` and `show stat` can be executed with the user level. Obviously, using the `user` level (less privileges) is more secure than using the `admin` level.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.