### PR TITLE
Use UID for dockerfile to allow runasNonRoot to be used.

### DIFF
--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -168,8 +168,10 @@ RUN for iter in {1..10}; do \
 done; \
 (exit $exit_code)
 {{- end }}
+USER 1000
+{{- else }}
+USER 0
 {{- end }}
-USER {{ .user }}
 
 {{- range $i, $port := .ExposePorts }}
 EXPOSE {{ $port }}


### PR DESCRIPTION
See 
https://github.com/elastic/cloud-on-k8s/pull/6688#issuecomment-1514363649
and
https://github.com/elastic/cloud-on-k8s/issues/6740

Similar change was recently merged into [elasticsearch](https://github.com/elastic/elasticsearch/pull/95390) for the same issue.

This change will allow the beats container in Kubernetes to be ran with runAsNonRoot as it checks against the numeric UID, and not a name.

Without this change you encounter the following error:
```
  state:                                                                                                                                                                                                                                                                                                               │
│       waiting:                                                                                                                                                                                                                                                                                                           │
│         message: 'container has runAsNonRoot and image has non-numeric user (metricbeat),                                                                                                                                                                                                                                │
│           cannot verify user is non-root (pod: "elasticsearch-es-mixed-2_beats-3064(51b07a17-26c4-4301-9380-ea6fe3e75aca)",    
```