### PR TITLE
Remove NOTE about port in Cloud ID

### DIFF
--- a/libbeat/docs/output-cloud.asciidoc
+++ b/libbeat/docs/output-cloud.asciidoc
@@ -42,8 +42,6 @@ The Cloud ID, which can be found in the {ess} web console, is used by
 overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings.
 For more on locating and configuring the Cloud ID, see {ece-ref}/ece-cloud-id.html[Configure Beats and Logstash with Cloud ID].
 
-NOTE: The base64 encoded `cloud.id` found in the {ess} web console does not explicitly specify a port. This means that {beatname_uc} will default to using port 443 when using `cloud.id`, not the commonly configured cloud endpoint port 9243.
-
 ==== `cloud.auth`
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and


### PR DESCRIPTION
Remove a NOTE section telling the `cloud.id` does not explicitly specify a port because it does specify a port nowadays.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR fixes a small doc glitch that the NOTE section to be removed is no longer valid.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

The doc should stay as accurate as possbile.

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

https://github.com/elastic/apm-server/pull/11100

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
