### PR TITLE
Disable flaky test x-pack/metricbeat/module/sql/query.TestOracle

### DIFF
--- a/x-pack/metricbeat/module/sql/query/query_integration_test.go
+++ b/x-pack/metricbeat/module/sql/query/query_integration_test.go
@@ -228,6 +228,7 @@ func TestPostgreSQL(t *testing.T) {
 }
 
 func TestOracle(t *testing.T) {
+	t.Skip("Flaky test: test containers fail over attempt to bind port 5500 https://github.com/elastic/beats/issues/35105")
 	service := compose.EnsureUp(t, "oracle")
 	host, port, _ := net.SplitHostPort(service.Host())
 	cfg := testFetchConfig{


### PR DESCRIPTION
`TestOracle` fails because of errors bringing up its support container (port 5500 is already bound, presumably a container is trying to start before another has shut down). Disable it so it doesn't block CI for unrelated changes. [Issue](https://github.com/elastic/beats/issues/35105)