### PR TITLE
[updatecli] update elastic stack version for testing 7.17.11-31efa078

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.11-ad2a1253-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.11-31efa078-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -22,7 +22,7 @@ services:
     - "ingest.geoip.downloader.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.17.11-ad2a1253-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:7.17.11-31efa078-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -32,7 +32,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.11-ad2a1253-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.11-31efa078-SNAPSHOT
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600


### PR DESCRIPTION



<Actions>
    <action id="5213870796bdb904cecfa5bf58c03e2071f6c84f7abd09ebe2fc3f55f24a068b">
        <h3>Bump elastic-stack to latest snapshot version</h3>
        <details id="e1467303820a62307ce747d1b2cf10db2f7fc32dc526da860cf87f1c25a549fe">
            <summary>Update snapshot.yml</summary>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, the next time it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [chat](https://matrix.to/#/#Updatecli_community:gitter.im)

<img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="200" height="200">
