### PR TITLE
Improvements to event handling flows

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -16423,6 +16423,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 --------------------------------------------------------------------------------
+Dependency : github.com/goccy/go-json
+Version: v0.9.11
+Licence type (autodetected): MIT
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/goccy/go-json@v0.9.11/LICENSE:
+
+MIT License
+
+Copyright (c) 2020 Masaaki Goshima
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/godbus/dbus/v5
 Version: v5.0.6
 Licence type (autodetected): BSD-2-Clause
@@ -36239,37 +36270,6 @@ Contents of probable licence file $GOMODCACHE/github.com/gobuffalo/here@v0.6.7/L
 The MIT License (MIT)
 
 Copyright (c) 2019 Mark Bates
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
---------------------------------------------------------------------------------
-Dependency : github.com/goccy/go-json
-Version: v0.9.11
-Licence type (autodetected): MIT
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/goccy/go-json@v0.9.11/LICENSE:
-
-MIT License
-
-Copyright (c) 2020 Masaaki Goshima
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/go.mod
+++ b/go.mod
@@ -208,6 +208,7 @@ require (
 	github.com/elastic/mito v1.3.0
 	github.com/elastic/toutoumomoma v0.0.0-20221026030040-594ef30cb640
 	github.com/foxcpp/go-mockdns v0.0.0-20201212160233-ede2f9158d15
+	github.com/goccy/go-json v0.9.11
 	github.com/google/cel-go v0.15.3
 	github.com/googleapis/gax-go/v2 v2.7.0
 	github.com/gorilla/handlers v1.5.1
@@ -274,7 +275,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gobuffalo/here v0.6.7 // indirect
-	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/godror/knownpb v0.1.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
 	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect

--- a/libbeat/common/event.go
+++ b/libbeat/common/event.go
@@ -19,12 +19,13 @@ package common
 
 import (
 	"encoding"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/goccy/go-json"
 
 	"github.com/pkg/errors"
 

--- a/libbeat/publisher/processing/processors.go
+++ b/libbeat/publisher/processing/processors.go
@@ -170,7 +170,6 @@ func addMeta(event *beat.Event, meta mapstr.M) {
 	if event.Meta == nil {
 		event.Meta = meta
 	} else {
-		event.Meta.Clone()
 		event.Meta.DeepUpdate(meta)
 	}
 }


### PR DESCRIPTION
## What does this PR do?
Looking at the code, I've noticed that some of the event-handling cases can be improved and optimized for memory and compute time consumption.

I've encountered two flows that can be improved:
1. Event handling by the processing pipeline (step number 2 in code), which handles the client event metadata.
2. Event normalization using reflection for marshaling and unmarshalling of maps and structures.

In the first bullet, we've cloned the metadata of the event without using its value which created unnecessary work that got thrown away immediately.

I wrote a benchmark that triggers this scenario.
Benchmark running with the current code that clones:
```
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003477 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003455 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003890 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003349 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003675 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003766 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003661 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003591 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003307 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0003641 ns/op	       0 B/op	       0 allocs/op
```
Benchmark after the removal of the clone:
```
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0002491 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001869 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001627 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001727 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001832 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001735 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001935 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001676 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001805 ns/op	       0 B/op	       0 allocs/op
BenchmarkTestProcessorsConfigs/with_client_metadata-10	         0.0001759 ns/op	       0 B/op	       0 allocs/op
```

**You can see the following improvements:**
**1. ~2x decrease in time per operation**

In the second bullet, I noticed that we are spending time and allocations when we are marshaling and unmarshalling data.
This is because the library that handles the encoding/decoding (`encoding/json`) underneath uses reflection that can be avoided.
**In order to minimize risk, I replaced the library with a different library that allocates less and performs better in the reflection use case.
The new library rollbacks to the previous library if needed.
The performance and allocations can be further improved using other libraries (for example `easyjson`), but this would require more code changes and be riskier.**

Benchmark running with the old library:
```
BenchmarkConvertToGenericEventNetString-10            	 4335504	       264.2 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4331215	       268.4 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4481466	       271.8 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4589874	       262.7 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4569351	       263.6 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4470567	       263.4 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4501324	       266.9 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4582464	       263.9 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4570873	       263.2 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4558904	       264.3 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1064 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1087 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1064 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1063 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1057 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1069 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1078 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1053 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1083 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1065 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2934220	       403.4 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2970553	       402.2 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2930146	       409.1 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2962081	       396.6 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2954677	       398.7 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 3005870	       406.5 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2989573	       396.5 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 3046209	       404.8 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2946354	       400.0 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2982468	       399.9 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4940491	       246.0 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4813208	       251.6 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4772302	       247.2 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4868930	       244.0 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4795166	       251.1 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4814371	       256.0 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4827192	       256.7 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4781359	       253.3 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4721844	       261.6 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4665540	       259.6 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2620862	       455.3 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2653094	       444.4 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2693540	       436.5 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2763322	       432.4 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2765877	       443.8 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2709534	       433.4 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2768233	       435.3 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2765174	       436.0 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2612952	       448.8 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2746555	       448.7 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4627606	       237.6 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 5044587	       231.4 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 5154033	       234.4 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4998332	       238.2 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 5164933	       235.4 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 5096384	       239.0 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4881368	       242.2 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 5141474	       231.8 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 5098616	       250.3 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 5171582	       232.2 ns/op	     688 B/op	       5 allocs/op
```

Benchmark running with the new library:
```
BenchmarkConvertToGenericEventNetString-10            	 4021738	       290.7 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4070048	       291.3 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4184167	       290.0 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4102251	       286.1 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4067162	       282.9 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4259503	       281.8 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4275900	       302.0 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4117359	       285.4 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4173651	       284.8 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventNetString-10            	 4155738	       287.4 ns/op	     720 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1812450	       657.1 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1821576	       653.2 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1826787	       674.0 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1747426	       661.1 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1827610	       674.6 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1819189	       658.0 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1834231	       659.6 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1771803	       665.2 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1807875	       680.9 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1759754	       662.9 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2646211	       445.2 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2747725	       430.0 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2787075	       428.3 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2681956	       436.1 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2806077	       451.2 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2690936	       450.9 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2741937	       427.2 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2580769	       435.2 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2845666	       432.1 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventMapStr-10               	 2708415	       436.5 ns/op	    1344 B/op	       8 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4183039	       267.7 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4590121	       270.6 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4378677	       265.9 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4516857	       268.5 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4583670	       260.2 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4615844	       260.1 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4604018	       261.2 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4408066	       262.4 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4583383	       259.9 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventStringSlice-10          	 4589907	       265.8 ns/op	     728 B/op	       6 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2624875	       471.7 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2591566	       464.0 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2577888	       466.7 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2565608	       472.5 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2537497	       470.2 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2589926	       480.3 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2567025	       464.0 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2615685	       467.0 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2655370	       451.2 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventCustomStringSlice-10    	 2650232	       453.6 ns/op	     864 B/op	      13 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4805229	       257.2 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4517374	       262.4 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4810243	       251.5 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4670187	       257.4 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4638025	       272.8 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4688593	       248.5 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4849538	       244.2 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4807332	       265.7 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4447825	       263.3 ns/op	     688 B/op	       5 allocs/op
BenchmarkConvertToGenericEventStringPointer-10        	 4824384	       250.1 ns/op	     688 B/op	       5 allocs/op
```

Notice the improvement in the use case that uses reflection `ConvertToGenericEventMapStringString`.
Old implementation:
```
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1064 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1087 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1064 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1063 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1057 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1069 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1078 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1053 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1083 ns/op	    1736 B/op	      22 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1000000	      1065 ns/op	    1736 B/op	      22 allocs/op
```
New implementation:
```
BenchmarkConvertToGenericEventMapStringString-10      	 1812450	       657.1 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1821576	       653.2 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1826787	       674.0 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1747426	       661.1 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1827610	       674.6 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1819189	       658.0 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1834231	       659.6 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1771803	       665.2 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1807875	       680.9 ns/op	    1451 B/op	      14 allocs/op
BenchmarkConvertToGenericEventMapStringString-10      	 1759754	       662.9 ns/op	    1451 B/op	      14 allocs/op
```

**You can see the following improvements:**
**1. ~36% decrease in number of allocations per operation**
**2. ~83% increase in number of operations total (almost ~2x improvement)**
**3. ~39% decrease in time per operation (almost ~2x improvement)**
**4. ~16% decrease in bytes allocated per operation**

## Why is it important?
Event handling is a significant hot path for all Elastic beats and every tiny improvement in this codebase area will improve the performance across all of Elastic products interact with events.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally
There are already unit tests and I've added another benchmark `BenchmarkTestProcessorsConfigs`.