### PR TITLE
x-pack/filebeat/input/netflow: allow v9 template sharing

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -251,6 +251,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Add MySQL authentication message parsing and `related.ip` and `related.user` fields {pull}34810[34810]
 - Mention `mito` CEL tool in CEL input docs. {pull}34959[34959]
 - Add nginx ingress_controller parsing if one of upstreams fails to return response {pull}34787[34787]
+- Allow neflow v9 and ipfix templates to be shared between source addresses. {pull}35036[35036]
 
 *Auditbeat*
    - Migration of system/package module storage from gob encoding to flatbuffer encoding in bolt db. {pull}34817[34817]

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -21,6 +21,9 @@
   # Share Templates
   # This option allows v9 and ipfix templates to be shared within a session without
   # reference to the origin of the template.
+  #
+  # Setting this to true is not recommended as it can result in the wrong template
+  # being applied under certain conditions, but it may be required for some systems.
   #share_templates: false
 
   # Queue size limits the number of netflow packets that are queued awaiting

--- a/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
+++ b/x-pack/filebeat/_meta/config/filebeat.inputs.reference.xpack.yml.tmpl
@@ -18,6 +18,11 @@
   # Only applicable to v9 and ipfix protocols. A value of zero disables expiration.
   #expiration_timeout: 30m
 
+  # Share Templates
+  # This option allows v9 and ipfix templates to be shared within a session without
+  # reference to the origin of the template.
+  #share_templates: false
+
   # Queue size limits the number of netflow packets that are queued awaiting
   # processing.
   #queue_size: 8192

--- a/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-netflow.asciidoc
@@ -56,6 +56,17 @@ Only applicable to v9 and IPFIX protocols. A value of zero disables expiration.
 
 [float]
 [[queue_size]]
+==== `share_templates`
+
+This option allows v9 and ipfix templates to be shared within a session without
+reference to the origin of the template.
+
+Note that setting this to true is not recommended as it can result in the wrong
+template being applied under certain conditions, but it may be required for some
+systems.
+
+[float]
+[[queue_size]]
 ==== `queue_size`
 
 The maximum number of packets that can be queued for processing.

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3389,6 +3389,11 @@ filebeat.inputs:
   # Only applicable to v9 and ipfix protocols. A value of zero disables expiration.
   #expiration_timeout: 30m
 
+  # Share Templates
+  # This option allows v9 and ipfix templates to be shared within a session without
+  # reference to the origin of the template.
+  #share_templates: false
+
   # Queue size limits the number of netflow packets that are queued awaiting
   # processing.
   #queue_size: 8192

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3392,6 +3392,9 @@ filebeat.inputs:
   # Share Templates
   # This option allows v9 and ipfix templates to be shared within a session without
   # reference to the origin of the template.
+  #
+  # Setting this to true is not recommended as it can result in the wrong template
+  # being applied under certain conditions, but it may be required for some systems.
   #share_templates: false
 
   # Queue size limits the number of netflow packets that are queued awaiting

--- a/x-pack/filebeat/input/netflow/config.go
+++ b/x-pack/filebeat/input/netflow/config.go
@@ -22,6 +22,7 @@ type config struct {
 	PacketQueueSize           int           `config:"queue_size"`
 	CustomDefinitions         []string      `config:"custom_definitions"`
 	DetectSequenceReset       bool          `config:"detect_sequence_reset"`
+	ShareTemplates            bool          `config:"share_templates"`
 }
 
 var defaultConfig = config{
@@ -38,4 +39,5 @@ var defaultConfig = config{
 	ExpirationTimeout:   time.Minute * 30,
 	PacketQueueSize:     8192,
 	DetectSequenceReset: true,
+	ShareTemplates:      false,
 }

--- a/x-pack/filebeat/input/netflow/decoder/config/config.go
+++ b/x-pack/filebeat/input/netflow/decoder/config/config.go
@@ -14,18 +14,20 @@ import (
 
 // Config stores the configuration used by the NetFlow Collector.
 type Config struct {
-	protocols   []string
-	logOutput   io.Writer
-	expiration  time.Duration
-	detectReset bool
-	fields      fields.FieldDict
+	protocols       []string
+	logOutput       io.Writer
+	expiration      time.Duration
+	detectReset     bool
+	fields          fields.FieldDict
+	sharedTemplates bool
 }
 
 var defaultCfg = Config{
-	protocols:   []string{},
-	logOutput:   ioutil.Discard,
-	expiration:  time.Hour,
-	detectReset: true,
+	protocols:       []string{},
+	logOutput:       ioutil.Discard,
+	expiration:      time.Hour,
+	detectReset:     true,
+	sharedTemplates: false,
 }
 
 // Defaults returns a configuration object with defaults settings:
@@ -78,6 +80,14 @@ func (c *Config) WithCustomFields(dicts ...fields.FieldDict) *Config {
 	for _, dict := range dicts {
 		c.fields.Merge(dict)
 	}
+	return c
+}
+
+// WithSharedTemplates allows to toggle the sharing of templates within
+// a v9 neflow session. If it is not enabled, the source address must match
+// the address of the source of the template.
+func (c *Config) WithSharedTemplates(enabled bool) *Config {
+	c.sharedTemplates = enabled
 	return c
 }
 

--- a/x-pack/filebeat/input/netflow/decoder/config/config.go
+++ b/x-pack/filebeat/input/netflow/decoder/config/config.go
@@ -84,8 +84,8 @@ func (c *Config) WithCustomFields(dicts ...fields.FieldDict) *Config {
 }
 
 // WithSharedTemplates allows to toggle the sharing of templates within
-// a v9 neflow session. If it is not enabled, the source address must match
-// the address of the source of the template.
+// a v9 neflow or ipfix session. If it is not enabled, the source address
+// must match the address of the source of the template.
 func (c *Config) WithSharedTemplates(enabled bool) *Config {
 	c.sharedTemplates = enabled
 	return c

--- a/x-pack/filebeat/input/netflow/decoder/ipfix/ipfix_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/ipfix/ipfix_test.go
@@ -81,7 +81,7 @@ func TestMessageWithOptions(t *testing.T) {
 
 func TestOptionTemplates(t *testing.T) {
 	addr := test.MakeAddress(t, "127.0.0.1:12345")
-	key := v9.MakeSessionKey(addr, 1234)
+	key := v9.MakeSessionKey(addr, 1234, false)
 
 	t.Run("Single options template", func(t *testing.T) {
 		proto := New(config.Defaults())

--- a/x-pack/filebeat/input/netflow/decoder/v9/session.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/session.go
@@ -22,7 +22,11 @@ type SessionKey struct {
 }
 
 // MakeSessionKey returns a session key.
-func MakeSessionKey(addr net.Addr, sourceID uint32) SessionKey {
+func MakeSessionKey(addr net.Addr, sourceID uint32, shared bool) SessionKey {
+	if shared {
+		// If templates are shared, do not store the addr.
+		return SessionKey{SourceID: sourceID}
+	}
 	return SessionKey{addr.String(), sourceID}
 }
 

--- a/x-pack/filebeat/input/netflow/decoder/v9/session_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/session_test.go
@@ -21,7 +21,7 @@ import (
 var logger = log.New(ioutil.Discard, "", 0)
 
 func makeSessionKey(t testing.TB, ipPortPair string, domain uint32) SessionKey {
-	return MakeSessionKey(test.MakeAddress(t, ipPortPair), domain)
+	return MakeSessionKey(test.MakeAddress(t, ipPortPair), domain, false)
 }
 
 func TestSessionMap_GetOrCreate(t *testing.T) {

--- a/x-pack/filebeat/input/netflow/decoder/v9/v9.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/v9.go
@@ -25,12 +25,13 @@ const (
 )
 
 type NetflowV9Protocol struct {
-	decoder     Decoder
-	logger      *log.Logger
-	Session     SessionMap
-	timeout     time.Duration
-	done        chan struct{}
-	detectReset bool
+	decoder        Decoder
+	logger         *log.Logger
+	Session        SessionMap
+	timeout        time.Duration
+	done           chan struct{}
+	detectReset    bool
+	shareTemplates bool
 }
 
 func init() {
@@ -79,7 +80,7 @@ func (p *NetflowV9Protocol) OnPacket(buf *bytes.Buffer, source net.Addr) (flows 
 	}
 	buf = payload
 
-	session := p.Session.GetOrCreate(MakeSessionKey(source, header.SourceID))
+	session := p.Session.GetOrCreate(MakeSessionKey(source, header.SourceID, p.shareTemplates))
 	remote := source.String()
 
 	p.logger.Printf("Packet from:%s src:%d seq:%d", remote, header.SourceID, header.SequenceNo)

--- a/x-pack/filebeat/input/netflow/decoder/v9/v9_test.go
+++ b/x-pack/filebeat/input/netflow/decoder/v9/v9_test.go
@@ -30,7 +30,7 @@ func TestNetflowProtocol_New(t *testing.T) {
 func TestOptionTemplates(t *testing.T) {
 	const sourceID = 1234
 	addr := test.MakeAddress(t, "127.0.0.1:12345")
-	key := MakeSessionKey(addr, sourceID)
+	key := MakeSessionKey(addr, sourceID, false)
 
 	t.Run("Single options template", func(t *testing.T) {
 		proto := New(config.Defaults())

--- a/x-pack/filebeat/input/netflow/input.go
+++ b/x-pack/filebeat/input/netflow/input.go
@@ -117,7 +117,8 @@ func NewInput(
 		WithExpiration(config.ExpirationTimeout).
 		WithLogOutput(&logDebugWrapper{Logger: logger}).
 		WithCustomFields(customFields...).
-		WithSequenceResetEnabled(config.DetectSequenceReset))
+		WithSequenceResetEnabled(config.DetectSequenceReset).
+		WithSharedTemplates(config.ShareTemplates))
 	if err != nil {
 		return nil, errors.Wrapf(err, "error initializing netflow decoder")
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds an option to allow users to specify sharing of v9 and ipfix templates within a session without regard to the template/flow origin.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This behaviour is the default option in logstash and the current filebeat behaviour is blocking users migrating from logstash.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
