### PR TITLE
metricbeat/module/postgresql: Improve healthcheck for Postgres

### DIFF
--- a/metricbeat/module/postgresql/docker-compose.yml
+++ b/metricbeat/module/postgresql/docker-compose.yml
@@ -2,17 +2,18 @@ version: '2.3'
 
 services:
   postgresql:
-    image: docker.elastic.co/integrations-ci/beats-postgresql:${POSTGRESQL_VERSION:-13.2}-2
+    image: docker.elastic.co/integrations-ci/beats-postgresql:${POSTGRESQL_VERSION:-13.11}-2
     build:
       context: ./_meta
       args:
-        POSTGRESQL_VERSION: ${POSTGRESQL_VERSION:-13.2}
+        POSTGRESQL_VERSION: ${POSTGRESQL_VERSION:-13.11}
     environment:
       POSTGRES_PASSWORD: postgres
     ports:
       - 5432
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -p 5432"]
-      interval: 5s
-      timeout: 5s
+      test: ['CMD-SHELL', 'psql -h localhost -p 5432 -U postgres -c select 1 -d postgres']
+      interval: 15s
+      timeout: 30s
       retries: 5
+      start_period: 15s

--- a/metricbeat/module/postgresql/statement/statement_integration_test.go
+++ b/metricbeat/module/postgresql/statement/statement_integration_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	t.Skip("Flaky test: https://github.com/elastic/beats/issues/35995")
 	service := compose.EnsureUp(t, "postgresql")
 
 	f := mbtest.NewReportingMetricSetV2Error(t, getConfig(service.Host()))


### PR DESCRIPTION
## What does this PR do?

Improve healthcheck for Postgres to reduce the flakiness in integration tests.

## Why is it important?

Flaky tests lead to instability of CI and could lead to unnecessary blocking of PRs and unreliable tests. In my opinion, `start_period` and reason mentioned in https://github.com/peter-evans/docker-compose-healthcheck/issues/16#issuecomment-1420377736 is something that could help us as this improves healthcheck.

Also bumped the fallback version for the image to the latest minor of the same major release to avoid any issues. Currently, my latest major is 15 and currently, I've set the fallback version to 13.11 so that it doesn't change the major.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
- [x] I have made my commit title and message explanatory about the purpose and the reason of the change

## How to test this PR locally

As the flaky tests are not reproducible, we'll do a soak testing i.e., soak it for some time to see if it really reduced the flakiness of integration tests or not.

## Related issues

- Relates https://github.com/elastic/obs-infraobs-team/issues/1150
- Closes https://github.com/elastic/beats/issues/35995#issuecomment-1657704361
- Relates https://github.com/elastic/obs-infraobs-team/issues/1150#issuecomment-1657968550
- Relates https://github.com/peter-evans/docker-compose-healthcheck/issues/16#issuecomment-1420377736
- Relates https://github.com/docker-library/postgres/issues/146#issuecomment-872486465
- Relates https://github.com/moby/moby/pull/28679