### PR TITLE
Clarify that early_limit cannot be modified within the Okta module

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,6 +16,7 @@ https://github.com/elastic/beats/compare/v8.8.2\...v8.9.0[View commits]
 
 *Filebeat*
 
+- Improve documentation for Okta module. {pull}36211[36211]
 - Add support in s3 input for JSON with array of objects. {pull}35475[35475]
 - RFC5424 syslog timestamps with offset 'Z' will be treated as UTC rather than using the default timezone. {pull}35360[35360]
 - Fixed a minor code error in the GCS input scheduler where a config value was being used directly instead of the source struct. {pull}35729[35729]

--- a/x-pack/filebeat/module/okta/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/okta/_meta/docs.asciidoc
@@ -99,14 +99,8 @@ An initial interval can be defined. The first time the module starts, will fetch
 
 *`input.request.rate_limit.early_limit`*::
 
-You can override the default rate-limiting behavior in <<filebeat-input-httpjson>>.
-The default for the Okta module is to use up to 89% of the Okta rate-limit,
-which should avoid Okta Warnings on rate-limit usage.
-+
-[source.yaml]
-----
-    input.request.rate_limit.early_limit: 0.89
-----
+The Okta module will use up to 89% of the Okta rate-limit,
+which should avoid Okta Warnings on rate-limit usage. This value cannot be modified. 
 
 [float]
 === Example dashboard


### PR DESCRIPTION
## What does this PR do?

The early_limit has a [hardcoded value](https://github.com/elastic/beats/blob/main/x-pack/filebeat/module/okta/system/config/input.yml#L25) set to .89. This change updates our documentation to clarify that this value cannot be modified. 

## Why is it important?

The current version of the documentation notes that a user can override the default rate-limiting behavior. However, since this value has been hardcoded within this module it cannot be overridden. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
- [x] I have made my commit title and message explanatory about the purpose and the reason of the change

