### PR TITLE
Make all docker images consistent for future updates

### DIFF
--- a/dev-tools/kubernetes/filebeat/Dockerfile.debug
+++ b/dev-tools/kubernetes/filebeat/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:alpine3.15 as builder
+FROM golang:1.19.10 as builder
 
 ENV PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/go/bin:/usr/local/go/bin
 

--- a/dev-tools/kubernetes/heartbeat/Dockerfile.debug
+++ b/dev-tools/kubernetes/heartbeat/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:alpine3.15 as builder
+FROM golang:1.19.10 as builder
 
 ENV PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/go/bin:/usr/local/go/bin
 

--- a/dev-tools/kubernetes/metricbeat/Dockerfile.debug
+++ b/dev-tools/kubernetes/metricbeat/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM golang:alpine3.15 as builder
+FROM golang:1.19.10 as builder
 
 ENV PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/go/bin:/usr/local/go/bin
 

--- a/metricbeat/module/http/_meta/Dockerfile
+++ b/metricbeat/module/http/_meta/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5
+FROM golang:1.19.10
 
 COPY test/main.go main.go
 

--- a/metricbeat/module/nats/_meta/Dockerfile
+++ b/metricbeat/module/nats/_meta/Dockerfile
@@ -2,16 +2,16 @@ ARG NATS_VERSION=2.0.4
 FROM nats:$NATS_VERSION
 
 # build stage
-FROM golang:1.13-alpine3.11 AS build-env
-RUN apk --no-cache add build-base git mercurial gcc
-RUN cd src && go get -d github.com/nats-io/nats.go/
-RUN cd src/github.com/nats-io/nats.go/examples/nats-bench && git checkout tags/v1.10.0 && go build .
+FROM golang:1.19.10 AS build-env
+RUN apt-get install git mercurial gcc
+RUN git clone https://github.com/nats-io/nats.go.git /nats-go
+RUN cd /nats-go/examples/nats-bench && git checkout tags/v1.10.0 && go build .
 
 # create an enhanced container with nc command available since nats is based
 # on scratch image making healthcheck impossible
 FROM alpine:latest
 COPY --from=0 / /opt/nats
-COPY --from=build-env /go/src/github.com/nats-io/nats.go/examples/nats-bench/nats-bench /nats-bench
+COPY --from=build-env /nats-go/examples/nats-bench/nats-bench /nats-bench
 COPY run.sh /run.sh
 # Expose client, management, and cluster ports
 EXPOSE 4222 8222 6222

--- a/metricbeat/module/vsphere/_meta/Dockerfile
+++ b/metricbeat/module/vsphere/_meta/Dockerfile
@@ -1,7 +1,7 @@
 ARG VSPHERE_GOLANG_VERSION
-FROM golang:${VSPHERE_GOLANG_VERSION}-alpine
+FROM golang:${VSPHERE_GOLANG_VERSION}
 
-RUN apk add --no-cache curl git
+RUN apt-get install curl git
 RUN go install github.com/vmware/govmomi/vcsim@v0.30.4
 
 HEALTHCHECK --interval=1s --retries=60 --timeout=10s CMD curl http://localhost:8989/

--- a/x-pack/metricbeat/module/stan/_meta/Dockerfile
+++ b/x-pack/metricbeat/module/stan/_meta/Dockerfile
@@ -2,17 +2,17 @@ ARG STAN_VERSION=0.15.1
 FROM nats-streaming:$STAN_VERSION
 
 # build stage
-FROM golang:1.13-alpine3.11 AS build-env
-RUN apk --no-cache add build-base git mercurial gcc
-RUN cd src && go get -d github.com/nats-io/stan.go/
-RUN cd src/github.com/nats-io/stan.go/examples/stan-bench && git checkout tags/v0.5.2 && go build .
+FROM golang:1.19.10 AS build-env
+RUN apt-get install git mercurial gcc
+RUN git clone https://github.com/nats-io/stan.go.git /stan-go
+RUN cd /stan-go/examples/stan-bench && git checkout tags/v0.5.2 && go build .
 
 # create an enhanced container with nc command available since nats is based
 # on scratch image making healthcheck impossible
 FROM alpine:latest
 RUN apk add --no-cache --upgrade bash
 COPY --from=0 nats-streaming-server /nats-streaming-server
-COPY --from=build-env /go/src/github.com/nats-io/stan.go/examples/stan-bench/stan-bench /stan-bench
+COPY --from=build-env /stan-go/examples/stan-bench/stan-bench /stan-bench
 # Expose client, management, and cluster ports
 EXPOSE 4222 8222
 ADD healthcheck.sh /healthcheck.sh


### PR DESCRIPTION
## What does this PR do?

We have update CLI that takes care of Docker image updates. In order to cover all the images we need to make them consistent first.

If we keep these images at older versions, we'll be constantly receiving CVE notifications, so it's easier to automate these updates even though these images are internal and are never released to the public.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It's a preparation step for another PR that will come later and will update the update CLI configuration to include all these paths.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I ran `docker build --no-cache .` on each changed Dockerfile.
