### PR TITLE
x-pack/filebeat/input/httpjson: add benchmarks

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -81,6 +81,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Fix the integration testcase docker port mapping for sql and oracle modules {pull}34221[34221]
 - Fix the ingest pipeline for mysql slowlog to parse schema name with dash {pull}34371[34372]
 - Fix the multiple host support for mongodb module {pull}34624[34624]
+- Skip HTTPJSON flakey test. {issue}34929[34929] {pull}35138[35138]
 
 ==== Added
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -157,6 +157,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Add support for different folders when testing data {pull}34467[34467]
 - Add logging of metric registration in inputmon. {pull}35647[35647]
 - Add Okta API package for entity analytics. {pull}35478[35478]
+- Add benchmarking to HTTPJSON input testing. {pull}35138[35138]
 
 ==== Deprecated
 

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -26,1164 +26,1163 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-func TestInput(t *testing.T) {
-	testCases := []struct {
-		name         string
-		setupServer  func(*testing.T, http.HandlerFunc, map[string]interface{})
-		baseConfig   map[string]interface{}
-		handler      http.HandlerFunc
-		expected     []string
-		expectedFile string
-	}{
-		{
-			name:        "Test simple GET request",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+var testCases = []struct {
+	name         string
+	setupServer  func(testing.TB, http.HandlerFunc, map[string]interface{})
+	baseConfig   map[string]interface{}
+	handler      http.HandlerFunc
+	expected     []string
+	expectedFile string
+}{
+	{
+		name:        "simple_GET_request",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
 		},
-		{
-			name:        "Test simple HTTPS GET request",
-			setupServer: newTestServer(httptest.NewTLSServer),
-			baseConfig: map[string]interface{}{
-				"interval":                      1,
-				"request.method":                http.MethodGet,
-				"request.ssl.verification_mode": "none",
-			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name:        "simple_HTTPS_GET_request",
+		setupServer: newTestServer(httptest.NewTLSServer),
+		baseConfig: map[string]interface{}{
+			"interval":                      1,
+			"request.method":                http.MethodGet,
+			"request.ssl.verification_mode": "none",
 		},
-		{
-			name:        "Test request honors rate limit",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":                     1,
-				"http_method":                  http.MethodGet,
-				"request.rate_limit.limit":     `[[.last_response.header.Get "X-Rate-Limit-Limit"]]`,
-				"request.rate_limit.remaining": `[[.last_response.header.Get "X-Rate-Limit-Remaining"]]`,
-				"request.rate_limit.reset":     `[[.last_response.header.Get "X-Rate-Limit-Reset"]]`,
-			},
-			handler:  rateLimitHandler(),
-			expected: []string{`{"hello":"world"}`},
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name:        "request_honors_rate_limit",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":                     1,
+			"http_method":                  http.MethodGet,
+			"request.rate_limit.limit":     `[[.last_response.header.Get "X-Rate-Limit-Limit"]]`,
+			"request.rate_limit.remaining": `[[.last_response.header.Get "X-Rate-Limit-Remaining"]]`,
+			"request.rate_limit.reset":     `[[.last_response.header.Get "X-Rate-Limit-Reset"]]`,
 		},
-		{
-			name:        "Test request retries when failed",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-			},
-			handler:  retryHandler(),
-			expected: []string{`{"hello":"world"}`},
+		handler:  rateLimitHandler(),
+		expected: []string{`{"hello":"world"}`},
+	},
+	{
+		name:        "request_retries_when_failed",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
 		},
-		{
-			name:        "Test POST request with body",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodPost,
-				"request.body": map[string]interface{}{
-					"test": "abc",
-				},
-			},
-			handler:  defaultHandler(http.MethodPost, `{"test":"abc"}`, ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
-		},
-		{
-			name:        "Test repeated POST requests",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       "100ms",
-				"request.method": http.MethodPost,
-			},
-			handler: defaultHandler(http.MethodPost, "", ""),
-			expected: []string{
-				`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`,
-				`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`,
+		handler:  retryHandler(),
+		expected: []string{`{"hello":"world"}`},
+	},
+	{
+		name:        "POST_request_with_body",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodPost,
+			"request.body": map[string]interface{}{
+				"test": "abc",
 			},
 		},
-		{
-			name:        "Test split by json objects array",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target": "body.hello",
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{`{"world":"moon"}`, `{"space":[{"cake":"pumpkin"}]}`},
+		handler:  defaultHandler(http.MethodPost, `{"test":"abc"}`, ""),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name:        "repeated_POST_requests",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       "100ms",
+			"request.method": http.MethodPost,
 		},
-		{
-			name:        "Test split by json objects array with keep parent",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target":      "body.hello",
+		handler: defaultHandler(http.MethodPost, "", ""),
+		expected: []string{
+			`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`,
+			`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`,
+		},
+	},
+	{
+		name:        "split_by_json_objects_array",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target": "body.hello",
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{`{"world":"moon"}`, `{"space":[{"cake":"pumpkin"}]}`},
+	},
+	{
+		name:        "split_by_json_objects_array_with_keep_parent",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target":      "body.hello",
+				"keep_parent": true,
+			},
+		},
+		handler: defaultHandler(http.MethodGet, "", ""),
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"hello":{"space":[{"cake":"pumpkin"}]}}`,
+		},
+	},
+	{
+		name:        "split_on_empty_array_without_ignore_empty_value",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target": "body.response.empty",
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
+		expected: []string{`{"response":{"empty":[]}}`},
+	},
+	{
+		name:        "split_on_empty_array_with_ignore_empty_value",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target":             "body.response.empty",
+				"ignore_empty_value": true,
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
+		expected: nil,
+	},
+	{
+		name:        "split_on_null_field_with_ignore_empty_value_keeping_parent",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target":             "body.response.empty",
+				"ignore_empty_value": true,
+				"keep_parent":        true,
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":null}}`),
+		expected: []string{`{"response":{"empty":null}}`},
+	},
+	{
+		name:        "split_on_empty_array_with_ignore_empty_value_keeping_parent",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target":             "body.response.empty",
+				"ignore_empty_value": true,
+				"keep_parent":        true,
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
+		expected: []string{`{"response":{"empty":[]}}`},
+	},
+	{
+		name:        "split_on_null_field_at_root_with_ignore_empty_value_keeping_parent",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target":             "body.response",
+				"ignore_empty_value": true,
+				"keep_parent":        true,
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", `{"response":null,"other":"data"}`),
+		expected: []string{`{"other":"data","response":null}`},
+	},
+	{
+		name:        "split_on_empty_array_at_root_with_ignore_empty_value_keeping_parent",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target":             "body.response",
+				"ignore_empty_value": true,
+				"keep_parent":        true,
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", `{"response":[],"other":"data"}`),
+		expected: []string{`{"other":"data","response":[]}`},
+	},
+	{
+		name:        "nested_split",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target": "body.hello",
+				"split": map[string]interface{}{
+					"target":      "body.space",
 					"keep_parent": true,
 				},
 			},
-			handler: defaultHandler(http.MethodGet, "", ""),
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"hello":{"space":[{"cake":"pumpkin"}]}}`,
+		},
+		handler: defaultHandler(http.MethodGet, "", ""),
+		expected: []string{
+			`{"world":"moon"}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name:        "split_events_by_not_found",
+		setupServer: newTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target": "body.unknown",
 			},
 		},
-		{
-			name:        "Test split on empty array without ignore_empty_value",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target": "body.response.empty",
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
-			expected: []string{`{"response":{"empty":[]}}`},
-		},
-		{
-			name:        "Test split on empty array with ignore_empty_value",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target":             "body.response.empty",
-					"ignore_empty_value": true,
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
-			expected: nil,
-		},
-		{
-			name:        "Test split on null field with ignore_empty_value keeping parent",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target":             "body.response.empty",
-					"ignore_empty_value": true,
-					"keep_parent":        true,
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":null}}`),
-			expected: []string{`{"response":{"empty":null}}`},
-		},
-		{
-			name:        "Test split on empty array with ignore_empty_value keeping parent",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target":             "body.response.empty",
-					"ignore_empty_value": true,
-					"keep_parent":        true,
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", `{"response":{"empty":[]}}`),
-			expected: []string{`{"response":{"empty":[]}}`},
-		},
-		{
-			name:        "Test split on null field at root with ignore_empty_value keeping parent",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target":             "body.response",
-					"ignore_empty_value": true,
-					"keep_parent":        true,
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", `{"response":null,"other":"data"}`),
-			expected: []string{`{"other":"data","response":null}`},
-		},
-		{
-			name:        "Test split on empty array at root with ignore_empty_value keeping parent",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target":             "body.response",
-					"ignore_empty_value": true,
-					"keep_parent":        true,
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", `{"response":[],"other":"data"}`),
-			expected: []string{`{"other":"data","response":[]}`},
-		},
-		{
-			name:        "Test nested split",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target": "body.hello",
-					"split": map[string]interface{}{
-						"target":      "body.space",
-						"keep_parent": true,
-					},
-				},
-			},
-			handler: defaultHandler(http.MethodGet, "", ""),
-			expected: []string{
-				`{"world":"moon"}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
-		},
-		{
-			name:        "Test split events by not found",
-			setupServer: newTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target": "body.unknown",
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{},
-		},
-		{
-			name: "Test date cursor",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerRequestTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				// mock timeNow func to return a fixed value
-				timeNow = func() time.Time {
-					t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
-					return t
-				}
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{},
+	},
+	{
+		name: "date_cursor",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerRequestTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			// mock timeNow func to return a fixed value
+			timeNow = func() time.Time {
+				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
+				return t
+			}
 
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL
-				t.Cleanup(server.Close)
-				t.Cleanup(func() { timeNow = time.Now })
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"request.transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target":  "url.params.$filter",
-							"value":   "alertCreationTime ge [[.cursor.timestamp]]",
-							"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
-						},
-					},
-				},
-				"cursor": map[string]interface{}{
-					"timestamp": map[string]interface{}{
-						"value": `[[index .last_response.body "@timestamp"]]`,
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+			t.Cleanup(func() { timeNow = time.Now })
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"request.transforms": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":  "url.params.$filter",
+						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
+						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
 					},
 				},
 			},
-			handler: dateCursorHandler(),
-			expected: []string{
-				`{"@timestamp":"2002-10-02T15:00:00Z","foo":"bar"}`,
-				`{"@timestamp":"2002-10-02T15:00:01Z","foo":"bar"}`,
-				`{"@timestamp":"2002-10-02T15:00:02Z","foo":"bar"}`,
+			"cursor": map[string]interface{}{
+				"timestamp": map[string]interface{}{
+					"value": `[[index .last_response.body "@timestamp"]]`,
+				},
 			},
 		},
-		{
-			name: "Test tracer filename sanitization",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerRequestTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				// mock timeNow func to return a fixed value
-				timeNow = func() time.Time {
-					t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
-					return t
-				}
+		handler: dateCursorHandler(),
+		expected: []string{
+			`{"@timestamp":"2002-10-02T15:00:00Z","foo":"bar"}`,
+			`{"@timestamp":"2002-10-02T15:00:01Z","foo":"bar"}`,
+			`{"@timestamp":"2002-10-02T15:00:02Z","foo":"bar"}`,
+		},
+	},
+	{
+		name: "tracer_filename_sanitization",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerRequestTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			// mock timeNow func to return a fixed value
+			timeNow = func() time.Time {
+				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
+				return t
+			}
 
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL
-				t.Cleanup(server.Close)
-				t.Cleanup(func() { timeNow = time.Now })
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+			t.Cleanup(func() { timeNow = time.Now })
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"request.transforms": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":  "url.params.$filter",
+						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
+						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
+					},
+				},
 			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"request.transforms": []interface{}{
+			"cursor": map[string]interface{}{
+				"timestamp": map[string]interface{}{
+					"value": `[[index .last_response.body "@timestamp"]]`,
+				},
+			},
+			"request.tracer.filename": "logs/http-request-trace-*.ndjson",
+		},
+		handler: dateCursorHandler(),
+		expected: []string{
+			`{"@timestamp":"2002-10-02T15:00:00Z","foo":"bar"}`,
+			`{"@timestamp":"2002-10-02T15:00:01Z","foo":"bar"}`,
+			`{"@timestamp":"2002-10-02T15:00:02Z","foo":"bar"}`,
+		},
+		expectedFile: filepath.Join("logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi.ndjson"),
+	},
+	{
+		name: "pagination",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerPaginationTransforms()
+			registerResponseTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       time.Millisecond,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target": "body.items",
+				"transforms": []interface{}{
 					map[string]interface{}{
 						"set": map[string]interface{}{
-							"target":  "url.params.$filter",
-							"value":   "alertCreationTime ge [[.cursor.timestamp]]",
-							"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
+							"target": "body.page",
+							"value":  "[[.last_response.page]]",
 						},
 					},
 				},
-				"cursor": map[string]interface{}{
-					"timestamp": map[string]interface{}{
-						"value": `[[index .last_response.body "@timestamp"]]`,
+			},
+			"response.pagination": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":                 "url.params.page",
+						"value":                  "[[.last_response.body.nextPageToken]]",
+						"fail_on_template_error": true,
 					},
 				},
-				"request.tracer.filename": "logs/http-request-trace-*.ndjson",
 			},
-			handler: dateCursorHandler(),
-			expected: []string{
-				`{"@timestamp":"2002-10-02T15:00:00Z","foo":"bar"}`,
-				`{"@timestamp":"2002-10-02T15:00:01Z","foo":"bar"}`,
-				`{"@timestamp":"2002-10-02T15:00:02Z","foo":"bar"}`,
-			},
-			expectedFile: filepath.Join("logs", "http-request-trace-httpjson-foo-eb837d4c-5ced-45ed-b05c-de658135e248_https_somesource_someapi.ndjson"),
 		},
-		{
-			name: "Test pagination",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerPaginationTransforms()
-				registerResponseTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       time.Millisecond,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target": "body.items",
-					"transforms": []interface{}{
-						map[string]interface{}{
-							"set": map[string]interface{}{
-								"target": "body.page",
-								"value":  "[[.last_response.page]]",
-							},
-						},
-					},
-				},
-				"response.pagination": []interface{}{
+		handler: paginationHandler(),
+		expected: []string{
+			`{"foo":"a","page":"0"}`, `{"foo":"b","page":"1"}`, `{"foo":"c","page":"0"}`, `{"foo":"d","page":"0"}`,
+			`{"foo":"a","page":"0"}`, `{"foo":"b","page":"1"}`, `{"foo":"c","page":"0"}`, `{"foo":"d","page":"0"}`,
+		},
+	},
+	{
+		name: "first_event",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerPaginationTransforms()
+			registerResponseTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target": "body.items",
+				"transforms": []interface{}{
 					map[string]interface{}{
 						"set": map[string]interface{}{
-							"target":                 "url.params.page",
-							"value":                  "[[.last_response.body.nextPageToken]]",
-							"fail_on_template_error": true,
+							"target":  "body.first",
+							"value":   "[[.cursor.first]]",
+							"default": "none",
 						},
 					},
 				},
 			},
-			handler: paginationHandler(),
-			expected: []string{
-				`{"foo":"a","page":"0"}`, `{"foo":"b","page":"1"}`, `{"foo":"c","page":"0"}`, `{"foo":"d","page":"0"}`,
-				`{"foo":"a","page":"0"}`, `{"foo":"b","page":"1"}`, `{"foo":"c","page":"0"}`, `{"foo":"d","page":"0"}`,
+			"response.pagination": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":                 "url.params.page",
+						"value":                  "[[.last_response.body.nextPageToken]]",
+						"fail_on_template_error": true,
+					},
+				},
+			},
+			"cursor": map[string]interface{}{
+				"first": map[string]interface{}{
+					"value": "[[.first_event.foo]]",
+				},
 			},
 		},
-		{
-			name: "Test first event",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerPaginationTransforms()
-				registerResponseTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target": "body.items",
-					"transforms": []interface{}{
-						map[string]interface{}{
-							"set": map[string]interface{}{
-								"target":  "body.first",
-								"value":   "[[.cursor.first]]",
-								"default": "none",
-							},
-						},
-					},
-				},
-				"response.pagination": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target":                 "url.params.page",
-							"value":                  "[[.last_response.body.nextPageToken]]",
-							"fail_on_template_error": true,
-						},
-					},
-				},
-				"cursor": map[string]interface{}{
-					"first": map[string]interface{}{
-						"value": "[[.first_event.foo]]",
-					},
-				},
-			},
-			handler:  paginationHandler(),
-			expected: []string{`{"first":"none", "foo":"a"}`, `{"first":"a", "foo":"b"}`, `{"first":"a", "foo":"c"}`, `{"first":"c", "foo":"d"}`},
+		handler:  paginationHandler(),
+		expected: []string{`{"first":"none", "foo":"a"}`, `{"first":"a", "foo":"b"}`, `{"first":"a", "foo":"c"}`, `{"first":"c", "foo":"d"}`},
+	},
+	{
+		name: "pagination_with_array_response",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerPaginationTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
 		},
-		{
-			name: "Test pagination with array response",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerPaginationTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.pagination": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target": "url.params.page",
-							"value":  `[[index (index .last_response.body 0) "nextPageToken"]]`,
-						},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.pagination": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target": "url.params.page",
+						"value":  `[[index (index .last_response.body 0) "nextPageToken"]]`,
 					},
 				},
 			},
-			handler:  paginationArrayHandler(),
-			expected: []string{`{"nextPageToken":"bar","foo":"bar"}`, `{"foo":"bar"}`, `{"foo":"bar"}`},
 		},
-		{
-			name: "Test oauth2",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL
-				config["auth.oauth2.token_url"] = server.URL + "/token"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":                  1,
-				"request.method":            http.MethodPost,
-				"auth.oauth2.client.id":     "a_client_id",
-				"auth.oauth2.client.secret": "a_client_secret",
-				"auth.oauth2.endpoint_params": map[string]interface{}{
-					"param1": "v1",
-				},
-				"auth.oauth2.scopes": []string{"scope1", "scope2"},
-			},
-			handler:  oauth2Handler,
-			expected: []string{`{"hello": "world"}`},
+		handler:  paginationArrayHandler(),
+		expected: []string{`{"nextPageToken":"bar","foo":"bar"}`, `{"foo":"bar"}`, `{"foo":"bar"}`},
+	},
+	{
+		name: "oauth2",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			config["auth.oauth2.token_url"] = server.URL + "/token"
+			t.Cleanup(server.Close)
 		},
-		{
-			name: "Test request transforms can access state from previous transforms",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerRequestTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL + "/test-path"
-				t.Cleanup(server.Close)
+		baseConfig: map[string]interface{}{
+			"interval":                  1,
+			"request.method":            http.MethodPost,
+			"auth.oauth2.client.id":     "a_client_id",
+			"auth.oauth2.client.secret": "a_client_secret",
+			"auth.oauth2.endpoint_params": map[string]interface{}{
+				"param1": "v1",
 			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodPost,
-				"request.transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target": "header.X-Foo",
-							"value":  "foo",
-						},
-					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target": "body.bar",
-							"value":  `[[.header.Get "X-Foo"]]`,
-						},
-					},
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target": "body.url.path",
-							"value":  `[[.url.Path]]`,
-						},
-					},
-				},
-			},
-			handler:  defaultHandler(http.MethodPost, `{"bar":"foo","url":{"path":"/test-path"}}`, ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+			"auth.oauth2.scopes": []string{"scope1", "scope2"},
 		},
-		{
-			name: "Test response transforms can't access request state from previous transforms",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerRequestTransforms()
-				registerResponseTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				server := httptest.NewServer(h)
-				config["request.url"] = server.URL
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       10,
-				"request.method": http.MethodGet,
-				"request.transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target": "header.X-Foo",
-							"value":  "foo",
-						},
-					},
-				},
-				"response.transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target": "body.bar",
-							"value":  `[[.header.Get "X-Foo"]]`,
-						},
-					},
-				},
-			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+		handler:  oauth2Handler,
+		expected: []string{`{"hello": "world"}`},
+	},
+	{
+		name: "request_transforms_can_access_state_from_previous_transforms",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerRequestTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL + "/test-path"
+			t.Cleanup(server.Close)
 		},
-		{
-			name:        "Test simple Chain GET request",
-			setupServer: newChainTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       10,
-				"request.method": http.MethodGet,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.records[:].id",
-						},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodPost,
+			"request.transforms": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target": "header.X-Foo",
+						"value":  "foo",
+					},
+				},
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target": "body.bar",
+						"value":  `[[.header.Get "X-Foo"]]`,
+					},
+				},
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target": "body.url.path",
+						"value":  `[[.url.Path]]`,
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
 		},
-		{
-			name: "Test multiple Chain GET request",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintln(w, `{"records":[{"id":1}]}`)
-					case "/1":
-						fmt.Fprintln(w, `{"file_name": "file_1"}`)
-					case "/file_1":
-						fmt.Fprintln(w, `{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				config["request.url"] = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.records[:].id"
-				config["chain.1.step.request.url"] = server.URL + "/$.file_name"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       10,
-				"request.method": http.MethodGet,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.records[:].id",
-						},
-					},
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.file_name",
-						},
+		handler:  defaultHandler(http.MethodPost, `{"bar":"foo","url":{"path":"/test-path"}}`, ""),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name: "response_transforms_can't_access_request_state_from_previous_transforms",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerRequestTransforms()
+			registerResponseTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			server := httptest.NewServer(h)
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       10,
+			"request.method": http.MethodGet,
+			"request.transforms": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target": "header.X-Foo",
+						"value":  "foo",
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+			"response.transforms": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target": "body.bar",
+						"value":  `[[.header.Get "X-Foo"]]`,
+					},
+				},
+			},
 		},
-		{
-			name: "Test date cursor while using chain",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerRequestTransforms()
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				// mock timeNow func to return a fixed value
-				timeNow = func() time.Time {
-					t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
-					return t
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name:        "simple_Chain_GET_request",
+		setupServer: newChainTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       10,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.records[:].id",
+					},
+				},
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name: "multiple_Chain_GET_request",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"records":[{"id":1}]}`)
+				case "/1":
+					fmt.Fprintln(w, `{"file_name": "file_1"}`)
+				case "/file_1":
+					fmt.Fprintln(w, `{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`)
 				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.records[:].id"
+			config["chain.1.step.request.url"] = server.URL + "/$.file_name"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       10,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.records[:].id",
+					},
+				},
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.file_name",
+					},
+				},
+			},
+		},
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name: "date_cursor_while_using_chain",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerRequestTransforms()
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			// mock timeNow func to return a fixed value
+			timeNow = func() time.Time {
+				t, _ := time.Parse(time.RFC3339, "2002-10-02T15:00:00Z")
+				return t
+			}
 
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintln(w, `{"records":[{"id":1}]}`)
-					case "/1":
-						fmt.Fprintln(w, `{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				config["request.url"] = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.records[:].id"
-				t.Cleanup(server.Close)
-				t.Cleanup(func() { timeNow = time.Now })
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"request.transforms": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target":  "url.params.$filter",
-							"value":   "alertCreationTime ge [[.cursor.timestamp]]",
-							"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
-						},
-					},
-				},
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.records[:].id",
-						},
-					},
-				},
-				"cursor": map[string]interface{}{
-					"timestamp": map[string]interface{}{
-						"value": `[[index .last_response.body "@timestamp"]]`,
-					},
-				},
-			},
-			handler:  dateCursorHandler(),
-			expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"records":[{"id":1}]}`)
+				case "/1":
+					fmt.Fprintln(w, `{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.records[:].id"
+			t.Cleanup(server.Close)
+			t.Cleanup(func() { timeNow = time.Now })
 		},
-		{
-			name:        "Test split by json objects array in chain",
-			setupServer: newChainTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.records[:].id",
-							"response.split": map[string]interface{}{
-								"target": "body.hello",
-							},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"request.transforms": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":  "url.params.$filter",
+						"value":   "alertCreationTime ge [[.cursor.timestamp]]",
+						"default": `alertCreationTime ge [[formatDate (now (parseDuration "-10m")) "2006-01-02T15:04:05Z"]]`,
+					},
+				},
+			},
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.records[:].id",
+					},
+				},
+			},
+			"cursor": map[string]interface{}{
+				"timestamp": map[string]interface{}{
+					"value": `[[index .last_response.body "@timestamp"]]`,
+				},
+			},
+		},
+		handler:  dateCursorHandler(),
+		expected: []string{`{"hello":[{"world":"moon"},{"space":[{"cake":"pumpkin"}]}]}`},
+	},
+	{
+		name:        "split_by_json_objects_array_in_chain",
+		setupServer: newChainTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.records[:].id",
+						"response.split": map[string]interface{}{
+							"target": "body.hello",
 						},
 					},
 				},
 			},
-			handler:  defaultHandler(http.MethodGet, "", ""),
-			expected: []string{`{"world":"moon"}`, `{"space":[{"cake":"pumpkin"}]}`},
 		},
-		{
-			name:        "Test split by json objects array with keep parent in chain",
-			setupServer: newChainTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.records[:].id",
-							"response.split": map[string]interface{}{
-								"target":      "body.hello",
+		handler:  defaultHandler(http.MethodGet, "", ""),
+		expected: []string{`{"world":"moon"}`, `{"space":[{"cake":"pumpkin"}]}`},
+	},
+	{
+		name:        "split_by_json_objects_array_with_keep_parent_in_chain",
+		setupServer: newChainTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.records[:].id",
+						"response.split": map[string]interface{}{
+							"target":      "body.hello",
+							"keep_parent": true,
+						},
+					},
+				},
+			},
+		},
+		handler: defaultHandler(http.MethodGet, "", ""),
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"hello":{"space":[{"cake":"pumpkin"}]}}`,
+		},
+	},
+	{
+		name:        "nested_split_in_chain",
+		setupServer: newChainTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.split": map[string]interface{}{
+				"target": "body.hello",
+			},
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.records[:].id",
+						"response.split": map[string]interface{}{
+							"target": "body.hello",
+							"split": map[string]interface{}{
+								"target":      "body.space",
 								"keep_parent": true,
 							},
 						},
 					},
 				},
 			},
-			handler: defaultHandler(http.MethodGet, "", ""),
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"hello":{"space":[{"cake":"pumpkin"}]}}`,
+		},
+		handler: defaultHandler(http.MethodGet, "", ""),
+		expected: []string{
+			`{"world":"moon"}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name:        "pagination_when_used_with_chaining",
+		setupServer: newChainPaginationTestServer(httptest.NewServer),
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.pagination": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":                 "url.value",
+						"value":                  "[[.last_response.body.nextLink]]",
+						"fail_on_template_error": true,
+					},
+				},
+			},
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.records[:].id",
+					},
+				},
 			},
 		},
-		{
-			name:        "Test nested split in chain",
-			setupServer: newChainTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.split": map[string]interface{}{
-					"target": "body.hello",
+		handler: defaultHandler(http.MethodGet, "", ""),
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_with_clause_and_first_response_object",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"exportId":"2212"}`)
+				case "/2212":
+					fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
+				case "/2212/1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId"
+			config["chain.1.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                     1,
+			"request.method":               http.MethodGet,
+			"response.save_first_response": true,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.exportId",
+					},
 				},
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.records[:].id",
-							"response.split": map[string]interface{}{
-								"target": "body.hello",
-								"split": map[string]interface{}{
-									"target":      "body.space",
-									"keep_parent": true,
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,.first_response.body.exportId",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_with_clause_with_hardcoded_value_1",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
+				case "/2212/1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,2212",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_with_clause_with_hardcoded_value_(no_dot_prefix)",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
+				case "/first_response.body.id/1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/first_response.body.id/2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                     1,
+			"request.method":               http.MethodGet,
+			"response.save_first_response": true,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,first_response.body.id",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_with_clause_with_hardcoded_value_(more_than_one_dot_prefix)",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
+				case "/..first_response.body.id/1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/..first_response.body.id/2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                     1,
+			"request.method":               http.MethodGet,
+			"response.save_first_response": true,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,..first_response.body.id",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "replace_with_clause_with_hardcoded_value_containing_'.'_(dots)",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
+				case "/.xyz.2212.abc./1":
+					fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
+				case "/.xyz.2212.abc./2":
+					fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			config["request.url"] = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodGet,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,.xyz.2212.abc.",
+					},
+				},
+			},
+		},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+		},
+	},
+	{
+		name: "global_transform_context_separation_with_parent_last_response_object",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			var serverURL string
+			registerPaginationTransforms()
+			registerRequestTransforms()
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintf(w, `{"files":[{"id":"1"},{"id":"2"}],"exportId":"2212", "nextLink":"%s/link1"}`, serverURL)
+				case "/link1":
+					fmt.Fprintln(w, `{"files":[{"id":"3"},{"id":"4"}], "exportId":"2213"}`)
+				case "/2212/1":
+					matchBody(w, r, `{"exportId":"2212"}`, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					matchBody(w, r, `{"exportId":"2212"}`, `{"space":{"cake":"pumpkin"}}`)
+				case "/2213/3":
+					matchBody(w, r, `{"exportId":"2213"}`, `{"hello":{"cake":"pumpkin"}}`)
+				case "/2213/4":
+					matchBody(w, r, `{"exportId":"2213"}`, `{"space":{"world":"moon"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			config["request.url"] = server.URL
+			serverURL = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                            1,
+			"request.method":                      http.MethodPost,
+			"response.request_body_on_pagination": true,
+			"response.pagination": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":                 "url.value",
+						"value":                  "[[.last_response.body.nextLink]]",
+						"fail_on_template_error": true,
+					},
+				},
+			},
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodPost,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,.parent_last_response.body.exportId",
+						"request.transforms": []interface{}{
+							map[string]interface{}{
+								"set": map[string]interface{}{
+									"target": "body.exportId",
+									"value":  "[[ .parent_last_response.body.exportId ]]",
 								},
 							},
 						},
 					},
 				},
 			},
-			handler: defaultHandler(http.MethodGet, "", ""),
-			expected: []string{
-				`{"world":"moon"}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
 		},
-		{
-			name:        "Test pagination when used with chaining",
-			setupServer: newChainPaginationTestServer(httptest.NewServer),
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.pagination": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target":                 "url.value",
-							"value":                  "[[.last_response.body.nextLink]]",
-							"fail_on_template_error": true,
-						},
-					},
-				},
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.records[:].id",
-						},
-					},
-				},
-			},
-			handler: defaultHandler(http.MethodGet, "", ""),
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+			`{"hello":{"cake":"pumpkin"}}`,
+			`{"space":{"world":"moon"}}`,
 		},
-		{
-			name: "Test replace_with clause and first_response object",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintln(w, `{"exportId":"2212"}`)
-					case "/2212":
-						fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
-					case "/2212/1":
-						fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
-					case "/2212/2":
-						fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				config["request.url"] = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId"
-				config["chain.1.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":                     1,
-				"request.method":               http.MethodGet,
-				"response.save_first_response": true,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.exportId",
-						},
-					},
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,.first_response.body.exportId",
-						},
-					},
-				},
-			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
-		},
-		{
-			name: "Test replace_with clause with hardcoded value_1",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
-					case "/2212/1":
-						fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
-					case "/2212/2":
-						fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				config["request.url"] = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,2212",
-						},
-					},
-				},
-			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
-		},
-		{
-			name: "Test replace_with clause with hardcoded value (no dot prefix)",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
-					case "/first_response.body.id/1":
-						fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
-					case "/first_response.body.id/2":
-						fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				config["request.url"] = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":                     1,
-				"request.method":               http.MethodGet,
-				"response.save_first_response": true,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,first_response.body.id",
-						},
-					},
-				},
-			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
-		},
-		{
-			name: "Test replace_with clause with hardcoded value (more than one dot prefix)",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
-					case "/..first_response.body.id/1":
-						fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
-					case "/..first_response.body.id/2":
-						fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				config["request.url"] = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":                     1,
-				"request.method":               http.MethodGet,
-				"response.save_first_response": true,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,..first_response.body.id",
-						},
-					},
-				},
-			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
-		},
-		{
-			name: "Test replace_with clause with hardcoded value containing '.' (dots)",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintln(w, `{"files":[{"id":"1"},{"id":"2"}]}`)
-					case "/.xyz.2212.abc./1":
-						fmt.Fprintln(w, `{"hello":{"world":"moon"}}`)
-					case "/.xyz.2212.abc./2":
-						fmt.Fprintln(w, `{"space":{"cake":"pumpkin"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				config["request.url"] = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodGet,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,.xyz.2212.abc.",
-						},
-					},
-				},
-			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-			},
-		},
-		{
-			name: "Test global transform context separation with parent_last_response object",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				var serverURL string
-				registerPaginationTransforms()
-				registerRequestTransforms()
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintf(w, `{"files":[{"id":"1"},{"id":"2"}],"exportId":"2212", "nextLink":"%s/link1"}`, serverURL)
-					case "/link1":
-						fmt.Fprintln(w, `{"files":[{"id":"3"},{"id":"4"}], "exportId":"2213"}`)
-					case "/2212/1":
-						matchBody(w, r, `{"exportId":"2212"}`, `{"hello":{"world":"moon"}}`)
-					case "/2212/2":
-						matchBody(w, r, `{"exportId":"2212"}`, `{"space":{"cake":"pumpkin"}}`)
-					case "/2213/3":
-						matchBody(w, r, `{"exportId":"2213"}`, `{"hello":{"cake":"pumpkin"}}`)
-					case "/2213/4":
-						matchBody(w, r, `{"exportId":"2213"}`, `{"space":{"world":"moon"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				config["request.url"] = server.URL
-				serverURL = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":                            1,
-				"request.method":                      http.MethodPost,
-				"response.request_body_on_pagination": true,
-				"response.pagination": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target":                 "url.value",
-							"value":                  "[[.last_response.body.nextLink]]",
-							"fail_on_template_error": true,
-						},
-					},
-				},
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodPost,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,.parent_last_response.body.exportId",
-							"request.transforms": []interface{}{
-								map[string]interface{}{
-									"set": map[string]interface{}{
-										"target": "body.exportId",
-										"value":  "[[ .parent_last_response.body.exportId ]]",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-				`{"hello":{"cake":"pumpkin"}}`,
-				`{"space":{"world":"moon"}}`,
-			},
-		},
-		{
-			name: "Test if cursor value is updated for root response with chaining & pagination",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				var serverURL string
-				registerPaginationTransforms()
-				registerRequestTransforms()
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintf(w, `{"files":[{"id":"1"},{"id":"2"}],"exportId":"2212", "createdAt":"22/02/2022", 
+	},
+	{
+		name: "cursor_value_is_updated_for_root_response_with_chaining_&_pagination",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			var serverURL string
+			registerPaginationTransforms()
+			registerRequestTransforms()
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintf(w, `{"files":[{"id":"1"},{"id":"2"}],"exportId":"2212", "createdAt":"22/02/2022",
 						"nextLink":"%s/link1"}`, serverURL)
-					case "/link1":
-						fmt.Fprintln(w, `{"files":[{"id":"3"},{"id":"4"}], "exportId":"2213", "createdAt":"24/04/2022"}`)
-					case "/2212/1":
-						matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"hello":{"world":"moon"}}`)
-					case "/2212/2":
-						matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"space":{"cake":"pumpkin"}}`)
-					case "/2213/3":
-						matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"hello":{"cake":"pumpkin"}}`)
-					case "/2213/4":
-						matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"space":{"world":"moon"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				config["request.url"] = server.URL
-				serverURL = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":                            1,
-				"request.method":                      http.MethodPost,
-				"response.request_body_on_pagination": true,
-				"response.pagination": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target":                 "url.value",
-							"value":                  "[[.last_response.body.nextLink]]",
-							"fail_on_template_error": true,
-						},
+				case "/link1":
+					fmt.Fprintln(w, `{"files":[{"id":"3"},{"id":"4"}], "exportId":"2213", "createdAt":"24/04/2022"}`)
+				case "/2212/1":
+					matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"space":{"cake":"pumpkin"}}`)
+				case "/2213/3":
+					matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"hello":{"cake":"pumpkin"}}`)
+				case "/2213/4":
+					matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"space":{"world":"moon"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			config["request.url"] = server.URL
+			serverURL = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                            1,
+			"request.method":                      http.MethodPost,
+			"response.request_body_on_pagination": true,
+			"response.pagination": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":                 "url.value",
+						"value":                  "[[.last_response.body.nextLink]]",
+						"fail_on_template_error": true,
 					},
 				},
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodPost,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,.parent_last_response.body.exportId",
-							"request.transforms": []interface{}{
-								map[string]interface{}{
-									"set": map[string]interface{}{
-										"target": "body.exportId",
-										"value":  "[[ .parent_last_response.body.exportId ]]",
-									},
+			},
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodPost,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,.parent_last_response.body.exportId",
+						"request.transforms": []interface{}{
+							map[string]interface{}{
+								"set": map[string]interface{}{
+									"target": "body.exportId",
+									"value":  "[[ .parent_last_response.body.exportId ]]",
 								},
-								map[string]interface{}{
-									"set": map[string]interface{}{
-										"target": "body.createdAt",
-										"value":  "[[ .cursor.last_published_login ]]",
-									},
+							},
+							map[string]interface{}{
+								"set": map[string]interface{}{
+									"target": "body.createdAt",
+									"value":  "[[ .cursor.last_published_login ]]",
 								},
 							},
 						},
 					},
 				},
-				"cursor": map[string]interface{}{
-					"last_published_login": map[string]interface{}{
-						"value": "[[ .last_event.createdAt ]]",
-					},
+			},
+			"cursor": map[string]interface{}{
+				"last_published_login": map[string]interface{}{
+					"value": "[[ .last_event.createdAt ]]",
 				},
 			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-				`{"hello":{"cake":"pumpkin"}}`,
-				`{"space":{"world":"moon"}}`,
-			},
 		},
-		{
-			name: "Test if cursor value is updated for root response with chaining & pagination along with split operator",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				var serverURL string
-				registerPaginationTransforms()
-				registerRequestTransforms()
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					switch r.URL.Path {
-					case "/":
-						fmt.Fprintf(w, `{"files":[{"id":"1"},{"id":"2"}],"exportId":"2212","time":[{"timeStamp":"22/02/2022"}], 
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+			`{"hello":{"cake":"pumpkin"}}`,
+			`{"space":{"world":"moon"}}`,
+		},
+	},
+	{
+		name: "cursor_value_is_updated_for_root_response_with_chaining_&_pagination_along_with_split_operator",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			var serverURL string
+			registerPaginationTransforms()
+			registerRequestTransforms()
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/":
+					fmt.Fprintf(w, `{"files":[{"id":"1"},{"id":"2"}],"exportId":"2212","time":[{"timeStamp":"22/02/2022"}],
 						"nextLink":"%s/link1"}`, serverURL)
-					case "/link1":
-						fmt.Fprintln(w, `{"files":[{"id":"3"},{"id":"4"}], "exportId":"2213","time":[{"timeStamp":"24/04/2022"}]}`)
-					case "/2212/1":
-						matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"hello":{"world":"moon"}}`)
-					case "/2212/2":
-						matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"space":{"cake":"pumpkin"}}`)
-					case "/2213/3":
-						matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"hello":{"cake":"pumpkin"}}`)
-					case "/2213/4":
-						matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"space":{"world":"moon"}}`)
-					}
-				})
-				server := httptest.NewServer(r)
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				config["request.url"] = server.URL
-				serverURL = server.URL
-				config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":                            1,
-				"request.method":                      http.MethodPost,
-				"response.request_body_on_pagination": true,
-				"response.pagination": []interface{}{
-					map[string]interface{}{
-						"set": map[string]interface{}{
-							"target":                 "url.value",
-							"value":                  "[[.last_response.body.nextLink]]",
-							"fail_on_template_error": true,
-						},
+				case "/link1":
+					fmt.Fprintln(w, `{"files":[{"id":"3"},{"id":"4"}], "exportId":"2213","time":[{"timeStamp":"24/04/2022"}]}`)
+				case "/2212/1":
+					matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"hello":{"world":"moon"}}`)
+				case "/2212/2":
+					matchBody(w, r, `{"createdAt":"22/02/2022","exportId":"2212"}`, `{"space":{"cake":"pumpkin"}}`)
+				case "/2213/3":
+					matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"hello":{"cake":"pumpkin"}}`)
+				case "/2213/4":
+					matchBody(w, r, `{"createdAt":"24/04/2022","exportId":"2213"}`, `{"space":{"world":"moon"}}`)
+				}
+			})
+			server := httptest.NewServer(r)
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			config["request.url"] = server.URL
+			serverURL = server.URL
+			config["chain.0.step.request.url"] = server.URL + "/$.exportId/$.files[:].id"
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":                            1,
+			"request.method":                      http.MethodPost,
+			"response.request_body_on_pagination": true,
+			"response.pagination": []interface{}{
+				map[string]interface{}{
+					"set": map[string]interface{}{
+						"target":                 "url.value",
+						"value":                  "[[.last_response.body.nextLink]]",
+						"fail_on_template_error": true,
 					},
 				},
-				"response.split": map[string]interface{}{
-					"target":      "body.time",
-					"type":        "array",
-					"keep_parent": true,
-				},
-				"chain": []interface{}{
-					map[string]interface{}{
-						"step": map[string]interface{}{
-							"request.method": http.MethodPost,
-							"replace":        "$.files[:].id",
-							"replace_with":   "$.exportId,.parent_last_response.body.exportId",
-							"request.transforms": []interface{}{
-								map[string]interface{}{
-									"set": map[string]interface{}{
-										"target": "body.exportId",
-										"value":  "[[ .parent_last_response.body.exportId ]]",
-									},
+			},
+			"response.split": map[string]interface{}{
+				"target":      "body.time",
+				"type":        "array",
+				"keep_parent": true,
+			},
+			"chain": []interface{}{
+				map[string]interface{}{
+					"step": map[string]interface{}{
+						"request.method": http.MethodPost,
+						"replace":        "$.files[:].id",
+						"replace_with":   "$.exportId,.parent_last_response.body.exportId",
+						"request.transforms": []interface{}{
+							map[string]interface{}{
+								"set": map[string]interface{}{
+									"target": "body.exportId",
+									"value":  "[[ .parent_last_response.body.exportId ]]",
 								},
-								map[string]interface{}{
-									"set": map[string]interface{}{
-										"target": "body.createdAt",
-										"value":  "[[ .cursor.last_published_login ]]",
-									},
+							},
+							map[string]interface{}{
+								"set": map[string]interface{}{
+									"target": "body.createdAt",
+									"value":  "[[ .cursor.last_published_login ]]",
 								},
 							},
 						},
 					},
 				},
-				"cursor": map[string]interface{}{
-					"last_published_login": map[string]interface{}{
-						"value": "[[ .last_event.time.timeStamp ]]",
-					},
+			},
+			"cursor": map[string]interface{}{
+				"last_published_login": map[string]interface{}{
+					"value": "[[ .last_event.time.timeStamp ]]",
 				},
 			},
-			expected: []string{
-				`{"hello":{"world":"moon"}}`,
-				`{"space":{"cake":"pumpkin"}}`,
-				`{"hello":{"cake":"pumpkin"}}`,
-				`{"space":{"world":"moon"}}`,
-			},
 		},
-		{
-			name: "Test simple XML decode",
-			setupServer: func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
-				registerDecoders()
-				registerRequestTransforms()
-				r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					const text = `<?xml version="1.0" encoding="UTF-8"?>
+		expected: []string{
+			`{"hello":{"world":"moon"}}`,
+			`{"space":{"cake":"pumpkin"}}`,
+			`{"hello":{"cake":"pumpkin"}}`,
+			`{"space":{"world":"moon"}}`,
+		},
+	},
+	{
+		name: "Test simple XML decode",
+		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
+			registerDecoders()
+			registerRequestTransforms()
+			r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				const text = `<?xml version="1.0" encoding="UTF-8"?>
 <order orderid="56733" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="sales.xsd">
   <sender>Ástríðr Ragnar</sender>
   <address>
@@ -1202,19 +1201,19 @@ func TestInput(t *testing.T) {
   </item>
 </order>
 `
-					io.ReadAll(r.Body)
-					r.Body.Close()
-					w.Write([]byte(text))
-				})
-				server := httptest.NewServer(r)
-				t.Cleanup(func() { registeredTransforms = newRegistry() })
-				config["request.url"] = server.URL
-				t.Cleanup(server.Close)
-			},
-			baseConfig: map[string]interface{}{
-				"interval":       1,
-				"request.method": http.MethodGet,
-				"response.xsd": `<?xml version="1.0" encoding="UTF-8" ?>
+				io.ReadAll(r.Body)
+				r.Body.Close()
+				w.Write([]byte(text))
+			})
+			server := httptest.NewServer(r)
+			t.Cleanup(func() { registeredTransforms = newRegistry() })
+			config["request.url"] = server.URL
+			t.Cleanup(server.Close)
+		},
+		baseConfig: map[string]interface{}{
+			"interval":       1,
+			"request.method": http.MethodGet,
+			"response.xsd": `<?xml version="1.0" encoding="UTF-8" ?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="order">
     <xs:complexType>
@@ -1248,41 +1247,41 @@ func TestInput(t *testing.T) {
   </xs:element>
 </xs:schema>
 `,
-			},
-			handler: defaultHandler(http.MethodGet, "", ""),
-			expected: []string{mapstr.M{
-				"order": map[string]interface{}{
-					"address": map[string]interface{}{
-						"address": "Beekplantsoen 594, 2 hoog, 6849 IG",
-						"city":    "Boekend",
-						"company": "Sydøstlige Gruppe",
-						"country": "Netherlands",
-						"name":    "Joord Lennart",
-					},
-					"item": []interface{}{
-						map[string]interface{}{
-							"cost":   99.95,
-							"name":   "Egil's Saga",
-							"note":   "Free Sample",
-							"number": 1,
-							"sent":   false,
-						},
-					},
-					"noNamespaceSchemaLocation": "sales.xsd",
-					"orderid":                   "56733",
-					"sender":                    "Ástríðr Ragnar",
-					"xsi":                       "http://www.w3.org/2001/XMLSchema-instance",
-				},
-			}.String()},
 		},
-	}
+		handler: defaultHandler(http.MethodGet, "", ""),
+		expected: []string{mapstr.M{
+			"order": map[string]interface{}{
+				"address": map[string]interface{}{
+					"address": "Beekplantsoen 594, 2 hoog, 6849 IG",
+					"city":    "Boekend",
+					"company": "Sydøstlige Gruppe",
+					"country": "Netherlands",
+					"name":    "Joord Lennart",
+				},
+				"item": []interface{}{
+					map[string]interface{}{
+						"cost":   99.95,
+						"name":   "Egil's Saga",
+						"note":   "Free Sample",
+						"number": 1,
+						"sent":   false,
+					},
+				},
+				"noNamespaceSchemaLocation": "sales.xsd",
+				"orderid":                   "56733",
+				"sender":                    "Ástríðr Ragnar",
+				"xsi":                       "http://www.w3.org/2001/XMLSchema-instance",
+			},
+		}.String()},
+	},
+}
 
-	for _, testCase := range testCases {
-		tc := testCase
-		t.Run(tc.name, func(t *testing.T) {
-			tc.setupServer(t, tc.handler, tc.baseConfig)
+func TestInput(t *testing.T) {
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			test.setupServer(t, test.handler, test.baseConfig)
 
-			cfg := conf.MustNewConfigFrom(tc.baseConfig)
+			cfg := conf.MustNewConfigFrom(test.baseConfig)
 
 			conf := defaultConfig()
 			assert.NoError(t, cfg.Unpack(&conf))
@@ -1298,7 +1297,7 @@ func TestInput(t *testing.T) {
 			assert.Equal(t, "httpjson-stateless", input.Name())
 			assert.NoError(t, input.Test(v2.TestContext{}))
 
-			chanClient := beattest.NewChanClient(len(tc.expected))
+			chanClient := beattest.NewChanClient(len(test.expected))
 			t.Cleanup(func() { _ = chanClient.Close() })
 
 			ctx, cancel := newV2Context()
@@ -1312,7 +1311,7 @@ func TestInput(t *testing.T) {
 			timeout := time.NewTimer(5 * time.Second)
 			t.Cleanup(func() { _ = timeout.Stop() })
 
-			if len(tc.expected) == 0 {
+			if len(test.expected) == 0 {
 				select {
 				case <-timeout.C:
 				case got := <-chanClient.Channel:
@@ -1328,22 +1327,22 @@ func TestInput(t *testing.T) {
 			for {
 				select {
 				case <-timeout.C:
-					t.Errorf("timed out waiting for %d events", len(tc.expected))
+					t.Errorf("timed out waiting for %d events", len(test.expected))
 					cancel()
 					return
 				case got := <-chanClient.Channel:
 					val, err := got.Fields.GetValue("message")
 					assert.NoError(t, err)
-					assert.JSONEq(t, tc.expected[receivedCount], val.(string))
+					assert.JSONEq(t, test.expected[receivedCount], val.(string))
 					receivedCount += 1
-					if receivedCount == len(tc.expected) {
+					if receivedCount == len(test.expected) {
 						cancel()
 						break wait
 					}
 				}
 			}
-			if tc.expectedFile != "" {
-				if _, err := os.Stat(filepath.Join(tempDir, tc.expectedFile)); err == nil {
+			if test.expectedFile != "" {
+				if _, err := os.Stat(filepath.Join(tempDir, test.expectedFile)); err == nil {
 					assert.NoError(t, g.Wait())
 				} else {
 					t.Errorf("Expected log filename not found")
@@ -1354,10 +1353,70 @@ func TestInput(t *testing.T) {
 	}
 }
 
+func BenchmarkInput(b *testing.B) {
+	for _, test := range testCases {
+		b.Run(test.name, func(b *testing.B) {
+			test.setupServer(b, test.handler, test.baseConfig)
+
+			cfg := conf.MustNewConfigFrom(test.baseConfig)
+
+			conf := defaultConfig()
+			assert.NoError(b, cfg.Unpack(&conf))
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				input := newStatelessInput(conf)
+
+				chanClient := beattest.NewChanClient(len(test.expected))
+				b.Cleanup(func() { _ = chanClient.Close() })
+
+				ctx, cancel := newV2Context()
+				b.Cleanup(cancel)
+
+				var g errgroup.Group
+				g.Go(func() error {
+					return input.Run(ctx, chanClient)
+				})
+
+				timeout := time.NewTimer(5 * time.Second)
+				b.Cleanup(func() { _ = timeout.Stop() })
+
+				if len(test.expected) == 0 {
+					select {
+					case <-timeout.C:
+					case got := <-chanClient.Channel:
+						b.Errorf("unexpected event: %v", got)
+					}
+					cancel()
+					assert.NoError(b, g.Wait())
+					return
+				}
+
+				var receivedCount int
+			wait:
+				for {
+					select {
+					case <-timeout.C:
+						b.Errorf("timed out waiting for %d events", len(test.expected))
+						cancel()
+						return
+					case <-chanClient.Channel:
+						receivedCount += 1
+						if receivedCount == len(test.expected) {
+							cancel()
+							break wait
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
 func newTestServer(
 	newServer func(http.Handler) *httptest.Server,
-) func(*testing.T, http.HandlerFunc, map[string]interface{}) {
-	return func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
 		server := newServer(h)
 		config["request.url"] = server.URL
 		t.Cleanup(server.Close)
@@ -1366,8 +1425,8 @@ func newTestServer(
 
 func newChainTestServer(
 	newServer func(http.Handler) *httptest.Server,
-) func(*testing.T, http.HandlerFunc, map[string]interface{}) {
-	return func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
 		r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch r.URL.Path {
 			case "/":
@@ -1385,8 +1444,8 @@ func newChainTestServer(
 
 func newChainPaginationTestServer(
 	newServer func(http.Handler) *httptest.Server,
-) func(*testing.T, http.HandlerFunc, map[string]interface{}) {
-	return func(t *testing.T, h http.HandlerFunc, config map[string]interface{}) {
+) func(testing.TB, http.HandlerFunc, map[string]interface{}) {
+	return func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
 		registerPaginationTransforms()
 		var serverURL string
 		r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/x-pack/filebeat/input/httpjson/input_test.go
+++ b/x-pack/filebeat/input/httpjson/input_test.go
@@ -33,6 +33,8 @@ var testCases = []struct {
 	handler      http.HandlerFunc
 	expected     []string
 	expectedFile string
+
+	skipReason string
 }{
 	{
 		name:        "simple_GET_request",
@@ -379,6 +381,8 @@ var testCases = []struct {
 		},
 	},
 	{
+		skipReason: "flakey test - see https://github.com/elastic/beats/issues/34929",
+
 		name: "first_event",
 		setupServer: func(t testing.TB, h http.HandlerFunc, config map[string]interface{}) {
 			registerPaginationTransforms()
@@ -1279,6 +1283,10 @@ var testCases = []struct {
 func TestInput(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
+			if test.skipReason != "" {
+				t.Skipf("skip: %s", test.skipReason)
+			}
+
 			test.setupServer(t, test.handler, test.baseConfig)
 
 			cfg := conf.MustNewConfigFrom(test.baseConfig)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds benchmarking for the HTTPJSON input as a prelude to a refactor and revision. It also refactors the structure of the testing code to separate the test table from the test function; this is partly to allow sharing of test cases between the tests and benchmarks, and partly for clarity.

Test names are altered to reduce stutter and make direct copy/paste of the name in terminal output from `go test` findable in the Go source.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This is needed to allow a comparison between HTTPJSON and the new CEL input (the original reason), to guard against perf regressions in an upcoming revision, and to allow us to direct performance improvement work based on evidence. The formatting changes in the test table are QoL.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Recommend hide whitespace for review of test file changes.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `go test` in x-pack/filebeat/input/httpjson, optionally with `-bench .` and friends.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

- For #34929

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
