### PR TITLE
updatecli: it uses an env variable

### DIFF
--- a/.ci/bump-golang-7.17.yml
+++ b/.ci/bump-golang-7.17.yml
@@ -121,7 +121,6 @@ targets:
       # This list differs from the main branch, this is the main reason we have a separate job
       files:
         - ./metricbeat/Dockerfile
-        - ./metricbeat/module/vsphere/_meta/Dockerfile
         - ./metricbeat/module/nats/_meta/Dockerfile
         - ./metricbeat/module/http/_meta/Dockerfile
         - ./filebeat/Dockerfile

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -126,7 +126,6 @@ targets:
         - ./x-pack/functionbeat/Dockerfile
         - ./metricbeat/module/nats/_meta/Dockerfile
         - ./metricbeat/module/http/_meta/Dockerfile
-        - ./metricbeat/module/vsphere/_meta/Dockerfile
         - ./dev-tools/kubernetes/metricbeat/Dockerfile.debug
         - ./dev-tools/kubernetes/filebeat/Dockerfile.debug
         - ./dev-tools/kubernetes/heartbeat/Dockerfile.debug


### PR DESCRIPTION
## What does this PR do?

Remove the file from the auto-golang bump 

## Why is it important?

It uses an env variable instead.

## Test

As long as `gh` and `updatecli` are installed then

```bash
$ GIT_USER=You_User \
  GIT_EMAIL=Your_Email \
  GITHUB_TOKEN=GITHUB_TOKEN=$(gh auth token) \
  JOB_URL=nop \
  updatecli diff --config .ci/bump-golang.yml
```

See https://github.com/elastic/beats/pull/35931#issuecomment-1649340054