### PR TITLE
Report status per unit

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -206,6 +206,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 *Affecting all Beats*
 
 - Added append Processor which will append concrete values or values from a field to target. {issue}29934[29934] {pull}33364[33364]
+- When running under Elastic-Agent the status is now reported per Unit instead of the whole Beat {issue}35874[35874] {pull}36183[36183]
 
 *Auditbeat*
 

--- a/libbeat/common/reload/reload.go
+++ b/libbeat/common/reload/reload.go
@@ -44,6 +44,9 @@ type ConfigWithMeta struct {
 
 	// DiagCallback is a diagnostic handler associated with the underlying unit that maps to the config
 	DiagCallback DiagnosticHandler
+
+	// InputUnitID is the unit's ID that generated this ConfigWithMeta
+	InputUnitID string
 }
 
 // ReloadableList provides a method to reload the configuration of a list of entities

--- a/x-pack/libbeat/management/input_reload_test.go
+++ b/x-pack/libbeat/management/input_reload_test.go
@@ -70,7 +70,7 @@ func TestInputReload(t *testing.T) {
 				Id:             "input-unit-1",
 				Type:           proto.UnitType_INPUT,
 				ConfigStateIdx: 1,
-				State:          proto.State_HEALTHY,
+				State:          proto.State_STARTING,
 				LogLevel:       proto.UnitLogLevel_DEBUG,
 				Config: &proto.UnitExpectedConfig{
 					Id:   "log-input",

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -662,9 +662,9 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 		_ = unit.UpdateState(client.UnitStateStopped, "Stopped", nil)
 	}
 
-	// now update the statuses of all units
-	// if there isn't an error with the input, we set it as
-	// healthy because there is no way to know more information about it.
+	// now update the statuses of all units that contain only healthy
+	// inputs. If there isn't an error with the inputs, we set the unit as
+	// healthy because there is no way to know more information about its inputs.
 	for _, unit := range healthyInputs {
 		expected := unit.Expected()
 		if expected.State == client.UnitStateStopped {

--- a/x-pack/libbeat/management/managerV2.go
+++ b/x-pack/libbeat/management/managerV2.go
@@ -21,6 +21,7 @@ import (
 	gproto "google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v2"
 
+	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/features"
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
@@ -355,8 +356,11 @@ func (cm *BeatV2Manager) SetPayload(payload map[string]interface{}) {
 
 // updateStatuses updates the status for all units to match the status of the entire manager.
 //
-// This is done because beats at the moment cannot manage different status per unit, something
+// This is done because beats at the moment cannot fully manage different status per unit, something
 // that is new in the V2 control protocol but not supported in beats itself.
+//
+// Errors while starting/reloading inputs are already reported by unit, but
+// the shutdown process is still not being handled by unit.
 func (cm *BeatV2Manager) updateStatuses() {
 	status := getUnitState(cm.status)
 	message := cm.message
@@ -545,7 +549,18 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 	var outputUnit *client.Unit
 	var inputUnits []*client.Unit
 	var stoppingUnits []*client.Unit
-	var errs multierror.Errors
+	healthyInputs := map[string]*client.Unit{}
+	unitErrors := map[string][]error{}
+
+	// as the very last action, set the state of the failed units
+	defer func() {
+		for _, unit := range units {
+			errs := unitErrors[unit.ID()]
+			if len(errs) != 0 {
+				unit.UpdateState(client.UnitStateFailed, errors.Join(errs...).Error(), nil)
+			}
+		}
+	}()
 
 	for _, unit := range units {
 		expected := unit.Expected()
@@ -558,11 +573,11 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 			// unit is expected to update its feature flags
 			featuresCfg, err := features.NewConfigFromProto(expected.Features)
 			if err != nil {
-				errs = append(errs, err)
+				unitErrors[unit.ID()] = append(unitErrors[unit.ID()], err)
 			}
 
 			if err := features.UpdateFromConfig(featuresCfg); err != nil {
-				errs = append(errs, err)
+				unitErrors[unit.ID()] = append(unitErrors[unit.ID()], err)
 			}
 
 			cm.lastBeatFeaturesCfg = featuresCfg
@@ -584,6 +599,7 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 			outputUnit = unit
 		} else if unit.Type() == client.UnitTypeInput {
 			inputUnits = append(inputUnits, unit)
+			healthyInputs[unit.ID()] = unit
 		} else {
 			cm.logger.Errorf("unit %s as an unknown type %+v", unit.ID(), unit.Type())
 		}
@@ -605,24 +621,23 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 	}
 	if err != nil {
 		// Output creation failed, there is no point in going any further
-		// because there is no output read the events.
+		// because there is no output to read events.
 		//
 		// Trying to start inputs will eventually lead them to deadlock
 		// waiting for the output. Log input will deadlock when starting,
 		// effectively blocking this manager.
-		err = fmt.Errorf("could not start output: %w", err)
-		outputUnit.UpdateState(client.UnitStateFailed, err.Error(), nil)
-		cm.status = lbmanagement.Failed
-		cm.message = err.Error()
+		cm.logger.Errorw("could not start output", "error", err)
 
-		// If there are any other errors, set the status accordingly.
-		// If len(errs), then the there were no previous and the only
-		// error has been reported already.
-		if len(errs) > 0 {
-			errs = append(errs, err)
-			cm.message = fmt.Sprintf("%s", errs)
+		msg := fmt.Sprintf("could not start output: %s", err)
+		if err := outputUnit.UpdateState(client.UnitStateFailed, msg, nil); err != nil {
+			cm.logger.Errorw("setting output state", "error", err)
 		}
+
 		return
+	}
+
+	if err := outputUnit.UpdateState(client.UnitStateHealthy, "Healthy", nil); err != nil {
+		cm.logger.Errorw("setting output state", "error", err)
 	}
 
 	// compute the input configuration
@@ -630,7 +645,16 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 	// in v2 only a single input type will be started per component, so we don't need to
 	// worry about getting multiple re-loaders (we just need the one for the type)
 	if err := cm.reloadInputs(inputUnits); err != nil {
-		errs = append(errs, err)
+		merror := &multierror.MultiError{}
+		if errors.As(err, &merror) {
+			for _, err := range merror.Errors {
+				unitErr := cfgfile.UnitError{}
+				if errors.As(err, &unitErr) {
+					unitErrors[unitErr.UnitID] = append(unitErrors[unitErr.UnitID], unitErr.Err)
+					delete(healthyInputs, unitErr.UnitID)
+				}
+			}
+		}
 	}
 
 	// report the stopping units as stopped
@@ -638,26 +662,18 @@ func (cm *BeatV2Manager) reload(units map[unitKey]*client.Unit) {
 		_ = unit.UpdateState(client.UnitStateStopped, "Stopped", nil)
 	}
 
-	// any error during reload changes the whole state of the beat to failed
-	if len(errs) > 0 {
-		cm.status = lbmanagement.Failed
-		cm.message = fmt.Sprintf("%s", errs)
-	}
-
 	// now update the statuses of all units
-	cm.mx.Lock()
-	status := getUnitState(cm.status)
-	message := cm.message
-	payload := cm.payload
-	cm.mx.Unlock()
-	for _, unit := range units {
+	// if there isn't an error with the input, we set it as
+	// healthy because there is no way to know more information about it.
+	for _, unit := range healthyInputs {
 		expected := unit.Expected()
 		if expected.State == client.UnitStateStopped {
 			// unit is expected to be stopping (don't adjust the state as the state is now managed by the
 			// `reload` method and will be marked stopped in that code path)
 			continue
 		}
-		err := unit.UpdateState(status, message, payload)
+
+		err := unit.UpdateState(client.UnitStateHealthy, "Healthy", nil)
 		if err != nil {
 			cm.logger.Errorf("Failed to update unit %s status: %s", unit.ID(), err)
 		}
@@ -752,6 +768,7 @@ func (cm *BeatV2Manager) reloadInputs(inputUnits []*client.Unit) error {
 		// we want to add the diagnostic handler that's specific to the unit, and not the gobal diagnostic handler
 		for _, in := range inputCfg {
 			in.DiagCallback = diagnosticHandler{client: unit, log: cm.logger.Named("diagnostic-manager")}
+			in.InputUnitID = unit.ID()
 		}
 		inputCfgs[unit.ID()] = expected.Config
 		inputBeatCfgs = append(inputBeatCfgs, inputCfg...)


### PR DESCRIPTION
## What does this PR do?

This PR updates the ManagerV2 to set status per Unit based on its inputs. If any input on a Unit returns an error when starting the whole Unit is set as failed. If multiple inputs return an error, all errors are reported in the `Message` field.

If the output unit returns an error when starting, only the output Unit is set as failed. All other input unit states are not modified (this was the behaviour before this PR).

## Why is it important?

It allow users to better understand which unit has failed and which ones are working.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
- [x] I have made my commit title and message explanatory about the purpose and the reason of the change

~~## Author's Checklist~~
## How to test this PR locally
1. Build a development version of the Elastic-Agent
2. Build Filebeat from this PR (from the `x-pack` folder)
3. Replace Filebeat's binary from the Elastic-Agent `components` sub folder by the one you built
4. Run the Elastic-Agent with a standalone policy and two input units, one must contain an error (use the policy below)
5. Run the status command: `./elastic-agent status --output full`
6. Only one input unit must report as `FAILED`.

<details><summary>elastic-agent.yml</summary>
<p>

```yaml
outputs:
  default:
    type: elasticsearch
    hosts:
      - https://localhost:9200
    username: "elastic"
    password: "changeme"
    ssl.verification_mode: none


inputs:
  - type: filestream
    id: input-1
    streams:
      - id: filestream-input-id-stream-block
        data_stream:
          dataset: generic
        paths:
          - /var/log/*.log
  - type: filestream
    id: input-2
    streams:
      - id: filestream-input-id-stream-block
        data_stream:
          dataset: generic
        pathsBroken:
          - /var/log/*.log

agent.monitoring:
  enabled: false
  logs: false
  metrics: false
```

</p>
</details> 

<details><summary>Expected output</summary>
<p>

```
┌─ fleet
│  └─ status: (STOPPED) Not enrolled into Fleet
└─ elastic-agent
   ├─ status: (DEGRADED) 1 or more components/units in a failed state
   ├─ info
   │  ├─ id: dde03f6c-733d-420b-b9b5-075923d14b9b
   │  ├─ version: 8.10.0
   │  └─ commit: f2e4f71775af532b0e256287829df41b6fd8a962
   └─ filestream-default
      ├─ status: (HEALTHY) Healthy: communicating with pid '1664568'
      ├─ filestream-default
      │  ├─ status: (HEALTHY) Healthy
      │  └─ type: OUTPUT
      ├─ filestream-default-input-1
      │  ├─ status: (HEALTHY) Healthy
      │  └─ type: INPUT
      └─ filestream-default-input-2
         ├─ status: (FAILED) no path is configured accessing config
         └─ type: INPUT
```

</p>
</details> 

## Related issues

- Closes #35874

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~