### PR TITLE
Update logstash.asciidoc load balancing verbiage

### DIFF
--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -272,8 +272,9 @@ is best used with load balancing mode enabled. Example: If you have 2 hosts and
 ===== `loadbalance`
 
 If set to true and multiple {ls} hosts are configured, the output plugin
-load balances published events onto all {ls} hosts. If set to false,
-the output plugin sends all events to only one host (determined at random) and
+load balances published events across all {ls} hosts. While events are evenly distributed, they are not duplicated. 
+A single event is only published to a single host.
+If set to false, the output plugin sends all events to only one host (determined at random) and
 will switch to another host if the selected one becomes unresponsive. The default value is false.
 
 ["source","yaml",subs="attributes"]


### PR DESCRIPTION
"...the output plugin load balances published events onto all Logstash hosts.", could be interrupted as a single event gets published to all of the hosts; however, a single event is only published to a single host.
Added a short sentence to remove ambiguity.

<!-- Type of change
- Docs
-->

## What does this PR do?

Amends the documentation of the load-balancing option. The current documentation may be interrupted to duplicate events by those less familiar with load-balancing conventions.

## Why is it important?

Documentation should always be explicit as to whether events may or may not be duplicated.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ]~~ I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

- [ ] review doc changes

## How to test this PR locally

documentation - NA

## Related issues

documentation - NA

## Use cases

documentation - NA
