### PR TITLE
.github/dependabot.yml - Revert team based segmentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,5 @@
 ---
 version: 2
-# This section is segmented by the responsible GitHub teams in order
-# to make it clear who is responsible for reviewing.
 updates:
   - package-ecosystem: gomod
     directory: /
@@ -10,8 +8,8 @@ updates:
     labels:
       - automation
       - dependabot
-      - Team:Elastic-Agent-Data-Plane
     allow:
+      # Team:Elastic-Agent-Data-Plane
       - dependency-name: github.com/elastic/elastic-agent-autodiscover
       - dependency-name: github.com/elastic/elastic-agent-client/*
       - dependency-name: github.com/elastic/elastic-agent-libs
@@ -29,18 +27,9 @@ updates:
       - dependency-name: go.elastic.co/apm/*
       - dependency-name: go.elastic.co/ecszap
       - dependency-name: go.elastic.co/go-licence-detector
-    reviewers:
-      - elastic/elastic-agent-data-plane
-    open-pull-requests-limit: 2
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
-    labels:
-      - automation
-      - dependabot
-      - Team:Security-External Integrations
-    allow:
+      # Team:Service-Integrations
+      - dependency-name: github.com/elastic/bayeux
+      # Team:Security-External Integrations
       - dependency-name: github.com/elastic/go-libaudit/*
       - dependency-name: github.com/elastic/go-perf
       - dependency-name: github.com/elastic/go-seccomp-bpf
@@ -48,19 +37,4 @@ updates:
     ignore:
       # Skip github.com/elastic/mito because it requires documentation updates.
       - dependency-name: github.com/elastic/mito
-    reviewers:
-      - elastic/security-external-integrations
-    open-pull-requests-limit: 2
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
-    labels:
-      - automation
-      - dependabot
-      - Team:Service-Integrations
-    allow:
-      - dependency-name: github.com/elastic/bayeux
-    reviewers:
-      - elastic/obs-infraobs-integrations
     open-pull-requests-limit: 2


### PR DESCRIPTION
## Proposed commit message

Dependabot does not allow multiple configurations for a given Go module. So this reverts the change to segment the configuration along team boundaries with explicit team-based reviewer requirements. It was complaining about

```
The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
The property '#/updates/2' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
```

as pointed out in https://github.com/elastic/beats/pull/36158#issuecomment-1665700688.
