### PR TITLE
Fix linting error with receiver names

### DIFF
--- a/libbeat/esleg/eslegclient/enc.go
+++ b/libbeat/esleg/eslegclient/enc.go
@@ -170,62 +170,62 @@ func (g *gzipEncoder) resetState() {
 	}
 }
 
-func (b *gzipEncoder) Reset() {
-	b.buf.Reset()
-	b.gzip.Reset(b.buf)
+func (g *gzipEncoder) Reset() {
+	g.buf.Reset()
+	g.gzip.Reset(g.buf)
 }
 
-func (b *gzipEncoder) Reader() io.Reader {
-	b.gzip.Close()
-	return b.buf
+func (g *gzipEncoder) Reader() io.Reader {
+	g.gzip.Close()
+	return g.buf
 }
 
-func (b *gzipEncoder) AddHeader(header *http.Header) {
+func (g *gzipEncoder) AddHeader(header *http.Header) {
 	header.Add("Content-Type", "application/json; charset=UTF-8")
 	header.Add("Content-Encoding", "gzip")
 }
 
-func (b *gzipEncoder) Marshal(obj interface{}) error {
-	b.Reset()
-	return b.AddRaw(obj)
+func (g *gzipEncoder) Marshal(obj interface{}) error {
+	g.Reset()
+	return g.AddRaw(obj)
 }
 
 var nl = []byte("\n")
 
-func (b *gzipEncoder) AddRaw(obj interface{}) error {
+func (g *gzipEncoder) AddRaw(obj interface{}) error {
 	var err error
 	switch v := obj.(type) {
 	case beat.Event:
-		err = b.folder.Fold(event{Timestamp: v.Timestamp, Fields: v.Fields})
+		err = g.folder.Fold(event{Timestamp: v.Timestamp, Fields: v.Fields})
 	case *beat.Event:
-		err = b.folder.Fold(event{Timestamp: v.Timestamp, Fields: v.Fields})
+		err = g.folder.Fold(event{Timestamp: v.Timestamp, Fields: v.Fields})
 	default:
-		err = b.folder.Fold(obj)
+		err = g.folder.Fold(obj)
 	}
 
 	if err != nil {
-		b.resetState()
+		g.resetState()
 	}
 
-	_, err = b.gzip.Write(nl)
+	_, err = g.gzip.Write(nl)
 	if err != nil {
-		b.resetState()
+		g.resetState()
 	}
 
 	return nil
 }
 
-func (b *gzipEncoder) Add(meta, obj interface{}) error {
-	pos := b.buf.Len()
-	if err := b.AddRaw(meta); err != nil {
-		b.buf.Truncate(pos)
+func (g *gzipEncoder) Add(meta, obj interface{}) error {
+	pos := g.buf.Len()
+	if err := g.AddRaw(meta); err != nil {
+		g.buf.Truncate(pos)
 		return err
 	}
-	if err := b.AddRaw(obj); err != nil {
-		b.buf.Truncate(pos)
+	if err := g.AddRaw(obj); err != nil {
+		g.buf.Truncate(pos)
 		return err
 	}
 
-	b.gzip.Flush()
+	g.gzip.Flush()
 	return nil
 }


### PR DESCRIPTION
Nit linting error fix.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

This commit fixes a linting error with the `esleg/enc.go`, submitted separately from the PR that I noticed it in order to keep the original PR clean of such changes.

This should not have any side-effect on the codebase, it just removes the golangci-lint validation error.
```
enc.go:218:23: ST1016: methods on the same type should have the same receiver name (seen 1x "g", 6x "b") (stylecheck)
```

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

