### PR TITLE
Highlight Take over is in beta

### DIFF
--- a/filebeat/docs/howto/migrate-to-filestream.asciidoc
+++ b/filebeat/docs/howto/migrate-to-filestream.asciidoc
@@ -97,6 +97,8 @@ defined `log` input, we need to add `take_over: true` to each new `filestream`. 
 that the new `filestream` inputs will continue ingesting files from the same offset where the `log`
 inputs stopped.
 
+WARNING: The `take over` mode is in beta.
+
 IMPORTANT: If this parameter is not set, all the files will be re-ingested from the beginning
 and this will lead to data duplication. Please, double-check that this parameter is set.
 


### PR DESCRIPTION
- Docs change

## What does this PR do?

Highlights `take_over` is in beta

The warning is in the `take_over` option itself, on a separate page https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-filestream.html#filebeat-input-filestream-take-over

## Why is it important?

Sets expectations for users.

## Checklist

- [ ] We might need to port this from 8.7.0 and main ?