### PR TITLE
Resolve all linter issues for the `filestream` package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,8 +50,6 @@ linters:
     - unused # checks Go code for unused constants, variables, functions and types
     - govet # Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
     - ineffassign # detects when assignments to existing variables are not used
-    - structcheck # finds unused struct fields
-    - varcheck # Finds unused global variables and constants
     - asciicheck # simple linter to check that your code does not contain non-ASCII identifiers
     - bodyclose # checks whether HTTP response body is closed successfully
     - durationcheck # check for two durations multiplied together

--- a/filebeat/input/filestream/filestream.go
+++ b/filebeat/input/filestream/filestream.go
@@ -67,7 +67,7 @@ func newFileReader(
 	config readerConfig,
 	closerConfig closerConfig,
 ) (*logFile, error) {
-	offset, err := f.Seek(0, os.SEEK_CUR)
+	offset, err := f.Seek(0, io.SeekCurrent)
 	if err != nil {
 		return nil, err
 	}
@@ -137,17 +137,23 @@ func (f *logFile) Read(buf []byte) (int, error) {
 
 func (f *logFile) startFileMonitoringIfNeeded() {
 	if f.closeInactive > 0 || f.closeRemoved || f.closeRenamed {
-		f.tg.Go(func(ctx context.Context) error {
+		err := f.tg.Go(func(ctx context.Context) error {
 			f.periodicStateCheck(ctx)
 			return nil
 		})
+		if err != nil {
+			f.log.Errorf("failed to start file monitoring: %w", err)
+		}
 	}
 
 	if f.closeAfterInterval > 0 {
-		f.tg.Go(func(ctx context.Context) error {
+		err := f.tg.Go(func(ctx context.Context) error {
 			f.closeIfTimeout(ctx)
 			return nil
 		})
+		if err != nil {
+			f.log.Errorf("failed to schedule a file close: %w", err)
+		}
 	}
 }
 
@@ -158,12 +164,15 @@ func (f *logFile) closeIfTimeout(ctx unison.Canceler) {
 }
 
 func (f *logFile) periodicStateCheck(ctx unison.Canceler) {
-	timed.Periodic(ctx, f.checkInterval, func() error {
+	err := timed.Periodic(ctx, f.checkInterval, func() error {
 		if f.shouldBeClosed() {
 			f.readerCtx.Cancel()
 		}
 		return nil
 	})
+	if err != nil {
+		f.log.Errorf("failed to schedule a periodic state check: %w", err)
+	}
 }
 
 func (f *logFile) shouldBeClosed() bool {
@@ -221,7 +230,7 @@ func isSameFile(path string, info os.FileInfo) bool {
 // errorChecks determines the cause for EOF errors, and how the EOF event should be handled
 // based on the config options.
 func (f *logFile) errorChecks(err error) error {
-	if err != io.EOF {
+	if !errors.Is(err, io.EOF) {
 		f.log.Error("Unexpected state reading from %s; error: %s", f.file.Name(), err)
 		return err
 	}
@@ -256,6 +265,6 @@ func (f *logFile) handleEOF() error {
 func (f *logFile) Close() error {
 	f.readerCtx.Cancel()
 	err := f.file.Close()
-	f.tg.Stop() // Wait until all resources are released for sure.
+	_ = f.tg.Stop() // Wait until all resources are released for sure.
 	return err
 }

--- a/filebeat/input/filestream/filestream_test.go
+++ b/filebeat/input/filestream/filestream_test.go
@@ -80,8 +80,7 @@ func TestLogFileTimedClosing(t *testing.T) {
 			}
 
 			err = readUntilError(reader)
-
-			assert.Equal(t, test.expectedErr, err)
+			assert.ErrorIs(t, err, test.expectedErr)
 		})
 	}
 }

--- a/filebeat/input/filestream/identifier_inode_deviceid.go
+++ b/filebeat/input/filestream/identifier_inode_deviceid.go
@@ -48,16 +48,16 @@ func newINodeMarkerIdentifier(cfg *conf.C) (fileIdentifier, error) {
 	}
 	err := cfg.Unpack(&config)
 	if err != nil {
-		return nil, fmt.Errorf("error while reading configuration of INode + marker file configuration: %v", err)
+		return nil, fmt.Errorf("error while reading configuration of INode + marker file configuration: %w", err)
 	}
 
 	fi, err := os.Stat(config.MarkerPath)
 	if err != nil {
-		return nil, fmt.Errorf("error while opening marker file at %s: %v", config.MarkerPath, err)
+		return nil, fmt.Errorf("error while opening marker file at %s: %w", config.MarkerPath, err)
 	}
 	markerContent, err := ioutil.ReadFile(config.MarkerPath)
 	if err != nil {
-		return nil, fmt.Errorf("error while reading marker file at %s: %v", config.MarkerPath, err)
+		return nil, fmt.Errorf("error while reading marker file at %s: %w", config.MarkerPath, err)
 	}
 	return &inodeMarkerIdentifier{
 		log:                       logp.NewLogger("inode_marker_identifier_" + filepath.Base(config.MarkerPath)),

--- a/filebeat/input/filestream/internal/input-logfile/clean.go
+++ b/filebeat/input/filestream/internal/input-logfile/clean.go
@@ -44,10 +44,13 @@ type cleaner struct {
 // once the last event has been ACKed.
 func (c *cleaner) run(canceler unison.Canceler, store *store, interval time.Duration) {
 	started := time.Now()
-	timed.Periodic(canceler, interval, func() error {
+	err := timed.Periodic(canceler, interval, func() error {
 		gcStore(c.log, started, store)
 		return nil
 	})
+	if err != nil {
+		c.log.Errorf("failed to start the registry cleaning routine: %w", err)
+	}
 }
 
 // gcStore looks for resources to remove and deletes these. `gcStore` receives

--- a/filebeat/input/filestream/internal/input-logfile/publish.go
+++ b/filebeat/input/filestream/internal/input-logfile/publish.go
@@ -132,7 +132,10 @@ func (op *updateOp) Execute(store *store, n uint) {
 		resource.cursor = resource.pendingCursor()
 		resource.pendingCursorValue = nil
 	} else {
-		typeconv.Convert(&resource.cursor, op.delta)
+		err := typeconv.Convert(&resource.cursor, op.delta)
+		if err != nil {
+			store.log.Errorf("failed to perform type conversion: %w", err)
+		}
 	}
 
 	if resource.internalState.Updated.Before(op.timestamp) {

--- a/filebeat/input/filestream/internal/input-logfile/publish_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/publish_test.go
@@ -39,8 +39,8 @@ func TestPublish(t *testing.T) {
 			PublishFunc: func(event beat.Event) { actual = event },
 		}
 		publisher := cursorPublisher{nil, client, &cursor}
-		publisher.Publish(beat.Event{}, "test")
-
+		err := publisher.Publish(beat.Event{}, "test")
+		require.NoError(t, err)
 		require.NotNil(t, actual.Private)
 	})
 
@@ -54,7 +54,8 @@ func TestPublish(t *testing.T) {
 			PublishFunc: func(event beat.Event) { actual = event },
 		}
 		publisher := cursorPublisher{nil, client, &cursor}
-		publisher.Publish(beat.Event{}, nil)
+		err := publisher.Publish(beat.Event{}, nil)
+		require.NoError(t, err)
 		require.Nil(t, actual.Private)
 	})
 

--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -27,6 +27,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/cleanup"
 	"github.com/elastic/beats/v7/libbeat/common/transform/typeconv"
 	"github.com/elastic/beats/v7/libbeat/statestore"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-concert"
 	"github.com/elastic/go-concert/unison"
@@ -369,7 +370,7 @@ func (s *store) resetCursor(key string, cur interface{}) error {
 	r.activeCursorOperations = 0
 	r.pendingCursorValue = nil
 	r.pendingUpdate = nil
-	typeconv.Convert(&r.cursor, cur) //nolint: errcheck // not changing behaviour on this commit
+	typeconv.Convert(&r.cursor, cur) //nolint:errcheck // not changing behaviour on this commit
 
 	s.writeState(r)
 
@@ -539,7 +540,8 @@ func (r *resource) copyWithNewKey(key string) *resource {
 // pendingCursor returns the current published cursor state not yet ACKed.
 //
 // Note: The stateMutex must be locked when calling pendingCursor.
-// nolint: errcheck // not changing behaviour on this commit
+//
+//nolint:errcheck // not changing behaviour on this commit
 func (r *resource) pendingCursor() interface{} {
 	if r.pendingUpdate != nil {
 		var tmp interface{}

--- a/filebeat/input/filestream/internal/input-logfile/store_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/store_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// nolint: errcheck // Some errors are not checked on tests/helper functions
+//nolint:errcheck // Some errors are not checked on tests/helper functions
 package input_logfile
 
 import (
@@ -30,6 +30,7 @@ import (
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/statestore"
 	"github.com/elastic/beats/v7/libbeat/statestore/storetest"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-concert/unison"
 )
@@ -396,7 +397,7 @@ func TestSourceStore_UpdateIdentifiers(t *testing.T) {
 	})
 }
 
-// nolint: dupl // Test code won't be refactored on this commit
+//nolint:dupl // Test code won't be refactored on this commit
 func TestSourceStore_CleanIf(t *testing.T) {
 	t.Run("entries are cleaned when function returns true", func(t *testing.T) {
 		backend := createSampleStore(t, map[string]state{
@@ -471,7 +472,7 @@ func closeStoreWith(fn func(s *store)) func() {
 	}
 }
 
-// nolint: unparam // It's a test helper
+//nolint:unparam // It's a test helper
 func testOpenStore(t *testing.T, prefix string, persistentStore StateStore) *store {
 	if persistentStore == nil {
 		persistentStore = createSampleStore(t, nil)
@@ -568,7 +569,8 @@ func storeInSyncSnapshot(store *store) map[string]state {
 // fails with Errorf if the state differ.
 //
 // Note: testify is too strict when comparing timestamp, better use checkEqualStoreState.
-// nolint: unparam // It's a test helper
+//
+//nolint:unparam // It's a test helper
 func checkEqualStoreState(t *testing.T, want, got map[string]state) bool {
 	t.Helper()
 	if d := cmp.Diff(want, got); d != "" {

--- a/filebeat/input/filestream/prospector.go
+++ b/filebeat/input/filestream/prospector.go
@@ -26,6 +26,7 @@ import (
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	"github.com/elastic/beats/v7/libbeat/beat"
+
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-concert/unison"
 )
@@ -125,7 +126,8 @@ func (p *fileProspector) Init(
 }
 
 // Run starts the fileProspector which accepts FS events from a file watcher.
-// nolint: dupl // Different prospectors have a similar run method
+//
+//nolint:dupl // Different prospectors have a similar run method
 func (p *fileProspector) Run(ctx input.Context, s loginp.StateMetadataUpdater, hg loginp.HarvesterGroup) {
 	log := ctx.Logger.With("prospector", prospectorDebugKey)
 	log.Debug("Starting prospector")

--- a/filebeat/input/filestream/prospector_test.go
+++ b/filebeat/input/filestream/prospector_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// nolint: errcheck // It's a test file
+//nolint:errcheck // It's a test file
 package filestream
 
 import (


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

So, we have no more old issues highlighted on our PRs.

Also removed deprecated linters.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

It increased the quality of the code, uncovers some previously hidden errors and makes it more welcoming for external contributors who decide to open a PR to the `filestream` package.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

run

```sh
golangci-lint run ./...
```

in `./filebeat/input/filestream`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

- Closes https://github.com/elastic/beats/issues/35212