### PR TITLE
filebeat/scripts/mage - Remove installation of journald deps from crossBuild

### DIFF
--- a/filebeat/scripts/mage/build.go
+++ b/filebeat/scripts/mage/build.go
@@ -18,25 +18,9 @@
 package mage
 
 import (
-	"github.com/magefile/mage/mg"
 	"go.uber.org/multierr"
 
 	devtools "github.com/elastic/beats/v7/dev-tools/mage"
-)
-
-// declare journald dependencies for cross build target
-var (
-	journaldPlatforms = []devtools.PlatformDescription{
-		devtools.Linux386, devtools.LinuxAMD64,
-		devtools.LinuxARM64, devtools.LinuxARM5, devtools.LinuxARM6, devtools.LinuxARM7,
-		devtools.LinuxMIPS, devtools.LinuxMIPSLE, devtools.LinuxMIPS64LE,
-		devtools.LinuxPPC64LE,
-		devtools.LinuxS390x,
-	}
-
-	journaldDeps = devtools.NewPackageInstaller().
-			AddEach(journaldPlatforms, "libsystemd-dev").
-			Add(devtools.Linux386, "libsystemd0", "libgcrypt20")
 )
 
 // GolangCrossBuild builds the Beat binary inside the golang-builder and then
@@ -55,7 +39,6 @@ func GolangCrossBuild() error {
 func golangCrossBuild() error {
 	conf := devtools.DefaultGolangCrossBuildArgs()
 	if devtools.Platform.GOOS == "linux" {
-		mg.Deps(journaldDeps.Installer(devtools.Platform.Name))
 		conf.ExtraFlags = append(conf.ExtraFlags, "-tags=withjournald")
 	}
 	return devtools.GolangCrossBuild(conf)
@@ -63,5 +46,5 @@ func golangCrossBuild() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
-	return devtools.CrossBuild(devtools.ImageSelector(devtools.CrossBuildImage))
+	return devtools.CrossBuild()
 }

--- a/filebeat/scripts/mage/build.go
+++ b/filebeat/scripts/mage/build.go
@@ -46,5 +46,5 @@ func golangCrossBuild() error {
 
 // CrossBuild cross-builds the beat for all target platforms.
 func CrossBuild() error {
-	return devtools.CrossBuild()
+	return devtools.CrossBuild(devtools.ImageSelector(devtools.CrossBuildImage))
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

The golang-crossbuild images contain the journald development dependencies so
the build steps do not need make changes to the environment before building.

Fixes #34938


## Why is it important?

~Packaging builds are failing.~ (see https://github.com/elastic/beats/issues/34938#issuecomment-1485646966)

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

`cd filebeat; SNAPSHOT=true mage -v package`

## Related issues

- Fixes #34938
