### PR TITLE
Fix Docs links

### DIFF
--- a/dev-tools/mage/settings.go
+++ b/dev-tools/mage/settings.go
@@ -386,11 +386,10 @@ func beatVersion() (string, error) {
 }
 
 var (
-	beatDocBranchRegex     = regexp.MustCompile(`(?m)doc-branch:\s*([^\s]+)\r?$`)
-	beatDocSiteBranchRegex = regexp.MustCompile(`(?m)doc-site-branch:\s*([^\s]+)\r?$`)
-	beatDocBranchValue     string
-	beatDocBranchErr       error
-	beatDocBranchOnce      sync.Once
+	beatDocBranchRegex = regexp.MustCompile(`(?m)doc-branch:\s*([^\s]+)\r?$`)
+	beatDocBranchValue string
+	beatDocBranchErr   error
+	beatDocBranchOnce  sync.Once
 )
 
 // BeatDocBranch returns the documentation branch name associated with the

--- a/filebeat/modules.d/apache.yml.disabled
+++ b/filebeat/modules.d/apache.yml.disabled
@@ -1,5 +1,5 @@
 # Module: apache
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-apache.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-apache.html
 
 - module: apache
   # Access logs

--- a/filebeat/modules.d/auditd.yml.disabled
+++ b/filebeat/modules.d/auditd.yml.disabled
@@ -1,5 +1,5 @@
 # Module: auditd
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-auditd.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-auditd.html
 
 - module: auditd
   log:

--- a/filebeat/modules.d/elasticsearch.yml.disabled
+++ b/filebeat/modules.d/elasticsearch.yml.disabled
@@ -1,5 +1,5 @@
 # Module: elasticsearch
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-elasticsearch.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-elasticsearch.html
 
 - module: elasticsearch
   # Server log

--- a/filebeat/modules.d/haproxy.yml.disabled
+++ b/filebeat/modules.d/haproxy.yml.disabled
@@ -1,5 +1,5 @@
 # Module: haproxy
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-haproxy.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-haproxy.html
 
 - module: haproxy
   # All logs

--- a/filebeat/modules.d/icinga.yml.disabled
+++ b/filebeat/modules.d/icinga.yml.disabled
@@ -1,5 +1,5 @@
 # Module: icinga
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-icinga.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-icinga.html
 
 - module: icinga
   # Main logs

--- a/filebeat/modules.d/iis.yml.disabled
+++ b/filebeat/modules.d/iis.yml.disabled
@@ -1,5 +1,5 @@
 # Module: iis
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-iis.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-iis.html
 
 - module: iis
   # Access logs

--- a/filebeat/modules.d/kafka.yml.disabled
+++ b/filebeat/modules.d/kafka.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kafka
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-kafka.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-kafka.html
 
 - module: kafka
   # All logs

--- a/filebeat/modules.d/kibana.yml.disabled
+++ b/filebeat/modules.d/kibana.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kibana
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-kibana.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-kibana.html
 
 - module: kibana
   # Server logs

--- a/filebeat/modules.d/logstash.yml.disabled
+++ b/filebeat/modules.d/logstash.yml.disabled
@@ -1,5 +1,5 @@
 # Module: logstash
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-logstash.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-logstash.html
 
 - module: logstash
   # logs

--- a/filebeat/modules.d/mongodb.yml.disabled
+++ b/filebeat/modules.d/mongodb.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mongodb
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-mongodb.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-mongodb.html
 
 - module: mongodb
   # All logs

--- a/filebeat/modules.d/mysql.yml.disabled
+++ b/filebeat/modules.d/mysql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mysql
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-mysql.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-mysql.html
 
 - module: mysql
   # Error logs

--- a/filebeat/modules.d/nats.yml.disabled
+++ b/filebeat/modules.d/nats.yml.disabled
@@ -1,5 +1,5 @@
 # Module: nats
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-nats.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-nats.html
 
 - module: nats
   # All logs

--- a/filebeat/modules.d/nginx.yml.disabled
+++ b/filebeat/modules.d/nginx.yml.disabled
@@ -1,5 +1,5 @@
 # Module: nginx
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-nginx.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-nginx.html
 
 - module: nginx
   # Access logs

--- a/filebeat/modules.d/osquery.yml.disabled
+++ b/filebeat/modules.d/osquery.yml.disabled
@@ -1,5 +1,5 @@
 # Module: osquery
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-osquery.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-osquery.html
 
 - module: osquery
   result:

--- a/filebeat/modules.d/pensando.yml.disabled
+++ b/filebeat/modules.d/pensando.yml.disabled
@@ -1,5 +1,5 @@
 # Module: pensando
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-pensando.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-pensando.html
 
 - module: pensando
 # Firewall logs

--- a/filebeat/modules.d/postgresql.yml.disabled
+++ b/filebeat/modules.d/postgresql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: postgresql
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-postgresql.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-postgresql.html
 
 - module: postgresql
   # All logs

--- a/filebeat/modules.d/redis.yml.disabled
+++ b/filebeat/modules.d/redis.yml.disabled
@@ -1,5 +1,5 @@
 # Module: redis
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-redis.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-redis.html
 
 - module: redis
   # Main logs

--- a/filebeat/modules.d/santa.yml.disabled
+++ b/filebeat/modules.d/santa.yml.disabled
@@ -1,5 +1,5 @@
 # Module: santa
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-santa.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-santa.html
 
 - module: santa
   log:

--- a/filebeat/modules.d/system.yml.disabled
+++ b/filebeat/modules.d/system.yml.disabled
@@ -1,5 +1,5 @@
 # Module: system
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-system.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-system.html
 
 - module: system
   # Syslog

--- a/filebeat/modules.d/traefik.yml.disabled
+++ b/filebeat/modules.d/traefik.yml.disabled
@@ -1,5 +1,5 @@
 # Module: traefik
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-traefik.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-traefik.html
 
 - module: traefik
   # Access logs

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,5 +1,5 @@
 :stack-version: 8.9.0
-:doc-branch: main
+:doc-branch: master
 :go-version: 1.19.9
 :release-state: unreleased
 :python: 3.7

--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,8 +1,5 @@
 :stack-version: 8.9.0
 :doc-branch: main
-// FIXME: once elastic.co docs have been switched over to use `main`, remove
-// the `doc-site-branch` line below as well as any references to it in the code.
-:doc-site-branch: master
 :go-version: 1.19.9
 :release-state: unreleased
 :python: 3.7

--- a/metricbeat/modules.d/aerospike.yml.disabled
+++ b/metricbeat/modules.d/aerospike.yml.disabled
@@ -1,5 +1,5 @@
 # Module: aerospike
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-aerospike.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-aerospike.html
 
 - module: aerospike
   #metricsets:

--- a/metricbeat/modules.d/apache.yml.disabled
+++ b/metricbeat/modules.d/apache.yml.disabled
@@ -1,5 +1,5 @@
 # Module: apache
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-apache.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-apache.html
 
 - module: apache
   #metricsets:

--- a/metricbeat/modules.d/beat-xpack.yml.disabled
+++ b/metricbeat/modules.d/beat-xpack.yml.disabled
@@ -1,5 +1,5 @@
 # Module: beat
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-beat.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-beat.html
 
 - module: beat
   xpack.enabled: true

--- a/metricbeat/modules.d/beat.yml.disabled
+++ b/metricbeat/modules.d/beat.yml.disabled
@@ -1,5 +1,5 @@
 # Module: beat
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-beat.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-beat.html
 
 - module: beat
   metricsets:

--- a/metricbeat/modules.d/ceph-mgr.yml.disabled
+++ b/metricbeat/modules.d/ceph-mgr.yml.disabled
@@ -1,5 +1,5 @@
 # Module: ceph
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-ceph.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-ceph.html
 
 - module: ceph
   metricsets:

--- a/metricbeat/modules.d/ceph.yml.disabled
+++ b/metricbeat/modules.d/ceph.yml.disabled
@@ -1,5 +1,5 @@
 # Module: ceph
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-ceph.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-ceph.html
 
 - module: ceph
   #metricsets:

--- a/metricbeat/modules.d/consul.yml.disabled
+++ b/metricbeat/modules.d/consul.yml.disabled
@@ -1,5 +1,5 @@
 # Module: consul
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-consul.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-consul.html
 
 - module: consul
   metricsets:

--- a/metricbeat/modules.d/couchbase.yml.disabled
+++ b/metricbeat/modules.d/couchbase.yml.disabled
@@ -1,5 +1,5 @@
 # Module: couchbase
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-couchbase.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-couchbase.html
 
 - module: couchbase
   #metricsets:

--- a/metricbeat/modules.d/couchdb.yml.disabled
+++ b/metricbeat/modules.d/couchdb.yml.disabled
@@ -1,5 +1,5 @@
 # Module: couchdb
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-couchdb.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-couchdb.html
 
 - module: couchdb
   metricsets: ["server"]

--- a/metricbeat/modules.d/docker.yml.disabled
+++ b/metricbeat/modules.d/docker.yml.disabled
@@ -1,5 +1,5 @@
 # Module: docker
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-docker.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-docker.html
 
 - module: docker
   #metricsets:

--- a/metricbeat/modules.d/dropwizard.yml.disabled
+++ b/metricbeat/modules.d/dropwizard.yml.disabled
@@ -1,5 +1,5 @@
 # Module: dropwizard
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-dropwizard.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-dropwizard.html
 
 - module: dropwizard
   #metricsets:

--- a/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch-xpack.yml.disabled
@@ -1,5 +1,5 @@
 # Module: elasticsearch
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-elasticsearch.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
   xpack.enabled: true

--- a/metricbeat/modules.d/elasticsearch.yml.disabled
+++ b/metricbeat/modules.d/elasticsearch.yml.disabled
@@ -1,5 +1,5 @@
 # Module: elasticsearch
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-elasticsearch.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-elasticsearch.html
 
 - module: elasticsearch
   #metricsets:

--- a/metricbeat/modules.d/envoyproxy.yml.disabled
+++ b/metricbeat/modules.d/envoyproxy.yml.disabled
@@ -1,5 +1,5 @@
 # Module: envoyproxy
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-envoyproxy.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-envoyproxy.html
 
 - module: envoyproxy
   #metricsets:

--- a/metricbeat/modules.d/etcd.yml.disabled
+++ b/metricbeat/modules.d/etcd.yml.disabled
@@ -1,5 +1,5 @@
 # Module: etcd
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-etcd.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-etcd.html
 
 - module: etcd
   #metricsets:

--- a/metricbeat/modules.d/golang.yml.disabled
+++ b/metricbeat/modules.d/golang.yml.disabled
@@ -1,5 +1,5 @@
 # Module: golang
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-golang.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-golang.html
 
 - module: golang
   #metricsets:

--- a/metricbeat/modules.d/graphite.yml.disabled
+++ b/metricbeat/modules.d/graphite.yml.disabled
@@ -1,5 +1,5 @@
 # Module: graphite
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-graphite.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-graphite.html
 
 - module: graphite
   #metricsets:

--- a/metricbeat/modules.d/haproxy.yml.disabled
+++ b/metricbeat/modules.d/haproxy.yml.disabled
@@ -1,5 +1,5 @@
 # Module: haproxy
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-haproxy.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-haproxy.html
 
 - module: haproxy
   #metricsets:

--- a/metricbeat/modules.d/http.yml.disabled
+++ b/metricbeat/modules.d/http.yml.disabled
@@ -1,5 +1,5 @@
 # Module: http
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-http.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-http.html
 
 - module: http
   #metricsets:

--- a/metricbeat/modules.d/jolokia.yml.disabled
+++ b/metricbeat/modules.d/jolokia.yml.disabled
@@ -1,5 +1,5 @@
 # Module: jolokia
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-jolokia.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-jolokia.html
 
 - module: jolokia
   #metricsets: ["jmx"]

--- a/metricbeat/modules.d/kafka.yml.disabled
+++ b/metricbeat/modules.d/kafka.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kafka
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-kafka.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kafka.html
 
 # Kafka metrics collected using the Kafka protocol
 - module: kafka

--- a/metricbeat/modules.d/kibana-xpack.yml.disabled
+++ b/metricbeat/modules.d/kibana-xpack.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kibana
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-kibana.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html
 
 - module: kibana
   xpack.enabled: true

--- a/metricbeat/modules.d/kibana.yml.disabled
+++ b/metricbeat/modules.d/kibana.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kibana
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-kibana.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kibana.html
 
 - module: kibana
   #metricsets:

--- a/metricbeat/modules.d/kubernetes.yml.disabled
+++ b/metricbeat/modules.d/kubernetes.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kubernetes
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-kubernetes.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kubernetes.html
 
 # Node metrics, from kubelet:
 - module: kubernetes

--- a/metricbeat/modules.d/kvm.yml.disabled
+++ b/metricbeat/modules.d/kvm.yml.disabled
@@ -1,5 +1,5 @@
 # Module: kvm
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-kvm.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-kvm.html
 
 - module: kvm
   #metricsets:

--- a/metricbeat/modules.d/linux.yml.disabled
+++ b/metricbeat/modules.d/linux.yml.disabled
@@ -1,5 +1,5 @@
 # Module: linux
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-linux.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-linux.html
 
 - module: linux
   period: 10s

--- a/metricbeat/modules.d/logstash-xpack.yml.disabled
+++ b/metricbeat/modules.d/logstash-xpack.yml.disabled
@@ -1,5 +1,5 @@
 # Module: logstash
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-logstash.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html
 
 - module: logstash
   xpack.enabled: true

--- a/metricbeat/modules.d/logstash.yml.disabled
+++ b/metricbeat/modules.d/logstash.yml.disabled
@@ -1,5 +1,5 @@
 # Module: logstash
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-logstash.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-logstash.html
 
 - module: logstash
   #metricsets:

--- a/metricbeat/modules.d/memcached.yml.disabled
+++ b/metricbeat/modules.d/memcached.yml.disabled
@@ -1,5 +1,5 @@
 # Module: memcached
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-memcached.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-memcached.html
 
 - module: memcached
 #  metricsets: ["stats"]

--- a/metricbeat/modules.d/mongodb.yml.disabled
+++ b/metricbeat/modules.d/mongodb.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mongodb
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-mongodb.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mongodb.html
 
 - module: mongodb
   #metricsets:

--- a/metricbeat/modules.d/munin.yml.disabled
+++ b/metricbeat/modules.d/munin.yml.disabled
@@ -1,5 +1,5 @@
 # Module: munin
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-munin.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-munin.html
 
 - module: munin
   #metricsets:

--- a/metricbeat/modules.d/mysql.yml.disabled
+++ b/metricbeat/modules.d/mysql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mysql
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-mysql.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mysql.html
 
 - module: mysql
   #metricsets:

--- a/metricbeat/modules.d/nats.yml.disabled
+++ b/metricbeat/modules.d/nats.yml.disabled
@@ -1,5 +1,5 @@
 # Module: nats
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-nats.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-nats.html
 
 - module: nats
   metricsets:

--- a/metricbeat/modules.d/nginx.yml.disabled
+++ b/metricbeat/modules.d/nginx.yml.disabled
@@ -1,5 +1,5 @@
 # Module: nginx
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-nginx.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-nginx.html
 
 - module: nginx
   #metricsets:

--- a/metricbeat/modules.d/openmetrics.yml.disabled
+++ b/metricbeat/modules.d/openmetrics.yml.disabled
@@ -1,5 +1,5 @@
 # Module: openmetrics
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-openmetrics.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-openmetrics.html
 
 - module: openmetrics
   metricsets: ['collector']

--- a/metricbeat/modules.d/php_fpm.yml.disabled
+++ b/metricbeat/modules.d/php_fpm.yml.disabled
@@ -1,5 +1,5 @@
 # Module: php_fpm
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-php_fpm.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-php_fpm.html
 
 - module: php_fpm
   #metricsets:

--- a/metricbeat/modules.d/postgresql.yml.disabled
+++ b/metricbeat/modules.d/postgresql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: postgresql
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-postgresql.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-postgresql.html
 
 - module: postgresql
   #metricsets:

--- a/metricbeat/modules.d/prometheus.yml.disabled
+++ b/metricbeat/modules.d/prometheus.yml.disabled
@@ -1,5 +1,5 @@
 # Module: prometheus
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-prometheus.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-prometheus.html
 
 # Metrics collected from a Prometheus endpoint
 - module: prometheus

--- a/metricbeat/modules.d/rabbitmq.yml.disabled
+++ b/metricbeat/modules.d/rabbitmq.yml.disabled
@@ -1,5 +1,5 @@
 # Module: rabbitmq
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-rabbitmq.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-rabbitmq.html
 
 - module: rabbitmq
   #metricsets:

--- a/metricbeat/modules.d/redis.yml.disabled
+++ b/metricbeat/modules.d/redis.yml.disabled
@@ -1,5 +1,5 @@
 # Module: redis
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-redis.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-redis.html
 
 - module: redis
   #metricsets:

--- a/metricbeat/modules.d/system.yml
+++ b/metricbeat/modules.d/system.yml
@@ -1,5 +1,5 @@
 # Module: system
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-system.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-system.html
 
 - module: system
   period: 10s

--- a/metricbeat/modules.d/traefik.yml.disabled
+++ b/metricbeat/modules.d/traefik.yml.disabled
@@ -1,5 +1,5 @@
 # Module: traefik
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-traefik.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-traefik.html
 
 - module: traefik
   metricsets: ["health"]

--- a/metricbeat/modules.d/uwsgi.yml.disabled
+++ b/metricbeat/modules.d/uwsgi.yml.disabled
@@ -1,5 +1,5 @@
 # Module: uwsgi
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-uwsgi.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-uwsgi.html
 
 - module: uwsgi
   #metricsets:

--- a/metricbeat/modules.d/vsphere.yml.disabled
+++ b/metricbeat/modules.d/vsphere.yml.disabled
@@ -1,5 +1,5 @@
 # Module: vsphere
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-vsphere.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-vsphere.html
 
 - module: vsphere
   #metricsets:

--- a/metricbeat/modules.d/windows.yml.disabled
+++ b/metricbeat/modules.d/windows.yml.disabled
@@ -1,5 +1,5 @@
 # Module: windows
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-windows.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-windows.html
 
 - module: windows
   metricsets:

--- a/metricbeat/modules.d/zookeeper.yml.disabled
+++ b/metricbeat/modules.d/zookeeper.yml.disabled
@@ -1,5 +1,5 @@
 # Module: zookeeper
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-zookeeper.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-zookeeper.html
 
 - module: zookeeper
   #metricsets:

--- a/x-pack/filebeat/modules.d/activemq.yml.disabled
+++ b/x-pack/filebeat/modules.d/activemq.yml.disabled
@@ -1,5 +1,5 @@
 # Module: activemq
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-activemq.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-activemq.html
 
 - module: activemq
   # Audit logs

--- a/x-pack/filebeat/modules.d/aws.yml.disabled
+++ b/x-pack/filebeat/modules.d/aws.yml.disabled
@@ -1,5 +1,5 @@
 # Module: aws
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-aws.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-aws.html
 
 - module: aws
   cloudtrail:

--- a/x-pack/filebeat/modules.d/awsfargate.yml.disabled
+++ b/x-pack/filebeat/modules.d/awsfargate.yml.disabled
@@ -1,5 +1,5 @@
 # Module: awsfargate
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-awsfargate.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-awsfargate.html
 
 - module: awsfargate
   log:

--- a/x-pack/filebeat/modules.d/azure.yml.disabled
+++ b/x-pack/filebeat/modules.d/azure.yml.disabled
@@ -1,5 +1,5 @@
 # Module: azure
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-azure.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-azure.html
 
 - module: azure
   # All logs

--- a/x-pack/filebeat/modules.d/barracuda.yml.disabled
+++ b/x-pack/filebeat/modules.d/barracuda.yml.disabled
@@ -1,5 +1,5 @@
 # Module: barracuda
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-barracuda.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-barracuda.html
 
 - module: barracuda
   waf:

--- a/x-pack/filebeat/modules.d/bluecoat.yml.disabled
+++ b/x-pack/filebeat/modules.d/bluecoat.yml.disabled
@@ -1,5 +1,5 @@
 # Module: bluecoat
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-bluecoat.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-bluecoat.html
 
 - module: bluecoat
   director:

--- a/x-pack/filebeat/modules.d/cef.yml.disabled
+++ b/x-pack/filebeat/modules.d/cef.yml.disabled
@@ -1,5 +1,5 @@
 # Module: cef
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-cef.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-cef.html
 
 - module: cef
   log:

--- a/x-pack/filebeat/modules.d/checkpoint.yml.disabled
+++ b/x-pack/filebeat/modules.d/checkpoint.yml.disabled
@@ -1,5 +1,5 @@
 # Module: checkpoint
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-checkpoint.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-checkpoint.html
 
 - module: checkpoint
   firewall:

--- a/x-pack/filebeat/modules.d/cisco.yml.disabled
+++ b/x-pack/filebeat/modules.d/cisco.yml.disabled
@@ -1,5 +1,5 @@
 # Module: cisco
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-cisco.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-cisco.html
 
 - module: cisco
   asa:

--- a/x-pack/filebeat/modules.d/coredns.yml.disabled
+++ b/x-pack/filebeat/modules.d/coredns.yml.disabled
@@ -1,5 +1,5 @@
 # Module: coredns
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-coredns.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-coredns.html
 
 - module: coredns
   # Fileset for native deployment

--- a/x-pack/filebeat/modules.d/crowdstrike.yml.disabled
+++ b/x-pack/filebeat/modules.d/crowdstrike.yml.disabled
@@ -1,5 +1,5 @@
 # Module: crowdstrike
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-crowdstrike.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-crowdstrike.html
 
 - module: crowdstrike
   

--- a/x-pack/filebeat/modules.d/cyberarkpas.yml.disabled
+++ b/x-pack/filebeat/modules.d/cyberarkpas.yml.disabled
@@ -1,5 +1,5 @@
 # Module: cyberarkpas
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-cyberarkpas.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-cyberarkpas.html
 
 - module: cyberarkpas
   audit:

--- a/x-pack/filebeat/modules.d/cylance.yml.disabled
+++ b/x-pack/filebeat/modules.d/cylance.yml.disabled
@@ -1,5 +1,5 @@
 # Module: cylance
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-cylance.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-cylance.html
 
 - module: cylance
   protect:

--- a/x-pack/filebeat/modules.d/envoyproxy.yml.disabled
+++ b/x-pack/filebeat/modules.d/envoyproxy.yml.disabled
@@ -1,5 +1,5 @@
 # Module: envoyproxy
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-envoyproxy.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-envoyproxy.html
 
 - module: envoyproxy
   # Fileset for native deployment

--- a/x-pack/filebeat/modules.d/f5.yml.disabled
+++ b/x-pack/filebeat/modules.d/f5.yml.disabled
@@ -1,5 +1,5 @@
 # Module: f5
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-f5.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-f5.html
 
 - module: f5
   bigipapm:

--- a/x-pack/filebeat/modules.d/fortinet.yml.disabled
+++ b/x-pack/filebeat/modules.d/fortinet.yml.disabled
@@ -1,5 +1,5 @@
 # Module: fortinet
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-fortinet.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-fortinet.html
 
 - module: fortinet
   firewall:

--- a/x-pack/filebeat/modules.d/gcp.yml.disabled
+++ b/x-pack/filebeat/modules.d/gcp.yml.disabled
@@ -1,5 +1,5 @@
 # Module: gcp
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-gcp.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-gcp.html
 
 - module: gcp
   vpcflow:

--- a/x-pack/filebeat/modules.d/google_workspace.yml.disabled
+++ b/x-pack/filebeat/modules.d/google_workspace.yml.disabled
@@ -1,5 +1,5 @@
 # Module: google_workspace
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-google_workspace.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-google_workspace.html
 
 - module: google_workspace
   saml:

--- a/x-pack/filebeat/modules.d/ibmmq.yml.disabled
+++ b/x-pack/filebeat/modules.d/ibmmq.yml.disabled
@@ -1,5 +1,5 @@
 # Module: ibmmq
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-ibmmq.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-ibmmq.html
 
 - module: ibmmq
   # All logs

--- a/x-pack/filebeat/modules.d/imperva.yml.disabled
+++ b/x-pack/filebeat/modules.d/imperva.yml.disabled
@@ -1,5 +1,5 @@
 # Module: imperva
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-imperva.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-imperva.html
 
 - module: imperva
   securesphere:

--- a/x-pack/filebeat/modules.d/infoblox.yml.disabled
+++ b/x-pack/filebeat/modules.d/infoblox.yml.disabled
@@ -1,5 +1,5 @@
 # Module: infoblox
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-infoblox.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-infoblox.html
 
 - module: infoblox
   nios:

--- a/x-pack/filebeat/modules.d/iptables.yml.disabled
+++ b/x-pack/filebeat/modules.d/iptables.yml.disabled
@@ -1,5 +1,5 @@
 # Module: iptables
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-iptables.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-iptables.html
 
 - module: iptables
   log:

--- a/x-pack/filebeat/modules.d/juniper.yml.disabled
+++ b/x-pack/filebeat/modules.d/juniper.yml.disabled
@@ -1,5 +1,5 @@
 # Module: juniper
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-juniper.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-juniper.html
 
 - module: juniper
   junos:

--- a/x-pack/filebeat/modules.d/microsoft.yml.disabled
+++ b/x-pack/filebeat/modules.d/microsoft.yml.disabled
@@ -1,5 +1,5 @@
 # Module: microsoft
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-microsoft.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-microsoft.html
 
 - module: microsoft
   # ATP configuration

--- a/x-pack/filebeat/modules.d/misp.yml.disabled
+++ b/x-pack/filebeat/modules.d/misp.yml.disabled
@@ -1,5 +1,5 @@
 # Module: misp
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-misp.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-misp.html
 
 # Deprecated in 7.14.0: Recommended to migrate to the Threat Intel module.
 

--- a/x-pack/filebeat/modules.d/mssql.yml.disabled
+++ b/x-pack/filebeat/modules.d/mssql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mssql
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-mssql.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-mssql.html
 
 - module: mssql
   # Fileset for native deployment

--- a/x-pack/filebeat/modules.d/mysqlenterprise.yml.disabled
+++ b/x-pack/filebeat/modules.d/mysqlenterprise.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mysqlenterprise
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-mysqlenterprise.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-mysqlenterprise.html
 
 - module: mysqlenterprise
   audit:

--- a/x-pack/filebeat/modules.d/netflow.yml.disabled
+++ b/x-pack/filebeat/modules.d/netflow.yml.disabled
@@ -1,5 +1,5 @@
 # Module: netflow
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-netflow.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-netflow.html
 
 - module: netflow
   log:

--- a/x-pack/filebeat/modules.d/netscout.yml.disabled
+++ b/x-pack/filebeat/modules.d/netscout.yml.disabled
@@ -1,5 +1,5 @@
 # Module: netscout
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-netscout.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-netscout.html
 
 - module: netscout
   sightline:

--- a/x-pack/filebeat/modules.d/o365.yml.disabled
+++ b/x-pack/filebeat/modules.d/o365.yml.disabled
@@ -1,5 +1,5 @@
 # Module: o365
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-o365.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-o365.html
 
 - module: o365
   audit:

--- a/x-pack/filebeat/modules.d/okta.yml.disabled
+++ b/x-pack/filebeat/modules.d/okta.yml.disabled
@@ -1,5 +1,5 @@
 # Module: okta
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-okta.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-okta.html
 
 - module: okta
   system:

--- a/x-pack/filebeat/modules.d/oracle.yml.disabled
+++ b/x-pack/filebeat/modules.d/oracle.yml.disabled
@@ -1,5 +1,5 @@
 # Module: oracle
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-oracle.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-oracle.html
 
 - module: oracle
   database_audit:

--- a/x-pack/filebeat/modules.d/panw.yml.disabled
+++ b/x-pack/filebeat/modules.d/panw.yml.disabled
@@ -1,5 +1,5 @@
 # Module: panw
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-panw.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-panw.html
 
 - module: panw
   panos:

--- a/x-pack/filebeat/modules.d/proofpoint.yml.disabled
+++ b/x-pack/filebeat/modules.d/proofpoint.yml.disabled
@@ -1,5 +1,5 @@
 # Module: proofpoint
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-proofpoint.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-proofpoint.html
 
 - module: proofpoint
   emailsecurity:

--- a/x-pack/filebeat/modules.d/rabbitmq.yml.disabled
+++ b/x-pack/filebeat/modules.d/rabbitmq.yml.disabled
@@ -1,5 +1,5 @@
 # Module: rabbitmq
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-rabbitmq.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-rabbitmq.html
 
 - module: rabbitmq
   # All logs

--- a/x-pack/filebeat/modules.d/radware.yml.disabled
+++ b/x-pack/filebeat/modules.d/radware.yml.disabled
@@ -1,5 +1,5 @@
 # Module: radware
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-radware.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-radware.html
 
 - module: radware
   defensepro:

--- a/x-pack/filebeat/modules.d/salesforce.yml.disabled
+++ b/x-pack/filebeat/modules.d/salesforce.yml.disabled
@@ -1,5 +1,5 @@
 # Module: salesforce
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-salesforce.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-salesforce.html
 
 - module: salesforce
 

--- a/x-pack/filebeat/modules.d/snort.yml.disabled
+++ b/x-pack/filebeat/modules.d/snort.yml.disabled
@@ -1,5 +1,5 @@
 # Module: snort
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-snort.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-snort.html
 
 - module: snort
   log:

--- a/x-pack/filebeat/modules.d/snyk.yml.disabled
+++ b/x-pack/filebeat/modules.d/snyk.yml.disabled
@@ -1,5 +1,5 @@
 # Module: snyk
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-snyk.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-snyk.html
 
 - module: snyk
   audit:

--- a/x-pack/filebeat/modules.d/sonicwall.yml.disabled
+++ b/x-pack/filebeat/modules.d/sonicwall.yml.disabled
@@ -1,5 +1,5 @@
 # Module: sonicwall
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-sonicwall.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-sonicwall.html
 
 - module: sonicwall
   firewall:

--- a/x-pack/filebeat/modules.d/sophos.yml.disabled
+++ b/x-pack/filebeat/modules.d/sophos.yml.disabled
@@ -1,5 +1,5 @@
 # Module: sophos
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-sophos.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-sophos.html
 
 - module: sophos
   xg:

--- a/x-pack/filebeat/modules.d/squid.yml.disabled
+++ b/x-pack/filebeat/modules.d/squid.yml.disabled
@@ -1,5 +1,5 @@
 # Module: squid
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-squid.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-squid.html
 
 - module: squid
   log:

--- a/x-pack/filebeat/modules.d/suricata.yml.disabled
+++ b/x-pack/filebeat/modules.d/suricata.yml.disabled
@@ -1,5 +1,5 @@
 # Module: suricata
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-suricata.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-suricata.html
 
 - module: suricata
   # All logs

--- a/x-pack/filebeat/modules.d/threatintel.yml.disabled
+++ b/x-pack/filebeat/modules.d/threatintel.yml.disabled
@@ -1,5 +1,5 @@
 # Module: threatintel
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-threatintel.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-threatintel.html
 
 - module: threatintel
   abuseurl:

--- a/x-pack/filebeat/modules.d/tomcat.yml.disabled
+++ b/x-pack/filebeat/modules.d/tomcat.yml.disabled
@@ -1,5 +1,5 @@
 # Module: tomcat
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-tomcat.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-tomcat.html
 
 - module: tomcat
   log:

--- a/x-pack/filebeat/modules.d/zeek.yml.disabled
+++ b/x-pack/filebeat/modules.d/zeek.yml.disabled
@@ -1,5 +1,5 @@
 # Module: zeek
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-zeek.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-zeek.html
 
 - module: zeek
   capture_loss:

--- a/x-pack/filebeat/modules.d/zookeeper.yml.disabled
+++ b/x-pack/filebeat/modules.d/zookeeper.yml.disabled
@@ -1,5 +1,5 @@
 # Module: zookeeper
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-zookeeper.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-zookeeper.html
 
 - module: zookeeper
   # All logs

--- a/x-pack/filebeat/modules.d/zoom.yml.disabled
+++ b/x-pack/filebeat/modules.d/zoom.yml.disabled
@@ -1,5 +1,5 @@
 # Module: zoom
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-zoom.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-zoom.html
 
 - module: zoom
   webhook:

--- a/x-pack/filebeat/modules.d/zscaler.yml.disabled
+++ b/x-pack/filebeat/modules.d/zscaler.yml.disabled
@@ -1,5 +1,5 @@
 # Module: zscaler
-# Docs: https://www.elastic.co/guide/en/beats/filebeat/main/filebeat-module-zscaler.html
+# Docs: https://www.elastic.co/guide/en/beats/filebeat/master/filebeat-module-zscaler.html
 
 - module: zscaler
   zia:

--- a/x-pack/metricbeat/modules.d/activemq.yml.disabled
+++ b/x-pack/metricbeat/modules.d/activemq.yml.disabled
@@ -1,5 +1,5 @@
 # Module: activemq
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-activemq.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-activemq.html
 
 - module: activemq
   metricsets: ['broker', 'queue', 'topic']

--- a/x-pack/metricbeat/modules.d/airflow.yml.disabled
+++ b/x-pack/metricbeat/modules.d/airflow.yml.disabled
@@ -1,5 +1,5 @@
 # Module: airflow
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-airflow.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-airflow.html
 
 - module: airflow
   host: "localhost"

--- a/x-pack/metricbeat/modules.d/aws.yml.disabled
+++ b/x-pack/metricbeat/modules.d/aws.yml.disabled
@@ -1,5 +1,5 @@
 # Module: aws
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-aws.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-aws.html
 
 - module: aws
   period: 1m

--- a/x-pack/metricbeat/modules.d/awsfargate.yml.disabled
+++ b/x-pack/metricbeat/modules.d/awsfargate.yml.disabled
@@ -1,5 +1,5 @@
 # Module: awsfargate
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-awsfargate.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-awsfargate.html
 
 - module: awsfargate
   period: 10s

--- a/x-pack/metricbeat/modules.d/azure.yml.disabled
+++ b/x-pack/metricbeat/modules.d/azure.yml.disabled
@@ -1,5 +1,5 @@
 # Module: azure
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-azure.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-azure.html
 
 - module: azure
   metricsets:

--- a/x-pack/metricbeat/modules.d/cloudfoundry.yml.disabled
+++ b/x-pack/metricbeat/modules.d/cloudfoundry.yml.disabled
@@ -1,5 +1,5 @@
 # Module: cloudfoundry
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-cloudfoundry.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-cloudfoundry.html
 
 - module: cloudfoundry
   metricsets:

--- a/x-pack/metricbeat/modules.d/cockroachdb.yml.disabled
+++ b/x-pack/metricbeat/modules.d/cockroachdb.yml.disabled
@@ -1,5 +1,5 @@
 # Module: cockroachdb
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-cockroachdb.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-cockroachdb.html
 
 - module: cockroachdb
   metricsets: ['status']

--- a/x-pack/metricbeat/modules.d/containerd.yml.disabled
+++ b/x-pack/metricbeat/modules.d/containerd.yml.disabled
@@ -1,5 +1,5 @@
 # Module: containerd
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-containerd.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-containerd.html
 
 - module: containerd
   metricsets: ["cpu", "memory", "blkio"]

--- a/x-pack/metricbeat/modules.d/coredns.yml.disabled
+++ b/x-pack/metricbeat/modules.d/coredns.yml.disabled
@@ -1,5 +1,5 @@
 # Module: coredns
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-coredns.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-coredns.html
 
 - module: coredns
   metricsets: ["stats"]

--- a/x-pack/metricbeat/modules.d/enterprisesearch-xpack.yml.disabled
+++ b/x-pack/metricbeat/modules.d/enterprisesearch-xpack.yml.disabled
@@ -1,5 +1,5 @@
 # Module: enterprisesearch
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-enterprisesearch.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-enterprisesearch.html
 
 - module: enterprisesearch
   xpack.enabled: true

--- a/x-pack/metricbeat/modules.d/enterprisesearch.yml.disabled
+++ b/x-pack/metricbeat/modules.d/enterprisesearch.yml.disabled
@@ -1,5 +1,5 @@
 # Module: enterprisesearch
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-enterprisesearch.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-enterprisesearch.html
 
 - module: enterprisesearch
   metricsets: ["health", "stats"]

--- a/x-pack/metricbeat/modules.d/gcp.yml.disabled
+++ b/x-pack/metricbeat/modules.d/gcp.yml.disabled
@@ -1,5 +1,5 @@
 # Module: gcp
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-gcp.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-gcp.html
 
 - module: gcp
   metricsets:

--- a/x-pack/metricbeat/modules.d/ibmmq.yml.disabled
+++ b/x-pack/metricbeat/modules.d/ibmmq.yml.disabled
@@ -1,5 +1,5 @@
 # Module: ibmmq
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-ibmmq.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-ibmmq.html
 
 - module: ibmmq
   metricsets: ['qmgr']

--- a/x-pack/metricbeat/modules.d/iis.yml.disabled
+++ b/x-pack/metricbeat/modules.d/iis.yml.disabled
@@ -1,5 +1,5 @@
 # Module: iis
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-iis.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-iis.html
 
 - module: iis
   metricsets:

--- a/x-pack/metricbeat/modules.d/istio.yml.disabled
+++ b/x-pack/metricbeat/modules.d/istio.yml.disabled
@@ -1,5 +1,5 @@
 # Module: istio
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-istio.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-istio.html
 
 # Istio mesh. To collect all Mixer-generated metrics. For versions of Istio prior to 1.5.
 - module: istio

--- a/x-pack/metricbeat/modules.d/mssql.yml.disabled
+++ b/x-pack/metricbeat/modules.d/mssql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: mssql
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-mssql.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-mssql.html
 
 - module: mssql
   metricsets:

--- a/x-pack/metricbeat/modules.d/oracle.yml.disabled
+++ b/x-pack/metricbeat/modules.d/oracle.yml.disabled
@@ -1,5 +1,5 @@
 # Module: oracle
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-oracle.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-oracle.html
 
 # Module: oracle
 

--- a/x-pack/metricbeat/modules.d/prometheus.yml.disabled
+++ b/x-pack/metricbeat/modules.d/prometheus.yml.disabled
@@ -1,5 +1,5 @@
 # Module: prometheus
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-prometheus.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-prometheus.html
 
 - module: prometheus
   period: 10s

--- a/x-pack/metricbeat/modules.d/redisenterprise.yml.disabled
+++ b/x-pack/metricbeat/modules.d/redisenterprise.yml.disabled
@@ -1,5 +1,5 @@
 # Module: redisenterprise
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-redisenterprise.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-redisenterprise.html
 
 - module: redisenterprise
   metricsets:

--- a/x-pack/metricbeat/modules.d/sql.yml.disabled
+++ b/x-pack/metricbeat/modules.d/sql.yml.disabled
@@ -1,5 +1,5 @@
 # Module: sql
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-sql.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-sql.html
 
 - module: sql
   metricsets:

--- a/x-pack/metricbeat/modules.d/stan.yml.disabled
+++ b/x-pack/metricbeat/modules.d/stan.yml.disabled
@@ -1,5 +1,5 @@
 # Module: stan
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-stan.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-stan.html
 
 - module: stan
   metricsets: ["stats", "subscriptions", "channels"]

--- a/x-pack/metricbeat/modules.d/statsd.yml.disabled
+++ b/x-pack/metricbeat/modules.d/statsd.yml.disabled
@@ -1,5 +1,5 @@
 # Module: statsd
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-statsd.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-statsd.html
 
 - module: statsd
   host: "localhost"

--- a/x-pack/metricbeat/modules.d/syncgateway.yml.disabled
+++ b/x-pack/metricbeat/modules.d/syncgateway.yml.disabled
@@ -1,5 +1,5 @@
 # Module: syncgateway
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-syncgateway.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-syncgateway.html
 
 - module: syncgateway
   metricsets:

--- a/x-pack/metricbeat/modules.d/tomcat.yml.disabled
+++ b/x-pack/metricbeat/modules.d/tomcat.yml.disabled
@@ -1,5 +1,5 @@
 # Module: tomcat
-# Docs: https://www.elastic.co/guide/en/beats/metricbeat/main/metricbeat-module-tomcat.html
+# Docs: https://www.elastic.co/guide/en/beats/metricbeat/master/metricbeat-module-tomcat.html
 
 - module: tomcat
   metricsets: ['threading', 'cache', 'memory', 'requests']


### PR DESCRIPTION
## What does this PR do?

Reverts the `Docs` link from `BEATNAME/modules.d/MODULE.yml.disabled` to use `master` instead of `main` introduced by #35226.
It also reverts https://github.com/elastic/beats/pull/35693 as it did not fix the problem.

## Why is it important?

The links are broken

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

- Relates #35226
- Closes https://github.com/elastic/ingest-dev/issues/2111

