### PR TITLE
Add changelog for go-sysinfo hostname change.

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -233,6 +233,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Reload Beat when TLS certificates or key files are modified. {issue}34408[34408] {pull}34416[34416]
 - Upgrade version of elastic-agent-autodiscover to v0.6.1 for improved memory consumption on k8s. {pull}35483[35483]
 - Added `orchestrator.cluster.id` and `orchestrator.cluster.name` fields to the add_cloud_metadata processor, AWS cloud provider. {pull}35182[35182]
+- Lowercase reported hostnames per Elastic Common Schema (ECS) guidelines for the host.name field. Upgraded github.com/elastic/go-sysinfo to 1.11.0. {pull}35652[35652]
 
 *Auditbeat*
 


### PR DESCRIPTION
What the summary says, adds a changelog entry for the user facing hostname case change mentioned in the release notes of https://github.com/elastic/beats/pull/35652.

Pairs with https://github.com/elastic/elastic-agent/pull/2767.