### PR TITLE
Do not print context canceled errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -70,6 +70,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Make sure k8s watchers are closed when closing k8s meta processor. {pull}35630[35630]
 - Upgraded apache arrow library used in x-pack/libbeat/reader/parquet from v11 to v12.0.1 in order to fix cross-compilation issues {pull}35640[35640]
 - Fix panic when MaxRetryInterval is specified, but RetryInterval is not {pull}35820[35820]
+- Do not print context cancelled error message when running under agent {pull}36005[36005]
 
 
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -70,7 +70,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Make sure k8s watchers are closed when closing k8s meta processor. {pull}35630[35630]
 - Upgraded apache arrow library used in x-pack/libbeat/reader/parquet from v11 to v12.0.1 in order to fix cross-compilation issues {pull}35640[35640]
 - Fix panic when MaxRetryInterval is specified, but RetryInterval is not {pull}35820[35820]
-- Do not print context cancelled error message when running under agent {pull}36005[36005]
+- Do not print context cancelled error message when running under agent {pull}36006[36006]
 
 
 

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -437,6 +437,7 @@ func (cm *BeatV2Manager) watchErrChan(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case err := <-cm.client.Errors():
+			// Don't print the context canceled errors that happen normally during shutdown, restart, etc
 			if !errors.Is(context.Canceled, err) {
 				cm.logger.Errorf("elastic-agent-client error: %s", err)
 			}

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -437,7 +437,10 @@ func (cm *BeatV2Manager) watchErrChan(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case err := <-cm.client.Errors():
-			cm.logger.Errorf("elastic-agent-client error: %s", err)
+			if !errors.Is(context.Canceled, err) {
+				cm.logger.Errorf("elastic-agent-client error: %s", err)
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/elastic/beats/issues/36005

A simple one-liner fix that checks to see if we have a context-canceled error before printing an error message. Done to prevent log spam that happens during restart/shutdown operations:
```
elastic-agent-client error: rpc error: code = Canceled desc = context canceled
```

## Why is it important?

Removes a source a log spam.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have made corresponding change to the default configuration files~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

