### PR TITLE
Simplify input configuration under Elastic-Agent

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -202,6 +202,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add setup option `--force-enable-module-filesets`, that will act as if all filesets have been enabled in a module during setup. {issue}30915[30915] {pull}36286[36286]
 - [Azure] Add input metrics to the azure-eventhub input. {pull}35739[35739]
 - Reduce HTTPJSON metrics allocations. {pull}36282[36282]
+- Add support for a simplified input configuraton when running under Elastic-Agent {pull}36390[36390]
 
 *Auditbeat*
 

--- a/x-pack/libbeat/management/simple_input_config_test.go
+++ b/x-pack/libbeat/management/simple_input_config_test.go
@@ -1,0 +1,157 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package management
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/elastic/beats/v7/libbeat/common/reload"
+	"github.com/elastic/beats/v7/libbeat/tests/integration"
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-client/v7/pkg/client/mock"
+	"github.com/elastic/elastic-agent-client/v7/pkg/proto"
+)
+
+func TestSimpleInputConfig(t *testing.T) {
+	// Uncomment the line below to see the debug logs for this test
+	// logp.DevelopmentSetup(logp.WithLevel(logp.DebugLevel), logp.WithSelectors("*"))
+	r := reload.NewRegistry()
+
+	output := &mockOutput{
+		ReloadFn: func(config *reload.ConfigWithMeta) error {
+			return nil
+		},
+	}
+	r.MustRegisterOutput(output)
+	inputs := &mockReloadable{
+		ReloadFn: func(configs []*reload.ConfigWithMeta) error {
+			return nil
+		},
+	}
+	r.MustRegisterInput(inputs)
+
+	stateReached := atomic.Bool{}
+	units := []*proto.UnitExpected{
+		{
+			Id:             "output-unit",
+			Type:           proto.UnitType_OUTPUT,
+			State:          proto.State_HEALTHY,
+			ConfigStateIdx: 1,
+			LogLevel:       proto.UnitLogLevel_DEBUG,
+			Config: &proto.UnitExpectedConfig{
+				Id:   "default",
+				Type: "mock",
+				Name: "mock",
+				Source: integration.RequireNewStruct(t,
+					map[string]interface{}{
+						"Is":        "this",
+						"required?": "Yes!",
+					}),
+			},
+		},
+		{
+			Id:             "input-unit",
+			Type:           proto.UnitType_INPUT,
+			State:          proto.State_HEALTHY,
+			ConfigStateIdx: 1,
+			LogLevel:       proto.UnitLogLevel_DEBUG,
+			Config: &proto.UnitExpectedConfig{
+				Id:   "the-id-in-the-input-config",
+				Type: "filestream",
+				// All fields get repeated here, including ID.
+				Source: integration.RequireNewStruct(t,
+					map[string]interface{}{
+						"paths": []any{
+							"/tmp/logfile.log",
+						},
+					},
+				),
+			},
+		},
+	}
+
+	desiredState := []*proto.UnitExpected{
+		{
+			Id:             "output-unit",
+			Type:           proto.UnitType_OUTPUT,
+			State:          proto.State_HEALTHY,
+			ConfigStateIdx: 1,
+			LogLevel:       proto.UnitLogLevel_DEBUG,
+			Config: &proto.UnitExpectedConfig{
+				Id:   "default",
+				Type: "filestream",
+				Name: "mock",
+				Source: integration.RequireNewStruct(t,
+					map[string]interface{}{
+						"this":     "is",
+						"required": true,
+					}),
+			},
+		},
+		{
+			Id:             "input-unit",
+			Type:           proto.UnitType_INPUT,
+			State:          proto.State_HEALTHY,
+			ConfigStateIdx: 1,
+			LogLevel:       proto.UnitLogLevel_DEBUG,
+		},
+	}
+
+	server := &mock.StubServerV2{
+		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
+			// If the desired state has been reached, return nil
+			// so the manager can shutdown.
+			if stateReached.Load() {
+				return nil
+			}
+
+			if DoesStateMatch(observed, desiredState, 0) {
+				stateReached.Store(true)
+			}
+			return &proto.CheckinExpected{
+				Units: units,
+			}
+		},
+		ActionImpl: func(response *proto.ActionResponse) error { return nil },
+	}
+
+	if err := server.Start(); err != nil {
+		t.Fatalf("could not start mock Elastic-Agent server: %s", err)
+	}
+	defer server.Stop()
+
+	client := client.NewV2(
+		fmt.Sprintf(":%d", server.Port),
+		"",
+		client.VersionInfo{},
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	m, err := NewV2AgentManagerWithClient(
+		&Config{
+			Enabled: true,
+		},
+		r,
+		client,
+	)
+	if err != nil {
+		t.Fatalf("could not instantiate ManagerV2: %s", err)
+	}
+
+	if err := m.Start(); err != nil {
+		t.Fatalf("could not start ManagerV2: %s", err)
+	}
+	defer m.Stop()
+
+	require.Eventually(t, func() bool {
+		return stateReached.Load()
+	}, 10*time.Second, 100*time.Millisecond, "desired state, output failed, was not reached")
+}


### PR DESCRIPTION
## Proposed commit message

Simplify the input configuration when running under Elastic-Agent by allowing units without the `streams` key. When they do not have a `streams` key, all the input configuration is ready from the unit's root level.

This case is only supported for the `filestream` input.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~

## How to test this PR locally
1. Get a stack deployment (elastic-package, cloud, etc)
1. Build Filebeat from the x-pack directory
2. Get a compatible version of the Elastic-Agent (or edit `libbeat/version/version.go` before building Filebeat)
3. Replace the Filebeat binary that came with Elastic Agent by the one you build
4. Run Elastic-Agent standalone with the following input configuration:
    ```yaml
    outputs:
      default:
        type: elasticsearch
        hosts:
          - https://localhost:443
        username: "elastic"
        password: "changeme"
    
    inputs:
      - type: filestream
        id: unique-id-per-input
        paths:
          - /tmp/log.log
    ````
5. Generate some logs, you can use the following script
    ```
    #!/bin/sh
    
    i=0
    while true
    do
        let i++
        data="$(date) - $i"
        echo $data >> /tmp/log.log
        sleep 1
    done
    ```
6. Go to Kibana and make sure the data is being ingested.

## Related issues
- Closes [#123](https://github.com/elastic/elastic-agent/issues/2416)


~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
