### PR TITLE
Make linter requirements compatible with gofmt in 1.19

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,8 +119,6 @@ linters-settings:
   nolintlint:
     # Enable to ensure that nolint directives are all used. Default is true.
     allow-unused: false
-    # Disable to ensure that nolint directives don't have a leading space. Default is true.
-    allow-leading-space: false
     # Exclude following linters from requiring an explanation.  Default is [].
     allow-no-explanation: []
     # Enable to require an explanation of nonzero length after each nolint directive. Default is false.


### PR DESCRIPTION
The old linter definitions required no space at the beginning of a `nolint` comment line, but in 1.19 `gofmt` always inserts a space there, making the linter requirements incompatible with the `make check` requirements. This PR removes that requirement so the new `gofmt` behavior passes.