### PR TITLE
Skip integration and system tests for stan module

### DIFF
--- a/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
+++ b/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestData(t *testing.T) {
+	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))
@@ -24,6 +25,7 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))

--- a/x-pack/metricbeat/module/stan/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/stan/stats/stats_integration_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestData(t *testing.T) {
+	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))
@@ -24,6 +25,7 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))

--- a/x-pack/metricbeat/module/stan/subscriptions/subscriptions_integration_test.go
+++ b/x-pack/metricbeat/module/stan/subscriptions/subscriptions_integration_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestData(t *testing.T) {
+	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))
@@ -24,6 +25,7 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))

--- a/x-pack/metricbeat/module/stan/test_stan.py
+++ b/x-pack/metricbeat/module/stan/test_stan.py
@@ -16,8 +16,8 @@ class TestStan(XPackTest):
         "channels",
         "subscriptions",
     ])
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @unittest.skip("tests failing: https://github.com/elastic/beats/issues/34844")
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_metricset(self, metricset):
         """
         stan metricset tests

--- a/x-pack/metricbeat/module/stan/test_stan.py
+++ b/x-pack/metricbeat/module/stan/test_stan.py
@@ -17,6 +17,7 @@ class TestStan(XPackTest):
         "subscriptions",
     ])
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    @unittest.skip("tests failing: https://github.com/elastic/beats/issues/34844")
     def test_metricset(self, metricset):
         """
         stan metricset tests

--- a/x-pack/metricbeat/module/stan/test_stan.py
+++ b/x-pack/metricbeat/module/stan/test_stan.py
@@ -7,6 +7,7 @@ from xpack_metricbeat import XPackTest, metricbeat
 STAN_FIELDS = metricbeat.COMMON_FIELDS + ["stan"]
 
 
+@unittest.skip("tests failing: https://github.com/elastic/beats/issues/34844")
 class TestStan(XPackTest):
 
     COMPOSE_SERVICES = ['stan']
@@ -16,7 +17,6 @@ class TestStan(XPackTest):
         "channels",
         "subscriptions",
     ])
-    @unittest.skip("tests failing: https://github.com/elastic/beats/issues/34844")
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_metricset(self, metricset):
         """


### PR DESCRIPTION
## What does this PR do?

This PR skips the integration and system tests for the x-pack metricbeat `stan` module.

## Why is it important?

Currently, these tests are [consistently failing on `main`](https://github.com/elastic/beats/issues/34844) and blocking PRs from being merged (as their builds are failing as well on the same tests).  They are also failing on `8.7`, `8.6`, and `7.17` branches.

