### PR TITLE
Defer queue creation / activate proxy queue

### DIFF
--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -78,6 +78,8 @@ type EventListener interface {
 	// ACK Events from the output and pipeline queue are forwarded to ACKEvents.
 	// The number of reported events only matches the known number of events downstream.
 	// ACKers might need to keep track of dropped events by themselves.
+	// TODO: This method is never called by any live pipeline, it should
+	// be deleted.
 	ACKEvents(n int)
 
 	// ClientClosed informs the ACKer that the Client used to publish to the pipeline has been closed.

--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -48,11 +48,18 @@ type IndexSelector interface {
 }
 
 // Group configures and combines multiple clients into load-balanced group of clients
-// being managed by the publisher pipeline.
+// being managed by the publisher pipeline. If QueueSettings is set then the
+// pipeline will use the specified settings object to create the queue. QueueSettings
+// must be one of memqueue.Settings, diskqueue.Settings, proxyqueue.Settings.
+// Currently it is only used to activate the proxy queue when using the Shipper
+// output, but it also provides a natural migration path for moving queue
+// configuration into the outputs.
 type Group struct {
 	Clients   []Client
 	BatchSize int
 	Retry     int
+	// Must be one of memqueue.Settings, diskqueue.Settings, proxyqueue.Settings.
+	QueueSettings interface{}
 }
 
 // RegisterType registers a new output type.

--- a/libbeat/outputs/shipper/shipper.go
+++ b/libbeat/outputs/shipper/shipper.go
@@ -25,6 +25,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	"github.com/elastic/beats/v7/libbeat/publisher"
+	proxyqueue "github.com/elastic/beats/v7/libbeat/publisher/queue/proxy"
+
 	"github.com/elastic/elastic-agent-shipper-client/pkg/helpers"
 	sc "github.com/elastic/elastic-agent-shipper-client/pkg/proto"
 	"github.com/elastic/elastic-agent-shipper-client/pkg/proto/messages"
@@ -106,7 +108,11 @@ func makeShipper(
 
 	swb := outputs.WithBackoff(s, config.Backoff.Init, config.Backoff.Max)
 
-	return outputs.Success(config.BulkMaxSize, config.MaxRetries, swb)
+	return outputs.Group{
+		Clients:       []outputs.Client{swb},
+		Retry:         config.MaxRetries,
+		QueueSettings: proxyqueue.Settings{BatchSize: config.BulkMaxSize},
+	}, nil
 }
 
 // Connect establishes connection to the shipper server and implements `outputs.Connectable`.

--- a/libbeat/publisher/pipeline/client_test.go
+++ b/libbeat/publisher/pipeline/client_test.go
@@ -146,7 +146,7 @@ func TestClientWaitClose(t *testing.T) {
 	err := logp.TestingSetup()
 	assert.Nil(t, err)
 
-	q := memqueue.NewQueue(logp.L(), memqueue.Settings{Events: 1})
+	q := memqueue.NewQueue(logp.L(), nil, memqueue.Settings{Events: 1})
 	pipeline := makePipeline(Settings{}, q)
 	defer pipeline.Close()
 

--- a/libbeat/publisher/pipeline/module.go
+++ b/libbeat/publisher/pipeline/module.go
@@ -48,7 +48,7 @@ type Monitors struct {
 // OutputFactory is used by the publisher pipeline to create an output instance.
 // If the group returned can be empty. The pipeline will accept events, but
 // eventually block.
-type OutputFactory func(outputs.Observer) (string, outputs.Group, error)
+type outputFactory func(outputs.Observer) (string, outputs.Group, error)
 
 func init() {
 	flag.BoolVar(&publishDisabled, "N", false, "Disable actual publishing for testing")
@@ -108,7 +108,7 @@ func LoadWithSettings(
 
 func loadOutput(
 	monitors Monitors,
-	makeOutput OutputFactory,
+	makeOutput outputFactory,
 ) (outputs.Group, error) {
 	if publishDisabled {
 		return outputs.Group{}, nil

--- a/libbeat/publisher/pipeline/pipeline.go
+++ b/libbeat/publisher/pipeline/pipeline.go
@@ -21,6 +21,7 @@
 package pipeline
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -33,6 +34,8 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -62,10 +65,12 @@ type Pipeline struct {
 
 	observer observer
 
-	// wait close support
-	waitOnClose      bool
+	// wait close support. If eventWaitGroup is non-nil, then publishing
+	// an event through this pipeline will increment it and acknowledging
+	// a published event will decrement it, so the pipeline can wait on
+	// the group on shutdown to allow pending events to be acknowledged.
 	waitCloseTimeout time.Duration
-	waitCloseGroup   sync.WaitGroup
+	eventWaitGroup   *sync.WaitGroup
 
 	// closeRef signal propagation support
 	guardStartSigPropagation sync.Once
@@ -128,35 +133,33 @@ func New(
 		beatInfo:         beat,
 		monitors:         monitors,
 		observer:         nilObserver,
-		waitOnClose:      settings.WaitCloseMode == WaitOnPipelineClose && settings.WaitClose > 0,
 		waitCloseTimeout: settings.WaitClose,
 		processors:       settings.Processors,
+	}
+	if settings.WaitCloseMode == WaitOnPipelineClose && settings.WaitClose > 0 {
+		// If wait-on-close is enabled, give the pipeline a WaitGroup for
+		// events that have been Published but not yet ACKed.
+		p.eventWaitGroup = &sync.WaitGroup{}
 	}
 
 	if monitors.Metrics != nil {
 		p.observer = newMetricsObserver(monitors.Metrics)
 	}
 
-	ackCallback := func(eventCount int) {
-		p.observer.queueACKed(eventCount)
-		if p.waitOnClose {
-			p.waitCloseGroup.Add(-eventCount)
-		}
-	}
-
+	// Convert the raw queue config to a parsed Settings object that will
+	// be used during queue creation. This lets us fail immediately on startup
+	// if there's a configuration problem.
 	queueType := defaultQueueType
 	if b := userQueueConfig.Name(); b != "" {
 		queueType = b
 	}
-	queueConfig := queueConfig{
-		logger:      monitors.Logger,
-		queueType:   queueType,
-		userConfig:  userQueueConfig.Config(),
-		ackCallback: ackCallback,
-		inQueueSize: settings.InputQueueSize,
+	queueSettings, err := queueSettingsForUserConfig(
+		queueType, userQueueConfig.Config(), settings.InputQueueSize)
+	if err != nil {
+		return nil, err
 	}
 
-	output, err := newOutputController(beat, monitors, p.observer, queueConfig)
+	output, err := newOutputController(beat, monitors, p.observer, p.eventWaitGroup, queueSettings)
 	if err != nil {
 		return nil, err
 	}
@@ -175,10 +178,10 @@ func (p *Pipeline) Close() error {
 
 	log.Debug("close pipeline")
 
-	if p.waitOnClose {
+	if p.eventWaitGroup != nil {
 		ch := make(chan struct{})
 		go func() {
-			p.waitCloseGroup.Wait()
+			p.eventWaitGroup.Wait()
 			ch <- struct{}{}
 		}()
 
@@ -229,7 +232,6 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	}
 
 	waitClose := cfg.WaitClose
-	reportEvents := p.waitOnClose
 
 	processors, err := p.createEventProcessing(cfg.Processing, publishDisabled)
 	if err != nil {
@@ -237,7 +239,7 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 	}
 
 	client := &client{
-		pipeline:       p,
+		logger:         p.monitors.Logger,
 		closeRef:       cfg.CloseRef,
 		done:           make(chan struct{}),
 		isOpen:         atomic.MakeBool(true),
@@ -245,21 +247,22 @@ func (p *Pipeline) ConnectWith(cfg beat.ClientConfig) (beat.Client, error) {
 		processors:     processors,
 		eventFlags:     eventFlags,
 		canDrop:        canDrop,
-		reportEvents:   reportEvents,
+		eventWaitGroup: p.eventWaitGroup,
+		observer:       p.observer,
 	}
 
 	ackHandler := cfg.EventListener
 
 	producerCfg := queue.ProducerConfig{}
 
-	if reportEvents || cfg.ClientListener != nil {
+	if client.eventWaitGroup != nil || cfg.ClientListener != nil {
 		producerCfg.OnDrop = func(event interface{}) {
 			publisherEvent, _ := event.(publisher.Event)
 			if cfg.ClientListener != nil {
 				cfg.ClientListener.DroppedOnPublish(publisherEvent.Content)
 			}
-			if reportEvents {
-				p.waitCloseGroup.Add(-1)
+			if client.eventWaitGroup != nil {
+				client.eventWaitGroup.Add(-1)
 			}
 		}
 	}
@@ -385,4 +388,27 @@ func (p *Pipeline) createEventProcessing(cfg beat.ProcessingConfig, noPublish bo
 // OutputReloader returns a reloadable object for the output section of this pipeline
 func (p *Pipeline) OutputReloader() OutputReloader {
 	return p.outputController
+}
+
+// Parses the given config and returns a memqueue.Settings or
+// diskqueue.Settings based on it. This helper exists to frontload config
+// parsing errors: if there is an error in the queue config, we want it to
+// show up as fatal during initialization, even if the queue itself isn't
+// created until later.
+func queueSettingsForUserConfig(queueType string, userConfig *conf.C, inQueueSize int) (interface{}, error) {
+	switch queueType {
+	case memqueue.QueueType:
+		settings, err := memqueue.SettingsForUserConfig(userConfig)
+		if err != nil {
+			return nil, err
+		}
+		// The memory queue has a special override during pipeline
+		// initialization for the size of its API channel buffer.
+		settings.InputQueueSize = inQueueSize
+		return settings, nil
+	case diskqueue.QueueType:
+		return diskqueue.SettingsForUserConfig(userConfig)
+	default:
+		return nil, fmt.Errorf("unrecognized queue type '%v'", queueType)
+	}
 }

--- a/libbeat/publisher/queue/diskqueue/benchmark_test.go
+++ b/libbeat/publisher/queue/diskqueue/benchmark_test.go
@@ -100,7 +100,7 @@ func setup(b *testing.B, encrypt bool, compress bool, protobuf bool) (*diskQueue
 	}
 	s.UseCompression = compress
 	s.UseProtobuf = protobuf
-	q, err := NewQueue(logp.L(), s)
+	q, err := NewQueue(logp.L(), nil, s)
 	if err != nil {
 		panic(err)
 	}

--- a/libbeat/publisher/queue/diskqueue/config.go
+++ b/libbeat/publisher/queue/diskqueue/config.go
@@ -58,10 +58,6 @@ type Settings struct {
 	// this limit can keep it from overflowing memory.
 	WriteAheadLimit int
 
-	// A callback that is called when an event is successfully
-	// written to disk.
-	WriteToDiskCallback func(eventCount int)
-
 	// RetryInterval specifies how long to wait before retrying a fatal error
 	// writing to disk. If MaxRetryInterval is nonzero, subsequent retries will
 	// use exponential backoff up to the specified limit.

--- a/libbeat/publisher/queue/diskqueue/queue.go
+++ b/libbeat/publisher/queue/diskqueue/queue.go
@@ -104,7 +104,11 @@ type metricsRequestResponse struct {
 
 // NewQueue returns a disk-based queue configured with the given logger
 // and settings, creating it if it doesn't exist.
-func NewQueue(logger *logp.Logger, settings Settings) (*diskQueue, error) {
+func NewQueue(
+	logger *logp.Logger,
+	writeToDiskCallback func(eventCount int),
+	settings Settings,
+) (*diskQueue, error) {
 	logger = logger.Named("diskqueue")
 	logger.Debugf(
 		"Initializing disk queue at path %v", settings.directoryPath())
@@ -209,7 +213,7 @@ func NewQueue(logger *logp.Logger, settings Settings) (*diskQueue, error) {
 		acks: newDiskQueueACKs(logger, nextReadPosition, positionFile),
 
 		readerLoop:  newReaderLoop(settings),
-		writerLoop:  newWriterLoop(logger, settings),
+		writerLoop:  newWriterLoop(logger, writeToDiskCallback, settings),
 		deleterLoop: newDeleterLoop(settings),
 
 		producerWriteRequestChan: make(chan producerWriteRequest),

--- a/libbeat/publisher/queue/diskqueue/queue_test.go
+++ b/libbeat/publisher/queue/diskqueue/queue_test.go
@@ -89,7 +89,7 @@ func TestMetrics(t *testing.T) {
 	// lower max segment size so we can get multiple segments
 	settings.MaxSegmentSize = 100
 
-	testQueue, err := NewQueue(logp.L(), settings)
+	testQueue, err := NewQueue(logp.L(), nil, settings)
 	require.NoError(t, err)
 	defer testQueue.Close()
 
@@ -124,7 +124,7 @@ func makeTestQueue() queuetest.QueueFactory {
 		}
 		settings := DefaultSettings()
 		settings.Path = dir
-		queue, _ := NewQueue(logp.L(), settings)
+		queue, _ := NewQueue(logp.L(), nil, settings)
 		return testQueue{
 			diskQueue: queue,
 			teardown: func() {

--- a/libbeat/publisher/queue/diskqueue/writer_loop.go
+++ b/libbeat/publisher/queue/diskqueue/writer_loop.go
@@ -71,6 +71,10 @@ type writerLoop struct {
 	// The logger for the writer loop, assigned when the queue creates it.
 	logger *logp.Logger
 
+	// A callback that, if set, should be invoked with an event count when
+	// events are successfully written to disk.
+	writeToDiskCallback func(eventCount int)
+
 	// The writer loop listens on requestChan for frames to write, and
 	// writes them to disk immediately (all queue capacity checking etc. is
 	// done by the core loop before sending it to the writer).
@@ -96,11 +100,16 @@ type writerLoop struct {
 	buffer *bytes.Buffer
 }
 
-func newWriterLoop(logger *logp.Logger, settings Settings) *writerLoop {
+func newWriterLoop(
+	logger *logp.Logger,
+	writeToDiskCallback func(eventCount int),
+	settings Settings,
+) *writerLoop {
 	buffer := &bytes.Buffer{}
 	return &writerLoop{
-		logger:   logger,
-		settings: settings,
+		logger:              logger,
+		writeToDiskCallback: writeToDiskCallback,
+		settings:            settings,
 
 		requestChan:  make(chan writerLoopRequest, 1),
 		responseChan: make(chan writerLoopResponse),
@@ -235,8 +244,8 @@ outerLoop:
 	_ = wl.outputFile.Sync()
 
 	// If the queue has an ACK listener, notify it the frames were written.
-	if wl.settings.WriteToDiskCallback != nil {
-		wl.settings.WriteToDiskCallback(totalACKCount)
+	if wl.writeToDiskCallback != nil {
+		wl.writeToDiskCallback(totalACKCount)
 	}
 
 	// Notify any producers with ACK listeners that their frames were written.

--- a/libbeat/publisher/queue/memqueue/broker.go
+++ b/libbeat/publisher/queue/memqueue/broker.go
@@ -81,7 +81,6 @@ type broker struct {
 }
 
 type Settings struct {
-	ACKCallback    func(eventCount int)
 	Events         int
 	FlushMinEvents int
 	FlushTimeout   time.Duration
@@ -122,6 +121,7 @@ type chanList struct {
 // workers handling incoming messages and ACKs have been shut down.
 func NewQueue(
 	logger *logp.Logger,
+	ackCallback func(eventCount int),
 	settings Settings,
 ) *broker {
 	var (
@@ -159,7 +159,7 @@ func NewQueue(
 		// internal broker and ACK handler channels
 		scheduledACKs: make(chan chanList),
 
-		ackCallback: settings.ACKCallback,
+		ackCallback: ackCallback,
 		metricChan:  make(chan metricsRequest),
 	}
 

--- a/libbeat/publisher/queue/memqueue/queue_test.go
+++ b/libbeat/publisher/queue/memqueue/queue_test.go
@@ -103,7 +103,7 @@ func TestQueueMetricsBuffer(t *testing.T) {
 }
 
 func queueTestWithSettings(t *testing.T, settings Settings, eventsToTest int, testName string) {
-	testQueue := NewQueue(nil, settings)
+	testQueue := NewQueue(nil, nil, settings)
 	defer testQueue.Close()
 
 	// Send events to queue
@@ -143,7 +143,7 @@ func TestProducerCancelRemovesEvents(t *testing.T) {
 
 func makeTestQueue(sz, minEvents int, flushTimeout time.Duration) queuetest.QueueFactory {
 	return func(_ *testing.T) queue.Queue {
-		return NewQueue(nil, Settings{
+		return NewQueue(nil, nil, Settings{
 			Events:         sz,
 			FlushMinEvents: minEvents,
 			FlushTimeout:   flushTimeout,
@@ -258,22 +258,22 @@ func TestEntryIDs(t *testing.T) {
 	}
 
 	t.Run("acking in forward order with directEventLoop reports the right event IDs", func(t *testing.T) {
-		testQueue := NewQueue(nil, Settings{Events: 1000})
+		testQueue := NewQueue(nil, nil, Settings{Events: 1000})
 		testForward(testQueue)
 	})
 
 	t.Run("acking in reverse order with directEventLoop reports the right event IDs", func(t *testing.T) {
-		testQueue := NewQueue(nil, Settings{Events: 1000})
+		testQueue := NewQueue(nil, nil, Settings{Events: 1000})
 		testBackward(testQueue)
 	})
 
 	t.Run("acking in forward order with bufferedEventLoop reports the right event IDs", func(t *testing.T) {
-		testQueue := NewQueue(nil, Settings{Events: 1000, FlushMinEvents: 2, FlushTimeout: time.Microsecond})
+		testQueue := NewQueue(nil, nil, Settings{Events: 1000, FlushMinEvents: 2, FlushTimeout: time.Microsecond})
 		testForward(testQueue)
 	})
 
 	t.Run("acking in reverse order with bufferedEventLoop reports the right event IDs", func(t *testing.T) {
-		testQueue := NewQueue(nil, Settings{Events: 1000, FlushMinEvents: 2, FlushTimeout: time.Microsecond})
+		testQueue := NewQueue(nil, nil, Settings{Events: 1000, FlushMinEvents: 2, FlushTimeout: time.Microsecond})
 		testBackward(testQueue)
 	})
 }

--- a/libbeat/publisher/queue/proxy/broker.go
+++ b/libbeat/publisher/queue/proxy/broker.go
@@ -59,8 +59,7 @@ type broker struct {
 }
 
 type Settings struct {
-	ACKCallback func(eventCount int)
-	BatchSize   int
+	BatchSize int
 }
 
 type queueEntry struct {
@@ -82,11 +81,14 @@ type blockedRequests struct {
 	last  *blockedRequest
 }
 
+const QueueType = "proxy"
+
 // NewQueue creates a new broker based in-memory queue holding up to sz number of events.
 // If waitOnClose is set to true, the broker will block on Close, until all internal
 // workers handling incoming messages and ACKs have been shut down.
 func NewQueue(
 	logger *logp.Logger,
+	ackCallback func(eventCount int),
 	settings Settings,
 ) *broker {
 	if logger == nil {
@@ -102,7 +104,7 @@ func NewQueue(
 		pushChan: make(chan *pushRequest),
 		getChan:  make(chan getRequest),
 
-		ackCallback: settings.ACKCallback,
+		ackCallback: ackCallback,
 	}
 
 	b.wg.Add(1)

--- a/libbeat/publisher/queue/proxy/queue_test.go
+++ b/libbeat/publisher/queue/proxy/queue_test.go
@@ -54,7 +54,7 @@ func TestBasicEventFlow(t *testing.T) {
 	logger := logp.NewLogger("proxy-queue-tests")
 
 	// Create a proxy queue where each batch is at most 2 events
-	testQueue := NewQueue(logger, Settings{BatchSize: 2})
+	testQueue := NewQueue(logger, nil, Settings{BatchSize: 2})
 	defer testQueue.Close()
 
 	listener := newTestACKListener()
@@ -84,7 +84,7 @@ func TestBlockedProducers(t *testing.T) {
 	logger := logp.NewLogger("proxy-queue-tests")
 
 	// Create a proxy queue where each batch is at most 2 events
-	testQueue := NewQueue(logger, Settings{BatchSize: 2})
+	testQueue := NewQueue(logger, nil, Settings{BatchSize: 2})
 	defer testQueue.Close()
 
 	listener := newTestACKListener()
@@ -125,7 +125,7 @@ func TestOutOfOrderACK(t *testing.T) {
 	logger := logp.NewLogger("proxy-queue-tests")
 
 	// Create a proxy queue where each batch is at most 2 events
-	testQueue := NewQueue(logger, Settings{BatchSize: 2})
+	testQueue := NewQueue(logger, nil, Settings{BatchSize: 2})
 	defer testQueue.Close()
 
 	listener := newTestACKListener()
@@ -167,7 +167,7 @@ func TestOutOfOrderACK(t *testing.T) {
 func TestWriteAfterClose(t *testing.T) {
 	logger := logp.NewLogger("proxy-queue-tests")
 
-	testQueue := NewQueue(logger, Settings{BatchSize: 2})
+	testQueue := NewQueue(logger, nil, Settings{BatchSize: 2})
 	producer := testQueue.Producer(queue.ProducerConfig{})
 	testQueue.Close()
 


### PR DESCRIPTION
(This is probably ready for comments but I've left it as a draft while I work on testing.)

Defer creation of the beats queue until the full output configuration is received; Activate the proxy queue when the Shipper output is in use.

The proxy queue is meant to track event acknowledgments without storing event data in memory, to avoid a doubled memory cost for events stored in both Beats and the Shipper. However, [activating it](https://github.com/elastic/beats/issues/34396) has required multiple refactoring passes, since previously the queue was created globally before receiving any output configuration. Now that previous work has moved queue logic into `outputController`, this PR completes the work by activating the queue-related hooks so queue creation is delayed and queue clients are blocked until the output is active.

The important changes are:
- `outputs.Group` now has a new field, `QueueSettings`, with which an output can specify the settings to use when creating the queue.
- `outputController.Set`, which gives the output controller its output worker group, is now responsible for creating the queue when a nonempty output is assigned (previously this was done on initialization).
- `outputController.queueProducer` can now be called before the queue is created, in which case it accumulates requests that then block until queue creation.
- refactor: the queue's acknowledgment callback is now a parameter to queue creation rather than an element of the various `Settings` structs. The callback is used for bookkeeping in the pipeline and needs to be controlled by the queue creator, while everything else in `{memqueue,diskqueue,proxyqueue}.Settings` can be safely set by the output.
- refactor: pipeline waitgroup / event tracking. Various event transitions involve calling into the pipeline observer or the pipeline's global event wait group. These are now passed down as creation parameters to the `client` and `outputController` so both components can update them in a consistent way instead of distributing the logic across various callbacks and explicit `Pipeline` pointers.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

There are two paths to testing this PR: one is to make sure that normal queue settings continue to apply, both standalone and under agent. This should just involve making sure that events reach the output without errors. The other is to test with the shipper output and verify that data can flow to the shipper, that event acknowledgments are received, and that the beat memory use remains low even when many events are queued by the shipper.

## Related issues

- Resolves https://github.com/elastic/beats/issues/34396