### PR TITLE
Add `include_message` to the parser config validation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -125,6 +125,7 @@ https://github.com/elastic/beats/compare/v8.7.1\...main[Check the HEAD diff]
 - RFC5424 syslog timestamps with offset 'Z' will be treated as UTC rather than using the default timezone. {pull}35360[35360]
 - [system] sync system/auth dataset with system integration 1.29.0. {pull}35581[35581]
 - Fix filestream false positive log error "filestream input with ID 'xyz' already exists" {issue}31767[31767]
+- Fix error when trying to use `include_message` parser {issue}35440[35440]
 
 *Heartbeat*
 

--- a/libbeat/reader/parser/parser.go
+++ b/libbeat/reader/parser/parser.go
@@ -121,6 +121,13 @@ func NewConfig(pCfg CommonConfig, parsers []config.Namespace) (*Config, error) {
 			if err != nil {
 				return nil, fmt.Errorf("error while parsing syslog parser config: %w", err)
 			}
+		case "include_message":
+			config := filter.DefaultConfig()
+			cfg := ns.Config()
+			err := cfg.Unpack(&config)
+			if err != nil {
+				return nil, fmt.Errorf("error while parsing include_message parser config: %w", err)
+			}
 		default:
 			return nil, fmt.Errorf("%s: %w", name, ErrNoSuchParser)
 		}

--- a/libbeat/reader/parser/parser_test.go
+++ b/libbeat/reader/parser/parser_test.go
@@ -686,6 +686,40 @@ func TestContainerParser(t *testing.T) {
 	}
 }
 
+func TestParserIncludeMessages(t *testing.T) {
+	parserConfig := map[string]interface{}{
+		"parsers": []map[string]interface{}{
+			{
+				"include_message": map[string]interface{}{
+					"patterns": []string{"^INCLUDE"},
+				},
+			},
+		},
+	}
+
+	lines := "INCLUDE - FOO\ndo not include this line\n\nINCLUDE BAR\n"
+	expectedMessages := []string{
+		"INCLUDE - FOO\n",
+		"INCLUDE BAR\n",
+	}
+
+	cfg := config.MustNewConfigFrom(parserConfig)
+	var c inputParsersConfig
+	err := cfg.Unpack(&c)
+	require.NoError(t, err)
+
+	p := c.Parsers.Create(testReader(lines))
+
+	readMsgs := []string{}
+	msg, err := p.Next()
+	for err == nil {
+		readMsgs = append(readMsgs, string(msg.Content))
+		msg, err = p.Next()
+	}
+
+	require.Equal(t, expectedMessages, readMsgs, "fii")
+}
+
 type testParsersConfig struct {
 	Parsers []config.Namespace `struct:"parsers"`
 }


### PR DESCRIPTION
## What does this PR do?
It adds the `include_message` parser to `parser.NewConfig` validation logic.

## Why is it important?

This parser could not be used before, Filebeat would fail to start

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally
1. Create a Filebeat configuration that uses the `include_message` parser:
```
- type: filestream
  paths:
    - /tmp/test.log

  parsers:
  - include_message:
      patterns: ["^A", "^B"]
```

2. Run Filebeat
3. It should start and only include messages matching the reg exps.

## Related issues
- Fixes #35440

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
