### PR TITLE
Fix ignoring external input configuration in `take_over: true` mode

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -105,6 +105,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Remove 'onFilteredOut' and 'onDroppedOnPublish' callback logs {issue}36299[36299] {pull}36399[36399]
 - Added a fix for Crowdstrike pipeline handling process arrays {pull}36496[36496]
 - Ensure winlog input retains metric collection when handling recoverable errors. {issue}36479[36479] {pull}36483[36483]
+- Fix ignoring external input configuration in `take_over: true` mode {issue}36378[36378] {pull}36395[36395]
 
 *Heartbeat*
 

--- a/filebeat/beater/filebeat.go
+++ b/filebeat/beater/filebeat.go
@@ -502,9 +502,17 @@ func newPipelineLoaderFactory(esConfig *conf.C) fileset.PipelineLoaderFactory {
 // some of the filestreams might want to take over the loginput state
 // if their `take_over` flag is set to `true`.
 func processLogInputTakeOver(stateStore StateStore, config *cfg.Config) error {
+	inputs, err := fetchInputConfiguration(config)
+	if err != nil {
+		return fmt.Errorf("Failed to fetch input configuration when attempting take over: %w", err)
+	}
+	if len(inputs) == 0 {
+		return nil
+	}
+
 	store, err := stateStore.Access()
 	if err != nil {
-		return fmt.Errorf("Failed to access state for attempting take over: %w", err)
+		return fmt.Errorf("Failed to access state when attempting take over: %w", err)
 	}
 	defer store.Close()
 	logger := logp.NewLogger("filestream-takeover")
@@ -514,5 +522,49 @@ func processLogInputTakeOver(stateStore StateStore, config *cfg.Config) error {
 
 	backuper := backup.NewRegistryBackuper(logger, registryHome)
 
-	return takeover.TakeOverLogInputStates(logger, store, backuper, config)
+	return takeover.TakeOverLogInputStates(logger, store, backuper, inputs)
+}
+
+// fetches all the defined input configuration available at Filebeat startup including external files.
+func fetchInputConfiguration(config *cfg.Config) (inputs []*conf.C, err error) {
+	if len(config.Inputs) == 0 {
+		inputs = []*conf.C{}
+	} else {
+		inputs = config.Inputs
+	}
+
+	// reading external input configuration if defined
+	var dynamicInputCfg cfgfile.DynamicConfig
+	if config.ConfigInput != nil {
+		err = config.ConfigInput.Unpack(&dynamicInputCfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unpack the dynamic input configuration: %w", err)
+		}
+	}
+	if dynamicInputCfg.Path == "" {
+		return inputs, nil
+	}
+
+	cfgPaths, err := filepath.Glob(dynamicInputCfg.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve external input configuration paths: %w", err)
+	}
+
+	if len(cfgPaths) == 0 {
+		return inputs, nil
+	}
+
+	// making a copy so we can safely extend the slice
+	inputs = make([]*conf.C, len(config.Inputs))
+	copy(inputs, config.Inputs)
+
+	for _, p := range cfgPaths {
+		externalInputs, err := cfgfile.LoadList(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load external input configuration: %w", err)
+		}
+		inputs = append(inputs, externalInputs...)
+	}
+
+	return inputs, nil
 }

--- a/filebeat/beater/filebeat_test.go
+++ b/filebeat/beater/filebeat_test.go
@@ -1,0 +1,163 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elastic/beats/v7/filebeat/config"
+	conf "github.com/elastic/elastic-agent-libs/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+type inputEntry struct {
+	ID string `config:"id"`
+}
+
+func TestFetchInputConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "config1.yml"), []byte(`
+- type: filestream
+  id: external-1
+  paths:
+    - "/some"
+- type: filestream
+  id: external-2
+  paths:
+    - "/another"
+`), 0777)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(dir, "config2.yml.disabled"), []byte(`
+- type: filestream
+  id: disabled
+  paths:
+    - "/some"
+`), 0777)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name       string
+		configFile string
+		expected   []inputEntry
+	}{
+		{
+			name: "loads mixed configuration",
+			configFile: `
+filebeat.config.inputs:
+  enabled: true
+  path: ` + dir + `/*.yml
+filebeat.inputs:
+  - type: filestream
+    id: internal
+    paths:
+      - "/another"
+output.console:
+  enabled: true
+`,
+			expected: []inputEntry{
+				{
+					ID: "internal",
+				},
+				{
+					ID: "external-1",
+				},
+				{
+					ID: "external-2",
+				},
+			},
+		},
+		{
+			name: "loads only internal configuration",
+			configFile: `
+filebeat.inputs:
+  - type: filestream
+    id: internal
+    paths:
+      - "/another"
+output.console:
+  enabled: true
+`,
+			expected: []inputEntry{
+				{
+					ID: "internal",
+				},
+			},
+		},
+		{
+			name: "loads only external configuration",
+			configFile: `
+filebeat.config.inputs:
+  enabled: true
+  path: ` + dir + `/*.yml
+output.console:
+  enabled: true
+`,
+			expected: []inputEntry{
+				{
+					ID: "external-1",
+				},
+				{
+					ID: "external-2",
+				},
+			},
+		},
+		{
+			name: "loads nothing",
+			configFile: `
+filebeat.config.inputs:
+  enabled: true
+  path: ` + dir + `/*.nothing
+output.console:
+  enabled: true
+`,
+			expected: []inputEntry{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawConfig, err := conf.NewConfigFrom(tc.configFile)
+			require.NoError(t, err)
+
+			cfg := struct {
+				Filebeat config.Config `config:"filebeat"`
+			}{
+				Filebeat: config.DefaultConfig,
+			}
+			err = rawConfig.Unpack(&cfg)
+			require.NoError(t, err)
+
+			inputs, err := fetchInputConfiguration(&cfg.Filebeat)
+			require.NoError(t, err)
+
+			actual := []inputEntry{}
+
+			for _, i := range inputs {
+				var entry inputEntry
+				err := i.Unpack(&entry)
+				require.NoError(t, err)
+				actual = append(actual, entry)
+			}
+
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
The take-over mode didn't take into account external configuration files. Now it's reading the merged configuration that contains the externally defined inputs too.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

1. Create a directory with 2 YAML files, let's say it's `/test/config/inputs.d`:

`filebeat-before.yml`

```yaml
- type: log
  paths:
    - "/test/logs/error2.log"
- type: log
  paths:
    - "/test/logs/error3.log"
```

`filebeat-after.yml.disabled`

```yaml
- type: filestream
  id: my-filestream-id-2
  take_over: true
  paths:
    - "/test/logs/error2.log"
- type: filestream
  id: my-filestream-id-3
  take_over: true
  paths:
    - "/test/logs/error3.log"
```

2. Create the main config file in `/test/config/filebeat.yml`

```yaml
filebeat.config.inputs:
  enabled: true
  path: /test/config/inputs.d/*.yml
filebeat.inputs:
  - type: log
    paths:
      - "/test/logs/error1.log"
logging:
  level: debug
output.console:
  enabled: true
path.data: "/test/data"

```

Note, you need to adjust the root path `/test` to your own.

3. Create the log files in `/test/logs` with any lines you'd like, the filenames are `error1.log`, `error2.log` and `error3.log`.

4. Run filebeat with the following script (you can override the `FILEBEAT_ROOT` variable:

```sh
#!/bin/bash

set -e

FILEBEAT_ROOT=~/Projects/beats/filebeat

cd $FILEBEAT_ROOT
rm -f ./filebeat
go build
cd -

$FILEBEAT_ROOT/filebeat run -e -c /test/config/filebeat.yml 2> output.json | jq .
```

You should see events according to the lines written to the log files, in my case it's:

```json
{
  "@timestamp": "2023-09-13T12:10:26.583Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.11.0"
  },
  "input": {
    "type": "log"
  },
  "host": {
    "name": "hostname"
  },
  "agent": {
    "type": "filebeat",
    "version": "8.11.0",
    "ephemeral_id": "e6d49bb0-8a89-4a8b-a6f8-82df9a3fb2a0",
    "id": "55657aaf-2d01-41d0-a3b1-2a548ad1a6b6",
    "name": "hostname"
  },
  "ecs": {
    "version": "8.0.0"
  },
  "log": {
    "offset": 0,
    "file": {
      "path": "/test/logs/error1.log"
    }
  },
  "message": "test"
}
{
  "@timestamp": "2023-09-13T12:10:26.584Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.11.0"
  },
  "host": {
    "name": "hostname"
  },
  "agent": {
    "ephemeral_id": "e6d49bb0-8a89-4a8b-a6f8-82df9a3fb2a0",
    "id": "55657aaf-2d01-41d0-a3b1-2a548ad1a6b6",
    "name": "hostname",
    "type": "filebeat",
    "version": "8.11.0"
  },
  "message": "test3",
  "log": {
    "offset": 0,
    "file": {
      "path": "/test/logs/error3.log"
    }
  },
  "input": {
    "type": "log"
  },
  "ecs": {
    "version": "8.0.0"
  }
}
{
  "@timestamp": "2023-09-13T12:10:26.584Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.11.0"
  },
  "agent": {
    "type": "filebeat",
    "version": "8.11.0",
    "ephemeral_id": "e6d49bb0-8a89-4a8b-a6f8-82df9a3fb2a0",
    "id": "55657aaf-2d01-41d0-a3b1-2a548ad1a6b6",
    "name": "hostname"
  },
  "ecs": {
    "version": "8.0.0"
  },
  "message": "test2",
  "log": {
    "file": {
      "path": "/test/logs/error2.log"
    },
    "offset": 0
  },
  "input": {
    "type": "log"
  },
  "host": {
    "name": "hostname"
  }
}
```

5. Now switch everything to filestreams with `take_over: true`, for that:

Switch the main config to:

```yaml
filebeat.config.inputs:
  enabled: true
  path: /test/config/inputs.d/*.yml
filebeat.inputs:
  - type: filestream
    id: my-filestream-1
    take_over: true
    paths:
      - "/test/logs/error1.log"
logging:
  level: debug
output.console:
  enabled: true
path.data: "/test/data"
```

Note, we switched the input to filestream.

Rename the files:

* `filebeat-after.yml.disabled` -> `filebeat-after.yml`
* `filebeat-before.yml` -> `filebeat-before.yml.disabled`

6. Run Filebeat with the same script as before and you should not see any events this time (this means the offsets were successfully migrated). Check `output.json`, it should contain the following log lines:

```json
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 194
  },
  "message": "found 1 patterns for filestream `my-filestream-1`",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 194
  },
  "message": "found 1 patterns for filestream `my-filestream-id-2`",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 194
  },
  "message": "found 1 patterns for filestream `my-filestream-id-3`",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 167
  },
  "message": "found 3 filestream inputs in `take over` mode",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 128
  },
  "message": "found loginput state `filebeat::logs::native::123539340-16777230` to take over by `filestream::my-filestream-1::native::123539340-16777230`",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 128
  },
  "message": "found loginput state `filebeat::logs::native::128995786-16777230` to take over by `filestream::my-filestream-id-2::native::128995786-16777230`",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 128
  },
  "message": "found loginput state `filebeat::logs::native::128995795-16777230` to take over by `filestream::my-filestream-id-3::native::128995795-16777230`",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "backup/registry.go",
    "file.line": 62
  },
  "message": "Attempting to find the checkpoint...",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "backup/registry.go",
    "file.line": 70
  },
  "message": "Checkpoint not found",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "backup/registry.go",
    "file.line": 74
  },
  "message": "Checking if the registry log exists at /test/data/registry/filebeat/log.json...",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "backup/registry.go",
    "file.line": 81
  },
  "message": "Found the registry log at /test/data/registry/filebeat/log.json",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.457+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "backup/registry.go",
    "file.line": 84
  },
  "message": "Creating backups for [/test/data/registry/filebeat/log.json]...",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
{
  "log.level": "info",
  "@timestamp": "2023-09-13T14:13:42.458+0200",
  "log.logger": "filestream-takeover",
  "log.origin": {
    "file.name": "takeover/takeover.go",
    "file.line": 87
  },
  "message": "filestream inputs took over 3 file(s) from loginputs",
  "service.name": "filebeat",
  "ecs.version": "1.6.0"
}
```

7. Now write to the `error1.log`, `error2.log` and `error3.log` files and make sure you see the events from filestream on the console, like this one:

```sh
echo "another_test" >> error1.log
```

```json
{
  "@timestamp": "2023-09-13T12:17:16.506Z",
  "@metadata": {
    "beat": "filebeat",
    "type": "_doc",
    "version": "8.11.0"
  },
  "input": {
    "type": "filestream"
  },
  "ecs": {
    "version": "8.0.0"
  },
  "host": {
    "name": "hostname"
  },
  "agent": {
    "type": "filebeat",
    "version": "8.11.0",
    "ephemeral_id": "1d1bbbd1-6912-497f-8a3e-000617cdb163",
    "id": "55657aaf-2d01-41d0-a3b1-2a548ad1a6b6",
    "name": "hostname"
  },
  "log": {
    "offset": 5,
    "file": {
      "path": "/test/logs/error1.log",
      "device_id": 16777230,
      "inode": 123539340
    }
  },
  "message": "another_test"
}
```

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #36378
