### PR TITLE
Restart Beat after install on deb package

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -61,6 +61,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Eliminate cloning of event in deepUpdate {pull}35945[35945]
 - Fix ndjson parser to store JSON fields correctly under `target` {issue}29395[29395]
 - Support build of projects outside of beats directory {pull}36126[36126]
+- After upgrade the deb package now restarts the Beat service {issue}34089[34089] {pull}36201[36201]
 
 
 

--- a/dev-tools/packaging/files/linux/systemd-daemon-reload.sh
+++ b/dev-tools/packaging/files/linux/systemd-daemon-reload.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-systemctl daemon-reload 2> /dev/null
-exit 0

--- a/dev-tools/packaging/packages.yml
+++ b/dev-tools/packaging/packages.yml
@@ -19,7 +19,7 @@ shared:
   # Deb/RPM spec for community beats.
   - &deb_rpm_spec
     <<: *common
-    post_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/files/linux/systemd-daemon-reload.sh'
+    post_install_script: '{{ elastic_beats_dir }}/dev-tools/packaging/templates/deb/postinstall.sh.tmpl'
     files:
       /usr/share/{{.BeatName}}/bin/{{.BeatName}}{{.BinaryExt}}:
         source: build/golang-crossbuild/{{.BeatName}}-{{.GOOS}}-{{.Platform.Arch}}{{.BinaryExt}}

--- a/dev-tools/packaging/templates/deb/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/deb/postinstall.sh.tmpl
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+systemctl daemon-reload 2> /dev/null
+systemctl is-active {{.BeatName}} --quiet && systemctl start {{.BeatName}}
+exit 0
+

--- a/dev-tools/packaging/templates/deb/postinstall.sh.tmpl
+++ b/dev-tools/packaging/templates/deb/postinstall.sh.tmpl
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/sh
 
 systemctl daemon-reload 2> /dev/null
-systemctl is-active {{.BeatName}} --quiet && systemctl start {{.BeatName}}
+systemctl is-active {{.BeatName}} --quiet && systemctl restart {{.BeatName}}
 exit 0
 


### PR DESCRIPTION
## What does this PR do?

This commit restarts the Beat after the deb package is installed. When upgrading a Beat via deb packages this is required for the new version to start running.

The post install script checks whether the Beat is running, if so, then it restarts the service.


## Why is it important?

- Closes https://github.com/elastic/beats/issues/34089

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
- [x] I have made my commit title and message explanatory about the purpose and the reason of the change

~~## Author's Checklist~~

## How to test this PR locally

1. Get a Debian box (like the `debian10` vagrant VM on this repo)
2. Download and install any deb package from Filebeat < 8.10.0
3. Get a Stack deployment (like elastic-package, Elastic Cloud, etc)
4. Configure Filebeat to ingest some logs (see script below)
5. Start the filebeat service: `systemctl start filebeat`
6. Package this branch as deb: `PACKAGES=deb PLATFORMS=linux/amd64 mage package`
7. Copy `build/distributions/filebeat-oss-8.10.0-amd64.deb` to your Debian box
8. Install it `sudo dpkg -i filebeat-oss-8.10.0-amd64.deb`
9. Ensure Filebeat restarted and the logs are now sent by the new version. You can do it in Kibana by selecting the fields `message` and `agent.version` in "Discover"

Script to generate logs:
```bash
#!/bin/bash

i=0
while true
do
    let i++
    data="$(date) - $i"
    echo $data >> /tmp/log.log
    sleep 1
done
```

## Related issues

- Closes https://github.com/elastic/beats/issues/34089

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~