### PR TITLE
Fix the wrong event type for a new file

### DIFF
--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -202,6 +202,7 @@ func (w *fileWatcher) watch(ctx unison.Canceler) {
 		// no need to react on empty new files
 		if fd.Info.Size() == 0 {
 			w.log.Warnf("file %q has no content yet, skipping", fd.Filename)
+			delete(paths, path)
 			continue
 		}
 		select {

--- a/filebeat/input/filestream/fswatch_test.go
+++ b/filebeat/input/filestream/fswatch_test.go
@@ -295,8 +295,7 @@ scanner:
 			e := fw.Event()
 			expEvent := loginp.FSEvent{
 				NewPath: filename,
-				OldPath: filename,
-				Op:      loginp.OpWrite,
+				Op:      loginp.OpCreate,
 				Descriptor: loginp.FileDescriptor{
 					Filename: filename,
 					Info:     testFileInfo{name: basename, size: 5}, // +5 bytes appended


### PR DESCRIPTION
## What does this PR do?

It's supposed to emit a `create` event, not a `write` event when a previously ignored empty file gets written to.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
-  Follow up to #36076
