### PR TITLE
Workaround for debian stretch

### DIFF
--- a/metricbeat/module/kafka/_meta/Dockerfile
+++ b/metricbeat/module/kafka/_meta/Dockerfile
@@ -8,6 +8,11 @@ ENV KAFKA_LOGS_DIR="/kafka-logs"
 ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
 ENV TERM=linux
 
+# TODO: use newer base
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list \
+    && sed -i '/stretch-updates/d' /etc/apt/sources.list 
+    
 RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat dnsutils
 
 RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && \

--- a/x-pack/filebeat/input/gcppubsub/_meta/Dockerfile
+++ b/x-pack/filebeat/input/gcppubsub/_meta/Dockerfile
@@ -1,6 +1,11 @@
 FROM debian:stretch
 ARG SDK_VERSION
 
+# TODO: use newer base
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list \
+    && sed -i '/stretch-updates/d' /etc/apt/sources.list 
+
 RUN \
     apt-get update \
 	&& apt-get install -y \


### PR DESCRIPTION
[Debian stretch was moved to archive](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html) which means Docker images are failing when trying to curl security.debian.org

This PR adds a workaround for that to unblock builds. 
Owners of integration should consider moving to newer base

Failure example: https://github.com/elastic/beats/pull/35196