### PR TITLE
filebeat/input/tcp - Fix panic in linux input metrics (#35068)

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -106,7 +106,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix the ignore_inactive option being ignored in Filebeat's filestream input {pull}34770[34770]
 - Fix TestMultiEventForEOFRetryHandlerInput unit test of CometD input {pull}34903[34903]
 - Add input instance id to request trace filename for httpjson and cel inputs {pull}35024[35024]
-- Fix panic in UDP input on Linux when collecting socket metrics from OS. {issue}35064[35064]
+- Fix panic in TCP and UDP inputs on Linux when collecting socket metrics from OS. {issue}35064[35064]
 
 *Heartbeat*
 

--- a/filebeat/input/tcp/input_test.go
+++ b/filebeat/input/tcp/input_test.go
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcNetTCP(t *testing.T) {
+	t.Run("with_match", func(t *testing.T) {
+		rx, err := procNetTCP("testdata/proc_net_tcp.txt", []string{"0100007F:17AC"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.EqualValues(t, 1, rx)
+	})
+
+	t.Run("without_match", func(t *testing.T) {
+		_, err := procNetTCP("testdata/proc_net_tcp.txt", []string{"FOO:BAR", "BAR:BAZ"})
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "entry not found")
+		}
+	})
+}

--- a/filebeat/input/tcp/testdata/proc_net_tcp.txt
+++ b/filebeat/input/tcp/testdata/proc_net_tcp.txt
@@ -1,0 +1,2 @@
+  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   1: 0100007F:17AC 00000000:0000 0A 00000000:00000001 00:00000000 00000000     0        0 104724420 1 0000000000000000 100 0 0 10 0

--- a/filebeat/input/udp/input.go
+++ b/filebeat/input/udp/input.go
@@ -264,7 +264,7 @@ func procNetUDP(path string, addr []string) (rx, drops int64, err error) {
 	}
 	lines := bytes.Split(b, []byte("\n"))
 	if len(lines) < 2 {
-		return 0, 0, fmt.Errorf("/proc/net/udp entry not found for %s (no line)", addr)
+		return 0, 0, fmt.Errorf("%s entry not found for %s (no line)", path, addr)
 	}
 	for _, l := range lines[1:] {
 		f := bytes.Fields(l)
@@ -284,7 +284,7 @@ func procNetUDP(path string, addr []string) (rx, drops int64, err error) {
 			return rx, drops, nil
 		}
 	}
-	return 0, 0, fmt.Errorf("/proc/net/udp entry not found for %s", addr)
+	return 0, 0, fmt.Errorf("%s entry not found for %s", path, addr)
 }
 
 func contains(b []byte, addr []string) bool {


### PR DESCRIPTION
## What does this PR do?

A panic occurred while parsing /proc/net/tcp and reaching the final empty line. This occurred on Linux when the desired socket was not found in the list.

Fixes #35064

## Why is it important?

The panic causes Filebeat to exit.

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Fixes #35064
- Relates #35068
