### PR TITLE
libbeat/monitoring/inputmon - Add defensive check for empty ID or input type

### DIFF
--- a/libbeat/monitoring/inputmon/input_test.go
+++ b/libbeat/monitoring/inputmon/input_test.go
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package inputmon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestNewInputMonitor(t *testing.T) {
+	const (
+		inputType = "foo-input"
+		id        = "my-id"
+	)
+
+	testCases := []struct {
+		Input          string
+		ID             string
+		OptionalParent *monitoring.Registry
+		PublicMetrics  bool // Are the metrics registered in the global metric namespace making them public?
+	}{
+		{Input: inputType, ID: id, PublicMetrics: true},
+		{Input: "", ID: id, PublicMetrics: false},
+		{Input: inputType, ID: "", PublicMetrics: false},
+		{Input: "", ID: "", PublicMetrics: false},
+
+		{Input: inputType, ID: id, OptionalParent: globalRegistry(), PublicMetrics: true},
+		{Input: "", ID: id, OptionalParent: globalRegistry(), PublicMetrics: false},
+		{Input: inputType, ID: "", OptionalParent: globalRegistry(), PublicMetrics: false},
+		{Input: "", ID: "", OptionalParent: globalRegistry(), PublicMetrics: false},
+
+		{Input: inputType, ID: id, OptionalParent: monitoring.NewRegistry(), PublicMetrics: false},
+		{Input: "", ID: id, OptionalParent: monitoring.NewRegistry(), PublicMetrics: false},
+		{Input: inputType, ID: "", OptionalParent: monitoring.NewRegistry(), PublicMetrics: false},
+		{Input: "", ID: "", OptionalParent: monitoring.NewRegistry(), PublicMetrics: false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		testName := fmt.Sprintf("with_id=%v/with_input=%v/custom_parent=%v/public_metrics=%v",
+			tc.ID != "", tc.Input != "", tc.OptionalParent != nil, tc.PublicMetrics)
+
+		t.Run(testName, func(t *testing.T) {
+			reg, unreg := NewInputRegistry(tc.Input, tc.ID, tc.OptionalParent)
+			defer unreg()
+			assert.NotNil(t, reg)
+
+			// Verify that metrics are registered when a custom parent registry is given.
+			if tc.OptionalParent != nil && tc.OptionalParent != globalRegistry() {
+				assert.NotNil(t, tc.OptionalParent.Get(tc.ID))
+			}
+
+			// Verify whether the metrics are exposed in the global registry which makes the public.
+			parent := globalRegistry().GetRegistry(tc.ID)
+			if tc.PublicMetrics {
+				assert.NotNil(t, parent)
+			} else {
+				assert.Nil(t, parent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Add a defensive check to prevent metrics from being registered into the global 'dataset' namespace when the ID or input type are empty.

This is not in response to any known problem. There was already a similar check on HTTP `/inputs/` endpoint that would have prevented metrics from inputs with an ID or input type from being exposed. This pushes that check earlier and in effect "null routes" those metrics an a manner that is transparent to the callers.

I would consider an empty input type to be a developer mistake whereas an the ID is user controllable. So you could conceive of having a hard error (like a panic) if input type were empty. At the moment I'm taking a softer approach in the defense.

Relates #35354

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #35354
