### PR TITLE
x-pack/filebeat/input/awss3: relax queue_url constraints for non-standard endpoints

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -159,6 +159,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Add logging of metric registration in inputmon. {pull}35647[35647]
 - Add Okta API package for entity analytics. {pull}35478[35478]
 - Add benchmarking to HTTPJSON input testing. {pull}35138[35138]
+- Allow non-AWS endpoints for testing Filebeat awss3 input. {issue}35496[35496] {pull}35520[35520]
 
 ==== Deprecated
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -304,6 +304,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Mark CEL input as GA. {pull}35559[35559]
 - Add metrics for gcp-pubsub input. {pull}35614[35614]
 - [GCS] Added scheduler debug logs and improved the context passing mechanism by removing them from struct params and passing them as function arguments. {pull}35674[35674]
+- Allow non-AWS endpoints for awss3 input. {issue}35496[35496] {pull}35520[35520]
 
 *Auditbeat*
    - Migration of system/package module storage from gob encoding to flatbuffer encoding in bolt db. {pull}34817[34817]

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -261,7 +261,7 @@ URL of the AWS SQS queue that messages will be received from. (Required when `bu
 ==== `region_name`
 
 The name of the AWS region of the end point for testing purposes. This option
-must not be set when using amazonaws.com end points.
+must not be set when using amazonaws end points that provide a region.
 
 [float]
 ==== `visibility_timeout`

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -258,6 +258,12 @@ configuring multiline options.
 URL of the AWS SQS queue that messages will be received from. (Required when `bucket_arn` and `non_aws_bucket_name` are not set).
 
 [float]
+==== `region_name`
+
+The name of the AWS region of the end point for testing purposes. This option
+must not be set when using amazonaws.com end points.
+
+[float]
 ==== `visibility_timeout`
 
 The duration that the received SQS messages are hidden from subsequent retrieve

--- a/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-aws-s3.asciidoc
@@ -258,10 +258,10 @@ configuring multiline options.
 URL of the AWS SQS queue that messages will be received from. (Required when `bucket_arn` and `non_aws_bucket_name` are not set).
 
 [float]
-==== `region_name`
+==== `region`
 
-The name of the AWS region of the end point for testing purposes. This option
-must not be set when using amazonaws end points that provide a region.
+The name of the AWS region of the end point. If this option is given it
+takes precedence over the region name obtained from the `queue_url` value.
 
 [float]
 ==== `visibility_timeout`

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -27,7 +27,7 @@ type config struct {
 	SQSScript           *scriptConfig        `config:"sqs.notification_parsing_script"`
 	MaxNumberOfMessages int                  `config:"max_number_of_messages"`
 	QueueURL            string               `config:"queue_url"`
-	RegionName          string               `config:"region_name"`
+	RegionName          string               `config:"region"`
 	BucketARN           string               `config:"bucket_arn"`
 	NonAWSBucketName    string               `config:"non_aws_bucket_name"`
 	BucketListInterval  time.Duration        `config:"bucket_list_interval"`
@@ -77,13 +77,6 @@ func (c *config) Validate() error {
 
 	if (c.BucketARN != "" || c.NonAWSBucketName != "") && c.NumberOfWorkers <= 0 {
 		return fmt.Errorf("number_of_workers <%v> must be greater than 0", c.NumberOfWorkers)
-	}
-
-	if c.QueueURL != "" {
-		region, _ := getRegionFromQueueURL(c.QueueURL, c.AWSConfig.Endpoint)
-		if region != "" && c.RegionName != "" {
-			return fmt.Errorf("region_name <%s> must not be set with a queue_url containing a region name", c.RegionName)
-		}
 	}
 
 	if c.QueueURL != "" && (c.VisibilityTimeout <= 0 || c.VisibilityTimeout.Hours() > 12) {

--- a/x-pack/filebeat/input/awss3/config.go
+++ b/x-pack/filebeat/input/awss3/config.go
@@ -7,8 +7,6 @@ package awss3
 import (
 	"errors"
 	"fmt"
-	"net/url"
-	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -81,13 +79,10 @@ func (c *config) Validate() error {
 		return fmt.Errorf("number_of_workers <%v> must be greater than 0", c.NumberOfWorkers)
 	}
 
-	if c.QueueURL != "" && c.RegionName != "" {
-		u, err := url.Parse(c.QueueURL)
-		if err != nil {
-			return fmt.Errorf("invalid queue_url: %w", err)
-		}
-		if strings.HasSuffix(u.Host, ".amazonaws.com") {
-			return fmt.Errorf("region_name <%s> must not be set with an amazonaws.com queue_url", c.RegionName)
+	if c.QueueURL != "" {
+		region, _ := getRegionFromQueueURL(c.QueueURL, c.AWSConfig.Endpoint)
+		if region != "" && c.RegionName != "" {
+			return fmt.Errorf("region_name <%s> must not be set with a queue_url containing a region name", c.RegionName)
 		}
 	}
 

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -57,7 +57,7 @@ func TestConfig(t *testing.T) {
 		nonAWSS3Bucket string
 		config         mapstr.M
 		expectedErr    string
-		expectedCfg    func(queueURL, s3Bucket string, nonAWSS3Bucket string) config
+		expectedCfg    func(queueURL, s3Bucket, nonAWSS3Bucket string) config
 	}{
 		{
 			name:           "input with defaults for queueURL",
@@ -80,7 +80,7 @@ func TestConfig(t *testing.T) {
 				"number_of_workers": 5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
 				c := makeConfig("", s3Bucket, "")
 				c.NumberOfWorkers = 5
 				return c
@@ -100,7 +100,7 @@ func TestConfig(t *testing.T) {
 				},
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
 				c := makeConfig(queueURL, "", "")
 				regex := match.MustCompile("/CloudTrail/")
 				c.FileSelectors = []fileSelectorConfig{
@@ -113,17 +113,17 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "non-AWS endpoint with explicit region",
+			name:           "non-AWS_endpoint_with_explicit_region",
 			queueURL:       queueURL,
 			s3Bucket:       "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
-				"queue_url":   queueURL,
-				"region_name": "region",
-				"endpoint":    "ep",
+				"queue_url": queueURL,
+				"region":    "region",
+				"endpoint":  "ep",
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
 				c := makeConfig(queueURL, "", "")
 				c.RegionName = "region"
 				c.AWSConfig.Endpoint = "ep"
@@ -131,29 +131,40 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			name:           "explicit AWS endpoint with explicit region",
+			name:           "explicit_AWS_endpoint_with_explicit_region",
 			queueURL:       queueURL,
 			s3Bucket:       "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
-				"queue_url":   "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
-				"region_name": "region",
-				"endpoint":    "amazonaws.com",
+				"queue_url": "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+				"region":    "region",
+				"endpoint":  "amazonaws.com",
 			},
-			expectedErr: "region_name <region> must not be set with a queue_url containing a region name",
-			expectedCfg: nil,
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "")
+				c.QueueURL = "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs"
+				c.AWSConfig.Endpoint = "amazonaws.com"
+				c.RegionName = "region"
+				return c
+			},
 		},
 		{
-			name:           "inferred AWS endpoint with explicit region",
+			name:           "inferred_AWS_endpoint_with_explicit_region",
 			queueURL:       queueURL,
 			s3Bucket:       "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
-				"queue_url":   "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
-				"region_name": "region",
+				"queue_url": "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+				"region":    "region",
 			},
-			expectedErr: "region_name <region> must not be set with a queue_url containing a region name",
-			expectedCfg: nil,
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "")
+				c.QueueURL = "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs"
+				c.RegionName = "region"
+				return c
+			},
 		},
 		{
 			name:           "localstack_with_region_name",
@@ -161,11 +172,11 @@ func TestConfig(t *testing.T) {
 			s3Bucket:       "",
 			nonAWSS3Bucket: "",
 			config: mapstr.M{
-				"queue_url":   "http://localhost:4566/000000000000/sample-queue",
-				"region_name": "myregion",
+				"queue_url": "http://localhost:4566/000000000000/sample-queue",
+				"region":    "myregion",
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
 				c := makeConfig(queueURL, "", "")
 				c.RegionName = "myregion"
 				return c
@@ -365,7 +376,7 @@ func TestConfig(t *testing.T) {
 				"number_of_workers":   5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
 				c := makeConfig("", "", nonAWSS3Bucket)
 				c.NumberOfWorkers = 5
 				return c
@@ -448,7 +459,7 @@ func TestConfig(t *testing.T) {
 				"number_of_workers":       5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
 				c := makeConfig("", s3Bucket, "")
 				c.BackupConfig.BackupToBucketArn = "arn:aws:s3:::bBucket"
 				c.BackupConfig.BackupToBucketPrefix = "backup"
@@ -468,7 +479,7 @@ func TestConfig(t *testing.T) {
 				"number_of_workers":             5,
 			},
 			expectedErr: "",
-			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedCfg: func(queueURL, s3Bucket, nonAWSS3Bucket string) config {
 				c := makeConfig("", "", nonAWSS3Bucket)
 				c.NonAWSBucketName = nonAWSS3Bucket
 				c.BackupConfig.NonAWSBackupToBucketName = "bBucket"

--- a/x-pack/filebeat/input/awss3/config_test.go
+++ b/x-pack/filebeat/input/awss3/config_test.go
@@ -60,38 +60,38 @@ func TestConfig(t *testing.T) {
 		expectedCfg    func(queueURL, s3Bucket string, nonAWSS3Bucket string) config
 	}{
 		{
-			"input with defaults for queueURL",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "input with defaults for queueURL",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url": queueURL,
 			},
-			"",
-			makeConfig,
+			expectedErr: "",
+			expectedCfg: makeConfig,
 		},
 		{
-			"input with defaults for s3Bucket",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "input with defaults for s3Bucket",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
 				"number_of_workers": 5,
 			},
-			"",
-			func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
 				c := makeConfig("", s3Bucket, "")
 				c.NumberOfWorkers = 5
 				return c
 			},
 		},
 		{
-			"input with file_selectors",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "input with file_selectors",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url": queueURL,
 				"file_selectors": []mapstr.M{
 					{
@@ -99,8 +99,8 @@ func TestConfig(t *testing.T) {
 					},
 				},
 			},
-			"",
-			func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
 				c := makeConfig(queueURL, "", "")
 				regex := match.MustCompile("/CloudTrail/")
 				c.FileSelectors = []fileSelectorConfig{
@@ -113,283 +113,311 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			"error on no queueURL and s3Bucket and nonAWSS3Bucket",
-			"",
-			"",
-			"",
-			mapstr.M{
+			name:           "non-AWS endpoint with explicit region",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
+				"queue_url":   queueURL,
+				"region_name": "region",
+			},
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+				c := makeConfig(queueURL, "", "")
+				c.RegionName = "region"
+				return c
+			},
+		},
+		{
+			name:           "AWS endpoint with explicit region",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
+				"queue_url":   "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+				"region_name": "region",
+			},
+			expectedErr: "region_name <region> must not be set with an amazonaws.com queue_url accessing config",
+			expectedCfg: nil,
+		},
+		{
+			name:           "error on no queueURL and s3Bucket and nonAWSS3Bucket",
+			queueURL:       "",
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":           "",
 				"bucket_arn":          "",
 				"non_aws_bucket_name": "",
 			},
-			"neither queue_url, bucket_arn nor non_aws_bucket_name were provided",
-			nil,
+			expectedErr: "neither queue_url, bucket_arn nor non_aws_bucket_name were provided",
+			expectedCfg: nil,
 		},
 		{
-			"error on both queueURL and s3Bucket",
-			queueURL,
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error on both queueURL and s3Bucket",
+			queueURL:       queueURL,
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":  queueURL,
 				"bucket_arn": s3Bucket,
 			},
-			"queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <> cannot be set at the same time",
-			nil,
+			expectedErr: "queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <> cannot be set at the same time",
+			expectedCfg: nil,
 		},
 		{
-			"error on both queueURL and NonAWSS3Bucket",
-			queueURL,
-			"",
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "error on both queueURL and NonAWSS3Bucket",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"queue_url":           queueURL,
 				"non_aws_bucket_name": nonAWSS3Bucket,
 			},
-			"queue_url <https://example.com>, bucket_arn <>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
-			nil,
+			expectedErr: "queue_url <https://example.com>, bucket_arn <>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
+			expectedCfg: nil,
 		},
 		{
-			"error on both s3Bucket and NonAWSS3Bucket",
-			"",
-			s3Bucket,
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "error on both s3Bucket and NonAWSS3Bucket",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"bucket_arn":          s3Bucket,
 				"non_aws_bucket_name": nonAWSS3Bucket,
 			},
-			"queue_url <>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
-			nil,
+			expectedErr: "queue_url <>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
+			expectedCfg: nil,
 		},
 		{
-			"error on queueURL, s3Bucket, and NonAWSS3Bucket",
-			queueURL,
-			s3Bucket,
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "error on queueURL, s3Bucket, and NonAWSS3Bucket",
+			queueURL:       queueURL,
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"queue_url":           queueURL,
 				"bucket_arn":          s3Bucket,
 				"non_aws_bucket_name": nonAWSS3Bucket,
 			},
-			"queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
-			nil,
+			expectedErr: "queue_url <https://example.com>, bucket_arn <arn:aws:s3:::aBucket>, non_aws_bucket_name <minio-bucket> cannot be set at the same time",
+			expectedCfg: nil,
 		},
 		{
-			"error on api_timeout == 0",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on api_timeout == 0",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":   queueURL,
 				"api_timeout": "0",
 			},
-			"api_timeout <0s> must be greater than the sqs.wait_time <20s",
-			nil,
+			expectedErr: "api_timeout <0s> must be greater than the sqs.wait_time <20s",
+			expectedCfg: nil,
 		},
 		{
-			"error on visibility_timeout == 0",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on visibility_timeout == 0",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":          queueURL,
 				"visibility_timeout": "0",
 			},
-			"visibility_timeout <0s> must be greater than 0 and less than or equal to 12h",
-			nil,
+			expectedErr: "visibility_timeout <0s> must be greater than 0 and less than or equal to 12h",
+			expectedCfg: nil,
 		},
 		{
-			"error on visibility_timeout > 12h",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on visibility_timeout > 12h",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":          queueURL,
 				"visibility_timeout": "12h1ns",
 			},
-			"visibility_timeout <12h0m0.000000001s> must be greater than 0 and less than or equal to 12h",
-			nil,
+			expectedErr: "visibility_timeout <12h0m0.000000001s> must be greater than 0 and less than or equal to 12h",
+			expectedCfg: nil,
 		},
 		{
-			"error on bucket_list_interval == 0",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error on bucket_list_interval == 0",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":           s3Bucket,
 				"bucket_list_interval": "0",
 			},
-			"bucket_list_interval <0s> must be greater than 0",
-			nil,
+			expectedErr: "bucket_list_interval <0s> must be greater than 0",
+			expectedCfg: nil,
 		},
 		{
-			"error on number_of_workers == 0",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error on number_of_workers == 0",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
 				"number_of_workers": "0",
 			},
-			"number_of_workers <0> must be greater than 0",
-			nil,
+			expectedErr: "number_of_workers <0> must be greater than 0",
+			expectedCfg: nil,
 		},
 		{
-			"error on max_number_of_messages == 0",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on max_number_of_messages == 0",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":              queueURL,
 				"max_number_of_messages": "0",
 			},
-			"max_number_of_messages <0> must be greater than 0",
-			nil,
+			expectedErr: "max_number_of_messages <0> must be greater than 0",
+			expectedCfg: nil,
 		},
 		{
-			"error on buffer_size == 0 ",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on buffer_size == 0 ",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":   queueURL,
 				"buffer_size": "0",
 			},
-			"buffer_size <0> must be greater than 0",
-			nil,
+			expectedErr: "buffer_size <0> must be greater than 0",
+			expectedCfg: nil,
 		},
 		{
-			"error on max_bytes == 0 ",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on max_bytes == 0 ",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url": queueURL,
 				"max_bytes": "0",
 			},
-			"max_bytes <0> must be greater than 0",
-			nil,
+			expectedErr: "max_bytes <0> must be greater than 0",
+			expectedCfg: nil,
 		},
 		{
-			"error on expand_event_list_from_field and content_type != application/json ",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on expand_event_list_from_field and content_type != application/json ",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":                    queueURL,
 				"expand_event_list_from_field": "Records",
 				"content_type":                 "text/plain",
 			},
-			"content_type must be `application/json` when expand_event_list_from_field is used",
-			nil,
+			expectedErr: "content_type must be `application/json` when expand_event_list_from_field is used",
+			expectedCfg: nil,
 		},
 		{
-			"error on expand_event_list_from_field and content_type != application/json ",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error on expand_event_list_from_field and content_type != application/json ",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":                   s3Bucket,
 				"expand_event_list_from_field": "Records",
 				"content_type":                 "text/plain",
 			},
-			"content_type must be `application/json` when expand_event_list_from_field is used",
-			nil,
+			expectedErr: "content_type must be `application/json` when expand_event_list_from_field is used",
+			expectedCfg: nil,
 		},
 		{
-			"input with defaults for non-AWS S3 Bucket",
-			"",
-			"",
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "input with defaults for non-AWS S3 Bucket",
+			queueURL:       "",
+			s3Bucket:       "",
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"non_aws_bucket_name": nonAWSS3Bucket,
 				"number_of_workers":   5,
 			},
-			"",
-			func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
 				c := makeConfig("", "", nonAWSS3Bucket)
 				c.NumberOfWorkers = 5
 				return c
 			},
 		},
 		{
-			"error on FIPS with non-AWS S3 Bucket",
-			"",
-			"",
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "error on FIPS with non-AWS S3 Bucket",
+			queueURL:       "",
+			s3Bucket:       "",
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"non_aws_bucket_name": nonAWSS3Bucket,
 				"number_of_workers":   5,
 				"fips_enabled":        true,
 			},
-			"fips_enabled cannot be used with a non-AWS S3 bucket.",
-			nil,
+			expectedErr: "fips_enabled cannot be used with a non-AWS S3 bucket.",
+			expectedCfg: nil,
 		},
 		{
-			"error on path_style with AWS native S3 Bucket",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error on path_style with AWS native S3 Bucket",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
 				"number_of_workers": 5,
 				"path_style":        true,
 			},
-			"path_style can only be used when polling non-AWS S3 services",
-			nil,
+			expectedErr: "path_style can only be used when polling non-AWS S3 services",
+			expectedCfg: nil,
 		},
 		{
-			"error on path_style with AWS SQS Queue",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on path_style with AWS SQS Queue",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":         queueURL,
 				"number_of_workers": 5,
 				"path_style":        true,
 			},
-			"path_style can only be used when polling non-AWS S3 services",
-			nil,
+			expectedErr: "path_style can only be used when polling non-AWS S3 services",
+			expectedCfg: nil,
 		},
 		{
-			"error on provider with AWS native S3 Bucket",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error on provider with AWS native S3 Bucket",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":        s3Bucket,
 				"number_of_workers": 5,
 				"provider":          "asdf",
 			},
-			"provider can only be overridden when polling non-AWS S3 services",
-			nil,
+			expectedErr: "provider can only be overridden when polling non-AWS S3 services",
+			expectedCfg: nil,
 		},
 		{
-			"error on provider with AWS SQS Queue",
-			queueURL,
-			"",
-			"",
-			mapstr.M{
+			name:           "error on provider with AWS SQS Queue",
+			queueURL:       queueURL,
+			s3Bucket:       "",
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"queue_url":         queueURL,
 				"number_of_workers": 5,
 				"provider":          "asdf",
 			},
-			"provider can only be overridden when polling non-AWS S3 services",
-			nil,
+			expectedErr: "provider can only be overridden when polling non-AWS S3 services",
+			expectedCfg: nil,
 		},
 		{
-			"backup_to_bucket with AWS",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "backup_to_bucket with AWS",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":              s3Bucket,
 				"backup_to_bucket_arn":    "arn:aws:s3:::bBucket",
 				"backup_to_bucket_prefix": "backup",
 				"number_of_workers":       5,
 			},
-			"",
-			func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
 				c := makeConfig("", s3Bucket, "")
 				c.BackupConfig.BackupToBucketArn = "arn:aws:s3:::bBucket"
 				c.BackupConfig.BackupToBucketPrefix = "backup"
@@ -398,18 +426,18 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			"backup_to_bucket with non-AWS",
-			"",
-			"",
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "backup_to_bucket with non-AWS",
+			queueURL:       "",
+			s3Bucket:       "",
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"non_aws_bucket_name":           nonAWSS3Bucket,
 				"non_aws_backup_to_bucket_name": "bBucket",
 				"backup_to_bucket_prefix":       "backup",
 				"number_of_workers":             5,
 			},
-			"",
-			func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
+			expectedErr: "",
+			expectedCfg: func(queueURL, s3Bucket string, nonAWSS3Bucket string) config {
 				c := makeConfig("", "", nonAWSS3Bucket)
 				c.NonAWSBucketName = nonAWSS3Bucket
 				c.BackupConfig.NonAWSBackupToBucketName = "bBucket"
@@ -419,86 +447,86 @@ func TestConfig(t *testing.T) {
 			},
 		},
 		{
-			"error with non-AWS backup and AWS source",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error with non-AWS backup and AWS source",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":                    s3Bucket,
 				"non_aws_backup_to_bucket_name": "bBucket",
 				"number_of_workers":             5,
 			},
-			"backup to non-AWS bucket can only be used for non-AWS sources",
-			nil,
+			expectedErr: "backup to non-AWS bucket can only be used for non-AWS sources",
+			expectedCfg: nil,
 		},
 		{
-			"error with AWS backup and non-AWS source",
-			"",
-			"",
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "error with AWS backup and non-AWS source",
+			queueURL:       "",
+			s3Bucket:       "",
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"non_aws_bucket_name":  nonAWSS3Bucket,
 				"backup_to_bucket_arn": "arn:aws:s3:::bBucket",
 				"number_of_workers":    5,
 			},
-			"backup to AWS bucket can only be used for AWS sources",
-			nil,
+			expectedErr: "backup to AWS bucket can only be used for AWS sources",
+			expectedCfg: nil,
 		},
 		{
-			"error with same bucket backup and empty backup prefix",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error with same bucket backup and empty backup prefix",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":           s3Bucket,
 				"backup_to_bucket_arn": s3Bucket,
 				"number_of_workers":    5,
 			},
-			"backup_to_bucket_prefix is a required property when source and backup bucket are the same",
-			nil,
+			expectedErr: "backup_to_bucket_prefix is a required property when source and backup bucket are the same",
+			expectedCfg: nil,
 		},
 		{
-			"error with same bucket backup (non-AWS) and empty backup prefix",
-			"",
-			"",
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "error with same bucket backup (non-AWS) and empty backup prefix",
+			queueURL:       "",
+			s3Bucket:       "",
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"non_aws_bucket_name":           nonAWSS3Bucket,
 				"non_aws_backup_to_bucket_name": nonAWSS3Bucket,
 				"number_of_workers":             5,
 			},
-			"backup_to_bucket_prefix is a required property when source and backup bucket are the same",
-			nil,
+			expectedErr: "backup_to_bucket_prefix is a required property when source and backup bucket are the same",
+			expectedCfg: nil,
 		},
 		{
-			"error with same bucket backup and backup prefix equal to list prefix",
-			"",
-			s3Bucket,
-			"",
-			mapstr.M{
+			name:           "error with same bucket backup and backup prefix equal to list prefix",
+			queueURL:       "",
+			s3Bucket:       s3Bucket,
+			nonAWSS3Bucket: "",
+			config: mapstr.M{
 				"bucket_arn":              s3Bucket,
 				"backup_to_bucket_arn":    s3Bucket,
 				"number_of_workers":       5,
 				"backup_to_bucket_prefix": "processed_",
 				"bucket_list_prefix":      "processed_",
 			},
-			"backup_to_bucket_prefix cannot be the same as bucket_list_prefix, this will create an infinite loop",
-			nil,
+			expectedErr: "backup_to_bucket_prefix cannot be the same as bucket_list_prefix, this will create an infinite loop",
+			expectedCfg: nil,
 		},
 		{
-			"error with same bucket backup (non-AWS) and backup prefix equal to list prefix",
-			"",
-			"",
-			nonAWSS3Bucket,
-			mapstr.M{
+			name:           "error with same bucket backup (non-AWS) and backup prefix equal to list prefix",
+			queueURL:       "",
+			s3Bucket:       "",
+			nonAWSS3Bucket: nonAWSS3Bucket,
+			config: mapstr.M{
 				"non_aws_bucket_name":           nonAWSS3Bucket,
 				"non_aws_backup_to_bucket_name": nonAWSS3Bucket,
 				"number_of_workers":             5,
 				"backup_to_bucket_prefix":       "processed_",
 				"bucket_list_prefix":            "processed_",
 			},
-			"backup_to_bucket_prefix cannot be the same as bucket_list_prefix, this will create an infinite loop",
-			nil,
+			expectedErr: "backup_to_bucket_prefix cannot be the same as bucket_list_prefix, this will create an infinite loop",
+			expectedCfg: nil,
 		},
 	}
 

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -115,9 +115,12 @@ func (in *s3Input) Run(inputContext v2.Context, pipeline beat.Pipeline) error {
 	defer cancelInputCtx()
 
 	if in.config.QueueURL != "" {
-		regionName, err := getRegionFromQueueURL(in.config.QueueURL, in.config.AWSConfig.Endpoint)
-		if err != nil {
-			return fmt.Errorf("failed to get AWS region from queue_url: %w", err)
+		regionName := in.config.RegionName
+		if regionName == "" {
+			regionName, err = getRegionFromQueueURL(in.config.QueueURL, in.config.AWSConfig.Endpoint)
+			if err != nil {
+				return fmt.Errorf("failed to get AWS region from queue_url: %w", err)
+			}
 		}
 
 		in.awsConfig.Region = regionName

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -311,9 +311,11 @@ func getRegionFromQueueURL(queueURL string, endpoint string) (string, error) {
 		return "", fmt.Errorf(queueURL + " is not a valid URL")
 	}
 	if url.Scheme == "https" && url.Host != "" {
-		queueHostSplit := strings.Split(url.Host, ".")
-		if len(queueHostSplit) > 2 && (strings.Join(queueHostSplit[2:], ".") == endpoint || (endpoint == "" && queueHostSplit[2] == "amazonaws")) {
-			return queueHostSplit[1], nil
+		queueHostSplit := strings.SplitN(url.Host, ".", 3)
+		if len(queueHostSplit) == 3 {
+			if queueHostSplit[2] == endpoint || (endpoint == "" && strings.HasPrefix(queueHostSplit[2], "amazonaws.")) {
+				return queueHostSplit[1], nil
+			}
 		}
 	}
 	return "", fmt.Errorf("QueueURL is not in format: https://sqs.{REGION_ENDPOINT}.{ENDPOINT}/{ACCOUNT_NUMBER}/{QUEUE_NAME}")

--- a/x-pack/filebeat/input/awss3/input.go
+++ b/x-pack/filebeat/input/awss3/input.go
@@ -119,7 +119,7 @@ func (in *s3Input) Run(inputContext v2.Context, pipeline beat.Pipeline) error {
 		if err != nil && in.config.RegionName == "" {
 			return fmt.Errorf("failed to get AWS region from queue_url: %w", err)
 		}
-		if in.config.RegionName != "" && regionName != in.config.RegionName {
+		if in.config.RegionName != "" && regionName != "" && regionName != in.config.RegionName {
 			inputContext.Logger.Warnf("configured region disagrees with queue_url region: %q != %q: using %[1]q",
 				in.config.RegionName, regionName)
 			regionName = in.config.RegionName

--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -5,35 +5,108 @@
 package awss3
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetProviderFromDomain(t *testing.T) {
-	assert.Equal(t, "aws", getProviderFromDomain("", ""))
-	assert.Equal(t, "aws", getProviderFromDomain("c2s.ic.gov", ""))
-	assert.Equal(t, "abc", getProviderFromDomain("abc.com", "abc"))
-	assert.Equal(t, "xyz", getProviderFromDomain("oraclecloud.com", "xyz"))
-	assert.Equal(t, "aws", getProviderFromDomain("amazonaws.com", ""))
-	assert.Equal(t, "aws", getProviderFromDomain("c2s.sgov.gov", ""))
-	assert.Equal(t, "aws", getProviderFromDomain("c2s.ic.gov", ""))
-	assert.Equal(t, "aws", getProviderFromDomain("amazonaws.com.cn", ""))
-	assert.Equal(t, "backblaze", getProviderFromDomain("https://backblazeb2.com", ""))
-	assert.Equal(t, "cloudflare", getProviderFromDomain("https://1234567890.r2.cloudflarestorage.com", ""))
-	assert.Equal(t, "wasabi", getProviderFromDomain("https://wasabisys.com", ""))
-	assert.Equal(t, "digitalocean", getProviderFromDomain("https://digitaloceanspaces.com", ""))
-	assert.Equal(t, "dreamhost", getProviderFromDomain("https://dream.io", ""))
-	assert.Equal(t, "scaleway", getProviderFromDomain("https://scw.cloud", ""))
-	assert.Equal(t, "gcp", getProviderFromDomain("https://googleapis.com", ""))
-	assert.Equal(t, "arubacloud", getProviderFromDomain("https://cloud.it", ""))
-	assert.Equal(t, "linode", getProviderFromDomain("https://linodeobjects.com", ""))
-	assert.Equal(t, "vultr", getProviderFromDomain("https://vultrobjects.com", ""))
-	assert.Equal(t, "ibm", getProviderFromDomain("https://appdomain.cloud", ""))
-	assert.Equal(t, "alibaba", getProviderFromDomain("https://aliyuncs.com", ""))
-	assert.Equal(t, "oracle", getProviderFromDomain("https://oraclecloud.com", ""))
-	assert.Equal(t, "exoscale", getProviderFromDomain("https://exo.io", ""))
-	assert.Equal(t, "upcloud", getProviderFromDomain("https://upcloudobjects.com", ""))
-	assert.Equal(t, "iland", getProviderFromDomain("https://ilandcloud.com", ""))
-	assert.Equal(t, "zadara", getProviderFromDomain("https://zadarazios.com", ""))
+	tests := []struct {
+		endpoint string
+		override string
+		want     string
+	}{
+		{endpoint: "", override: "", want: "aws"},
+		{endpoint: "c2s.ic.gov", want: "aws"},
+		{endpoint: "abc.com", override: "abc", want: "abc"},
+		{endpoint: "oraclecloud.com", override: "xyz", want: "xyz"},
+		{endpoint: "amazonaws.com", want: "aws"},
+		{endpoint: "c2s.sgov.gov", want: "aws"},
+		{endpoint: "c2s.ic.gov", want: "aws"},
+		{endpoint: "amazonaws.com.cn", want: "aws"},
+		{endpoint: "https://backblazeb2.com", want: "backblaze"},
+		{endpoint: "https://1234567890.r2.cloudflarestorage.com", want: "cloudflare"},
+		{endpoint: "https://wasabisys.com", want: "wasabi"},
+		{endpoint: "https://digitaloceanspaces.com", want: "digitalocean"},
+		{endpoint: "https://dream.io", want: "dreamhost"},
+		{endpoint: "https://scw.cloud", want: "scaleway"},
+		{endpoint: "https://googleapis.com", want: "gcp"},
+		{endpoint: "https://cloud.it", want: "arubacloud"},
+		{endpoint: "https://linodeobjects.com", want: "linode"},
+		{endpoint: "https://vultrobjects.com", want: "vultr"},
+		{endpoint: "https://appdomain.cloud", want: "ibm"},
+		{endpoint: "https://aliyuncs.com", want: "alibaba"},
+		{endpoint: "https://oraclecloud.com", want: "oracle"},
+		{endpoint: "https://exo.io", want: "exoscale"},
+		{endpoint: "https://upcloudobjects.com", want: "upcloud"},
+		{endpoint: "https://ilandcloud.com", want: "iland"},
+		{endpoint: "https://zadarazios.com", want: "zadara"},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.want, getProviderFromDomain(test.endpoint, test.override),
+			"for endpoint=%q and override=%q", test.endpoint, test.override)
+	}
+}
+
+func TestGetRegionFromQueueURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		queueURL string
+		endpoint string
+		want     string
+		wantErr  error
+	}{
+		{
+			name:     "amazonaws.com_domain_with_blank_endpoint",
+			queueURL: "https://sqs.us-east-1.amazonaws.com/627959692251/test-s3-logs",
+			want:     "us-east-1",
+		},
+		{
+			name:     "abc.xyz_and_domain_with_matching_endpoint",
+			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint: "abc.xyz",
+			want:     "us-east-1",
+		},
+		{
+			name:     "abc.xyz_and_domain_with_blank_endpoint",
+			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			wantErr:  errBadQueueURL,
+		},
+		{
+			name:     "abc.xyz_and_domain_with_different_endpoint",
+			queueURL: "https://sqs.us-east-1.abc.xyz/627959692251/test-s3-logs",
+			endpoint: "googlecloud.com",
+			wantErr:  errBadQueueURL,
+		},
+		{
+			name:     "invalid_queue_url",
+			queueURL: ":foo",
+			wantErr:  errors.New(":foo is not a valid URL"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := getRegionFromQueueURL(test.queueURL, test.endpoint)
+			if !sameError(err, test.wantErr) {
+				t.Errorf("unexpected error: got:%v want:%v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Errorf("unexpected result: got:%q want:%q", got, test.want)
+			}
+		})
+	}
+}
+
+func sameError(a, b error) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil, b == nil:
+		return false
+	default:
+		return a.Error() == b.Error()
+	}
 }

--- a/x-pack/filebeat/input/awss3/input_test.go
+++ b/x-pack/filebeat/input/awss3/input_test.go
@@ -55,6 +55,7 @@ func TestGetRegionFromQueueURL(t *testing.T) {
 		name     string
 		queueURL string
 		endpoint string
+		deflt    string
 		want     string
 		wantErr  error
 	}{
@@ -81,6 +82,18 @@ func TestGetRegionFromQueueURL(t *testing.T) {
 			wantErr:  errBadQueueURL,
 		},
 		{
+			name:     "localstack",
+			queueURL: "http://localhost:4566/000000000000/filebeat-s3-integtest-d9clk9",
+			deflt:    "localstack",
+			want:     "localstack",
+		},
+		{
+			name:     "localstack_sns",
+			queueURL: "http://localhost:4566/000000000000/filebeat-s3-integtest-sns-d9clk9",
+			deflt:    "localstack_sns",
+			want:     "localstack_sns",
+		},
+		{
 			name:     "invalid_queue_url",
 			queueURL: ":foo",
 			wantErr:  errors.New(":foo is not a valid URL"),
@@ -89,7 +102,7 @@ func TestGetRegionFromQueueURL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := getRegionFromQueueURL(test.queueURL, test.endpoint)
+			got, err := getRegionFromQueueURL(test.queueURL, test.endpoint, test.deflt)
 			if !sameError(err, test.wantErr) {
 				t.Errorf("unexpected error: got:%v want:%v", err, test.wantErr)
 			}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Currently, the queue_url option is used to obtain the region name for the SQS receiver. This prevents pointing the input at other sources for testing, so add a region_name option to provide an alternative way to provide the region name for non-AWS endpoints.

To avoid confusion, log a warning if the user configures the region option in conjunction with amazonaws.com endpoints such that they disagree.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This is needed for supporting tests of inputs using s3.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #35496

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
