### PR TITLE
[Filebeat] entityanalytics_azure - Fix accidental error overwrite in defer statement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,7 @@ CHANGELOG*
 /x-pack/filebeat/input/awss3/ @elastic/obs-cloud-monitoring
 /x-pack/filebeat/input/azureblobstorage/ @elastic/security-external-integrations
 /x-pack/filebeat/input/cel/ @elastic/security-external-integrations
+/x-pack/filebeat/input/entityanalytics/ @elastic/security-external-integrations
 /x-pack/filebeat/input/gcppubsub/ @elastic/security-external-integrations
 /x-pack/filebeat/input/gcs/ @elastic/security-external-integrations
 /x-pack/filebeat/input/http_endpoint/ @elastic/security-external-integrations

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -113,6 +113,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Sanitize filenames for request tracer in httpjson and cel inputs. {pull}35143[35143]
 - decode_cef processor: Fix ECS output by making `observer.ip` into an array of strings instead of string. {issue}35140[35140] {pull}35149[35149]
 - Fix handling of MySQL audit logs with strict JSON parser. {issue}35158[35158] {pull}35160[35160]
+- Fix accidental error overwrite in defer statement in entityanalytics Azure AD input. {issue}35153[35153] {pull}35169[35169]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/authenticator/oauth2/oauth2.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/authenticator/oauth2/oauth2.go
@@ -36,6 +36,13 @@ type authResponse struct {
 	AccessToken  string `json:"access_token"`
 	ExpiresIn    int    `json:"expires_in"`
 	ExtExpiresIn int    `json:"ext_expires_in"`
+
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+	ErrorCodes       []int  `json:"error_codes"`
+	CorrelationID    string `json:"correlation_id"`
+	TraceID          string `json:"trace_id"`
+	ErrorURI         string `json:"error_uri"`
 }
 
 // conf contains parameters needed to configure the authenticator.
@@ -89,7 +96,7 @@ func (a *oauth2) renewToken(ctx context.Context) error {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("token request returned unexpected status code: %d body: %s", res.StatusCode, string(resData))
+		return fmt.Errorf("token request returned unexpected status code: %s, body: %s", res.Status, string(resData))
 	}
 
 	var authRes authResponse


### PR DESCRIPTION
## What does this PR do?

- In both the full sync and incremental update functions in Azure AD, a defer statement was always overriding the error value from the function. If an error occurred during the sync/update operation, it would be overwritten by the defer.
- Since the error value produced in the defer was not used elsewhere, it is now stored in its own variable
- Added additional error information for OAuth2 response
- Added test case for error OAuth2 response
- Add SEI as codeowner of entityanalytics input

## Why is it important?

- Errors are being squelched.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Added unit test in `oauth2_test` to test propagation of error values from OAuth2 response
- Testing with expired token is also possible (did this in my testing). Resulting log is below.

## Related issues

- Closes #35153

## Logs

Error that is now surfaced from original issue:

```json
{
  "log.level": "error",
  "@timestamp": "2023-04-21T12:15:58.347-0500",
  "log.logger": "input.entity-analytics-azure-ad",
  "log.origin": {
    "file.name": "azuread/azure.go",
    "file.line": 97
  },
  "message": "Error running full sync",
  "service.name": "filebeat",
  "id": "azure-1",
  "tenant_id": "aa40685b-417d-4664-b4ec-8f7640719adb",
  "provider": "azure-ad",
  "error": {
    "message": "unable to fetch users: unable to get bearer token: failed to renew token: token request returned unexpected status code: 401 Unauthorized, body: {\"error\":\"invalid_client\",\"error_description\":\"AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request is the client secret value, not the client secret ID, for a secret added to app 'c57471ff-3d81-4743-b75d-94060efe5492'.\\r\\nTrace ID: 00826744-6fc6-447e-b7fb-4dfb74972900\\r\\nCorrelation ID: 514cff95-0870-43ba-bd8c-3235ef640a7d\\r\\nTimestamp: 2023-04-21 17:15:58Z\",\"error_codes\":[7000215],\"timestamp\":\"2023-04-21 17:15:58Z\",\"trace_id\":\"00826744-6fc6-447e-b7fb-4dfb74972900\",\"correlation_id\":\"514cff95-0870-43ba-bd8c-3235ef640a7d\",\"error_uri\":\"https://login.microsoftonline.com/error?code=7000215\"}"
  },
  "ecs.version": "1.6.0"
}
```
