### PR TITLE
[Backport] [8.6] [34406] Clarify usage of kubernetes pod labels

### DIFF
--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -252,6 +252,10 @@ By default it is `true`.
 if the `annotations.dedot` config is set to be `true` in the provider config, then `.` in annotations will be replaced
 with `_`. By default it is `true`.
 
+NOTE: Starting from 8.6 release `kubernetes.labels.*` used in config templating are not dedoted regardless of `labels.dedot` value.
+This config parameter only affects the fields added in the final Elasticsearch document. For example, for a pod with label `app.kubernetes.io/name=ingress-nginx`
+the matching condition should be `condition: ${kubernetes.labels.app.kubernetes.io/name} == "ingress-nginx"`. If `labels.dedot` is set to `true`(default value)
+the label will be stored in Elasticsearch as `kubernetes.labels.app_kubernetes_io/name`. The same applies for kubernetes annotations.
 
 For example:
 


### PR DESCRIPTION
Manual backport of #34406 to 8.6

It was reported to the Docs team that the note added via #34406 to the [Kubernetes section](https://www.elastic.co/guide/en/beats/filebeat/8.7/configuration-autodiscover.html#_kubernetes) of the Autodiscover docs page references `8.6`, but the note appears only in `8.7` and later docs versions. So, this backports the change into the `8.6` branch. 

CC @jeanfabrice @MichaelKatsoulis 

![Screenshot 2023-05-26 at 12 19 41 PM](https://github.com/elastic/beats/assets/41695641/fd82c13e-ce39-4674-a450-a989fa359ac1)
