### PR TITLE
[Winlog] attempt to close and reopen eventlog if EOF encountered

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -220,7 +220,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Fix panic due to misrepresented buffer use. {pull}35437[35437]
 - Prevent panic on closing iterators on empty channels in experimental API. {issue}33966[33966] {pull}35423[35423]
 - Allow program termination when attempting to open an absent channel. {pull}35474[35474]
-- Close and Re-open EventLog if error EOF is encountered. {pull}XXXXX[XXXXX]
+- Close and reopen EventLog if error EOF is encountered. {pull}35662[35662]
 
 *Functionbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -220,6 +220,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Fix panic due to misrepresented buffer use. {pull}35437[35437]
 - Prevent panic on closing iterators on empty channels in experimental API. {issue}33966[33966] {pull}35423[35423]
 - Allow program termination when attempting to open an absent channel. {pull}35474[35474]
+- Close and Re-open EventLog if error EOF is encountered. {pull}XXXXX[XXXXX]
 
 *Functionbeat*
 

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -135,24 +135,24 @@ runLoop:
 		for cancelCtx.Err() == nil {
 			records, err := api.Read()
 			if eventlog.IsRecoverable(err) {
-				log.Errorw("Encountered recoverable error when reading from Windows Event Log", "error", err, "channel", api.Channel())
+				log.Errorw("Encountered recoverable error when reading from Windows Event Log", "error", err)
 				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr, "channel", api.Channel())
+					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
 				}
 				continue runLoop
 			}
 			if !api.IsFile() && eventlog.IsChannelNotFound(err) {
-				log.Errorw("Encountered channel not found error when reading from Windows Event Log", "error", err, "channel", api.Channel())
+				log.Errorw("Encountered channel not found error when reading from Windows Event Log", "error", err)
 				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr, "channel", api.Channel())
+					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
 				}
 				continue runLoop
 			}
 
 			if !api.IsFile() && errors.Is(err, io.EOF) {
-				log.Errorw("Encountered EOF error when reading from Windows Event Log", "error", err, "channel", api.Channel())
+				log.Errorw("Encountered EOF error when reading from Windows Event Log", "error", err)
 				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr, "channel", api.Channel())
+					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
 				}
 				continue runLoop
 			}

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -135,24 +135,24 @@ runLoop:
 		for cancelCtx.Err() == nil {
 			records, err := api.Read()
 			if eventlog.IsRecoverable(err) {
-				log.Errorw("Encountered recoverable error when reading from Windows Event Log", "error", err)
+				log.Errorw("Encountered recoverable error when reading from Windows Event Log", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
+					log.Errorw("Error closing Windows Event Log handle", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}
 			if !api.IsFile() && eventlog.IsChannelNotFound(err) {
-				log.Errorw("Encountered channel not found error when reading from Windows Event Log", "error", err)
+				log.Errorw("Encountered channel not found error when reading from Windows Event Log", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
+					log.Errorw("Error closing Windows Event Log handle", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}
 
 			if !api.IsFile() && errors.Is(err, io.EOF) {
-				log.Errorw("Encountered EOF error when reading from Windows Event Log", "error", err)
+				log.Errorw("Encountered EOF error when reading from Windows Event Log", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
+					log.Errorw("Error closing Windows Event Log handle", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -149,6 +149,14 @@ runLoop:
 				continue runLoop
 			}
 
+			if !api.IsFile() && errors.Is(err, io.EOF) {
+				log.Errorw("Encountered EOF error when reading from Windows Event Log", "error", err)
+				if closeErr := api.Close(); closeErr != nil {
+					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
+				}
+				continue runLoop
+			}
+
 			if err != nil {
 				if errors.Is(err, io.EOF) {
 					log.Debugw("End of Winlog event stream reached", "error", err)

--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -178,14 +178,22 @@ runLoop:
 			if eventlog.IsRecoverable(err) {
 				e.log.Warnw("Read() encountered recoverable error. Reopening handle...", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					e.log.Warnw("Close() error.", "error", err)
+					e.log.Warnw("Close() error for channel %q.", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}
 			if !api.IsFile() && eventlog.IsChannelNotFound(err) {
 				e.log.Warnw("Read() encountered channel not found error for channel %q. Reopening handle...", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					e.log.Warnw("Close() error.", "error", err)
+					e.log.Warnw("Close() error for channel %q.", "error", closeErr, "channel", api.Channel())
+				}
+				continue runLoop
+			}
+
+			if !api.IsFile() && errors.Is(err, io.EOF) {
+				e.log.Warnw("Read() encountered EOF for channel %q.  Reopening handle...", "error", err, "channel", api.Channel())
+				if closeErr := api.Close(); closeErr != nil {
+					e.log.Warnw("Close() error for channel %q.", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}

--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -178,22 +178,22 @@ runLoop:
 			if eventlog.IsRecoverable(err) {
 				e.log.Warnw("Read() encountered recoverable error. Reopening handle...", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					e.log.Warnw("Close() error for channel %q.", "error", closeErr, "channel", api.Channel())
+					e.log.Warnw("Close() error.", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}
 			if !api.IsFile() && eventlog.IsChannelNotFound(err) {
-				e.log.Warnw("Read() encountered channel not found error for channel %q. Reopening handle...", "error", err, "channel", api.Channel())
+				e.log.Warnw("Read() encountered channel not found error for channel. Reopening handle...", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					e.log.Warnw("Close() error for channel %q.", "error", closeErr, "channel", api.Channel())
+					e.log.Warnw("Close() error.", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}
 
 			if !api.IsFile() && errors.Is(err, io.EOF) {
-				e.log.Warnw("Read() encountered EOF for channel %q.  Reopening handle...", "error", err, "channel", api.Channel())
+				e.log.Warnw("Read() encountered EOF for channel.  Reopening handle...", "error", err, "channel", api.Channel())
 				if closeErr := api.Close(); closeErr != nil {
-					e.log.Warnw("Close() error for channel %q.", "error", closeErr, "channel", api.Channel())
+					e.log.Warnw("Close() error.", "error", closeErr, "channel", api.Channel())
 				}
 				continue runLoop
 			}


### PR DESCRIPTION
## What does this PR do?

If EOF is encountered while trying to read events from an EventLog (not file), then try to close the event log and re-open.

## Why is it important?

We have seen instances where reading from EventLogs has returned EOF causing Winlogbeat to exit.  We haven't been able to reproduce the behavior locally.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally



## Related issues


