### PR TITLE
[Heartbeat] Fix NPE on reloads with run_from

### DIFF
--- a/heartbeat/monitors/factory.go
+++ b/heartbeat/monitors/factory.go
@@ -170,7 +170,7 @@ func (f *RunnerFactory) Create(p beat.Pipeline, c *conf.C) (cfgfile.Runner, erro
 		geoMap, _ := util.GeoConfigToMap(loc.Geo)
 		err = c.Merge(map[string]interface{}{
 			"run_from": map[string]interface{}{
-				"id":  f.beatLocation.ID,
+				"id":  loc.ID,
 				"geo": geoMap,
 			},
 		})

--- a/heartbeat/monitors/factory_test.go
+++ b/heartbeat/monitors/factory_test.go
@@ -241,6 +241,71 @@ func TestDisabledMonitor(t *testing.T) {
 	}
 }
 
+func TestRunFrom(t *testing.T) {
+	tests := []struct {
+		name string
+		loc  *hbconfig.LocationWithID
+	}{
+		{
+			"no location",
+			nil,
+		},
+		{
+			"with id",
+			&hbconfig.LocationWithID{
+				ID: "test",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		confMap := map[string]interface{}{
+			"type":     "test",
+			"urls":     []string{"http://example.net"},
+			"schedule": "@every 1ms",
+			"name":     "test",
+		}
+		if tt.loc != nil {
+			geo, err := util.GeoConfigToMap(tt.loc.Geo)
+			require.NoError(t, err)
+			confMap["run_from"] = map[string]interface{}{
+				"id":  tt.loc.ID,
+				"geo": geo,
+			}
+		}
+
+		conf, err := config.NewConfigFrom(confMap)
+		require.NoError(t, err)
+
+		reg, _, _ := mockPluginsReg()
+		mockPipeline := &MockPipeline{}
+
+		f, sched, fClose := makeMockFactory(reg)
+		defer fClose()
+		defer sched.Stop()
+
+		makeTestMon := func() (*Monitor, error) {
+			mIface, err := f.Create(mockPipeline, conf)
+			if mIface == nil {
+				return nil, err
+			} else {
+				return mIface.(*Monitor), err
+			}
+		}
+
+		// Would fail if the previous newMonitor didn't free the monitor.id
+		m1, m1Err := makeTestMon()
+		require.NoError(t, m1Err)
+
+		if tt.loc == nil {
+			var emptyLoc *hbconfig.LocationWithID
+			require.Equal(t, emptyLoc, m1.stdFields.RunFrom)
+		} else {
+			require.Equal(t, tt.loc, m1.stdFields.RunFrom)
+		}
+	}
+}
+
 func TestDuplicateMonitorIDs(t *testing.T) {
 	serverMonConf := mockPluginConf(t, "custom", "custom", "@every 1ms", "http://example.net")
 	badConf := mockBadPluginConf(t, "custom")


### PR DESCRIPTION
we incorrectly always read from the beat location which may be null, this fixes that.

No changelog since this bug has never been released.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Testing

Test by reloading via file the following config: with the `run_from` field present and not

```
- type: http
  id: treload
  name: treload
  urls: "https://blog.andrewvc.com"
  schedule: "@every 15s"
  run_from:
    id: testid
    geo:
      name: htnoeu
```