### PR TITLE
Pin PyYAML version to 5.3.1 to avoid CI errors temporarily

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -162,6 +162,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Add benchmarking to HTTPJSON input testing. {pull}35138[35138]
 - Allow non-AWS endpoints for testing Filebeat awss3 input. {issue}35496[35496] {pull}35520[35520]
 - Add AUTH (username) and SSL/TLS support for Redis module {pull}35240[35240]
+- Pin PyYAML version to 5.3.1 to avoid CI errors temporarily {pull}36091[36091]
 
 ==== Deprecated
 

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -36,7 +36,7 @@ pyrsistent==0.16.0
 pytest==7.3.2
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
-PyYAML==5.4.1
+PyYAML==5.3.1
 redis==4.4.4
 requests==2.31.0
 semver==2.8.1

--- a/libbeat/tests/system/requirements_aix.txt
+++ b/libbeat/tests/system/requirements_aix.txt
@@ -35,7 +35,7 @@ pyrsistent==0.16.0
 pytest==7.3.2
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
-PyYAML==5.4.1
+PyYAML==5.3.1
 redis==4.4.4
 requests==2.31.0
 semver==2.8.1

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade docker-compose==1.23.2
 RUN pip3 install --upgrade setuptools==47.3.2
-RUN pip3 install --upgrade PyYAML==6.0.0
+RUN pip3 install --upgrade PyYAML==5.3.1
 
 # Oracle instant client
 RUN cd /usr/lib \

--- a/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
+++ b/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
@@ -5,7 +5,7 @@ docutils==0.15.2
 jmespath==0.9.5
 pyasn1==0.4.8
 python-dateutil==2.8.1
-PyYAML==5.4.1
+PyYAML==5.3.1
 rsa==4.7.2
 s3transfer==0.3.3
 six==1.14.0


### PR DESCRIPTION
## What does this PR do?

CPython 3.0 was released recently which has introduced a regression that leads to failures when installing PyYAML (and perhaps other packages too). This is a temporary fix and this commits needs to be reverted when a proper fix is available.

## Why is it important?

If we don't fix it CI would keep failing.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- https://github.com/yaml/pyyaml/issues/601
- https://github.com/yaml/pyyaml/pull/702
- https://github.com/cds-snc/notification-utils/pull/227#issue-1808380492