### PR TITLE
[Docs] Update logging.files.permissions documentation to consider umask

### DIFF
--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -40,6 +40,9 @@ That means in case there are some states where the TTL expired, these are only r
 
 The permissions mask to apply on registry data file. The default value is 0600. The permissions option must be a valid Unix-style file permissions mask expressed in octal notation. In Go, numbers in octal notation must start with 0.
 
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to an umask of 0027.
+
 This option is not supported on Windows.
 
 Examples:

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -231,6 +231,9 @@ The permissions mask to apply when rotating log files. The default value is
 expressed in octal notation. In Go, numbers in octal notation must start with
 '0'.
 
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to an umask of 0027.
+
 This option is not supported on Windows.
 
 Examples:


### PR DESCRIPTION
## What does this PR do?

It updates the logging.files.permissions documentation to consider umask as previously done in https://github.com/elastic/beats/pull/28347, but for some reason isn't present in the current docs. The correct is [7.16](https://www.elastic.co/guide/en/beats/filebeat/7.16/configuration-logging.html#_logging_files_permissions), but the other versions do not have it. See [7.17](https://www.elastic.co/guide/en/beats/filebeat/7.17/configuration-logging.html#_logging_files_permissions), [8.1](https://www.elastic.co/guide/en/beats/filebeat/8.1/configuration-logging.html#_logging_files_permissions), [main](https://www.elastic.co/guide/en/beats/filebeat/master/configuration-logging.html#_logging_files_permissions)

## Why is it important?

Avoid confusion due to missing documentation

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

N/A
## Related issues

- Closes #35256 

