### PR TITLE
Adding default value for prefix

### DIFF
--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -241,7 +241,7 @@ This options specific which URL path to accept requests on. Defaults to `/`
 [float]
 ==== `prefix`
 
-This option specifies which prefix the incoming request will be mapped to.
+This option specifies which prefix the incoming request will be mapped to. Defaults to `json`
 
 [float]
 ==== `include_headers`


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Based on https://github.com/elastic/beats/blob/e6d97ce62e54a9c914fdfc5c336e44f452f199a6/x-pack/filebeat/input/http_endpoint/config.go#L48, the value of `prefix` defaults to `json` but the public facing documentation doesn't include this. The aim of this PR is to make this clear.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Make it clear what the default value of `prefix` is.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


