### PR TITLE
winlogbeat/sys/wineventlog: don't panic on nil iterator/renderer close

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -199,6 +199,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Clarify query term limits warning and remove link to missing Microsoft doc page. {pull}34715[34715]
 - Improve documentation for event_logs.name configuration. {pull}34931[34931]
 - Move repeated channel not found errors to debug level.  {issue}35314[35314] {pull}35317[35317]
+- Prevent panic on closing iterators on empty channels in experimental API. {issue}33966[33966] {pull}35423[35423]
 
 *Functionbeat*
 

--- a/winlogbeat/eventlog/wineventlog_experimental.go
+++ b/winlogbeat/eventlog/wineventlog_experimental.go
@@ -343,6 +343,9 @@ func (l *winEventLogExp) createBookmarkFromEvent(evtHandle win.EvtHandle) (strin
 func (l *winEventLogExp) Close() error {
 	l.log.Debug("Closing event log reader handles.")
 	l.metrics.close()
+	if l.iterator == nil {
+		return l.renderer.Close()
+	}
 	return multierr.Combine(
 		l.iterator.Close(),
 		l.renderer.Close(),

--- a/winlogbeat/sys/wineventlog/iterator.go
+++ b/winlogbeat/sys/wineventlog/iterator.go
@@ -196,6 +196,9 @@ func (itr *EventIterator) Err() error {
 
 // Close closes the subscription handle and any unread event handles.
 func (itr *EventIterator) Close() error {
+	if itr == nil {
+		return errors.New("closing nil event iterator")
+	}
 	itr.mutex.Lock()
 	defer itr.mutex.Unlock()
 

--- a/winlogbeat/sys/wineventlog/renderer.go
+++ b/winlogbeat/sys/wineventlog/renderer.go
@@ -22,6 +22,7 @@ package wineventlog
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -74,6 +75,9 @@ func NewRenderer(session EvtHandle, log *logp.Logger) (*Renderer, error) {
 
 // Close closes all handles held by the Renderer.
 func (r *Renderer) Close() error {
+	if r == nil {
+		return errors.New("closing nil renderer")
+	}
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

In the case that an experimental API EventLog has been opened against a non-available log channel, the EventLog will be closed. This unconditionally closes the EventIterator and Renderer that the EventLog hold. The EventIterator is only valid after a successful call to Open and so may be nil when a valid EventLog is closed, resulting in a nil-deref [panic](https://github.com/elastic/beats/issues/33966#issuecomment-1542526853).

	panic: runtime error: invalid memory address or nil pointer dereference
	[signal 0xc0000005 code=0x0 addr=0x0 pc=0xc33574]

	goroutine 96 [running]:
	github.com/elastic/beats/v7/winlogbeat/sys/wineventlog.(*EventIterator).Close(0x0)
		github.com/elastic/beats/v7/winlogbeat/sys/wineventlog/iterator.go:199 +0x34
	github.com/elastic/beats/v7/winlogbeat/eventlog.(*winEventLogExp).Close(0xc00056cc80)
		github.com/elastic/beats/v7/winlogbeat/eventlog/wineventlog_experimental.go:347 +0xb6
	github.com/elastic/beats/v7/winlogbeat/beater.(*eventLogger).run.func3()
		github.com/elastic/beats/v7/winlogbeat/beater/eventlogger.go:128 +0x9f
	github.com/elastic/beats/v7/winlogbeat/beater.(*eventLogger).run(0xc0001aa600, 0xc0000b9020, {0x3608470?, 0xc0002bdb80}, {{0x0, 0x0}, 0x0, {0x0, 0x0, 0x0}, ...}, ...)
		github.com/elastic/beats/v7/winlogbeat/beater/eventlogger.go:149 +0xa6a
	github.com/elastic/beats/v7/winlogbeat/beater.(*Winlogbeat).processEventLog(0x0?, 0x0?, 0x0?, {{0x0, 0x0}, 0x0, {0x0, 0x0, 0x0}, {0x0, ...}}, ...)
		github.com/elastic/beats/v7/winlogbeat/beater/winlogbeat.go:203 +0xb3
	created by github.com/elastic/beats/v7/winlogbeat/beater.(*Winlogbeat).Run
		github.com/elastic/beats/v7/winlogbeat/beater/winlogbeat.go:171 +0x37a

So place a nil-check in the preamble to the EventIterator and Renderer's Close methods and return an error to be logged in the case that they are nil. A call to Renderer.Close should never encounter a nil receiver, but include the guard for prudence.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

We should not allow the program to panic in this situation.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #33966

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
