### PR TITLE
[MetricBeat][AWS] Add AWS autoscaling group tags

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -282,6 +282,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Add beta ingest_pipeline metricset to Elasticsearch module for ingest pipeline monitoring {pull}34012[34012]
 - Handle duplicated TYPE line for prometheus metrics {issue}18813[18813] {pull}33865[33865]
 - Add GCP Carbon Footprint metricbeat data {pull}34820[34820]
+- Add AWS autoscaling group tags {pull}35093[35093]
 
 *Packetbeat*
 

--- a/go.mod
+++ b/go.mod
@@ -188,6 +188,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.1
 	github.com/Azure/go-autorest/autorest/adal v0.9.14
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.17
+	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.23.4
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.20.4
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.15.8
 	github.com/aws/smithy-go v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.14 h1:bJv4Y9QOiW0GZPStgLgpGrpdfRD
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.14/go.mod h1:R1HF8ZDdcRFfAGF+13En4LSHi2IrrNuPQCaxgWCeGyY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.4 h1:wusoY1MJ9JNrPoX3n4kxY4MTIUivCiXvTYQbYh59yxs=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.4/go.mod h1:cHTMyJVEXRUZ25f8V+pq6CAwoYARarJRFGf3XH4eIxE=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.23.4 h1:Qop3ydJL2UUp7ploxghzC4p4uUZZR8ibL//tTWpBlAU=
+github.com/aws/aws-sdk-go-v2/service/autoscaling v1.23.4/go.mod h1:5BgmRWVztWrXOkafO2vCDxsBVCUIXTX+hGBFgoqEbKA=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.20.4 h1:faP794ma9ZY/24XAV8cm/lkQzRFSg3zBHCi5Nc8+CaM=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.20.4/go.mod h1:ybjChNDMfPtc7f8ILTb+ov6CpE/KtAae9fD8HHtYfzU=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.18.2 h1:UecVUEdx3xe80X+guNwR2hN1d4L4v4qX2SHLYd/4cIk=

--- a/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/cloudwatch/_meta/docs.asciidoc
@@ -10,6 +10,7 @@ ec2:DescribeRegions
 cloudwatch:GetMetricData
 cloudwatch:ListMetrics
 tag:getResources
+autoscaling:DescribeTags
 sts:GetCallerIdentity
 iam:ListAccountAliases
 ----


### PR DESCRIPTION
- Enhancement


## What does this PR do?

Add tags for aws autoscaling group metrics in aws module. 

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->


* Resourcegroupstagging.GetResources API can't get autocaling group tags

https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/supported-services.html

>  The TagResources and UntagResources operations of AWS Resource Groups Tagging API work as documented with Auto Scaling Groups. However, the GetTagKey, GetTagValues and GetResources operations aren't supported at this time and return an empty response for this service.

* Autoscaling Group DescribeTags API

https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_DescribeTags.html


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

-  #31303
