### PR TITLE
[8.2](backport #35257) [Docs] Update logging.files.permissions documentation to consider umask

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Beats
-Copyright 2014-2022 Elasticsearch BV
+Copyright 2014-2023 Elasticsearch BV
 
 This product includes software developed by The Apache Software 
 Foundation (http://www.apache.org/).

--- a/filebeat/docs/filebeat-general-options.asciidoc
+++ b/filebeat/docs/filebeat-general-options.asciidoc
@@ -40,6 +40,9 @@ That means in case there are some states where the TTL expired, these are only r
 
 The permissions mask to apply on registry data file. The default value is 0600. The permissions option must be a valid Unix-style file permissions mask expressed in octal notation. In Go, numbers in octal notation must start with 0.
 
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to an umask of 0027.
+
 This option is not supported on Windows.
 
 Examples:

--- a/libbeat/docs/loggingconfig.asciidoc
+++ b/libbeat/docs/loggingconfig.asciidoc
@@ -231,6 +231,9 @@ The permissions mask to apply when rotating log files. The default value is
 expressed in octal notation. In Go, numbers in octal notation must start with
 '0'.
 
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to an umask of 0027.
+
 This option is not supported on Windows.
 
 Examples:


### PR DESCRIPTION
manual backport of https://github.com/elastic/beats/pull/35257