### PR TITLE
Metricbeat AWS Module Docs Fix - Cherry picked from 96f67e8

### DIFF
--- a/metricbeat/docs/modules/aws.asciidoc
+++ b/metricbeat/docs/modules/aws.asciidoc
@@ -58,6 +58,17 @@ the `endpoint-code` part, such as `amazonaws.com`, `amazonaws.com.cn`, `c2s.ic.g
 
 If endpoint is specified, `regions` config becomes required. For example:
 
+* *tags_filter*
+
+The tags to filter against. If tags are given in config, then only
+collect metrics from resources that have tag key and tag value matches the filter.
+For example, if tags parameter is given as `Organization=Engineering` under
+`AWS/ELB` namespace, then only collect metrics from ELBs with tag name equals to
+`Organization` and tag value equals to `Engineering`.
+
+Note: tag filtering only works for metricsets with `resource_type` specified in the 
+metricset-specific configuration.
+
 [source,yaml]
 ----
 - module: aws
@@ -66,6 +77,9 @@ If endpoint is specified, `regions` config becomes required. For example:
   regions: cn-north-1
   metricsets:
     - ec2
+  tags_filter:
+    - key: "Organization"
+      value: "Engineering"
 ----
 
 The aws module comes with a predefined dashboard. For example:
@@ -75,14 +89,9 @@ image::./images/metricbeat-aws-overview.png[]
 [float]
 == Metricsets
 
-Currently, we have `billing`, `cloudwatch`, `dynamodb`, `ebs`, `ec2`, `elb`,
-`lambda`, `natgateway`, `rds`, `s3_daily_storage`, `s3_request`, `sns`, `sqs`,
+Currently, we have `billing`, `cloudwatch`, `dynamodb`, `ebs`, `ec2`, `elb`, `kinesis`
+`lambda`, `mtest`, `natgateway`, `rds`, `s3_daily_storage`, `s3_request`, `sns`, `sqs`,
 `transitgateway`, `usage` and `vpn` metricset in `aws` module.
-
-Collecting `tags` for `ec2`, `rds`, `cloudwatch`, and metricset created based on
-`cloudwatch` using light module is supported.
-
-* *tags.*: Tag key value pairs from aws resources. A tag is a label that user assigns to an AWS resource.
 
 [float]
 === `billing`

--- a/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/aws/_meta/docs.asciidoc
@@ -48,6 +48,17 @@ the `endpoint-code` part, such as `amazonaws.com`, `amazonaws.com.cn`, `c2s.ic.g
 
 If endpoint is specified, `regions` config becomes required. For example:
 
+* *tags_filter*
+
+The tags to filter against. If tags are given in config, then only
+collect metrics from resources that have tag key and tag value matches the filter.
+For example, if tags parameter is given as `Organization=Engineering` under
+`AWS/ELB` namespace, then only collect metrics from ELBs with tag name equals to
+`Organization` and tag value equals to `Engineering`.
+
+Note: tag filtering only works for metricsets with `resource_type` specified in the 
+metricset-specific configuration.
+
 [source,yaml]
 ----
 - module: aws
@@ -56,6 +67,9 @@ If endpoint is specified, `regions` config becomes required. For example:
   regions: cn-north-1
   metricsets:
     - ec2
+  tags_filter:
+    - key: "Organization"
+      value: "Engineering"
 ----
 
 The aws module comes with a predefined dashboard. For example:
@@ -65,14 +79,9 @@ image::./images/metricbeat-aws-overview.png[]
 [float]
 == Metricsets
 
-Currently, we have `billing`, `cloudwatch`, `dynamodb`, `ebs`, `ec2`, `elb`,
-`lambda`, `natgateway`, `rds`, `s3_daily_storage`, `s3_request`, `sns`, `sqs`,
+Currently, we have `billing`, `cloudwatch`, `dynamodb`, `ebs`, `ec2`, `elb`, `kinesis`
+`lambda`, `mtest`, `natgateway`, `rds`, `s3_daily_storage`, `s3_request`, `sns`, `sqs`,
 `transitgateway`, `usage` and `vpn` metricset in `aws` module.
-
-Collecting `tags` for `ec2`, `rds`, `cloudwatch`, and metricset created based on
-`cloudwatch` using light module is supported.
-
-* *tags.*: Tag key value pairs from aws resources. A tag is a label that user assigns to an AWS resource.
 
 [float]
 === `billing`


### PR DESCRIPTION
## What does this PR do?

Add documentation about the `tags_filter` feature. 

## Why is it important?

This feature has been backported but it is not present in the [documentation](https://www.elastic.co/guide/en/beats/metricbeat/7.17/metricbeat-module-aws.html). We had a related SDH, where the user thought that the tags processor is doing what `tags_filter` is doing. As a result, this generated a large bill because they were not aware that API calls are still made for all resources regardless of the tags. 

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

## How to test this PR locally

## Related issues

## Use cases

## Screenshots

## Logs

