### PR TITLE
Set providers parameter in config to aws for provider_aws_ec2_test.go

### DIFF
--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -310,7 +310,7 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 					Tags: []types.TagDescription{},
 				}, nil
 			},
-			processorOverwrite: false,
+			processorOverwrite: true,
 			previousEvent: mapstr.M{
 				"cloud.provider": "aws",
 			},
@@ -349,6 +349,7 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 
 			config, err := conf.NewConfigFrom(map[string]interface{}{
 				"overwrite": tc.processorOverwrite,
+				"providers": []string{"aws"},
 			})
 			if err != nil {
 				t.Fatalf("error creating config from map: %s", err.Error())


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR is to set `providers` parameter in config to `aws` for `provider_aws_ec2_test.go`. This will make sure `add_cloud_meta` collects metadata from the right provider. This is also the workaround for this processor when seeing wrong cloud provider information is detected.

For example, we are seeing `gcp` related metadata is collected when running `provider_aws_ec2_test.go` is run:
```
=== RUN   TestRetrieveAWSMetadataEC2/only_cloud.provider_pre-informed,_no_overwrite
{"log.level":"debug","@timestamp":"2023-06-08T18:07:59.591Z","log.logger":"add_cloud_metadata","log.origin":{"file.name":"add_cloud_metadata/providers.go","file.line":130},"message":"add_cloud_metadata: starting to fetch metadata, timeout=3s","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2023-06-08T18:07:59.600Z","log.logger":"add_cloud_metadata","log.origin":{"file.name":"add_cloud_metadata/providers.go","file.line":167},"message":"add_cloud_metadata: received disposition for gcp after 8.997301ms. result=[provider:gcp, error=<nil>, metadata={\"cloud\":{\"account\":{\"id\":\"elastic-ci-prod\"},\"availability_zone\":\"us-central1-b\",\"instance\":{\"id\":\"2845190703127964801\",\"name\":\"beats-ci-immutable-ubuntu-2204-1686245982352075891\"},\"machine\":{\"type\":\"n1-highmem-8\"},\"project\":{\"id\":\"elastic-ci-prod\"},\"provider\":\"gcp\",\"region\":\"us-central1\",\"service\":{\"name\":\"GCE\"}}}]","ecs.version":"1.6.0"}
{"log.level":"debug","@timestamp":"2023-06-08T18:07:59.600Z","log.logger":"add_cloud_metadata","log.origin":{"file.name":"add_cloud_metadata/providers.go","file.line":133},"message":"add_cloud_metadata: fetchMetadata ran for 9.187238ms","ecs.version":"1.6.0"}
{"log.level":"info","@timestamp":"2023-06-08T18:07:59.600Z","log.logger":"add_cloud_metadata","log.origin":{"file.name":"add_cloud_metadata/add_cloud_metadata.go","file.line":104},"message":"add_cloud_metadata: hosting provider type detected as gcp, metadata={\"cloud\":{\"account\":{\"id\":\"elastic-ci-prod\"},\"availability_zone\":\"us-central1-b\",\"instance\":{\"id\":\"2845190703127964801\",\"name\":\"beats-ci-immutable-ubuntu-2204-1686245982352075891\"},\"machine\":{\"type\":\"n1-highmem-8\"},\"project\":{\"id\":\"elastic-ci-prod\"},\"provider\":\"gcp\",\"region\":\"us-central1\",\"service\":{\"name\":\"GCE\"}}}","ecs.version":"1.6.0"}
    
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes https://github.com/elastic/beats/issues/35722