### PR TITLE
remove method actually deletes the current implementation

### DIFF
--- a/filebeat/input/filestream/internal/input-logfile/store.go
+++ b/filebeat/input/filestream/internal/input-logfile/store.go
@@ -383,9 +383,10 @@ func (s *store) remove(key string) error {
 	if resource == nil {
 		return fmt.Errorf("resource '%s' not found", key)
 	}
-	s.UpdateTTL(resource, 0)
+	s.ephemeralStore.Remove(resource)
 	return nil
 }
+
 
 // UpdateTTL updates the time-to-live of a resource. Inactive resources with expired TTL are subject to removal.
 // The TTL value is part of the internal state, and will be written immediately to the persistent store.


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
-->
- Enhancement

## What does this PR do?

<!-- Mandatory

-->
In this updated version of the remove function, instead of updating the TTL of the resource to 0, we directly remove the resource from the ```ephemeralStore``` using its ```Remove``` method. This should fix the issue and properly delete the resource from memory.

## Why is it important?

<!-- Mandatory
-->
The original implementation set the TTL of the resource to 0, which retained the resource’s state in memory and made another set operation record in the registry log. This might have been done to optimize the deletion process and delay it until some kind of garbage collection. However, when files are deleted, their states are retained in memory and another set operation record is made in the registry log, which is much larger than the delete operation line. This could potentially cause issues with memory usage and registry log size.
The updated code I provided directly removes the resource from the ```ephemeralStore``` using its ```Remove``` method. This should properly delete the resource from memory and avoid making another set operation record in the registry log.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~[ ] I have commented my code, particularly in hard-to-understand areas~~
~~[ ] I have made corresponding changes to the documentation~~
~~[ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
