### PR TITLE
[Filebeat] Add dataset support to output

### DIFF
--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -25,7 +25,7 @@ filebeat.inputs:
   id: my-filestream-id
 
   # Change to true to enable this input configuration.
-  enabled: false
+  enabled: true
 
   # Paths that should be crawled and fetched. Glob based paths.
   paths:
@@ -141,12 +141,15 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # Protocol - either `http` (default) or `https`.
-  #protocol: "https"
+  protocol: "https"
+  ssl.verification_mode: "none"
+
+  dataset: "foo"
 
   # Authentication credentials - either API key or username/password.
   #api_key: "id:api_key"
-  #username: "elastic"
-  #password: "changeme"
+  username: "elastic"
+  password: "changeme"
 
 # ------------------------------ Logstash Output -------------------------------
 #output.logstash:

--- a/libbeat/idxmgmt/std.go
+++ b/libbeat/idxmgmt/std.go
@@ -168,6 +168,14 @@ func (s *indexSupport) BuildSelector(cfg *config.C) (outputs.IndexSelector, erro
 		}
 	}
 
+	if cfg.HasField("dataset") {
+		indexName, err = cfg.String("dataset", -1)
+		indexName = "logs-" + indexName + "-default"
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// no index name configuration found yet -> define default index name based on
 	// beat.Info provided to the indexSupport on during setup.
 	if indexName == "" {


### PR DESCRIPTION
Note: Please review the concept, not the code. The code will change / be cleaned up.

This adds `dataset` config support to the output of Beats (all Beast, not just Filebeat). This is similar to https://github.com/elastic/beats/pull/35287 but instead on the input side. As the index value is overwritten, also patterns could be used to set this value like described in https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html#index-option-es

It is expected that the following 3 configs are supported:

```
data_stream.type
data_stream.dataset
data_stream.namespace
```

If one of the 3 values is set, the other ones get their defaults and the [data stream naming scheme](https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme) is used. Config values must be validated. Docs must be added.

The benefit of having this is that it would make it much easier for users to use the data stream naming scheme by default for their data.

It should be discussed, if this setting on the output really makes sense. The reason is that the data stream naming scheme encourages to use different dataset for different data types. But setting it on the output would send all data to the same data stream if no patterns are used. This is beneficial in the context of data sink inputs like syslog. At the same time, it could be argued that this setting will already be available at the input level.

Another option is that we set a default to `logs-filebeat-default` if `data_stream.type` is set. Like this users still have a single data stream but are setup with the data stream naming scheme and can use routing as a follow up to start to split up the data.
