### PR TITLE
[Heartbeat] remove Synthetics beta label

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -283,6 +283,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 *Heartbeat*
 - Users can now configure max scheduler job limits per monitor type via env var. {pull}34307[34307]
 - Added status to monitor run log report.
+- Removed beta label for browser monitors. {pull}35424[35424].
 
 
 *Metricbeat*

--- a/heartbeat/docs/monitors/monitor-browser.asciidoc
+++ b/heartbeat/docs/monitors/monitor-browser.asciidoc
@@ -6,7 +6,7 @@ See the {observability-guide}/synthetics-quickstart.html[quick start guide].
 
 NOTE: While it is possible to configure browser monitors via the heartbeat YAML config files, we highly recommend using project monitors instead! See the https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html#synthetic-monitor-choose-project[Elastic synthetics docs].
 
-beta[] The options described here configure {beatname_uc} to run the synthetic
+The options described here configure {beatname_uc} to run the synthetic
 monitoring test projects via Synthetic Agent on the Chromium browser.
 Additional shared options are defined in <<monitor-options>>.
 

--- a/x-pack/heartbeat/monitors/browser/browser.go
+++ b/x-pack/heartbeat/monitors/browser/browser.go
@@ -9,11 +9,9 @@ package browser
 import (
 	"fmt"
 	"os"
-	"sync"
 	"syscall"
 
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/beats/v7/heartbeat/ecserr"
 	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
@@ -24,8 +22,6 @@ func init() {
 	plugin.Register("browser", create, "synthetic", "synthetics/synthetic")
 }
 
-var showExperimentalOnce = sync.Once{}
-
 func create(name string, cfg *config.C) (p plugin.Plugin, err error) {
 	// We don't want users running synthetics in environments that don't have the required GUI libraries etc, so we check
 	// this flag. When we're ready to support the many possible configurations of systems outside the docker environment
@@ -33,10 +29,6 @@ func create(name string, cfg *config.C) (p plugin.Plugin, err error) {
 	if os.Getenv("ELASTIC_SYNTHETICS_CAPABLE") != "true" {
 		return plugin.Plugin{}, ecserr.NewNotSyntheticsCapableError()
 	}
-
-	showExperimentalOnce.Do(func() {
-		logp.Info("Synthetic browser monitor detected! Please note synthetic monitors are a beta feature!")
-	})
 
 	// We do not use user.Current() which does not reflect setuid changes!
 	if syscall.Geteuid() == 0 && security.NodeChildProcCred == nil {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Summary

Remove beta references inside heartbeat docs and remove synthetics beta label: 
```
Synthetic browser monitor detected! Please note synthetic monitors are a beta feature!
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

