### PR TITLE
Fix panic when MaxRetryInterval is specified, but RetryInterval is not

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -67,6 +67,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - 'add_cloud_metadata' processor - update azure metadata api version to get missing `cloud.account.id` field
 - Make sure k8s watchers are closed when closing k8s meta processor. {pull}35630[35630]
 - Upgraded apache arrow library used in x-pack/libbeat/reader/parquet from v11 to v12.0.1 in order to fix cross-compilation issues {pull}35640[35640]
+- Fix panic when MaxRetryInterval is specified, but RetryInterval is not {pull}35820[35820]
 
 *Auditbeat*
 

--- a/libbeat/publisher/queue/diskqueue/config.go
+++ b/libbeat/publisher/queue/diskqueue/config.go
@@ -166,7 +166,7 @@ func SettingsForUserConfig(config *config.C) (Settings, error) {
 		settings.RetryInterval = *userConfig.RetryInterval
 	}
 	if userConfig.MaxRetryInterval != nil {
-		settings.MaxRetryInterval = *userConfig.RetryInterval
+		settings.MaxRetryInterval = *userConfig.MaxRetryInterval
 	}
 
 	return settings, nil


### PR DESCRIPTION
## What does this PR do?

In disk queue configuration, it seems like the `MaxRetryInterval` is read from the wrong field, which leads to a panic when `RetryInterval` is not provided.

Also, `MaxRetryInterval` doesn't seem configurable at all as it is. 

## Why is it important?

So `MaxRetryInterval` can be configured

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have made corresponding changes to the documentation~~
- ~~I have made corresponding change to the default configuration files~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Logs

```
{"panic": "runtime error: invalid memory address or nil pointer dereference", "stack": "github.com/elastic/beats/v7/libbeat/cmd/instance.Run.func1.1\n\t/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:170\nruntime.gopanic\n\t/usr/local/go/src/runtime/panic.go:1038\nruntime.panicmem\n\t/usr/local/go/src/runtime/panic.go:221\nruntime.sigpanic\n\t/usr/local/go/src/runtime/signal_unix.go:735\ngithub.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue.SettingsForUserConfig\n\t/go/src/github.com/elastic/beats/libbeat/publisher/queue/diskqueue/config.go:165\ngithub.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue.queueFactory\n\t/go/src/github.com/elastic/beats/libbeat/publisher/queue/diskqueue/queue.go:104\ngithub.com/elastic/beats/v7/libbeat/publisher/pipeline.createQueueBuilder.func1\n\t/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/module.go:197\ngithub.com/elastic/beats/v7/libbeat/publisher/pipeline.New\n\t/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/pipeline.go:176\ngithub.com/elastic/beats/v7/libbeat/publisher/pipeline.LoadWithSettings\n\t/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/module.go:108\ngithub.com/elastic/beats/v7/libbeat/publisher/pipeline.Load\n\t/go/src/github.com/elastic/beats/libbeat/publisher/pipeline/module.go:76\ngithub.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).createBeater\n\t/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:383\ngithub.com/elastic/beats/v7/libbeat/cmd/instance.(*Beat).launch\n\t/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:459\ngithub.com/elastic/beats/v7/libbeat/cmd/instance.Run.func1\n\t/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:215\ngithub.com/elastic/beats/v7/libbeat/cmd/instance.Run\n\t/go/src/github.com/elastic/beats/libbeat/cmd/instance/beat.go:216\ngithub.com/elastic/beats/v7/libbeat/cmd.genRunCmd.func1\n\t/go/src/github.com/elastic/beats/libbeat/cmd/run.go:36\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950\ngithub.com/spf13/cobra.(*Command).Execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887\nmain.main\n\t/go/src/github.com/elastic/beats/x-pack/filebeat/main.go:22\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:255"}
```
