### PR TITLE
Remove timeouts v2 manager integration tests

### DIFF
--- a/x-pack/libbeat/management/tests/init.go
+++ b/x-pack/libbeat/management/tests/init.go
@@ -79,7 +79,8 @@ func SetupTestEnv(t *testing.T, config *proto.UnitExpectedConfig, runtime time.D
 	err := os.Mkdir(outPath, 0775)
 	require.NoError(t, err)
 
-	server := NewMockServer(t, runtime, config, outPath)
+	start := time.Now()
+	server := NewMockServer(t, func(_ string) bool { return time.Since(start) > runtime }, config, outPath)
 	t.Logf("Resetting fleet manager...")
 	err = ResetFleetManager(server)
 	require.NoError(t, err)

--- a/x-pack/libbeat/management/tests/mbtest/metricbeat_v2_test.go
+++ b/x-pack/libbeat/management/tests/mbtest/metricbeat_v2_test.go
@@ -44,7 +44,7 @@ func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
 			},
 			Source: tests.RequireNewStruct(map[string]interface{}{
 				"metricsets": []interface{}{"cpu"},
-				"period":     "2s",
+				"period":     "1s",
 				"processors": []interface{}{
 					map[string]interface{}{
 						"add_fields": map[string]interface{}{
@@ -63,13 +63,13 @@ func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
 			},
 			Source: tests.RequireNewStruct(map[string]interface{}{
 				"metricsets": []interface{}{"memory"},
-				"period":     "2s",
+				"period":     "1s",
 			}),
 		},
 	}
 
 	expectedMBStreams.Streams = mbStreams
-	outPath, server := tests.SetupTestEnv(t, expectedMBStreams, time.Second*6)
+	outPath, server := tests.SetupTestEnv(t, expectedMBStreams, time.Second*40)
 
 	defer server.Srv.Stop()
 	defer func() {
@@ -77,10 +77,42 @@ func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	// After runfor seconds, this should shut down, allowing us to check the output
-	t.Logf("Running beats...")
-	err := cmd.RootCmd.Execute()
-	require.NoError(t, err)
+	go func() {
+		t.Logf("Running beats...")
+		err := cmd.RootCmd.Execute()
+		require.NoError(t, err)
+	}()
+
+	found := false
+	for {
+		if found {
+			server.Client.Stop()
+			server.Srv.Stop()
+			break
+		}
+		time.Sleep(time.Second)
+		// check to see we have at least one event from both metricsets
+		events := tests.ReadEvents(t, outPath)
+		memoryEvt := false
+		cpuEvt := false
+		for _, evt := range events {
+			if found, _ := evt.GetValue("data_stream.dataset"); found != nil {
+				dataset, ok := found.(string)
+				if ok {
+					if dataset == "system.cpu" {
+						cpuEvt = true
+					}
+					if dataset == "system.memory" {
+						memoryEvt = true
+					}
+				}
+			}
+			if cpuEvt && memoryEvt {
+				t.Logf("found memory and CPU events")
+				found = true
+			}
+		}
+	}
 
 	t.Logf("Reading events...")
 	events := tests.ReadEvents(t, outPath)
@@ -98,13 +130,13 @@ func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
 		// make sure the V2 shim isn't overwriting any custom processors
 		"@metadata.testfield": true,
 	}
-	tests.ValuesExist(t, expectedCPUMetaValues, events, tests.ONCE)
+	tests.ValuesExist(t, expectedCPUMetaValues, events, tests.ONCE, "expectedCPUMetaValues")
 
 	expectedMemoryMetaValues := map[string]interface{}{
 		"@metadata.stream_id": "system/metrics-system.memory-default-system",
 		"data_stream.dataset": "system.memory",
 	}
-	tests.ValuesExist(t, expectedMemoryMetaValues, events, tests.ONCE)
+	tests.ValuesExist(t, expectedMemoryMetaValues, events, tests.ONCE, "expectedMemoryMetaValues")
 
 	// Look for proper CPU/memory config
 	expectedCPU := map[string]interface{}{
@@ -112,7 +144,7 @@ func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
 		"system.cpu.total":          nil,
 		"system.memory.actual.free": nil,
 	}
-	tests.ValuesExist(t, expectedCPU, events, tests.ONCE)
+	tests.ValuesExist(t, expectedCPU, events, tests.ONCE, "expectedCPU")
 
 	// If there's a config issue, metricbeat will fallback to default metricsets. Make sure they don't exist.
 	disabledMetricsets := []string{
@@ -120,5 +152,5 @@ func TestSingleMetricbeatMetricsetWithProcessors(t *testing.T) {
 		"system.load",
 		"system.process_summary",
 	}
-	tests.ValuesDoNotExist(t, disabledMetricsets, events)
+	tests.ValuesDoNotExist(t, disabledMetricsets, events, "disabledMetricsets")
 }

--- a/x-pack/libbeat/management/tests/mock_server.go
+++ b/x-pack/libbeat/management/tests/mock_server.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
 	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
@@ -27,7 +26,7 @@ type MockV2Handler struct {
 }
 
 // NewMockServer returns a mocked elastic-agent V2 controller
-func NewMockServer(t *testing.T, runtime time.Duration, inputConfig *proto.UnitExpectedConfig, outPath string) MockV2Handler {
+func NewMockServer(t *testing.T, canStop func(string) bool, inputConfig *proto.UnitExpectedConfig, outPath string) MockV2Handler {
 	unitOneID := mock.NewID()
 	unitOutID := mock.NewID()
 
@@ -57,8 +56,6 @@ func NewMockServer(t *testing.T, runtime time.Duration, inputConfig *proto.UnitE
 		}),
 	}
 
-	start := time.Now()
-
 	stopping := false
 	srv := mock.StubServerV2{
 		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
@@ -69,8 +66,8 @@ func NewMockServer(t *testing.T, runtime time.Duration, inputConfig *proto.UnitE
 				if !stopping && (len(observed.Units) == 0 || observed.Units[0].State == proto.State_STARTING) {
 					return sendUnitsWithState(proto.State_HEALTHY, inputConfig, logOutputStream, unitOneID, unitOutID, 1)
 				} else if !stopping && checkUnitStateHealthy(observed.Units) {
-					if time.Since(start) > runtime {
-						// remove the units once they've been healthy for a given period of time
+					if canStop(outPath) {
+						// remove the units once the callback says we can
 						stopping = true
 						return sendUnitsWithState(proto.State_STOPPED, inputConfig, logOutputStream, unitOneID, unitOutID, 1)
 					}

--- a/x-pack/libbeat/management/tests/output_read.go
+++ b/x-pack/libbeat/management/tests/output_read.go
@@ -22,6 +22,21 @@ type findFieldsMode string
 const ALL findFieldsMode = "all"
 const ONCE findFieldsMode = "once"
 
+// ReadLogLines returns the total count of NDJSON events in the log path
+func ReadLogLines(t *testing.T, path string) int {
+	files, err := filepath.Glob(filepath.Join(path, "*.ndjson"))
+	require.NoError(t, err)
+
+	events := 0
+	for _, file := range files {
+		rawFile, err := os.ReadFile(file)
+		require.NoError(t, err)
+		lines := strings.Split(string(rawFile), "\n")
+		events += len(lines)
+	}
+	return events
+}
+
 // ReadEvents reads the ndjson output we get from the beats file output
 func ReadEvents(t *testing.T, path string) []mapstr.M {
 	files, err := filepath.Glob(filepath.Join(path, "*.ndjson"))
@@ -50,7 +65,7 @@ func ReadEvents(t *testing.T, path string) []mapstr.M {
 // the values map takes keys in the form of keys in the events map, which may be in dot form: "system.cpu.cores", etc.
 // The value for the map should be the expected value, or a `nil` if you merely want to check for the presence of a field.
 // the mode determines if `ValuesExist` must exist in all events, or just one.
-func ValuesExist(t *testing.T, values map[string]interface{}, events []mapstr.M, mode findFieldsMode) {
+func ValuesExist(t *testing.T, values map[string]interface{}, events []mapstr.M, mode findFieldsMode, info string) {
 	for searchKey, val := range values {
 		var foundCount = 0
 		for eventIter, event := range events {
@@ -64,30 +79,35 @@ func ValuesExist(t *testing.T, values map[string]interface{}, events []mapstr.M,
 				if val == evt {
 					foundCount++
 				} else if val != evt && mode == ALL {
-					t.Errorf("Key %s was found in event %d, but value was unexpected. Expected %#v, got %#v", searchKey, eventIter, val, evt)
+					t.Errorf("test %s: Key %s was found in event %d, but value was unexpected. Expected %#v, got %#v", info, searchKey, eventIter, val, evt)
 				}
 			}
 		}
 		if mode == ALL {
 			if foundCount != len(events) {
-				t.Errorf("Expected to find key %s in all %d events, but key was only found %d times.", searchKey, len(events), foundCount)
+				t.Errorf("test %s: Expected to find key %s in all %d events, but key was only found %d times.", info, searchKey, len(events), foundCount)
 			}
 		}
 		if mode == ONCE {
 			if foundCount == 0 {
-				t.Errorf("Did not find key %s in any events", searchKey)
+				if val == nil {
+					t.Errorf("test %s: Did not find key %s in any events", info, searchKey)
+				} else {
+					t.Errorf("test %s: Did not find key %s and value %#v in any events", info, searchKey, val)
+				}
+
 			}
 		}
 	}
 }
 
 // ValuesDoNotExist checks to make sure that the given keys do not exist in any events.
-func ValuesDoNotExist(t *testing.T, values []string, events []mapstr.M) {
+func ValuesDoNotExist(t *testing.T, values []string, events []mapstr.M, info string) {
 	for _, key := range values {
 		for eventIter, event := range events {
 			evt, _ := event.GetValue(key)
 			if evt != nil {
-				t.Errorf("key %s with value %#v was found in event %d in the output", key, evt, eventIter)
+				t.Errorf("test %s: key %s with value %#v was found in event %d in the output", info, key, evt, eventIter)
 			}
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

A quick fix for some issues that @faec ran into

This changes how the V2 manager integration tests work. Instead of relying on a timeout to tell us when to shut down, it waits until a condition is met, in this case, the tests will now wait until they have enough data to test against.

## Why is it important?

This was a source of test failures.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

