### PR TITLE
Skip all unreliable tests from the past month.

### DIFF
--- a/filebeat/tests/system/test_input.py
+++ b/filebeat/tests/system/test_input.py
@@ -282,6 +282,7 @@ class Test(BaseTest):
 
         filebeat.check_wait(exit_code=1)
 
+    @unittest.skip("Skipped as flaky: https://github.com/elastic/beats/issues/34982")
     def test_no_paths_defined(self):
         """
         In case a input is defined but doesn't contain any paths, input must return error which

--- a/libbeat/outputs/shipper/shipper_test.go
+++ b/libbeat/outputs/shipper/shipper_test.go
@@ -277,6 +277,7 @@ func TestPublish(t *testing.T) {
 	shipperProcessor = toShipperEvent
 
 	t.Run("cancels the batch when a different server responds", func(t *testing.T) {
+		t.Skip("Flaky test: https://github.com/elastic/beats/issues/34984")
 		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 		defer cancel()
 

--- a/x-pack/filebeat/input/cometd/input_test.go
+++ b/x-pack/filebeat/input/cometd/input_test.go
@@ -391,6 +391,7 @@ func assertEventMatches(t *testing.T, expected bay.MaybeMsg, got beat.Event) {
 }
 
 func TestMultiEventForEOFRetryHandlerInput(t *testing.T) {
+	t.Skip("Flaky test: https://github.com/elastic/beats/issues/34956")
 	var err error
 
 	expectedEventCount := 2

--- a/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
@@ -9,6 +9,7 @@ class Test(XPackTest):
 
     COMPOSE_SERVICES = ['oracle']
 
+    @unittest.skip("Flaky test: https://github.com/elastic/beats/issues/34993")
     @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_query(self):
         """


### PR DESCRIPTION
Skip all unreliable tests from the path month. The tests can be fixed and then reenabled separately.

- Relates https://github.com/elastic/beats/issues/34993
- Relates https://github.com/elastic/beats/issues/34982
- Relates https://github.com/elastic/beats/issues/34984
- Relates https://github.com/elastic/beats/issues/34956