### PR TITLE
.github/workflows/post-dependabot.yml - Fix invalid job name

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -10,7 +10,7 @@ on:
       - 'dependabot/go_modules/**'
 
 jobs:
-  update-notice.txt:
+  update-notice:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this PR do?

Fix invalid job name.

```
Invalid workflow file: .github/workflows/post-dependabot.yml#L13
The workflow is not valid. .github/workflows/post-dependabot.yml (Line: 13, Col: 3): The
identifier 'update-notice.txt' is invalid. IDs may only contain alphanumeric characters,
'_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters.
```

Relates: #35538
