### PR TITLE
Added verification fallback to https://artifacts.elastic.co/GPG-KEY-elastic-agent

### DIFF
--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download_test.go
@@ -1,0 +1,34 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFallbackIsAppended(t *testing.T) {
+	testCases := []struct {
+		name        string
+		passedBytes []string
+		expectedLen int
+	}{
+		{"nil input", nil, 1},
+		{"empty input", []string{}, 1},
+		{"valid input", []string{"pgp-bytes"}, 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := appendFallbackPGP(tc.passedBytes)
+			// check default fallback is passed and is very last
+			require.NotNil(t, res)
+			require.Equal(t, tc.expectedLen, len(res))
+			require.Equal(t, download.PgpSourceURIPrefix+defaultUpgradeFallbackPGP, res[len(res)-1])
+		})
+	}
+}

--- a/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download_test.go
+++ b/x-pack/elastic-agent/pkg/agent/application/upgrade/step_download_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/elastic/beats/v7/x-pack/elastic-agent/pkg/artifact/download"
+
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Backport of https://github.com/elastic/elastic-agent/pull/2980

## What does this PR do?

This PRs adds a fallback to a downloader. When downloadArtifact is called, it appends a fallback key into a passed keys collection.
This key is used as a last resort for signature verification of downloaded packages and is useful when embedded key is no longer used. 
This option is used regardless of mode in which ugprade was triggered let it be standalone CLI trigger or managed action. 
 
## Why is it important?

Option to support older agents when keys are rotated.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `./changelog/fragments` using the [changelog tool](https://github.com/elastic/elastic-agent#changelog)
- [ ] I have added an integration test or an E2E test

## How to test this

- temper embedded key
- build agent locally
- install built agent (managed)
- try to upgrade 
- should pass (first verification with embedded key fails, fallback should be fine)
