### PR TITLE
libbeat/monitoring/inputmon: log key, id and input type when registering/deregistering metrics

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -154,6 +154,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Add the file path of the instance lock on the error when it's is already locked {pull}33788[33788]
 - Add DropFields processor to js API {pull}33458[33458]
 - Add support for different folders when testing data {pull}34467[34467]
+- Add logging of metric registration in inputmon. {pull}35647[35647]
 
 ==== Deprecated
 

--- a/libbeat/monitoring/inputmon/input.go
+++ b/libbeat/monitoring/inputmon/input.go
@@ -20,6 +20,9 @@ package inputmon
 import (
 	"strings"
 
+	"github.com/google/uuid"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
@@ -49,11 +52,23 @@ func NewInputRegistry(inputType, id string, optionalParent *monitoring.Registry)
 	// the monitoring registry, and we want a consistent flat level of nesting
 	key := sanitizeID(id)
 
+	// Log the registration to ease tracking down duplicate ID registrations.
+	// Logged at INFO rather than DEBUG since it is not in a hot path and having
+	// the information available by default can short-circuit requests for debug
+	// logs during support interactions.
+	log := logp.NewLogger("metric_registry")
+	// Make an orthogonal ID to allow tracking register/deregister pairs.
+	uuid := uuid.New().String()
+	log.Infow("registering", "input_type", inputType, "id", id, "key", key, "uuid", uuid)
+
 	reg = parentRegistry.NewRegistry(key)
 	monitoring.NewString(reg, "input").Set(inputType)
 	monitoring.NewString(reg, "id").Set(id)
 
-	return reg, func() { parentRegistry.Remove(key) }
+	return reg, func() {
+		log.Infow("unregistering", "input_type", inputType, "id", id, "key", key, "uuid", uuid)
+		parentRegistry.Remove(key)
+	}
 }
 
 func sanitizeID(id string) string {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This notes under "metric_registry" all inputmon-handled metric registration and deregistration, linking register and deregister operations by use of a unique ID unrelated to the request.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

We have had a number of cases where metric registrations have been duplicated, this addition allows us to identify pairs of registration/deregistration and correlate with prior un-deregistered registrations with the same name. The logging at INFO level speeds recovery of the information with minimal additional log load.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] Marked as backporting for benefits to support.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
