### PR TITLE
backport: Add 8.10 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -263,3 +263,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.10 branch
+    conditions:
+      - merged
+      - label=backport-v8.10.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.10"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 8.10 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821