### PR TITLE
x-pack/filebeat/input/aws-s3 - Fix test case race condition

### DIFF
--- a/x-pack/filebeat/input/awss3/metrics_test.go
+++ b/x-pack/filebeat/input/awss3/metrics_test.go
@@ -94,10 +94,13 @@ func TestInputMetricsSQSWorkerUtilization(t *testing.T) {
 var fakeTimeMs = &atomic.Int64{}
 
 func useFakeCurrentTimeThenReset() (reset func()) {
-	currentTime = func() time.Time {
-		return time.UnixMilli(fakeTimeMs.Load())
+	clockValue.Swap(clock{
+		Now: func() time.Time {
+			return time.UnixMilli(fakeTimeMs.Load())
+		},
+	})
+	reset = func() {
+		clockValue.Swap(realClock)
 	}
-	return func() {
-		currentTime = time.Now
-	}
+	return reset
 }


### PR DESCRIPTION
## What does this PR do?

Fixes race condition in tests reading/writing the `currentTime` func.

This guards access to the "clock" via a atomic.Value. Another more elaborate fix would be to eliminate the global "clock" and inject a clock into every instance via the constructor, but wiring that up to pass the clock through to everywhere would be larger change. Given that this only affects tests I'm using this simpler fix.

Fixes #35418

## Why is it important?

Make the aws-s3 test pass when `go test -race .` is used.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

