### PR TITLE
[Heartbeat] Deprecate aws_elb provider

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -313,6 +313,8 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 
 *Heartbeat*
 
+- Deprecate aws_elb autodiscover provider. {pull}36191[36191]
+
 
 *Metricbeat*
 

--- a/libbeat/docs/shared-autodiscover.asciidoc
+++ b/libbeat/docs/shared-autodiscover.asciidoc
@@ -371,9 +371,9 @@ endif::autodiscoverJolokia[]
 
 ifdef::autodiscoverAWSELB[]
 [float]
-===== Amazon ELBs
+===== Amazon ELBs (Deprecated)
 
-*Note: This provider is experimental*
+*Note: This provider is now deprecated and will be removed in a future release.*
 
 The Amazon ELB autodiscover provider discovers https://aws.amazon.com/elasticloadbalancing/[ELBs] and their listeners. This is useful when you don't want to connect
 directly to a service, but rather to the ELB fronting a pool of services.

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -44,7 +44,7 @@ func AutodiscoverBuilder(
 	c *conf.C,
 	keystore keystore.Keystore,
 ) (autodiscover.Provider, error) {
-	cfgwarn.Experimental("aws_elb autodiscover is experimental")
+	cfgwarn.Deprecate("8.11.0", "aws_elb autodiscover is now deprecated.")
 
 	config := awsauto.DefaultConfig()
 	err := c.Unpack(&config)

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -44,7 +44,7 @@ func AutodiscoverBuilder(
 	c *conf.C,
 	keystore keystore.Keystore,
 ) (autodiscover.Provider, error) {
-	cfgwarn.Deprecate("8.11.0", "aws_elb autodiscover is now deprecated.")
+	cfgwarn.Deprecate("", "aws_elb autodiscover is now deprecated and will be removed in a future release.")
 
 	config := awsauto.DefaultConfig()
 	err := c.Unpack(&config)

--- a/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
+++ b/x-pack/libbeat/autodiscover/providers/aws/elb/provider.go
@@ -80,7 +80,7 @@ func AutodiscoverBuilder(
 		config.Regions = completeRegionsList
 	}
 
-	var clients []autodiscoverElbClient
+	clients := make([]autodiscoverElbClient, 0, len(config.Regions))
 	for _, region := range config.Regions {
 		awsCfg, err := awscommon.InitializeAWSConfig(awscommon.ConfigAWS{
 			AccessKeyID:     config.AWSConfig.AccessKeyID,


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds deprecation notice to aws_elb provider:
```
DEPRECATED: aws_elb autodiscover is now deprecated and will be removed in a future release.
```

Closes #29782.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
- [x] I have made my commit title and message explanatory about the purpose and the reason of the change

## How to test this PR locally

1. Set up aws_elb provider:
```
heartbeat.autodiscover:
  providers:
  - type: aws_elb
    period: 1m
    regions: ["us-east-1", "us-east-2"]
    access_key_id: my-access-key
    secret_access_key: my-secret-access-key
    templates:
    - condition:
        equals.port: 8080
      config:
      - type: tcp
        hosts: ["${data.host}:${data.port}"]
        schedule: "@every 5s"
        timeout: 1s
```
2. Look for deprecation notice:
```
{"log.level":"warn","@timestamp":"2023-08-01T11:16:19.092+0200","log.logger":"cfgwarn","log.origin":{"file.name":"elb/provider.go","file.line":47},"message":"DEPRECATED: aws_elb autodiscover is now deprecated and will be removed in a future release.","service.name":"heartbeat","ecs.version":"1.6.0"}
```
