### PR TITLE
[filebeat] Check for duplicate ID for filestream metrics

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -142,7 +142,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix CEL input JSON marshalling of nested objects. {issue}35763[35763] {pull}35774[35774]
 - Fix metric collection in GCPPubSub input. {pull}35773[35773]
 - Fix end point deregistration in http_endpoint input. {issue}35899[35899] {pull}35903[35903]
-- Fix duplicate ID panic in filestream metrics. {issue}35964[35964] {pull}1[1]
+- Fix duplicate ID panic in filestream metrics. {issue}35964[35964] {pull}35972[35972]
 
 *Heartbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -142,6 +142,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix CEL input JSON marshalling of nested objects. {issue}35763[35763] {pull}35774[35774]
 - Fix metric collection in GCPPubSub input. {pull}35773[35773]
 - Fix end point deregistration in http_endpoint input. {issue}35899[35899] {pull}35903[35903]
+- Fix duplicate ID panic in filestream metrics. {issue}35964[35964] {pull}1[1]
 
 *Heartbeat*
 

--- a/filebeat/input/filestream/internal/input-logfile/input.go
+++ b/filebeat/input/filestream/internal/input-logfile/input.go
@@ -30,6 +30,7 @@ import (
 
 type managedInput struct {
 	userID           string
+	metricsID        string
 	manager          *InputManager
 	ackCH            *updateChan
 	sourceIdentifier *sourceIdentifier
@@ -61,7 +62,7 @@ func (inp *managedInput) Run(
 	defer cancel()
 	ctx.Cancelation = cancelCtx
 
-	metrics := NewMetrics(ctx.ID)
+	metrics := NewMetrics(inp.metricsID)
 	defer metrics.Close()
 
 	hg := &defaultHarvesterGroup{

--- a/filebeat/input/filestream/internal/input-logfile/manager.go
+++ b/filebeat/input/filestream/internal/input-logfile/manager.go
@@ -177,10 +177,13 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 			" duplication, please add an ID and restart Filebeat")
 	}
 
+	metricsID := settings.ID
 	cim.idsMux.Lock()
 	if _, exists := cim.ids[settings.ID]; exists {
 		cim.Logger.Errorf("filestream input with ID '%s' already exists, this "+
-			"will lead to data duplication, please use a different ID", settings.ID)
+			"will lead to data duplication, please use a different ID. Metrics "+
+			"collection has been disabled on this input.", settings.ID)
+		metricsID = ""
 	}
 
 	// TODO: improve how inputs with empty IDs are tracked.
@@ -223,6 +226,7 @@ func (cim *InputManager) Create(config *conf.C) (v2.Input, error) {
 		manager:          cim,
 		ackCH:            cim.ackCH,
 		userID:           settings.ID,
+		metricsID:        metricsID,
 		prospector:       prospector,
 		harvester:        harvester,
 		sourceIdentifier: sourceIdentifier,


### PR DESCRIPTION
## What does this PR do?

- If a duplicate ID was used for filestream, set the ID for metrics to an empty string to prevent a panic.
- A valid metrics instance will still be generated, but collection of metrics will not occur.

## Why is it important?

Fixes a panic that can occur when a duplicate ID is used.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

Create a config with duplicate IDs, such as:

```yaml
filebeat:
  inputs:
    - type: filestream
      id: foo
      paths:
        - /tmp/foo
    - type: filestream
      id: foo
      paths:
        - /tmp/foo2
output:
  file:
    enabled: true
```

Run filebeat. The first instance should register with metrics. Subsequent instances will still register, but with an empty string. This still creates a valid metrics instance, but does not collect and report metrics.

## Related issues

- Closes #35964 

## Logs

> filestream input with ID 'foo' already exists, this will lead to data duplication, please use a different ID. Metrics collection has been disabled on this input.

```
{"log.level":"error","@timestamp":"2023-06-29T16:55:26.299Z","log.logger":"input","log.origin":{"file.name":"input-logfile/manager.go","file.line":183},"message":"filestream input with ID 'foo' already exists, this will lead to data duplication, please use a different ID. Metrics collection has been disabled on this input.","service.name":"filebeat","ecs.version":"1.6.0"}
```
