### PR TITLE
awscloudwatch-filebeat - support milliseconds precision

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -65,6 +65,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix Beats started by agent do not respect the allow_older_versions: true configuration flag {issue}34227[34227] {pull}34964[34964]
 - Fix performance issues when we have a lot of inputs starting and stopping by allowing to disable global processors under fleet. {issue}35000[35000] {pull}35031[35031]
 - In cases where the matcher detects a non-string type in a match statement, report the error as a debug statement, and not a warning statement. {pull}35119[35119]
+- awscloudwatch-filebeat - support milliseconds precision {pull}35236[35236]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/awscloudwatch/input_test.go
+++ b/x-pack/filebeat/input/awscloudwatch/input_test.go
@@ -121,10 +121,10 @@ func TestGetStartPosition(t *testing.T) {
 func TestCreateEvent(t *testing.T) {
 	logEvent := &types.FilteredLogEvent{
 		EventId:       awssdk.String("id-1"),
-		IngestionTime: awssdk.Int64(1590000000000),
+		IngestionTime: awssdk.Int64(1590000000123),
 		LogStreamName: awssdk.String("logStreamName1"),
 		Message:       awssdk.String("test-message-1"),
-		Timestamp:     awssdk.Int64(1600000000000),
+		Timestamp:     awssdk.Int64(1600000000123),
 	}
 
 	expectedEventFields := mapstr.M{
@@ -136,12 +136,12 @@ func TestCreateEvent(t *testing.T) {
 		"awscloudwatch": mapstr.M{
 			"log_group":      "logGroup1",
 			"log_stream":     *logEvent.LogStreamName,
-			"ingestion_time": time.Unix(*logEvent.IngestionTime/1000, 0),
+			"ingestion_time": time.UnixMilli(*logEvent.IngestionTime),
 		},
 		"aws.cloudwatch": mapstr.M{
 			"log_group":      "logGroup1",
 			"log_stream":     *logEvent.LogStreamName,
-			"ingestion_time": time.Unix(*logEvent.IngestionTime/1000, 0),
+			"ingestion_time": time.UnixMilli(*logEvent.IngestionTime),
 		},
 		"cloud": mapstr.M{
 			"provider": "aws",

--- a/x-pack/filebeat/input/awscloudwatch/processor.go
+++ b/x-pack/filebeat/input/awscloudwatch/processor.go
@@ -51,7 +51,7 @@ func (p *logProcessor) publish(ack *awscommon.EventACKTracker, event *beat.Event
 
 func createEvent(logEvent types.FilteredLogEvent, logGroup string, regionName string) beat.Event {
 	event := beat.Event{
-		Timestamp: time.Unix(*logEvent.Timestamp/1000, 0).UTC(),
+		Timestamp: time.UnixMilli(*logEvent.Timestamp).UTC(),
 		Fields: mapstr.M{
 			"message":       *logEvent.Message,
 			"log.file.path": logGroup + "/" + *logEvent.LogStreamName,
@@ -62,12 +62,12 @@ func createEvent(logEvent types.FilteredLogEvent, logGroup string, regionName st
 			"awscloudwatch": mapstr.M{
 				"log_group":      logGroup,
 				"log_stream":     *logEvent.LogStreamName,
-				"ingestion_time": time.Unix(*logEvent.IngestionTime/1000, 0),
+				"ingestion_time": time.UnixMilli(*logEvent.IngestionTime),
 			},
 			"aws.cloudwatch": mapstr.M{
 				"log_group":      logGroup,
 				"log_stream":     *logEvent.LogStreamName,
-				"ingestion_time": time.Unix(*logEvent.IngestionTime/1000, 0),
+				"ingestion_time": time.UnixMilli(*logEvent.IngestionTime),
 			},
 			"cloud": mapstr.M{
 				"provider": "aws",


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Bugfix PR based on [this](https://discuss.elastic.co/t/filebeat-for-aws-cloudwatch-does-not-support-timestamps-with-milliseconds/327338) forums post. It makes sure that milliseconds are not removed from the message.

## Why is it important?

It is very difficult to work with the logs that do not have milliseconds precision when there are multiple log messages from within the same second.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~I have commented my code, particularly in hard-to-understand areas~
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have made corresponding change to the default configuration files~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
