### PR TITLE
Update renaming arm labels

### DIFF
--- a/auditbeat/Jenkinsfile.yml
+++ b/auditbeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test auditbeat for arm"
@@ -108,7 +108,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/filebeat/Jenkinsfile.yml
+++ b/filebeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test filebeat for arm"
@@ -112,7 +112,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/heartbeat/Jenkinsfile.yml
+++ b/heartbeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test heartbeat for arm"
@@ -102,7 +102,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/libbeat/Jenkinsfile.yml
+++ b/libbeat/Jenkinsfile.yml
@@ -15,7 +15,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test libbeat for arm"

--- a/metricbeat/Jenkinsfile.yml
+++ b/metricbeat/Jenkinsfile.yml
@@ -98,7 +98,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/packetbeat/Jenkinsfile.yml
+++ b/packetbeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test packetbeat for arm"
@@ -100,7 +100,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/x-pack/auditbeat/Jenkinsfile.yml
+++ b/x-pack/auditbeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/auditbeat for arm"
@@ -101,7 +101,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/x-pack/dockerlogbeat/Jenkinsfile.yml
+++ b/x-pack/dockerlogbeat/Jenkinsfile.yml
@@ -36,7 +36,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/x-pack/elastic-agent/Jenkinsfile.yml
+++ b/x-pack/elastic-agent/Jenkinsfile.yml
@@ -22,7 +22,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/elastic-agent for arm"
@@ -107,7 +107,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/x-pack/filebeat/Jenkinsfile.yml
+++ b/x-pack/filebeat/Jenkinsfile.yml
@@ -17,7 +17,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/filebeat for arm"
@@ -142,7 +142,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/x-pack/functionbeat/Jenkinsfile.yml
+++ b/x-pack/functionbeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/functionbeat for arm"

--- a/x-pack/heartbeat/Jenkinsfile.yml
+++ b/x-pack/heartbeat/Jenkinsfile.yml
@@ -91,7 +91,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/x-pack/libbeat/Jenkinsfile.yml
+++ b/x-pack/libbeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/libbeat for arm"

--- a/x-pack/metricbeat/Jenkinsfile.yml
+++ b/x-pack/metricbeat/Jenkinsfile.yml
@@ -122,7 +122,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being

--- a/x-pack/packetbeat/Jenkinsfile.yml
+++ b/x-pack/packetbeat/Jenkinsfile.yml
@@ -16,7 +16,7 @@ stages:
     arm:
         mage: "mage build unitTest"
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         when:                  ## Override the top-level when.
             comments:
                 - "/test x-pack/packetbeat for arm"
@@ -101,7 +101,7 @@ stages:
         e2e:
             enabled: false
         platforms:             ## override default label in this specific stage.
-          - "arm"
+          - "ubuntu-2204-aarch64"
         stage: packaging
         when:
             branches: false    ## Only on a PR basis for the time being


### PR DESCRIPTION
Manual backport of https://github.com/elastic/beats/pull/34383 to 7.17 to fix the 7.17 ARM packaging stages.