### PR TITLE
winlogbeat metrics - Set input type as "winlog"

### DIFF
--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -664,7 +664,7 @@ func newInputMetrics(name, id string) *inputMetrics {
 	if id == "" {
 		return nil
 	}
-	reg, unreg := inputmon.NewInputRegistry(name, id, nil)
+	reg, unreg := inputmon.NewInputRegistry("winlog", id, nil)
 	out := &inputMetrics{
 		unregister:  unreg,
 		name:        monitoring.NewString(reg, "provider"),


### PR DESCRIPTION
## What does this PR do?

Identify the Windows event log readers as input type `winlog` in metrics published through the /inputs/ API.

Fixes #34885

## Why is it important?

This gives the input a consistent type name in the [`/inputs/` API](https://www.elastic.co/guide/en/beats/filebeat/master/http-endpoint.html#_inputs) data.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
