### PR TITLE
Fix a comment that wasn't properly updated in previous PR

### DIFF
--- a/libbeat/outputs/output_reg.go
+++ b/libbeat/outputs/output_reg.go
@@ -49,9 +49,8 @@ type IndexSelector interface {
 }
 
 // Group configures and combines multiple clients into load-balanced group of clients
-// being managed by the publisher pipeline. If QueueSettings is set then the
-// pipeline will use it to create the queue. QueueSettings must be one of
-// memqueue.Settings, diskqueue.Settings, proxyqueue.Settings.
+// being managed by the publisher pipeline.
+// If QueueFactory is set then the pipeline will use it to create the queue.
 // Currently it is only used to activate the proxy queue when using the Shipper
 // output, but it also provides a natural migration path for moving queue
 // configuration into the outputs.


### PR DESCRIPTION
Comment-only cleanup: during the review of https://github.com/elastic/beats/pull/35118, a particular field was changed from using a settings object to using a factory, but the associated comment didn't get updated so the checked-in code still reflects the now-nonexistent settings field.