### PR TITLE
Log error when setting data into the persistent store fails

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/publish.go
+++ b/filebeat/input/filestream/internal/input-logfile/publish.go
@@ -145,7 +145,7 @@ func (op *updateOp) Execute(store *store, n uint) {
 	err := store.persistentStore.Set(resource.key, resource.inSyncStateSnapshot())
 	if err != nil {
 		if !statestore.IsClosed(err) {
-			store.log.Errorf("Failed to update state in the registry for '%v'", resource.key)
+			store.log.Errorf("Failed to update state in the registry for '%v': %s", resource.key, err)
 		}
 	} else {
 		resource.stored = true

--- a/filebeat/input/v2/input-cursor/publish.go
+++ b/filebeat/input/v2/input-cursor/publish.go
@@ -143,7 +143,7 @@ func (op *updateOp) Execute(n uint) {
 	err := op.store.persistentStore.Set(resource.key, resource.inSyncStateSnapshot())
 	if err != nil {
 		if !statestore.IsClosed(err) {
-			op.store.log.Errorf("Failed to update state in the registry for '%v'", resource.key)
+			op.store.log.Errorf("Failed to update state in the registry for '%v': %s", resource.key, err)
 		}
 	} else {
 		resource.internalInSync = true


### PR DESCRIPTION
## What does this PR do?

Logs the error when Filebeat fails to set a state into the persistent store (registry)

## Why is it important?

Currently we only know the operation failed and the entry that failed, however we do not know why it failed.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
