### PR TITLE
packetbeat/sniffer - Use non-deprecated logger statements

### DIFF
--- a/packetbeat/sniffer/afpacket.go
+++ b/packetbeat/sniffer/afpacket.go
@@ -17,12 +17,14 @@
 
 package sniffer
 
-import "fmt"
+import (
+	"fmt"
+)
 
-// Computes the block_size and the num_blocks in such a way that the
-// allocated mmap buffer is close to but smaller than target_size_mb.
-// The restriction is that the block_size must be divisible by both the
-// frame size and page size.
+// afpacketComputeSize computes the block_size and the num_blocks in such a way
+// that the allocated mmap buffer is close to but smaller than target_size_mb.
+// The restriction is that the block_size must be divisible by both the frame
+// size and page size.
 func afpacketComputeSize(targetSizeMb, snaplen, pageSize int) (frameSize, blockSize, numBlocks int, err error) {
 	if snaplen < pageSize {
 		frameSize = pageSize / (pageSize / snaplen)
@@ -35,7 +37,7 @@ func afpacketComputeSize(targetSizeMb, snaplen, pageSize int) (frameSize, blockS
 	numBlocks = (targetSizeMb * 1024 * 1024) / blockSize
 
 	if numBlocks == 0 {
-		return 0, 0, 0, fmt.Errorf("Buffer size too small")
+		return 0, 0, 0, fmt.Errorf("buffer size too small")
 	}
 
 	return frameSize, blockSize, numBlocks, nil

--- a/packetbeat/sniffer/afpacket_linux.go
+++ b/packetbeat/sniffer/afpacket_linux.go
@@ -41,21 +41,25 @@ type afpacketHandle struct {
 	promiscPreviousState         bool
 	promiscPreviousStateDetected bool
 	device                       string
+	log                          *logp.Logger
 }
 
 func newAfpacketHandle(device string, snaplen, block_size, num_blocks int, timeout time.Duration, autoPromiscMode bool) (*afpacketHandle, error) {
 	var err error
 	var promiscEnabled bool
+	log := logp.NewLogger("sniffer")
 
 	if autoPromiscMode {
 		promiscEnabled, err = isPromiscEnabled(device)
 		if err != nil {
-			logp.Err("Failed to get promiscuous mode for device '%s': %v", device, err)
+			log.Errorf("Failed to get promiscuous mode for device '%s': %v", device, err)
 		}
 
 		if !promiscEnabled {
 			if setPromiscErr := setPromiscMode(device, true); setPromiscErr != nil {
-				logp.Warn("Failed to set promiscuous mode for device '%s'. Packetbeat may be unable to see any network traffic. Please follow packetbeat FAQ to learn about mitigation: Error: %v", device, err)
+				log.Warnf("Failed to set promiscuous mode for device '%s'. "+
+					"Packetbeat may be unable to see any network traffic. Please follow packetbeat "+
+					"FAQ to learn about mitigation: Error: %v", device, err)
 			}
 		}
 	}
@@ -65,6 +69,7 @@ func newAfpacketHandle(device string, snaplen, block_size, num_blocks int, timeo
 		frameSize:                    snaplen,
 		device:                       device,
 		promiscPreviousStateDetected: autoPromiscMode && err == nil,
+		log:                          log,
 	}
 
 	if device == "any" {
@@ -115,7 +120,7 @@ func (h *afpacketHandle) Close() {
 	// previous state detected only if auto mode was on
 	if h.promiscPreviousStateDetected {
 		if err := setPromiscMode(h.device, h.promiscPreviousState); err != nil {
-			logp.Warn("Failed to reset promiscuous mode for device '%s'. Your device might be in promiscuous mode.: %v", h.device, err)
+			h.log.Warnf("Failed to reset promiscuous mode for device '%s'. Your device might be in promiscuous mode.: %v", h.device, err)
 		}
 	}
 }
@@ -129,7 +134,6 @@ func isPromiscEnabled(device string) (bool, error) {
 	if e != nil {
 		return false, e
 	}
-
 	defer syscall.Close(s)
 
 	var ifreq struct {
@@ -137,7 +141,7 @@ func isPromiscEnabled(device string) (bool, error) {
 		flags uint16
 	}
 
-	copy(ifreq.name[:], []byte(device))
+	copy(ifreq.name[:], device)
 	_, _, ep := syscall.Syscall(syscall.SYS_IOCTL, uintptr(s), syscall.SIOCGIFFLAGS, uintptr(unsafe.Pointer(&ifreq)))
 	if ep != 0 {
 		return false, fmt.Errorf("ioctl command SIOCGIFFLAGS failed to get device flags for %v: return code %d", device, ep)
@@ -146,12 +150,10 @@ func isPromiscEnabled(device string) (bool, error) {
 	return ifreq.flags&uint16(syscall.IFF_PROMISC) != 0, nil
 }
 
-// setPromiscMode enables promisc mode if configured.
-// this makes maintenance for user simpler without any additional manual steps
-// issue [700](https://github.com/elastic/beats/issues/700)
+// setPromiscMode enables promisc mode if configured. This is a no-op when device is 'any'.
 func setPromiscMode(device string, enabled bool) error {
 	if device == "any" {
-		logp.Warn("Cannot set promiscuous mode to device 'any'")
+		logp.L().Named("sniffer").Warn("Cannot set promiscuous mode for device 'any'")
 		return nil
 	}
 

--- a/packetbeat/sniffer/afpacket_nonlinux.go
+++ b/packetbeat/sniffer/afpacket_nonlinux.go
@@ -21,35 +21,34 @@
 package sniffer
 
 import (
-	"fmt"
+	"errors"
 	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 )
 
+var errAFPacketLinuxOnly = errors.New("af_packet MMAP sniffing is only available on Linux")
+
 type afpacketHandle struct{}
 
-func newAfpacketHandle(device string, snaplen int, blockSize int, numBlocks int,
-	timeout time.Duration, enableAutoPromiscMode bool) (*afpacketHandle, error,
-) {
-	return nil, fmt.Errorf("Afpacket MMAP sniffing is only available on Linux")
+func newAfpacketHandle(_ string, _, _, _ int, _ time.Duration, _ bool) (*afpacketHandle, error) {
+	return nil, errAFPacketLinuxOnly
 }
 
-func (h *afpacketHandle) ReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
-	return data, ci, fmt.Errorf("Afpacket MMAP sniffing is only available on Linux")
+func (*afpacketHandle) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
+	return nil, gopacket.CaptureInfo{}, errAFPacketLinuxOnly
 }
 
-func (h *afpacketHandle) SetBPFFilter(expr string) (_ error) {
-	return fmt.Errorf("Afpacket MMAP sniffing is only available on Linux")
+func (*afpacketHandle) SetBPFFilter(_ string) error {
+	return errAFPacketLinuxOnly
 }
 
-func (h *afpacketHandle) LinkType() layers.LinkType {
-	return layers.LinkTypeEthernet
+func (*afpacketHandle) LinkType() layers.LinkType {
+	return 0
 }
 
-func (h *afpacketHandle) Close() {
-}
+func (*afpacketHandle) Close() {}
 
 // isAfpacketErrTimeout returns whether the error is afpacket.ErrTimeout, always false on
 // non-linux systems.

--- a/packetbeat/sniffer/device.go
+++ b/packetbeat/sniffer/device.go
@@ -34,10 +34,10 @@ import (
 
 var deviceAnySupported = runtime.GOOS == "linux"
 
-// ListDevicesNames returns the list of adapters available for sniffing on
-// this computer. If the withDescription parameter is set to true, a human
-// readable version of the adapter name is added. If the withIP parameter
-// is set to true, IP address of the adapter is added.
+// ListDeviceNames returns the list of adapters available for sniffing on this
+// computer. If the withDescription parameter is set to true, a human-readable
+// version of the adapter name is added. If the withIP parameter is set to
+// true, IP address of the adapter is added.
 func ListDeviceNames(withDescription, withIP bool) ([]string, error) {
 	devices, err := pcap.FindAllDevs()
 	if err != nil {
@@ -148,7 +148,7 @@ func resolveDeviceName(name string) (string, error) {
 		return "", fmt.Errorf("invalid device index %d: %w", index, err)
 	}
 
-	logp.Info("Resolved device index %d to device: %s", index, name)
+	logp.L().Named("sniffer").Info("Resolved device index %d to device: %s", index, name)
 	return name, nil
 }
 

--- a/packetbeat/sniffer/file.go
+++ b/packetbeat/sniffer/file.go
@@ -37,6 +37,8 @@ type fileHandler struct {
 
 	topSpeed bool
 	lastTS   time.Time
+
+	log *logp.Logger
 }
 
 func newFileHandler(file string, topSpeed bool, maxLoopCount int) (*fileHandler, error) {
@@ -44,6 +46,7 @@ func newFileHandler(file string, topSpeed bool, maxLoopCount int) (*fileHandler,
 		file:         file,
 		topSpeed:     topSpeed,
 		maxLoopCount: maxLoopCount,
+		log:          logp.NewLogger("sniffer"),
 	}
 	if err := h.open(); err != nil {
 		return nil, err
@@ -77,7 +80,7 @@ func (h *fileHandler) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 			return data, ci, err
 		}
 
-		logp.Debug("sniffer", "Reopening the file")
+		h.log.Debug("Reopening the file")
 		if err = h.open(); err != nil {
 			return nil, ci, fmt.Errorf("failed to reopen file: %w", err)
 		}
@@ -96,7 +99,7 @@ func (h *fileHandler) ReadPacketData() ([]byte, gopacket.CaptureInfo, error) {
 		if sleep > 0 {
 			time.Sleep(sleep)
 		} else {
-			logp.Warn("Time in pcap went backwards: %d", sleep)
+			h.log.Warnf("Time in pcap went backwards: %d", sleep)
 		}
 	}
 

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -45,6 +45,7 @@ import (
 type Sniffer struct {
 	sniffers []sniffer
 	cancel   func()
+	log      *logp.Logger
 }
 
 type sniffer struct {
@@ -64,6 +65,8 @@ type sniffer struct {
 	filter string
 
 	decoders Decoders
+
+	log *logp.Logger
 }
 
 type snifferHandle interface {
@@ -83,26 +86,30 @@ const (
 // only, but no device is opened yet. Accessing and configuring the actual device
 // is done by the Run method.
 func New(testMode bool, _ string, decoders Decoders, interfaces []config.InterfaceConfig) (*Sniffer, error) {
-	s := &Sniffer{sniffers: make([]sniffer, len(interfaces))}
+	s := &Sniffer{
+		sniffers: make([]sniffer, len(interfaces)),
+		log:      logp.NewLogger("sniffer"),
+	}
 
 	for i, iface := range interfaces {
 		child := sniffer{
 			state:         atomic.MakeInt32(snifferInactive),
 			followDefault: iface.PollDefaultRoute > 0 && strings.HasPrefix(iface.Device, "default_route"),
 			decoders:      decoders,
+			log:           s.log,
 		}
 
-		logp.Debug("sniffer", "interface: %d, BPF filter: '%s'", i, iface.BpfFilter)
+		s.log.Debugf("interface: %d, BPF filter: '%s'", i, iface.BpfFilter)
 
 		// pre-check and normalize configuration:
 		// - resolve potential device name
 		// - check for file output
 		// - set some defaults
 		if iface.File != "" {
-			logp.Debug("sniffer", "Reading from file: %s", iface.File)
+			s.log.Debugf("Reading from file: %s", iface.File)
 
 			if iface.BpfFilter != "" {
-				logp.Warn("Packet filters are not applied to pcap files.")
+				s.log.Warn("Packet filters are not applied to pcap files. Ignoring BFP filter.")
 			}
 
 			// we read file with the pcap provider
@@ -130,7 +137,7 @@ func New(testMode bool, _ string, decoders Decoders, interfaces []config.Interfa
 				if t := iface.Type; t == "autodetect" || t == "" {
 					iface.Type = "pcap"
 				}
-				logp.Debug("sniffer", "Sniffer type: %s device: %s", iface.Type, child.device)
+				s.log.Debugf("Sniffer type: %s device: %s", iface.Type, child.device)
 			}
 		}
 
@@ -156,7 +163,7 @@ func validateConfig(filter string, cfg *config.InterfaceConfig) error {
 
 	switch cfg.Type {
 	case "pcap":
-		return validatePcapConfig(cfg)
+		return nil
 	case "af_packet":
 		return validateAfPacketConfig(cfg)
 	default:
@@ -170,10 +177,6 @@ func validatePcapFilter(expr string) error {
 	}
 	_, err := pcap.NewBPF(layers.LinkTypeEthernet, 65535, expr)
 	return err
-}
-
-func validatePcapConfig(cfg *config.InterfaceConfig) error {
-	return nil
 }
 
 func validateAfPacketConfig(cfg *config.InterfaceConfig) error {
@@ -216,7 +219,7 @@ func (s *Sniffer) Run() error {
 // the control of the poller.
 func (s *sniffer) pollDefaultRoute(ctx context.Context, device chan<- string, refresh <-chan struct{}) {
 	go func() {
-		logp.Info("starting default route poller")
+		s.log.Info("starting default route poller")
 
 		// Prime the channel.
 		current := s.device
@@ -227,13 +230,13 @@ func (s *sniffer) pollDefaultRoute(ctx context.Context, device chan<- string, re
 		for {
 			select {
 			case <-tick.C:
-				logp.Debug("sniffer", "polling default route")
+				s.log.Debug("polling default route")
 				current = s.poll(current, device)
 			case <-refresh:
-				logp.Debug("sniffer", "requested new default route")
+				s.log.Debug("requested new default route")
 				current = s.poll(current, device)
 			case <-ctx.Done():
-				logp.Info("closing default route poller")
+				s.log.Info("closing default route poller")
 				close(device)
 				tick.Stop()
 				return
@@ -250,16 +253,16 @@ func (s *sniffer) pollDefaultRoute(ctx context.Context, device chan<- string, re
 }
 
 // poll returns the current default route interface and sends it on device
-// if it has change from the old default route interface. If device resolution
+// if it has a change from the old default route interface. If device resolution
 // fails, the default route interface is left unchanged.
 func (s *sniffer) poll(old string, device chan<- string) (current string) {
 	current, err := resolveDeviceName(s.config.Device)
 	if err != nil {
-		logp.Warn("sniffer failed to poll default route device: %v", err)
+		s.log.Warnf("sniffer failed to poll default route device: %v", err)
 		return old
 	}
 	if current != old {
-		logp.Info("sniffer changing default route device: %s -> %s", old, current)
+		s.log.Infof("sniffer changing default route device: %s -> %s", old, current)
 		s.state.Store(snifferInactive) // Mark current device as stale. ¯\_(ツ)_/¯
 		device <- current              // Pass the new device name.
 		defaultRouteMetric.Set(current)
@@ -316,7 +319,7 @@ func (s *sniffer) sniffOneDynamic(ctx context.Context, device string, last layer
 
 	linkType := handle.LinkType()
 	if dec == nil || linkType != last {
-		logp.Info("changing link type: %d -> %d", last, linkType)
+		s.log.Infof("changing link type: %d -> %d", last, linkType)
 		var cleanup func()
 		dec, cleanup, err = s.decoders(linkType, device)
 		if err != nil {
@@ -337,7 +340,7 @@ func (s *sniffer) sniffHandle(ctx context.Context, handle snifferHandle, dec *de
 	if s.config.Dumpfile != "" {
 		const timeSuffixFormat = "20060102150405"
 		filename := fmt.Sprintf("%s-%s.pcap", s.config.Dumpfile, time.Now().Format(timeSuffixFormat))
-		logp.Info("creating new dump file %s", filename)
+		s.log.Infof("creating new dump file %s", filename)
 		f, err := os.Create(filename)
 		if err != nil {
 			return err
@@ -366,7 +369,7 @@ func (s *sniffer) sniffHandle(ctx context.Context, handle snifferHandle, dec *de
 	for s.state.Load() == snifferActive {
 		select {
 		case <-ctx.Done():
-			logp.Info("sniffing cancelled: %q", s.config.Device)
+			s.log.Infof("sniffing cancelled: %q", s.config.Device)
 
 			// Return nil since this must have been due to an errgroup
 			// termination and any error that caused that will already
@@ -382,9 +385,7 @@ func (s *sniffer) sniffHandle(ctx context.Context, handle snifferHandle, dec *de
 
 		data, ci, err := handle.ReadPacketData()
 		if err == pcap.NextErrorTimeoutExpired || isAfpacketErrTimeout(err) { //nolint:errorlint // pcap.NextErrorTimeoutExpired is not wrapped.
-			logp.Debug("sniffer", "timed out")
-
-			// If we have timed out too many times and we are following
+			// If we have timed out too many times, and we are following
 			// a default route, request a new default route interface.
 			const maxTimeouts = 10 // Place-holder until we have a sensible notion of how big this should be.
 			timeouts++
@@ -414,7 +415,7 @@ func (s *sniffer) sniffHandle(ctx context.Context, handle snifferHandle, dec *de
 				default:
 					// Don't request to refresh if already requested.
 				}
-				logp.Warn("error during packet capture: %v", err)
+				s.log.Warnf("error during packet capture: %v", err)
 				continue
 			}
 
@@ -436,7 +437,9 @@ func (s *sniffer) sniffHandle(ctx context.Context, handle snifferHandle, dec *de
 			}
 		}
 
-		logp.Debug("sniffer", "Packet number: %d", packets)
+		if s.config.OneAtATime {
+			s.log.Debugw("Packet received.", "network.packets", packets)
+		}
 		dec.OnPacket(data, &ci)
 	}
 
@@ -461,13 +464,13 @@ func (s *sniffer) open(device string) (snifferHandle, error) {
 // Stop marks a sniffer as stopped. The Run method will return once the stop
 // signal has been given.
 func (s *Sniffer) Stop() {
-	logp.Debug("sniffer", "sending stop to all sniffers")
+	s.log.Debug("sending stop to all sniffers")
 	for _, c := range s.sniffers {
-		logp.Debug("sniffer", "sending closing to %s", c.config.Device)
+		s.log.Debugf("sending closing to %s", c.config.Device)
 		c.state.Store(snifferClosing)
 	}
 	if s.cancel != nil {
-		logp.Debug("sniffer", "cancelling sniffers")
+		s.log.Debug("cancelling sniffers")
 		s.cancel()
 	}
 }


### PR DESCRIPTION
## What does this PR do?

This is some minor maintenance to the Packetbeat sniffer package. Changes include:

- Replace deprecated logger calls with a named per-instance logger. All log statements from the package will name contain log.logger=sniffer.
- Fix a few nits in the godoc and comments.
- Correct errors that used capitalized error strings.
- Replace unused params with underscore.
- Remove unused receiver in methods.
- Remove two extremely verbose logging statements from the sniffer hot path ("timed out" and "Packet number: %d").

## Why is it important?

Code quality.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
