### PR TITLE
libbeat/monitoring/inputmon - Ignore dataset metrics without name and id

### DIFF
--- a/libbeat/monitoring/inputmon/httphandler.go
+++ b/libbeat/monitoring/inputmon/httphandler.go
@@ -74,7 +74,7 @@ func (h *handler) allInputs(w http.ResponseWriter, req *http.Request) {
 		}
 
 		// Require all entries to have an 'input' and 'id' to be accessed through this API.
-		if _, ok = m["id"].(string); !ok {
+		if id, ok = m["id"].(string); !ok || id == "" {
 			continue
 		}
 

--- a/libbeat/monitoring/inputmon/httphandler.go
+++ b/libbeat/monitoring/inputmon/httphandler.go
@@ -74,7 +74,7 @@ func (h *handler) allInputs(w http.ResponseWriter, req *http.Request) {
 		}
 
 		// Require all entries to have an 'input' and 'id' to be accessed through this API.
-		if id, ok = m["id"].(string); !ok || id == "" {
+		if id, ok := m["id"].(string); !ok || id == "" {
 			continue
 		}
 

--- a/libbeat/monitoring/inputmon/httphandler.go
+++ b/libbeat/monitoring/inputmon/httphandler.go
@@ -73,10 +73,17 @@ func (h *handler) allInputs(w http.ResponseWriter, req *http.Request) {
 			continue
 		}
 
-		if requestedType != "" {
-			if typ, ok := m["input"].(string); ok && !strings.EqualFold(typ, requestedType) {
-				continue
-			}
+		// Require all entries to have an 'input' and 'id' to be accessed through this API.
+		inputType, ok := m["input"].(string)
+		if !ok {
+			continue
+		}
+		if _, ok = m["id"].(string); !ok {
+			continue
+		}
+
+		if requestedType != "" && !strings.EqualFold(inputType, requestedType) {
+			continue
 		}
 
 		filtered = append(filtered, m)

--- a/libbeat/monitoring/inputmon/httphandler.go
+++ b/libbeat/monitoring/inputmon/httphandler.go
@@ -74,15 +74,11 @@ func (h *handler) allInputs(w http.ResponseWriter, req *http.Request) {
 		}
 
 		// Require all entries to have an 'input' and 'id' to be accessed through this API.
-		inputType, ok := m["input"].(string)
-		if !ok {
-			continue
-		}
 		if _, ok = m["id"].(string); !ok {
 			continue
 		}
-
-		if requestedType != "" && !strings.EqualFold(inputType, requestedType) {
+		
+		if inputType, ok := m["input"].(string); !ok || (requestedType != "" && !strings.EqualFold(inputType, requestedType)) {
 			continue
 		}
 

--- a/libbeat/monitoring/inputmon/httphandler.go
+++ b/libbeat/monitoring/inputmon/httphandler.go
@@ -77,7 +77,7 @@ func (h *handler) allInputs(w http.ResponseWriter, req *http.Request) {
 		if _, ok = m["id"].(string); !ok {
 			continue
 		}
-		
+
 		if inputType, ok := m["input"].(string); !ok || (requestedType != "" && !strings.EqualFold(inputType, requestedType)) {
 			continue
 		}

--- a/libbeat/monitoring/inputmon/httphandler_test.go
+++ b/libbeat/monitoring/inputmon/httphandler_test.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -55,6 +56,13 @@ func TestHandler(t *testing.T) {
 	parent := monitoring.NewRegistry()
 	reg, _ := NewInputRegistry("foo", "123abc", parent)
 	monitoring.NewInt(reg, "gauge").Set(13344)
+
+	// Register legacy metrics without id or input. This must be ignored.
+	{
+		legacy := parent.NewRegistry("f49c0680-fc5f-4b78-bd98-7b16628f9a77")
+		monitoring.NewString(legacy, "name").Set("/var/log/wifi.log")
+		monitoring.NewTimestamp(legacy, "last_event_published_time").Set(time.Now())
+	}
 
 	r := mux.NewRouter()
 	s := httptest.NewServer(r)


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This filters metrics from the /inputs/ endpoint for entities that lack an input `name` and `id`.

This is needed because we continued to use the "dataset" namespace in the monitoring registry instead of using a new one like "inputs". Originally I planned to use to new namespace but I stayed with `dataset` because I wanted to prevent a breaking change for existing users of the /dataset API endpoint. This meant that metrics from the log input (and possibly others) that don't yet follow the conventions need to be filtered.

## Why is it important?

The data being produced from the [`/inputs/` API](https://www.elastic.co/guide/en/beats/filebeat/master/http-endpoint.html#_inputs) is different than what we expected.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #33859

## Logs

Prior to this change when using the `log` input you would get data like this from the `/inputs/` API. This data lacks an `id` or an `input` name. Plus it creates an entry for every file rather than one entry for the log input itself (which could lead to a lot more data than we expected).

```
% curl http://localhost:6060/inputs/ | jq .
[
  {
    "last_event_published_time": "2023-03-21T17:07:30.704Z",
    "last_event_timestamp": "2023-03-21T17:07:30.704Z",
    "name": "/var/log/jamf.log",
    "read_offset": 173391,
    "size": 536730,
    "start_time": "2023-03-21T21:07:30.136Z"
  },
  {
    "last_event_published_time": "2023-03-21T17:07:30.704Z",
    "last_event_timestamp": "2023-03-21T17:07:30.704Z",
    "name": "/var/log/install.log",
    "read_offset": 275589,
    "size": 25889274,
    "start_time": "2023-03-21T21:07:30.142Z"
  }
]
```