### PR TITLE
Make  Beats tech leads the owners of go.mod.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,12 @@
 # https://github.community/t/codeowners-file-with-a-not-file-type-condition/1423/9
 CHANGELOG*
 
+# The tech leads of the teams working in Beats share ownership of the Go module dependencies and related files.
+/.github/CODEOWNERS/ @elastic/beats-tech-leads
+/.go.mod/ @elastic/beats-tech-leads
+/.go.sum/ @elastic/beats-tech-leads
+/NOTICE.txt/ @elastic/beats-tech-leads
+
 /.ci/ @elastic/elastic-agent-data-plane
 /.github/ @elastic/elastic-agent-data-plane
 /auditbeat/ @elastic/security-external-integrations


### PR DESCRIPTION
We have found the Elastic Agent team is being required to review PRs exclusively because we are the maintainers of go.mod and related files. To avoid making us the bottleneck for these changes, we've created the [Beats Tech Leads](https://github.com/orgs/elastic/teams/beats-tech-leads) team so that we can share ownership of these files and unblock our own teams faster. 

The alternative is to mark these files as unowned, but since go.mod updates can be critical to product security I don't want to leave these files ownerless. I will also make this group the owner of the CODEOWNER file itself.