### PR TITLE
Fix linter typecheck rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ issues:
     - text: "undeclared name:"
       linters:
         - typecheck
-    - text: "imported but not used"
+    - text: "imported and not used"
       linters:
         - typecheck
     # From mage we are priting to the console to ourselves


### PR DESCRIPTION
The `golangci` linter's `typecheck` test has a broken check: it will flag packages as "imported and not used" when the package is only imported for its types rather than its functions. We have a rule in the config to disable the check, however it used the string "imported but not used" and the current linter message has changed slightly; this PR updates the config to detect the new text.