### PR TITLE
[Heartbeat] Fix run from location in states loader

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -141,6 +141,7 @@ with the ecs field name `container`. {pull}34403[34403]
 automatic splitting at root level, if root level element is an array. {pull}34155[34155]
 - Fix broken mapping for state.ends field. {pull}34891[34891]
 - Fix issue using projects in airgapped environments by disabling npm audit. {pull}34936[34936]
+- Fix broken state ID location naming. {pull}35336[35336]
 
 *Heartbeat*
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -131,6 +131,7 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 		}),
 		trace: trace,
 	}
+	logp.L().Infof("heartbeat starting, running from: %v", parsedConfig.RunFrom.ID)
 	return bt, nil
 }
 
@@ -300,7 +301,7 @@ func makeStatesClient(cfg *conf.C, replace func(monitorstate.StateLoader), runFr
 	}
 
 	if esClient != nil {
-		logp.L().Info("replacing states loader")
+		logp.L().Info("using ES states loader")
 		replace(monitorstate.MakeESLoader(esClient, "synthetics-*,heartbeat-*", runFrom))
 	}
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -131,7 +131,11 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 		}),
 		trace: trace,
 	}
-	logp.L().Infof("heartbeat starting, running from: %v", parsedConfig.RunFrom.ID)
+	runFromID := "<unknown location>"
+	if parsedConfig.RunFrom != nil {
+		runFromID = parsedConfig.RunFrom.ID
+	}
+	logp.L().Infof("heartbeat starting, running from: %v", runFromID)
 	return bt, nil
 }
 

--- a/heartbeat/hbtestllext/isdefs.go
+++ b/heartbeat/hbtestllext/isdefs.go
@@ -18,6 +18,8 @@
 package hbtestllext
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -61,6 +63,22 @@ var IsMonitorState = isdef.Is("isState", func(path llpath.Path, v interface{}) *
 	}
 	return llresult.ValidResult(path)
 })
+
+var IsMonitorStateInLocation = func(locName string) isdef.IsDef {
+	locPattern := fmt.Sprintf("^%s-[a-z0-9]+-0$", locName)
+	stateIdMatch := regexp.MustCompile(locPattern)
+	return isdef.Is("isState", func(path llpath.Path, v interface{}) *llresult.Results {
+		s, ok := v.(monitorstate.State)
+		if !ok {
+			return llresult.SimpleResult(path, false, "expected a monitorstate.State")
+		}
+
+		if !stateIdMatch.MatchString(s.ID) {
+			return llresult.SimpleResult(path, false, fmt.Sprintf("ID %s does not match regexp pattern /%s/", s.ID, locPattern))
+		}
+		return llresult.ValidResult(path)
+	})
+}
 
 var IsECSErr = func(expectedErr *ecserr.ECSErr) isdef.IsDef {
 	return isdef.Is("matches ECS ERR", func(path llpath.Path, v interface{}) *llresult.Results {

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -167,12 +167,15 @@ func (f *RunnerFactory) Create(p beat.Pipeline, c *conf.C) (cfgfile.Runner, erro
 	}
 	loc := getLocation(f.beatLocation, sf)
 	geoMap, _ := util.GeoConfigToMap(loc.Geo)
-	c.Merge(map[string]interface{}{
+	err = c.Merge(map[string]interface{}{
 		"run_from": map[string]interface{}{
 			"id":  f.beatLocation.ID,
 			"geo": geoMap,
 		},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("could not merge location into monitor map: %w", err)
+	}
 
 	monitor, err := newMonitor(c, f.pluginsReg, pc, f.addTask, f.stateLoader, safeStop)
 	if err != nil {

--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -159,6 +159,21 @@ func (f *RunnerFactory) Create(p beat.Pipeline, c *conf.C) (cfgfile.Runner, erro
 	if err != nil {
 		return nil, fmt.Errorf("could not create pipeline client via factory: %w", err)
 	}
+
+	// The state loader needs the beat location to accurately load the last state
+	sf, err := stdfields.ConfigToStdMonitorFields(c)
+	if err != nil {
+		return nil, fmt.Errorf("could not load stdfields in factory: %w", err)
+	}
+	loc := getLocation(f.beatLocation, sf)
+	geoMap, _ := util.GeoConfigToMap(loc.Geo)
+	c.Merge(map[string]interface{}{
+		"run_from": map[string]interface{}{
+			"id":  f.beatLocation.ID,
+			"geo": geoMap,
+		},
+	})
+
 	monitor, err := newMonitor(c, f.pluginsReg, pc, f.addTask, f.stateLoader, safeStop)
 	if err != nil {
 		return nil, fmt.Errorf("factory could not create monitor: %w", err)
@@ -183,6 +198,18 @@ func (f *RunnerFactory) CheckConfig(config *conf.C) error {
 	return checkMonitorConfig(config, plugin.GlobalPluginsReg)
 }
 
+func getLocation(beatLocation *config.LocationWithID, sf stdfields.StdMonitorFields) (loc *config.LocationWithID) {
+	// Use the monitor-specific location if possible, otherwise use the beat's location
+	// Generally speaking direct HB users would use the beat location, and the synthetics service may as well (TBD)
+	// while Fleet configured monitors will always use a per location monitor
+	if sf.RunFrom != nil {
+		loc = sf.RunFrom
+	} else {
+		loc = beatLocation
+	}
+	return loc
+}
+
 func newCommonPublishConfigs(info beat.Info, beatLocation *config.LocationWithID, cfg *conf.C) (pipetool.ConfigEditor, error) {
 	var settings publishSettings
 	if err := cfg.Unpack(&settings); err != nil {
@@ -195,16 +222,8 @@ func newCommonPublishConfigs(info beat.Info, beatLocation *config.LocationWithID
 	}
 
 	// Early stage processors for setting data_stream, event.dataset, and index to write to
+	loc := getLocation(beatLocation, sf)
 
-	// Use the monitor-specific location if possible, otherwise use the beat's location
-	// Generally speaking direct HB users would use the beat location, and the synthetics service may as well (TBD)
-	// while Fleet configured monitors will always use a per location monitor
-	var loc *config.LocationWithID
-	if sf.RunFrom != nil {
-		loc = sf.RunFrom
-	} else {
-		loc = beatLocation
-	}
 	preProcs, err := preProcessors(info, loc, settings, sf.Type)
 	if err != nil {
 		return nil, err

--- a/heartbeat/monitors/wrappers/monitorstate/monitorstate.go
+++ b/heartbeat/monitors/wrappers/monitorstate/monitorstate.go
@@ -74,6 +74,13 @@ type State struct {
 	ctr             int
 }
 
+func (s *State) String() string {
+	if s == nil {
+		return "<monitorstate:nil>"
+	}
+	return fmt.Sprintf("<monitorstate:id=%s,started=%s,up=%d,down=%d>", s.ID, s.StartedAt, s.Up, s.Down)
+}
+
 func (s *State) incrementCounters(status StateStatus) {
 	s.DurationMs = time.Since(s.StartedAt).Milliseconds()
 	s.Checks++

--- a/heartbeat/monitors/wrappers/monitorstate/tracker.go
+++ b/heartbeat/monitors/wrappers/monitorstate/tracker.go
@@ -65,6 +65,7 @@ func (t *Tracker) RecordStatus(sf stdfields.StdMonitorFields, newStatus StateSta
 	state := t.getCurrentState(sf)
 	if state == nil {
 		state = newMonitorState(sf, newStatus, 0, t.flappingEnabled)
+		logp.L().Infof("initializing new state for monitor %s: %s", sf.ID, state.String())
 		t.states[sf.ID] = state
 	} else {
 		state.recordCheck(sf, newStatus)
@@ -84,6 +85,9 @@ func (t *Tracker) getCurrentState(sf stdfields.StdMonitorFields) (state *State) 
 	for i := 0; i < tries; i++ {
 		loadedState, err = t.stateLoader(sf)
 		if err == nil {
+			if loadedState != nil {
+				logp.L().Infof("loaded previous state for monitor %s: %s", sf.ID, loadedState.String())
+			}
 			break
 		}
 

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -19,15 +19,13 @@ heartbeat.config.monitors:
   # How often to check for changes
   reload.period: 5s
 
-heartbeat.run_once: true
-
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
   # Set enabled to true (or delete the following line) to enable this example monitor
-  enabled: true
+  enabled: false
   # ID used to uniquely identify this monitor in elasticsearch even if the config changes
-  id: my-monitor-aoeuncoaeuc
+  id: my-monitor
   # Human readable display name for this service in Uptime UI and elsewhere
   name: My Monitor
   # List or urls to query
@@ -38,8 +36,6 @@ heartbeat.monitors:
   #timeout: 16s
   # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
   #service.name: my-apm-service-name
-heartbeat.run_from:
-  id: minneapolis
 
 # Experimental: Set this to true to run heartbeat monitors exactly once at startup
 #heartbeat.run_once: true
@@ -102,9 +98,9 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 # ---------------------------- Elasticsearch Output ----------------------------
-#output.elasticsearch:
+output.elasticsearch:
   # Array of hosts to connect to.
-  #hosts: ["localhost:9200"]
+  hosts: ["localhost:9200"]
 
   # Protocol - either `http` (default) or `https`.
   #protocol: "https"

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -19,13 +19,15 @@ heartbeat.config.monitors:
   # How often to check for changes
   reload.period: 5s
 
+heartbeat.run_once: true
+
 # Configure monitors inline
 heartbeat.monitors:
 - type: http
   # Set enabled to true (or delete the following line) to enable this example monitor
-  enabled: false
+  enabled: true
   # ID used to uniquely identify this monitor in elasticsearch even if the config changes
-  id: my-monitor
+  id: my-monitor-aoeuncoaeuc
   # Human readable display name for this service in Uptime UI and elsewhere
   name: My Monitor
   # List or urls to query
@@ -36,6 +38,8 @@ heartbeat.monitors:
   #timeout: 16s
   # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
   #service.name: my-apm-service-name
+heartbeat.run_from:
+  id: minneapolis
 
 # Experimental: Set this to true to run heartbeat monitors exactly once at startup
 #heartbeat.run_once: true
@@ -98,9 +102,9 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 # ---------------------------- Elasticsearch Output ----------------------------
-output.elasticsearch:
+#output.elasticsearch:
   # Array of hosts to connect to.
-  hosts: ["localhost:9200"]
+  #hosts: ["localhost:9200"]
 
   # Protocol - either `http` (default) or `https`.
   #protocol: "https"

--- a/x-pack/heartbeat/scenarios/basics_test.go
+++ b/x-pack/heartbeat/scenarios/basics_test.go
@@ -83,6 +83,7 @@ func TestRunFromOverride(t *testing.T) {
 	scenarioDB.RunAllWithATwist(t, TwistAddRunFrom, func(t *testing.T, mtr *framework.MonitorTestRun, err error) {
 		for _, e := range mtr.Events() {
 			testslike.Test(t, lookslike.MustCompile(map[string]interface{}{
+				"state": hbtestllext.IsMonitorStateInLocation(TestLocationDefault.ID),
 				"observer": map[string]interface{}{
 					"name": TestLocationDefault.ID,
 					"geo": map[string]interface{}{


### PR DESCRIPTION
The states loader currently does not correctly read the location from the `heartbeat.run_from.id` config option. It's currently only applied to the `observer.*` fields. This patch fixes that. It also makes the logs more clear.

Note that we now log on each __initial__ state for a monitor. This means one more log line, but only on the first exec of that monitor.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] below test has been run

## How to test this PR locally

Enable a monitor, either lightweight or browser, and set in your hearbeat config:

```
heartbeat.run_once: true
heartbeat.run_from:
  id: minneapolis
```

Then run with

```
mage build && ./heartbeat -e -E cloud.id=$CLOUD_ID -E cloud.auth=$CLOUD_AUTH -E output.elasticsearch.allow_older_versions=
true 2>&1 | jq .message
```

Look for the output:

```
"no previous state found for monitor my-monitor-aoeuncoaeuc in Elasticsearch (loc=minneapolis)"
"initializing new state for monitor my-monitor-aoeuncoaeuc: <monitorstate:id=minneapolis-187e85ec8e9-0,started=2023-05-04 15:05:38.665323551 -0500 CDT m=+1.134478775,up=0,down=1>"
```

for your monitor, if it does not have previous state in ES

And if it does have previous state (which it should on the next run):

```
"loaded previous state for monitor my-monitor-aoeuncoaeuc: <monitorstate:id=minneapolis-187e85ec8e9-0,started=2023-05-04 15:05:38.665323551 -0500 CDT,up=0,down=1>"
```

Note that the state ID should look like: `minneapolis-187e85ec8e9-0` where the first string is the `run_from.id` value.