### PR TITLE
Log any FQDN lookup errors and fallback to OS-reported hostname

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -13685,6 +13685,37 @@ Contents of probable licence file $GOMODCACHE/github.com/fearful-symmetry/gorapl
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/foxcpp/go-mockdns
+Version: v0.0.0-20201212160233-ede2f9158d15
+Licence type (autodetected): MIT
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/foxcpp/go-mockdns@v0.0.0-20201212160233-ede2f9158d15/LICENSE:
+
+MIT License
+
+Copyright © 2019 Max Mazurov <fox.cpp@disroot.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/elastic/fsevents
 Version: v0.0.0-20181029231046-e1d381a4d270
 Licence type (autodetected): BSD-3-Clause

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10626,11 +10626,11 @@ these terms.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/elastic-agent-system-metrics
-Version: v0.5.0
+Version: v0.5.1-0.20230328163318-a87a0b315c42
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-system-metrics@v0.5.0/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-system-metrics@v0.5.1-0.20230328163318-a87a0b315c42/LICENSE.txt:
 
                                  Apache License
                            Version 2.0, January 2004
@@ -12566,11 +12566,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/go-structform@v
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-sysinfo
-Version: v1.9.1-0.20230215152520-f544eca983fb
+Version: v1.9.1-0.20230328042007-6dcfe88b8359
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-sysinfo@v1.9.1-0.20230215152520-f544eca983fb/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-sysinfo@v1.9.1-0.20230328042007-6dcfe88b8359/LICENSE.txt:
 
 
                                  Apache License

--- a/go.mod
+++ b/go.mod
@@ -200,6 +200,7 @@ require (
 	github.com/elastic/go-elasticsearch/v8 v8.2.0
 	github.com/elastic/mito v0.0.0-20230302005114-1dda06e81678
 	github.com/elastic/toutoumomoma v0.0.0-20221026030040-594ef30cb640
+	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15
 	github.com/google/cel-go v0.13.0
 	github.com/googleapis/gax-go/v2 v2.6.0
 	github.com/gorilla/handlers v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	github.com/elastic/elastic-agent-autodiscover v0.5.0
 	github.com/elastic/elastic-agent-libs v0.3.3
 	github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3
-	github.com/elastic/elastic-agent-system-metrics v0.5.0
+	github.com/elastic/elastic-agent-system-metrics v0.5.1-0.20230328163318-a87a0b315c42
 	github.com/elastic/go-elasticsearch/v8 v8.2.0
 	github.com/elastic/mito v0.0.0-20230302005114-1dda06e81678
 	github.com/elastic/toutoumomoma v0.0.0-20221026030040-594ef30cb640

--- a/go.mod
+++ b/go.mod
@@ -79,7 +79,7 @@ require (
 	github.com/elastic/go-perf v0.0.0-20191212140718-9c656876f595
 	github.com/elastic/go-seccomp-bpf v1.3.0
 	github.com/elastic/go-structform v0.0.10
-	github.com/elastic/go-sysinfo v1.9.1-0.20230215152520-f544eca983fb
+	github.com/elastic/go-sysinfo v1.9.1-0.20230328042007-6dcfe88b8359
 	github.com/elastic/go-ucfg v0.8.6
 	github.com/elastic/gosigar v0.14.2
 	github.com/fatih/color v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -618,8 +618,8 @@ github.com/elastic/elastic-agent-libs v0.3.3 h1:iE8XhqQ0zRBLba+eu6ScZED0DYcVP/r2
 github.com/elastic/elastic-agent-libs v0.3.3/go.mod h1:nRkcK96PSJfK232cJRx17n9+/MVAIOzs5ghZdzXJAMo=
 github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3 h1:sb+25XJn/JcC9/VL8HX4r4QXSUq4uTNzGS2kxOE7u1U=
 github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3/go.mod h1:rWarFM7qYxJKsi9WcV6ONcFjH/NA3niDNpTxO+8/GVI=
-github.com/elastic/elastic-agent-system-metrics v0.5.0 h1:1pJHWsq5FRQbUCk4JFTDY3ULa4f4+FA6H6rDhTr051s=
-github.com/elastic/elastic-agent-system-metrics v0.5.0/go.mod h1:v/t/qgYueW3ZOm7SZhYY3ng9GWDddDLu7pmG4Ra3PBs=
+github.com/elastic/elastic-agent-system-metrics v0.5.1-0.20230328163318-a87a0b315c42 h1:oJQbTUpFlD/CXKw6N5gWNOjfofwStp+nR49m1wKv6zc=
+github.com/elastic/elastic-agent-system-metrics v0.5.1-0.20230328163318-a87a0b315c42/go.mod h1:jBVJTZFtoxQkGmqutGGRSulkRhjgIO2PY059m+HLG4k=
 github.com/elastic/elastic-transport-go/v8 v8.1.0 h1:NeqEz1ty4RQz+TVbUrpSU7pZ48XkzGWQj02k5koahIE=
 github.com/elastic/elastic-transport-go/v8 v8.1.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270 h1:cWPqxlPtir4RoQVCpGSRXmLqjEHpJKbR60rxh1nQZY4=

--- a/go.sum
+++ b/go.sum
@@ -647,8 +647,8 @@ github.com/elastic/go-structform v0.0.9/go.mod h1:CZWf9aIRYY5SuKSmOhtXScE5uQiLZN
 github.com/elastic/go-structform v0.0.10 h1:oy08o/Ih2hHTkNcRY/1HhaYvIp5z6t8si8gnCJPDo1w=
 github.com/elastic/go-structform v0.0.10/go.mod h1:CZWf9aIRYY5SuKSmOhtXScE5uQiLZNqAFnwKR4OrIM4=
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
-github.com/elastic/go-sysinfo v1.9.1-0.20230215152520-f544eca983fb h1:dTYv5aVpYzI53KJwDM/Hue68YU/PHkLJD/5jDl1fGSs=
-github.com/elastic/go-sysinfo v1.9.1-0.20230215152520-f544eca983fb/go.mod h1:j/gGAinRS+z3loQ/1pO+s9pCyQsna8U13kqhF1Aa0fg=
+github.com/elastic/go-sysinfo v1.9.1-0.20230328042007-6dcfe88b8359 h1:qSCKykLGlUcO/wzq3xH+wtPHM2KCpQnqXOKClSg5K2w=
+github.com/elastic/go-sysinfo v1.9.1-0.20230328042007-6dcfe88b8359/go.mod h1:j/gGAinRS+z3loQ/1pO+s9pCyQsna8U13kqhF1Aa0fg=
 github.com/elastic/go-ucfg v0.8.5/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=
 github.com/elastic/go-ucfg v0.8.6 h1:stUeyh2goTgGX+/wb9gzKvTv0YB0231LTpKUgCKj4U0=
 github.com/elastic/go-ucfg v0.8.6/go.mod h1:4E8mPOLSUV9hQ7sgLEJ4bvt0KhMuDJa8joDT2QGAEKA=

--- a/go.sum
+++ b/go.sum
@@ -705,6 +705,7 @@ github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNy
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15 h1:nLPjjvpUAODOR6vY/7o0hBIk8iTr19Fvmf8aFx/kC7A=
 github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15/go.mod h1:tPg4cp4nseejPd+UKxtCVQ2hUxNTZ7qQZJa7CLriIeo=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -249,14 +249,11 @@ func NewBeat(name, indexPrefix, v string, elasticLicensed bool) (*Beat, error) {
 		return nil, fmt.Errorf("failed to get host information: %w", err)
 	}
 
-	info := h.Info()
-	fqdn := info.FQDN
-	if fqdn == "" {
-		// If FQDN is empty, it's likely we encountered some errors
-		// while trying to look it up. FQDN lookup is "best effort" so
-		// log the errors, fallback to the OS-reported hostname, and
-		// move on.
-		logp.NewLogger(name).Infof("unable to lookup FQDN: %s", info.FQDNError.String())
+	fqdn, err := h.FQDN()
+	if err != nil {
+		// FQDN lookup is "best effort".  We log the error, fallback to
+		// the OS-reported hostname, and move on.
+		logp.NewLogger(name).Infof("unable to lookup FQDN: %s", err.Error())
 		fqdn = hostname
 	}
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -602,7 +602,7 @@ func (b *Beat) RegisterHostname(useFQDN bool) {
 
 	// state.host
 	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
-	monitoring.NewFunc(stateRegistry, "host", host.ReportInfo(useFQDN), monitoring.Report)
+	monitoring.NewFunc(stateRegistry, "host", host.ReportInfo(hostname), monitoring.Report)
 }
 
 // TestConfig check all settings are ok and the beat can be run

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -799,7 +799,7 @@ func (b *Beat) configure(settings Settings) error {
 	if err != nil {
 		// FQDN lookup is "best effort".  We log the error, fallback to
 		// the OS-reported hostname, and move on.
-		logp.Warn("unable to lookup FQDN: %s, using hostname = %s", err.Error(), b.Info.Hostname)
+		logp.Warn("unable to lookup FQDN: %s, using hostname = %s as FQDN", err.Error(), b.Info.Hostname)
 		b.Info.FQDN = b.Info.Hostname
 	} else {
 		b.Info.FQDN = fqdn

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -253,7 +253,7 @@ func NewBeat(name, indexPrefix, v string, elasticLicensed bool) (*Beat, error) {
 	if err != nil {
 		// FQDN lookup is "best effort".  We log the error, fallback to
 		// the OS-reported hostname, and move on.
-		logp.NewLogger(name).Infof("unable to lookup FQDN: %s", err.Error())
+		logp.NewLogger(name).Infof("unable to lookup FQDN: %s, using hostname = %s", err.Error(), hostname)
 		fqdn = hostname
 	}
 

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -149,7 +149,7 @@ func (p *addHostMetadata) loadData() error {
 		if err != nil {
 			// FQDN lookup is "best effort".  We log the error, fallback to
 			// the OS-reported hostname, and move on.
-			p.logger.Infof("unable to lookup FQDN: %s", err.Error())
+			p.logger.Infof("unable to lookup FQDN: %s, using hostname = %s", err.Error(), hostname)
 		} else {
 			hostname = fqdn
 		}

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -143,7 +143,19 @@ func (p *addHostMetadata) loadData() error {
 		return err
 	}
 
-	data := host.MapHostInfo(features.FQDN(), h.Info())
+	hostname := h.Info().Hostname
+	if features.FQDN() {
+		fqdn, err := h.FQDN()
+		if err != nil {
+			// FQDN lookup is "best effort".  We log the error, fallback to
+			// the OS-reported hostname, and move on.
+			p.logger.Infof("unable to lookup FQDN: %s", err.Error())
+		} else {
+			hostname = fqdn
+		}
+	}
+
+	data := host.MapHostInfo(h.Info(), hostname)
 	if p.config.NetInfoEnabled {
 		// IP-address and MAC-address
 		var ipList, hwList, err = util.GetNetInfo()

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -39,9 +39,15 @@ import (
 const processorName = "add_host_metadata"
 const logName = "processor." + processorName
 
+var (
+	reg *monitoring.Registry
+)
+
 func init() {
 	processors.RegisterPlugin(processorName, New)
 	jsprocessor.RegisterPlugin("AddHostMetadata", New)
+
+	reg = monitoring.Default.NewRegistry(logName, monitoring.DoNotReport)
 }
 
 type metrics struct {
@@ -67,16 +73,10 @@ func New(cfg *config.C) (processors.Processor, error) {
 		return nil, fmt.Errorf("fail to unpack the %v configuration: %w", processorName, err)
 	}
 
-	// Logging and metrics (each processor instance has a unique ID).
-	var (
-		logger = logp.NewLogger(logName)
-		reg    = monitoring.Default.NewRegistry(logName, monitoring.DoNotReport)
-	)
-
 	p := &addHostMetadata{
 		config: c,
 		data:   mapstr.NewPointer(nil),
-		logger: logger,
+		logger: logp.NewLogger(logName),
 		metrics: metrics{
 			FQDNLookupFailed: monitoring.NewInt(reg, "fqdn_lookup_failed"),
 		},

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -149,7 +149,7 @@ func (p *addHostMetadata) loadData() error {
 		if err != nil {
 			// FQDN lookup is "best effort".  We log the error, fallback to
 			// the OS-reported hostname, and move on.
-			p.logger.Warnf("unable to lookup FQDN: %s, using hostname = %s", err.Error(), hostname)
+			p.logger.Warnf("unable to lookup FQDN: %s, using hostname = %s as FQDN", err.Error(), hostname)
 		} else {
 			hostname = fqdn
 		}

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -149,7 +149,7 @@ func (p *addHostMetadata) loadData() error {
 		if err != nil {
 			// FQDN lookup is "best effort".  We log the error, fallback to
 			// the OS-reported hostname, and move on.
-			p.logger.Infof("unable to lookup FQDN: %s, using hostname = %s", err.Error(), hostname)
+			p.logger.Warnf("unable to lookup FQDN: %s, using hostname = %s", err.Error(), hostname)
 		} else {
 			hostname = fqdn
 		}

--- a/libbeat/processors/add_host_metadata/add_host_metadata.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata.go
@@ -19,14 +19,12 @@ package add_host_metadata
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/common/atomic"
 	"github.com/elastic/beats/v7/libbeat/features"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	jsprocessor "github.com/elastic/beats/v7/libbeat/processors/script/javascript/module/processor"
@@ -37,10 +35,6 @@ import (
 	"github.com/elastic/elastic-agent-system-metrics/metric/system/host"
 	"github.com/elastic/go-sysinfo"
 )
-
-// instanceID is used to assign each instance of this
-// processor a unique monitoring namespace.
-var instanceID = atomic.MakeUint32(0)
 
 const processorName = "add_host_metadata"
 const logName = "processor." + processorName
@@ -75,9 +69,8 @@ func New(cfg *config.C) (processors.Processor, error) {
 
 	// Logging and metrics (each processor instance has a unique ID).
 	var (
-		id     = int(instanceID.Inc())
-		logger = logp.NewLogger(logName).With("instance_id", id)
-		reg    = monitoring.Default.NewRegistry(logName+"."+strconv.Itoa(id), monitoring.DoNotReport)
+		logger = logp.NewLogger(logName)
+		reg    = monitoring.Default.NewRegistry(logName, monitoring.DoNotReport)
 	)
 
 	p := &addHostMetadata{

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -19,6 +19,7 @@ package add_host_metadata
 
 import (
 	"fmt"
+	"github.com/elastic/elastic-agent-libs/monitoring"
 	"net"
 	"os"
 	"runtime"
@@ -42,6 +43,10 @@ var (
 	hostID   = "9C7FAB7B"
 )
 
+func deregisterMonitoringRegistry() {
+	monitoring.Default.Remove(logName)
+}
+
 func TestConfigDefault(t *testing.T) {
 	event := &beat.Event{
 		Fields:    mapstr.M{},
@@ -51,6 +56,8 @@ func TestConfigDefault(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
+	defer deregisterMonitoringRegistry()
+
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -98,6 +105,8 @@ func TestConfigNetInfoDisabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
+	defer deregisterMonitoringRegistry()
+
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -149,6 +158,7 @@ func TestConfigName(t *testing.T) {
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
+	defer deregisterMonitoringRegistry()
 
 	newEvent, err := p.Run(event)
 	assert.NoError(t, err)
@@ -181,6 +191,7 @@ func TestConfigGeoEnabled(t *testing.T) {
 
 	testConfig, err := conf.NewConfigFrom(config)
 	assert.NoError(t, err)
+	defer deregisterMonitoringRegistry()
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
@@ -207,6 +218,7 @@ func TestConfigGeoDisabled(t *testing.T) {
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
+	defer deregisterMonitoringRegistry()
 
 	newEvent, err := p.Run(event)
 
@@ -224,6 +236,8 @@ func TestEventWithReplaceFieldsFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
+	defer deregisterMonitoringRegistry()
+
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -304,6 +318,8 @@ func TestEventWithReplaceFieldsTrue(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
+	defer deregisterMonitoringRegistry()
+
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -480,6 +496,7 @@ func TestExpireCacheOnFQDNReportingChange(t *testing.T) {
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
+	defer deregisterMonitoringRegistry()
 
 	ahmP, ok := p.(*addHostMetadata)
 	require.True(t, ok)
@@ -561,6 +578,7 @@ func TestFQDNLookup(t *testing.T) {
 
 			p, err := New(testConfig)
 			require.NoError(t, err)
+			defer deregisterMonitoringRegistry()
 
 			addHostMetadataP, ok := p.(*addHostMetadata)
 			require.True(t, ok)

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -495,17 +495,21 @@ func TestExpireCacheOnFQDNReportingChange(t *testing.T) {
 
 	// Toggle the FQDN feature flag; this should cause the cache
 	// to expire.
-	features.UpdateFromConfig(conf.MustNewConfigFrom(map[string]interface{}{
+	err = features.UpdateFromConfig(conf.MustNewConfigFrom(map[string]interface{}{
 		"features.fqdn.enabled": true,
 	}))
+	require.NoError(t, err)
+
 	expired = ahmP.expired()
 	require.True(t, expired)
 
 	// Set the FQDN feature flag to the same value; this should NOT
 	// cause the cache to expire.
-	features.UpdateFromConfig(conf.MustNewConfigFrom(map[string]interface{}{
+	err = features.UpdateFromConfig(conf.MustNewConfigFrom(map[string]interface{}{
 		"features.fqdn.enabled": true,
 	}))
+	require.NoError(t, err)
+
 	expired = ahmP.expired()
 	require.False(t, expired)
 }

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -25,8 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/monitoring"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -44,10 +42,6 @@ var (
 	hostID   = "9C7FAB7B"
 )
 
-func deregisterMonitoringRegistry() {
-	monitoring.Default.Remove(logName)
-}
-
 func TestConfigDefault(t *testing.T) {
 	event := &beat.Event{
 		Fields:    mapstr.M{},
@@ -57,8 +51,6 @@ func TestConfigDefault(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
-	defer deregisterMonitoringRegistry()
-
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -106,8 +98,6 @@ func TestConfigNetInfoDisabled(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
-	defer deregisterMonitoringRegistry()
-
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -159,7 +149,6 @@ func TestConfigName(t *testing.T) {
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
-	defer deregisterMonitoringRegistry()
 
 	newEvent, err := p.Run(event)
 	assert.NoError(t, err)
@@ -192,7 +181,6 @@ func TestConfigGeoEnabled(t *testing.T) {
 
 	testConfig, err := conf.NewConfigFrom(config)
 	assert.NoError(t, err)
-	defer deregisterMonitoringRegistry()
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
@@ -219,7 +207,6 @@ func TestConfigGeoDisabled(t *testing.T) {
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
-	defer deregisterMonitoringRegistry()
 
 	newEvent, err := p.Run(event)
 
@@ -237,8 +224,6 @@ func TestEventWithReplaceFieldsFalse(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
-	defer deregisterMonitoringRegistry()
-
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -319,8 +304,6 @@ func TestEventWithReplaceFieldsTrue(t *testing.T) {
 	assert.NoError(t, err)
 
 	p, err := New(testConfig)
-	defer deregisterMonitoringRegistry()
-
 	switch runtime.GOOS {
 	case "windows", "darwin", "linux":
 		assert.NoError(t, err)
@@ -497,7 +480,6 @@ func TestExpireCacheOnFQDNReportingChange(t *testing.T) {
 
 	p, err := New(testConfig)
 	require.NoError(t, err)
-	defer deregisterMonitoringRegistry()
 
 	ahmP, ok := p.(*addHostMetadata)
 	require.True(t, ok)
@@ -579,7 +561,6 @@ func TestFQDNLookup(t *testing.T) {
 
 			p, err := New(testConfig)
 			require.NoError(t, err)
-			defer deregisterMonitoringRegistry()
 
 			addHostMetadataP, ok := p.(*addHostMetadata)
 			require.True(t, ok)

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -19,12 +19,13 @@ package add_host_metadata
 
 import (
 	"fmt"
-	"github.com/elastic/elastic-agent-libs/monitoring"
 	"net"
 	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -19,19 +19,22 @@ package add_host_metadata
 
 import (
 	"fmt"
+	"net"
+	"os"
 	"runtime"
 	"testing"
 	"time"
-
-	"github.com/elastic/beats/v7/libbeat/features"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/features"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/go-sysinfo/types"
+
+	"github.com/foxcpp/go-mockdns"
 )
 
 var (
@@ -505,4 +508,82 @@ func TestExpireCacheOnFQDNReportingChange(t *testing.T) {
 	}))
 	expired = ahmP.expired()
 	require.False(t, expired)
+}
+
+func TestFQDNLookup(t *testing.T) {
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		cnameLookupResult             string
+		expectedHostName              string
+		expectedFQDNLookupFailedCount int64
+	}{
+		"lookup_succeeds": {
+			cnameLookupResult:             "foo.bar.baz.",
+			expectedHostName:              "foo.bar.baz",
+			expectedFQDNLookupFailedCount: 0,
+		},
+		"lookup_fails": {
+			cnameLookupResult:             "",
+			expectedHostName:              hostname,
+			expectedFQDNLookupFailedCount: 1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Mock CNAME resolution
+			srv, _ := mockdns.NewServer(map[string]mockdns.Zone{
+				hostname + ".": {
+					CNAME: test.cnameLookupResult,
+				},
+				test.cnameLookupResult: {
+					A: []string{"1.1.1.1"},
+				},
+			}, false)
+			defer srv.Close()
+
+			srv.PatchNet(net.DefaultResolver)
+			defer mockdns.UnpatchNet(net.DefaultResolver)
+
+			// Enable FQDN feature flag
+			err = features.UpdateFromConfig(fqdnFeatureFlagConfig(true))
+			require.NoError(t, err)
+			defer func() {
+				err = features.UpdateFromConfig(fqdnFeatureFlagConfig(true))
+				require.NoError(t, err)
+			}()
+
+			// Create processor and check that FQDN lookup failed
+			testConfig, err := conf.NewConfigFrom(map[string]interface{}{})
+			require.NoError(t, err)
+
+			p, err := New(testConfig)
+			require.NoError(t, err)
+
+			addHostMetadataP, ok := p.(*addHostMetadata)
+			require.True(t, ok)
+			require.Equal(t, test.expectedFQDNLookupFailedCount, addHostMetadataP.metrics.FQDNLookupFailed.Get())
+
+			// Run event through processor and check that hostname reported
+			// by processor is same as OS-reported hostname
+			event := &beat.Event{
+				Fields:    mapstr.M{},
+				Timestamp: time.Now(),
+			}
+			newEvent, err := p.Run(event)
+			require.NoError(t, err)
+
+			v, err := newEvent.GetValue("host.name")
+			require.NoError(t, err)
+			require.Equal(t, test.expectedHostName, v)
+		})
+	}
+}
+
+func fqdnFeatureFlagConfig(fqdnEnabled bool) *conf.C {
+	return conf.MustNewConfigFrom(map[string]interface{}{
+		"features.fqdn.enabled": fqdnEnabled,
+	})
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR fixes a bug wherein a Beat would fail to start if the FQDN lookup failed.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

FQDN lookup is "best effort".  As such, if the lookup fails for some reason, we should not fail to start a Beat or halt execution otherwise.  Instead, we should fallback to the OS-provided hostname and continue execution.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build Filebeat (or any other Beat) with this PR.
   ```sh
   cd beats/filebeat
   mage clean build
   ```

2. Set hostname to something that wouldn't resolve via DNS.  On MacOS this can be done via:
   ```sh
   orig_hostname=$(hostname -f)
   sudo scutil --set HostName cowchicken
   ```

3. Run `filebeat version`.  This command should report the version as usual and NOT fail with an FQDN-related error (as reported in #34910)
   ```sh
   ./filebeat version
   ```
   ```
   filebeat version 8.8.0 (arm64), libbeat 8.8.0 [528128f44ee870cedca830d8acbf63d8ee35ae26 built 2023-03-28 16:45:09 +0000 UTC]
   ```

4. Create a configuration file for the Beat that enables the `add_host_metadata` processor and also enables the FQDN feature flag.
   ```sh
   cat <<EOF >filebeat.test.yml
   filebeat.inputs:
   - type: stdin
   
   processors:
   - add_host_metadata: ~
   
   features.fqdn.enabled: true
   output.console.enabled: true
   EOF
   ```

5.  Start the Beat with the above configuration and look for log entries mentioning `FQDN`.  You should see two log entries in all, one from Beat initialization and one from the `add_host_metadata` processor.

    ```sh
    ./filebeat -c ./filebeat.test.yml -e 2>&1 | grep -i fqdn
    ```

    ```
    {"log.level":"warn","@timestamp":"2023-03-28T11:38:17.639-0700","log.origin":{"file.name":"instance/beat.go","file.line":802},"message":"unable to lookup FQDN: could not get FQDN, all methods failed: failed looking up CNAME: lookup cowchicken: no such host: failed looking up IP: lookup cowchicken: no such host, using hostname = cowchicken as FQDN","service.name":"filebeat","ecs.version":"1.6.0"}
    {"log.level":"warn","@timestamp":"2023-03-28T11:38:17.642-0700","log.logger":"add_host_metadata","log.origin":{"file.name":"add_host_metadata/add_host_metadata.go","file.line":152},"message":"unable to lookup FQDN: could not get FQDN, all methods failed: failed looking up CNAME: lookup cowchicken: no such host: failed looking up IP: lookup cowchicken: no such host, using hostname = cowchicken as FQDN","service.name":"filebeat","ecs.version":"1.6.0"}
    ```

99. Reset hostname at the end of the test.  On MacOS this can be done via:
    ```sh
    sudo scutil --set HostName $orig_hostname
    ```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #34910
- Follow up to https://github.com/elastic/beats/pull/34456

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
