### PR TITLE
[Docs] add link to cloud docs on configuring Cloud ID

### DIFF
--- a/libbeat/docs/output-cloud.asciidoc
+++ b/libbeat/docs/output-cloud.asciidoc
@@ -40,6 +40,7 @@ These settings can be also specified at the command line, like this:
 The Cloud ID, which can be found in the {ess} web console, is used by
 {beatname_uc} to resolve the {es} and {kib} URLs. This setting
 overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings.
+For more on locating and configuring the Cloud ID, see {ece-ref}/ece-cloud-id.html[Configure Beats and Logstash with Cloud ID].
 
 NOTE: The base64 encoded `cloud.id` found in the {ess} web console does not explicitly specify a port. This means that {beatname_uc} will default to using port 443 when using `cloud.id`, not the commonly configured cloud endpoint port 9243.
 


### PR DESCRIPTION
## What does this PR do?

This PR closes [Issue 27237](https://github.com/elastic/beats/issues/27237).

It adds a link to the **Configure Beats and Logstash with Cloud ID** page in the Elastic Cloud docs.

## Why is it important?

Users have had issues finding this information in the past.