### PR TITLE
Add TransactionType into allowedDimensions for Azure storage account.

### DIFF
--- a/x-pack/metricbeat/module/azure/storage/storage.go
+++ b/x-pack/metricbeat/module/azure/storage/storage.go
@@ -15,7 +15,7 @@ const defaultStorageAccountNamespace = "Microsoft.Storage/storageAccounts"
 
 var (
 	storageServiceNamespaces = []string{"/blobServices", "/tableServices", "/queueServices", "/fileServices"}
-	allowedDimensions        = []string{"ResponseType", "ApiName", "GeoType", "Authentication", "BlobType", "Tier", "FileShare"}
+	allowedDimensions        = []string{"ResponseType", "ApiName", "GeoType", "Authentication", "BlobType", "Tier", "FileShare", "TransactionType"}
 )
 
 // init registers the MetricSet with the central registry as soon as the program


### PR DESCRIPTION
- Enhancement


## Proposed commit message

To enable TSDB functionality without data loss, make sure all dimension fields are set to "true." While dimensions like "GeoType," "Authentication," "BlobType," "Tier," and "FileShare" were recently added, alongside existing dimensions "ApiName" and "ResponseType," the "TransactionType" dimension was overlooked. This PR corrects that by adding the "TransactionType" dimension, ensuring complete TSDB functionality for Azure Storage Account.



## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.



## Related issues

- Closes #36312 



