### PR TITLE
Mark syslog processor as GA and improve documentation

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -149,7 +149,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add warning message to SysV init scripts for RPM-based systems that lack `/etc/rc.d/init.d/functions`. {issue}35708[35708] {pull}36188[36188]
 - Mark `translate_sid` processor is GA. {issue}36279[36279] {pull}36280[36280]
 - dns processor: Add support for forward lookups (`A`, `AAAA`, and `TXT`). {issue}11416[11416] {pull}36394[36394]
-- Mark `syslog` processor as GA, improve docs about how processor handles syslog messages. {issue}36416[36416] {pull}1[1]
+- Mark `syslog` processor as GA, improve docs about how processor handles syslog messages. {issue}36416[36416] {pull}36417[36417]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -149,6 +149,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add warning message to SysV init scripts for RPM-based systems that lack `/etc/rc.d/init.d/functions`. {issue}35708[35708] {pull}36188[36188]
 - Mark `translate_sid` processor is GA. {issue}36279[36279] {pull}36280[36280]
 - dns processor: Add support for forward lookups (`A`, `AAAA`, and `TXT`). {issue}11416[11416] {pull}36394[36394]
+- Mark `syslog` processor as GA, improve docs about how processor handles syslog messages. {issue}36416[36416] {pull}1[1]
 
 *Auditbeat*
 

--- a/libbeat/processors/syslog/docs/syslog.asciidoc
+++ b/libbeat/processors/syslog/docs/syslog.asciidoc
@@ -5,7 +5,12 @@
 <titleabbrev>syslog</titleabbrev>
 ++++
 
-experimental[]
+The syslog processor parses RFC 3146 and/or RFC 5424 formatted syslog messages
+that are stored in a field. The processor itself does not handle receiving syslog
+messages from external sources. This is done through an input, such as the TCP
+input. Certain integrations, when enabled through configuration, will embed the
+syslog processor to process syslog messages, such as Custom TCP Logs and
+Custom UDP Logs.
 
 [float]
 ==== Configuration


### PR DESCRIPTION
## Proposed commit message

- Removed the experimental tag for the syslog processor to mark processor as GA.
- Improve documentation of the syslog processor to note that it does not directly handle receiving external messages.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues
- Closes #36416 