### PR TITLE
x-pack/filebeat/input/cel: don't panic when redact option is not specified

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -100,6 +100,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix handling of Juniper SRX structured data when there is no leading junos element. {issue}36270[36270] {pull}36308[36308]
 - Remove erroneous error log in GCPPubSub input. {pull}36296[36296]
 - Fix Filebeat Cisco module with missing escape character {issue}36325[36325] {pull}36326[36326]
+- Fix panic when redact option is not provided to CEL input. {issue}36387[36387] {pull}36388[36388]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/cel/input_test.go
+++ b/x-pack/filebeat/input/cel/input_test.go
@@ -1571,14 +1571,26 @@ func paginationArrayHandler() http.HandlerFunc {
 }
 
 var redactorTests = []struct {
-	name   string
-	state  mapstr.M
-	mask   []string
-	delete bool
+	name  string
+	state mapstr.M
+	cfg   *redact
 
 	wantOrig   string
 	wantRedact string
 }{
+	{
+		name: "nil_redact",
+		state: mapstr.M{
+			"auth": mapstr.M{
+				"user": "fred",
+				"pass": "top_secret",
+			},
+			"other": "data",
+		},
+		cfg:        nil,
+		wantOrig:   `{"auth":{"pass":"top_secret","user":"fred"},"other":"data"}`,
+		wantRedact: `{"auth":{"pass":"top_secret","user":"fred"},"other":"data"}`,
+	},
 	{
 		name: "auth_no_delete",
 		state: mapstr.M{
@@ -1588,8 +1600,10 @@ var redactorTests = []struct {
 			},
 			"other": "data",
 		},
-		mask:       []string{"auth"},
-		delete:     false,
+		cfg: &redact{
+			Fields: []string{"auth"},
+			Delete: false,
+		},
 		wantOrig:   `{"auth":{"pass":"top_secret","user":"fred"},"other":"data"}`,
 		wantRedact: `{"auth":"*","other":"data"}`,
 	},
@@ -1602,8 +1616,10 @@ var redactorTests = []struct {
 			},
 			"other": "data",
 		},
-		mask:       []string{"auth"},
-		delete:     true,
+		cfg: &redact{
+			Fields: []string{"auth"},
+			Delete: true,
+		},
 		wantOrig:   `{"auth":{"pass":"top_secret","user":"fred"},"other":"data"}`,
 		wantRedact: `{"other":"data"}`,
 	},
@@ -1616,8 +1632,10 @@ var redactorTests = []struct {
 			},
 			"other": "data",
 		},
-		mask:       []string{"auth.pass"},
-		delete:     false,
+		cfg: &redact{
+			Fields: []string{"auth.pass"},
+			Delete: false,
+		},
 		wantOrig:   `{"auth":{"pass":"top_secret","user":"fred"},"other":"data"}`,
 		wantRedact: `{"auth":{"pass":"*","user":"fred"},"other":"data"}`,
 	},
@@ -1630,8 +1648,10 @@ var redactorTests = []struct {
 			},
 			"other": "data",
 		},
-		mask:       []string{"auth.pass"},
-		delete:     true,
+		cfg: &redact{
+			Fields: []string{"auth.pass"},
+			Delete: true,
+		},
 		wantOrig:   `{"auth":{"pass":"top_secret","user":"fred"},"other":"data"}`,
 		wantRedact: `{"auth":{"user":"fred"},"other":"data"}`,
 	},
@@ -1644,8 +1664,10 @@ var redactorTests = []struct {
 			},
 			"other": "data",
 		},
-		mask:       []string{"cursor.key"},
-		delete:     false,
+		cfg: &redact{
+			Fields: []string{"cursor.key"},
+			Delete: false,
+		},
 		wantOrig:   `{"cursor":[{"key":"val_one","other":"data"},{"key":"val_two","other":"data"}],"other":"data"}`,
 		wantRedact: `{"cursor":[{"key":"*","other":"data"},{"key":"*","other":"data"}],"other":"data"}`,
 	},
@@ -1658,8 +1680,10 @@ var redactorTests = []struct {
 			},
 			"other": "data",
 		},
-		mask:       []string{"cursor.key"},
-		delete:     true,
+		cfg: &redact{
+			Fields: []string{"cursor.key"},
+			Delete: true,
+		},
 		wantOrig:   `{"cursor":[{"key":"val_one","other":"data"},{"key":"val_two","other":"data"}],"other":"data"}`,
 		wantRedact: `{"cursor":[{"other":"data"},{"other":"data"}],"other":"data"}`,
 	},
@@ -1668,7 +1692,7 @@ var redactorTests = []struct {
 func TestRedactor(t *testing.T) {
 	for _, test := range redactorTests {
 		t.Run(test.name, func(t *testing.T) {
-			got := fmt.Sprint(redactor{state: test.state, mask: test.mask, delete: test.delete})
+			got := fmt.Sprint(redactor{state: test.state, cfg: test.cfg})
 			orig := fmt.Sprint(test.state)
 			if orig != test.wantOrig {
 				t.Errorf("unexpected original state after redaction:\n--- got\n--- want\n%s", cmp.Diff(orig, test.wantOrig))


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The redaction code currently panics when the redact option is not specified. It is recommended that this not be used unspecified, and we did initially consider erroring in this case, but decided against it. So fix the panic.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #36387

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
