### PR TITLE
retry pip upgrade

### DIFF
--- a/dev-tools/mage/pytest.go
+++ b/dev-tools/mage/pytest.go
@@ -18,6 +18,7 @@
 package mage
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -30,7 +31,6 @@ import (
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
-	"github.com/pkg/errors"
 )
 
 // WINDOWS USERS:
@@ -254,14 +254,16 @@ func PythonVirtualenv(forceCreate bool) (string, error) {
 		"VIRTUAL_ENV": ve,
 	}
 
+	vePython := virtualenvPath(ve, pythonExe)
+	// Ensure we are using the latest pip version.
+	// use method described at https://pip.pypa.io/en/stable/installation/#upgrading-pip
+	if err = sh.RunWith(env, vePython, "-m", "pip", "install", "--upgrade", "pip"); err != nil {
+		fmt.Printf("warn: failed to upgrade pip (ignoring): %v", err)
+	}
+
 	pip := virtualenvPath(ve, "pip")
 	pipUpgrade := func(pkg string) error {
 		return sh.RunWith(env, pip, "install", "-U", pkg)
-	}
-
-	// Ensure we are using the latest pip version.
-	if err = pipUpgrade("pip"); err != nil {
-		fmt.Printf("warn: failed to upgrade pip (ignoring): %v", err)
 	}
 
 	// First ensure that wheel is installed so that bdists build cleanly.

--- a/dev-tools/vagrant_scripts/winProvision.ps1
+++ b/dev-tools/vagrant_scripts/winProvision.ps1
@@ -58,19 +58,7 @@ if (-Not (Get-Command "python" -ErrorAction SilentlyContinue)) {
 }
 
 echo "Updating pip"
-For ($i = 0; $i -lt 5) {
-	try {
-		python -m pip install --upgrade pip 2>&1 | %{ "$_" }
-		Break
-	} catch {
-		Echo "updating pip failed"
-		$i++
-		if ($i -eq 5) {
-			Throw $_
-		}
-		Start-Sleep 5
-	}
-}
+python -m pip install --upgrade pip 2>&1 | %{ "$_" }
 
 if (-Not (Get-Command "git" -ErrorAction SilentlyContinue)) {
     echo "Installing git"

--- a/dev-tools/vagrant_scripts/winProvision.ps1
+++ b/dev-tools/vagrant_scripts/winProvision.ps1
@@ -58,7 +58,19 @@ if (-Not (Get-Command "python" -ErrorAction SilentlyContinue)) {
 }
 
 echo "Updating pip"
-python -m pip install --upgrade pip 2>&1 | %{ "$_" }
+For ($i = 0; $i -lt 5) {
+	try {
+		python -m pip install --upgrade pip 2>&1 | %{ "$_" }
+		Break
+	} catch {
+		Echo "updating pip failed"
+		$i++
+		if ($i -eq 5) {
+			Throw $_
+		}
+		Start-Sleep 5
+	}
+}
 
 if (-Not (Get-Command "git" -ErrorAction SilentlyContinue)) {
     echo "Installing git"


### PR DESCRIPTION
## What does this PR do?

changes method used to upgrade pip for python test framework

## Why is it important?

Occasionally in CI we would see errors like:

```
[2023-05-05T17:59:04.678Z] ERROR: Could not install packages due to an EnvironmentError: [WinError 5] Access is denied: 'C:\\Users\\jenkins\\AppData\\Local\\Temp\\pip-uninstall-x4fgjn5h\\pip.exe'
[2023-05-05T17:59:04.679Z] Consider using the `--user` option or check the permissions.
[2023-05-05T17:59:04.679Z] 
[2023-05-05T17:59:14.319Z] warn: failed to upgrade pip (ignoring): running "null\build\ve\windows\Scripts\pip install -U pip" failed with exit code 1ERROR: Exception:
[2023-05-05T17:59:14.320Z] Traceback (most recent call last):
```

Windows can have permission issues with binaries that upgrade themselves.  This is the "officially recommended" way to update pip from https://pip.pypa.io/en/stable/installation/#upgrading-pip and https://stackoverflow.com/questions/15221473/how-do-i-update-upgrade-pip-itself-from-inside-my-virtual-environment

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

Run the following on a Windows machine.  python should be installed and pip upgraded to current.

``` bash
mage clean
mage pythonVirtualEnv
```

## Related issues

- Relates #35353
