### PR TITLE
Fix cockroachdb/cockroach Docker image for CI

### DIFF
--- a/x-pack/metricbeat/module/cockroachdb/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/cockroachdb/_meta/Dockerfile
@@ -1,8 +1,6 @@
 ARG COCKROACHDB_VERSION
 FROM cockroachdb/cockroach:v${COCKROACHDB_VERSION}
 
-RUN apt-get update && apt-get install -y curl
-
 HEALTHCHECK --interval=1s --retries=90 CMD curl -q http://localhost:8080/_stats/vars
 
-CMD ["start", "--insecure"]
+CMD ["start-single-node", "--insecure"]

--- a/x-pack/metricbeat/module/cockroachdb/docker-compose.yml
+++ b/x-pack/metricbeat/module/cockroachdb/docker-compose.yml
@@ -2,10 +2,10 @@ version: '2.3'
 
 services:
   cockroachdb:
-    image: docker.elastic.co/integrations-ci/beats-cockroachdb:${COCKROACHDB_VERSION:-19.1.1}-1
+    image: docker.elastic.co/integrations-ci/beats-cockroachdb:${COCKROACHDB_VERSION:-22.1.19}-1
     build:
       context: ./_meta
       args:
-        COCKROACHDB_VERSION: ${COCKROACHDB_VERSION:-19.1.1}
+        COCKROACHDB_VERSION: ${COCKROACHDB_VERSION:-22.1.19}
     ports:
       - 8080


### PR DESCRIPTION
Updating cocroachdb/cockroach docker image for CI due to issues like this: 
```
[2023-04-25T06:11:20.938Z] Service 'cockroachdb' failed to build: The command '/bin/sh -c apt-get update && apt-get install -y curl' returned a non-zero code: 100
[2023-04-25T06:11:20.938Z]     status_integration_test.go:32: failed to start service 'cockroachdb: exit status 1
```
Fixes: #35211