### PR TITLE
auditbeat/module/file_integrity/fileorigin_test.go - Create file per sub-test

### DIFF
--- a/auditbeat/module/file_integrity/fileorigin_test.go
+++ b/auditbeat/module/file_integrity/fileorigin_test.go
@@ -21,13 +21,13 @@
 package file_integrity
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -50,49 +50,57 @@ func TestDarwinWhereFroms(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("Unsupported platform")
 	}
-	f, err := ioutil.TempFile("", "wherefrom")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(f.Name())
 
 	t.Run("no origin", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "no_origin")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
 		origin, err := GetFileOrigin(f.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		assert.Len(t, origin, 0)
 	})
 	t.Run("valid origin", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "valid_origin")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		//nolint:gosec // Using file.Name() as an argument is safe.
 		err = exec.Command("xattr", "-w", "-x", key, value, f.Name()).Run()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		origin, err := GetFileOrigin(f.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		assert.Len(t, origin, 2)
 		assert.Equal(t, "https://artifacts.elastic.co/downloads/beats/auditbeat/auditbeat-6.1.1-darwin-x86_64.tar.gz", origin[0])
 		assert.Equal(t, "https://www.elastic.co/downloads/beats/auditbeat", origin[1])
 	})
 	t.Run("empty origin", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "empty_origin")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		//nolint:gosec // Using file.Name() as an argument is safe.
 		err = exec.Command("xattr", "-w", "-x", key, "", f.Name()).Run()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		origin, err := GetFileOrigin(f.Name())
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		assert.Len(t, origin, 0)
 	})
 	t.Run("bad origin", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "bad_origin")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		//nolint:gosec // Using file.Name() as an argument is safe.
 		err = exec.Command("xattr", "-w", "-x", key, "01 23 45 67", f.Name()).Run()
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err := GetFileOrigin(f.Name())
+		require.NoError(t, err)
+
+		_, err = GetFileOrigin(f.Name())
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
## What does this PR do?

Instead of sharing the same file while handle is open across sub-tests, create a new temp file for each sub-test and close it after creating it.

I couldn't reproduce the flaky test case, but I figured it can't hurt to further isolate each sub-test with separate files. The tests are each modifying the file extended attributes (so maybe there is some race related to the filesystem extended attributes?).

Relates #33033

## Why is it important?

Flaky tests degrade developer experience.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Relates #33033
