### PR TITLE
x-pack/filebeat/input/http_endpoint: Add CRC validation for webhooks

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -275,6 +275,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Allow neflow v9 and ipfix templates to be shared between source addresses. {pull}35036[35036]
 - Add support for collecting IPv6 metrics. {pull}35123[35123]
 - Add oracle authentication messages parsing {pull}35127[35127]
+- Add support for CRC validation in Filebeat's HTTP endpoint input. {pull}35204[35204]
 
 *Auditbeat*
    - Migration of system/package module storage from gob encoding to flatbuffer encoding in bolt db. {pull}34817[34817]

--- a/filebeat/docs/modules/zoom.asciidoc
+++ b/filebeat/docs/modules/zoom.asciidoc
@@ -17,7 +17,7 @@ include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for Zoom webhook logs. The module creates an HTTP listener that accepts incoming webhooks from Zoom.
 
-To configure Zoom to send webhooks to the filebeat module, please follow the https://marketplace.zoom.us/docs/guides/build/webhook-only-app[Zoom Documentation].
+To configure Zoom to send webhooks to the filebeat module, please follow the https://developers.zoom.us/docs/api/rest/webhook-only-app[Zoom Documentation].
 
 include::../include/gs-link.asciidoc[]
 

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -144,4 +145,24 @@ func parseTimestamp(timestamp string) (time.Time, error) {
 	}
 
 	return time.Time{}, ErrInvalidTimestamp
+}
+
+// Look for a key (may be nested as for example `key1.key2`) inside a JSON decoded tree
+// Returns true/false and the key value if found
+func SearchJSONKeys(obj mapstr.M, nestedKey string) (interface{}, bool) {
+	keys := strings.Split(nestedKey, ".")
+
+	for i, key := range keys {
+		if _, ok := obj[key].(mapstr.M); !ok {
+			return nil, false
+		}
+
+		if i == len(keys)-1 {
+			return obj[key], true
+		}
+
+		obj = obj[key].(mapstr.M)
+	}
+
+	return nil, false
 }

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -20,8 +20,8 @@ package jsontransform
 import (
 	"errors"
 	"fmt"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/logp"

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -153,15 +153,21 @@ func SearchJSONKeys(obj mapstr.M, nestedKey string) (interface{}, bool) {
 	keys := strings.Split(nestedKey, ".")
 
 	for i, key := range keys {
-		if _, ok := obj[key].(mapstr.M); !ok {
+		value, exists := obj[key]
+		if !exists {
 			return nil, false
 		}
 
 		if i == len(keys)-1 {
-			return obj[key], true
+			return value, true
 		}
 
-		obj = obj[key].(mapstr.M)
+		switch v := value.(type) {
+		case map[string]interface{}:
+			return SearchJSONKeys(v, strings.Join(keys[i+1:], "."))
+		default:
+			return nil, false
+		}
 	}
 
 	return nil, false

--- a/libbeat/common/jsontransform/jsonhelper.go
+++ b/libbeat/common/jsontransform/jsonhelper.go
@@ -20,7 +20,6 @@ package jsontransform
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -145,30 +144,4 @@ func parseTimestamp(timestamp string) (time.Time, error) {
 	}
 
 	return time.Time{}, ErrInvalidTimestamp
-}
-
-// Look for a key (may be nested as for example `key1.key2`) inside a JSON decoded tree
-// Returns true/false and the key value if found
-func SearchJSONKeys(obj mapstr.M, nestedKey string) (interface{}, bool) {
-	keys := strings.Split(nestedKey, ".")
-
-	for i, key := range keys {
-		value, exists := obj[key]
-		if !exists {
-			return nil, false
-		}
-
-		if i == len(keys)-1 {
-			return value, true
-		}
-
-		switch v := value.(type) {
-		case map[string]interface{}:
-			return SearchJSONKeys(v, strings.Join(keys[i+1:], "."))
-		default:
-			return nil, false
-		}
-	}
-
-	return nil, false
 }

--- a/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-http-endpoint.asciidoc
@@ -131,6 +131,19 @@ Authentication or checking that a specific header includes a specific value
   secret.value: secretheadertoken
 ----
 
+Validate webhook endpoint for a specific provider using CRC
+["source","yaml",subs="attributes"]
+----
+{beatname_lc}.inputs:
+- type: http_endpoint
+  enabled: true
+  listen_address: 192.168.1.1
+  listen_port: 8080
+  secret.header: someheadername
+  secret.value: secretheadertoken
+  crc.provider: webhookProvider
+----
+
 Validate a HMAC signature from a specific header
 ["source","yaml",subs="attributes"]
 ----
@@ -255,6 +268,10 @@ For example, `["content-type"]` will become `["Content-Type"]` when the filebeat
 
 This option copies the raw unmodified body of the incoming request to the event.original field as a string before sending the event to Elasticsearch.
 
+[float]
+==== `crc.provider`
+
+This option defines the provider of the webhook that uses CRC (Challenge-Response Check) for validating the endpoint. The HTTP endpoint input is responsible for ensuring the authenticity of incoming webhook requests by generating and verifying a unique token. By specifying the `crc.provider`, you ensure that the system correctly handles the specific CRC validation process required by the chosen provider.
 
 [id="{beatname_lc}-input-{type}-common-options"]
 include::../../../../filebeat/docs/inputs/input-common-options.asciidoc[]

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Available providers for CRC validation
-var ValidCRCProviders = []string{
+var validCRCProviders = []string{
 	"Zoom",
 }
 
@@ -108,7 +108,7 @@ func (c *config) Validate() error {
 func validateCRCProvider(value string) error {
 	value = strings.ToLower(value)
 
-	for _, v := range ValidCRCProviders {
+	for _, v := range validCRCProviders {
 		if strings.ToLower(v) == value {
 			return nil
 		}

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -38,9 +38,6 @@ type config struct {
 	HMACType              string                  `config:"hmac.type"`
 	HMACPrefix            string                  `config:"hmac.prefix"`
 	CRCProvider           string                  `config:"crc.provider"`
-	CRCKey                string                  `config:"crc.key"`
-	CRCValue              string                  `config:"crc.value"`
-	CRCToken              string                  `config:"crc.token"`
 	IncludeHeaders        []string                `config:"include_headers"`
 	PreserveOriginalEvent bool                    `config:"preserve_original_event"`
 }
@@ -64,9 +61,6 @@ func defaultConfig() config {
 		HMACType:      "",
 		HMACPrefix:    "",
 		CRCProvider:   "",
-		CRCKey:        "",
-		CRCValue:      "",
-		CRCToken:      "",
 	}
 }
 
@@ -97,8 +91,8 @@ func (c *config) Validate() error {
 		err := validateCRCProvider(c.CRCProvider)
 		if err != nil {
 			return err
-		} else if c.CRCToken == "" || c.SecretValue == "" {
-			return errors.New("secret.value and crc.token are required when crc.provider is defined")
+		} else if c.SecretValue == "" {
+			return errors.New("secret.value is required when crc.provider is defined")
 		}
 	}
 
@@ -107,7 +101,6 @@ func (c *config) Validate() error {
 
 func validateCRCProvider(value string) error {
 	value = strings.ToLower(value)
-
 	for _, v := range validCRCProviders {
 		if strings.ToLower(v) == value {
 			return nil

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -97,8 +97,8 @@ func (c *config) Validate() error {
 		err := validateCRCProvider(c.CRCProvider)
 		if err != nil {
 			return err
-		} else if c.CRCToken == "" {
-			return errors.New("CRC token required when CRC provider is defined")
+		} else if c.CRCToken == "" || c.SecretValue == "" {
+			return errors.New("secret.value and crc.token are required when crc.provider is defined")
 		}
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -30,7 +30,7 @@ func validateCRC(h *httpHandler, plainToken string) (string, int, error) {
 	return response, status, err
 }
 
-// Generate CRC response to validate a CRC request
+// Generate response to validate a CRC request
 func generateZoomCRC(secretValue string, plainToken string) (string, int, error) {
 	hash := hmac.New(sha256.New, []byte(secretValue))
 	var err error

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -12,42 +12,99 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/elastic/beats/v7/libbeat/common/jsontransform"
+	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-func validateCRC(h *httpHandler, plainToken string) (string, int, error) {
-	var response string
-	var status int
-	var err error
+type Validator func(crcValidator, mapstr.M) (int, string, error)
 
-	switch strings.ToLower(h.CRCProvider) {
-	case "zoom":
-		response, status, err = generateZoomCRC(h.secretValue, plainToken)
-	default:
-		h.log.Debugw("Unable to validate CRC request. Unrecognized provider.")
-		err = fmt.Errorf("unrecognized CRC provider")
-	}
-
-	return response, status, err
+type crcValidator struct {
+	provider       string    // Name of the webhook provider
+	key            string    // Key to identify CRC requests (optional)
+	value          string    // Value of the field to identify CRC requests (optional)
+	challenge      string    // key of the challenge token
+	challengeValue string    // Value of the challenge token
+	secret         string    // Webhook's secret token
+	validator      Validator // Function to calculate the challenge
+	output         mapstr.M  // Output JSON template
 }
 
-// Generate response to validate a CRC request
-func generateZoomCRC(secretValue string, plainToken string) (string, int, error) {
-	hash := hmac.New(sha256.New, []byte(secretValue))
+// Create new CRC handler based in the webhook provider
+func newCRC(crcProvider string, secret string) crcValidator {
+	var newCRC crcValidator
+	switch strings.ToLower(crcProvider) {
+	case "zoom":
+		newCRC = newZoomCRC(secret)
+	default:
+		// Do nothing
+	}
+	return newCRC
+}
+
+// Initialize CRC struct for Zoom provider
+func newZoomCRC(secretValue string) crcValidator {
+	return crcValidator{
+		provider:       "zoom",
+		key:            "event",
+		value:          "endpoint.url_validation",
+		challenge:      "payload.plainToken",
+		challengeValue: "",
+		secret:         secretValue,
+		validator:      validateZoomCRC,
+		output: mapstr.M{
+			"plainToken":     "",
+			"encryptedToken": "",
+		},
+	}
+}
+
+// Validate a CRC request for Zoom
+func validateZoomCRC(crc crcValidator, obj mapstr.M) (int, string, error) {
+	// Verify it is a CRC request
+	if crc.key != "" && crc.value != "" {
+		crcValue, found := jsontransform.SearchJSONKeys(obj, crc.key)
+		if !found {
+			return 0, "", errNotCRC
+		}
+		crcValue, ok := crcValue.(string)
+		if !ok {
+			err := fmt.Errorf("failed decoding '%s' from CRC request", crc.key)
+			return 0, "", err
+		} else if crcValue != crc.value {
+			return 0, "", errNotCRC
+		}
+	}
+
+	challengeValue, found := jsontransform.SearchJSONKeys(obj, crc.challenge)
+	if !found {
+		return 0, "", errNotCRC
+	}
+
+	var ok bool
+	crc.challengeValue, ok = challengeValue.(string)
+	if !ok {
+		err := fmt.Errorf("failed decoding '%s' from CRC request", crc.challenge)
+		return 0, "", err
+	}
+
+	// Generate hash based on the plainToken
+	hash := hmac.New(sha256.New, []byte(crc.secret))
 	var err error
-	_, err = hash.Write([]byte(plainToken))
+	_, err = hash.Write([]byte(crc.challengeValue))
 	if err != nil {
-		return "", 0, err
+		return 0, "", err
 	}
 	encryptedToken := hex.EncodeToString(hash.Sum(nil))
 
-	jsonMap := make(map[string]string)
-	jsonMap["plainToken"] = plainToken
-	jsonMap["encryptedToken"] = encryptedToken
+	// Generate response
+	crc.output["plainToken"] = crc.challengeValue
+	crc.output["encryptedToken"] = encryptedToken
 
-	response, err := json.Marshal(jsonMap)
+	response, err := json.Marshal(crc.output)
 	if err != nil {
-		return "", 0, err
+		return 0, "", err
 	}
 
-	return string(response), http.StatusOK, nil
+	return http.StatusOK, string(response), nil
 }

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -16,19 +16,9 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-// Type Validator points to the function in charge of validating
-// CRC requests defined for each provider in the crcValidator struct.
-//
-// Params:
-//
-//	*crcValidator: pointer to the CRC handler for the webhook provider
-//	mapstr.M: input JSON to be validated
-//
-// Returns:
-//
-//	status: response code to send back to the endpoint
-//	resp: response body
-//	error: failure reason if proceed
+// Validator is a CRC validation function type. It applies the provided validator
+// to the challenge sent by an API and returns an HTTP status code and response
+// body to be sent to the challenging API server.
 type Validator func(*crcValidator, mapstr.M) (status int, resp string, _ error)
 
 func (v *crcValidator) validate(m mapstr.M) (status int, resp string, _ error) {

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -13,21 +13,19 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/elastic/beats/v7/libbeat/common/jsontransform"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 type Validator func(crcValidator, mapstr.M) (int, string, error)
 
 type crcValidator struct {
-	provider       string    // Name of the webhook provider
-	key            string    // Key to identify CRC requests (optional)
-	value          string    // Value of the field to identify CRC requests (optional)
-	challenge      string    // key of the challenge token
-	challengeValue string    // Value of the challenge token
-	secret         string    // Webhook's secret token
-	validator      Validator // Function to calculate the challenge
-	output         mapstr.M  // Output JSON template
+	provider  string    // Name of the webhook provider
+	key       string    // Key to identify CRC requests (optional)
+	value     string    // Value of the field to identify CRC requests (optional)
+	challenge string    // Key of the challenge token
+	secret    string    // Webhook's secret token
+	validator Validator // Function to process the CRC request
+	output    mapstr.M  // Output JSON template
 }
 
 // Create new CRC handler based in the webhook provider
@@ -45,13 +43,12 @@ func newCRC(crcProvider string, secret string) crcValidator {
 // Initialize CRC struct for Zoom provider
 func newZoomCRC(secretValue string) crcValidator {
 	return crcValidator{
-		provider:       "zoom",
-		key:            "event",
-		value:          "endpoint.url_validation",
-		challenge:      "payload.plainToken",
-		challengeValue: "",
-		secret:         secretValue,
-		validator:      validateZoomCRC,
+		provider:  "zoom",
+		key:       "event",
+		value:     "endpoint.url_validation",
+		challenge: "payload.plainToken",
+		secret:    secretValue,
+		validator: validateZoomCRC,
 		output: mapstr.M{
 			"plainToken":     "",
 			"encryptedToken": "",
@@ -59,51 +56,49 @@ func newZoomCRC(secretValue string) crcValidator {
 	}
 }
 
-// Validate a CRC request for Zoom
 func validateZoomCRC(crc crcValidator, obj mapstr.M) (int, string, error) {
-	// Verify it is a CRC request
-	if crc.key != "" && crc.value != "" {
-		crcValue, found := jsontransform.SearchJSONKeys(obj, crc.key)
-		if !found {
-			return 0, "", errNotCRC
-		}
-		crcValue, ok := crcValue.(string)
-		if !ok || crcValue == "" {
-			err := fmt.Errorf("failed decoding '%s' from CRC request", crc.key)
-			return 0, "", err
-		} else if crcValue != crc.value {
-			return 0, "", errNotCRC
-		}
+	/* Verify it is a CRC request. It must contain the following data:
+	{
+	  "payload": {
+	    "plainToken": ""
+	  },
+	  "event": "endpoint.url_validation"
 	}
-
-	challengeValue, found := jsontransform.SearchJSONKeys(obj, crc.challenge)
-	if !found {
+	*/
+	event, ok := obj["event"].(string)
+	if !ok || event != "endpoint.url_validation" {
 		return 0, "", errNotCRC
 	}
 
-	var ok bool
-	crc.challengeValue, ok = challengeValue.(string)
-	if !ok || crc.challengeValue == "" {
+	payload, ok := obj["payload"].(map[string]interface{})
+	if !ok {
+		return 0, "", errNotCRC
+	}
+
+	challengeValue, ok := payload["plainToken"].(string)
+	if !ok {
+		return 0, "", errNotCRC
+	} else if challengeValue == "" {
 		err := fmt.Errorf("failed decoding '%s' from CRC request", crc.challenge)
-		return 0, "", err
+		return http.StatusBadRequest, "", err
 	}
 
 	// Generate hash based on the plainToken
 	hash := hmac.New(sha256.New, []byte(crc.secret))
 	var err error
-	_, err = hash.Write([]byte(crc.challengeValue))
+	_, err = hash.Write([]byte(challengeValue))
 	if err != nil {
-		return 0, "", err
+		return http.StatusInternalServerError, "", err
 	}
 	encryptedToken := hex.EncodeToString(hash.Sum(nil))
 
 	// Generate response
-	crc.output["plainToken"] = crc.challengeValue
+	crc.output["plainToken"] = challengeValue
 	crc.output["encryptedToken"] = encryptedToken
 
 	response, err := json.Marshal(crc.output)
 	if err != nil {
-		return 0, "", err
+		return http.StatusInternalServerError, "", err
 	}
 
 	return http.StatusOK, string(response), nil

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -1,0 +1,53 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package http_endpoint
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"crypto/hmac"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"net/http"
+)
+
+func validateCRC(h *httpHandler, plainToken string) (string, int, error) {
+	var response string
+    var status int
+    var err error
+
+	switch strings.ToLower(h.CRCProvider){
+	case "zoom":
+		response, status, err = generateZoomCRC(h.secretValue, plainToken)
+	default:
+		h.log.Debugw("Unable to validate CRC request. Unrecognized provider.")
+		err = fmt.Errorf("unrecognized CRC provider")
+	}
+
+	return response, status, err
+}
+
+// Generate CRC response to validate a CRC request
+func generateZoomCRC(secretValue string, plainToken string) (string, int, error) {
+	hash := hmac.New(sha256.New, []byte(secretValue))
+	var err error
+	_, err = hash.Write([]byte(plainToken))
+	if err != nil {
+		return "", 0, err
+	}
+	encryptedToken := hex.EncodeToString(hash.Sum(nil))
+
+	jsonMap := make(map[string]string)
+	jsonMap["plainToken"] = plainToken
+	jsonMap["encryptedToken"] = encryptedToken
+
+	response, err := json.Marshal(jsonMap)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return string(response), http.StatusOK, nil
+}

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -68,7 +68,7 @@ func validateZoomCRC(crc crcValidator, obj mapstr.M) (int, string, error) {
 			return 0, "", errNotCRC
 		}
 		crcValue, ok := crcValue.(string)
-		if !ok {
+		if !ok || crcValue == "" {
 			err := fmt.Errorf("failed decoding '%s' from CRC request", crc.key)
 			return 0, "", err
 		} else if crcValue != crc.value {
@@ -83,7 +83,7 @@ func validateZoomCRC(crc crcValidator, obj mapstr.M) (int, string, error) {
 
 	var ok bool
 	crc.challengeValue, ok = challengeValue.(string)
-	if !ok {
+	if !ok || crc.challengeValue == "" {
 		err := fmt.Errorf("failed decoding '%s' from CRC request", crc.challenge)
 		return 0, "", err
 	}

--- a/x-pack/filebeat/input/http_endpoint/crc.go
+++ b/x-pack/filebeat/input/http_endpoint/crc.go
@@ -5,21 +5,21 @@
 package http_endpoint
 
 import (
-	"encoding/hex"
-	"encoding/json"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
-	"strings"
 	"net/http"
+	"strings"
 )
 
 func validateCRC(h *httpHandler, plainToken string) (string, int, error) {
 	var response string
-    var status int
-    var err error
+	var status int
+	var err error
 
-	switch strings.ToLower(h.CRCProvider){
+	switch strings.ToLower(h.CRCProvider) {
 	case "zoom":
 		response, status, err = generateZoomCRC(h.secretValue, plainToken)
 	default:

--- a/x-pack/filebeat/input/http_endpoint/crc_test.go
+++ b/x-pack/filebeat/input/http_endpoint/crc_test.go
@@ -16,12 +16,12 @@ import (
 
 func Test_validateZoomCRC(t *testing.T) {
 	testCases := []struct {
-		name         string       // Sub-test name.
-		crc          crcValidator // Load CRC parameters.
-		inputJSON    mapstr.M     // Input JSON event.
-		wantStatus   int          // Expected response code.
-		wantResponse string       // Expected response message.
-		wantError    error        // Expected error
+		name         string        // Sub-test name.
+		crc          *crcValidator // Load CRC parameters.
+		inputJSON    mapstr.M      // Input JSON event.
+		wantStatus   int           // Expected response code.
+		wantResponse string        // Expected response message.
+		wantError    error         // Expected error
 	}{
 		{
 			name: "valid request",
@@ -59,7 +59,7 @@ func Test_validateZoomCRC(t *testing.T) {
 			},
 			wantStatus:   http.StatusBadRequest,
 			wantResponse: "",
-			wantError:    fmt.Errorf("failed decoding 'payload.plainToken' from CRC request"),
+			wantError:    fmt.Errorf("failed decoding \"payload.plainToken\" from CRC request"),
 		},
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/crc_test.go
+++ b/x-pack/filebeat/input/http_endpoint/crc_test.go
@@ -9,8 +9,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
 func Test_validateZoomCRC(t *testing.T) {

--- a/x-pack/filebeat/input/http_endpoint/crc_test.go
+++ b/x-pack/filebeat/input/http_endpoint/crc_test.go
@@ -1,0 +1,76 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package http_endpoint
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateZoomCRC(t *testing.T) {
+	testCases := []struct {
+		name         string       // Sub-test name.
+		crc          crcValidator // Load CRC parameters.
+		inputJSON    mapstr.M     // Input JSON event.
+		wantStatus   int          // Expected response code.
+		wantResponse string       // Expected response message.
+		wantError    error        // Expected error
+	}{
+		{
+			name: "valid request",
+			crc:  newCRC("Zoom", "secretValueTest"),
+			inputJSON: mapstr.M{
+				"payload": map[string]interface{}{
+					"plainToken": "qgg8vlvZRS6UYooatFL8Aw",
+				},
+				"event_ts": int64(1654503849680),
+				"event":    "endpoint.url_validation",
+			},
+			wantStatus:   http.StatusOK,
+			wantResponse: `{"encryptedToken":"70c1f2e2e6ca2d39297490d1f9142c7d701415ea8e6151f6562a08fa657a40ff","plainToken":"qgg8vlvZRS6UYooatFL8Aw"}`,
+			wantError:    nil,
+		},
+		{
+			name: "not CRC request",
+			crc:  newCRC("Zoom", "secretValueTest"),
+			inputJSON: mapstr.M{
+				"key": "sample_event",
+			},
+			wantStatus:   0,
+			wantResponse: "",
+			wantError:    errNotCRC,
+		},
+		{
+			name: "empty challenge value",
+			crc:  newCRC("Zoom", "secretValueTest"),
+			inputJSON: mapstr.M{
+				"payload": map[string]interface{}{
+					"plainToken": "",
+				},
+				"event_ts": int64(1654503849680),
+				"event":    "endpoint.url_validation",
+			},
+			wantStatus:   http.StatusBadRequest,
+			wantResponse: "",
+			wantError:    fmt.Errorf("failed decoding 'payload.plainToken' from CRC request"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Execute CRC validation
+			responseCode, responseBody, err := tc.crc.validator(tc.crc, tc.inputJSON)
+
+			// Validate responses
+			assert.Equal(t, tc.wantStatus, responseCode)
+			assert.Equal(t, tc.wantResponse, responseBody)
+			assert.Equal(t, tc.wantError, err)
+		})
+	}
+}

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -72,7 +72,7 @@ func (h *httpHandler) apiResponse(w http.ResponseWriter, r *http.Request) {
 				// CRC request processed
 				break
 			} else if !errors.Is(err, errNotCRC) {
-				sendAPIErrorResponse(w, r, h.log, http.StatusInternalServerError, err)
+				sendAPIErrorResponse(w, r, h.log, http.StatusBadRequest, err)
 				return
 			}
 		}

--- a/x-pack/filebeat/input/http_endpoint/handler.go
+++ b/x-pack/filebeat/input/http_endpoint/handler.go
@@ -38,11 +38,11 @@ type httpHandler struct {
 	includeHeaders        []string
 	preserveOriginalEvent bool
 
-	secretValue           string
-	CRCProvider           string
-	CRCKey                string
-	CRCValue              string
-	CRCToken              string
+	secretValue string
+	CRCProvider string
+	CRCKey      string
+	CRCValue    string
+	CRCToken    string
 }
 
 // Triggers if middleware validation returns successful
@@ -73,21 +73,21 @@ func (h *httpHandler) apiResponse(w http.ResponseWriter, r *http.Request) {
 	if (h.CRCProvider != "") && found {
 		CRCToken, ok := CRCToken.(string)
 		if !ok {
-			err := fmt.Errorf("failed decoding '%s' from CRC request.", h.CRCToken)
+			err := fmt.Errorf("failed decoding '%s' from CRC request", h.CRCToken)
 			sendAPIErrorResponse(w, r, h.log, http.StatusBadRequest, err)
 			return
 		}
-		if (h.CRCKey != "" && h.CRCValue != "") {
+		if h.CRCKey != "" && h.CRCValue != "" {
 			CRCValue, found := jsontransform.SearchJSONKeys(objs[0], h.CRCKey)
 			CRCValue, ok := CRCValue.(string)
 			if !found || !ok || (CRCValue != h.CRCValue) {
-				err := fmt.Errorf("failed decoding '%s' from CRC request.", h.CRCKey)
+				err := fmt.Errorf("failed decoding '%s' from CRC request", h.CRCKey)
 				sendAPIErrorResponse(w, r, h.log, http.StatusBadRequest, err)
 				return
 			}
 		}
 		var err error
-		responseBody, responseCode, err = validateCRC(h, string(CRCToken))
+		responseBody, responseCode, err = validateCRC(h, CRCToken)
 		if err != nil {
 			sendAPIErrorResponse(w, r, h.log, http.StatusInternalServerError, err)
 			return

--- a/x-pack/filebeat/input/http_endpoint/handler_test.go
+++ b/x-pack/filebeat/input/http_endpoint/handler_test.go
@@ -269,32 +269,6 @@ func Test_apiResponse(t *testing.T) {
 			wantResponse: `{"encryptedToken":"70c1f2e2e6ca2d39297490d1f9142c7d701415ea8e6151f6562a08fa657a40ff","plainToken":"qgg8vlvZRS6UYooatFL8Aw"}`,
 		},
 		{
-			name: "validate CRC request",
-			conf: config{
-				SecretHeader: "secretHeaderTest",
-				SecretValue:  "secretValueTest",
-				CRCProvider:  "Zoom",
-			},
-			request: func() *http.Request {
-				buf := bytes.NewBufferString(
-					`{
-						"event_ts":1654503849680,
-						"event":"endpoint.url_validation",
-						"payload": {
-							"plainToken":"qgg8vlvZRS6UYooatFL8Aw"
-						}
-					}`,
-				)
-				req := httptest.NewRequest(http.MethodPost, "/", buf)
-				req.Header.Set("Content-Type", "application/json")
-				req.Header.Set("secretHeaderTest", "secretValueTest")
-				return req
-			}(),
-			events:       nil,
-			wantStatus:   http.StatusOK,
-			wantResponse: `{"encryptedToken":"70c1f2e2e6ca2d39297490d1f9142c7d701415ea8e6151f6562a08fa657a40ff","plainToken":"qgg8vlvZRS6UYooatFL8Aw"}`,
-		},
-		{
 			name: "malformed CRC request",
 			conf: config{
 				SecretHeader: "secretHeaderTest",

--- a/x-pack/filebeat/input/http_endpoint/handler_test.go
+++ b/x-pack/filebeat/input/http_endpoint/handler_test.go
@@ -159,12 +159,16 @@ func (p *publisher) Publish(e beat.Event) {
 
 func Test_apiResponse(t *testing.T) {
 	testCases := []struct {
-		name    string        // Sub-test name.
-		request *http.Request // Input request.
-		events  []mapstr.M    // Expected output events.
+		name         string        // Sub-test name.
+		conf         config        // Load configuration.
+		request      *http.Request // Input request.
+		events       []mapstr.M    // Expected output events.
+		wantStatus   int           // Expected response code.
+		wantResponse string        // Expected response message.
 	}{
 		{
 			name: "single event",
+			conf: defaultConfig(),
 			request: func() *http.Request {
 				req := httptest.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"id":0}`))
 				req.Header.Set("Content-Type", "application/json")
@@ -177,9 +181,12 @@ func Test_apiResponse(t *testing.T) {
 					},
 				},
 			},
+			wantStatus:   http.StatusOK,
+			wantResponse: `{"message": "success"}`,
 		},
 		{
 			name: "single event gzip",
+			conf: defaultConfig(),
 			request: func() *http.Request {
 				buf := new(bytes.Buffer)
 				b := gzip.NewWriter(buf)
@@ -198,9 +205,12 @@ func Test_apiResponse(t *testing.T) {
 					},
 				},
 			},
+			wantStatus:   http.StatusOK,
+			wantResponse: `{"message": "success"}`,
 		},
 		{
 			name: "multiple events gzip",
+			conf: defaultConfig(),
 			request: func() *http.Request {
 				events := []string{
 					`{"id":0}`,
@@ -229,6 +239,34 @@ func Test_apiResponse(t *testing.T) {
 					},
 				},
 			},
+			wantStatus:   http.StatusOK,
+			wantResponse: `{"message": "success"}`,
+		},
+		{
+			name: "validate CRC request",
+			conf: config{
+				SecretHeader: "secretHeaderTest",
+				SecretValue:  "secretValueTest",
+				CRCProvider:  "Zoom",
+			},
+			request: func() *http.Request {
+				buf := bytes.NewBufferString(
+					`{
+						"event_ts":1654503849680,
+						"event":"endpoint.url_validation",
+						"payload": {
+							"plainToken":"qgg8vlvZRS6UYooatFL8Aw"
+						}
+					}`,
+				)
+				req := httptest.NewRequest(http.MethodPost, "/", buf)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("secretHeaderTest", "secretValueTest")
+				return req
+			}(),
+			events:       nil,
+			wantStatus:   http.StatusOK,
+			wantResponse: `{"encryptedToken":"70c1f2e2e6ca2d39297490d1f9142c7d701415ea8e6151f6562a08fa657a40ff","plainToken":"qgg8vlvZRS6UYooatFL8Aw"}`,
 		},
 	}
 
@@ -236,16 +274,15 @@ func Test_apiResponse(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
 			pub := new(publisher)
-			conf := defaultConfig()
-			apiHandler := newHandler(conf, pub, logp.NewLogger("http_endpoint.test"))
+			apiHandler := newHandler(tc.conf, pub, logp.NewLogger("http_endpoint.test"))
 
 			// Execute handler.
 			respRec := httptest.NewRecorder()
 			apiHandler.ServeHTTP(respRec, tc.request)
 
 			// Validate responses.
-			assert.Equal(t, http.StatusOK, respRec.Code)
-			assert.Equal(t, conf.ResponseBody, respRec.Body.String())
+			assert.Equal(t, tc.wantStatus, respRec.Code)
+			assert.Equal(t, tc.wantResponse, respRec.Body.String())
 			require.Len(t, pub.events, len(tc.events))
 
 			for i, evt := range pub.events {

--- a/x-pack/filebeat/input/http_endpoint/handler_test.go
+++ b/x-pack/filebeat/input/http_endpoint/handler_test.go
@@ -318,7 +318,7 @@ func Test_apiResponse(t *testing.T) {
 			}(),
 			events:       nil,
 			wantStatus:   http.StatusBadRequest,
-			wantResponse: `{"message":"failed decoding 'payload.plainToken' from CRC request"}`,
+			wantResponse: `{"message":"failed decoding \"payload.plainToken\" from CRC request"}`,
 		},
 	}
 

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -259,11 +259,7 @@ func newHandler(c config, pub stateless.Publisher, log *logp.Logger) http.Handle
 		responseBody:          c.ResponseBody,
 		includeHeaders:        canonicalizeHeaders(c.IncludeHeaders),
 		preserveOriginalEvent: c.PreserveOriginalEvent,
-		secretValue:           c.SecretValue,
-		CRCProvider:           c.CRCProvider,
-		CRCKey:                c.CRCKey,
-		CRCValue:              c.CRCValue,
-		CRCToken:              c.CRCToken,
+		crc:                   newCRC(c.CRCProvider, c.SecretValue),
 	}
 
 	return newAPIValidationHandler(http.HandlerFunc(handler.apiResponse), validator, log)

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -7,11 +7,13 @@ package http_endpoint
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"reflect"
 	"sync"
+	"time"
 
 	v2 "github.com/elastic/beats/v7/filebeat/input/v2"
 	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
@@ -86,7 +88,7 @@ func (e *httpEndpoint) Test(_ v2.TestContext) error {
 
 func (e *httpEndpoint) Run(ctx v2.Context, publisher stateless.Publisher) error {
 	err := servers.serve(ctx, e, publisher)
-	if err != nil && err != http.ErrServerClosed {
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("unable to start server due to error: %w", err)
 	}
 	return nil
@@ -138,7 +140,7 @@ func (p *pool) serve(ctx v2.Context, e *httpEndpoint, pub stateless.Publisher) e
 
 	mux := http.NewServeMux()
 	mux.Handle(pattern, newHandler(e.config, pub, log))
-	srv := &http.Server{Addr: e.addr, TLSConfig: e.tlsConfig, Handler: mux}
+	srv := &http.Server{Addr: e.addr, TLSConfig: e.tlsConfig, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	s = &server{
 		idOf: map[string]string{pattern: ctx.ID},
 		tls:  e.config.TLS,

--- a/x-pack/filebeat/input/http_endpoint/input.go
+++ b/x-pack/filebeat/input/http_endpoint/input.go
@@ -257,6 +257,11 @@ func newHandler(c config, pub stateless.Publisher, log *logp.Logger) http.Handle
 		responseBody:          c.ResponseBody,
 		includeHeaders:        canonicalizeHeaders(c.IncludeHeaders),
 		preserveOriginalEvent: c.PreserveOriginalEvent,
+		secretValue:           c.SecretValue,
+		CRCProvider:           c.CRCProvider,
+		CRCKey:                c.CRCKey,
+		CRCValue:              c.CRCValue,
+		CRCToken:              c.CRCToken,
 	}
 
 	return newAPIValidationHandler(http.HandlerFunc(handler.apiResponse), validator, log)

--- a/x-pack/filebeat/input/http_endpoint/validate.go
+++ b/x-pack/filebeat/input/http_endpoint/validate.go
@@ -14,7 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -79,12 +79,12 @@ func (v *apiValidator) ValidateHeader(r *http.Request) (int, error) {
 
 		// We need access to the request body to validate the signature, but we
 		// must leave the body intact for future processing.
-		buf, err := ioutil.ReadAll(r.Body)
+		buf, err := io.ReadAll(r.Body)
 		if err != nil {
 			return http.StatusInternalServerError, fmt.Errorf("failed to read request body: %w", err)
 		}
 		// Set r.Body back to untouched original value.
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
+		r.Body = io.NopCloser(bytes.NewBuffer(buf))
 
 		// Compute HMAC of raw body.
 		var mac hash.Hash

--- a/x-pack/filebeat/module/zoom/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zoom/_meta/docs.asciidoc
@@ -10,7 +10,7 @@ include::{libbeat-dir}/shared/integration-link.asciidoc[]
 
 This is a module for Zoom webhook logs. The module creates an HTTP listener that accepts incoming webhooks from Zoom.
 
-To configure Zoom to send webhooks to the filebeat module, please follow the https://marketplace.zoom.us/docs/guides/build/webhook-only-app[Zoom Documentation].
+To configure Zoom to send webhooks to the filebeat module, please follow the https://developers.zoom.us/docs/api/rest/webhook-only-app[Zoom Documentation].
 
 include::../include/gs-link.asciidoc[]
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Added support to process CRC requests in the filebeat's http_endpoint input.

Currently, the only module that we support with CRC webhook validation is Zoom, so it has been added the procedure to process Zoom CRC requests according to [its documentation](https://developers.zoom.us/docs/api/rest/webhook-reference/#validate-your-webhook-endpoint).

It has been added a new setting `crc.provider` to the `http_endpoint` configuration to choose the webhook provider in case the list of supported services is in the future.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
Currently, the HTTP endpoint can only send static responses. Some use cases such as the CRC validation require dynamic responses based on the content of the request or other data.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

For now, the only allowed provider for CRC requests is [Zoom](https://developers.zoom.us/docs/api/rest/webhook-reference/#validate-your-webhook-endpoint), so we have to add the `crc.provider` setting as follows in the `filebeat.yml` file:
```yml
- type: http_endpoint
  enabled: true
  listen_address: localhost
  listen_port: 5066
  url: "/test/"
  response_code: 200
  response_body: '{"message": "test success"}'
  secret.header: "secretHeaderTest"
  secret.value: "secretValueTest"
  crc.provider: "Zoom"
```

It is also needed to have the webhook configured with a secret token, for this purpose, options `secret.header` and `secret.value` should be set.

Once filebeat is running, we can send HTTP requests to verify that it behaves as expected.

**Regular event**

```
# curl -X POST http://localhost:5066/test/ -H 'Content-Type: application/json' -H 'secretHeaderTest: secretValueTest' -d '{"message":"test_event"}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:5066...
* Connected to localhost (127.0.0.1) port 5066 (#0)
> POST /test/ HTTP/1.1
> Host: localhost:5066
> User-Agent: curl/7.87.0
> Accept: */*
> Content-Type: application/json
> secretHeaderTest: secretValueTest
> Content-Length: 24
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Thu, 27 Apr 2023 12:34:03 GMT
< Content-Length: 27
<
* Connection #0 to host localhost left intact
{"message": "test success"}#
```

For this request, we can see the response is the expected (the configured one), we also check that the event is generated and sent:

```js
{
  "@timestamp": "2023-04-27T12:34:03.228Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.8.0"
  },
  "json": {
    "message": "test_event"
  },
  "input": {
    "type": "http_endpoint"
  },
  "ecs": {
    "version": "8.0.0"
  },
...
```

**CRC request**

```
# curl -X POST http://localhost:5066/test/ -H 'Content-Type: application/json' -H 'secretHeaderTest: secretValueTest' -d '{"event_ts":1654503849680,"event":"endpoint.url_validation","payload":{"plainToken":"qgg8vlvZRS6UYooatFL8Aw"}}' -v
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:5066...
* Connected to localhost (127.0.0.1) port 5066 (#0)
> POST /test/ HTTP/1.1
> Host: localhost:5066
> User-Agent: curl/7.87.0
> Accept: */*
> Content-Type: application/json
> secretHeaderTest: secretValueTest
> Content-Length: 110
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Thu, 27 Apr 2023 12:36:00 GMT
< Content-Length: 123
<
* Connection #0 to host localhost left intact
{"encryptedToken":"70c1f2e2e6ca2d39297490d1f9142c7d701415ea8e6151f6562a08fa657a40ff","plainToken":"qgg8vlvZRS6UYooatFL8Aw"}#
```

In this case, when sending a CRC request event to the server, the response message contains the hash of the challenge token. In addition, no event is generated.

## Related issues

Closes https://github.com/elastic/beats/issues/35100
