### PR TITLE
[Winlogbeat] Document 21 Event ID clause limit under certain situations

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -301,6 +301,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 
 - Add metrics for log event processing. {pull}33922[33922]
 - Add metrics documentation for event processing. {issue}34887[34887] {pull}34889[34889]
+- Add note in documentation about 21 event ID clause limit {issue}35048[35048] {pull}0[0]
 
 *Elastic Log Driver*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -301,7 +301,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 
 - Add metrics for log event processing. {pull}33922[33922]
 - Add metrics documentation for event processing. {issue}34887[34887] {pull}34889[34889]
-- Add note in documentation about 21 event ID clause limit {issue}35048[35048] {pull}0[0]
+- Add note in documentation about 21 event ID clause limit {issue}35048[35048] {pull}35049[35049]
 
 *Elastic Log Driver*
 

--- a/winlogbeat/docs/winlogbeat-options.asciidoc
+++ b/winlogbeat/docs/winlogbeat-options.asciidoc
@@ -251,7 +251,11 @@ logs.
 `WARN EventLog[Application] Open() error. No events will be read from this
 source. The specified query is invalid.`
 
-If you have more than 22 event IDs, you can workaround this Windows limitation
+In some cases, the limit may be lower than 22 conditions. For instance, using a
+mixture of ranges and single event IDs, along with an additional parameter such
+as `ignore older`, results in a limit of 21 conditions.
+
+If you have more than 22 conditions, you can workaround this Windows limitation
 by using a drop_event[drop-event] processor to do the filtering after
 {beatname_uc} has received the events from Windows. The filter shown below is
 equivalent to `event_id: 903, 1024, 4624` but can be expanded beyond 22


### PR DESCRIPTION

## What does this PR do?

- Added note in documentation about a situation where the event ID clause limit is lower than the claimed 22 clause limit.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #35048
