### PR TITLE
Remove unnecessary logging

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -202,7 +202,7 @@ func startHarvester(
 				return nil
 			}
 
-			return err
+			return fmt.Errorf("error while adding new reader to the bookkeeper %w", err)
 		}
 
 		ctx.Cancelation = harvesterCtx

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -193,13 +193,16 @@ func startHarvester(
 			// behaviour of the Filestream input, it's not really an error, it's just an situation.
 			// If the harvester is already running we don't need to start a new one.
 			// At the moment of writing even the returned error is ignored. So the
-			// only real effect of the next line is to not start a second harvester.
+			// only real effect of this branch is to not start a second harvester.
 			//
 			// Currently the only places this error is checked is on task.Group and the
 			// only thing it does is to log the error. So to avoid unnecessary errors,
 			// we just return nil.
-			//nolint: nilerr // Read the comment above
-			return nil
+			if errors.Is(err, ErrHarvesterAlreadyRunning) {
+				return nil
+			}
+
+			return err
 		}
 
 		ctx.Cancelation = harvesterCtx

--- a/filebeat/input/filestream/internal/input-logfile/harvester.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester.go
@@ -189,10 +189,17 @@ func startHarvester(
 
 		harvesterCtx, cancelHarvester, err := hg.readers.newContext(srcID, canceler)
 		if err != nil {
-			// The returned may or not be collected by the caller, thus logging
-			// it here is important.
-			ctx.Logger.Errorf("error while adding new reader to the bookkeeper %v", err)
-			return fmt.Errorf("error while adding new reader to the bookkeeper %w", err)
+			// The only possible returned error is ErrHarvesterAlreadyRunning, which is a normal
+			// behaviour of the Filestream input, it's not really an error, it's just an situation.
+			// If the harvester is already running we don't need to start a new one.
+			// At the moment of writing even the returned error is ignored. So the
+			// only real effect of the next line is to not start a second harvester.
+			//
+			// Currently the only places this error is checked is on task.Group and the
+			// only thing it does is to log the error. So to avoid unnecessary errors,
+			// we just return nil.
+			//nolint: nilerr // Read the comment above
+			return nil
 		}
 
 		ctx.Cancelation = harvesterCtx


### PR DESCRIPTION
## What does this PR do?

The log line remove by this commit is unnecessary, it is not an actual
error in the sense something will not work. It only means the
harvester is already running for this file so another one does not
need to be started. Keeping this log line will only spam our log files
and make users worried.


## Why is it important?

It was spamming our logs and would make our uses worry for no good reason

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~

## How to test this PR locally
Run Filebeat with the `filestream` input enabled, you should not see log errors like:
- `error while adding new reader to the bookkeeper harvester is already running for file`
- `harvester:: error while adding new reader to the bookkeeper harvester is already running for file`


~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
