### PR TITLE
Add doc-site-branch to version.asciidoc

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -386,11 +386,11 @@ func beatVersion() (string, error) {
 }
 
 var (
-	beatDocBranchRegex = regexp.MustCompile(`(?m)doc-branch:\s*([^\s]+)\r?$`)
+	beatDocBranchRegex     = regexp.MustCompile(`(?m)doc-branch:\s*([^\s]+)\r?$`)
 	beatDocSiteBranchRegex = regexp.MustCompile(`(?m)doc-site-branch:\s*([^\s]+)\r?$`)
-	beatDocBranchValue string
-	beatDocBranchErr   error
-	beatDocBranchOnce  sync.Once
+	beatDocBranchValue     string
+	beatDocBranchErr       error
+	beatDocBranchOnce      sync.Once
 )
 
 // BeatDocBranch returns the documentation branch name associated with the

--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -387,6 +387,7 @@ func beatVersion() (string, error) {
 
 var (
 	beatDocBranchRegex = regexp.MustCompile(`(?m)doc-branch:\s*([^\s]+)\r?$`)
+	beatDocSiteBranchRegex = regexp.MustCompile(`(?m)doc-site-branch:\s*([^\s]+)\r?$`)
 	beatDocBranchValue string
 	beatDocBranchErr   error
 	beatDocBranchOnce  sync.Once

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,5 +1,8 @@
 :stack-version: 8.9.0
 :doc-branch: main
+// FIXME: once elastic.co docs have been switched over to use `main`, remove
+// the `doc-site-branch` line below as well as any references to it in the code.
+:doc-site-branch: master
 :go-version: 1.19.9
 :release-state: unreleased
 :python: 3.7


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fixes the docs for the `main` branch

## Why is it important?

Because the links on elastic.co are broken:

>doesn't work: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-consul.html
>works:        https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-consul.html

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

N/A

## Related issues

N/A
