### PR TITLE
[Metricbeat][Kubernetes] Add test metrics family to scheduler, proxy and controller manager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@ CHANGELOG*
 /licenses/ @elastic/elastic-agent-data-plane
 /metricbeat/ @elastic/elastic-agent-data-plane
 /metricbeat/docs/ # Listed without an owner to avoid maintaining doc ownership for each input and module.
+/metricbeat/helper/kubernetes @elastic/obs-cloudnative-monitoring
 /metricbeat/module/ @elastic/integrations
 /metricbeat/module/apache @elastic/obs-infraobs-integrations
 /metricbeat/module/beat/ @elastic/infra-monitoring-ui

--- a/metricbeat/helper/kubernetes/ktest/ktest.go
+++ b/metricbeat/helper/kubernetes/ktest/ktest.go
@@ -47,14 +47,14 @@ func GetTestCases(files []string) ptest.TestCases {
 	return cases
 }
 
-// TestStateMetricsFamily
+// TestMetricsFamily
 // This function reads the metric files and checks if the resource fetched metrics exist in it.
 // It only checks the family metric, because if the metric doesn't have any data, we don't have a way
 // to know the labels from the file.
 // The test fails if the metric does not exist in any of the files.
 // A warning is printed if the metric is not present in all of them.
 // Nothing happens, otherwise.
-func TestStateMetricsFamily(t *testing.T, files []string, mapping *p.MetricsMapping) {
+func TestMetricsFamily(t *testing.T, files []string, mapping *p.MetricsMapping) {
 	metricsFiles := map[string][]string{}
 	for i := 0; i < len(files); i++ {
 		content, err := ioutil.ReadFile(files[i])

--- a/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
+++ b/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
@@ -50,5 +50,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
+++ b/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
@@ -20,6 +20,7 @@
 package controllermanager
 
 import (
+	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
 	"testing"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
@@ -27,25 +28,27 @@ import (
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 )
 
+var files = []string{
+	"./_meta/test/metrics.1.25",
+	"./_meta/test/metrics.1.26",
+	"./_meta/test/metrics.1.27",
+}
+
 func TestEventMapping(t *testing.T) {
-	ptest.TestMetricSet(t, "kubernetes", "controllermanager",
-		ptest.TestCases{
-			ptest.TestCase{
-				MetricsFile:  "./_meta/test/metrics.1.25",
-				ExpectedFile: "./_meta/test/metrics.1.25.expected",
-			},
-			ptest.TestCase{
-				MetricsFile:  "./_meta/test/metrics.1.26",
-				ExpectedFile: "./_meta/test/metrics.1.26.expected",
-			},
-			ptest.TestCase{
-				MetricsFile:  "./_meta/test/metrics.1.27",
-				ExpectedFile: "./_meta/test/metrics.1.27.expected",
-			},
-		},
-	)
+	var testCases ptest.TestCases
+	for _, file := range files {
+		testCases = append(testCases, ptest.TestCase{
+			MetricsFile:  file,
+			ExpectedFile: file + ".expected",
+		})
+	}
+	ptest.TestMetricSet(t, "kubernetes", "controllermanager", testCases)
 }
 
 func TestData(t *testing.T) {
 	mbtest.TestDataFiles(t, "kubernetes", "controllermanager")
+}
+
+func TestMetricsFamily(t *testing.T) {
+	k.TestStateMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
+++ b/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
@@ -21,11 +21,10 @@ package controllermanager
 
 import (
 	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
-	"testing"
-
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"testing"
 )
 
 var files = []string{

--- a/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
+++ b/metricbeat/module/kubernetes/controllermanager/controllermanager_test.go
@@ -20,11 +20,12 @@
 package controllermanager
 
 import (
+	"testing"
+
 	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
-	"testing"
 )
 
 var files = []string{

--- a/metricbeat/module/kubernetes/proxy/proxy_test.go
+++ b/metricbeat/module/kubernetes/proxy/proxy_test.go
@@ -52,5 +52,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/proxy/proxy_test.go
+++ b/metricbeat/module/kubernetes/proxy/proxy_test.go
@@ -21,11 +21,12 @@
 package proxy
 
 import (
+	"testing"
+
 	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
-	"testing"
 )
 
 var files = []string{

--- a/metricbeat/module/kubernetes/proxy/proxy_test.go
+++ b/metricbeat/module/kubernetes/proxy/proxy_test.go
@@ -22,12 +22,10 @@ package proxy
 
 import (
 	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
-	"testing"
-
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
-
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"testing"
 )
 
 var files = []string{

--- a/metricbeat/module/kubernetes/proxy/proxy_test.go
+++ b/metricbeat/module/kubernetes/proxy/proxy_test.go
@@ -21,6 +21,7 @@
 package proxy
 
 import (
+	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
 	"testing"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
@@ -29,25 +30,27 @@ import (
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 )
 
+var files = []string{
+	"./_meta/test/metrics.1.25",
+	"./_meta/test/metrics.1.26",
+	"./_meta/test/metrics.1.27",
+}
+
 func TestEventMapping(t *testing.T) {
-	ptest.TestMetricSet(t, "kubernetes", "proxy",
-		ptest.TestCases{
-			{
-				MetricsFile:  "./_meta/test/metrics.1.25",
-				ExpectedFile: "./_meta/test/metrics.1.25.expected",
-			},
-			{
-				MetricsFile:  "./_meta/test/metrics.1.26",
-				ExpectedFile: "./_meta/test/metrics.1.26.expected",
-			},
-			ptest.TestCase{
-				MetricsFile:  "./_meta/test/metrics.1.27",
-				ExpectedFile: "./_meta/test/metrics.1.27.expected",
-			},
-		},
-	)
+	var testCases ptest.TestCases
+	for _, file := range files {
+		testCases = append(testCases, ptest.TestCase{
+			MetricsFile:  file,
+			ExpectedFile: file + ".expected",
+		})
+	}
+	ptest.TestMetricSet(t, "kubernetes", "proxy", testCases)
 }
 
 func TestData(t *testing.T) {
 	mbtest.TestDataFiles(t, "kubernetes", "proxy")
+}
+
+func TestMetricsFamily(t *testing.T) {
+	k.TestStateMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/scheduler/scheduler_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_test.go
@@ -52,5 +52,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/scheduler/scheduler_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_test.go
@@ -21,6 +21,7 @@
 package scheduler
 
 import (
+	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
 	"testing"
 
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
@@ -29,25 +30,27 @@ import (
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
 )
 
+var files = []string{
+	"./_meta/test/metrics.1.25",
+	"./_meta/test/metrics.1.26",
+	"./_meta/test/metrics.1.27",
+}
+
 func TestEventMapping(t *testing.T) {
-	ptest.TestMetricSet(t, "kubernetes", "scheduler",
-		ptest.TestCases{
-			{
-				MetricsFile:  "./_meta/test/metrics.1.25",
-				ExpectedFile: "./_meta/test/metrics.1.25.expected",
-			},
-			{
-				MetricsFile:  "./_meta/test/metrics.1.26",
-				ExpectedFile: "./_meta/test/metrics.1.26.expected",
-			},
-			ptest.TestCase{
-				MetricsFile:  "./_meta/test/metrics.1.27",
-				ExpectedFile: "./_meta/test/metrics.1.27.expected",
-			},
-		},
-	)
+	var testCases ptest.TestCases
+	for _, file := range files {
+		testCases = append(testCases, ptest.TestCase{
+			MetricsFile:  file,
+			ExpectedFile: file + ".expected",
+		})
+	}
+	ptest.TestMetricSet(t, "kubernetes", "scheduler", testCases)
 }
 
 func TestData(t *testing.T) {
 	mbtest.TestDataFiles(t, "kubernetes", "scheduler")
+}
+
+func TestMetricsFamily(t *testing.T) {
+	k.TestStateMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/scheduler/scheduler_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_test.go
@@ -22,12 +22,10 @@ package scheduler
 
 import (
 	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
-	"testing"
-
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
-
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
+	"testing"
 )
 
 var files = []string{

--- a/metricbeat/module/kubernetes/scheduler/scheduler_test.go
+++ b/metricbeat/module/kubernetes/scheduler/scheduler_test.go
@@ -21,11 +21,12 @@
 package scheduler
 
 import (
+	"testing"
+
 	k "github.com/elastic/beats/v7/metricbeat/helper/kubernetes/ktest"
 	"github.com/elastic/beats/v7/metricbeat/helper/prometheus/ptest"
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
 	_ "github.com/elastic/beats/v7/metricbeat/module/kubernetes"
-	"testing"
 )
 
 var files = []string{

--- a/metricbeat/module/kubernetes/state_container/state_container_test.go
+++ b/metricbeat/module/kubernetes/state_container/state_container_test.go
@@ -44,5 +44,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_cronjob/state_cronjob_test.go
+++ b/metricbeat/module/kubernetes/state_cronjob/state_cronjob_test.go
@@ -45,5 +45,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_daemonset/state_daemonset_test.go
+++ b/metricbeat/module/kubernetes/state_daemonset/state_daemonset_test.go
@@ -47,5 +47,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_deployment/state_deployment_test.go
+++ b/metricbeat/module/kubernetes/state_deployment/state_deployment_test.go
@@ -46,5 +46,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_job/state_job_test.go
+++ b/metricbeat/module/kubernetes/state_job/state_job_test.go
@@ -46,5 +46,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_node/state_node_test.go
+++ b/metricbeat/module/kubernetes/state_node/state_node_test.go
@@ -47,5 +47,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume_test.go
+++ b/metricbeat/module/kubernetes/state_persistentvolume/state_persistentvolume_test.go
@@ -45,5 +45,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim_test.go
+++ b/metricbeat/module/kubernetes/state_persistentvolumeclaim/state_persistentvolumeclaim_test.go
@@ -45,5 +45,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_pod/state_pod_test.go
+++ b/metricbeat/module/kubernetes/state_pod/state_pod_test.go
@@ -47,5 +47,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_replicaset/state_replicaset_test.go
+++ b/metricbeat/module/kubernetes/state_replicaset/state_replicaset_test.go
@@ -47,5 +47,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_resourcequota/state_resourcequota_test.go
+++ b/metricbeat/module/kubernetes/state_resourcequota/state_resourcequota_test.go
@@ -45,5 +45,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_service/state_service_test.go
+++ b/metricbeat/module/kubernetes/state_service/state_service_test.go
@@ -46,5 +46,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_statefulset/state_statefulset_test.go
+++ b/metricbeat/module/kubernetes/state_statefulset/state_statefulset_test.go
@@ -48,5 +48,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }

--- a/metricbeat/module/kubernetes/state_storageclass/state_storageclass_test.go
+++ b/metricbeat/module/kubernetes/state_storageclass/state_storageclass_test.go
@@ -45,5 +45,5 @@ func TestData(t *testing.T) {
 }
 
 func TestMetricsFamily(t *testing.T) {
-	k.TestStateMetricsFamily(t, files, mapping)
+	k.TestMetricsFamily(t, files, mapping)
 }


### PR DESCRIPTION
## What does this PR do?

Currently, all `state_*` metricsets have a test that runs `TestStateMetricsFamily` in the testing file. However, controller manager, scheduler and proxy metricsets were missing that. This PR fixes that. 

This testing function was first introduced [in this PR](https://github.com/elastic/beats/pull/34448).

