### PR TITLE
Revert "ci: disable upstream integration"

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -38,8 +38,7 @@ pipeline {
   triggers {
     issueCommentTrigger('(?i)^\\/packag[ing|e]$')
     // disable upstream trigger on a PR basis
-    // NOTE(v1v): disable the upstream integration for 8.7.1 release
-    //upstream("Beats/beats/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
+    upstream("Beats/beats/${ env.JOB_BASE_NAME.startsWith('PR-') ? 'none' : env.JOB_BASE_NAME }")
   }
   parameters {
     booleanParam(name: 'run_e2e', defaultValue: true, description: 'Allow to disable the e2e tets. This workaround will generate broken/buggy binaries.')


### PR DESCRIPTION
Reverts #35179.

In #35179, we temporarily prevented upstream builds from triggering the Beats Packaging (DRA) job while `8.7.1` was being released, because the DRA was being re-built too frequently.  This PR reverts that change so the upstream trigger is re-enabled.