### PR TITLE
make test fqdn lookup deterministic

### DIFF
--- a/libbeat/processors/add_host_metadata/add_host_metadata_test.go
+++ b/libbeat/processors/add_host_metadata/add_host_metadata_test.go
@@ -524,8 +524,8 @@ func TestFQDNLookup(t *testing.T) {
 		expectedFQDNLookupFailedCount int64
 	}{
 		"lookup_succeeds": {
-			cnameLookupResult:             "foo.bar.baz.",
-			expectedHostName:              "foo.bar.baz",
+			cnameLookupResult:             "example.com.",
+			expectedHostName:              "example.com",
 			expectedFQDNLookupFailedCount: 0,
 		},
 		"lookup_fails": {
@@ -569,6 +569,8 @@ func TestFQDNLookup(t *testing.T) {
 			addHostMetadataP, ok := p.(*addHostMetadata)
 			require.True(t, ok)
 			require.Equal(t, test.expectedFQDNLookupFailedCount, addHostMetadataP.metrics.FQDNLookupFailed.Get())
+			// reset so next run is correct, registry is global
+			addHostMetadataP.metrics.FQDNLookupFailed.Set(0)
 
 			// Run event through processor and check that hostname reported
 			// by processor is same as OS-reported hostname


### PR DESCRIPTION
## What does this PR do?

For `add_host_metadata` FQDN tests, this change resets the `FQDNLookupFailed` metric after every run.  Without this the order of the tests could cause the comparison of the metrics to fail.

Also changed to the RFC 6761 reserved name "example.com" for testing lookups.

## Why is it important?

Make `add_host_metadata` FQDN unit tests deterministic.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

```bash
cd libbeat/processors/add_host_metadata
while go test -count 1 -run TestFQDN; do; done
```

## Related issues

- Closes #35528
