### PR TITLE
auditbeat/module/file_integrity: add support for selinux and posix_acl_access xattrs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -221,6 +221,7 @@ automatic splitting at root level, if root level element is an array. {pull}3415
 
 *Auditbeat*
 
+- Add support for `security.selinux` and `system.posix_acl_access` extended attributes to FIM. {issue}36265[36265] {pull}36310[36310]
 
 *Filebeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -21271,6 +21271,41 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/pkg/xattr
+Version: v0.4.9
+Licence type (autodetected): BSD-2-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/pkg/xattr@v0.4.9/LICENSE:
+
+Copyright (c) 2012 Dave Cheney. All rights reserved.
+Copyright (c) 2014 Kuba Podgórski. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/pmezard/go-difflib
 Version: v1.0.0
 Licence type (autodetected): BSD-3-Clause

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -23,7 +23,6 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
-	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -328,7 +327,7 @@ func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {
 			file["selinux"] = info.SELinux
 		}
 		if info.POSIXACLAccess != "" {
-			a, err := aclText(info.POSIXACLAccess)
+			a, err := aclText([]byte(info.POSIXACLAccess))
 			if err == nil {
 				file["posix_acl_access"] = a
 			}
@@ -370,11 +369,7 @@ func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {
 	return out
 }
 
-func aclText(s string) ([]string, error) {
-	b, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(s, "0s"))
-	if err != nil {
-		return nil, err
-	}
+func aclText(b []byte) ([]string, error) {
 	if (len(b)-4)%8 != 0 {
 		return nil, fmt.Errorf("unexpected ACL length: %d", len(b))
 	}

--- a/auditbeat/module/file_integrity/event.go
+++ b/auditbeat/module/file_integrity/event.go
@@ -127,20 +127,22 @@ type Event struct {
 
 // Metadata contains file metadata.
 type Metadata struct {
-	Inode  uint64      `json:"inode"`
-	UID    uint32      `json:"uid"`
-	GID    uint32      `json:"gid"`
-	SID    string      `json:"sid"`
-	Owner  string      `json:"owner"`
-	Group  string      `json:"group"`
-	Size   uint64      `json:"size"`
-	MTime  time.Time   `json:"mtime"`  // Last modification time.
-	CTime  time.Time   `json:"ctime"`  // Last metadata change time.
-	Type   Type        `json:"type"`   // File type (dir, file, symlink).
-	Mode   os.FileMode `json:"mode"`   // Permissions
-	SetUID bool        `json:"setuid"` // setuid bit (POSIX only)
-	SetGID bool        `json:"setgid"` // setgid bit (POSIX only)
-	Origin []string    `json:"origin"` // External origin info for the file (MacOS only)
+	Inode          uint64      `json:"inode"`
+	UID            uint32      `json:"uid"`
+	GID            uint32      `json:"gid"`
+	SID            string      `json:"sid"`
+	Owner          string      `json:"owner"`
+	Group          string      `json:"group"`
+	Size           uint64      `json:"size"`
+	MTime          time.Time   `json:"mtime"`            // Last modification time.
+	CTime          time.Time   `json:"ctime"`            // Last metadata change time.
+	Type           Type        `json:"type"`             // File type (dir, file, symlink).
+	Mode           os.FileMode `json:"mode"`             // Permissions
+	SetUID         bool        `json:"setuid"`           // setuid bit (POSIX only)
+	SetGID         bool        `json:"setgid"`           // setgid bit (POSIX only)
+	Origin         []string    `json:"origin"`           // External origin info for the file (MacOS only)
+	SELinux        string      `json:"selinux"`          // security.selinux xattr value (Linux only)
+	POSIXACLAccess string      `json:"posix_acl_access"` // system.posix_acl_access xattr value (Linux only)
 }
 
 // NewEventFromFileInfo creates a new Event based on data from a os.FileInfo
@@ -332,14 +334,14 @@ func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {
 		file[k] = v
 	}
 
-	out.MetricSetFields.Put("event.kind", "event")              //nolint:errcheck // Will not error.
-	out.MetricSetFields.Put("event.category", []string{"file"}) //nolint:errcheck // Will not error.
+	out.MetricSetFields.Put("event.kind", "event")
+	out.MetricSetFields.Put("event.category", []string{"file"})
 	if e.Action > 0 {
 		actions := e.Action.InOrder(existedBefore, e.Info != nil)
-		out.MetricSetFields.Put("event.type", actions.ECSTypes())      //nolint:errcheck // Will not error.
-		out.MetricSetFields.Put("event.action", actions.StringArray()) //nolint:errcheck // Will not error.
+		out.MetricSetFields.Put("event.type", actions.ECSTypes())
+		out.MetricSetFields.Put("event.action", actions.StringArray())
 	} else {
-		out.MetricSetFields.Put("event.type", None.ECSTypes()) //nolint:errcheck // Will not error.
+		out.MetricSetFields.Put("event.type", None.ECSTypes())
 	}
 
 	if n := len(e.errors); n > 0 {
@@ -348,9 +350,9 @@ func buildMetricbeatEvent(e *Event, existedBefore bool) mb.Event {
 			errors[idx] = err.Error()
 		}
 		if n == 1 {
-			out.MetricSetFields.Put("error.message", errors[0]) //nolint:errcheck // Will not error.
+			out.MetricSetFields.Put("error.message", errors[0])
 		} else {
-			out.MetricSetFields.Put("error.message", errors) //nolint:errcheck // Will not error.
+			out.MetricSetFields.Put("error.message", errors)
 		}
 	}
 	return out

--- a/auditbeat/module/file_integrity/fileinfo_posix.go
+++ b/auditbeat/module/file_integrity/fileinfo_posix.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 
 	"github.com/joeshaw/multierror"
+	"github.com/pkg/xattr"
 )
 
 // NewMetadata returns a new Metadata object. If an error is returned it is
@@ -67,6 +68,11 @@ func NewMetadata(path string, info os.FileInfo) (*Metadata, error) {
 		fileInfo.Owner = owner.Username
 	}
 
+	getExtendedAttributes(path, map[string]*string{
+		"security.selinux":        &fileInfo.SELinux,
+		"system.posix_acl_access": &fileInfo.POSIXACLAccess,
+	})
+
 	group, err := user.LookupGroupId(strconv.Itoa(int(fileInfo.GID)))
 	if err != nil {
 		errs = append(errs, err)
@@ -77,4 +83,20 @@ func NewMetadata(path string, info os.FileInfo) (*Metadata, error) {
 		errs = append(errs, err)
 	}
 	return fileInfo, errs.Err()
+}
+
+func getExtendedAttributes(path string, dst map[string]*string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	for n, d := range dst {
+		att, err := xattr.FGet(f, n)
+		if err != nil {
+			continue
+		}
+		*d = string(att)
+	}
 }

--- a/auditbeat/module/file_integrity/fileinfo_posix.go
+++ b/auditbeat/module/file_integrity/fileinfo_posix.go
@@ -20,6 +20,7 @@
 package file_integrity
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/user"
@@ -97,6 +98,11 @@ func getExtendedAttributes(path string, dst map[string]*string) {
 		if err != nil {
 			continue
 		}
-		*d = string(att)
+		*d = string(trimNull(att))
 	}
+}
+
+func trimNull(b []byte) []byte {
+	b, _, _ = bytes.Cut(b, []byte{0})
+	return b
 }

--- a/auditbeat/module/file_integrity/flatbuffers.go
+++ b/auditbeat/module/file_integrity/flatbuffers.go
@@ -257,16 +257,18 @@ func fbDecodeMetadata(e *schema.Event) *Metadata {
 	}
 	mode := os.FileMode(info.Mode())
 	rtn := &Metadata{
-		Inode:  info.Inode(),
-		UID:    info.Uid(),
-		GID:    info.Gid(),
-		SID:    string(info.Sid()),
-		Mode:   mode & ^(os.ModeSetuid | os.ModeSetgid),
-		Size:   info.Size(),
-		MTime:  time.Unix(0, info.MtimeNs()).UTC(),
-		CTime:  time.Unix(0, info.CtimeNs()).UTC(),
-		SetUID: mode&os.ModeSetuid != 0,
-		SetGID: mode&os.ModeSetgid != 0,
+		Inode:          info.Inode(),
+		UID:            info.Uid(),
+		GID:            info.Gid(),
+		SID:            string(info.Sid()),
+		Mode:           mode & ^(os.ModeSetuid | os.ModeSetgid),
+		Size:           info.Size(),
+		MTime:          time.Unix(0, info.MtimeNs()).UTC(),
+		CTime:          time.Unix(0, info.CtimeNs()).UTC(),
+		SetUID:         mode&os.ModeSetuid != 0,
+		SetGID:         mode&os.ModeSetgid != 0,
+		SELinux:        string(info.Selinux()),
+		POSIXACLAccess: string(info.PosixAclAccess()),
 	}
 
 	switch info.Type() {

--- a/auditbeat/module/file_integrity/flatbuffers.go
+++ b/auditbeat/module/file_integrity/flatbuffers.go
@@ -125,11 +125,16 @@ func fbWriteMetadata(b *flatbuffers.Builder, m *Metadata) flatbuffers.UOffsetT {
 		return 0
 	}
 
-	var sidOffset flatbuffers.UOffsetT
+	var sidOffset, selinuxOffset, aclAccessOffset flatbuffers.UOffsetT
 	if m.SID != "" {
 		sidOffset = b.CreateString(m.SID)
 	}
-
+	if m.SELinux != "" {
+		selinuxOffset = b.CreateString(m.SELinux)
+	}
+	if m.POSIXACLAccess != "" {
+		aclAccessOffset = b.CreateString(m.POSIXACLAccess)
+	}
 	schema.MetadataStart(b)
 	schema.MetadataAddInode(b, m.Inode)
 	schema.MetadataAddUid(b, m.UID)
@@ -159,6 +164,12 @@ func fbWriteMetadata(b *flatbuffers.Builder, m *Metadata) flatbuffers.UOffsetT {
 		schema.MetadataAddType(b, schema.TypeDir)
 	case SymlinkType:
 		schema.MetadataAddType(b, schema.TypeSymlink)
+	}
+	if selinuxOffset > 0 {
+		schema.MetadataAddSelinux(b, selinuxOffset)
+	}
+	if aclAccessOffset > 0 {
+		schema.MetadataAddPosixAclAccess(b, aclAccessOffset)
 	}
 	return schema.MetadataEnd(b)
 }

--- a/auditbeat/module/file_integrity/schema.fbs
+++ b/auditbeat/module/file_integrity/schema.fbs
@@ -31,6 +31,8 @@ table Metadata {
   mtime_ns:long;
   ctime_ns:long;
   type:Type = 1;
+  selinux:string;
+  posix_acl_access:string;
 }
 
 table Hash {

--- a/auditbeat/module/file_integrity/schema/Metadata.go
+++ b/auditbeat/module/file_integrity/schema/Metadata.go
@@ -154,8 +154,24 @@ func (rcv *Metadata) MutateType(n Type) bool {
 	return rcv._tab.MutateByteSlot(20, byte(n))
 }
 
+func (rcv *Metadata) Selinux() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(22))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *Metadata) PosixAclAccess() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(24))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
 func MetadataStart(builder *flatbuffers.Builder) {
-	builder.StartObject(9)
+	builder.StartObject(11)
 }
 func MetadataAddInode(builder *flatbuffers.Builder, inode uint64) {
 	builder.PrependUint64Slot(0, inode, 0)
@@ -183,6 +199,12 @@ func MetadataAddCtimeNs(builder *flatbuffers.Builder, ctimeNs int64) {
 }
 func MetadataAddType(builder *flatbuffers.Builder, type_ Type) {
 	builder.PrependByteSlot(8, byte(type_), 1)
+}
+func MetadataAddSelinux(builder *flatbuffers.Builder, selinux flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(9, flatbuffers.UOffsetT(selinux), 0)
+}
+func MetadataAddPosixAclAccess(builder *flatbuffers.Builder, posixAclAccess flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(10, flatbuffers.UOffsetT(posixAclAccess), 0)
 }
 func MetadataEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()

--- a/go.mod
+++ b/go.mod
@@ -215,6 +215,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/lestrrat-go/jwx/v2 v2.0.11
 	github.com/pierrec/lz4/v4 v4.1.15
+	github.com/pkg/xattr v0.4.9
 	github.com/shirou/gopsutil/v3 v3.22.10
 	go.elastic.co/apm/module/apmelasticsearch/v2 v2.0.0
 	go.elastic.co/apm/module/apmhttp/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -1359,6 +1359,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/pkg/xattr v0.4.9 h1:5883YPCtkSd8LFbs13nXplj9g9tlrwoJRjgpgMu1/fE=
+github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -1974,6 +1976,7 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211102192858-4dd72447c267/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

In environments where SELinux is employed then it is useful to monitor file metadata for changes to SELinux labels. A change to labeling can impact security posture. Similarly in environments where file ACLs are used (e.g. getfacl, setfacl) it is useful to monitor for changes to these ACLs (just like it is useful to monitor permissions in the file mode). So add support for the filesystem extended attributes (xattrs) named security.selinux and system.posix_acl_access that detail these.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #36265

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

Sample event:

```json
{
  "@metadata": {
    "beat": "auditbeat",
    "type": "_doc",
    "version": "8.10.0"
  },
  "@timestamp": "2023-08-16T14:30:29.388Z",
  "agent": {
    "ephemeral_id": "b7d1b2b6-712a-48d7-8de2-b419afd46d75",
    "id": "1681fe91-1cc8-460e-9e7e-fb1fe9b29348",
    "name": "linux",
    "type": "auditbeat",
    "version": "8.10.0"
  },
  "ecs": {
    "version": "8.0.0"
  },
  "event": {
    "action": [
      "attributes_modified"
    ],
    "category": [
      "file"
    ],
    "dataset": "file",
    "kind": "event",
    "module": "file_integrity",
    "type": [
      "change"
    ]
  },
  "file": {
    "ctime": "2023-08-16T14:30:29.384Z",
    "extension": "bar",
    "gid": "0",
    "group": "root",
    "hash": {
      "sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
    },
    "inode": "71102",
    "mode": "0674",
    "mtime": "2023-08-14T20:49:03.249Z",
    "owner": "root",
    "path": "/foo.bar",
    "posix_acl_access": [
      "user::rw-",
      "user:landscape:-wx",
      "group::r--",
      "mask::rwx",
      "other::r--"
    ],
    "selinux": "system_u:object_r:quota_db_t:s0",
    "size": 0,
    "type": "file",
    "uid": "0"
  },
  "host": {
    "name": "linux"
  },
  "service": {
    "type": "file_integrity"
  }
}
```
