### PR TITLE
Add post-dependabot GH action to update NOTICE.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "daily"
     labels:
       - automation
+      - Team:Elastic-Agent-Data-Plane
     allow:
       - dependency-name: "github.com/elastic/*"
     reviewers:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -1,0 +1,37 @@
+# Follow-on actions relating to dependabot PRs. In elastic/beats, any changes to
+# dependencies contained in go.mod requires the change to be reflected in the
+# NOTICE.txt file. When dependabot creates a branch for a go_modules change this
+# will update the NOTICE.txt file for that change.
+name: post-dependabot
+
+on:
+  push:
+    branches:
+      - 'dependabot/go_modules/**'
+
+jobs:
+  update-notice.txt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: .go-version
+
+      - name: update NOTICE.txt
+        run: make notice
+
+      - name: check for modified NOTICE.txt
+        id: notice-check
+        run: echo "modified=$(if git diff-index --quiet HEAD -- NOTICE.txt; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
+
+      - name: commit NOTICE.txt
+        if: steps.notice-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'dependabot[bot]'
+          git config --global user.email 'dependabot[bot]@users.noreply.github.com'
+          git add NOTICE.txt
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -m "Update NOTICE.txt"
+          git push


### PR DESCRIPTION
## What does this PR do?

In elastic/beats, any changes to dependencies contained in go.mod requires the change to be reflected in the NOTICE.txt file. When dependabot creates a branch for a go_modules change this will update the NOTICE.txt file for that change.

Relates #35525

## Why is it important?

It avoids having dependabot PRs immediately fail to pass CI checks because of an out-of-date NOTICE.txt file. This saves a developer from having to manually update dependabot PRs.

## Author notes

Another option here would be to not commit the NOTICE.txt file to the repo. The file only needs to be included in distributions of the product. So as long as we continue to verify that the file can be generated without error during CI checks then I think it could be replaced by a static version like elastic/elasticsearch's [NOTICE.txt](https://github.com/elastic/elasticsearch/blob/main/NOTICE.txt). During packaging we can generate the full version and include it into distributions.