### PR TITLE
Fix typo in go.mod and go.sum file names.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,8 +14,8 @@ CHANGELOG*
 
 # The tech leads of the teams working in Beats share ownership of the Go module dependencies and related files.
 /.github/CODEOWNERS/ @elastic/beats-tech-leads
-/.go.mod/ @elastic/beats-tech-leads
-/.go.sum/ @elastic/beats-tech-leads
+/go.mod/ @elastic/beats-tech-leads
+/go.sum/ @elastic/beats-tech-leads
 /NOTICE.txt/ @elastic/beats-tech-leads
 
 /.ci/ @elastic/elastic-agent-data-plane


### PR DESCRIPTION
Remove leading dots and trailing slashes which set the ownership on non-existent directories.