### PR TITLE
[Heartbeat] Add nil check to diagnostics processor serializer

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -149,6 +149,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Fix project monitor temp directories permission to include group access. {pull}35398[35398]
 - Fix output pipeline exit on run_once. {pull}35376[35376]
 - Fix formatting issue with socket trace timeout. {pull}35434[35434]
+- Fix serialization of processors when running diagnostics. {pull}35698[35698]
 
 *Heartbeat*
 

--- a/libbeat/publisher/processing/default.go
+++ b/libbeat/publisher/processing/default.go
@@ -261,9 +261,13 @@ func newBuilder(
 // Processors returns a string description of the processor config
 func (b *builder) Processors() []string {
 	procList := []string{}
-	for _, proc := range b.processors.list {
-		procList = append(procList, proc.String())
+
+	if b.processors != nil {
+		for _, proc := range b.processors.list {
+			procList = append(procList, proc.String())
+		}
 	}
+
 	return procList
 }
 

--- a/libbeat/publisher/processing/default_test.go
+++ b/libbeat/publisher/processing/default_test.go
@@ -480,6 +480,14 @@ func TestProcessingClose(t *testing.T) {
 	assert.True(t, factoryProcessor.closed)
 }
 
+func TestProcessingDiagnostics(t *testing.T) {
+	factory, err := MakeDefaultSupport(true, nil)(beat.Info{}, logp.L(), config.NewConfig())
+	require.NoError(t, err)
+
+	p := factory.Processors()
+	assert.Empty(t, p)
+}
+
 func fromJSON(in string) mapstr.M {
 	var tmp mapstr.M
 	err := json.Unmarshal([]byte(in), &tmp)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Closes #35635.
Related to #35031.

TL;DR: We are seeing segfaults when running `elastic-agent diagnostics` on heartbeat policies. Traced back to a nested `nil` access. AFAIK, there're other beats affected by the same problem.

- Add `nil` check to diagnostics processor serializer.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

- Build agent locally.
- Enroll an agent in a synthetics policy.
- Run `elastic-agent diagnostics`.
-  Check no segfault error is reported and `.zip` contains parsed synthetic policies.

#
