### PR TITLE
[Metricbeat]Move kibana module object instatiation and validations out of metrics…

### DIFF
--- a/metricbeat/module/kibana/cluster_actions/cluster_actions.go
+++ b/metricbeat/module/kibana/cluster_actions/cluster_actions.go
@@ -54,24 +54,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	actionsHTTP, err := helper.NewHTTP(ms.BaseMetricSet)
-	if err != nil {
-		return nil, err
-	}
-	kibanaVersion, err := kibana.GetVersion(actionsHTTP, kibana.ClusterActionsPath)
-	if err != nil {
-		return nil, err
-	}
-
-	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
-	if !isMetricsAPIAvailable {
-		const errorMsg = "the %v cluster actions is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return nil, fmt.Errorf(errorMsg, ms.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
-	}
-
 	return &MetricSet{
 		MetricSet:   ms,
-		actionsHTTP: actionsHTTP,
 	}, nil
 }
 
@@ -79,9 +63,35 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
+	if err = m.init(); err != nil {
+		return err
+	}
+
 	if err = m.fetchMetrics(r); err != nil {
 		return fmt.Errorf("error trying to get cluster action data from Kibana: %w", err)
 	}
+
+	return nil
+}
+
+func (m *MetricSet) init() error {
+	actionsHTTP, err := helper.NewHTTP(m.BaseMetricSet)
+	if err != nil {
+		return err
+	}
+
+	kibanaVersion, err := kibana.GetVersion(actionsHTTP, kibana.ClusterActionsPath)
+	if err != nil {
+		return err
+	}
+
+	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
+	if !isMetricsAPIAvailable {
+		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
+		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
+	}
+
+	m.actionsHTTP = actionsHTTP
 
 	return nil
 }

--- a/metricbeat/module/kibana/cluster_actions/cluster_actions.go
+++ b/metricbeat/module/kibana/cluster_actions/cluster_actions.go
@@ -76,7 +76,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 		return err
 	}
 
-	if (!versionSupported) {
+	if !versionSupported {
 		return nil
 	}
 
@@ -87,10 +87,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (err error, versionSupported bool) {
+func (m *MetricSet) validate() (error, bool) {
 	kibanaVersion, err := kibana.GetVersion(m.actionsHTTP, kibana.ClusterActionsPath)
 	if err != nil {
-		return err, false;
+		return err, false
 	}
 
 	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
@@ -101,10 +101,10 @@ func (m *MetricSet) validate() (err error, versionSupported bool) {
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
 
-		return nil, false;
+		return nil, false
 	}
 
-	return nil, true;
+	return nil, true
 }
 
 func (m *MetricSet) fetchMetrics(r mb.ReporterV2) error {

--- a/metricbeat/module/kibana/cluster_actions/cluster_actions.go
+++ b/metricbeat/module/kibana/cluster_actions/cluster_actions.go
@@ -19,6 +19,7 @@ package cluster_actions
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -44,7 +45,8 @@ var (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*kibana.MetricSet
-	actionsHTTP *helper.HTTP
+	actionsHTTP                       *helper.HTTP
+	lastRunningKibanaMessageTimestamp time.Time
 }
 
 // New create a new instance of the MetricSet
@@ -88,8 +90,11 @@ func (m *MetricSet) validate() error {
 
 	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
 	if !isMetricsAPIAvailable {
-		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
+		if time.Since(m.lastRunningKibanaMessageTimestamp) > 5*time.Minute {
+			m.lastRunningKibanaMessageTimestamp = time.Now()
+			const errorMsg = "the %v cluster actions is only supported with Kibana >= %v. You are currently running Kibana %v"
+			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
+		}
 	}
 
 	return nil

--- a/metricbeat/module/kibana/cluster_actions/cluster_actions.go
+++ b/metricbeat/module/kibana/cluster_actions/cluster_actions.go
@@ -87,7 +87,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (error, bool) {
+func (m *MetricSet) validate() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.actionsHTTP, kibana.ClusterActionsPath)
 	if err != nil {
 		return err, false

--- a/metricbeat/module/kibana/cluster_actions/cluster_actions.go
+++ b/metricbeat/module/kibana/cluster_actions/cluster_actions.go
@@ -54,8 +54,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	actionsHTTP, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MetricSet{
-		MetricSet: ms,
+		MetricSet:   ms,
+		actionsHTTP: actionsHTTP,
 	}, nil
 }
 
@@ -63,7 +69,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
-	if err = m.init(); err != nil {
+	if err = m.validate(); err != nil {
 		return err
 	}
 
@@ -74,13 +80,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) init() error {
-	actionsHTTP, err := helper.NewHTTP(m.BaseMetricSet)
-	if err != nil {
-		return err
-	}
-
-	kibanaVersion, err := kibana.GetVersion(actionsHTTP, kibana.ClusterActionsPath)
+func (m *MetricSet) validate() error {
+	kibanaVersion, err := kibana.GetVersion(m.actionsHTTP, kibana.ClusterActionsPath)
 	if err != nil {
 		return err
 	}
@@ -90,8 +91,6 @@ func (m *MetricSet) init() error {
 		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
 		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 	}
-
-	m.actionsHTTP = actionsHTTP
 
 	return nil
 }

--- a/metricbeat/module/kibana/cluster_actions/cluster_actions.go
+++ b/metricbeat/module/kibana/cluster_actions/cluster_actions.go
@@ -55,7 +55,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	return &MetricSet{
-		MetricSet:   ms,
+		MetricSet: ms,
 	}, nil
 }
 

--- a/metricbeat/module/kibana/cluster_rules/cluster_rules.go
+++ b/metricbeat/module/kibana/cluster_rules/cluster_rules.go
@@ -76,7 +76,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 		return err
 	}
 
-	if (!versionSupported) {
+	if !versionSupported {
 		return nil
 	}
 
@@ -87,10 +87,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (err error, versionSupported bool) {
+func (m *MetricSet) validate() (error, bool) {
 	kibanaVersion, err := kibana.GetVersion(m.rulesHTTP, kibana.ClusterRulesPath)
 	if err != nil {
-		return err, false;
+		return err, false
 	}
 
 	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
@@ -101,10 +101,10 @@ func (m *MetricSet) validate() (err error, versionSupported bool) {
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
 
-		return nil, false;
+		return nil, false
 	}
 
-	return nil, true;
+	return nil, true
 }
 
 func (m *MetricSet) fetchMetrics(r mb.ReporterV2) error {

--- a/metricbeat/module/kibana/cluster_rules/cluster_rules.go
+++ b/metricbeat/module/kibana/cluster_rules/cluster_rules.go
@@ -71,8 +71,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
-	if err = m.validate(); err != nil {
+	err, versionSupported := m.validate()
+	if err != nil {
 		return err
+	}
+
+	if (!versionSupported) {
+		return nil
 	}
 
 	if err = m.fetchMetrics(r); err != nil {
@@ -82,10 +87,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() error {
+func (m *MetricSet) validate() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.rulesHTTP, kibana.ClusterRulesPath)
 	if err != nil {
-		return err
+		return err, false;
 	}
 
 	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
@@ -95,9 +100,11 @@ func (m *MetricSet) validate() error {
 			const errorMsg = "the %v cluster rules is only supported with Kibana >= %v. You are currently running Kibana %v"
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
+
+		return nil, false;
 	}
 
-	return nil
+	return nil, true;
 }
 
 func (m *MetricSet) fetchMetrics(r mb.ReporterV2) error {

--- a/metricbeat/module/kibana/cluster_rules/cluster_rules.go
+++ b/metricbeat/module/kibana/cluster_rules/cluster_rules.go
@@ -87,7 +87,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (error, bool) {
+func (m *MetricSet) validate() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.rulesHTTP, kibana.ClusterRulesPath)
 	if err != nil {
 		return err, false

--- a/metricbeat/module/kibana/cluster_rules/cluster_rules.go
+++ b/metricbeat/module/kibana/cluster_rules/cluster_rules.go
@@ -19,6 +19,7 @@ package cluster_rules
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -44,7 +45,8 @@ var (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*kibana.MetricSet
-	rulesHTTP *helper.HTTP
+	rulesHTTP                         *helper.HTTP
+	lastRunningKibanaMessageTimestamp time.Time
 }
 
 // New create a new instance of the MetricSet
@@ -88,8 +90,11 @@ func (m *MetricSet) validate() error {
 
 	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
 	if !isMetricsAPIAvailable {
-		const errorMsg = "the %v cluster rules is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.RulesAPIAvailableVersion, kibanaVersion)
+		if time.Since(m.lastRunningKibanaMessageTimestamp) > 5*time.Minute {
+			m.lastRunningKibanaMessageTimestamp = time.Now()
+			const errorMsg = "the %v cluster rules is only supported with Kibana >= %v. You are currently running Kibana %v"
+			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
+		}
 	}
 
 	return nil

--- a/metricbeat/module/kibana/cluster_rules/cluster_rules.go
+++ b/metricbeat/module/kibana/cluster_rules/cluster_rules.go
@@ -54,25 +54,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	rulesHTTP, err := helper.NewHTTP(ms.BaseMetricSet)
-	if err != nil {
-		return nil, err
-	}
-
-	kibanaVersion, err := kibana.GetVersion(rulesHTTP, kibana.ClusterRulesPath)
-	if err != nil {
-		return nil, err
-	}
-
-	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
-	if !isMetricsAPIAvailable {
-		const errorMsg = "the %v cluster rules is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return nil, fmt.Errorf(errorMsg, ms.FullyQualifiedName(), kibana.RulesAPIAvailableVersion, kibanaVersion)
-	}
-
 	return &MetricSet{
 		MetricSet: ms,
-		rulesHTTP: rulesHTTP,
 	}, nil
 }
 
@@ -80,9 +63,35 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
+	if err = m.init(); err != nil {
+		return err
+	}
+
 	if err = m.fetchMetrics(r); err != nil {
 		return fmt.Errorf("error trying to get cluster rule data from Kibana: %w", err)
 	}
+
+	return nil
+}
+
+func (m *MetricSet) init() error {
+	rulesHTTP, err := helper.NewHTTP(m.BaseMetricSet)
+	if err != nil {
+		return err
+	}
+
+	kibanaVersion, err := kibana.GetVersion(rulesHTTP, kibana.ClusterRulesPath)
+	if err != nil {
+		return err
+	}
+
+	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
+	if !isMetricsAPIAvailable {
+		const errorMsg = "the %v cluster rules is only supported with Kibana >= %v. You are currently running Kibana %v"
+		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.RulesAPIAvailableVersion, kibanaVersion)
+	}
+
+	m.rulesHTTP = rulesHTTP
 
 	return nil
 }

--- a/metricbeat/module/kibana/node_actions/node_actions.go
+++ b/metricbeat/module/kibana/node_actions/node_actions.go
@@ -87,7 +87,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (error, bool) {
+func (m *MetricSet) validate() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.actionsHTTP, kibana.NodeActionsPath)
 	if err != nil {
 		return err, false

--- a/metricbeat/module/kibana/node_actions/node_actions.go
+++ b/metricbeat/module/kibana/node_actions/node_actions.go
@@ -54,8 +54,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	actionsHTTP, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MetricSet{
-		MetricSet: ms,
+		MetricSet:   ms,
+		actionsHTTP: actionsHTTP,
 	}, nil
 }
 
@@ -63,7 +69,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
-	if err = m.init(); err != nil {
+	if err = m.validate(); err != nil {
 		return err
 	}
 
@@ -74,13 +80,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) init() error {
-	actionsHTTP, err := helper.NewHTTP(m.BaseMetricSet)
-	if err != nil {
-		return err
-	}
-
-	kibanaVersion, err := kibana.GetVersion(actionsHTTP, kibana.NodeActionsPath)
+func (m *MetricSet) validate() error {
+	kibanaVersion, err := kibana.GetVersion(m.actionsHTTP, kibana.NodeActionsPath)
 	if err != nil {
 		return err
 	}
@@ -90,8 +91,6 @@ func (m *MetricSet) init() error {
 		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
 		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 	}
-
-	m.actionsHTTP = actionsHTTP
 
 	return nil
 }

--- a/metricbeat/module/kibana/node_actions/node_actions.go
+++ b/metricbeat/module/kibana/node_actions/node_actions.go
@@ -76,7 +76,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 		return err
 	}
 
-	if (!versionSupported) {
+	if !versionSupported {
 		return nil
 	}
 
@@ -87,10 +87,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (err error, versionSupported bool) {
+func (m *MetricSet) validate() (error, bool) {
 	kibanaVersion, err := kibana.GetVersion(m.actionsHTTP, kibana.NodeActionsPath)
 	if err != nil {
-		return err, false;
+		return err, false
 	}
 
 	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
@@ -101,7 +101,7 @@ func (m *MetricSet) validate() (err error, versionSupported bool) {
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
 
-		return nil, false;
+		return nil, false
 	}
 
 	return err, true

--- a/metricbeat/module/kibana/node_actions/node_actions.go
+++ b/metricbeat/module/kibana/node_actions/node_actions.go
@@ -71,8 +71,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
-	if err = m.validate(); err != nil {
+	err, versionSupported := m.validate()
+	if err != nil {
 		return err
+	}
+
+	if (!versionSupported) {
+		return nil
 	}
 
 	if err = m.fetchMetrics(r); err != nil {
@@ -82,10 +87,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() error {
+func (m *MetricSet) validate() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.actionsHTTP, kibana.NodeActionsPath)
 	if err != nil {
-		return err
+		return err, false;
 	}
 
 	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
@@ -95,9 +100,11 @@ func (m *MetricSet) validate() error {
 			const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
+
+		return nil, false;
 	}
 
-	return nil
+	return err, true
 }
 
 func (m *MetricSet) fetchMetrics(r mb.ReporterV2) error {

--- a/metricbeat/module/kibana/node_actions/node_actions.go
+++ b/metricbeat/module/kibana/node_actions/node_actions.go
@@ -54,25 +54,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
-	actionsHTTP, err := helper.NewHTTP(ms.BaseMetricSet)
-	if err != nil {
-		return nil, err
-	}
-
-	kibanaVersion, err := kibana.GetVersion(actionsHTTP, kibana.NodeActionsPath)
-	if err != nil {
-		return nil, err
-	}
-
-	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
-	if !isMetricsAPIAvailable {
-		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return nil, fmt.Errorf(errorMsg, ms.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
-	}
-
 	return &MetricSet{
 		MetricSet:   ms,
-		actionsHTTP: actionsHTTP,
 	}, nil
 }
 
@@ -80,9 +63,35 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
+	if err = m.init(); err != nil {
+		return err
+	}
+
 	if err = m.fetchMetrics(r); err != nil {
 		return fmt.Errorf("error trying to get node action data from Kibana: %w", err)
 	}
+
+	return nil
+}
+
+func (m *MetricSet) init() error {
+	actionsHTTP, err := helper.NewHTTP(m.BaseMetricSet)
+	if err != nil {
+		return err
+	}
+
+	kibanaVersion, err := kibana.GetVersion(actionsHTTP, kibana.NodeActionsPath)
+	if err != nil {
+		return err
+	}
+
+	isMetricsAPIAvailable := kibana.IsActionsAPIAvailable(kibanaVersion)
+	if !isMetricsAPIAvailable {
+		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
+		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
+	}
+
+	m.actionsHTTP = actionsHTTP
 
 	return nil
 }

--- a/metricbeat/module/kibana/node_actions/node_actions.go
+++ b/metricbeat/module/kibana/node_actions/node_actions.go
@@ -55,7 +55,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 	}
 
 	return &MetricSet{
-		MetricSet:   ms,
+		MetricSet: ms,
 	}, nil
 }
 

--- a/metricbeat/module/kibana/node_rules/node_rules.go
+++ b/metricbeat/module/kibana/node_rules/node_rules.go
@@ -76,7 +76,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 		return err
 	}
 
-	if (!versionSupported) {
+	if !versionSupported {
 		return nil
 	}
 
@@ -87,10 +87,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (err error, versionSupported bool) {
+func (m *MetricSet) validate() (error, bool) {
 	kibanaVersion, err := kibana.GetVersion(m.rulesHTTP, kibana.NodeRulesPath)
 	if err != nil {
-		return err, false;
+		return err, false
 	}
 
 	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
@@ -101,10 +101,10 @@ func (m *MetricSet) validate() (err error, versionSupported bool) {
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
 
-		return nil, false;
+		return nil, false
 	}
 
-	return err, true;
+	return err, true
 }
 
 func (m *MetricSet) fetchMetrics(r mb.ReporterV2) error {

--- a/metricbeat/module/kibana/node_rules/node_rules.go
+++ b/metricbeat/module/kibana/node_rules/node_rules.go
@@ -71,8 +71,13 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
-	if err = m.validate(); err != nil {
+	err, versionSupported := m.validate()
+	if err != nil {
 		return err
+	}
+
+	if (!versionSupported) {
+		return nil
 	}
 
 	if err = m.fetchMetrics(r); err != nil {
@@ -82,10 +87,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() error {
+func (m *MetricSet) validate() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.rulesHTTP, kibana.NodeRulesPath)
 	if err != nil {
-		return err
+		return err, false;
 	}
 
 	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
@@ -95,9 +100,11 @@ func (m *MetricSet) validate() error {
 			const errorMsg = "the %v node rules is only supported with Kibana >= %v. You are currently running Kibana %v"
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
+
+		return nil, false;
 	}
 
-	return nil
+	return err, true;
 }
 
 func (m *MetricSet) fetchMetrics(r mb.ReporterV2) error {

--- a/metricbeat/module/kibana/node_rules/node_rules.go
+++ b/metricbeat/module/kibana/node_rules/node_rules.go
@@ -87,7 +87,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) validate() (error, bool) {
+func (m *MetricSet) validate() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.rulesHTTP, kibana.NodeRulesPath)
 	if err != nil {
 		return err, false

--- a/metricbeat/module/kibana/node_rules/node_rules.go
+++ b/metricbeat/module/kibana/node_rules/node_rules.go
@@ -19,6 +19,7 @@ package node_rules
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -44,7 +45,8 @@ var (
 // MetricSet type defines all fields of the MetricSet
 type MetricSet struct {
 	*kibana.MetricSet
-	rulesHTTP *helper.HTTP
+	rulesHTTP                         *helper.HTTP
+	lastRunningKibanaMessageTimestamp time.Time
 }
 
 // New create a new instance of the MetricSet
@@ -88,8 +90,11 @@ func (m *MetricSet) validate() error {
 
 	isMetricsAPIAvailable := kibana.IsRulesAPIAvailable(kibanaVersion)
 	if !isMetricsAPIAvailable {
-		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
-		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
+		if time.Since(m.lastRunningKibanaMessageTimestamp) > 5*time.Minute {
+			m.lastRunningKibanaMessageTimestamp = time.Now()
+			const errorMsg = "the %v node rules is only supported with Kibana >= %v. You are currently running Kibana %v"
+			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
+		}
 	}
 
 	return nil

--- a/metricbeat/module/kibana/node_rules/node_rules.go
+++ b/metricbeat/module/kibana/node_rules/node_rules.go
@@ -54,8 +54,14 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	rulesHTTP, err := helper.NewHTTP(base)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MetricSet{
 		MetricSet: ms,
+		rulesHTTP: rulesHTTP,
 	}, nil
 }
 
@@ -63,7 +69,7 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 // It returns the event which is then forward to the output. In case of an error, a
 // descriptive error must be returned.
 func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
-	if err = m.init(); err != nil {
+	if err = m.validate(); err != nil {
 		return err
 	}
 
@@ -74,13 +80,8 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) init() error {
-	rulesHTTP, err := helper.NewHTTP(m.BaseMetricSet)
-	if err != nil {
-		return err
-	}
-
-	kibanaVersion, err := kibana.GetVersion(rulesHTTP, kibana.NodeRulesPath)
+func (m *MetricSet) validate() error {
+	kibanaVersion, err := kibana.GetVersion(m.rulesHTTP, kibana.NodeRulesPath)
 	if err != nil {
 		return err
 	}
@@ -90,8 +91,6 @@ func (m *MetricSet) init() error {
 		const errorMsg = "the %v node actions is only supported with Kibana >= %v. You are currently running Kibana %v"
 		return fmt.Errorf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 	}
-
-	m.rulesHTTP = rulesHTTP
 
 	return nil
 }

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -81,7 +81,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 		return err
 	}
 
-	if (!versionSupported) {
+	if !versionSupported {
 		return nil
 	}
 
@@ -92,10 +92,10 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) init() (err error, versionSupported bool) {
+func (m *MetricSet) init() (error, bool) {
 	kibanaVersion, err := kibana.GetVersion(m.statsHTTP, kibana.StatsPath)
 	if err != nil {
-		return err, false;
+		return err, false
 	}
 
 	isStatsAPIAvailable := kibana.IsStatsAPIAvailable(kibanaVersion)
@@ -106,12 +106,12 @@ func (m *MetricSet) init() (err error, versionSupported bool) {
 			m.Logger().Debugf(errorMsg, m.FullyQualifiedName(), kibana.ActionsAPIAvailableVersion, kibanaVersion)
 		}
 
-		return nil, false;
+		return nil, false
 	}
 
 	m.isUsageExcludable = kibana.IsUsageExcludable(kibanaVersion)
 
-	return err, true;
+	return err, true
 }
 
 func (m *MetricSet) fetchStats(r mb.ReporterV2) error {

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -92,7 +92,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 	return nil
 }
 
-func (m *MetricSet) init() (error, bool) {
+func (m *MetricSet) init() (err error, versionSupported bool) {
 	kibanaVersion, err := kibana.GetVersion(m.statsHTTP, kibana.StatsPath)
 	if err != nil {
 		return err, false

--- a/metricbeat/module/kibana/stats/stats.go
+++ b/metricbeat/module/kibana/stats/stats.go
@@ -59,8 +59,16 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 		return nil, err
 	}
 
+	statsHTTP, err := helper.NewHTTP(ms.BaseMetricSet)
+	if err != nil {
+		return nil, err
+	}
+
+	statsHTTP.SetHeaderDefault(productorigin.Header, productorigin.Beats)
+
 	return &MetricSet{
 		MetricSet: ms,
+		statsHTTP: statsHTTP,
 	}, nil
 }
 
@@ -80,14 +88,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) (err error) {
 }
 
 func (m *MetricSet) init() error {
-	statsHTTP, err := helper.NewHTTP(m.BaseMetricSet)
-	if err != nil {
-		return err
-	}
-
-	statsHTTP.SetHeaderDefault(productorigin.Header, productorigin.Beats)
-
-	kibanaVersion, err := kibana.GetVersion(statsHTTP, kibana.StatsPath)
+	kibanaVersion, err := kibana.GetVersion(m.statsHTTP, kibana.StatsPath)
 	if err != nil {
 		return err
 	}
@@ -101,7 +102,6 @@ func (m *MetricSet) init() error {
 		}
 	}
 
-	m.statsHTTP = statsHTTP
 	m.isUsageExcludable = kibana.IsUsageExcludable(kibanaVersion)
 
 	return nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR moves HTTP calls that were happening in `node_rules`, `node_actions`, `cluster_rules` and `cluster_actions` metricsets constructors to stop metricbeat from failing to start, in case Kibana is not available when MB starts.



## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

With this change, as soon as Kibana becomes available, metricbeat will start collecting metrics for the metricsets mentioned above and won't crash in case Kibana is not started.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

With Kibana instance down:

- Pull this branch and start metricbeat from the source https://github.com/elastic/kibana/blob/main/x-pack/plugins/monitoring/dev_docs/how_to/running_components_from_source.md#metricbeat

```bash
{"log.level":"error","@timestamp":"2023-05-09T13:00:47.810-0300","log.origin":{"file.name":"module/wrapper.go","file.line":256},"message":"Error fetching data for metricset kibana.stats: error making http request: Get \"http://localhost:5601/ftw/api/status\": dial tcp [::1]:5601: connect: connection refused","service.name":"metricbeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-05-09T13:00:47.821-0300","log.origin":{"file.name":"module/wrapper.go","file.line":256},"message":"Error fetching data for metricset kibana.cluster_actions: error making http request: Get \"http://localhost:5601/ftw/api/status\": dial tcp 127.0.0.1:5601: connect: connection refused","service.name":"metricbeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-05-09T13:00:49.468-0300","log.origin":{"file.name":"module/wrapper.go","file.line":256},"message":"Error fetching data for metricset kibana.node_actions: error making http request: Get \"http://localhost:5601/ftw/api/status\": dial tcp [::1]:5601: connect: connection refused","service.name":"metricbeat","ecs.version":"1.6.0"}
```

Start Kibana

While it is starting:
```bash
{"log.level":"error","@timestamp":"2023-05-09T13:01:57.814-0300","log.origin":{"file.name":"module/wrapper.go","file.line":256},"message":"Error fetching data for metricset kibana.stats: error making http request: Get \"http://localhost:5601/ftw/api/status\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)","service.name":"metricbeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-05-09T13:01:57.822-0300","log.origin":{"file.name":"module/wrapper.go","file.line":256},"message":"Error fetching data for metricset kibana.cluster_actions: error making http request: Get \"http://localhost:5601/ftw/api/status\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","service.name":"metricbeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-05-09T13:01:59.472-0300","log.origin":{"file.name":"module/wrapper.go","file.line":256},"message":"Error fetching data for metricset kibana.node_actions: error making http request: Get \"http://localhost:5601/ftw/api/status\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)","service.name":"metricbeat","ecs.version":"1.6.0"}
{"log.level":"error","@timestamp":"2023-05-09T13:02:01.815-0300","log.origin":{"file.name":"module/wrapper.go","file.line":256},"message":"Error fetching data for metricset kibana.node_rules: error making http request: Get \"http://localhost:5601/ftw/api/status\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)","service.name":"metricbeat","ecs.version":"1.6.0"}
```

Once the initialization ends:

```bash
{"log.level":"info","@timestamp":"2023-05-09T13:03:43.314-0300","log.logger":"monitoring","log.origin":{"file.name":"log/log.go","file.line":187},"message":"Non-zero metrics in the last 30s","service.name":"metricbeat","monitoring":{"metrics":{"beat":{"cpu":{"system":{"ticks":6,"time":{"ms":1}},"total":{"ticks":19,"time":{"ms":4},"value":19},"user":{"ticks":13,"time":{"ms":3}}},"info":{"ephemeral_id":"dd257e36-df96-415f-92f8-1ff01e434116","uptime":{"ms":190072},"version":"8.9.0"},"memstats":{"gc_next":16884416,"memory_alloc":13517488,"memory_total":162990496,"rss":64159744},"runtime":{"goroutines":160}},"libbeat":{"config":{"module":{"running":0}},"output":{"events":{"acked":153,"active":0,"batches":15,"duplicates":93,"total":246},"read":{"bytes":8892},"write":{"bytes":419503}},"pipeline":{"clients":14,"events":{"active":0,"published":246,"total":246},"queue":{"acked":246}}},"metricbeat":{"elasticsearch":{"cluster_stats":{"events":3,"success":3},"enrich":{"events":3,"success":3},"index":{"events":87,"success":87},"index_recovery":{"events":39,"success":39},"index_summary":{"events":3,"success":3},"node_stats":{"events":3,"success":3},"shard":{"events":93,"success":93}},"kibana":{"cluster_actions":{"events":3,"success":3},"cluster_rules":{"events":3,"success":3},"node_actions":{"events":3,"success":3},"node_rules":{"events":3,"success":3},"stats":{"events":3,"success":3}}},"system":{"load":{"1":12.397,"15":8.0547,"5":10.6929,"norm":{"1":1.2397,"15":0.8055,"5":1.0693}}}},"ecs.version":"1.6.0"}}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->

closes https://github.com/elastic/beats/issues/34135
closes https://github.com/elastic/beats/issues/34682
