### PR TITLE
filebeat/input/{tcp,udp}: fix resolution of device address during metric initialisation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -110,6 +110,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Make CEL input's `now` global variable static for evaluation lifetime. {pull}36107[36107]
 - Update mito CEL extension library to v1.5.0. {pull}36146[36146]
 - Filter out duplicate paths resolved from matching globs. {issue}36253[36253] {pull}36256[36256]
+- Fix handling of TCP/UDP address resolution during metric initialization. {issue}35064[35064] {pull}36287[36287]
 
 *Heartbeat*
 

--- a/filebeat/input/internal/procnet/procnet.go
+++ b/filebeat/input/internal/procnet/procnet.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package procnet provides support for obtaining and formatting /proc/net
+// network addresses for linux systems.
+package procnet
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// Addrs returns the linux /proc/net/tcp or /proc/net/udp addresses for the
+// provided host address, addr. addr is a host:port address and host may be
+// an IPv4 or IPv6 address, or an FQDN for the host. The returned slices
+// contain the string representations of the address as they would appear in
+// the /proc/net tables.
+func Addrs(addr string, log *logp.Logger) (addr4, addr6 []string, err error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get address for %s: could not split host and port: %w", addr, err)
+	}
+	ip, err := net.LookupIP(host)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get address for %s: %w", addr, err)
+	}
+	pn, err := strconv.ParseInt(port, 10, 16)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get port for %s: %w", addr, err)
+	}
+	addr4 = make([]string, 0, len(ip))
+	addr6 = make([]string, 0, len(ip))
+	for _, p := range ip {
+		// Ensure the length of the net.IP is canonicalised to the standard
+		// length for the format, as the net package may return IPv4 addresses
+		// as the IPv6 form ::ffff:wwxxyyzz. So if we only compare len(p) to
+		// the len constants all addresses may appear to be IPv6.
+		switch {
+		case len(p.To4()) == net.IPv4len:
+			addr4 = append(addr4, IPv4(p, int(pn)))
+		case len(p.To16()) == net.IPv6len:
+			addr6 = append(addr6, IPv6(p, int(pn)))
+		default:
+			log.Warnf("unexpected addr length %d for %s", len(p), p)
+		}
+	}
+	return addr4, addr6, nil
+}
+
+// IPv4 returns the string representation of an IPv4 address in a /proc/net table.
+func IPv4(ip net.IP, port int) string {
+	return fmt.Sprintf("%08X:%04X", reverse(ip.To4()), port)
+}
+
+// IPv6 returns the string representation of an IPv6 address in a /proc/net table.
+func IPv6(ip net.IP, port int) string {
+	return fmt.Sprintf("%032X:%04X", reverse(ip.To16()), port)
+}
+
+func reverse(b []byte) []byte {
+	c := make([]byte, len(b))
+	for i, e := range b {
+		c[len(b)-1-i] = e
+	}
+	return c
+}

--- a/filebeat/input/internal/procnet/procnet_test.go
+++ b/filebeat/input/internal/procnet/procnet_test.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package procnet
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestAddrs(t *testing.T) {
+	t.Run("ipv4", func(t *testing.T) {
+		addr4, addr6, err := Addrs("0.0.0.0:9001", logp.L())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(addr4) == 0 {
+			t.Errorf("expected addr in addr4 for IPv4 address: %v", addr6)
+		}
+		if len(addr6) != 0 {
+			t.Errorf("unexpected addrs in addr6 for IPv4 address: %v", addr6)
+		}
+	})
+
+	t.Run("ipv6", func(t *testing.T) {
+		addr4, addr6, err := Addrs("[::]:9001", logp.L())
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(addr4) != 0 {
+			t.Errorf("expected addr in addr4 for IPv4 address: %v", addr6)
+		}
+		if len(addr6) == 0 {
+			t.Errorf("unexpected addrs in addr6 for IPv4 address: %v", addr6)
+		}
+	})
+}

--- a/filebeat/input/tcp/input.go
+++ b/filebeat/input/tcp/input.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/rcrowley/go-metrics"
 
+	"github.com/elastic/beats/v7/filebeat/input/internal/procnet"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
 	"github.com/elastic/beats/v7/filebeat/inputsource"
@@ -195,54 +196,16 @@ func newInputMetrics(id, device string, poll time.Duration, log *logp.Logger) *i
 	out.device.Set(device)
 
 	if poll > 0 && runtime.GOOS == "linux" {
-		host, port, err := net.SplitHostPort(device)
+		addr4, addr6, err := procnet.Addrs(device, log)
 		if err != nil {
-			log.Warnf("failed to get address for %s: could not split host and port:", err)
+			log.Warn(err)
 			return out
-		}
-		ip, err := net.LookupIP(host)
-		if err != nil {
-			log.Warnf("failed to get address for %s: %v", device, err)
-			return out
-		}
-		pn, err := strconv.ParseInt(port, 10, 16)
-		if err != nil {
-			log.Warnf("failed to get port for %s: %v", device, err)
-			return out
-		}
-		addr := make([]string, 0, len(ip))
-		addr6 := make([]string, 0, len(ip))
-		for _, p := range ip {
-			switch len(p) {
-			case net.IPv4len:
-				addr = append(addr, ipv4KernelAddr(p, int(pn)))
-			case net.IPv6len:
-				addr6 = append(addr6, ipv6KernelAddr(p, int(pn)))
-			default:
-				log.Warnf("unexpected addr length %d for %s", len(p), p)
-			}
 		}
 		out.done = make(chan struct{})
-		go out.poll(addr, addr6, poll, log)
+		go out.poll(addr4, addr6, poll, log)
 	}
 
 	return out
-}
-
-func ipv4KernelAddr(ip net.IP, port int) string {
-	return fmt.Sprintf("%08X:%04X", reverse(ip.To4()), port)
-}
-
-func ipv6KernelAddr(ip net.IP, port int) string {
-	return fmt.Sprintf("%032X:%04X", reverse(ip.To16()), port)
-}
-
-func reverse(b []byte) []byte {
-	c := make([]byte, len(b))
-	for i, e := range b {
-		c[len(b)-1-i] = e
-	}
-	return c
 }
 
 // log logs metric for the given packet.

--- a/filebeat/input/tcp/input_test.go
+++ b/filebeat/input/tcp/input_test.go
@@ -22,13 +22,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/filebeat/input/internal/procnet"
 )
 
 func TestProcNetTCP(t *testing.T) {
 	t.Run("IPv4", func(t *testing.T) {
 		path := "testdata/proc_net_tcp.txt"
 		t.Run("with_match", func(t *testing.T) {
-			addr := []string{ipv4KernelAddr(net.IP{0x7f, 0x00, 0x00, 0x01}, 0x17ac)}
+			addr := []string{procnet.IPv4(net.IP{0x7f, 0x00, 0x00, 0x01}, 0x17ac)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -39,7 +41,7 @@ func TestProcNetTCP(t *testing.T) {
 		})
 
 		t.Run("leading_zero", func(t *testing.T) {
-			addr := []string{ipv4KernelAddr(net.IP{0x00, 0x7f, 0x01, 0x00}, 0x17af)}
+			addr := []string{procnet.IPv4(net.IP{0x00, 0x7f, 0x01, 0x00}, 0x17af)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -50,7 +52,7 @@ func TestProcNetTCP(t *testing.T) {
 		})
 
 		t.Run("unspecified", func(t *testing.T) {
-			addr := []string{ipv4KernelAddr(net.ParseIP("0.0.0.0"), 0x17ac)}
+			addr := []string{procnet.IPv4(net.ParseIP("0.0.0.0"), 0x17ac)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -62,8 +64,8 @@ func TestProcNetTCP(t *testing.T) {
 
 		t.Run("without_match", func(t *testing.T) {
 			addr := []string{
-				ipv4KernelAddr(net.IP{0xde, 0xad, 0xbe, 0xef}, 0xf00d),
-				ipv4KernelAddr(net.IP{0xba, 0x1d, 0xfa, 0xce}, 0x1135),
+				procnet.IPv4(net.IP{0xde, 0xad, 0xbe, 0xef}, 0xf00d),
+				procnet.IPv4(net.IP{0xba, 0x1d, 0xfa, 0xce}, 0x1135),
 			}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			_, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)
@@ -87,7 +89,7 @@ func TestProcNetTCP(t *testing.T) {
 	t.Run("IPv6", func(t *testing.T) {
 		path := "testdata/proc_net_tcp6.txt"
 		t.Run("with_match", func(t *testing.T) {
-			addr := []string{ipv6KernelAddr(net.IP{0: 0x7f, 3: 0x01, 15: 0}, 0x17ac)}
+			addr := []string{procnet.IPv6(net.IP{0: 0x7f, 3: 0x01, 15: 0}, 0x17ac)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -98,7 +100,7 @@ func TestProcNetTCP(t *testing.T) {
 		})
 
 		t.Run("leading_zero", func(t *testing.T) {
-			addr := []string{ipv6KernelAddr(net.IP{1: 0x7f, 2: 0x01, 15: 0}, 0x17af)}
+			addr := []string{procnet.IPv6(net.IP{1: 0x7f, 2: 0x01, 15: 0}, 0x17af)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -109,7 +111,7 @@ func TestProcNetTCP(t *testing.T) {
 		})
 
 		t.Run("unspecified", func(t *testing.T) {
-			addr := []string{ipv6KernelAddr(net.ParseIP("[::]"), 0x17ac)}
+			addr := []string{procnet.IPv6(net.ParseIP("[::]"), 0x17ac)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -121,8 +123,8 @@ func TestProcNetTCP(t *testing.T) {
 
 		t.Run("without_match", func(t *testing.T) {
 			addr := []string{
-				ipv6KernelAddr(net.IP{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef}, 0xf00d),
-				ipv6KernelAddr(net.IP{0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce}, 0x1135),
+				procnet.IPv6(net.IP{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef}, 0xf00d),
+				procnet.IPv6(net.IP{0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce}, 0x1135),
 			}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			_, err := procNetTCP(path, addr, hasUnspecified, addrIsUnspecified)

--- a/filebeat/input/udp/input.go
+++ b/filebeat/input/udp/input.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/rcrowley/go-metrics"
 
+	"github.com/elastic/beats/v7/filebeat/input/internal/procnet"
 	input "github.com/elastic/beats/v7/filebeat/input/v2"
 	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
 	"github.com/elastic/beats/v7/filebeat/inputsource"
@@ -188,54 +189,16 @@ func newInputMetrics(id, device string, buflen uint64, poll time.Duration, log *
 	out.bufferLen.Set(buflen)
 
 	if poll > 0 && runtime.GOOS == "linux" {
-		host, port, err := net.SplitHostPort(device)
+		addr, addr6, err := procnet.Addrs(device, log)
 		if err != nil {
-			log.Warnf("failed to get address for %s: could not split host and port:", err)
+			log.Warn(err)
 			return out
-		}
-		ip, err := net.LookupIP(host)
-		if err != nil {
-			log.Warnf("failed to get address for %s: %v", device, err)
-			return out
-		}
-		pn, err := strconv.ParseInt(port, 10, 16)
-		if err != nil {
-			log.Warnf("failed to get port for %s: %v", device, err)
-			return out
-		}
-		addr := make([]string, 0, len(ip))
-		addr6 := make([]string, 0, len(ip))
-		for _, p := range ip {
-			switch len(p) {
-			case net.IPv4len:
-				addr = append(addr, ipv4KernelAddr(p, int(pn)))
-			case net.IPv6len:
-				addr6 = append(addr6, ipv6KernelAddr(p, int(pn)))
-			default:
-				log.Warnf("unexpected addr length %d for %s", len(p), p)
-			}
 		}
 		out.done = make(chan struct{})
 		go out.poll(addr, addr6, poll, log)
 	}
 
 	return out
-}
-
-func ipv4KernelAddr(ip net.IP, port int) string {
-	return fmt.Sprintf("%08X:%04X", reverse(ip.To4()), port)
-}
-
-func ipv6KernelAddr(ip net.IP, port int) string {
-	return fmt.Sprintf("%032X:%04X", reverse(ip.To16()), port)
-}
-
-func reverse(b []byte) []byte {
-	c := make([]byte, len(b))
-	for i, e := range b {
-		c[len(b)-1-i] = e
-	}
-	return c
 }
 
 // log logs metric for the given packet.

--- a/filebeat/input/udp/input_test.go
+++ b/filebeat/input/udp/input_test.go
@@ -22,13 +22,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/filebeat/input/internal/procnet"
 )
 
 func TestProcNetUDP(t *testing.T) {
 	t.Run("IPv4", func(t *testing.T) {
 		path := "testdata/proc_net_udp.txt"
 		t.Run("with_match", func(t *testing.T) {
-			addr := []string{ipv4KernelAddr(net.IP{0x0a, 0x64, 0x08, 0x25}, 0x1bbe)}
+			addr := []string{procnet.IPv4(net.IP{0x0a, 0x64, 0x08, 0x25}, 0x1bbe)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, drops, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -40,7 +42,7 @@ func TestProcNetUDP(t *testing.T) {
 		})
 
 		t.Run("leading_zero", func(t *testing.T) {
-			addr := []string{ipv4KernelAddr(net.IP{0x00, 0x7f, 0x01, 0x00}, 0x1eef)}
+			addr := []string{procnet.IPv4(net.IP{0x00, 0x7f, 0x01, 0x00}, 0x1eef)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, drops, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -52,7 +54,7 @@ func TestProcNetUDP(t *testing.T) {
 		})
 
 		t.Run("unspecified", func(t *testing.T) {
-			addr := []string{ipv4KernelAddr(net.ParseIP("0.0.0.0"), 0x1bbe)}
+			addr := []string{procnet.IPv4(net.ParseIP("0.0.0.0"), 0x1bbe)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, drops, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -65,8 +67,8 @@ func TestProcNetUDP(t *testing.T) {
 
 		t.Run("without_match", func(t *testing.T) {
 			addr := []string{
-				ipv4KernelAddr(net.IP{0xde, 0xad, 0xbe, 0xef}, 0xf00d),
-				ipv4KernelAddr(net.IP{0xba, 0x1d, 0xfa, 0xce}, 0x1135),
+				procnet.IPv4(net.IP{0xde, 0xad, 0xbe, 0xef}, 0xf00d),
+				procnet.IPv4(net.IP{0xba, 0x1d, 0xfa, 0xce}, 0x1135),
 			}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			_, _, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)
@@ -90,7 +92,7 @@ func TestProcNetUDP(t *testing.T) {
 	t.Run("IPv6", func(t *testing.T) {
 		path := "testdata/proc_net_udp6.txt"
 		t.Run("with_match", func(t *testing.T) {
-			addr := []string{ipv6KernelAddr(net.IP{0: 0x7f, 3: 0x01, 15: 0}, 0x1bbd)}
+			addr := []string{procnet.IPv6(net.IP{0: 0x7f, 3: 0x01, 15: 0}, 0x1bbd)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, drops, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -102,7 +104,7 @@ func TestProcNetUDP(t *testing.T) {
 		})
 
 		t.Run("leading_zero", func(t *testing.T) {
-			addr := []string{ipv6KernelAddr(net.IP{1: 0x7f, 2: 0x81, 15: 0}, 0x1eef)}
+			addr := []string{procnet.IPv6(net.IP{1: 0x7f, 2: 0x81, 15: 0}, 0x1eef)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, drops, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -114,7 +116,7 @@ func TestProcNetUDP(t *testing.T) {
 		})
 
 		t.Run("unspecified", func(t *testing.T) {
-			addr := []string{ipv6KernelAddr(net.ParseIP("[::]"), 0x1bbd)}
+			addr := []string{procnet.IPv6(net.ParseIP("[::]"), 0x1bbd)}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			rx, drops, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)
 			if err != nil {
@@ -127,8 +129,8 @@ func TestProcNetUDP(t *testing.T) {
 
 		t.Run("without_match", func(t *testing.T) {
 			addr := []string{
-				ipv6KernelAddr(net.IP{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef}, 0xf00d),
-				ipv6KernelAddr(net.IP{0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce}, 0x1135),
+				procnet.IPv6(net.IP{0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef}, 0xf00d),
+				procnet.IPv6(net.IP{0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce, 0xba, 0x1d, 0xfa, 0xce}, 0x1135),
 			}
 			hasUnspecified, addrIsUnspecified, bad := containsUnspecifiedAddr(addr)
 			_, _, err := procNetUDP(path, addr, hasUnspecified, addrIsUnspecified)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The net package may return IPv4 addresses as an `IPv6len` `net.IP` value with a ::ffff: prefix before the four IPv4 octets[1]. This means that we may incorrectly assign all addresses to the IPv6 class rather than to the IPv4 class that is expected. This results in loss of metrics for the input and confusing warnings complaining about an absent address in /proc/net/{tcp,udp}6.

Fix this by using the `To4` and `To16` methods which are guaranteed to return a `net.IP` that is the expected length for the class and compare against that length.

[1]https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/ip.go;l=62


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] New tests fail without the use of the `To4` method.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #35064 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
