### PR TITLE
x-pack/filebeat/input/azureblobstorage: reduce tested maximum worker load

### DIFF
--- a/x-pack/filebeat/input/azureblobstorage/input_test.go
+++ b/x-pack/filebeat/input/azureblobstorage/input_test.go
@@ -399,7 +399,7 @@ func Test_StorageClient(t *testing.T) {
 }
 
 func Test_Concurrency(t *testing.T) {
-	for _, workers := range []int{100, 1000, 2000, 3000} {
+	for _, workers := range []int{100, 1000, 2000} {
 		t.Run(fmt.Sprintf("TestConcurrency_%d_Workers", workers), func(t *testing.T) {
 			const expectedLen = mock.TotalRandomDataSets
 			serv := httptest.NewServer(mock.AzureConcurrencyServer())


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The 3000 workers test case is unreasonably high; there is no real justification for this many workers operating on a network-bound system and there is some reason to believe that on some systems this may be causing system i/o resource depletion and failure of unrelated tests. The issue that is being tested here is uncovered by as few as 100 workers. So remove the largest case.

Potentially related failure
```
=== Failed
=== FAIL: x-pack/filebeat/input/azureblobstorage Test_Concurrency/TestConcurrency_3000_Workers (100.30s)
    input_test.go:463: timed out waiting for 10000 events
    input_test.go:470: failed to get all events: got:3103 want:10000

=== FAIL: x-pack/filebeat/input/azureblobstorage Test_Concurrency (129.25s)

=== FAIL: x-pack/filebeat/input/cel TestInput/date_cursor (1.04s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:64971/" is unreachable: dial tcp 127.0.0.1:64971: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/tracer_filename_sanitization (1.03s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:65345/" is unreachable: dial tcp 127.0.0.1:65345: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/pagination_cursor_object (1.07s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:53001/" is unreachable: dial tcp 127.0.0.1:53001: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/pagination_cursor_array (1.07s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:53906/" is unreachable: dial tcp 127.0.0.1:53906: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/first_event_cursor (1.07s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:54664/" is unreachable: dial tcp 127.0.0.1:54664: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/OAuth2 (1.06s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:57168/" is unreachable: dial tcp 127.0.0.1:57168: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/simple_multistep_GET_request (1.09s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:59546/" is unreachable: dial tcp 127.0.0.1:59546: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/three_step_GET_request (1.17s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:60335/" is unreachable: dial tcp 127.0.0.1:60335: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput/type_error_message (1.07s)
    input_test.go:1242: unexpected error running test: url "http://127.0.0.1:61105/" is unreachable: dial tcp 127.0.0.1:61105: i/o timeout

=== FAIL: x-pack/filebeat/input/cel TestInput (29.89s)

=== FAIL: x-pack/filebeat/input/cometd TestMultiInput (1.00s)
    input_test.go:355: 
        	Error Trace:	/Users/runner/work/beats/beats/x-pack/filebeat/input/cometd/input_test.go:355
        	Error:      	Received unexpected error:
        	            	not able to get events.
        	Test:       	TestMultiInput
```
#36354

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
