### PR TITLE
Add detail for fqdn feature docs

### DIFF
--- a/libbeat/docs/shared-feature-flags.asciidoc
+++ b/libbeat/docs/shared-feature-flags.asciidoc
@@ -31,8 +31,8 @@ You can specify the following options in the `features` section of the +{beatnam
 ==== `fqdn`
 
 Contains configuration for the FQDN reporting feature. When this feature is
-enabled, {beatname_uc} reports the fully-qualified domain name for the host
-on which it's running.
+enabled, the fully-qualified domain name for the host is reported in the
+`host.name` field in events produced by {beatname_uc}.
 
 For FQDN reporting to work as expected, the hostname of the current host must either:
 

--- a/libbeat/docs/shared-feature-flags.asciidoc
+++ b/libbeat/docs/shared-feature-flags.asciidoc
@@ -7,8 +7,8 @@
 
 The Feature Flags section of the +{beatname_lc}.yml+ config file contains
 settings in {beatname_uc} that are disabled by default. These may include 
-experimental features, changes to behaviors within {beatname_uc} or its 
-components, or settings that could cause a breaking change. For example a
+experimental features, changes to behaviors within {beatname_uc}, or 
+settings that could cause a breaking change. For example a
 setting that changes information included in events might be inconsistent with
 the naming pattern expected in your configured {beatname_uc} output.
 

--- a/libbeat/docs/shared-feature-flags.asciidoc
+++ b/libbeat/docs/shared-feature-flags.asciidoc
@@ -1,16 +1,24 @@
 [[configuration-feature-flags]]
-== Configure Feature Flags
+== Configure feature flags
 
 ++++
-<titleabbrev>Feature Flags</titleabbrev>
+<titleabbrev>Feature flags</titleabbrev>
 ++++
 
-Example configuration with the FQDN feature flag enabled:
+The Feature Flags section of the +{beatname_lc}.yml+ config file contains
+settings in {beatname_uc} that are disabled by default. These may include 
+experimental features, changes to behaviors within {beatname_uc} or its 
+components, or settings that could cause a breaking change. For example a
+setting that changes information included in events might be inconsistent with
+the naming pattern expected in your configured {beatname_uc} output.
 
-["source","yaml"]
+To enable any of the settings listed on this page, change the associated `enabled`
+flag from `false` to `true`.
+
+[source,yaml]
 ----
 features:
-  fqdn:
+  mysetting:
     enabled: true
 ----
 
@@ -22,8 +30,27 @@ You can specify the following options in the `features` section of the +{beatnam
 [float]
 ==== `fqdn`
 
-Contains configuration for the FQDN reporting feature.  When this feature is enabled, {beatname_uc} will
-report the fully-qualified domain name for the host on which it's running.
+Contains configuration for the FQDN reporting feature. When this feature is
+enabled, {beatname_uc} reports the fully-qualified domain name for the host
+on which it's running.
+
+For FQDN reporting to work as expected, the hostname of the current host must either:
+
+* Have a CNAME entry defined in DNS.
+* Have one of its corresponding IP addresses respond successfully to a reverse
+DNS lookup.
+
+If neither pre-requisite is satisfied, `host.name` continues to report the
+hostname of the current host as if the FQDN feature flag were not enabled.
+
+Example configuration:
+
+[source,yaml]
+----
+features:
+  fqdn:
+    enabled: true
+----
 
 [float]
 ===== `enabled`


### PR DESCRIPTION
This updates the Beats [Feature flags page and the FQDN setting](https://www.elastic.co/guide/en/beats/metricbeat/master/configuration-feature-flags.html). I thought we needed to add new docs, but they were added already via https://github.com/elastic/beats/pull/34456, so this is just to provide a bit more info.

The additions here are based on discussion in [this similar PR](https://github.com/elastic/observability-docs/pull/2817) for the Elastic Agent docs.

Rel: https://github.com/elastic/ingest-dev/issues/1641

**Preview** (showing Metricbeat but all Beats are updated):

![Screenshot 2023-04-03 at 2 42 59 PM](https://user-images.githubusercontent.com/41695641/229598622-f3311816-4417-45b4-8c56-fd354c71444e.png)

