### PR TITLE
Bump PyYAML's version from 5.3.1 to avoid security risks

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -163,7 +163,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Allow non-AWS endpoints for testing Filebeat awss3 input. {issue}35496[35496] {pull}35520[35520]
 - Add AUTH (username) and SSL/TLS support for Redis module {pull}35240[35240]
 - Pin PyYAML version to 5.3.1 to avoid CI errors temporarily {pull}36091[36091]
-- Pin PyYAML version to 6.0.1 to avoid CI errors temporarily {pull}36119[36119]
+- Bump PyYAML's version from 5.3.1 to avoid security risks {pull}36119[36119]
 
 ==== Deprecated
 

--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -163,6 +163,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Allow non-AWS endpoints for testing Filebeat awss3 input. {issue}35496[35496] {pull}35520[35520]
 - Add AUTH (username) and SSL/TLS support for Redis module {pull}35240[35240]
 - Pin PyYAML version to 5.3.1 to avoid CI errors temporarily {pull}36091[36091]
+- Pin PyYAML version to 6.0.1 to avoid CI errors temporarily {pull}36119[36119]
 
 ==== Deprecated
 

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -36,7 +36,7 @@ pyrsistent==0.16.0
 pytest==7.3.2
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
-PyYAML==5.3.1
+PyYAML>=6.0.0
 redis==4.4.4
 requests==2.31.0
 semver==2.8.1

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -36,7 +36,7 @@ pyrsistent==0.16.0
 pytest==7.3.2
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
-PyYAML>=6.0.0
+PyYAML==5.4.1
 redis==4.4.4
 requests==2.31.0
 semver==2.8.1

--- a/libbeat/tests/system/requirements.txt
+++ b/libbeat/tests/system/requirements.txt
@@ -36,7 +36,7 @@ pyrsistent==0.16.0
 pytest==7.3.2
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
-PyYAML==5.4.1
+PyYAML~=5.4.1
 redis==4.4.4
 requests==2.31.0
 semver==2.8.1

--- a/libbeat/tests/system/requirements_aix.txt
+++ b/libbeat/tests/system/requirements_aix.txt
@@ -35,7 +35,7 @@ pyrsistent==0.16.0
 pytest==7.3.2
 pytest-rerunfailures==9.1.1
 pytest-timeout==1.4.2
-PyYAML==5.3.1
+PyYAML>=6.0.0
 redis==4.4.4
 requests==2.31.0
 semver==2.8.1

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade docker-compose==1.23.2
 RUN pip3 install --upgrade setuptools==47.3.2
-RUN pip3 install --upgrade PyYAML>=6.0.0
+RUN pip3 install --upgrade PyYAML==5.4.1
 
 # Oracle instant client
 RUN cd /usr/lib \

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade docker-compose==1.23.2
 RUN pip3 install --upgrade setuptools==47.3.2
-RUN pip3 install --upgrade PyYAML==5.4.1
+RUN pip3 install --upgrade PyYAML~=5.4.1
 
 # Oracle instant client
 RUN cd /usr/lib \

--- a/metricbeat/Dockerfile
+++ b/metricbeat/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install --upgrade pip==20.1.1
 RUN pip3 install --upgrade docker-compose==1.23.2
 RUN pip3 install --upgrade setuptools==47.3.2
-RUN pip3 install --upgrade PyYAML==5.3.1
+RUN pip3 install --upgrade PyYAML>=6.0.0
 
 # Oracle instant client
 RUN cd /usr/lib \

--- a/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
+++ b/metricbeat/module/kubernetes/_meta/terraform/eks/requirements.txt
@@ -5,7 +5,7 @@ docutils==0.15.2
 jmespath==0.9.5
 pyasn1==0.4.8
 python-dateutil==2.8.1
-PyYAML==5.3.1
+PyYAML>=6.0.0
 rsa==4.7.2
 s3transfer==0.3.3
 six==1.14.0


### PR DESCRIPTION
## What does this PR do?

CPython 3.0 was released recently which has introduced a regression that leads to failures when installing PyYAML (and perhaps other packages too). This is a temporary fix and this commits needs to be reverted when a proper fix is available. See: https://github.com/yaml/pyyaml/issues/601

https://github.com/elastic/beats/pull/36091 pinned the version of PyYAML to 5.3.1 but I found from a recent discussion https://github.com/yaml/pyyaml/issues/601#issuecomment-1638555590 that there's a CVE associated with the same: [CVE-2020-14343](https://www.cvedetails.com/cve/CVE-2020-14343/).

Also, see: https://github.com/aws/aws-cli/issues/8036#issuecomment-1638544754 and https://github.com/aws/aws-cli/issues/8036#issuecomment-1640932993

> But currently we are facing an issue because of docker-compose i.e., https://github.com/elastic/beats/pull/36119#issuecomment-1642837619 
> Bumping to 6.x.x for PyYAML results in dependency conflict but as we know that we cannot go with 5.4.1 as that will again result in CI failure because `CPython` latest is used instead of `CPython<3`


## Why is it important?

Fixes CI issues temporarily and also makes us safe from CVE-2020-14343.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- https://github.com/elastic/beats/pull/36091
- https://github.com/yaml/pyyaml/issues/601
- https://github.com/aws/aws-cli/issues/8036#issuecomment-1638544754
- https://www.cvedetails.com/cve/CVE-2020-14343/
- https://github.com/yaml/pyyaml/pull/726
- https://github.com/yaml/pyyaml/pull/726#issuecomment-1640481051 (Exactly our issue)
- PyYAML using CPython<3 but only for 6.0.1 https://github.com/yaml/pyyaml/pull/702
