### PR TITLE
Update docs for loadbalance settings in Beats outputs

### DIFF
--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -124,18 +124,17 @@ The default value is `1`.
 
 ===== `loadbalance`
 
-When `loadbalance: true` is set, {beatname_uc} sends data if-and-only-if it can
-send to all hosts in the list. {beatname_uc} connects to all hosts in the list
-and evenly distributes the events to them. This has the side effect of blocking
-publishing to all hosts if any one of them is down or exerting back-pressure.
+When `loadbalance: true` is set, {beatname_uc} connects to all configured
+hosts and sends data through all connections in parallel. If a connection
+fails, data is sent to the remaining hosts until it can be reestablished.
+Data will still be sent as long as {beatname_uc} can connect to at least
+one of its configured hosts.
 
-When `loadbalance: false` is set, {beatname_uc} picks a host at random from the
-list and sends data, switching over to other list entries in the event of a
-failure. {beatname_uc} also accepts a time to live (TTL), which causes it to
-voluntarily reestablish a connection to a new host after a time even if it is
-healthy. Otherwise, if a TTL is not set, as long as the first chosen endpoint is
-available, {beatname_uc} continues to communicate with it and only switches to
-another endpoint in case of a failure.
+When `loadbalance: false` is set, {beatname_uc} sends data to a single host
+at a time. The target host is chosen at random from the list of configured
+hosts, and all data is sent to that target until the connection fails, when
+a new target is selected. Data will still be sent as long as {beatname_uc}
+can connect to at least one of its configured hosts.
 
 The default value is `true`.
 

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -271,18 +271,20 @@ is best used with load balancing mode enabled. Example: If you have 2 hosts and
 [[loadbalance]]
 ===== `loadbalance`
 
-When `loadbalance: true` is set, {beatname_uc} sends data if-and-only-if it can
-send to all hosts in the list. {beatname_uc} connects to all hosts in the list
-and evenly distributes the events to them. This has the side effect of blocking
-publishing to all hosts if any one of them is down or exerting back-pressure.
+When `loadbalance: true` is set, {beatname_uc} connects to all configured
+hosts and sends data through all connections in parallel. If a connection
+fails, data is sent to the remaining hosts until it can be reestablished.
+Data will still be sent as long as {beatname_uc} can connect to at least
+one of its configured hosts.
 
-When `loadbalance: false` is set, {beatname_uc} picks a host at random from the
-list and sends data, switching over to other list entries in the event of a
-failure. {beatname_uc} also accepts a time to live (TTL), which causes it to
-voluntarily reestablish a connection to a new host after a time even if it is
-healthy. Otherwise, if a TTL is not set, as long as the first chosen endpoint is
-available, {beatname_uc} continues to communicate with it and only switches to
-another endpoint in case of a failure.
+When `loadbalance: false` is set, {beatname_uc} sends data to a single host
+at a time. The target host is chosen at random from the list of configured
+hosts, and all data is sent to that target until the connection fails, when
+a new target is selected. Data will still be sent as long as {beatname_uc}
+can connect to at least one of its configured hosts. To rotate through the
+list of configured hosts over time, use this option in conjunction with the
+`ttl` setting to close the connection at the configured interval and choose
+a new target host.
 
 The default value is `true`.
 

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -165,18 +165,17 @@ The number of workers to use for each host configured to publish events to Redis
 
 ===== `loadbalance`
 
-When `loadbalance: true` is set, {beatname_uc} sends data if-and-only-if it can
-send to all hosts in the list. {beatname_uc} connects to all hosts in the list
-and evenly distributes the events to them. This has the side effect of blocking
-publishing to all hosts if any one of them is down or exerting back-pressure.
+When `loadbalance: true` is set, {beatname_uc} connects to all configured
+hosts and sends data through all connections in parallel. If a connection
+fails, data is sent to the remaining hosts until it can be reestablished.
+Data will still be sent as long as {beatname_uc} can connect to at least
+one of its configured hosts.
 
-When `loadbalance: false` is set, {beatname_uc} picks a host at random from the
-list and sends data, switching over to other list entries in the event of a
-failure. {beatname_uc} also accepts a time to live (TTL), which causes it to
-voluntarily reestablish a connection to a new host after a time even if it is
-healthy. Otherwise, if a TTL is not set, as long as the first chosen endpoint is
-available, {beatname_uc} continues to communicate with it and only switches to
-another endpoint in case of a failure.
+When `loadbalance: false` is set, {beatname_uc} sends data to a single host
+at a time. The target host is chosen at random from the list of configured
+hosts, and all data is sent to that target until the connection fails, when
+a new target is selected. Data will still be sent as long as {beatname_uc}
+can connect to at least one of its configured hosts.
 
 The default value is `true`.
 


### PR DESCRIPTION
Clarify / fix some inaccuracies that had gotten into the `loadbalance` documentation, particularly:
- Beats will still send data to configured outputs as long as they can connect to _any_ of them, regardless of `loadbalance` settings
- The `ttl` setting is specific to the `logstash` output and shouldn't be referenced in documentation for the `elasticsearch` and `redis` outputs.