### PR TITLE
[Heartbeat] Remove integrations support under managed mode and deprecated sources

### DIFF
--- a/heartbeat/ecserr/ecserr.go
+++ b/heartbeat/ecserr/ecserr.go
@@ -128,3 +128,11 @@ func NewNotSyntheticsCapableError() *ECSErr {
 		"browser monitors cannot be created outside the official elastic docker image",
 	)
 }
+
+func NewUnsupportedMonitorTypeError(err error) *ECSErr {
+	return NewECSErr(
+		TYPE_IO,
+		"UNSUPPORTED_MONITOR_TYPE",
+		fmt.Sprintf("%s", err),
+	)
+}

--- a/heartbeat/monitors/active/http/http.go
+++ b/heartbeat/monitors/active/http/http.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/elastic/beats/v7/heartbeat/monitors"
 	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/libbeat/version"
 	conf "github.com/elastic/elastic-agent-libs/config"
@@ -46,6 +47,10 @@ func create(
 ) (p plugin.Plugin, err error) {
 	config := defaultConfig()
 	if err := cfg.Unpack(&config); err != nil {
+		return plugin.Plugin{}, err
+	}
+
+	if err := monitors.UnsupportedIntegrationType(cfg); err != nil {
 		return plugin.Plugin{}, err
 	}
 

--- a/heartbeat/monitors/active/icmp/icmp.go
+++ b/heartbeat/monitors/active/icmp/icmp.go
@@ -45,6 +45,10 @@ func create(
 	name string,
 	commonConfig *conf.C,
 ) (p plugin.Plugin, err error) {
+	if err := monitors.UnsupportedIntegrationType(commonConfig); err != nil {
+		return plugin.Plugin{}, err
+	}
+
 	loop, err := getStdLoop()
 	if err != nil {
 		logp.Warn("Failed to initialize ICMP loop %v", err)

--- a/heartbeat/monitors/active/tcp/tcp.go
+++ b/heartbeat/monitors/active/tcp/tcp.go
@@ -60,6 +60,10 @@ func createWithResolver(
 	cfg *conf.C,
 	resolver monitors.Resolver,
 ) (p plugin.Plugin, err error) {
+	if err := monitors.UnsupportedIntegrationType(cfg); err != nil {
+		return plugin.Plugin{}, err
+	}
+
 	jc, err := newJobFactory(cfg, resolver)
 	if err != nil {
 		return plugin.Plugin{}, err

--- a/heartbeat/monitors/util.go
+++ b/heartbeat/monitors/util.go
@@ -23,11 +23,14 @@ import (
 	"net"
 	"time"
 
+	"github.com/elastic/beats/v7/heartbeat/ecserr"
 	"github.com/elastic/beats/v7/heartbeat/eventext"
 	"github.com/elastic/beats/v7/heartbeat/look"
 	"github.com/elastic/beats/v7/heartbeat/monitors/jobs"
 	"github.com/elastic/beats/v7/heartbeat/monitors/wrappers"
 	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
@@ -260,4 +263,45 @@ func filterIPs(ips []net.IP, filt func(net.IP) bool) []net.IP {
 		}
 	}
 	return out
+}
+
+var ErrUnsupportedIntegration = fmt.Errorf("fleet-managed Elastic Synthetics Integrations are now unsupported, please consider migrating existing monitors to use either Project monitors or the Synthetics app. See the Elastic synthetics docs at https://www.elastic.co/guide/en/observability/current/synthetics-migrate-from-integration.html")
+
+type integrationConfig struct {
+	Type       string                  `config:"type" validate:"required"`
+	Processors processors.PluginConfig `config:"processors"`
+}
+type processorConfig struct {
+	Fields mapstr.M `config:"fields" validate:"required"`
+}
+
+// Prevent running deprecated integrations on managed mode.
+// Taking a conservative approach, need to check for managed without config_id
+func UnsupportedIntegrationType(cfg *conf.C) error {
+	var ic integrationConfig
+	if err := cfg.Unpack(&ic); err != nil {
+		return err
+	}
+
+	var addFieldsP []*processorConfig
+	for _, processor := range ic.Processors {
+		if cfg, err := processor.Child("add_fields", -1); err == nil {
+			var p processorConfig
+			if err = cfg.Unpack(&p); err == nil {
+				addFieldsP = append(addFieldsP, &p)
+			}
+		}
+	}
+
+	for _, p := range addFieldsP {
+		v, err := p.Fields.GetValue("monitor.fleet_managed")
+		if managed, ok := v.(bool); err == nil && ok && managed {
+			configID, _ := p.Fields.HasKey("config_id")
+			if !configID {
+				return ecserr.NewUnsupportedMonitorTypeError(ErrUnsupportedIntegration)
+			}
+		}
+	}
+
+	return nil
 }

--- a/x-pack/heartbeat/monitors/browser/browser.go
+++ b/x-pack/heartbeat/monitors/browser/browser.go
@@ -16,6 +16,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/beats/v7/heartbeat/ecserr"
+	"github.com/elastic/beats/v7/heartbeat/monitors"
 	"github.com/elastic/beats/v7/heartbeat/monitors/plugin"
 	"github.com/elastic/beats/v7/heartbeat/security"
 )
@@ -41,6 +42,10 @@ func create(name string, cfg *config.C) (p plugin.Plugin, err error) {
 	// We do not use user.Current() which does not reflect setuid changes!
 	if syscall.Geteuid() == 0 && security.NodeChildProcCred == nil {
 		return plugin.Plugin{}, fmt.Errorf("script monitors cannot be run as root")
+	}
+
+	if err := monitors.UnsupportedIntegrationType(cfg); err != nil {
+		return plugin.Plugin{}, err
 	}
 
 	s, err := NewProject(cfg)

--- a/x-pack/heartbeat/monitors/browser/source/local.go
+++ b/x-pack/heartbeat/monitors/browser/source/local.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"syscall"
 
+	"github.com/elastic/beats/v7/heartbeat/ecserr"
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/otiai10/copy"
@@ -33,27 +34,10 @@ func ErrInvalidPath(path string) error {
 	return fmt.Errorf("local source has invalid path '%s'", path)
 }
 
-func (l *LocalSource) Validate() error {
-	logp.L().Warn("local browser monitors are now deprecated! Please use project monitors instead. See the Elastic synthetics docs at https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html#synthetic-monitor-choose-project")
-	if l.OrigPath == "" {
-		return ErrNoPath
-	}
+var ErrLocalUnsupportedType = fmt.Errorf("local %s", ErrUnsupportedSource)
 
-	s, err := os.Stat(l.OrigPath)
-	base := ErrInvalidPath(l.OrigPath)
-	if err != nil {
-		return fmt.Errorf("%s: %w", base, err)
-	}
-	if !s.IsDir() {
-		return fmt.Errorf("path points to a non-directory: %w", base)
-	}
-	// ensure the used synthetics version dep used in project does not
-	// exceed our supported range
-	err = validatePackageJSON(path.Join(l.OrigPath, "package.json"))
-	if err != nil {
-		return err
-	}
-	return nil
+func (l *LocalSource) Validate() (err error) {
+	return ecserr.NewUnsupportedMonitorTypeError(ErrLocalUnsupportedType)
 }
 
 func (l *LocalSource) Fetch() (err error) {

--- a/x-pack/heartbeat/monitors/browser/source/source.go
+++ b/x-pack/heartbeat/monitors/browser/source/source.go
@@ -19,6 +19,8 @@ type Source struct {
 	ActiveMemo ISource        // cache for selected source
 }
 
+var ErrUnsupportedSource = fmt.Errorf("browser monitors are now removed! Please use project monitors instead. See the Elastic synthetics docs at https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html#synthetic-monitor-choose-project")
+
 func (s *Source) Active() ISource {
 	if s.ActiveMemo != nil {
 		return s.ActiveMemo

--- a/x-pack/heartbeat/monitors/browser/source/zipurl.go
+++ b/x-pack/heartbeat/monitors/browser/source/zipurl.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elastic/beats/v7/heartbeat/ecserr"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
@@ -42,12 +43,10 @@ type ZipURLSource struct {
 
 var ErrNoEtag = fmt.Errorf("no ETag header in zip file response. Heartbeat requires an etag to efficiently cache downloaded code")
 
+var ErrZipURLUnsupportedType = fmt.Errorf("zip_url %s", ErrUnsupportedSource)
+
 func (z *ZipURLSource) Validate() (err error) {
-	logp.L().Warn("Zip URL browser monitors are now deprecated! Please use project monitors instead. See the Elastic synthetics docs at https://www.elastic.co/guide/en/observability/current/synthetic-run-tests.html#synthetic-monitor-choose-project")
-	if z.httpClient == nil {
-		z.httpClient, _ = z.Transport.Client()
-	}
-	return err
+	return ecserr.NewUnsupportedMonitorTypeError(ErrZipURLUnsupportedType)
 }
 
 func (z *ZipURLSource) Fetch() error {


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/elastic/beats/issues/34506.
1. Remove support for `zip_url` and `local` browser sources.
2. Prevent running Synthetics Integrations when running under managed mode.

*Draft pending:  adding scenarios, integration policies tests and updating docs.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

