### PR TITLE
x-pack/filebeat : Sanitize trace log filename to support multiple OS

### DIFF
--- a/x-pack/filebeat/input/httpjson/input.go
+++ b/x-pack/filebeat/input/httpjson/input.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -113,7 +114,8 @@ func run(
 	stdCtx := ctxtool.FromCanceller(ctx.Cancelation)
 
 	if config.Request.Tracer != nil {
-		config.Request.Tracer.Filename = strings.ReplaceAll(config.Request.Tracer.Filename, "*", ctx.ID)
+		id := sanitizeFilePaths(ctx)
+		config.Request.Tracer.Filename = strings.ReplaceAll(config.Request.Tracer.Filename, "*", id)
 	}
 
 	httpClient, err := newHTTPClient(stdCtx, config, log)
@@ -157,6 +159,20 @@ func run(
 	log.Infof("Input stopped because context was cancelled with: %v", err)
 
 	return nil
+}
+
+/*
+The Request.Tracer.Filename may have ":" when a httpjson input has cursor config
+The MacOs Finder will treat this as path-separator and causes to show up strange filepaths.
+This function will sanitize characters like ":" and "/" to replace them with "_" just to be
+safe on all operating systems.
+*/
+func sanitizeFilePaths(ctx v2.Context) string {
+	id := strings.ReplaceAll(ctx.ID, ":", string(filepath.Separator))
+	id = filepath.Clean(id)
+	id = strings.ReplaceAll(id, string(filepath.Separator), "_")
+
+	return id
 }
 
 func newHTTPClient(ctx context.Context, config config, log *logp.Logger) (*httpClient, error) {


### PR DESCRIPTION

## What does this PR do?

This PR sanitizes the `request.tracer.filename` in filebeat config to replace `:` and `/` characters with `_` character.

## Why is it important?

`There is a problem with different path separators between HFS+ (colon, ':') and UFS (slash, '/'). This also means that HFS+ file names may contain the slash character and not colons, while the opposite is true for UFS file names.` [Reference](https://www.wsanchez.net/papers/USENIX_2000/)

So the file structure seems to be corrupted in MacOS if the filename has `:` and the same happens in Unix based systems if the filename has `/`. Hence replacing them with `_`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
