### PR TITLE
[doc] Update shared-docker.asciidoc to reflect correct base OS

### DIFF
--- a/libbeat/docs/shared-docker.asciidoc
+++ b/libbeat/docs/shared-docker.asciidoc
@@ -2,7 +2,7 @@
 === Run {beatname_uc} on Docker
 
 Docker images for {beatname_uc} are available from the Elastic Docker
-registry. The base image is https://hub.docker.com/_/centos/[centos:7].
+registry. The base image is https://hub.docker.com/_/ubuntu[ubuntu:20.04 LTS].
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co].


### PR DESCRIPTION
According to https://github.com/elastic/obs-infraobs-team/issues/613, we changed the Docker base images from `centos` to Ubuntu on all Beats systems.

I just confirmed this by following the steps at https://www.elastic.co/guide/en/beats/metricbeat/current/running-on-docker.html.

```
$ cat /etc/*release*
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.6 LTS"
NAME="Ubuntu"
VERSION="20.04.6 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.6 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

As such, we need to update the Beats documentation for all Beats, like Filebeat and Metricbeat, to reflect those changes. This should be backported to all Beats versions up to 8.1.0.