### PR TITLE
Support build of projects outside of beats directory

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -74,6 +74,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix recovering from invalid output configuration when running under Elastic-Agent {pull}36016[36016]
 - Improve StreamBuf append to improve performance when reading long lines from files. {pull}35928[35928]
 - Eliminate cloning of event in deepUpdate {pull}35945[35945]
+- Support build of projects outside of beats directory {pull}36126[36126]
 
 *Auditbeat*
 

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -139,6 +139,24 @@ func GolangCrossBuild(params BuildArgs) error {
 		return err
 	}
 
+	repoInfo, err := GetProjectRepoInfo()
+	if err != nil {
+		return fmt.Errorf("failed to determine repo root and package sub dir: %w", err)
+	}
+
+	projectMountPoint := filepath.ToSlash(filepath.Join("/go", "src", repoInfo.CanonicalRootImportPath))
+	// TODO: Resolve custom dir
+	// // use custom dir for build if given, subdir if not:
+	// cwd := repoInfo.SubDir
+	// if b.InDir != "" {
+	// 	cwd = b.InDir
+	// }
+	// workDir := filepath.ToSlash(filepath.Join(mountPoint, cwd))
+
+	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", projectMountPoint); err != nil {
+		return err
+	}
+
 	return Build(params)
 }
 

--- a/dev-tools/mage/build.go
+++ b/dev-tools/mage/build.go
@@ -139,20 +139,14 @@ func GolangCrossBuild(params BuildArgs) error {
 		return err
 	}
 
+	// Support projects outside of the beats directory.
 	repoInfo, err := GetProjectRepoInfo()
 	if err != nil {
-		return fmt.Errorf("failed to determine repo root and package sub dir: %w", err)
+		return err
 	}
 
+	// TODO: Support custom build dir/subdir
 	projectMountPoint := filepath.ToSlash(filepath.Join("/go", "src", repoInfo.CanonicalRootImportPath))
-	// TODO: Resolve custom dir
-	// // use custom dir for build if given, subdir if not:
-	// cwd := repoInfo.SubDir
-	// if b.InDir != "" {
-	// 	cwd = b.InDir
-	// }
-	// workDir := filepath.ToSlash(filepath.Join(mountPoint, cwd))
-
 	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", projectMountPoint); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What does this PR do?
There are `beats` that aren't part of the `beats` repository code-base.
`Cloudbeat` for example:
- https://github.com/elastic/cloudbeat

When calling the `mage package` that is based on the `beats` `mage` flows we are getting a failure:
```bash
Found Elastic Beats dir at /go/pkg/mod/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20230718065235-46adbacfb5a8
exec: git "config" "--global" "--add" "safe.directory" "/go/pkg/mod/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20230718065235-46adbacfb5a8"
>> build: Building cloudbeat-linux-amd64
exec: git "rev-parse" "HEAD"
fatal: detected dubious ownership in repository at '/go/src/github.com/elastic/cloudbeat'
To add an exception for this directory, call:
	git config --global --add safe.directory /go/src/github.com/elastic/cloudbeat
>>> Fixing file ownership issues from Docker at path=build/golang-crossbuild
chown took: 58.803µs, changed 1 files
>>> Fixing file ownership issues from Docker at path=build/golang-crossbuild/cloudbeat-linux-amd64
chown took: 13.401µs, changed 0 files
lstat build/golang-crossbuild/cloudbeat-linux-amd64: no such file or directory
Error: failed to expand template '-X github.com/elastic/beats/v7/libbeat/version.commit={{ commit }} -X github.com/elastic/beats/v7/libbeat/version.buildTime={{ date }}': template: inline:1:57: executing "inline" at <commit>: error calling commit: running "git rev-parse HEAD" failed with exit code 128
Error: failed building for linux/amd64: exit status 1
failed building for linux/amd64: exit status 1
```

I've investigated the code and saw that the `safe.directory` only triggers for `beats` directory:
```golang
	mountPoint, err := ElasticBeatsDir()
	if err != nil {
		return err
	}
	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", mountPoint); err != nil {
		return err
	}
```

I've added the `root` path of the project as well.

## Why is it important?
In order to support the building and packaging of `beats` that aren't part of the `beats` repository.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.