### PR TITLE
fix(sec): upgrade certifi to 2022.12.07

### DIFF
--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -2,7 +2,7 @@ attrs==19.3.0
 autopep8==1.5.4
 backports.ssl-match-hostname==3.5.0.1
 cached-property==1.4.2
-certifi==2022.12.7
+certifi==2022.12.07
 chardet==3.0.4
 deepdiff==4.2.0
 docker==6.0.1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in certifi 2022.12.7
- [CVE-2022-23491](https://www.oscs1024.com/hd/CVE-2022-23491)


### What did I do？
Upgrade certifi from 2022.12.7 to 2022.12.07 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS