### PR TITLE
Include all Dockerfiles that use Golang into the bump job

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -124,6 +124,13 @@ targets:
         - ./metricbeat/Dockerfile
         - ./packetbeat/Dockerfile
         - ./x-pack/functionbeat/Dockerfile
+        - ./metricbeat/module/nats/_meta/Dockerfile
+        - ./metricbeat/module/http/_meta/Dockerfile
+        - ./metricbeat/module/vsphere/_meta/Dockerfile
+        - ./dev-tools/kubernetes/metricbeat/Dockerfile.debug
+        - ./dev-tools/kubernetes/filebeat/Dockerfile.debug
+        - ./dev-tools/kubernetes/heartbeat/Dockerfile.debug
+        - ./x-pack/metricbeat/module/stan/_meta/Dockerfile
       matchpattern: 'FROM golang:\d+.\d+.\d+'
   update-gomod:
     name: "Update go.mod"


### PR DESCRIPTION
## What does this PR do?

So, we can avoid vulnerability reports from Snyk for the outdated images.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Quite a few issues reported by Snyk have to do with the Docker images that we have for testing and development, so we should include them into updates to avoid extra reports from Snyk.


It's a follow up to https://github.com/elastic/beats/pull/35919