### PR TITLE
Change log line for matcher condition

### DIFF
--- a/libbeat/conditions/matcher.go
+++ b/libbeat/conditions/matcher.go
@@ -93,7 +93,7 @@ func (c Matcher) Check(event ValuesMap) bool {
 		default:
 			str, err := ExtractString(value)
 			if err != nil {
-				logp.L().Named(logName).Warnf("unexpected type %T in %v condition as it accepts only strings.", value, c.name)
+				logp.L().Named(logName).Debugf("unexpected type %T in %v condition as it accepts only strings; value=%#v", value, c.name, value)
 				return false
 			}
 


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/elastic/beats/issues/35112

This is a simple one-liner fix that changes a log line from `Warn` to `Debug` and adds additional debug data.

There's also a conversation to be had about _if_ this is the best fix for the above issue; another possibility is that if we get a map or other non-string datatype, we can try to "search" it for a matching string. I decided against this, as it represents a somewhat non-obvious break from how the matcher behaves now, where something like `kubernetes.labels.app: elasticsearch` is understood as shorthand for "this key is at this position," and not "this key is somewhere here" and might lead to false positives. If we were to do such a thing, we might want some kind of `fuzzy_match` flag that the user can flip to tell the matcher that key-value access points are approximate. This also means we wouldn't "hide" bad configuration, in cases where a user enters a match statement that doesn't match the JSON in the way they were expecting.

## Why is it important?

This is causing a lot of log message spam.

## Checklist


- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
