### PR TITLE
packetbeat: fix handling of npcap.never_install configuration options from fleet

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -197,6 +197,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 
 - Fix double channel close panic when reloading. {pull}35324[35324]
 - Fix BPF filter setting not being applied to sniffers. {issue}35363[35363] {pull}35484[35484]
+- Fix handling of Npcap installation options from Fleet. {pull}35541[35541]
 
 *Winlogbeat*
 

--- a/packetbeat/beater/install_npcap_test.go
+++ b/packetbeat/beater/install_npcap_test.go
@@ -1,0 +1,234 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/management"
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+var canInstallNpcapTests = []struct {
+	name    string
+	cfg     string
+	managed bool
+	want    any
+}{
+	{
+		name: `packetbeat_never_install`,
+		cfg: `
+interfaces.device: default_route
+interfaces.poll_default_route: 1m
+interfaces.internal_networks:
+  - private
+
+npcap:
+  never_install: true
+
+protocols:
+- type: icmp
+  enabled: true
+`,
+		managed: false,
+		want:    false,
+	},
+	{
+		name: `packetbeat_can_install`,
+		cfg: `
+interfaces.device: default_route
+interfaces.poll_default_route: 1m
+interfaces.internal_networks:
+  - private
+
+protocols:
+- type: icmp
+  enabled: true
+`,
+		managed: false,
+		want:    true,
+	},
+	{
+		name: `fleet_never_install_single`,
+		cfg: `
+type: packet
+data_stream:
+  namespace: default
+processors:
+  - add_fields:
+      target: 'elastic_agent'
+      fields:
+        id: agent-id
+        version: 8.0.0
+        snapshot: false
+streams:
+  - type: icmp
+    interface:
+      device: default_route
+    procs:
+      enabled: true
+    data_stream:
+      dataset: packet.icmp
+      type: logs
+    npcap:
+      never_install: true
+`,
+		managed: true,
+		want:    false,
+	},
+	{
+		name: `fleet_can_install_single`,
+		cfg: `
+type: packet
+data_stream:
+  namespace: default
+processors:
+  - add_fields:
+      target: 'elastic_agent'
+      fields:
+        id: agent-id
+        version: 8.0.0
+        snapshot: false
+streams:
+  - type: icmp
+    interface:
+      device: default_route
+    procs:
+      enabled: true
+    data_stream:
+      dataset: packet.icmp
+      type: logs
+`,
+		managed: true,
+		want:    true,
+	},
+	{
+		name: `fleet_never_install_multi`,
+		cfg: `
+type: packet
+data_stream:
+  namespace: default
+processors:
+  - add_fields:
+      target: 'elastic_agent'
+      fields:
+        id: agent-id
+        version: 8.0.0
+        snapshot: false
+streams:
+  - type: http
+    interface:
+      device: en2
+      snaplen: 1514
+      type: af_packet
+      buffer_size_mb: 100
+    procs:
+      enabled: true
+      monitored:
+        - process: curl
+          cmdline_grep: curl
+    data_stream:
+      dataset: packet.http
+      type: logs
+  - type: icmp
+    interface:
+      device: default_route
+    procs:
+      enabled: true
+    data_stream:
+      dataset: packet.icmp
+      type: logs
+    npcap:
+      never_install: true
+`,
+		managed: true,
+		want:    false,
+	},
+	{
+		name: `fleet_can_install_multi`,
+		cfg: `
+type: packet
+data_stream:
+  namespace: default
+processors:
+  - add_fields:
+      target: 'elastic_agent'
+      fields:
+        id: agent-id
+        version: 8.0.0
+        snapshot: false
+streams:
+  - type: http
+    interface:
+      device: en2
+      snaplen: 1514
+      type: af_packet
+      buffer_size_mb: 100
+    procs:
+      enabled: true
+      monitored:
+        - process: curl
+          cmdline_grep: curl
+    data_stream:
+      dataset: packet.http
+      type: logs
+  - type: icmp
+    interface:
+      device: default_route
+    procs:
+      enabled: true
+    data_stream:
+      dataset: packet.icmp
+      type: logs
+`,
+		managed: true,
+		want:    true,
+	},
+}
+
+func TestCanInstallNpcap(t *testing.T) {
+	for _, test := range canInstallNpcapTests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := config.NewConfigFrom(test.cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			b := &beat.Beat{
+				BeatConfig: cfg,
+				Manager:    boolManager{managed: test.managed},
+			}
+			got, err := canInstallNpcap(b)
+			if err != nil {
+				t.Errorf("unexpected error from canInstallNpcap: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("unexpected result from canInstallNpcap: got=%t want=%t", got, test.want)
+			}
+		})
+	}
+}
+
+type boolManager struct {
+	managed bool
+
+	// For interface satisfaction.
+	management.Manager
+}
+
+func (m boolManager) Enabled() bool { return m.managed }

--- a/packetbeat/npcap/npcap.go
+++ b/packetbeat/npcap/npcap.go
@@ -56,7 +56,9 @@ func Install(ctx context.Context, log *logp.Logger, path, dst string, compat boo
 }
 
 func install(ctx context.Context, log *logp.Logger, path, dst string, compat bool) error {
-	if Version() != "" {
+	log.Info("installing Npcap DLL")
+	if version := Version(); version != "" {
+		log.Infof("replace existing version: %s", version)
 		// If we are here there is a runtime Npcap DLL loaded. We need to
 		// unload this to prevent the application being killed during the
 		// install.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Previously, the config option for blocking Npcap DLL installation on Windows under fleet was not properly handled due to differences in the shape of the configs by the time the decision is made for the action. This adds a tested helper to ensure that fleet configurations are properly handled.

Also add some logging at the beginning of the install process and a note when a previously installed Npcap is disabled.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The current behaviour does not respect user configurations.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Run `go test` in packetbeat/beater.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
