### PR TITLE
Add time-bounded contexts to AWS API calls

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -171,7 +171,6 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 
 *Metricbeat*
 
-- Add context with timeout in AWS API calls {pull}35425[35425]
 - in module/windows/perfmon, changed collection method of the second counter value required to create a displayable value {pull}32305[32305]
 - Fix and improve AWS metric period calculation to avoid zero-length intervals {pull}32724[32724]
 - Add missing cluster metadata to k8s module metricsets {pull}32979[32979] {pull}33032[33032]
@@ -186,7 +185,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Fix metadata enricher with correct container ids for pods with multiple containers in container metricset. Align `kubernetes.container.id` and `container.id` fields for state_container metricset. {pull}34516[34516]
 - Make generic SQL GA {pull}34637[34637]
 - Collect missing remote_cluster in elasticsearch ccr metricset {pull}34957[34957]
-
+- Add context with timeout in AWS API calls {pull}35425[35425]
 
 *Osquerybeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -168,6 +168,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 
 *Metricbeat*
 
+- Add context with timeout in AWS API calls {pull}35425[35425]
 - in module/windows/perfmon, changed collection method of the second counter value required to create a displayable value {pull}32305[32305]
 - Fix and improve AWS metric period calculation to avoid zero-length intervals {pull}32724[32724]
 - Add missing cluster metadata to k8s module metricsets {pull}32979[32979] {pull}33032[33032]

--- a/x-pack/metricbeat/module/aws/aws.go
+++ b/x-pack/metricbeat/module/aws/aws.go
@@ -87,7 +87,9 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 		return nil, fmt.Errorf("failed to get aws credentials, please check AWS credential in config: %w", err)
 	}
 
-	_, err = awsConfig.Credentials.Retrieve(context.Background())
+	ctx, cancel := getContextWithTimeout(DefaultApiTimeout)
+	defer cancel()
+	_, err = awsConfig.Credentials.Retrieve(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve aws credentials, please check AWS credential in config: %w", err)
 	}
@@ -126,7 +128,9 @@ func NewMetricSet(base mb.BaseMetricSet) (*MetricSet, error) {
 			o.EndpointOptions.UseFIPSEndpoint = awssdk.FIPSEndpointStateEnabled
 		}
 	})
-	outputIdentity, err := svcSts.GetCallerIdentity(context.TODO(), &sts.GetCallerIdentityInput{})
+	ctx, cancel = getContextWithTimeout(DefaultApiTimeout)
+	defer cancel()
+	outputIdentity, err := svcSts.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		base.Logger().Warn("failed to get caller identity, please check permission setting: ", err)
 	} else {
@@ -180,7 +184,9 @@ func getRegions(svc describeRegionsClient) ([]string, error) {
 }
 
 func getAccountName(svc *iam.Client, base mb.BaseMetricSet, metricSet MetricSet) string {
-	output, err := svc.ListAccountAliases(context.TODO(), &iam.ListAccountAliasesInput{})
+	ctx, cancel := getContextWithTimeout(DefaultApiTimeout)
+	defer cancel()
+	output, err := svc.ListAccountAliases(ctx, &iam.ListAccountAliasesInput{})
 
 	accountName := metricSet.AccountID
 	if err != nil {

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -19,7 +19,6 @@ import (
 )
 
 const DefaultApiTimeout = 5 * time.Second
-const CwApiTimeout = 10 * time.Second
 
 // GetStartTimeEndTime calculates start and end times for queries based on the current time and a duration.
 //
@@ -65,11 +64,9 @@ func GetListMetricsOutput(namespace string, regionName string, period time.Durat
 
 	paginator := cloudwatch.NewListMetricsPaginator(svcCloudwatch, listMetricsInput)
 
-	ctx, cancel := getContextWithTimeout(CwApiTimeout)
-	defer cancel()
 	// List metrics of a given namespace for each region
 	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(ctx)
+		page, err := paginator.NextPage(context.TODO())
 		if err != nil {
 			return metricsTotal, fmt.Errorf("error ListMetrics with Paginator, skipping region %s: %w", regionName, err)
 		}
@@ -100,12 +97,10 @@ func GetMetricDataResults(metricDataQueries []types.MetricDataQuery, svc cloudwa
 		}
 
 		paginator := cloudwatch.NewGetMetricDataPaginator(svc, getMetricDataInput)
-		ctx, cancel := getContextWithTimeout(CwApiTimeout)
-		defer cancel()
 		var err error
 		var page *cloudwatch.GetMetricDataOutput
 		for paginator.HasMorePages() {
-			if page, err = paginator.NextPage(ctx); err != nil {
+			if page, err = paginator.NextPage(context.TODO()); err != nil {
 				return getMetricDataOutput.MetricDataResults, fmt.Errorf("error GetMetricData with Paginator: %w", err)
 			}
 			getMetricDataOutput.MetricDataResults = append(getMetricDataOutput.MetricDataResults, page.MetricDataResults...)

--- a/x-pack/metricbeat/module/aws/utils.go
+++ b/x-pack/metricbeat/module/aws/utils.go
@@ -18,6 +18,9 @@ import (
 	resourcegroupstaggingapitypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 )
 
+const DefaultApiTimeout = 5 * time.Second
+const CwApiTimeout = 10 * time.Second
+
 // GetStartTimeEndTime calculates start and end times for queries based on the current time and a duration.
 //
 // Whilst the inputs to this function are continuous, the maximum period granularity we can consistently use
@@ -62,9 +65,11 @@ func GetListMetricsOutput(namespace string, regionName string, period time.Durat
 
 	paginator := cloudwatch.NewListMetricsPaginator(svcCloudwatch, listMetricsInput)
 
+	ctx, cancel := getContextWithTimeout(CwApiTimeout)
+	defer cancel()
 	// List metrics of a given namespace for each region
 	for paginator.HasMorePages() {
-		page, err := paginator.NextPage(context.TODO())
+		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			return metricsTotal, fmt.Errorf("error ListMetrics with Paginator, skipping region %s: %w", regionName, err)
 		}
@@ -95,10 +100,12 @@ func GetMetricDataResults(metricDataQueries []types.MetricDataQuery, svc cloudwa
 		}
 
 		paginator := cloudwatch.NewGetMetricDataPaginator(svc, getMetricDataInput)
+		ctx, cancel := getContextWithTimeout(CwApiTimeout)
+		defer cancel()
 		var err error
 		var page *cloudwatch.GetMetricDataOutput
 		for paginator.HasMorePages() {
-			if page, err = paginator.NextPage(context.TODO()); err != nil {
+			if page, err = paginator.NextPage(ctx); err != nil {
 				return getMetricDataOutput.MetricDataResults, fmt.Errorf("error GetMetricData with Paginator: %w", err)
 			}
 			getMetricDataOutput.MetricDataResults = append(getMetricDataOutput.MetricDataResults, page.MetricDataResults...)
@@ -118,6 +125,10 @@ func CheckTimestampInArray(timestamp time.Time, timestampArray []time.Time) (boo
 	return false, -1
 }
 
+func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
 // GetResourcesTags function queries AWS resource groupings tagging API
 // to get a resource tag mapping with specific resource type filters
 func GetResourcesTags(svc resourcegroupstaggingapi.GetResourcesAPIClient, resourceTypeFilters []string) (map[string][]resourcegroupstaggingapitypes.Tag, error) {
@@ -132,10 +143,12 @@ func GetResourcesTags(svc resourcegroupstaggingapi.GetResourcesAPIClient, resour
 	}
 
 	paginator := resourcegroupstaggingapi.NewGetResourcesPaginator(svc, getResourcesInput)
+	ctx, cancel := getContextWithTimeout(DefaultApiTimeout)
+	defer cancel()
 	var err error
 	var page *resourcegroupstaggingapi.GetResourcesOutput
 	for paginator.HasMorePages() {
-		if page, err = paginator.NextPage(context.TODO()); err != nil {
+		if page, err = paginator.NextPage(ctx); err != nil {
 			err = fmt.Errorf("error GetResources with Paginator: %w", err)
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR adds a time-limit to each AWS API call that is used in `metricbeat`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Two main reasons:
* If we encounter a failure in any API we call, we should fail fast.
* Some non-blocking APIs (e.g `GetResourceTags`) might not work in specific environments (e.g private subnets) and may delay or block the data collection.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/integrations/issues/6137
