### PR TITLE
Disable failing activemq tests

### DIFF
--- a/x-pack/metricbeat/module/activemq/test_activemq.py
+++ b/x-pack/metricbeat/module/activemq/test_activemq.py
@@ -7,8 +7,8 @@ import unittest
 from xpack_metricbeat import XPackTest, metricbeat
 
 
-@unittest.skip("tests failing: https://github.com/elastic/beats/issues/35851")
 @metricbeat.parameterized_with_supported_versions
+@unittest.skip("tests failing: https://github.com/elastic/beats/issues/35851")
 class ActiveMqTest(XPackTest):
     COMPOSE_SERVICES = ['activemq']
 

--- a/x-pack/metricbeat/module/activemq/test_activemq.py
+++ b/x-pack/metricbeat/module/activemq/test_activemq.py
@@ -7,6 +7,7 @@ import unittest
 from xpack_metricbeat import XPackTest, metricbeat
 
 
+@unittest.skip("tests failing: https://github.com/elastic/beats/issues/35851")
 @metricbeat.parameterized_with_supported_versions
 class ActiveMqTest(XPackTest):
     COMPOSE_SERVICES = ['activemq']


### PR DESCRIPTION
Skip the activemq test suite until we can determine why the tests are failing. 

- Relates https://github.com/elastic/beats/issues/35851