### PR TITLE
[doc] Add defaults for filebeat udp input.

### DIFF
--- a/filebeat/docs/inputs/input-common-udp-options.asciidoc
+++ b/filebeat/docs/inputs/input-common-udp-options.asciidoc
@@ -20,10 +20,11 @@ The host and UDP port to listen on for event streams.
 [id="{beatname_lc}-input-{type}-udp-read-buffer"]
 ==== `read_buffer`
 
-The size of the read buffer on the UDP socket.
+The size of the read buffer on the UDP socket. If not specified the default 
+from the operating system will be used.
 
 [float]
 [id="{beatname_lc}-input-{type}-udp-timeout"]
 ==== `timeout`
 
-The read and write timeout for socket operations.
+The read and write timeout for socket operations. The default is `5m`.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR includes default values for the Filebeat [UDP input](https://www.elastic.co/guide/en/beats/filebeat/8.8/filebeat-input-udp.html?edit=true). It includes the `timeout` default, which is specified in the [code](https://github.com/elastic/beats/blob/8597ca78aba6742961d4e235a565d87b7d21fc67/filebeat/input/udp/input.go#L74) but not in the docs. It also includes an explanation for the `read_buffer`, which will be provided by the OS.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Docs should contain this to assure users without the need to look at the code.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [X] I have made corresponding changes to the documentation

~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


Edit: I believe a backport to all version 8 would be beneficial, hope to get some input from the review about that.