### PR TITLE
[DOCS] Advise users to migrate from Filebeat to Elastic Agent

### DIFF
--- a/filebeat/docs/modules.asciidoc
+++ b/filebeat/docs/modules.asciidoc
@@ -9,6 +9,6 @@ modules.
 
 Filebeat modules require Elasticsearch 5.2 or later.
 
-NOTE: Bug fixes, enhancements, and new Filebeat modules are no longer implemented. We recommend that you {fleet-guide}/migrate-beats-to-agent.html[migrate to {agent}], whose integrations are actively maintained.
+NOTE: While {filebeat} modules are still supported, we recommend {agent} integrations over {filebeat} modules. Integrations provide a streamlined way to connect data from a variety of vendors to the {stack}. Refer to the full list of integrations [here](https://www.elastic.co/integrations/data-integrations). For more information, please refer to the [{beats} vs {agents} comparison](https://www.elastic.co/guide/en/fleet/current/beats-agent-comparison.html) documentation.
 
 include::modules_list.asciidoc[]

--- a/filebeat/docs/modules.asciidoc
+++ b/filebeat/docs/modules.asciidoc
@@ -9,4 +9,6 @@ modules.
 
 Filebeat modules require Elasticsearch 5.2 or later.
 
+NOTE: Bug fixes, enhancements, and new Filebeat modules are no longer implemented. We recommend that you {fleet-guide}/migrate-beats-to-agent.html[migrate to {agent}], whose integrations are actively maintained.
+
 include::modules_list.asciidoc[]

--- a/filebeat/docs/modules.asciidoc
+++ b/filebeat/docs/modules.asciidoc
@@ -9,6 +9,6 @@ modules.
 
 Filebeat modules require Elasticsearch 5.2 or later.
 
-NOTE: While {filebeat} modules are still supported, we recommend {agent} integrations over {filebeat} modules. Integrations provide a streamlined way to connect data from a variety of vendors to the {stack}. Refer to the full list of integrations https://www.elastic.co/integrations/data-integrations[here]. For more information, please refer to the {fleet-guide}/beats-agent-comparison.html[{beats} vs {agent} comparison documentation].
+NOTE: While {filebeat} modules are still supported, we recommend {agent} integrations over {filebeat} modules. Integrations provide a streamlined way to connect data from a variety of vendors to the {stack}. Refer to the https://www.elastic.co/integrations/data-integrations[full list of integrations]. For more information, please refer to the {fleet-guide}/beats-agent-comparison.html[{beats} vs {agent} comparison documentation].
 
 include::modules_list.asciidoc[]

--- a/filebeat/docs/modules.asciidoc
+++ b/filebeat/docs/modules.asciidoc
@@ -9,6 +9,6 @@ modules.
 
 Filebeat modules require Elasticsearch 5.2 or later.
 
-NOTE: While {filebeat} modules are still supported, we recommend {agent} integrations over {filebeat} modules. Integrations provide a streamlined way to connect data from a variety of vendors to the {stack}. Refer to the full list of integrations [here](https://www.elastic.co/integrations/data-integrations). For more information, please refer to the [{beats} vs {agents} comparison](https://www.elastic.co/guide/en/fleet/current/beats-agent-comparison.html) documentation.
+NOTE: While {filebeat} modules are still supported, we recommend {agent} integrations over {filebeat} modules. Integrations provide a streamlined way to connect data from a variety of vendors to the {stack}. Refer to the full list of integrations https://www.elastic.co/integrations/data-integrations[here]. For more information, please refer to the {fleet-guide}/beats-agent-comparison.html[{beats} vs {agent} comparison documentation].
 
 include::modules_list.asciidoc[]


### PR DESCRIPTION
## What does this PR do?

Adds a note to [Modules](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html) to advise users to migrate to Elastic Agent.

Preview: [Modules](https://beats_36157.docs-preview.app.elstc.co/guide/en/beats/filebeat/master/filebeat-modules.html)

## Why is it important?

While Filebeat modules are still supported, we do not typically apply bug fixes or enhancements to these modules, or ship any new modules. Our focus is now entirely on Elastic Agent integrations.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~ N/A
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~ N/A
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ N/A
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~ N/A

## Related issues

* Resolves https://github.com/elastic/security-docs/issues/3576 



