### PR TITLE
Add the default value of QoS levels in MQTT

### DIFF
--- a/filebeat/docs/inputs/input-mqtt.asciidoc
+++ b/filebeat/docs/inputs/input-mqtt.asciidoc
@@ -50,7 +50,7 @@ A list of topics to subscribe to and read from.
 
 An agreement level between the sender of a message and the receiver of a message that defines the guarantee of delivery.
 
-There are 3 QoS levels in MQTT:
+There are 3 QoS levels in MQTT. Defaults to `0`:
 
 * At most once (`0`),
 * At least once (`1`),


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
This change adds the default value of QoS levels in MQTT based on the following explanation.

If the field is not initialised then zero-value of the type is considered i.e., QoS field is of type int and for numeric types the default is 0 unless the field is initialized. https://github.com/elastic/beats/blob/5eb82caeda0fd76abb9547bb3ce39996ac1d2b50/filebeat/input/mqtt/config.go#L29

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
The addition provides an extra piece of information to confirm the default QoS level.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [v ] My code follows the style guidelines of this project
- [v] I have commented my code, particularly in hard-to-understand areas
- [v] I have made corresponding changes to the documentation
- [v ] I have made corresponding change to the default configuration files
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

