### PR TITLE
ci: disable upstream integration

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -38,7 +38,8 @@ pipeline {
   triggers {
     issueCommentTrigger('(?i)^\\/packag[ing|e]$')
     // disable upstream trigger on a PR basis
-    upstream("Beats/beats/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
+    // NOTE(v1v): disable the upstream integration for 8.7.1 release
+    //upstream("Beats/beats/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
   }
   parameters {
     booleanParam(name: 'run_e2e', defaultValue: true, description: 'Allow to disable the e2e tets. This workaround will generate broken/buggy binaries.')


### PR DESCRIPTION
## What does this PR do?

Disable upstream integration with the packaging and the build/test workflows

## Why is it important?

For simplicity, every single workflow has been defined independently and the `upstream` section is the one orchestrating them. Somehow, `DRA` is not needed to run for a short period of time.
