### PR TITLE
ci: retry DRA in a new CI runner

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -121,7 +121,13 @@ pipeline {
             expression { return env.IS_BRANCH_AVAILABLE == "true" }
           }
           steps {
-            runReleaseManager(type: 'snapshot', outputFile: env.DRA_OUTPUT)
+            // retryWithSleep and withNode can be remove once https://github.com/elastic/release-eng/issues/456
+            // (internal only) is fixed.
+            retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+              withNode(labels: 'ubuntu-22 && immutable', forceWorkspace: true) {
+                runReleaseManager(type: 'snapshot', outputFile: env.DRA_OUTPUT)
+              }
+            }
           }
           post {
             failure {
@@ -144,7 +150,13 @@ pipeline {
             }
           }
           steps {
-            runReleaseManager(type: 'staging', outputFile: env.DRA_OUTPUT)
+            // retryWithSleep and withNode can be remove once https://github.com/elastic/release-eng/issues/456
+            // (internal only) is fixed.
+            retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+              withNode(labels: 'ubuntu-22 && immutable', forceWorkspace: true) {
+                runReleaseManager(type: 'staging', outputFile: env.DRA_OUTPUT)
+              }
+            }
           }
           post {
             failure {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -193,15 +193,11 @@ def runReleaseManager(def args = [:]) {
     }
     sh(label: "prepare-release-manager-artifacts ${type}", script: ".ci/scripts/prepare-release-manager.sh ${type}")
     dockerLogin(secret: env.DOCKERELASTIC_SECRET, registry: env.DOCKER_REGISTRY)
-    // This can be remove once https://github.com/elastic/release-eng/issues/456 (internal only) is fixed.
-    def notifyRetry = { log(level: 'WARN', text: 'releaseManager failed, retry again') }
-    retryWithSleep(retries: 3, seconds: 60, backoff: true, sideEffect: notifyRetry) {
-      releaseManager(project: 'beats',
-                     version: env.BEAT_VERSION,
-                     type: type,
-                     artifactsFolder: 'build/distributions',
-                     outputFile: args.outputFile)
-    }
+    releaseManager(project: 'beats',
+                   version: env.BEAT_VERSION,
+                   type: type,
+                   artifactsFolder: 'build/distributions',
+                   outputFile: args.outputFile)
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

In this proposal I use a new ephemeral worker for the whole run regarding the DRA (that only runs for main and release branches) **NOTE**: so it's not possible to test this section on a PR


## Why is it important?

https://github.com/elastic/beats/pull/35410  was an attempt to fix temporary the issue with ephemeral tokens but it seems there are some other issues when reusing the workspace, somehow it gets corrupted.

<img width="1362" alt="image" src="https://github.com/elastic/beats/assets/2871786/91ec2c3b-7515-4ec7-9e1e-ccd1a370a206">
