### PR TITLE
Docs: add explanations to the loadbalance

### DIFF
--- a/filebeat/docs/load-balancing.asciidoc
+++ b/filebeat/docs/load-balancing.asciidoc
@@ -21,6 +21,13 @@ output.logstash:
 The `loadbalance` option is available for Redis, Logstash, and Elasticsearch
 outputs. The Kafka output handles load balancing internally.
 
+Beat’s loadbalance: true causes it to send data if-and-only-if it can send to all hosts in the list.
+
+When loadbalance: false, Filebeat will pick a host at random from the list and send data, failing over to other entries. It also accepts a ttl, which will cause it to voluntarily reestablish a connection to a new host after a time even if it is healthy.
+As long as the first chosen endpoint is available, then it continues to communicate with that one. It only switches to another endpoint in case of failure.
+
+When loadbalance: true is set, Filebeat will connect to all hosts in the list and evenly distribute the events to them. This has the side effect of blocking publishing to all hosts if any one of them is down or exerting back-pressure.
+
 The load balancer also supports multiple workers per host. The default is
 `worker: 1`. If you increase the number of workers, additional network
 connections will be used.  The total number of workers participating


### PR DESCRIPTION
The current official [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/load-balancing.html) does not explain how the load balance parameter works for filebeat.


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Docs
-->

## What does this PR do?
This PR aims to provide contextual explanations about the `loadbalance` setting in filebeat

## Why is it important?

Currently, the `loadbalance` setting is not explained in the documentation

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] The clarity of the explanations must follow the model of the official documentation
- [ ] Avoid syntax and spelling mistakes


## Use cases
Filebeat


