### PR TITLE
[Heartbeat] Add default TZ to heartbeat docker images

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -134,6 +134,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 - Fix temp dir running out of space with project monitors. {issue}35843[35843]
 - Fixing the grok expression outputs of log files {pull}35221[35221]
 - Enable heartbeat-wide publish timeout setting with run_once. {pull}35721[35721]
+- Added default timezone UTC to heartbeat docker images to fix synthetics journeys navigation errors. {pull}36193[36193]
 
 *Heartbeat*
 

--- a/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -121,6 +121,7 @@ RUN echo \
 
 # Setup synthetics env vars
 ENV ELASTIC_SYNTHETICS_CAPABLE=true
+ENV TZ=UTC
 ENV SUITES_DIR={{ $beatHome }}/suites
 ENV NODE_VERSION=18.16.0
 ENV PATH="$NODE_PATH/node/bin:$PATH"


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Fizes https://github.com/elastic/beats/issues/36117. Add default TZ value to fix synthetic journeys for timezone-triggered errors.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Unspecified timezone values can cause navigation errors on synthetics journeys.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
- [x] I have made my commit title and message explanatory about the purpose and the reason of the change

## How to test this PR locally

1. Build heartbeat docker image locally.
2. Create a journey that navigates to a Kibana URL.
3. Wait for Kibana login page to load properly.

