### PR TITLE
updatecli: use golang-crossbuild repository

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -25,6 +25,8 @@ actions:
       labels:
         - dependencies
         - backport-skip
+      description: |
+        Generated automatically with {{ requiredEnv "JOB_URL" }}
 
 sources:
   minor:

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -25,10 +25,6 @@ actions:
       labels:
         - dependencies
         - backport-skip
-      description: |
-        It requires the version to be bumped first in golang-crossbuild project, then a new release will be added to:
-        https://github.com/elastic/golang-crossbuild/releases/tag/v{{ source "latestGoVersion" }}.
-        Otherwise it will fail until the docker images are available.
 
 sources:
   minor:
@@ -47,15 +43,15 @@ sources:
     dependson:
       - minor
     transformers:
-      - trimprefix: go
+      - trimprefix: v
     spec:
-      owner: golang
-      repository: go
+      owner: elastic
+      repository: golang-crossbuild
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
       versionfilter:
         kind: regex
-        pattern: go1\.{{ source "minor" }}\.(\d*)$
+        pattern: v1\.{{ source "minor" }}\.(\d*)$
 
   gomod:
     dependson:

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
 jobs:
   bump:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this PR do?

Remove the non-dependency with elastic/golang-crossbuild and use the `elastic/golang-crossbuild` to search for the releases rather than `golang/go`
 
## Why is it important?

Remove 

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/2871786/236398036-176c2287-4097-4d7e-8049-1419fd1cf060.png">

In favour of using the latest known release from https://github.com/elastic/golang-crossbuild/releases

The existing automation in `elastic/golang-crossbuild` is in charge of `auto-merge` (see https://github.com/elastic/golang-crossbuild/blob/30b8ae9b4f6c7904b702e767d8ac630823b82ba7/.mergify.yml#L57-L66)