### PR TITLE
[libbeat] Register missing /debug/pprof/ routes in beat HTTP API server

### DIFF
--- a/libbeat/pprof/pprof.go
+++ b/libbeat/pprof/pprof.go
@@ -67,6 +67,12 @@ func HttpAttach(cfg *Config, mux handlerAttacher) error {
 	const path = "/debug/pprof"
 	return multierr.Combine(
 		mux.AttachHandler(path+"/", http.HandlerFunc(pprof.Index)),
+		mux.AttachHandler(path+"/allocs", http.HandlerFunc(pprof.Index)),
+		mux.AttachHandler(path+"/block", http.HandlerFunc(pprof.Index)),
+		mux.AttachHandler(path+"/goroutine", http.HandlerFunc(pprof.Index)),
+		mux.AttachHandler(path+"/heap", http.HandlerFunc(pprof.Index)),
+		mux.AttachHandler(path+"/mutex", http.HandlerFunc(pprof.Index)),
+		mux.AttachHandler(path+"/threadcreate", http.HandlerFunc(pprof.Index)),
 		mux.AttachHandler(path+"/cmdline", http.HandlerFunc(pprof.Cmdline)),
 		mux.AttachHandler(path+"/profile", http.HandlerFunc(pprof.Profile)),
 		mux.AttachHandler(path+"/symbol", http.HandlerFunc(pprof.Symbol)),


### PR DESCRIPTION
## What does this PR do?

Several pprof routes were returning 404. The route matching behavior changed due an earlier API server modification.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`. (this hasn't been released yet so if I can get it into 8.7.0 then it won't need a changelog)

## Related issues

- Relates #33859