### PR TITLE
fix: gcp remapping metric name log should use mapped value

### DIFF
--- a/x-pack/metricbeat/module/gcp/metrics/response_parser.go
+++ b/x-pack/metricbeat/module/gcp/metrics/response_parser.go
@@ -252,10 +252,8 @@ var reMapping = map[string]string{
 }
 
 func remap(l *logp.Logger, s string) string {
-	var newS string
-
 	if v, found := reMapping[s]; found {
-		l.Debugf("remapping %s to %s", s, newS)
+		l.Debugf("remapping %s to %s", s, v)
 		return v
 	}
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

- Enhancement:   fix debug logging 


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

