### PR TITLE
Disable flaky test (x-pack.metricbeat.module.sql.query.test_sql_oracle.Test)

### DIFF
--- a/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
@@ -9,8 +9,8 @@ class Test(XPackTest):
 
     COMPOSE_SERVICES = ['oracle']
 
+    #@unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @unittest.skip("Flaky test: https://github.com/elastic/beats/issues/34993")
-    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_query(self):
         """
         sql oracle custom query test

--- a/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
@@ -9,7 +9,7 @@ class Test(XPackTest):
 
     COMPOSE_SERVICES = ['oracle']
 
-    #@unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
+    # @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     @unittest.skip("Flaky test: https://github.com/elastic/beats/issues/34993")
     def test_query(self):
         """


### PR DESCRIPTION
`x-pack.metricbeat.module.sql.query.test_sql_oracle.Test` is broken (https://github.com/elastic/beats/issues/34993) and a PR was submitted to disable it last week (https://github.com/elastic/beats/pull/35030) however it's still [running and failing on active PRs](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-35078/10/testReport/junit/x-pack.metricbeat.module.sql.query.test_sql_oracle/Test/Extended___x_pack_metricbeat_cloudAWS___test_query/), presumably because the `@unittest.skip` directives didn't stack correctly in the unittest api. This PR removes the conflicting directive so the test will be skipped for real.