### PR TITLE
fix: updatecli to change go_version only

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -19,12 +19,12 @@ actions:
     kind: github/pullrequest
     scmid: githubConfig
     sourceid: latestGoVersion
+    title: '[Automation] Bump Golang version to {{ source "latestGoVersion" }}'
     spec:
       automerge: false
       labels:
         - dependencies
         - backport-skip
-      title: '[Automation] Bump Golang version to {{ source "latestGoVersion" }}'
       description: |
         It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to:
         https://github.com/elastic/golang-crossbuild/releases/tag/v{{ source "latestGoVersion" }}.
@@ -110,9 +110,9 @@ targets:
     scmid: githubConfig
     kind: file
     spec:
-      content: '{{ source "latestGoVersion" }}'
+      content: ':go-version: {{ source "latestGoVersion" }}'
       file: libbeat/docs/version.asciidoc
-      matchpattern: '\d+.\d+.\d+'
+      matchpattern: ':go-version: \d+.\d+.\d+'
   update-dockerfiles:
     name: "Update from dockerfiles"
     sourceid: latestGoVersion


### PR DESCRIPTION
## What does this PR do?

Filter the regex to match the one with the `go-version`

## Why is it important?

 otherwise the one with the stack will be changed, see https://github.com/elastic/beats/pull/35041/commits/badafce5ad8ae168c189c4ca6822db20f3f9efb4

## Test

I used this changeset in addition to:

```diff
diff --git a/.ci/bump-golang.yml b/.ci/bump-golang.yml
index 9b98297991..1e8ce4334b 100644
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -55,7 +55,8 @@ sources:
       username: '{{ requiredEnv "GIT_USER" }}'
       versionfilter:
         kind: regex
-        pattern: go1\.{{ source "minor" }}\.(\d*)$
+        #pattern: go1\.{{ source "minor" }}\.(\d*)$
+        pattern: go1\.20\.(\d*)$
 
   gomod:
     dependson:
```

and when I ran `GIT_USER=foo@gmail.com GIT_EMAIL=foo@gmail.com updatecli diff --config .ci/bump-golang.yml` it produced

```
update-version.asciidoc
-----------------------

**Dry Run enabled**

⚠ updated the [dry run] content of the file "/var/folders/hn/j6gds1qx1f5bysfn0qp0t03c0000gn/T/updatecli/github/elastic/beats/libbeat/docs/version.asciidoc"

--- /var/folders/hn/j6gds1qx1f5bysfn0qp0t03c0000gn/T/updatecli/github/elastic/beats/libbeat/docs/version.asciidoc
+++ /var/folders/hn/j6gds1qx1f5bysfn0qp0t03c0000gn/T/updatecli/github/elastic/beats/libbeat/docs/version.asciidoc
@@ -1,6 +1,6 @@
 :stack-version: 8.8.0
 :doc-branch: master
-:go-version: 1.19.8
+:go-version: 1.20.3
 :release-state: unreleased
 :python: 3.7
 :docker: 1.12


update-golang.ci
...
```