### PR TITLE
[Heartbeat]: fix error formatting on socktrace timeout

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -140,6 +140,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Fix issue using projects in airgapped environments by disabling npm audit. {pull}34936[34936]
 - Fix broken state ID location naming. {pull}35336[35336]
 - Fix output pipeline exit on run_once. {pull}35376[35376]
+- Fix formatting issue with socket trace timeout. {pull}35434[35434]
 
 *Heartbeat*
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -95,7 +95,7 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 		logp.L().Info("Setting up sock tracer at %s (wait: %s)", stConfig.Path, stConfig.Wait)
 		trace, err = tracer.NewSockTracer(stConfig.Path, stConfig.Wait)
 		if err != nil {
-			logp.L().Fatal("could not connect to socket trace at path %s after %s timeout: %s", stConfig.Path, stConfig.Wait, err)
+			logp.L().Fatalf("could not connect to socket trace at path %s after %s timeout: %w", stConfig.Path, stConfig.Wait, err)
 		}
 	}
 

--- a/heartbeat/beater/heartbeat.go
+++ b/heartbeat/beater/heartbeat.go
@@ -92,7 +92,7 @@ func New(b *beat.Beat, rawConfig *conf.C) (beat.Beater, error) {
 	if stConfig != nil {
 		// Note this, intentionally, blocks until connected to the trace endpoint
 		var err error
-		logp.L().Info("Setting up sock tracer at %s (wait: %s)", stConfig.Path, stConfig.Wait)
+		logp.L().Infof("Setting up sock tracer at %s (wait: %s)", stConfig.Path, stConfig.Wait)
 		trace, err = tracer.NewSockTracer(stConfig.Path, stConfig.Wait)
 		if err != nil {
 			logp.L().Fatalf("could not connect to socket trace at path %s after %s timeout: %w", stConfig.Path, stConfig.Wait, err)

--- a/heartbeat/tracer/tracer.go
+++ b/heartbeat/tracer/tracer.go
@@ -47,10 +47,10 @@ func NewSockTracer(path string, wait time.Duration) (st SockTracer, err error) {
 			return st, fmt.Errorf("wait time for sock trace exceeded: %s", wait)
 		}
 		if _, err := os.Stat(st.path); err == nil {
-			logp.L().Info("socktracer found file for unix socket: %s, will attempt to connect")
+			logp.L().Infof("socktracer found file for unix socket: %s, will attempt to connect")
 			break
 		} else {
-			logp.L().Info("socktracer could not find file for unix socket at: %s, will retry in %s", delay)
+			logp.L().Infof("socktracer could not find file for unix socket at: %s, will retry in %s", delay)
 			time.Sleep(delay)
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

Fixes the formatting issue when the socket tracing connection cannot be established within the configured timeout. 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

