### PR TITLE
[metricbeat] add healthcheck to docker-compose for integ tests

### DIFF
--- a/metricbeat/module/postgresql/docker-compose.yml
+++ b/metricbeat/module/postgresql/docker-compose.yml
@@ -11,3 +11,8 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - 5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -p 5432"]
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
## What does this PR do?

Adds a healthcheck to the docker-compose.yml file used for metricbeat integration tests.

## Why is it important?

occasionally in CI we get errors like:

```

[2023-05-17T21:49:46.861Z] === FAIL: metricbeat/module/postgresql/activity TestFetch (27.09s)
[2023-05-17T21:49:46.861Z]     activity_integration_test.go:40: Expected 0 error, had 1. [error in QueryStats: failed to obtain a connection with the database: pq: the database system is starting up]
```

adding the healthcheck means that postgresql will be "ready" before the test continues.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

In metricbeat directory

```
gotestsum --no-color -f standard-quiet --junitfile build/TEST-go-integration-postgresql.xml --jsonfile build/TEST-go-integration-postgresql.out.json -- -tags  integration ./module/postgresql/... -count 1
```

## Related issues

- Closes #35505
