### PR TITLE
dependabot - Segment by responsible team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,6 +109,7 @@ CHANGELOG*
 /x-pack/filebeat/input/azureblobstorage/ @elastic/security-external-integrations
 /x-pack/filebeat/input/azureeventhub/ @elastic/obs-cloud-monitoring
 /x-pack/filebeat/input/cel/ @elastic/security-external-integrations
+/x-pack/filebeat/input/cometd/ @elastic/obs-infraobs-integrations
 /x-pack/filebeat/input/entityanalytics/ @elastic/security-external-integrations
 /x-pack/filebeat/input/gcppubsub/ @elastic/security-external-integrations
 /x-pack/filebeat/input/gcs/ @elastic/security-external-integrations

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,64 @@
 ---
 version: 2
+# This section is segmented by the responsible GitHub teams in order
+# to make it clear who is responsible for reviewing.
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
+  - package-ecosystem: gomod
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     labels:
       - automation
+      - dependabot
       - Team:Elastic-Agent-Data-Plane
     allow:
-      - dependency-name: "github.com/elastic/*"
+      - dependency-name: github.com/elastic/elastic-agent-autodiscover
+      - dependency-name: github.com/elastic/elastic-agent-client/*
+      - dependency-name: github.com/elastic/elastic-agent-libs
+      - dependency-name: github.com/elastic/elastic-agent-shipper-client
+      - dependency-name: github.com/elastic/elastic-agent-system-metrics
+      - dependency-name: github.com/elastic/go-concert
+      - dependency-name: github.com/elastic/go-elasticsearch/*
+      - dependency-name: github.com/elastic/go-licenser
+      - dependency-name: github.com/elastic/go-lookslike
+      - dependency-name: github.com/elastic/go-lumber
+      - dependency-name: github.com/elastic/go-structform
+      - dependency-name: github.com/elastic/go-sysinfo
+      - dependency-name: github.com/elastic/go-ucfg
+      - dependency-name: github.com/elastic/gosigar
+      - dependency-name: go.elastic.co/apm/*
+      - dependency-name: go.elastic.co/ecszap
+      - dependency-name: go.elastic.co/go-licence-detector
     reviewers:
-      - "elastic/elastic-agent-data-plane"
-    open-pull-requests-limit: 10
+      - elastic/elastic-agent-data-plane
+    open-pull-requests-limit: 2
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - automation
+      - dependabot
+      - Team:Security-External Integrations
+    allow:
+      # Skip github.com/elastic/mito because it requires documentation updates.
+      - dependency-name: github.com/elastic/go-libaudit/*
+      - dependency-name: github.com/elastic/go-perf
+      - dependency-name: github.com/elastic/go-seccomp-bpf
+      - dependency-name: github.com/elastic/toutoumomoma
+    reviewers:
+      - elastic/security-external-integrations
+    open-pull-requests-limit: 2
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - automation
+      - dependabot
+      - Team:Service-Integrations
+    allow:
+      - dependency-name: github.com/elastic/bayeux
+    reviewers:
+      - elastic/obs-infraobs-integrations
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## What does this PR do?

Segment the dependabot config based on the responsible GitHub team in order to make it more clear who is responsible for approving the change.

The idea is that the repsonsible team is in the best position to know if the dependency should be updated, whether it should be backported, and what should be listed in the changelog.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

