### PR TITLE
Enable dependabot for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - automation
+    allow:
+      - dependency-name: "github.com/elastic/*"
+    reviewers:
+      - "elastic/elastic-agent-data-plane"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this PR do?

This enables the GitHub dependabot which will open PRs to keep the `go.mod` file updated when new releases are made for the project's dependencies.

This configures it to watch the go.mod file and update it when an Elastic project is released (`github.com/elastic/*`). I wanted to keep the scope small to start with, but this `allow` filter can be removed or expanded in the future.

## Why is it important?

This will help to ensure the project stays updated with the latest changes and bugfixes from other elastic projects.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
