### PR TITLE
Bump elastic-agent-client to v7.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/eapache/go-resiliency v1.2.0
 	github.com/eclipse/paho.mqtt.golang v1.3.5
-	github.com/elastic/elastic-agent-client/v7 v7.1.1
+	github.com/elastic/elastic-agent-client/v7 v7.1.2
 	github.com/elastic/go-concert v0.2.0
 	github.com/elastic/go-libaudit/v2 v2.3.2
 	github.com/elastic/go-licenser v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -504,8 +504,8 @@ github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3 h1:lnDkqiRFKm0rxdljqr
 github.com/elastic/dhcp v0.0.0-20200227161230-57ec251c7eb3/go.mod h1:aPqzac6AYkipvp4hufTyMj5PDIphF3+At8zr7r51xjY=
 github.com/elastic/elastic-agent-autodiscover v0.6.1 h1:vXR+3QVDL7Ij7IMKul13iIiDmM66HsX6MS6I0T4O8gw=
 github.com/elastic/elastic-agent-autodiscover v0.6.1/go.mod h1:yXYKFAG+Py+TcE4CCR8EAbJiYb+6Dz9sCDoWgOveqtU=
-github.com/elastic/elastic-agent-client/v7 v7.1.1 h1:Mob9Nme43P2FGyTQqLWQOWB1d5b54quXc7FPTPyzIic=
-github.com/elastic/elastic-agent-client/v7 v7.1.1/go.mod h1:zz0T6l1XcG3kLyDrW8hY8bpI9fES9qkXI3vanY9e0d8=
+github.com/elastic/elastic-agent-client/v7 v7.1.2 h1:p6KvvDMoFCBPvchxcx9cRXpRjsDaii0m/wE3lqQxpmM=
+github.com/elastic/elastic-agent-client/v7 v7.1.2/go.mod h1:G3Mk1pHXxvj3wC5FvsGUlPOsvapTB5SfrUmWiJDXT6Q=
 github.com/elastic/elastic-agent-libs v0.3.8 h1:kj8yNIu/dYrAfxXZKTmCsEgP6agAvmCra22TKTGsU+M=
 github.com/elastic/elastic-agent-libs v0.3.8/go.mod h1:h48hzjQcn6XPwfWRM5HimAKlsG0J92ULgAzdX+WedA8=
 github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3 h1:sb+25XJn/JcC9/VL8HX4r4QXSUq4uTNzGS2kxOE7u1U=


### PR DESCRIPTION
Dependency-only change, created with:

```
go get github.com/elastic/elastic-agent-client/v7@v7.1.2
go mod tidy
```