### PR TITLE
[Heartbeat] Add abort to internal trace

### DIFF
--- a/heartbeat/tracer/tracer.go
+++ b/heartbeat/tracer/tracer.go
@@ -27,14 +27,21 @@ import (
 )
 
 type Tracer interface {
-	Write(string) error
-	Close() error
+	Start()
+	Abort()
+	Close()
 }
 
 type SockTracer struct {
 	path string
 	sock net.Conn
 }
+
+const (
+	MSG_START = "start"
+	MSG_STOP  = "stop"
+	MSG_ABORT = "abort"
+)
 
 func NewSockTracer(path string, wait time.Duration) (st SockTracer, err error) {
 	st.path = path
@@ -63,16 +70,33 @@ func NewSockTracer(path string, wait time.Duration) (st SockTracer, err error) {
 	return st, nil
 }
 
-func (st SockTracer) Write(message string) error {
+func (st SockTracer) Start() {
+	err := st.write(MSG_START)
+	logp.L().Errorf("could not write start trace message: %s", err)
+}
+
+func (st SockTracer) Abort() {
+	err := st.write(MSG_ABORT)
+	logp.L().Errorf("could not write abort trace message: %s", err)
+	st.closeSock()
+}
+
+func (st SockTracer) Close() {
+	err := st.write(MSG_STOP)
+	logp.L().Errorf("could not write stop trace message: %s", err)
+	st.closeSock()
+}
+
+func (st SockTracer) closeSock() {
+	err := st.sock.Close()
+	logp.L().Errorf("could not close trace sock: %s", err)
+}
+
+func (st SockTracer) write(message string) error {
 	// Note, we don't need to worry about partial writes here: https://pkg.go.dev/io?utm_source=godoc#Writer
 	// an error will be returned here, which shouldn't really happen with unix sockets only
 	_, err := st.sock.Write([]byte(message + "\n"))
 	return err
-}
-
-func (st SockTracer) Close() error {
-	_ = st.Write("stop")
-	return st.sock.Close()
 }
 
 type NoopTracer struct{}
@@ -81,10 +105,11 @@ func NewNoopTracer() NoopTracer {
 	return NoopTracer{}
 }
 
-func (nt NoopTracer) Write(message string) error {
-	return nil
+func (nt NoopTracer) Start() {
 }
 
-func (nt NoopTracer) Close() error {
-	return nil
+func (nt NoopTracer) Abort() {
+}
+
+func (nt NoopTracer) Close() {
 }

--- a/heartbeat/tracer/tracer.go
+++ b/heartbeat/tracer/tracer.go
@@ -72,24 +72,32 @@ func NewSockTracer(path string, wait time.Duration) (st SockTracer, err error) {
 
 func (st SockTracer) Start() {
 	err := st.write(MSG_START)
-	logp.L().Errorf("could not write start trace message: %s", err)
+	if err != nil {
+		logp.L().Errorf("could not write start trace message: %s", err)
+	}
 }
 
 func (st SockTracer) Abort() {
 	err := st.write(MSG_ABORT)
-	logp.L().Errorf("could not write abort trace message: %s", err)
+	if err != nil {
+		logp.L().Errorf("could not write abort trace message: %s", err)
+	}
 	st.closeSock()
 }
 
 func (st SockTracer) Close() {
 	err := st.write(MSG_STOP)
-	logp.L().Errorf("could not write stop trace message: %s", err)
+	if err != nil {
+		logp.L().Errorf("could not write stop trace message: %s", err)
+	}
 	st.closeSock()
 }
 
 func (st SockTracer) closeSock() {
 	err := st.sock.Close()
-	logp.L().Errorf("could not close trace sock: %s", err)
+	if err != nil {
+		logp.L().Errorf("could not close trace sock: %s", err)
+	}
 }
 
 func (st SockTracer) write(message string) error {

--- a/heartbeat/tracer/tracer_test.go
+++ b/heartbeat/tracer/tracer_test.go
@@ -59,8 +59,10 @@ func TestSockTracer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
 			sockName, err := uuid.NewRandom()
 			require.NoError(t, err)
 			sockPath := filepath.Join(os.TempDir(), sockName.String())

--- a/heartbeat/tracer/tracer_test.go
+++ b/heartbeat/tracer/tracer_test.go
@@ -32,25 +32,49 @@ import (
 )
 
 func TestSockTracer(t *testing.T) {
-	sockName, err := uuid.NewRandom()
-	require.NoError(t, err)
-	sockPath := filepath.Join(os.TempDir(), sockName.String())
+	t.Parallel()
+	tests := []struct {
+		name  string
+		testF func(t *testing.T, st SockTracer, listenRes chan []string)
+	}{
+		{
+			"start/stop",
+			func(t *testing.T, st SockTracer, listenRes chan []string) {
+				st.Start()
+				st.Close()
 
-	listenRes := make(chan []string)
-	go func() {
-		listenRes <- listenTilClosed(t, sockPath)
-	}()
+				got := <-listenRes
+				require.Equal(t, []string{MSG_START, MSG_STOP}, got)
+			},
+		},
+		{
+			"abort",
+			func(t *testing.T, st SockTracer, listenRes chan []string) {
+				st.Abort()
 
-	st, err := NewSockTracer(sockPath, time.Second)
-	require.NoError(t, err)
+				got := <-listenRes
+				require.Equal(t, []string{MSG_ABORT}, got)
+			},
+		},
+	}
 
-	err = st.Write("start")
-	require.NoError(t, err)
-	err = st.Close()
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sockName, err := uuid.NewRandom()
+			require.NoError(t, err)
+			sockPath := filepath.Join(os.TempDir(), sockName.String())
 
-	got := <-listenRes
-	require.Equal(t, got, []string{"start", "stop"})
+			listenRes := make(chan []string)
+			go func() {
+				listenRes <- listenTilClosed(t, sockPath)
+			}()
+
+			st, err := NewSockTracer(sockPath, time.Second)
+			require.NoError(t, err)
+			tt.testF(t, st, listenRes)
+		})
+	}
 }
 
 func TestSockTracerWaitFail(t *testing.T) {


### PR DESCRIPTION
This change modifies the internal trace to send a message on a run_once abort due to a broken ES connection.

It also improves testing and cleans up the code by using methods instead of freeform strings for consistency.

This also moves logging to the trace library itself to make calling cleaner, since all a caller would do is log anyway.

No changelog since this is not a user facing change.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~