### PR TITLE
[Heartbeat] Improve sock tracer behavior

### DIFF
--- a/heartbeat/tracer/tracer.go
+++ b/heartbeat/tracer/tracer.go
@@ -66,11 +66,12 @@ func NewSockTracer(path string, wait time.Duration) (st SockTracer, err error) {
 func (st SockTracer) Write(message string) error {
 	// Note, we don't need to worry about partial writes here: https://pkg.go.dev/io?utm_source=godoc#Writer
 	// an error will be returned here, which shouldn't really happen with unix sockets only
-	_, err := st.sock.Write([]byte(message))
+	_, err := st.sock.Write([]byte(message + "\n"))
 	return err
 }
 
 func (st SockTracer) Close() error {
+	_ = st.Write("stop")
 	return st.sock.Close()
 }
 


### PR DESCRIPTION
Improve sock tracer behavior to:

1. Not prevent heartbeat from starting if it can't be initialized.
2. Make newline behavior more consistent, previously only the 'stop' message sent the newline

No changelog since this isn't an internally used tracing feature that would not impact users

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

In one terminal in x-pack/heartbeat

```
 rm /tmp/stest.sock; mage build && ./heartbeat -e -E heartbeat.socket_trace.wait=30s -E heartbeat.socket
_trace.path=/tmp/stest.sock  -E heartbeat.run_once=true| jq .message
```

After that starts, in another 

`nc -Ul /tmp/stest.sock`