### PR TITLE
Stop crossbuilding using Debian 8

### DIFF
--- a/dev-tools/mage/crossbuild.go
+++ b/dev-tools/mage/crossbuild.go
@@ -241,9 +241,7 @@ func CrossBuildImage(platform string) (string, error) {
 	case platform == "linux/s390x":
 		tagSuffix = "s390x-debian10"
 	case strings.HasPrefix(platform, "linux"):
-		// Use an older version of libc to gain greater OS compatibility.
-		// Debian 8 uses glibc 2.19.
-		tagSuffix = "main-debian8"
+		tagSuffix = "main-debian10"
 	}
 
 	goVersion, err := GoVersion()

--- a/filebeat/scripts/mage/build.go
+++ b/filebeat/scripts/mage/build.go
@@ -18,8 +18,6 @@
 package mage
 
 import (
-	"strings"
-
 	"github.com/magefile/mage/mg"
 	"go.uber.org/multierr"
 
@@ -65,21 +63,5 @@ func golangCrossBuild() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
-	return devtools.CrossBuild(devtools.ImageSelector(func(platform string) (string, error) {
-		image, err := devtools.CrossBuildImage(platform)
-		if err != nil {
-			return "", err
-		}
-		// Normally linux/amd64 and linux/386 binaries are build using debian7
-		// because it has an older glibc version that makes the binaries work on
-		// RHEL 6, but debian7 does not have the systemd libraries needed for
-		// the journald input.
-		//
-		// So use the debian8 image, but test the binary to ensure that the
-		// linked glibc version requirement is still compatible with RHEL6.
-		if platform == "linux/amd64" || platform == "linux/386" {
-			image = strings.ReplaceAll(image, "main-debian7", "main-debian8")
-		}
-		return image, nil
-	}))
+	return devtools.CrossBuild(devtools.ImageSelector(devtools.CrossBuildImage))
 }


### PR DESCRIPTION
## What does this PR do?

The GPG keys are expired and we should start building for the more recent version of Debian.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

We cannot build snapshots right now:

```
06:29:52 Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.18.10-main-debian8
06:29:58 >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=gcc, CXX=g++, GOARCH=386, GOARM=, GOOS=linux, PLATFORM_ID=linux-386]
06:29:58 >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=gcc, CXX=g++, GOARCH=amd64, GOARM=, GOOS=linux, PLATFORM_ID=linux-amd64]
06:30:05 W: GPG error: http://archive.debian.org/ jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.194.132 80]
06:30:05 
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-i386/Packages  404  Not Found [IP: 151.101.194.132 80]
06:30:05 
06:30:05 E: Some index files failed to download. They have been ignored, or old ones used instead.
06:30:05 Error: running "apt-get update" failed with exit code 100
06:30:05 Error: failed building for linux/386: exit status 100
06:30:05 failed building for linux/386: exit status 100
06:30:05 W: GPG error: http://archive.debian.org/ jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.66.132 80]
06:30:05 
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-i386/Packages  404  Not Found [IP: 151.101.66.132 80]
06:30:05 
06:30:05 E: Some index files failed to download. They have been ignored, or old ones used instead.
06:30:05 Error: running "apt-get update" failed with exit code 100
06:30:05 Error: failed building for linux/amd64: exit status 100
06:30:05 failed building for linux/amd64: exit status 100
```

https://internal-ci.elastic.co/job/elastic+unified-release+master+snapshot-multijob-7.17/361/display/redirect