### PR TITLE
Don't safe-wrap processors that don't have `Close`

### DIFF
--- a/libbeat/processors/safe_processor.go
+++ b/libbeat/processors/safe_processor.go
@@ -67,6 +67,12 @@ func SafeWrap(constructor Constructor) Constructor {
 		if err != nil {
 			return nil, err
 		}
+		// if the processor does not implement `Closer`
+		// it does not need a wrap
+		if _, ok := processor.(Closer); !ok {
+			return processor, nil
+		}
+
 		return &SafeProcessor{
 			Processor: processor,
 		}, nil

--- a/libbeat/processors/safe_processor_test.go
+++ b/libbeat/processors/safe_processor_test.go
@@ -33,29 +33,61 @@ type mockProcessor struct {
 	closeCount int
 }
 
-func newMockConstructor() (Constructor, *mockProcessor) {
-	p := mockProcessor{}
+func (p *mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
+	p.runCount++
+	return mockEvent, nil
+}
+
+func (p *mockProcessor) String() string {
+	return "mock-processor"
+}
+
+type mockCloserProcessor struct {
+	mockProcessor
+	closeCount int
+}
+
+func (p *mockCloserProcessor) Close() error {
+	p.closeCount++
+	return nil
+}
+
+func newMockCloserConstructor() (Constructor, *mockCloserProcessor) {
+	p := mockCloserProcessor{}
 	constructor := func(config *config.C) (Processor, error) {
 		return &p, nil
 	}
 	return constructor, &p
 }
 
-func (p *mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
-	p.runCount++
-	return mockEvent, nil
+func mockConstructor(config *config.C) (Processor, error) {
+	return &mockProcessor{}, nil
 }
 
-func (p *mockProcessor) Close() error {
-	p.closeCount++
-	return nil
+func mockCloserConstructor(config *config.C) (Processor, error) {
+	return &mockCloserProcessor{}, nil
 }
-func (p *mockProcessor) String() string {
-	return "mock-processor"
+
+func TestSafeWrap(t *testing.T) {
+	t.Run("does not wrap a non-closer processor", func(t *testing.T) {
+		nonCloser := mockConstructor
+		wrappedNonCloser := SafeWrap(nonCloser)
+		wp, err := wrappedNonCloser(nil)
+		require.NoError(t, err)
+		require.IsType(t, &mockProcessor{}, wp)
+	})
+
+	t.Run("wraps a closer processor", func(t *testing.T) {
+		closer := mockCloserConstructor
+		wrappedCloser := SafeWrap(closer)
+		wcp, err := wrappedCloser(nil)
+		require.NoError(t, err)
+		require.IsType(t, &SafeProcessor{}, wcp)
+	})
 }
 
 func TestSafeProcessor(t *testing.T) {
-	cons, p := newMockConstructor()
+	cons, p := newMockCloserConstructor()
 	var (
 		sp  Processor
 		err error
@@ -67,10 +99,11 @@ func TestSafeProcessor(t *testing.T) {
 	})
 
 	t.Run("propagates Run to a processor", func(t *testing.T) {
+		require.Equal(t, 0, p.runCount)
+
 		e, err := sp.Run(nil)
 		require.NoError(t, err)
 		require.Equal(t, e, mockEvent)
-
 		e, err = sp.Run(nil)
 		require.NoError(t, err)
 		require.Equal(t, e, mockEvent)
@@ -79,9 +112,10 @@ func TestSafeProcessor(t *testing.T) {
 	})
 
 	t.Run("propagates Close to a processor only once", func(t *testing.T) {
+		require.Equal(t, 0, p.closeCount)
+
 		err := Close(sp)
 		require.NoError(t, err)
-
 		err = Close(sp)
 		require.NoError(t, err)
 
@@ -89,9 +123,10 @@ func TestSafeProcessor(t *testing.T) {
 	})
 
 	t.Run("does not propagate Run when closed", func(t *testing.T) {
+		require.Equal(t, 2, p.runCount) // still 2 from the previous test case
 		e, err := sp.Run(nil)
 		require.Nil(t, e)
 		require.ErrorIs(t, err, ErrClosed)
-		require.Equal(t, 2, p.runCount) // still 2 from the previous test case
+		require.Equal(t, 2, p.runCount)
 	})
 }

--- a/libbeat/processors/safe_processor_test.go
+++ b/libbeat/processors/safe_processor_test.go
@@ -29,8 +29,7 @@ import (
 var mockEvent = &beat.Event{}
 
 type mockProcessor struct {
-	runCount   int
-	closeCount int
+	runCount int
 }
 
 func (p *mockProcessor) Run(event *beat.Event) (*beat.Event, error) {


### PR DESCRIPTION
## What does this PR do?

This will make the wrapping more efficient and will reduce unnecessary overhead.
It's a follow up to https://github.com/elastic/beats/pull/34647

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To maintain better performance of the processing pipeline.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

The change is covered with a unit test.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/pull/34647
