### PR TITLE
Fix the 7.17 Go version bump script.

### DIFF
--- a/.ci/bump-golang-7.17.yml
+++ b/.ci/bump-golang-7.17.yml
@@ -12,7 +12,7 @@ scms:
       repository: beats
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: 7.17
+      branch: "7.17"
 
 actions:
   beats:


### PR DESCRIPTION
Need to quote 7.17 so it is interpreted as a string and not a float.

