### PR TITLE
[Packetbeat] Fix BPF filter setting not being applied to sniffers

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -195,6 +195,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 *Packetbeat*
 
 - Fix double channel close panic when reloading. {pull}35324[35324]
+- Fix BPF filter setting not being applied to sniffers. {issue}35363[35363] {pull}35484[35484]
 
 *Winlogbeat*
 

--- a/packetbeat/sniffer/sniffer.go
+++ b/packetbeat/sniffer/sniffer.go
@@ -148,6 +148,7 @@ func New(testMode bool, _ string, decoders Decoders, interfaces []config.Interfa
 		}
 
 		child.config = iface
+		child.filter = iface.BpfFilter
 		s.sniffers[i] = child
 	}
 


### PR DESCRIPTION
## What does this PR do?

- Ensures that the BPF filter setting is applied to sniffers

## Why is it important?

BPF filters were not being applied to pcap and af_packet sniffers and were processing packets that were supposed to be filtered out.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Configure packetbeat to sniff an interface with either the `pcap` or `af_packet` (Linux only) type and configure a BPF filter. Turning on debug logging will either show packets being handled or the sniffer timing out. If you configured the BPF filter to handle traffic known to not exist, then you should see the sniffer time out. If the BPF filter had not applied properly, then it would be picking other traffic (this is especially the case if you connect to the test host using SSH).

## Related issues

- Closes #35363 
