### PR TITLE
Set the unit unhealthy if output fails to start

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -9,7 +9,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 ==== Breaking changes
 
 *Affecting all Beats*
-- Fix status reporting when output configuration is invalid running under Elastic-Agent {pull}35719[35719]
+- Fix status reporting to Elastic-Agent when output configuration is invalid running under Elastic-Agent {pull}35719[35719]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -9,6 +9,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 ==== Breaking changes
 
 *Affecting all Beats*
+- Fix status reporting when output configuration is invalid running under Elastic-Agent {pull}35719[35719]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/tests/integration/framework_test.go
+++ b/x-pack/filebeat/tests/integration/framework_test.go
@@ -134,3 +134,34 @@ func (b *BeatProc) openLogFile() *os.File {
 
 	return f
 }
+
+// createTempDir creates a temporary directory that can persist
+// after the test finishes.
+//
+// If the tests are run with -v, the temporary directory will
+// be logged.
+//
+// Call the returned cleanup function to remove
+// the temporary directory. If there are any errors
+// cleanup will call t.Error
+func createTempDir(t *testing.T) (string, func()) {
+	tempDir, err := filepath.Abs(filepath.Join("../../build/integration-tests/",
+		fmt.Sprintf("%s-%d", t.Name(), time.Now().Unix())))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(tempDir, 0766); err != nil {
+		t.Fatalf("cannot create tmp dir: %s, msg: %s", err, err.Error())
+	}
+	t.Logf("Temporary directory: %s", tempDir)
+
+	cleanup := func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Errorf("could not remove temp dir '%s': %s", tempDir, err)
+		}
+		t.Logf("Temporary directory '%s' removed", tempDir)
+	}
+
+	return tempDir, cleanup
+}

--- a/x-pack/filebeat/tests/integration/managerV2_test.go
+++ b/x-pack/filebeat/tests/integration/managerV2_test.go
@@ -46,17 +46,7 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 	// We create our own temp dir so the files can be persisted
 	// in case the test fails. This will help debugging issues
 	// locally and on CI.
-	//
-	// testSucceeded will be set to 'true' as the very last thing on this test,
-	// it allows us to use t.CleanUp to remove the temporary files
-	testSucceeded := false
-	tempDir, cleanup := createTempDir(t)
-
-	t.Cleanup(func() {
-		if testSucceeded {
-			cleanup()
-		}
-	})
+	tempDir := createTempDir(t)
 
 	logFilePath := filepath.Join(tempDir, "flog.log")
 	generateLogFile(t, logFilePath)
@@ -262,9 +252,6 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 		return filebeat.LogContains("ForceReload set to FALSE")
 	}, waitDeadlineOr5Min(), 100*time.Millisecond,
 		"String 'ForceReload set to FALSE' not found on Filebeat logs")
-
-	// Set it to true, so the temporary directory is removed
-	testSucceeded = true
 }
 
 // TestFailedOutputReportsUnhealthy ensures that if an output
@@ -277,15 +264,8 @@ func TestFailedOutputReportsUnhealthy(t *testing.T) {
 	// what caused it is going through Filebeat's logs.
 	ensureESIsRunning(t)
 
-	tempDir, cleanup := createTempDir(t)
+	tempDir := createTempDir(t)
 	finalStateReached := false
-	testSucceeded := false
-
-	t.Cleanup(func() {
-		if testSucceeded {
-			cleanup()
-		}
-	})
 
 	var units = []*proto.UnitExpected{
 		{
@@ -367,7 +347,6 @@ func TestFailedOutputReportsUnhealthy(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond, "Output unit did not report unhealthy")
 
 	t.Cleanup(server.Stop)
-	testSucceeded = true
 }
 
 func requireNewStruct(t *testing.T, v map[string]interface{}) *structpb.Struct {

--- a/x-pack/filebeat/tests/integration/managerV2_test.go
+++ b/x-pack/filebeat/tests/integration/managerV2_test.go
@@ -50,22 +50,11 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 	// testSucceeded will be set to 'true' as the very last thing on this test,
 	// it allows us to use t.CleanUp to remove the temporary files
 	testSucceeded := false
-	tempDir, err := filepath.Abs(filepath.Join("../../build/integration-tests/",
-		fmt.Sprintf("%s-%d", t.Name(), time.Now().Unix())))
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempDir, cleanup := createTempDir(t)
 
-	if err := os.MkdirAll(tempDir, 0766); err != nil {
-		t.Fatalf("cannot create tmp dir: %s, msg: %s", err, err.Error())
-	}
-	t.Logf("Temporary directory: %s", tempDir)
 	t.Cleanup(func() {
 		if testSucceeded {
-			if err := os.RemoveAll(tempDir); err != nil {
-				t.Fatalf("could not remove temp dir '%s': %s", tempDir, err)
-			}
-			t.Logf("Temporary directory '%s' removed", tempDir)
+			cleanup()
 		}
 	})
 

--- a/x-pack/filebeat/tests/integration/managerV2_test.go
+++ b/x-pack/filebeat/tests/integration/managerV2_test.go
@@ -278,6 +278,109 @@ func TestInputReloadUnderElasticAgent(t *testing.T) {
 	testSucceeded = true
 }
 
+// TestFailedOutputReportsUnhealthy ensures that if an output
+// fails to start and returns an error, the manager will set it
+// as failed and the inputs will not be started, which means
+// staying on the started state.
+func TestFailedOutputReportsUnhealthy(t *testing.T) {
+	// First things first, ensure ES is running and we can connect to it.
+	// If ES is not running, the test will timeout and the only way to know
+	// what caused it is going through Filebeat's logs.
+	ensureESIsRunning(t)
+
+	tempDir, cleanup := createTempDir(t)
+	finalStateReached := false
+	testSucceeded := false
+
+	t.Cleanup(func() {
+		if testSucceeded {
+			cleanup()
+		}
+	})
+
+	var units = []*proto.UnitExpected{
+		{
+			Id:             "output-unit-borken",
+			Type:           proto.UnitType_OUTPUT,
+			ConfigStateIdx: 1,
+			State:          proto.State_FAILED,
+			LogLevel:       proto.UnitLogLevel_DEBUG,
+			Config: &proto.UnitExpectedConfig{
+				Id:   "default",
+				Type: "logstash",
+				Name: "logstash",
+				Source: requireNewStruct(t,
+					map[string]interface{}{
+						"type":    "logstash",
+						"invalid": "configuration",
+					}),
+			},
+		},
+		// Also add an input unit to make sure it never leaves the
+		// starting state
+		{
+			Id:             "input-unit",
+			Type:           proto.UnitType_INPUT,
+			ConfigStateIdx: 1,
+			State:          proto.State_STARTING,
+			LogLevel:       proto.UnitLogLevel_DEBUG,
+			Config: &proto.UnitExpectedConfig{
+				Id:   "log-input",
+				Type: "log",
+				Name: "log",
+				Streams: []*proto.Stream{
+					{
+						Id: "log-input",
+						Source: requireNewStruct(t, map[string]interface{}{
+							"enabled": true,
+							"type":    "log",
+							"paths":   "/tmp/foo",
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	server := &mock.StubServerV2{
+		// The Beat will call the check-in function multiple times:
+		// - At least once at startup
+		// - At every state change (starting, configuring, healthy, etc)
+		// for every Unit.
+		//
+		// So we wait until the state matches the desired state
+		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
+			if management.DoesStateMatch(observed, units, 0) {
+				finalStateReached = true
+			}
+
+			return &proto.CheckinExpected{
+				Units: units,
+			}
+		},
+		ActionImpl: func(response *proto.ActionResponse) error { return nil },
+	}
+
+	require.NoError(t, server.Start())
+
+	filebeat := NewBeat(
+		t,
+		"../../filebeat.test",
+		tempDir,
+		"-E", fmt.Sprintf(`management.insecure_grpc_url_for_testing="localhost:%d"`, server.Port),
+		"-E", "management.enabled=true",
+	)
+
+	filebeat.Start()
+
+	require.Eventually(t, func() bool {
+		return finalStateReached
+	}, 30*time.Second, 100*time.Millisecond, "Output unit did not report unhealthy")
+
+	t.Cleanup(server.Stop)
+	testSucceeded = true
+}
+
 func requireNewStruct(t *testing.T, v map[string]interface{}) *structpb.Struct {
 	str, err := structpb.NewStruct(v)
 	if err != nil {

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -602,6 +602,8 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 		cm.message = err.Error()
 
 		// If there are any other errors, set the status accordingly.
+		// If len(errs), then the there were no previous and the only
+		// error has been reported already.
 		if len(errs) > 0 {
 			errs = append(errs, err)
 			cm.message = fmt.Sprintf("%s", errs)

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -591,7 +591,11 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 	// reload the output configuration
 	if err := cm.reloadOutput(outputUnit); err != nil {
 		// Output creation failed, there is no point in going any further
-		// because there is no output to send data
+		// because there is no output read the events.
+		//
+		// Trying to start inputs will eventually lead them to deadlock
+		// waiting for the output. Log input will deadlock when starting,
+		// effectively blocking this manager.
 		err = fmt.Errorf("could not start output: %w", err)
 		outputUnit.UpdateState(client.UnitStateFailed, err.Error(), nil)
 		cm.status = lbmanagement.Failed


### PR DESCRIPTION
## What does this PR do?
It fixes the status reporting when the output fails to start under Elastic-Agent and also prevents some deadlock conditions on inputs that will block its initialisation when the output is not ready.

## Why is it important?
- Fixes https://github.com/elastic/elastic-agent/issues/2554

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~

## How to test this PR locally


## Related issues

- https://github.com/elastic/elastic-agent/issues/2554

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
