### PR TITLE
.github/workflows/post-dependabot.yml - Allow write contents

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   update-notice:
+    permissions:
+      # Allow job to write to the branch.
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## What does this PR do?

Adding `permissions.contents: write` for this job because it needs to be able to write the updated NOTICE.txt to the affected branch.

Fixes "remote: Permission to elastic/beats.git denied to github-actions[bot]." ([link](https://github.com/elastic/beats/actions/runs/5060030033/jobs/9082385088?pr=35537#step:6:12))

Relates: #35538 


References:

- https://github.com/stefanzweifel/git-auto-commit-action#usage (says `contents: write` is required to push)
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ (I assumed elastic/beats had default read-only tokens, but I have confirmed that the setting is on "Read and write permissions". So I'm less sure that this will fix the issue.)
