### PR TITLE
Add test for the processor re-use issue

### DIFF
--- a/filebeat/channel/runner.go
+++ b/filebeat/channel/runner.go
@@ -80,7 +80,7 @@ func (f *onCreateFactory) Create(pipeline beat.PipelineConnector, cfg *conf.C) (
 //   - *processors*: list of local processors to be added to the processing pipeline
 //   - *keep_null*: keep or remove 'null' from events to be published
 //   - *_module_name* (hidden setting): Add fields describing the module name
-//   - *_ fileset_name* (hiddrn setting):
+//   - *_ fileset_name* (hidden setting):
 //   - *pipeline*: Configure the ES Ingest Node pipeline name to be used for events from this input
 //   - *index*: Configure the index name for events to be collected from this input
 //   - *type*: implicit event type

--- a/filebeat/channel/runner_mock_test.go
+++ b/filebeat/channel/runner_mock_test.go
@@ -1,0 +1,116 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package channel
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
+	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/stretchr/testify/require"
+)
+
+type runnerFactoryMock struct {
+	cfgfile.RunnerFactory
+	clientCount int
+	cfgs        []beat.ClientConfig
+}
+
+func (r *runnerFactoryMock) Create(p beat.PipelineConnector, config *conf.C) (cfgfile.Runner, error) {
+	// When using the connector multiple times to create a client
+	// it's using the same editor function for creating a new client
+	// with a modified configuration that includes predefined processing.
+	// This is why we must make sure nothing is re-used from one client to another.
+	for i := 0; i < r.clientCount; i++ {
+		client, err := p.ConnectWith(beat.ClientConfig{})
+		if err != nil {
+			return nil, err
+		}
+
+		// storing the config that the client was created with
+		// it's needed for the `Assert` later
+		r.cfgs = append(r.cfgs, client.(*clientMock).cfg)
+	}
+	return &struct {
+		cfgfile.Runner
+	}{}, nil
+}
+
+// Assert runs various checks for the clients created by the wrapped pipeline connector
+// We check that the processing configuration does not reference the same addresses as before,
+// re-using some parts of the processing configuration will result in various issues, such as:
+// * closing processors multiple times
+// * using closed processors
+// * modifiying an object shared by multiple pipeline clients
+func (r runnerFactoryMock) Assert(t *testing.T) {
+	t.Helper()
+
+	// we need to make sure `Assert` is called after `Create`
+	require.Len(t, r.cfgs, r.clientCount)
+
+	t.Run("new processing configuration each time", func(t *testing.T) {
+		for i, c1 := range r.cfgs {
+			for j, c2 := range r.cfgs {
+				if i == j {
+					continue
+				}
+
+				require.NotSamef(t, c1.Processing, c2.Processing, "processing configuration cannot be re-used")
+				require.NotSamef(t, c1.Processing.Meta, c2.Processing.Meta, "`Processing.Meta` cannot be re-used")
+				require.NotSamef(t, c1.Processing.Fields, c2.Processing.Fields, "`Processing.Fields` cannot be re-used")
+				require.NotSamef(t, c1.Processing.Processor, c2.Processing.Processor, "`Processing.Processor` cannot be re-used")
+			}
+		}
+	})
+
+	t.Run("new processors each time", func(t *testing.T) {
+		var processors []beat.Processor
+		for _, c := range r.cfgs {
+			processors = append(processors, c.Processing.Processor.All()...)
+		}
+
+		require.NotEmptyf(t, processors, "for this test the list of processors cannot be empty")
+
+		for i, p1 := range processors {
+			for j, p2 := range processors {
+				if i == j {
+					continue
+				}
+
+				require.NotSamef(t, p1, p2, "processors must not be re-used")
+			}
+		}
+	})
+}
+
+type clientMock struct {
+	beat.Client
+	cfg beat.ClientConfig
+}
+
+type pipelineConnectorMock struct {
+	beat.Pipeline
+}
+
+func (p *pipelineConnectorMock) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
+	client := &clientMock{
+		cfg: cfg,
+	}
+	return client, nil
+}

--- a/filebeat/channel/runner_mock_test.go
+++ b/filebeat/channel/runner_mock_test.go
@@ -22,7 +22,9 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
+
 	conf "github.com/elastic/elastic-agent-libs/config"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/filebeat/channel/runner_mock_test.go
+++ b/filebeat/channel/runner_mock_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 type runnerFactoryMock struct {
-	cfgfile.RunnerFactory
 	clientCount int
 	cfgs        []beat.ClientConfig
 }
@@ -52,6 +51,10 @@ func (r *runnerFactoryMock) Create(p beat.PipelineConnector, config *conf.C) (cf
 	return &struct {
 		cfgfile.Runner
 	}{}, nil
+}
+
+func (runnerFactoryMock) CheckConfig(config *conf.C) error {
+	return nil
 }
 
 // Assert runs various checks for the clients created by the wrapped pipeline connector
@@ -102,17 +105,22 @@ func (r runnerFactoryMock) Assert(t *testing.T) {
 }
 
 type clientMock struct {
-	beat.Client
 	cfg beat.ClientConfig
 }
 
-type pipelineConnectorMock struct {
-	beat.Pipeline
-}
+func (clientMock) Publish(beat.Event)      {}
+func (clientMock) PublishAll([]beat.Event) {}
+func (clientMock) Close() error            { return nil }
 
-func (p *pipelineConnectorMock) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
+type pipelineConnectorMock struct{}
+
+func (pipelineConnectorMock) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	client := &clientMock{
 		cfg: cfg,
 	}
 	return client, nil
+}
+
+func (pipelineConnectorMock) Connect() (beat.Client, error) {
+	return &clientMock{}, nil
 }

--- a/filebeat/channel/runner_test.go
+++ b/filebeat/channel/runner_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat/events"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/libbeat/processors/actions"
+	_ "github.com/elastic/beats/v7/libbeat/processors/add_cloud_metadata"
+	_ "github.com/elastic/beats/v7/libbeat/processors/add_kubernetes_metadata"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -210,4 +212,40 @@ func makeProcessors(procs ...processors.Processor) *processors.Processors {
 	procList := processors.NewList(nil)
 	procList.List = procs
 	return procList
+}
+
+func TestRunnerFactoryWithCommonInputSettings(t *testing.T) {
+
+	// we use `add_kubernetes_metadata` and `add_cloud_metadata`
+	// for testing because initially the problem we've discovered
+	// was visible with these 2 processors.
+	configYAML := `
+processors:
+  - add_kubernetes_metadata: ~
+  - add_cloud_metadata: ~
+keep_null: true
+publisher_pipeline:
+  disable_host: true
+type: "filestream"
+service.type: "module"
+pipeline: "test"
+index: "%{[fields.log_type]}-%{[agent.version]}-%{+yyyy.MM.dd}"
+`
+	cfg, err := conf.NewConfigWithYAML([]byte(configYAML), configYAML)
+	require.NoError(t, err)
+
+	b := beat.Info{} // not important for the test
+	rf := &runnerFactoryMock{
+		clientCount: 3, // we will create 3 clients from the wrapped pipeline
+	}
+	pcm := &pipelineConnectorMock{} // creates mock pipeline clients and will get wrapped
+
+	rfwc := RunnerFactoryWithCommonInputSettings(b, rf)
+
+	// create a wrapped runner, our mock runner will
+	// create the given amount of clients here using the wrapped pipeline connector.
+	_, err = rfwc.Create(pcm, cfg)
+	require.NoError(t, err)
+
+	rf.Assert(t)
 }


### PR DESCRIPTION
## What does this PR do?

It's a follow-up to https://github.com/elastic/beats/pull/34761

This test makes sure that none of the critical configuration fields are re-used between instances of the pipeline client.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Why is it important?

So, we don't have regressions in the future.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

I reverted the change made in https://github.com/elastic/beats/pull/34761 and saw the new test failing:

<img width="992" alt="Screenshot 2023-03-21 at 15 02 29" src="https://user-images.githubusercontent.com/887952/226633170-37381aae-ba62-4960-922f-bf851e601867.png">

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/pull/34761
- Closes https://github.com/elastic/beats/issues/34783