### PR TITLE
Remove unused pipeline callback ClientListener.FilteredOut

### DIFF
--- a/filebeat/beater/channels.go
+++ b/filebeat/beater/channels.go
@@ -149,7 +149,6 @@ func (*countingClientListener) Closing()   {}
 func (*countingClientListener) Closed()    {}
 func (*countingClientListener) Published() {}
 
-func (c *countingClientListener) FilteredOut(_ beat.Event) {}
 func (c *countingClientListener) DroppedOnPublish(_ beat.Event) {
 	c.wgEvents.Done()
 }
@@ -167,11 +166,6 @@ func (c *combinedClientListener) Closed() {
 func (c *combinedClientListener) Published() {
 	c.a.Published()
 	c.b.Published()
-}
-
-func (c *combinedClientListener) FilteredOut(event beat.Event) {
-	c.a.FilteredOut(event)
-	c.b.FilteredOut(event)
 }
 
 func (c *combinedClientListener) DroppedOnPublish(event beat.Event) {

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -136,7 +136,6 @@ type ClientListener interface {
 	Closed()  // Closed indicates the client being fully shutdown
 
 	Published()             // event has successfully entered the queue
-	FilteredOut(Event)      // event has been filtered out/dropped by processors
 	DroppedOnPublish(Event) // event has been dropped, while waiting for the queue
 }
 

--- a/libbeat/publisher/pipeline/client.go
+++ b/libbeat/publisher/pipeline/client.go
@@ -205,9 +205,6 @@ func (c *client) onPublished() {
 func (c *client) onFilteredOut(e beat.Event) {
 	c.logger.Debugf("Pipeline client receives callback 'onFilteredOut' for event: %+v", e)
 	c.observer.filteredEvent()
-	if c.clientListener != nil {
-		c.clientListener.FilteredOut(e)
-	}
 }
 
 func (c *client) onDroppedOnPublish(e beat.Event) {


### PR DESCRIPTION
Remove the `FilteredOut` callback from the `ClientListener` interface. This callback was redundant with the `EventListener.AddEvent(_, false)` callback, which is called under identical circumstances and at the same time, however unlike `AddEvent` no current listener implementations perform any actions in `FilteredOut`, nor is it documented anywhere outside its interface definition. This PR is just a cleanup, it doesn't change any behavior.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
