### PR TITLE
fix flaky integration tests

### DIFF
--- a/libbeat/tests/integration/template_test.go
+++ b/libbeat/tests/integration/template_test.go
@@ -223,7 +223,9 @@ logging:
 	mockbeat.Start()
 	mockbeat.WaitForLogs("mockbeat start running.", 60*time.Second)
 	mockbeat.WaitForLogs("Template with name \\\"mockbeat-9.9.9\\\" loaded.", 20*time.Second)
-	mockbeat.WaitForLogs("PublishEvents: 1 events have been published", 20*time.Second)
+	require.Eventually(t, func() bool {
+		return mockbeat.LogMatch("PublishEvents: [[:digit:]]+ events have been published")
+	}, 20*time.Second, 100*time.Millisecond, "looking for PublishEvents")
 
 	status, body, err := HttpDo(t, http.MethodGet, indexURL)
 	require.NoError(t, err)
@@ -293,7 +295,9 @@ logging:
 	mockbeat.WriteConfigFile(cfg)
 	mockbeat.Start()
 	mockbeat.WaitForLogs("mockbeat start running.", 60*time.Second)
-	mockbeat.WaitForLogs("PublishEvents: 1 events have been published", 20*time.Second)
+	require.Eventually(t, func() bool {
+		return mockbeat.LogMatch("PublishEvents: [[:digit:]]+ events have been published")
+	}, 20*time.Second, 100*time.Millisecond, "looking for PublishEvents")
 
 	u := fmt.Sprintf("%s/_index_template/%s", esUrl.String(), datastream)
 	r, _ := http.Get(u)


### PR DESCRIPTION
## What does this PR do?

fixes flaky TestTemplateDefault and TestTemplateDisabled integration tests

- tests assumed 1 event published, could be multiple
- added LogMatch function to framework to allow use of regexp
- added some more debug info when tests fail, useful in CI where we don't always get the directory contents

## Why is it important?

croissants should be flaky, not tests

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~
- [x] I have made my commit title and message explanatory about the purpose and the reason of the change

## How to test this PR locally

```
cd libbeat
mage goIntegTest
```

## Related issues

- Closes #36177

## Example output during failure

```
=== Failed
=== FAIL: libbeat/tests/integration TestTemplateDefault (22.19s)
    template_test.go:226:
        	Error Trace:	/Users/hinman/src/beats/libbeat/tests/integration/template_test.go:226
        	Error:      	Condition never satisfied
        	Test:       	TestTemplateDefault
        	Messages:   	looking for PublishEvents
    framework.go:131: Last 0 bytes of stderr:
    framework.go:137: Last 0 bytes of stdout:
    framework.go:146: Last 2325 bytes of /Users/hinman/src/beats/libbeat/build/integration-tests/TestTemplateDefault-1691078913/mockbeat-20230803.ndjson:
        "log.level":"debug","@timestamp":"2023-08-03T11:08:54.489-0500","log.logger":"elasticsearch","log.origin":{"file.name":"elasticsearch/client.go","file.line":264},"message":"PublishEvents: 2 events have been published to elasticsearch in 16.095375ms.","service.name":"mockbeat","ecs.version":"1.6.0"}
        {"log.level":"debug","@timestamp":"2023-08-03T11:08:54.489-0500","log.logger":"publisher","log.origin":{"file.name":"memqueue/ackloop.go","file.line":81},"message":"ackloop: return ack to broker loop:2","service.name":"mockbeat","ecs.version":"1.6.0"}
        {"log.level":"debug","@timestamp":"2023-08-03T11:08:54.489-0500","log.logger":"publisher","log.origin":{"file.name":"memqueue/ackloop.go","file.line":83},"message":"ackloop:  done send ack","service.name":"mockbeat","ecs.version":"1.6.0"}
        {"log.level":"debug","@timestamp":"2023-08-03T11:08:55.473-0500","log.logger":"processors","log.origin":{"file.name":"processing/processors.go","file.line":213},"message":"Publish event: {\n  \"@timestamp\": \"2023-08-03T16:08:55.472Z\",\n  \"@metadata\": {\n    \"beat\": \"mockbeat\",\n    \"type\": \"_doc\",\n    \"version\": \"9.9.9\"\n  },\n  \"message\": \"Mockbeat is alive!\",\n  \"ecs\": {\n    \"version\": \"8.0.0\"\n  },\n  \"host\": {\n    \"name\": \"elastic2\"\n  },\n  \"agent\": {\n    \"id\": \"0502d227-5202-4b68-940b-d64fbdb04dcb\",\n    \"name\": \"elastic2\",\n    \"type\": \"mockbeat\",\n    \"version\": \"9.9.9\",\n    \"ephemeral_id\": \"5a5a37e4-a9f6-459c-94e8-c5acbcaf668e\"\n  },\n  \"type\": \"mock\"\n}","service.name":"mockbeat","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2023-08-03T11:08:55.562-0500","log.logger":"service","log.origin":{"file.name":"service/service.go","file.line":52},"message":"Received signal \"interrupt\", stopping","service.name":"mockbeat","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2023-08-03T11:08:55.563-0500","log.logger":"mock","log.origin":{"file.name":"mock/mockbeat.go","file.line":82},"message":"Mockbeat Stop","service.name":"mockbeat","ecs.version":"1.6.0"}
        {"log.level":"debug","@timestamp":"2023-08-03T11:08:55.563-0500","log.origin":{"file.name":"numcpu/numcpu.go","file.line":41},"message":"Accurate CPU counts not available on platform, falling back to runtime.NumCPU for metrics","service.name":"mockbeat","ecs.version":"1.6.0"}
    framework.go:421: Temporary directory saved: /Users/hinman/src/beats/libbeat/build/integration-tests/TestTemplateDefault-1691078913
```	