### PR TITLE
[Azure] Set elastic/obs-cloud-monitoring team as owner of azure-eventhub input

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,6 +83,7 @@ CHANGELOG*
 /x-pack/filebeat/input/awscloudwatch/ @elastic/obs-cloud-monitoring
 /x-pack/filebeat/input/awss3/ @elastic/obs-cloud-monitoring
 /x-pack/filebeat/input/azureblobstorage/ @elastic/security-external-integrations
+/x-pack/filebeat/input/azureeventhub/ @elastic/obs-cloud-monitoring
 /x-pack/filebeat/input/cel/ @elastic/security-external-integrations
 /x-pack/filebeat/input/entityanalytics/ @elastic/security-external-integrations
 /x-pack/filebeat/input/gcppubsub/ @elastic/security-external-integrations


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Set `elastic/obs-cloud-monitoring` team as the owner of `azure-eventhub` input.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The `azure-eventhub` input doesn't have an owner and all review requests land on the `elastic/agent-data-plane` desk. 

The elastic/obs-cloud-monitoring maintained this input in the last 12+ months, so we are a good candidate to own this input.



