### PR TITLE
Correctly disable flaky test

### DIFF
--- a/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
+++ b/x-pack/metricbeat/module/sql/query/test_sql_oracle.py
@@ -5,12 +5,12 @@ import time
 from xpack_metricbeat import XPackTest, metricbeat
 
 
+@unittest.skip("Flaky test: https://github.com/elastic/beats/issues/34993")
 class Test(XPackTest):
 
     COMPOSE_SERVICES = ['oracle']
 
-    # @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
-    @unittest.skip("Flaky test: https://github.com/elastic/beats/issues/34993")
+    @unittest.skipUnless(metricbeat.INTEGRATION_TESTS, "integration test")
     def test_query(self):
         """
         sql oracle custom query test


### PR DESCRIPTION
I figured out the real reason this test was still causing CI failures despite [repeated](https://github.com/elastic/beats/pull/35030) [attempts](https://github.com/elastic/beats/pull/35083) to disable it: the failure was happening in the class setup, so even though the only individual test case was disabled, it was still causing an exception when the class itself couldn't bring up the support containers.

This PR disables the test class instead of just the method, which should prevent failures like [this](https://beats-ci.elastic.co/job/Beats/job/beats/job/PR-35078/15/testReport/x-pack.metricbeat.module.sql.query.test_sql_oracle/Test/Extended___x_pack_metricbeat_cloudAWS___test_query/) at head.
