### PR TITLE
Allow manually triggering the golang bump

### DIFF
--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -2,6 +2,7 @@
 name: bump-golang
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 20 * * 6"
 


### PR DESCRIPTION
Add on.[workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) to allow manually triggering the golang version bump action, in addition to running it on a fixed schedule.