### PR TITLE
Update references to ubuntu-18 in 7.x

### DIFF
--- a/dev-tools/Jenkinsfile.yml
+++ b/dev-tools/Jenkinsfile.yml
@@ -10,7 +10,7 @@ when:
     parameters:                ## when parameter was selected in the UI.
         - "dev-tools"
     tags: true                 ## for all the tags
-platform: "immutable && ubuntu-18" ## default label for all the stages
+platform: "immutable && ubuntu-22" ## default label for all the stages
 stages:
     lint:
         make: "make -C dev-tools check"

--- a/generator/Jenkinsfile.yml
+++ b/generator/Jenkinsfile.yml
@@ -13,7 +13,7 @@ when:
     parameters:                ## when parameter was selected in the UI.
         - "generator"
     tags: true                 ## for all the tags
-platform: "immutable && ubuntu-18" ## default label for all the stages
+platform: "immutable && ubuntu-22" ## default label for all the stages
 stages:
     metricbeat-test:
         make: "make -C generator/_templates/metricbeat test test-package"

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -11,7 +11,7 @@ when:
     parameters:                ## when parameter was selected in the UI.
         - "x-pack-elastic-agent"
     tags: true                 ## for all the tags
-platform: "immutable && ubuntu-18" ## default label for all the stages
+platform: "immutable && ubuntu-22" ## default label for all the stages
 stages:
     lint:
         make: |


### PR DESCRIPTION
The 7.17 build is failing, seemingly related to the backport of https://github.com/elastic/beats/pull/34355. It turns out there are three additional references to the old version `ubuntu-18` that are not present in the 8.x branches, and thus weren't updated. This PR fixes them.
