### PR TITLE
dns processor - Add A, AAAA, and TXT query support 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -147,6 +147,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - When running under Elastic-Agent the status is now reported per Unit instead of the whole Beat {issue}35874[35874] {pull}36183[36183]
 - Add warning message to SysV init scripts for RPM-based systems that lack `/etc/rc.d/init.d/functions`. {issue}35708[35708] {pull}36188[36188]
 - Mark `translate_sid` processor is GA. {issue}36279[36279] {pull}36280[36280]
+- dns processor: Add support for forward lookups (`A`, `AAAA`, and `TXT`). {issue}11416[11416] {pull}36394[36394]
 
 *Auditbeat*
 

--- a/libbeat/processors/dns/cache.go
+++ b/libbeat/processors/dns/cache.go
@@ -24,23 +24,23 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
-type ptrRecord struct {
-	host    string
+type successRecord struct {
+	data    []string
 	expires time.Time
 }
 
-func (r ptrRecord) IsExpired(now time.Time) bool {
+func (r successRecord) IsExpired(now time.Time) bool {
 	return now.After(r.expires)
 }
 
-type ptrCache struct {
+type successCache struct {
 	sync.RWMutex
-	data          map[string]ptrRecord
+	data          map[string]successRecord
 	maxSize       int
 	minSuccessTTL time.Duration
 }
 
-func (c *ptrCache) set(now time.Time, key string, ptr *PTR) {
+func (c *successCache) set(now time.Time, key string, result *result) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -48,14 +48,14 @@ func (c *ptrCache) set(now time.Time, key string, ptr *PTR) {
 		c.evict()
 	}
 
-	c.data[key] = ptrRecord{
-		host:    ptr.Host,
-		expires: now.Add(time.Duration(ptr.TTL) * time.Second),
+	c.data[key] = successRecord{
+		data:    result.Data,
+		expires: now.Add(time.Duration(result.TTL) * time.Second),
 	}
 }
 
 // evict removes a single random key from the cache.
-func (c *ptrCache) evict() {
+func (c *successCache) evict() {
 	var key string
 	for k := range c.data {
 		key = k
@@ -64,13 +64,13 @@ func (c *ptrCache) evict() {
 	delete(c.data, key)
 }
 
-func (c *ptrCache) get(now time.Time, key string) *PTR {
+func (c *successCache) get(now time.Time, key string) *result {
 	c.RLock()
 	defer c.RUnlock()
 
 	r, found := c.data[key]
 	if found && !r.IsExpired(now) {
-		return &PTR{r.host, uint32(r.expires.Sub(now) / time.Second)}
+		return &result{r.data, uint32(r.expires.Sub(now) / time.Second)}
 	}
 	return nil
 }
@@ -132,13 +132,13 @@ type cachedError struct {
 func (ce *cachedError) Error() string { return ce.err.Error() + " (from failure cache)" }
 func (ce *cachedError) Cause() error  { return ce.err }
 
-// PTRLookupCache is a cache for storing and retrieving the results of
-// reverse DNS queries. It caches the results of queries regardless of their
+// LookupCache is a cache for storing and retrieving the results of
+// DNS queries. It caches the results of queries regardless of their
 // outcome (success or failure).
-type PTRLookupCache struct {
-	success  *ptrCache
+type LookupCache struct {
+	success  *successCache
 	failure  *failureCache
-	resolver PTRResolver
+	resolver resolver
 	stats    cacheStats
 }
 
@@ -147,15 +147,15 @@ type cacheStats struct {
 	Miss *monitoring.Int
 }
 
-// NewPTRLookupCache returns a new cache.
-func NewPTRLookupCache(reg *monitoring.Registry, conf CacheConfig, resolver PTRResolver) (*PTRLookupCache, error) {
+// NewLookupCache returns a new cache.
+func NewLookupCache(reg *monitoring.Registry, conf CacheConfig, resolver resolver) (*LookupCache, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, err
 	}
 
-	c := &PTRLookupCache{
-		success: &ptrCache{
-			data:          make(map[string]ptrRecord, conf.SuccessCache.InitialCapacity),
+	c := &LookupCache{
+		success: &successCache{
+			data:          make(map[string]successRecord, conf.SuccessCache.InitialCapacity),
 			maxSize:       conf.SuccessCache.MaxCapacity,
 			minSuccessTTL: conf.SuccessCache.MinTTL,
 		},
@@ -174,36 +174,36 @@ func NewPTRLookupCache(reg *monitoring.Registry, conf CacheConfig, resolver PTRR
 	return c, nil
 }
 
-// LookupPTR performs a reverse lookup on the given IP address. A cached result
+// Lookup performs a lookup on the given query string. A cached result
 // will be returned if it is contained in the cache, otherwise a lookup is
 // performed.
-func (c PTRLookupCache) LookupPTR(ip string) (*PTR, error) {
+func (c LookupCache) Lookup(q string, qt queryType) (*result, error) {
 	now := time.Now()
 
-	ptr := c.success.get(now, ip)
-	if ptr != nil {
+	r := c.success.get(now, q)
+	if r != nil {
 		c.stats.Hit.Inc()
-		return ptr, nil
+		return r, nil
 	}
 
-	err := c.failure.get(now, ip)
+	err := c.failure.get(now, q)
 	if err != nil {
 		c.stats.Hit.Inc()
 		return nil, err
 	}
 	c.stats.Miss.Inc()
 
-	ptr, err = c.resolver.LookupPTR(ip)
+	r, err = c.resolver.Lookup(q, qt)
 	if err != nil {
-		c.failure.set(now, ip, &cachedError{err})
+		c.failure.set(now, q, &cachedError{err})
 		return nil, err
 	}
 
-	// We set the ptr.TTL to the minimum TTL in case it is less than that.
-	ptr.TTL = max(ptr.TTL, uint32(c.success.minSuccessTTL/time.Second))
+	// We set the result TTL to the minimum TTL in case it is less than that.
+	r.TTL = max(r.TTL, uint32(c.success.minSuccessTTL/time.Second))
 
-	c.success.set(now, ip, ptr)
-	return ptr, nil
+	c.success.set(now, q, r)
+	return r, nil
 }
 
 func max(a, b uint32) uint32 {

--- a/libbeat/processors/dns/cache.go
+++ b/libbeat/processors/dns/cache.go
@@ -132,10 +132,10 @@ type cachedError struct {
 func (ce *cachedError) Error() string { return ce.err.Error() + " (from failure cache)" }
 func (ce *cachedError) Cause() error  { return ce.err }
 
-// LookupCache is a cache for storing and retrieving the results of
+// lookupCache is a cache for storing and retrieving the results of
 // DNS queries. It caches the results of queries regardless of their
 // outcome (success or failure).
-type LookupCache struct {
+type lookupCache struct {
 	success  *successCache
 	failure  *failureCache
 	resolver resolver
@@ -147,13 +147,13 @@ type cacheStats struct {
 	Miss *monitoring.Int
 }
 
-// NewLookupCache returns a new cache.
-func NewLookupCache(reg *monitoring.Registry, conf CacheConfig, resolver resolver) (*LookupCache, error) {
+// newLookupCache returns a new cache.
+func newLookupCache(reg *monitoring.Registry, conf cacheConfig, resolver resolver) (*lookupCache, error) {
 	if err := conf.Validate(); err != nil {
 		return nil, err
 	}
 
-	c := &LookupCache{
+	c := &lookupCache{
 		success: &successCache{
 			data:          make(map[string]successRecord, conf.SuccessCache.InitialCapacity),
 			maxSize:       conf.SuccessCache.MaxCapacity,
@@ -177,7 +177,7 @@ func NewLookupCache(reg *monitoring.Registry, conf CacheConfig, resolver resolve
 // Lookup performs a lookup on the given query string. A cached result
 // will be returned if it is contained in the cache, otherwise a lookup is
 // performed.
-func (c LookupCache) Lookup(q string, qt queryType) (*result, error) {
+func (c lookupCache) Lookup(q string, qt queryType) (*result, error) {
 	now := time.Now()
 
 	r := c.success.get(now, q)

--- a/libbeat/processors/dns/cache_test.go
+++ b/libbeat/processors/dns/cache_test.go
@@ -42,9 +42,9 @@ func (r *stubResolver) Lookup(ip string, _ queryType) (*result, error) {
 }
 
 func TestCache(t *testing.T) {
-	c, err := NewLookupCache(
+	c, err := newLookupCache(
 		monitoring.NewRegistry(),
-		defaultConfig().CacheConfig,
+		defaultConfig().cacheConfig,
 		&stubResolver{})
 	if err != nil {
 		t.Fatal(err)
@@ -101,7 +101,7 @@ func TestCache(t *testing.T) {
 		assert.EqualValues(t, 3, c.stats.Miss.Get()) // Cache miss.
 	}
 
-	minTTL := defaultConfig().CacheConfig.SuccessCache.MinTTL
+	minTTL := defaultConfig().cacheConfig.SuccessCache.MinTTL
 	// Initial success returned TTL=0 with MinTTL.
 	r, err = c.Lookup(gatewayIP+"2", typePTR)
 	if assert.NoError(t, err) {

--- a/libbeat/processors/dns/cache_test.go
+++ b/libbeat/processors/dns/cache_test.go
@@ -29,85 +29,85 @@ import (
 
 type stubResolver struct{}
 
-func (r *stubResolver) LookupPTR(ip string) (*PTR, error) {
+func (r *stubResolver) Lookup(ip string, _ queryType) (*result, error) {
 	switch ip {
 	case gatewayIP:
-		return &PTR{Host: gatewayName, TTL: gatewayTTL}, nil
+		return &result{Data: []string{gatewayName}, TTL: gatewayTTL}, nil
 	case gatewayIP + "1":
 		return nil, io.ErrUnexpectedEOF
 	case gatewayIP + "2":
-		return &PTR{Host: gatewayName, TTL: 0}, nil
+		return &result{Data: []string{gatewayName}, TTL: 0}, nil
 	}
 	return nil, &dnsError{"fake lookup returned NXDOMAIN"}
 }
 
 func TestCache(t *testing.T) {
-	c, err := NewPTRLookupCache(
+	c, err := NewLookupCache(
 		monitoring.NewRegistry(),
-		defaultConfig.CacheConfig,
+		defaultConfig().CacheConfig,
 		&stubResolver{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Initial success query.
-	ptr, err := c.LookupPTR(gatewayIP)
+	r, err := c.Lookup(gatewayIP, typePTR)
 	if assert.NoError(t, err) {
-		assert.EqualValues(t, gatewayName, ptr.Host)
-		assert.EqualValues(t, gatewayTTL, ptr.TTL)
+		assert.EqualValues(t, []string{gatewayName}, r.Data)
+		assert.EqualValues(t, gatewayTTL, r.TTL)
 		assert.EqualValues(t, 0, c.stats.Hit.Get())
 		assert.EqualValues(t, 1, c.stats.Miss.Get())
 	}
 
 	// Cached success query.
-	ptr, err = c.LookupPTR(gatewayIP)
+	r, err = c.Lookup(gatewayIP, typePTR)
 	if assert.NoError(t, err) {
-		assert.EqualValues(t, gatewayName, ptr.Host)
+		assert.EqualValues(t, []string{gatewayName}, r.Data)
 		// TTL counts down while in cache.
-		assert.InDelta(t, gatewayTTL, ptr.TTL, 1)
+		assert.InDelta(t, gatewayTTL, r.TTL, 1)
 		assert.EqualValues(t, 1, c.stats.Hit.Get())
 		assert.EqualValues(t, 1, c.stats.Miss.Get())
 	}
 
 	// Initial failure query (like a dns error response code).
-	ptr, err = c.LookupPTR(gatewayIP + "0")
+	r, err = c.Lookup(gatewayIP+"0", typePTR)
 	if assert.Error(t, err) {
-		assert.Nil(t, ptr)
+		assert.Nil(t, r)
 		assert.EqualValues(t, 1, c.stats.Hit.Get())
 		assert.EqualValues(t, 2, c.stats.Miss.Get())
 	}
 
 	// Cached failure query.
-	ptr, err = c.LookupPTR(gatewayIP + "0")
+	r, err = c.Lookup(gatewayIP+"0", typePTR)
 	if assert.Error(t, err) {
-		assert.Nil(t, ptr)
+		assert.Nil(t, r)
 		assert.EqualValues(t, 2, c.stats.Hit.Get())
 		assert.EqualValues(t, 2, c.stats.Miss.Get())
 	}
 
 	// Initial network failure (like I/O timeout).
-	ptr, err = c.LookupPTR(gatewayIP + "1")
+	r, err = c.Lookup(gatewayIP+"1", typePTR)
 	if assert.Error(t, err) {
-		assert.Nil(t, ptr)
+		assert.Nil(t, r)
 		assert.EqualValues(t, 2, c.stats.Hit.Get())
 		assert.EqualValues(t, 3, c.stats.Miss.Get())
 	}
 
 	// Check for a cache hit for the network failure.
-	ptr, err = c.LookupPTR(gatewayIP + "1")
+	r, err = c.Lookup(gatewayIP+"1", typePTR)
 	if assert.Error(t, err) {
-		assert.Nil(t, ptr)
+		assert.Nil(t, r)
 		assert.EqualValues(t, 3, c.stats.Hit.Get())
 		assert.EqualValues(t, 3, c.stats.Miss.Get()) // Cache miss.
 	}
 
-	minTTL := defaultConfig.CacheConfig.SuccessCache.MinTTL
+	minTTL := defaultConfig().CacheConfig.SuccessCache.MinTTL
 	// Initial success returned TTL=0 with MinTTL.
-	ptr, err = c.LookupPTR(gatewayIP + "2")
+	r, err = c.Lookup(gatewayIP+"2", typePTR)
 	if assert.NoError(t, err) {
-		assert.EqualValues(t, gatewayName, ptr.Host)
+		assert.EqualValues(t, []string{gatewayName}, r.Data)
 
-		assert.EqualValues(t, minTTL/time.Second, ptr.TTL)
+		assert.EqualValues(t, minTTL/time.Second, r.TTL)
 		assert.EqualValues(t, 3, c.stats.Hit.Get())
 		assert.EqualValues(t, 4, c.stats.Miss.Get())
 
@@ -117,11 +117,11 @@ func TestCache(t *testing.T) {
 	}
 
 	// Cached success from a previous TTL=0 response.
-	ptr, err = c.LookupPTR(gatewayIP + "2")
+	r, err = c.Lookup(gatewayIP+"2", typePTR)
 	if assert.NoError(t, err) {
-		assert.EqualValues(t, gatewayName, ptr.Host)
+		assert.EqualValues(t, []string{gatewayName}, r.Data)
 		// TTL counts down while in cache.
-		assert.InDelta(t, minTTL/time.Second, ptr.TTL, 1)
+		assert.InDelta(t, minTTL/time.Second, r.TTL, 1)
 		assert.EqualValues(t, 4, c.stats.Hit.Get())
 		assert.EqualValues(t, 4, c.stats.Miss.Get())
 	}

--- a/libbeat/processors/dns/config.go
+++ b/libbeat/processors/dns/config.go
@@ -33,7 +33,7 @@ type config struct {
 	cacheConfig  `config:",inline"`
 	Nameservers  []string      `config:"nameservers"`              // Required on Windows. /etc/resolv.conf is used if none are given.
 	Timeout      time.Duration `config:"timeout"`                  // Per request timeout (with 2 nameservers the total timeout would be 2x).
-	Type         queryType     `config:"type" validate:"required"` // Reverse is the only supported type currently.
+	Type         queryType     `config:"type" validate:"required"` // One of A, AAAA, TXT or PTR (or reverse).
 	Action       fieldAction   `config:"action"`                   // Append or replace (defaults to append) when target exists.
 	TagOnFailure []string      `config:"tag_on_failure"`           // Tags to append when a failure occurs.
 	Fields       mapstr.M      `config:"fields"`                   // Mapping of source fields to target fields.
@@ -106,7 +106,7 @@ func (qt *queryType) Unpack(v string) error {
 	case "txt":
 		*qt = typeTXT
 	default:
-		return fmt.Errorf("invalid dns lookup type '%v' specified in "+
+		return fmt.Errorf("invalid dns lookup type '%s' specified in "+
 			"config (valid values are: A, AAAA, PTR, reverse, TXT)", v)
 	}
 	return nil

--- a/libbeat/processors/dns/config.go
+++ b/libbeat/processors/dns/config.go
@@ -28,35 +28,35 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
-// Config defines the configuration options for the DNS processor.
-type Config struct {
-	CacheConfig  `config:",inline"`
+// config defines the configuration options for the DNS processor.
+type config struct {
+	cacheConfig  `config:",inline"`
 	Nameservers  []string      `config:"nameservers"`              // Required on Windows. /etc/resolv.conf is used if none are given.
 	Timeout      time.Duration `config:"timeout"`                  // Per request timeout (with 2 nameservers the total timeout would be 2x).
 	Type         queryType     `config:"type" validate:"required"` // Reverse is the only supported type currently.
-	Action       FieldAction   `config:"action"`                   // Append or replace (defaults to append) when target exists.
+	Action       fieldAction   `config:"action"`                   // Append or replace (defaults to append) when target exists.
 	TagOnFailure []string      `config:"tag_on_failure"`           // Tags to append when a failure occurs.
 	Fields       mapstr.M      `config:"fields"`                   // Mapping of source fields to target fields.
 	Transport    string        `config:"transport"`                // Can be tls or udp.
 	reverseFlat  map[string]string
 }
 
-// FieldAction defines the behavior when the target field exists.
-type FieldAction uint8
+// fieldAction defines the behavior when the target field exists.
+type fieldAction uint8
 
-// List of FieldAction types.
+// List of fieldAction types.
 const (
-	ActionAppend FieldAction = iota
-	ActionReplace
+	actionAppend fieldAction = iota
+	actionReplace
 )
 
-var fieldActionNames = map[FieldAction]string{
-	ActionAppend:  "append",
-	ActionReplace: "replace",
+var fieldActionNames = map[fieldAction]string{
+	actionAppend:  "append",
+	actionReplace: "replace",
 }
 
 // String returns a field action name.
-func (fa FieldAction) String() string {
+func (fa fieldAction) String() string {
 	name, found := fieldActionNames[fa]
 	if found {
 		return name
@@ -64,13 +64,13 @@ func (fa FieldAction) String() string {
 	return "unknown (" + strconv.Itoa(int(fa)) + ")"
 }
 
-// Unpack unpacks a string to a FieldAction.
-func (fa *FieldAction) Unpack(v string) error {
+// Unpack unpacks a string to a fieldAction.
+func (fa *fieldAction) Unpack(v string) error {
 	switch strings.ToLower(v) {
 	case "", "append":
-		*fa = ActionAppend
+		*fa = actionAppend
 	case "replace":
-		*fa = ActionReplace
+		*fa = actionReplace
 	default:
 		return fmt.Errorf("invalid dns field action value '%v'", v)
 	}
@@ -112,14 +112,14 @@ func (qt *queryType) Unpack(v string) error {
 	return nil
 }
 
-// CacheConfig defines the success and failure caching parameters.
-type CacheConfig struct {
-	SuccessCache CacheSettings `config:"success_cache"`
-	FailureCache CacheSettings `config:"failure_cache"`
+// cacheConfig defines the success and failure caching parameters.
+type cacheConfig struct {
+	SuccessCache cacheSettings `config:"success_cache"`
+	FailureCache cacheSettings `config:"failure_cache"`
 }
 
-// CacheSettings define the caching behavior for an individual cache.
-type CacheSettings struct {
+// cacheSettings define the caching behavior for an individual cache.
+type cacheSettings struct {
 	// TTL value for items in cache. Not used for success because we use TTL
 	// from the DNS record.
 	TTL time.Duration `config:"ttl"`
@@ -136,7 +136,7 @@ type CacheSettings struct {
 }
 
 // Validate validates the data contained in the config.
-func (c *Config) Validate() error {
+func (c *config) Validate() error {
 	// Flatten the mapping of source fields to target fields.
 	c.reverseFlat = map[string]string{}
 	for k, v := range c.Fields.Flatten() {
@@ -159,8 +159,8 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// Validate validates the data contained in the CacheConfig.
-func (c *CacheConfig) Validate() error {
+// Validate validates the data contained in the cacheConfig.
+func (c *cacheConfig) Validate() error {
 	if c.SuccessCache.MinTTL <= 0 {
 		return fmt.Errorf("success_cache.min_ttl must be > 0")
 	}
@@ -185,15 +185,15 @@ func (c *CacheConfig) Validate() error {
 	return nil
 }
 
-func defaultConfig() Config {
-	return Config{
-		CacheConfig: CacheConfig{
-			SuccessCache: CacheSettings{
+func defaultConfig() config {
+	return config{
+		cacheConfig: cacheConfig{
+			SuccessCache: cacheSettings{
 				MinTTL:          time.Minute,
 				InitialCapacity: 1000,
 				MaxCapacity:     10000,
 			},
-			FailureCache: CacheSettings{
+			FailureCache: cacheSettings{
 				MinTTL:          time.Minute,
 				TTL:             time.Minute,
 				InitialCapacity: 1000,

--- a/libbeat/processors/dns/dns.go
+++ b/libbeat/processors/dns/dns.go
@@ -102,7 +102,7 @@ func (p *processor) processField(source, target string, action fieldAction, even
 
 	result, err := p.resolver.Lookup(strVal, p.Type)
 	if err != nil {
-		return fmt.Errorf("dns lookup (%v) of %v value '%v' failed: %w", p.Type, source, strVal, err)
+		return fmt.Errorf("dns lookup (%s) of %s value '%s' failed: %w", p.Type, source, strVal, err)
 	}
 
 	// PTR lookups return a scalar. All other lookup types return a string slice.
@@ -133,7 +133,7 @@ func setFieldValue(action fieldAction, event *beat.Event, key, value string) err
 		}
 		return err
 	default:
-		panic(fmt.Errorf("unexpected dns field action value encountered: %v", action))
+		panic(fmt.Errorf("unexpected dns field action value encountered: %s", action))
 	}
 }
 
@@ -158,7 +158,7 @@ func setFieldSliceValue(action fieldAction, event *beat.Event, key string, value
 		}
 		return err
 	default:
-		panic(fmt.Errorf("unexpected dns field action value encountered: %v", action))
+		panic(fmt.Errorf("unexpected dns field action value encountered: %s", action))
 	}
 }
 

--- a/libbeat/processors/dns/dns.go
+++ b/libbeat/processors/dns/dns.go
@@ -112,7 +112,7 @@ func (p *processor) processField(source, target string, action FieldAction, even
 	return setFieldSliceValue(action, event, target, result.Data)
 }
 
-func setFieldValue(action FieldAction, event *beat.Event, key string, value string) error {
+func setFieldValue(action FieldAction, event *beat.Event, key, value string) error {
 	switch action {
 	case ActionReplace:
 		_, err := event.PutValue(key, value)

--- a/libbeat/processors/dns/dns_test.go
+++ b/libbeat/processors/dns/dns_test.go
@@ -32,8 +32,10 @@ import (
 )
 
 func TestDNSProcessorRun(t *testing.T) {
+	c := defaultConfig()
+	c.Type = typePTR
 	p := &processor{
-		Config:   defaultConfig,
+		Config:   c,
 		resolver: &stubResolver{},
 		log:      logp.NewLogger(logName),
 	}
@@ -94,7 +96,8 @@ func TestDNSProcessorRun(t *testing.T) {
 	})
 
 	t.Run("metadata target", func(t *testing.T) {
-		config := defaultConfig
+		config := defaultConfig()
+		config.Type = typePTR
 		config.reverseFlat = map[string]string{
 			"@metadata.ip": "@metadata.domain",
 		}
@@ -121,12 +124,11 @@ func TestDNSProcessorRun(t *testing.T) {
 		assert.Equal(t, expMeta, newEvent.Meta)
 		assert.Equal(t, event.Fields, newEvent.Fields)
 	})
-
 }
 
 func TestDNSProcessorTagOnFailure(t *testing.T) {
 	p := &processor{
-		Config:   defaultConfig,
+		Config:   defaultConfig(),
 		resolver: &stubResolver{},
 		log:      logp.NewLogger(logName),
 	}
@@ -157,9 +159,9 @@ func TestDNSProcessorRunInParallel(t *testing.T) {
 	// This is a simple smoke test to make sure that there are no concurrency
 	// issues. It is most effective when run with the race detector.
 
-	conf := defaultConfig
+	conf := defaultConfig()
 	reg := monitoring.NewRegistry()
-	cache, err := NewPTRLookupCache(reg, conf.CacheConfig, &stubResolver{})
+	cache, err := NewLookupCache(reg, conf.CacheConfig, &stubResolver{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/dns/dns_test.go
+++ b/libbeat/processors/dns/dns_test.go
@@ -35,11 +35,11 @@ func TestDNSProcessorRun(t *testing.T) {
 	c := defaultConfig()
 	c.Type = typePTR
 	p := &processor{
-		Config:   c,
+		config:   c,
 		resolver: &stubResolver{},
 		log:      logp.NewLogger(logName),
 	}
-	p.Config.reverseFlat = map[string]string{
+	p.config.reverseFlat = map[string]string{
 		"source.ip": "source.domain",
 	}
 	t.Log(p.String())
@@ -60,7 +60,7 @@ func TestDNSProcessorRun(t *testing.T) {
 
 	const forwardDomain = "www." + gatewayName
 	t.Run("append", func(t *testing.T) {
-		p.Config.Action = ActionAppend
+		p.config.Action = actionAppend
 
 		event, err := p.Run(&beat.Event{
 			Fields: mapstr.M{
@@ -79,7 +79,7 @@ func TestDNSProcessorRun(t *testing.T) {
 	})
 
 	t.Run("replace", func(t *testing.T) {
-		p.Config.Action = ActionReplace
+		p.config.Action = actionReplace
 
 		event, err := p.Run(&beat.Event{
 			Fields: mapstr.M{
@@ -103,7 +103,7 @@ func TestDNSProcessorRun(t *testing.T) {
 		}
 
 		p := &processor{
-			Config:   config,
+			config:   config,
 			resolver: &stubResolver{},
 			log:      logp.NewLogger(logName),
 		}
@@ -128,12 +128,12 @@ func TestDNSProcessorRun(t *testing.T) {
 
 func TestDNSProcessorTagOnFailure(t *testing.T) {
 	p := &processor{
-		Config:   defaultConfig(),
+		config:   defaultConfig(),
 		resolver: &stubResolver{},
 		log:      logp.NewLogger(logName),
 	}
-	p.Config.TagOnFailure = []string{"_lookup_failed"}
-	p.Config.reverseFlat = map[string]string{
+	p.config.TagOnFailure = []string{"_lookup_failed"}
+	p.config.reverseFlat = map[string]string{
 		"source.ip":      "source.domain",
 		"destination.ip": "destination.domain",
 	}
@@ -151,7 +151,7 @@ func TestDNSProcessorTagOnFailure(t *testing.T) {
 
 	v, _ := event.GetValue("tags")
 	if assert.Len(t, v, 1) {
-		assert.ElementsMatch(t, v, p.Config.TagOnFailure)
+		assert.ElementsMatch(t, v, p.config.TagOnFailure)
 	}
 }
 
@@ -161,12 +161,12 @@ func TestDNSProcessorRunInParallel(t *testing.T) {
 
 	conf := defaultConfig()
 	reg := monitoring.NewRegistry()
-	cache, err := NewLookupCache(reg, conf.CacheConfig, &stubResolver{})
+	cache, err := newLookupCache(reg, conf.cacheConfig, &stubResolver{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	p := &processor{Config: conf, resolver: cache, log: logp.NewLogger(logName)}
-	p.Config.reverseFlat = map[string]string{"source.ip": "source.domain"}
+	p := &processor{config: conf, resolver: cache, log: logp.NewLogger(logName)}
+	p.config.reverseFlat = map[string]string{"source.ip": "source.domain"}
 
 	const numGoroutines = 10
 	const numEvents = 500

--- a/libbeat/processors/dns/doc.go
+++ b/libbeat/processors/dns/doc.go
@@ -16,7 +16,7 @@
 // under the License.
 
 // Package dns implements a processor that can perform DNS lookups by sending
-// a DNS request over UDP to a recursive nameserver. Each instance of the
+// a DNS request over UDP or TLS to a recursive nameserver. Each instance of the
 // processor is independent (no shared cache) so it's best to only define one
 // instance of the processor.
 //

--- a/libbeat/processors/dns/docs/dns.asciidoc
+++ b/libbeat/processors/dns/docs/dns.asciidoc
@@ -5,10 +5,10 @@
 <titleabbrev>dns</titleabbrev>
 ++++
 
-The `dns` processor performs reverse DNS lookups of IP addresses. It caches the
-responses that it receives in accordance to the time-to-live (TTL) value
-contained in the response. It also caches failures that occur during lookups.
-Each instance of this processor maintains its own independent cache.
+The `dns` processor performs DNS queries. It caches the responses that it
+receives in accordance to the time-to-live (TTL) value contained in the
+response. It also caches failures that occur during lookups. Each instance
+of this processor maintains its own independent cache.
 
 The processor uses its own DNS resolver to send requests to nameservers and does
 not use the operating system's resolver. It does not read any values contained
@@ -24,6 +24,16 @@ throughput you can achieve is 500 events per second (1000 milliseconds / 2
 milliseconds). If you have a high cache hit ratio then your throughput can be
 higher.
 
+The processor can send the following query types:
+
+- `A` - IPv4 addresses
+- `AAAA` - IPv6 addresses
+- `TXT` - arbitrary human-readable text data
+- `PTR` - reverse IP address lookups
+
+The output value is a list of strings for all query types except `PTR`. For
+`PTR` queries the output value is a string.
+
 This is a minimal configuration example that resolves the IP addresses contained
 in two fields.
 
@@ -33,8 +43,8 @@ processors:
   - dns:
       type: reverse
       fields:
-        source.ip: source.hostname
-        destination.ip: destination.hostname
+        source.ip: source.domain
+        destination.ip: destination.domain
 ----
 
 Next is a configuration example showing all options.
@@ -47,8 +57,8 @@ processors:
     action: append
     transport: tls
     fields:
-      server.ip: server.hostname
-      client.ip: client.hostname
+      server.ip: server.domain
+      client.ip: client.domain
     success_cache:
       capacity.initial: 1000
       capacity.max: 10000
@@ -64,8 +74,8 @@ processors:
 
 The `dns` processor has the following configuration settings:
 
-`type`:: The type of DNS lookup to perform. The only supported type is
-`reverse` which queries for a PTR record.
+`type`:: The type of DNS query to perform. The supported types are `A`, `AAAA`,
+`PTR` (or `reverse`), and `TXT`.
 
 `action`:: This defines the behavior of the processor when the target field
 already exists in the event. The options are `append` (default) and `replace`.
@@ -82,8 +92,10 @@ the memory for this number of items. Default value is `1000`.
 cache can hold. When the maximum capacity is reached a random item is evicted.
 Default value is `10000`.
 
-`success_cache.min_ttl`:: The duration of the minimum alternative cache TTL for successful DNS responses. Ensures that `TTL=0` successful reverse DNS responses can be cached.
-Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Default value is `1m`.
+`success_cache.min_ttl`:: The duration of the minimum alternative cache TTL for
+successful DNS responses. Ensures that `TTL=0` successful reverse DNS responses
+can be cached. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+Default value is `1m`.
 
 `failure_cache.capacity.initial`:: The initial number of items that the failure
 cache will be allocated to hold. When initialized the processor will allocate
@@ -107,7 +119,7 @@ for each DNS request so if you have 2 nameservers then the total timeout will be
 "h". Default value is `500ms`.
 
 `tag_on_failure`:: A list of tags to add to the event when any lookup fails. The
-tags are only added once even if multiple lookups fail. By default no tags are
+tags are only added once even if multiple lookups fail. By default, no tags are
 added upon failure.
 
 `transport`:: The type of transport connection that should be used can either be

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -252,7 +252,7 @@ func (res *miekgResolver) getOrCreateNameserverStats(ns string) *nameserverStats
 	return stats
 }
 
-func min[T uint32](a, b T) T {
+func min(a, b uint32) uint32 {
 	if a < b {
 		return a
 	}

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -157,7 +157,7 @@ func (res *miekgResolver) Lookup(q string, qt queryType) (*result, error) {
 
 		r, rtt, err := res.client.Exchange(m, server)
 		if err != nil {
-			// Try next server if any. Otherwise, return retErr.
+			// Try next server if any. Otherwise, return nameserverErr.
 			nameserverErr = err
 			stats.failure.Inc()
 			continue

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -19,7 +19,6 @@ package dns
 
 import (
 	"errors"
-	"golang.org/x/exp/constraints"
 	"math"
 	"net"
 	"strconv"

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -243,6 +243,8 @@ func (res *MiekgResolver) getOrCreateNameserverStats(ns string) *nameserverStats
 		failure:         monitoring.NewInt(reg, "failure"),
 		requestDuration: metrics.NewUniformSample(1028),
 	}
+
+	//nolint:errcheck // Register should never fail because this is a new empty registry.
 	adapter.NewGoMetrics(reg, "request_duration", adapter.Accept).
 		Register("histogram", metrics.NewHistogram(stats.requestDuration))
 	res.nsStats[ns] = stats

--- a/libbeat/processors/dns/resolver.go
+++ b/libbeat/processors/dns/resolver.go
@@ -46,9 +46,9 @@ type resolver interface {
 	Lookup(q string, qt queryType) (*result, error)
 }
 
-// MiekgResolver is a resolver that is implemented using github.com/miekg/dns
+// miekgResolver is a resolver that is implemented using github.com/miekg/dns
 // to send requests to DNS servers. It does not use the Go resolver.
-type MiekgResolver struct {
+type miekgResolver struct {
 	client  *dns.Client
 	servers []string
 
@@ -63,9 +63,9 @@ type nameserverStats struct {
 	requestDuration metrics.Sample  // Histogram of response times.
 }
 
-// NewMiekgResolver returns a new MiekgResolver. It returns an error if no
+// newMiekgResolver returns a new miekgResolver. It returns an error if no
 // nameserver are given and none can be read from /etc/resolv.conf.
-func NewMiekgResolver(reg *monitoring.Registry, timeout time.Duration, transport string, servers ...string) (*MiekgResolver, error) {
+func newMiekgResolver(reg *monitoring.Registry, timeout time.Duration, transport string, servers ...string) (*miekgResolver, error) {
 	// Use /etc/resolv.conf if no nameservers are given. (Won't work for Windows).
 	if len(servers) == 0 {
 		config, err := dns.ClientConfigFromFile(etcResolvConf)
@@ -106,7 +106,7 @@ func NewMiekgResolver(reg *monitoring.Registry, timeout time.Duration, transport
 		clientTransferType = "udp"
 	}
 
-	return &MiekgResolver{
+	return &miekgResolver{
 		client: &dns.Client{
 			Net:     clientTransferType,
 			Timeout: timeout,
@@ -131,7 +131,7 @@ func (e *dnsError) Error() string {
 }
 
 // Lookup performs a DNS query.
-func (res *MiekgResolver) Lookup(q string, qt queryType) (*result, error) {
+func (res *miekgResolver) Lookup(q string, qt queryType) (*result, error) {
 	if len(res.servers) == 0 {
 		return nil, errors.New("no dns servers configured")
 	}
@@ -215,7 +215,7 @@ func (res *MiekgResolver) Lookup(q string, qt queryType) (*result, error) {
 	panic("dns resolver Lookup() should have returned a response.")
 }
 
-func (res *MiekgResolver) getOrCreateNameserverStats(ns string) *nameserverStats {
+func (res *miekgResolver) getOrCreateNameserverStats(ns string) *nameserverStats {
 	// Trim port.
 	ns = ns[:strings.LastIndex(ns, ":")]
 

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
-var _ PTRResolver = (*MiekgResolver)(nil)
+var _ resolver = (*MiekgResolver)(nil)
 
 func TestMiekgResolverLookupPTR(t *testing.T) {
 	stop, addr, err := ServeDNS(FakeDNSHandler)
@@ -45,15 +45,15 @@ func TestMiekgResolverLookupPTR(t *testing.T) {
 	}
 
 	// Success
-	ptr, err := res.LookupPTR("8.8.8.8")
+	ptr, err := res.Lookup("8.8.8.8", typePTR)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.EqualValues(t, "google-public-dns-a.google.com", ptr.Host)
+	assert.EqualValues(t, "google-public-dns-a.google.com", ptr.Data[0])
 	assert.EqualValues(t, 19273, ptr.TTL)
 
 	// NXDOMAIN
-	_, err = res.LookupPTR("1.1.1.1")
+	_, err = res.Lookup("1.1.1.1", typePTR)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "NXDOMAIN")
 	}
@@ -91,21 +91,21 @@ func TestMiekgResolverLookupPTRTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// we use a self signed certificate for localhost
+	// we use a self-signed certificate for localhost
 	// we have to pass InsecureSSL to the DNS resolver
 	res.client.TLSConfig = &tls.Config{
 		InsecureSkipVerify: true,
 	}
 	// Success
-	ptr, err := res.LookupPTR("8.8.8.8")
+	ptr, err := res.Lookup("8.8.8.8", typePTR)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.EqualValues(t, "google-public-dns-a.google.com", ptr.Host)
+	assert.EqualValues(t, "google-public-dns-a.google.com", ptr.Data[0])
 	assert.EqualValues(t, 19273, ptr.TTL)
 
 	// NXDOMAIN
-	_, err = res.LookupPTR("1.1.1.1")
+	_, err = res.Lookup("1.1.1.1", typePTR)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "NXDOMAIN")
 	}

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
-var _ resolver = (*MiekgResolver)(nil)
+var _ resolver = (*miekgResolver)(nil)
 
 func TestMiekgResolverLookupPTR(t *testing.T) {
 	stop, addr, err := serveDNS(fakeDNSHandler)
@@ -43,7 +43,7 @@ func TestMiekgResolverLookupPTR(t *testing.T) {
 	}()
 
 	reg := monitoring.NewRegistry()
-	res, err := NewMiekgResolver(reg.NewRegistry(logName), 0, "udp", addr)
+	res, err := newMiekgResolver(reg.NewRegistry(logName), 0, "udp", addr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestMiekgResolverLookupPTRTLS(t *testing.T) {
 
 	reg := monitoring.NewRegistry()
 
-	res, err := NewMiekgResolver(reg.NewRegistry(logName), 0, "tls", addr)
+	res, err := newMiekgResolver(reg.NewRegistry(logName), 0, "tls", addr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -19,12 +19,14 @@ package dns
 
 import (
 	"crypto/tls"
+	"errors"
 	"net"
 	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
@@ -32,11 +34,13 @@ import (
 var _ resolver = (*MiekgResolver)(nil)
 
 func TestMiekgResolverLookupPTR(t *testing.T) {
-	stop, addr, err := ServeDNS(FakeDNSHandler)
+	stop, addr, err := serveDNS(fakeDNSHandler)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer stop()
+	defer func() {
+		require.NoError(t, stop())
+	}()
 
 	reg := monitoring.NewRegistry()
 	res, err := NewMiekgResolver(reg.NewRegistry(logName), 0, "udp", addr)
@@ -71,19 +75,22 @@ func TestMiekgResolverLookupPTR(t *testing.T) {
 
 func TestMiekgResolverLookupPTRTLS(t *testing.T) {
 	// Build Cert
-	cert, err := tls.X509KeyPair(CertPEMBlock, KeyPEMBlock)
+	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
 	if err != nil {
 		t.Fatalf("unable to build certificate: %v", err)
 	}
 	config := tls.Config{
 		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
 	}
 	// serve TLS with cert
-	stop, addr, err := ServeDNSTLS(FakeDNSHandler, &config)
+	stop, addr, err := serveDNSTLS(fakeDNSHandler, &config)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer stop()
+	defer func() {
+		require.NoError(t, stop())
+	}()
 
 	reg := monitoring.NewRegistry()
 
@@ -91,11 +98,11 @@ func TestMiekgResolverLookupPTRTLS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// we use a self-signed certificate for localhost
-	// we have to pass InsecureSSL to the DNS resolver
+	//nolint:gosec // Don't verify the self-signed cert. This is only for testing purposes.
 	res.client.TLSConfig = &tls.Config{
 		InsecureSkipVerify: true,
 	}
+
 	// Success
 	ptr, err := res.Lookup("8.8.8.8", typePTR)
 	if err != nil {
@@ -121,7 +128,7 @@ func TestMiekgResolverLookupPTRTLS(t *testing.T) {
 	assert.Equal(t, 12, metricCount)
 }
 
-func ServeDNS(h dns.HandlerFunc) (cancel func() error, addr string, err error) {
+func serveDNS(h dns.HandlerFunc) (cancel func() error, addr string, err error) {
 	// Setup listener on ephemeral port.
 
 	a, err := net.ResolveUDPAddr("udp4", "localhost:0")
@@ -136,11 +143,23 @@ func ServeDNS(h dns.HandlerFunc) (cancel func() error, addr string, err error) {
 	var s dns.Server
 	s.PacketConn = l
 	s.Handler = h
-	go s.ActivateAndServe()
-	return s.Shutdown, s.PacketConn.LocalAddr().String(), err
+
+	serveErr := make(chan error, 1)
+	go func() {
+		defer close(serveErr)
+		serveErr <- s.ActivateAndServe()
+	}()
+
+	cancel = func() error {
+		return errors.Join(
+			s.Shutdown(),
+			<-serveErr,
+		)
+	}
+	return cancel, s.PacketConn.LocalAddr().String(), err
 }
 
-func ServeDNSTLS(h dns.HandlerFunc, config *tls.Config) (cancel func() error, addr string, err error) {
+func serveDNSTLS(h dns.HandlerFunc, config *tls.Config) (cancel func() error, addr string, err error) {
 	// Setup listener on ephemeral port.
 	l, err := tls.Listen("tcp", "localhost:0", config)
 	if err != nil {
@@ -150,11 +169,23 @@ func ServeDNSTLS(h dns.HandlerFunc, config *tls.Config) (cancel func() error, ad
 	var s dns.Server
 	s.Handler = h
 	s.Listener = l
-	go s.ActivateAndServe()
-	return s.Shutdown, l.Addr().String(), err
+
+	serveErr := make(chan error, 1)
+	go func() {
+		defer close(serveErr)
+		serveErr <- s.ActivateAndServe()
+	}()
+
+	cancel = func() error {
+		return errors.Join(
+			s.Shutdown(),
+			<-serveErr,
+		)
+	}
+	return cancel, l.Addr().String(), err
 }
 
-func FakeDNSHandler(w dns.ResponseWriter, msg *dns.Msg) {
+func fakeDNSHandler(w dns.ResponseWriter, msg *dns.Msg) {
 	m := new(dns.Msg)
 	m.SetReply(msg)
 	switch {
@@ -164,11 +195,11 @@ func FakeDNSHandler(w dns.ResponseWriter, msg *dns.Msg) {
 	default:
 		m.SetRcode(msg, dns.RcodeNameError)
 	}
-	w.WriteMsg(m)
+	_ = w.WriteMsg(m)
 }
 
 var (
-	KeyPEMBlock = []byte(`-----BEGIN RSA PRIVATE KEY-----
+	keyPEMBlock = []byte(`-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEA2g2zpEtWaIUx5o6MEnWnGsf0Ba1SDc3AwgOmxeNIPBJYVCrk
 sWe8Qt/5nymReVFcum76995ncr/zT+e4e8l+hXuGzTKZJpOj27Igb0/wa3j2hIcu
 rnbzfwkJ+KMag2UUKdSo31ChMU+64bwziEXunF347Ot7dBLtw3PJKbabNCP+/oil
@@ -196,7 +227,7 @@ LatVl7h6ud25ZJYnP7DelGxHsZnDXNirLFlSB0CL4F6I5xNoBvCoH0Q8ckDSh4C7
 tlAyD5m9gwvgdkNFWq6/lcUPxGksTtTk8dGnhJz8pGlZvp6+dZCM
 -----END RSA PRIVATE KEY-----`)
 
-	CertPEMBlock = []byte(`-----BEGIN CERTIFICATE-----
+	certPEMBlock = []byte(`-----BEGIN CERTIFICATE-----
 MIIDaTCCAlGgAwIBAgIQGqg47wLgbjwwrZASuakmwjANBgkqhkiG9w0BAQsFADAy
 MRQwEgYDVQQKEwtMb2cgQ291cmllcjEaMBgGA1UEAxMRYmVhdHMuZWxhc3RpYy5j
 b20wHhcNMjAwNjIzMDY0NDEwWhcNMjEwNjIzMDY0NDEwWjAyMRQwEgYDVQQKEwtM

--- a/libbeat/processors/dns/resolver_test.go
+++ b/libbeat/processors/dns/resolver_test.go
@@ -70,7 +70,7 @@ func TestMiekgResolverLookupPTR(t *testing.T) {
 }
 
 func TestMiekgResolverLookupPTRTLS(t *testing.T) {
-	//Build Cert
+	// Build Cert
 	cert, err := tls.X509KeyPair(CertPEMBlock, KeyPEMBlock)
 	if err != nil {
 		t.Fatalf("unable to build certificate: %v", err)


### PR DESCRIPTION
## Proposed commit message

The dns processor previously supported only reverse DNS lookups.
This adds support for performing A, AAAA, and TXT record queries.

The `response.ptr.histogram` metric was renamed to `request_duration.histogram`.
This naming allows the metric to represent the duration of the DNS request
for all query types.

Closes https://github.com/elastic/beats/issues/11416

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #11416

## Examples

`filebeat.yml`:

```yaml
---

filebeat.inputs:
  - type: cel
    publisher_pipeline:
      disable_host: true
    interval: 1m
    resource:
      url: not_used_1
    redact:
      fields: ~
    program: |
      {
          'want_more': false,
          'events': [
              {
                'message': 'newyork.weather',
              }
          ],
      }
    processors:
      - dns:
          type: TXT
          nameservers: ['dns.toys']
          fields:
            message: weather

  - type: cel
    publisher_pipeline:
      disable_host: true
    interval: 1m
    resource:
      url: not_used_2
    redact:
      fields: ~
    program: |
      {
          'want_more': false,
          'events': [
              {
                  'host': {
                      'hostname': 'www.elastic.co'
                  }
              }
          ],
      }
    processors:
      - dns:
          type: A
          nameservers: ['8.8.8.8']
          fields:
            host.hostname: host.ip

  - type: cel
    publisher_pipeline:
      disable_host: true
    interval: 1m
    resource:
      url: not_used_3
    redact:
      fields: ~
    program: |
      {
          'want_more': false,
          'events': [
              {
                  'host': {
                      'hostname': 'ipv6.google.com'
                  }
              }
          ],
      }
    processors:
      - dns:
          type: AAAA
          nameservers: ['8.8.8.8']
          fields:
            host.hostname: host.ip

processors:
  - drop_fields:
      ignore_missing: true
      fields:
        - agent
        - ecs
        - input

output.console.enabled: true

http:
  host: localhost
  port: 5066
```

output events:

```json
{
  "@timestamp": "2023-08-22T13:57:30.641Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.11.0"
  },
  "host": {
    "hostname": "www.elastic.co",
    "ip": [
      "151.101.2.217",
      "151.101.66.217",
      "151.101.130.217",
      "151.101.194.217"
    ]
  }
}
{
  "@timestamp": "2023-08-22T13:57:30.639Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.11.0"
  },
  "weather": [
    "New York (US)",
    "21.00C (69.80F)",
    "60.60% hu.",
    "partlycloudy_day",
    "10:00, Tue",
    "New York (US)",
    "23.70C (74.66F)",
    "51.60% hu.",
    "cloudy",
    "12:00, Tue",
    "New York (US)",
    "25.40C (77.72F)",
    "46.30% hu.",
    "partlycloudy_day",
    "14:00, Tue",
    "New York (US)",
    "26.20C (79.16F)",
    "42.90% hu.",
    "fair_day",
    "16:00, Tue",
    "New York (US)",
    "25.50C (77.90F)",
    "42.70% hu.",
    "cloudy",
    "18:00, Tue"
  ],
  "message": "newyork.weather"
}
{
  "@timestamp": "2023-08-22T13:57:30.641Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.11.0"
  },
  "host": {
    "hostname": "ipv6.google.com",
    "ip": [
      "2607:f8b0:4004:c07::64",
      "2607:f8b0:4004:c07::66",
      "2607:f8b0:4004:c07::8a",
      "2607:f8b0:4004:c07::71"
    ]
  }
}
```

`% jq .processor dns-stats.json`

```json
{
  "dns": {
    "1": {
      "cache": {
        "hits": 0,
        "misses": 1
      },
      "dns_toys": {
        "failure": 0,
        "request_duration": {
          "histogram": {
            "count": 1,
            "max": 19227625,
            "mean": 19227625,
            "median": 19227625,
            "min": 19227625,
            "p75": 19227625,
            "p95": 19227625,
            "p99": 19227625,
            "p999": 19227625,
            "stddev": 0
          }
        },
        "success": 1
      }
    },
    "2": {
      "8_8_8_8": {
        "failure": 0,
        "request_duration": {
          "histogram": {
            "count": 1,
            "max": 8290708,
            "mean": 8290708,
            "median": 8290708,
            "min": 8290708,
            "p75": 8290708,
            "p95": 8290708,
            "p99": 8290708,
            "p999": 8290708,
            "stddev": 0
          }
        },
        "success": 1
      },
      "cache": {
        "hits": 0,
        "misses": 1
      }
    },
    "3": {
      "8_8_8_8": {
        "failure": 0,
        "request_duration": {
          "histogram": {
            "count": 1,
            "max": 19198583,
            "mean": 19198583,
            "median": 19198583,
            "min": 19198583,
            "p75": 19198583,
            "p95": 19198583,
            "p99": 19198583,
            "p999": 19198583,
            "stddev": 0
          }
        },
        "success": 1
      },
      "cache": {
        "hits": 0,
        "misses": 1
      }
    }
  }
}
```