### PR TITLE
Add `elastic/obs-cloud-monitoring` to own cloud-related processors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,7 +58,7 @@ CHANGELOG*
 /libbeat/processors/registered_domain/ @elastic/security-external-integrations
 /libbeat/processors/translate_sid/ @elastic/security-external-integrations
 /libbeat/processors/add_cloud_metadata @elastic/obs-cloud-monitoring
-/libbeat/processors/add_kubernetes_metadata @elastic/obs-cloud-monitoring
+/libbeat/processors/add_kubernetes_metadata @elastic/obs-cloudnative-monitoring
 /licenses/ @elastic/elastic-agent-data-plane
 /metricbeat/ @elastic/elastic-agent-data-plane
 /metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,8 @@ CHANGELOG*
 /libbeat/processors/dns/ @elastic/security-external-integrations
 /libbeat/processors/registered_domain/ @elastic/security-external-integrations
 /libbeat/processors/translate_sid/ @elastic/security-external-integrations
+/libbeat/processors/add_cloud_metadata @elastic/obs-cloud-monitoring
+/libbeat/processors/add_kubernetes_metadata @elastic/obs-cloud-monitoring
 /licenses/ @elastic/elastic-agent-data-plane
 /metricbeat/ @elastic/elastic-agent-data-plane
 /metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.


### PR DESCRIPTION
So, the code reviews are assigned properly.

According to @jlind23 the cloud metadata processor belongs to @elastic/obs-cloud-monitoring
and the Kubernetes metadata processors belongs to @elastic/obs-cloudnative-monitoring

I occasionally see PRs that are assigned to the data plane team but they're about internals of these two processors. I think it would be better if the owning teams review them.

I might be wrong about this ownership, if so, please leave a comment.