### PR TITLE
[add_cloud_metadata processor] add cloud.region field to GCE cloud provider

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -65,6 +65,7 @@ https://github.com/elastic/beats/compare/v8.2.0\...main[Check the HEAD diff]
 - Fix Beats started by agent do not respect the allow_older_versions: true configuration flag {issue}34227[34227] {pull}34964[34964]
 - Fix performance issues when we have a lot of inputs starting and stopping by allowing to disable global processors under fleet. {issue}35000[35000] {pull}35031[35031]
 - In cases where the matcher detects a non-string type in a match statement, report the error as a debug statement, and not a warning statement. {pull}35119[35119]
+- 'add_cloud_metadata' processor - add cloud.region field for GCE cloud provider
 
 *Auditbeat*
 

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -344,6 +344,7 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 				"type": "f1-micro",
 			},
 			"availability_zone": "us-east1-b",
+			"region":            "us-east1",
 			"project": mapstr.M{
 				"id": "test-dev",
 			},
@@ -392,6 +393,7 @@ func TestRetrieveGCEMetadataInK8s(t *testing.T) {
 				"type": "f1-micro",
 			},
 			"availability_zone": "us-east1-b",
+			"region":            "us-east1",
 			"project": mapstr.M{
 				"id": "test-dev",
 			},
@@ -457,6 +459,7 @@ func TestRetrieveGCEMetadataInK8sNotOverriden(t *testing.T) {
 				"type": "f1-micro",
 			},
 			"availability_zone": "us-east1-b",
+			"region":            "us-east1",
 			"project": mapstr.M{
 				"id": "test-dev",
 			},
@@ -511,6 +514,7 @@ func TestRetrieveGCEMetadataInK8sPartial(t *testing.T) {
 				"type": "f1-micro",
 			},
 			"availability_zone": "us-east1-b",
+			"region":            "us-east1",
 			"project": mapstr.M{
 				"id": "test-dev",
 			},


### PR DESCRIPTION
## What does this PR do?

Add cloud.region field to GCE cloud provider

## Why is it important?

To align with other cloud providers

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

Before:
<img width="1222" alt="Screenshot 2023-05-03 at 12 08 43" src="https://user-images.githubusercontent.com/28299531/235890645-f9356394-d49b-471a-8f5d-caeac9105e51.png">

After:
<img width="1084" alt="Screenshot 2023-05-03 at 12 16 08" src="https://user-images.githubusercontent.com/28299531/235890709-3a5e2ade-55ee-4ca9-988e-134635a5b3a9.png">


## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
