### PR TITLE
make TestDefaultHarvesterGroup test deterministic

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/harvester_test.go
+++ b/filebeat/input/filestream/internal/input-logfile/harvester_test.go
@@ -94,15 +94,13 @@ func TestReaderGroup(t *testing.T) {
 func TestDefaultHarvesterGroup(t *testing.T) {
 	source := &testSource{name: "/path/to/test"}
 
-	requireSourceAddedToBookkeeper :=
-		func(t *testing.T, hg *defaultHarvesterGroup, s Source) {
-			require.True(t, hg.readers.hasID(hg.identifier.ID(s)))
-		}
+	requireSourceAddedToBookkeeper := func(t *testing.T, hg *defaultHarvesterGroup, s Source) {
+		require.True(t, hg.readers.hasID(hg.identifier.ID(s)))
+	}
 
-	requireSourceRemovedFromBookkeeper :=
-		func(t *testing.T, hg *defaultHarvesterGroup, s Source) {
-			require.False(t, hg.readers.hasID(hg.identifier.ID(s)))
-		}
+	requireSourceRemovedFromBookkeeper := func(t *testing.T, hg *defaultHarvesterGroup, s Source) {
+		require.False(t, hg.readers.hasID(hg.identifier.ID(s)))
+	}
 
 	t.Run("assert a harvester is started in a goroutine", func(t *testing.T) {
 		var wg sync.WaitGroup
@@ -153,7 +151,8 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 
 		mockHarvester := &mockHarvester{
 			onRun: harvesterRun,
-			wg:    &wg}
+			wg:    &wg,
+		}
 		hg := testDefaultHarvesterGroup(t, mockHarvester)
 		hg.tg = task.NewGroup(1, time.Second, &logp.Logger{}, "")
 
@@ -222,13 +221,16 @@ func TestDefaultHarvesterGroup(t *testing.T) {
 
 		goroutinesChecker.WaitUntilIncreased(1)
 		// wait until harvester is started
-		if mockHarvester.getRunCount() == 1 {
-			requireSourceAddedToBookkeeper(t, hg, source)
-			// after started, stop it
-			hg.Stop(source)
-			goroutinesChecker.WaitUntilOriginalCount()
-		}
-
+		require.Eventually(t,
+			func() bool { return mockHarvester.getRunCount() == 1 },
+			5*time.Second,
+			10*time.Millisecond,
+			"run count must equal one")
+		requireSourceAddedToBookkeeper(t, hg, source)
+		// after started, stop it
+		hg.Stop(source)
+		_, err := goroutinesChecker.WaitUntilOriginalCount()
+		require.NoError(t, err)
 		requireSourceRemovedFromBookkeeper(t, hg, source)
 	})
 
@@ -458,6 +460,7 @@ func (tl *testLogger) Errorf(format string, args ...interface{}) {
 	sb.WriteString(fmt.Sprintf(format, args...))
 	sb.WriteString("\n")
 }
+
 func (tl *testLogger) String() string {
 	return (*strings.Builder)(tl).String()
 }


### PR DESCRIPTION
## What does this PR do?

In the TestDefaultHarvesterGroup unit test, added waiting for RunCount to be one before checking if added to bookkeeper, without this RunCount could be 0, so harvester wasn't stopped before check.


## Why is it important?

deterministic unit tests

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## How to test this PR locally

```bash
cd filebeat/input/filestream/internal/input-logfile
while go test -v -count 1 -run TestDefaultHarvesterGroup/assert_a_harvester_can_be_stopped_and_removed_from_bookkeeper; do :; done
```

## Related issues

- Closes #35552
