### PR TITLE
[updatecli] update elastic stack version for testing 8.8.0-49c28bdb

### DIFF
--- a/testing/environments/snapshot.yml
+++ b/testing/environments/snapshot.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0-9e4f7a5d-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.0-49c28bdb-SNAPSHOT
     # When extend is used it merges healthcheck.tests, see:
     # https://github.com/docker/compose/issues/8962
     # healthcheck:
@@ -31,7 +31,7 @@ services:
     - "./docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.8.0-9e4f7a5d-SNAPSHOT
+    image: docker.elastic.co/logstash/logstash:8.8.0-49c28bdb-SNAPSHOT
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 600
@@ -44,7 +44,7 @@ services:
       - 5055:5055
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.8.0-9e4f7a5d-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.8.0-49c28bdb-SNAPSHOT
     environment:
     - "ELASTICSEARCH_USERNAME=kibana_system_user"
     - "ELASTICSEARCH_PASSWORD=testing"


### PR DESCRIPTION



<Actions>
    <action id="347b1e36e6fb7378034f26af73b63afdeae5ff0ae8c872ec057c1a16e409c782">
        <h3>Bump elastic-stack to latest snapshot version</h3>
        <details id="e1467303820a62307ce747d1b2cf10db2f7fc32dc526da860cf87f1c25a549fe">
            <summary>Update snapshot.yml</summary>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, the next time it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [chat](https://matrix.to/#/#Updatecli_community:gitter.im)

<img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="200" height="200">
