### PR TITLE
Make all GoroutinesChecker methods be on a pointer receiver

### DIFF
--- a/libbeat/tests/resources/goroutines.go
+++ b/libbeat/tests/resources/goroutines.go
@@ -18,14 +18,13 @@
 package resources
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
 	"runtime/pprof"
 	"testing"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // This is the maximum waiting time for goroutine shutdown.

--- a/libbeat/tests/resources/goroutines.go
+++ b/libbeat/tests/resources/goroutines.go
@@ -42,8 +42,8 @@ type GoroutinesChecker struct {
 }
 
 // NewGoroutinesChecker creates a new GoroutinesChecker
-func NewGoroutinesChecker() GoroutinesChecker {
-	return GoroutinesChecker{
+func NewGoroutinesChecker() *GoroutinesChecker {
+	return &GoroutinesChecker{
 		before:              runtime.NumGoroutine(),
 		FinalizationTimeout: defaultFinalizationTimeout,
 	}

--- a/libbeat/tests/resources/goroutines.go
+++ b/libbeat/tests/resources/goroutines.go
@@ -50,7 +50,7 @@ func NewGoroutinesChecker() GoroutinesChecker {
 
 // Check if the number of goroutines has increased since the checker
 // was created
-func (c GoroutinesChecker) Check(t testing.TB) {
+func (c *GoroutinesChecker) Check(t testing.TB) {
 	t.Helper()
 	err := c.check()
 	if err != nil {
@@ -64,7 +64,7 @@ func dumpGoroutines() {
 	profile.WriteTo(os.Stdout, 2)
 }
 
-func (c GoroutinesChecker) check() error {
+func (c *GoroutinesChecker) check() error {
 	after, err := c.WaitUntilOriginalCount()
 	if err == ErrTimeout {
 		return fmt.Errorf("possible goroutines leak, before: %d, after: %d", c.before, after)
@@ -88,7 +88,7 @@ var ErrTimeout = fmt.Errorf("timeout waiting for finalization of goroutines")
 // present before we created the resource checker.
 // It returns the number of goroutines after the check and a timeout error
 // in case the wait has expired.
-func (c GoroutinesChecker) WaitUntilOriginalCount() (int, error) {
+func (c *GoroutinesChecker) WaitUntilOriginalCount() (int, error) {
 	timeout := time.Now().Add(c.FinalizationTimeout)
 
 	var after int

--- a/libbeat/tests/resources/goroutines.go
+++ b/libbeat/tests/resources/goroutines.go
@@ -24,6 +24,8 @@ import (
 	"runtime/pprof"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // This is the maximum waiting time for goroutine shutdown.
@@ -61,12 +63,12 @@ func (c *GoroutinesChecker) Check(t testing.TB) {
 
 func dumpGoroutines() {
 	profile := pprof.Lookup("goroutine")
-	profile.WriteTo(os.Stdout, 2)
+	_ = profile.WriteTo(os.Stdout, 2)
 }
 
 func (c *GoroutinesChecker) check() error {
 	after, err := c.WaitUntilOriginalCount()
-	if err == ErrTimeout {
+	if errors.Is(err, ErrTimeout) {
 		return fmt.Errorf("possible goroutines leak, before: %d, after: %d", c.before, after)
 	}
 	return err

--- a/libbeat/tests/resources/goroutines_test.go
+++ b/libbeat/tests/resources/goroutines_test.go
@@ -75,7 +75,7 @@ func TestGoroutinesChecker(t *testing.T) {
 
 // goroutineTesterControl helps keeping track of goroutines started for each test case.
 type goroutineTesterControl struct {
-	checker GoroutinesChecker
+	checker *GoroutinesChecker
 	blocker chan struct{}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Make all GoroutinesChecker methods be on a pointer receiver

## Why is it important?

It's not recommended to mix methods on the same type having a pointer and a non-pointer receiver.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

N/A

## Related issues

N/A