### PR TITLE
[Heartbeat] Normalize state location names

### DIFF
--- a/heartbeat/monitors/wrappers/monitorstate/monitorstate.go
+++ b/heartbeat/monitors/wrappers/monitorstate/monitorstate.go
@@ -19,6 +19,7 @@ package monitorstate
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/elastic/beats/v7/heartbeat/monitors/stdfields"
@@ -169,10 +170,13 @@ func (s *State) copy() *State {
 	return &copied
 }
 
+var normalizeRunFromIDRegexp = regexp.MustCompile("[^A-Za-z0-9_-]")
+
 func LoaderDBKey(sf stdfields.StdMonitorFields, at time.Time, ctr int) string {
 	rfid := "default"
 	if sf.RunFrom != nil {
-		rfid = sf.RunFrom.ID
+		rfid = normalizeRunFromIDRegexp.ReplaceAllString(sf.RunFrom.ID, "_")
+
 	}
 	return fmt.Sprintf("%s-%x-%x", rfid, at.UnixMilli(), ctr)
 }


### PR DESCRIPTION
We currently allow any chars in state location names, this normalizes them to [A-Za-z0-9_-_] for easier handling.

No changelog since no released version affected

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
