### PR TITLE
Promote IBM MQ module to GA

### DIFF
--- a/metricbeat/docs/modules/ibmmq.asciidoc
+++ b/metricbeat/docs/modules/ibmmq.asciidoc
@@ -10,8 +10,6 @@ This file is generated! See scripts/mage/docs_collector.go
 [role="xpack"]
 == IBM MQ module
 
-beta[]
-
 This module periodically fetches metrics from a containerized distribution of IBM MQ.
 
 [float]

--- a/metricbeat/docs/modules/ibmmq/qmgr.asciidoc
+++ b/metricbeat/docs/modules/ibmmq/qmgr.asciidoc
@@ -8,8 +8,6 @@ This file is generated! See scripts/mage/docs_collector.go
 [role="xpack"]
 === IBM MQ qmgr metricset
 
-beta[]
-
 include::../../../../x-pack/metricbeat/module/ibmmq/qmgr/_meta/docs.asciidoc[]
 
 This is a default metricset. If the host module is unconfigured, this metricset is enabled by default.

--- a/metricbeat/docs/modules_list.asciidoc
+++ b/metricbeat/docs/modules_list.asciidoc
@@ -142,8 +142,8 @@ This file is generated! See scripts/mage/docs_collector.go
 |<<metricbeat-module-http,HTTP>>     |image:./images/icon-no.png[No prebuilt dashboards]    |  
 .2+| .2+|  |<<metricbeat-metricset-http-json,json>>   
 |<<metricbeat-metricset-http-server,server>>   
-|<<metricbeat-module-ibmmq,IBM MQ>>  beta[]   |image:./images/icon-yes.png[Prebuilt dashboards are available]    |  
-.1+| .1+|  |<<metricbeat-metricset-ibmmq-qmgr,qmgr>> beta[]  
+|<<metricbeat-module-ibmmq,IBM MQ>>     |image:./images/icon-yes.png[Prebuilt dashboards are available]    |  
+.1+| .1+|  |<<metricbeat-metricset-ibmmq-qmgr,qmgr>>   
 |<<metricbeat-module-iis,IIS>>     |image:./images/icon-yes.png[Prebuilt dashboards are available]    |  
 .3+| .3+|  |<<metricbeat-metricset-iis-application_pool,application_pool>>   
 |<<metricbeat-metricset-iis-webserver,webserver>>   

--- a/x-pack/metricbeat/module/ibmmq/_meta/fields.yml
+++ b/x-pack/metricbeat/module/ibmmq/_meta/fields.yml
@@ -1,6 +1,6 @@
 - key: ibmmq
   title: 'IBM MQ'
-  release: beta
+  release: ga
   description: >
     IBM MQ module
   settings: ["ssl", "http"]

--- a/x-pack/metricbeat/module/ibmmq/fields.go
+++ b/x-pack/metricbeat/module/ibmmq/fields.go
@@ -19,5 +19,5 @@ func init() {
 // AssetIbmmq returns asset data.
 // This is the base64 encoded zlib format compressed contents of module/ibmmq.
 func AssetIbmmq() string {
-	return "eJxUzrGugkAQheF+n+LPNjSXF9jiFnYWFNbGAmTEjbuwMkPB2xvFRJ1ycr6cU3OTNRC7nO8OLFqSQLXfNTSHysEsSVqVQCfWOuhFz3MsFqcx8O8AtjB56pckDlTM4jho4OhVk//DX82KPzm4REm9hperGdssn/Ln2VokMMzTUt6fb7Gp30mPAAAA//+eWDd6"
+	return "eJxMjrGugkAURPv9ipNtaB4/sMUr7CworI0FyhU37sLKvRT8vUFMZMrJnJypecoSiNecXw4sWpJAdTw0NKfKwSRJWpVA3zroRG9TLBbHIfDvALYpeezmJA5UzOLQa+DsVZP/wz/Mir84uEdJnYYPVzO0WX7qNbaU1TSNc/k2e2Kj9ofeAQAA//+a1zXS"
 }

--- a/x-pack/metricbeat/module/ibmmq/qmgr/_meta/fields.yml
+++ b/x-pack/metricbeat/module/ibmmq/qmgr/_meta/fields.yml
@@ -1,1 +1,1 @@
-- release: beta
+- release: ga


### PR DESCRIPTION
## What does this PR do?

Changes the release state to GA

Steps to create this PR:

1. Edit thte yaml files under the _meta folders in the module directory and set the release state (ga in this case):
x-pack/metricbeat/module/ibmmq/_meta/fields.yml and x-pack/metricbeat/module/ibmmq/qmgr/_meta/fields.yml. Notice that the module and its metricsets can have different release states. You can have a GA module with Beta metricsets.
2. CD to the beats root and run `make update`

The following doc pages will be updated when you run the make script:

http://localhost:8000/guide/metricbeat-module-ibmmq.html
http://localhost:8000/guide/metricbeat-metricset-ibmmq-qmgr.html
http://localhost:8000/guide/metricbeat-modules.html

(I'll fix these ^^ links when the preview is available)

## Why is it important?

Removes the warning admonition from the docs.

## Checklist

- [x] My code follows the style guidelines of this project