### PR TITLE
Force install dependencies in old Debian with expired keys

### DIFF
--- a/dev-tools/mage/pkgdeps.go
+++ b/dev-tools/mage/pkgdeps.go
@@ -117,19 +117,23 @@ func installDependencies(arch string, pkgs ...string) error {
 		}
 	}
 
-	if err := sh.Run("apt-get", "update"); err != nil {
+	// TODO: This is only for debian 7 and should be removed when move to a newer OS. This flag is
+	// going to be used unnecessary when building using non-debian7 images
+	// (like when making the linux/arm binaries) and we should remove it soonish.
+	// See https://github.com/elastic/beats/v7/issues/11750 for more details.
+	if err := sh.Run("apt-get", "update", "-o", "Acquire::Check-Valid-Until=false"); err != nil {
 		return err
 	}
 
-	params := append([]string{"install", "-y", "--force-yes",
-		"--no-install-recommends",
-
-		// Journalbeat is built with old versions of Debian that don't update
-		// their repositories, so they have expired keys.
+	params := append([]string{
+		// Due to the expired GPG keys in the old Debian version we must use `--force-yes` additionally to `-y`.
+		"install", "-y", "--force-yes",
 		// Allow unauthenticated packages.
 		// This was not enough: "-o", "Acquire::Check-Valid-Until=false",
 		"--allow-unauthenticated",
+		"--no-install-recommends",
 	}, pkgs...)
+
 	return sh.Run("apt-get", params...)
 }
 

--- a/x-pack/auditbeat/magefile.go
+++ b/x-pack/auditbeat/magefile.go
@@ -218,7 +218,7 @@ func installDependencies(arch string, pkgs ...string) error {
 	// TODO: This is only for debian 7 and should be removed when move to a newer OS. This flag is
 	// going to be used unnecessary when building using non-debian7 images
 	// (like when making the linux/arm binaries) and we should remove it soonish.
-	// See https://github.com/elastic/beats/v7/issues/11750 for more details.
+	// See https://github.com/elastic/beats/issues/11750 for more details.
 	if err := sh.Run("apt-get", "update", "-o", "Acquire::Check-Valid-Until=false"); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?

This change is the same as https://github.com/elastic/beats/pull/33915 but for the rest of the Beats.

## Why is it important?

We cannot build snapshots right now:

```
06:29:52 Status: Downloaded newer image for docker.elastic.co/beats-dev/golang-crossbuild:1.18.10-main-debian8
06:29:58 >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=gcc, CXX=g++, GOARCH=386, GOARM=, GOOS=linux, PLATFORM_ID=linux-386]
06:29:58 >> Building using: cmd='build/mage-linux-amd64 golangCrossBuild', env=[CC=gcc, CXX=g++, GOARCH=amd64, GOARM=, GOOS=linux, PLATFORM_ID=linux-amd64]
06:30:05 W: GPG error: http://archive.debian.org/ jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.194.132 80]
06:30:05 
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-i386/Packages  404  Not Found [IP: 151.101.194.132 80]
06:30:05 
06:30:05 E: Some index files failed to download. They have been ignored, or old ones used instead.
06:30:05 Error: running "apt-get update" failed with exit code 100
06:30:05 Error: failed building for linux/386: exit status 100
06:30:05 failed building for linux/386: exit status 100
06:30:05 W: GPG error: http://archive.debian.org/ jessie Release: The following signatures were invalid: KEYEXPIRED 1587841717
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.66.132 80]
06:30:05 
06:30:05 W: Failed to fetch http://security.debian.org/debian-security/dists/jessie/updates/main/binary-i386/Packages  404  Not Found [IP: 151.101.66.132 80]
06:30:05 
06:30:05 E: Some index files failed to download. They have been ignored, or old ones used instead.
06:30:05 Error: running "apt-get update" failed with exit code 100
06:30:05 Error: failed building for linux/amd64: exit status 100
06:30:05 failed building for linux/amd64: exit status 100
```

https://internal-ci.elastic.co/job/elastic+unified-release+master+snapshot-multijob-7.17/361/display/redirect

## How to test locally

```sh
mage package
```