### PR TITLE
Revert "Skip integration and system tests for stan module"

### DIFF
--- a/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
+++ b/x-pack/metricbeat/module/stan/channels/channels_integration_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))
@@ -25,7 +24,6 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))

--- a/x-pack/metricbeat/module/stan/stats/stats_integration_test.go
+++ b/x-pack/metricbeat/module/stan/stats/stats_integration_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))
@@ -25,7 +24,6 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))

--- a/x-pack/metricbeat/module/stan/subscriptions/subscriptions_integration_test.go
+++ b/x-pack/metricbeat/module/stan/subscriptions/subscriptions_integration_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestData(t *testing.T) {
-	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))
@@ -25,7 +24,6 @@ func TestData(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
-	t.Skip("tests failing: https://github.com/elastic/beats/issues/34844")
 	service := compose.EnsureUp(t, "stan")
 
 	m := mbtest.NewFetcher(t, getConfig(service.Host()))

--- a/x-pack/metricbeat/module/stan/test_stan.py
+++ b/x-pack/metricbeat/module/stan/test_stan.py
@@ -7,7 +7,6 @@ from xpack_metricbeat import XPackTest, metricbeat
 STAN_FIELDS = metricbeat.COMMON_FIELDS + ["stan"]
 
 
-@unittest.skip("tests failing: https://github.com/elastic/beats/issues/34844")
 class TestStan(XPackTest):
 
     COMPOSE_SERVICES = ['stan']


### PR DESCRIPTION
Reverts elastic/beats#34852.

The root cause has been fixed via https://github.com/elastic/integrations/pull/5588.