### PR TITLE
x-pack/filebeat/processors/decode_cef - Fix ECS observer.ip

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -111,6 +111,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Correctly collect TCP and UDP metrics for unspecified address values. {pull}35111[35111]
 - Fix base for UDP and TCP queue metrics and UDP drops metric. {pull}35123[35123]
 - Sanitize filenames for request tracer in httpjson and cel inputs. {pull}35143[35143]
+- decode_cef processor: Fix ECS output by making `observer.ip` into an array of strings instead of string. {issue}35140[35140] {pull}35149[35149]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/module/cef/log/test/fp-ngfw-smc.log-expected.json
+++ b/x-pack/filebeat/module/cef/log/test/fp-ngfw-smc.log-expected.json
@@ -23,7 +23,9 @@
         "log.offset": 0,
         "message": "log server connection established",
         "observer.hostname": "10.1.1.40",
-        "observer.ip": "10.1.1.40",
+        "observer.ip": [
+            "10.1.1.40"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "6.6.1",
@@ -60,7 +62,9 @@
         "log.offset": 202,
         "message": "Communication error: No route to host (-3, 5, 0)",
         "observer.hostname": "10.1.1.40",
-        "observer.ip": "10.1.1.40",
+        "observer.ip": [
+            "10.1.1.40"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "6.6.1",
@@ -110,7 +114,9 @@
         "network.community_id": "1:jVNka6fvdh9Qms3nSigb93hGP6U=",
         "network.transport": "1",
         "observer.hostname": "10.1.1.40",
-        "observer.ip": "10.1.1.40",
+        "observer.ip": [
+            "10.1.1.40"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "6.6.1",
@@ -166,7 +172,9 @@
         "network.community_id": "1:gRGAPcxUiQY+cM2V/f6dU0AJnuI=",
         "network.transport": "17",
         "observer.hostname": "10.1.1.10",
-        "observer.ip": "10.1.1.10",
+        "observer.ip": [
+            "10.1.1.10"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "unknown",
@@ -222,7 +230,9 @@
         "network.community_id": "1:rdTu3DxOTXebXEr+rcV80Pk9a1s=",
         "network.transport": "1",
         "observer.hostname": "10.1.1.1",
-        "observer.ip": "10.1.1.1",
+        "observer.ip": [
+            "10.1.1.1"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "unknown",
@@ -275,7 +285,9 @@
         "network.application": "TCP",
         "network.transport": "6",
         "observer.hostname": "10.1.1.6",
-        "observer.ip": "10.1.1.6",
+        "observer.ip": [
+            "10.1.1.6"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "unknown",
@@ -318,7 +330,9 @@
         "log.offset": 1773,
         "message": "ECA_Metadata_login",
         "observer.hostname": "10.1.1.3",
-        "observer.ip": "10.1.1.3",
+        "observer.ip": [
+            "10.1.1.3"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "unknown",
@@ -364,7 +378,9 @@
         "log.offset": 1987,
         "message": "ECA_Metadata_logout",
         "observer.hostname": "10.1.1.10",
-        "observer.ip": "10.1.1.10",
+        "observer.ip": [
+            "10.1.1.10"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "unknown",
@@ -410,7 +426,9 @@
         "log.offset": 2205,
         "message": "ECA_Metadata_system_metadata_received",
         "observer.hostname": "10.1.1.8",
-        "observer.ip": "10.1.1.8",
+        "observer.ip": [
+            "10.1.1.8"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "unknown",
@@ -455,7 +473,9 @@
         "log.offset": 2439,
         "message": "TLS: Couldn't establish TLS connection (11, N/A)",
         "observer.hostname": "10.1.1.40",
-        "observer.ip": "10.1.1.40",
+        "observer.ip": [
+            "10.1.1.40"
+        ],
         "observer.product": "Firewall",
         "observer.vendor": "FORCEPOINT",
         "observer.version": "6.6.1",

--- a/x-pack/filebeat/processors/decode_cef/keys.ecs.go
+++ b/x-pack/filebeat/processors/decode_cef/keys.ecs.go
@@ -60,7 +60,12 @@ var ecsExtensionMapping = map[string]mappedField{
 	"destinationUserName":          {Target: "destination.user.name"},
 	"destinationUserPrivileges":    {Target: "destination.user.group.name"},
 	"deviceAction":                 {Target: "event.action"},
-	"deviceAddress":                {Target: "observer.ip"},
+	"deviceAddress": {
+		Target: "observer.ip",
+		Translate: func(in *cef.Field) (interface{}, error) {
+			return []string{in.String}, nil
+		},
+	},
 	"deviceDirection": {
 		Target: "network.direction",
 		Translate: func(in *cef.Field) (interface{}, error) {

--- a/x-pack/filebeat/processors/decode_cef/testdata/samples.log.golden.json
+++ b/x-pack/filebeat/processors/decode_cef/testdata/samples.log.golden.json
@@ -173,7 +173,9 @@
     },
     "message": "AppControl detectOnly",
     "observer": {
-      "ip": "192.168.33.128",
+      "ip": [
+        "192.168.33.128"
+      ],
       "product": "Deep Security Agent",
       "vendor": "Trend Micro",
       "version": "10.2.229"
@@ -1028,7 +1030,9 @@
     },
     "observer": {
       "hostname": "super",
-      "ip": "111.111.111.99",
+      "ip": [
+        "111.111.111.99"
+      ],
       "product": "ASA",
       "vendor": "CISCO"
     },
@@ -1106,7 +1110,9 @@
     "message": "File Opened",
     "observer": {
       "hostname": "VirtualXP",
-      "ip": "192.168.131.65",
+      "ip": [
+        "192.168.131.65"
+      ],
       "product": "ArcSight",
       "vendor": "ArcSight",
       "version": "7.0.5.7132.1"
@@ -1174,7 +1180,9 @@
     "message": "Agent [NAT] type [sdkrfilereader] started",
     "observer": {
       "hostname": "VirtualXP",
-      "ip": "192.168.0.65",
+      "ip": [
+        "192.168.0.65"
+      ],
       "product": "ArcSight",
       "vendor": "ArcSight",
       "version": "7.0.5.7132.1"
@@ -1235,7 +1243,9 @@
     "message": "File processing started",
     "observer": {
       "hostname": "VirtualXP",
-      "ip": "192.168.131.65",
+      "ip": [
+        "192.168.131.65"
+      ],
       "product": "ArcSight",
       "vendor": "ArcSight",
       "version": "7.0.5.7132.1"
@@ -1304,7 +1314,9 @@
     "message": "Process Stopped by User",
     "observer": {
       "hostname": "VirtualXP",
-      "ip": "192.168.131.65",
+      "ip": [
+        "192.168.131.65"
+      ],
       "product": "ArcSight",
       "vendor": "ArcSight",
       "version": "7.0.5.7132.1"


### PR DESCRIPTION
## What does this PR do?

Fix the ECS output format by making [`observer.ip`](https://www.elastic.co/guide/en/ecs/current/ecs-observer.html#field-observer-ip) into an array of strings instead of string.

Fixes #35140

## Why is it important?

Filebeat should follow the ECS definition precisely.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues


- Closes #35140

## Local Testing

`cd x-pack/filebeat && PYTEST_ADDOPTS="-k test_xpack_modules" TESTING_FILEBEAT_MODULES=cef GENERATE=true mage -v pythonIntegTest`