### PR TITLE
[Azure] [Billing] Add Azure resource tags from Usage Details API

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -229,6 +229,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Migrate Azure Billing, Monitor, and Storage metricsets to the newer SDK. {pull}33585[33585]
 - Add support for float64 values parsing for statsd metrics of counter type. {pull}35099[35099]
 - Add kubernetes.deployment.status.* fields for Kubernetes module {pull}35999[35999]
+- Add Azure resource tags support to Azure Billing module {pull}36428[36428]
 
 
 *Osquerybeat*

--- a/x-pack/metricbeat/module/azure/billing/data.go
+++ b/x-pack/metricbeat/module/azure/billing/data.go
@@ -61,7 +61,7 @@ func EventsMapping(
 					},
 				}
 				if len(legacy.Tags) > 0 {
-					_, _ = event.ModuleFields.Put("tags", legacy.Tags)
+					_, _ = event.ModuleFields.Put("resource.tags", legacy.Tags)
 				}
 
 				event.MetricSetFields = mapstr.M{
@@ -101,7 +101,7 @@ func EventsMapping(
 					},
 				}
 				if len(modern.Tags) > 0 {
-					_, _ = event.ModuleFields.Put("tags", modern.Tags)
+					_, _ = event.ModuleFields.Put("resource.tags", modern.Tags)
 				}
 
 				event.MetricSetFields = mapstr.M{

--- a/x-pack/metricbeat/module/azure/billing/data.go
+++ b/x-pack/metricbeat/module/azure/billing/data.go
@@ -60,6 +60,10 @@ func EventsMapping(
 						"group": legacy.Properties.ResourceGroup,
 					},
 				}
+				if len(legacy.Tags) > 0 {
+					_, _ = event.ModuleFields.Put("tags", legacy.Tags)
+				}
+
 				event.MetricSetFields = mapstr.M{
 					// original fields
 					"billing_period_id": legacy.ID,
@@ -96,6 +100,10 @@ func EventsMapping(
 						"group": strings.ToLower(*modern.Properties.ResourceGroup),
 					},
 				}
+				if len(modern.Tags) > 0 {
+					_, _ = event.ModuleFields.Put("tags", modern.Tags)
+				}
+
 				event.MetricSetFields = mapstr.M{
 					// original fields
 					"billing_period_id": modern.ID,

--- a/x-pack/metricbeat/module/azure/billing/data_test.go
+++ b/x-pack/metricbeat/module/azure/billing/data_test.go
@@ -25,6 +25,8 @@ func TestEventMapping(t *testing.T) {
 	name := "test"
 	billingAccountId := "123"
 	startDate := time.Time{}
+	tagName := "team"
+	tagValue := "obs-cloud-monitoring"
 
 	//
 	// Usage Details
@@ -49,6 +51,9 @@ func TestEventMapping(t *testing.T) {
 		ID:         &ID,
 		Kind:       &kind,
 		Properties: &props,
+		Tags: map[string]*string{
+			tagName: &tagValue,
+		},
 	}
 
 	//
@@ -102,15 +107,23 @@ func TestEventMapping(t *testing.T) {
 	// Check the results
 	//
 	for _, event := range events {
-		// if is an usage event
 		if ok, _ := event.MetricSetFields.HasKey("department_name"); ok {
+			//
+			// The event is a usage detail
+			//
 			val1, _ := event.MetricSetFields.GetValue("account_name")
 			assert.Equal(t, val1, &name)
 			val2, _ := event.MetricSetFields.GetValue("product")
 			assert.Equal(t, val2, &name)
 			val3, _ := event.MetricSetFields.GetValue("department_name")
 			assert.Equal(t, val3, &name)
+			tags, _ := event.ModuleFields.GetValue("resource.tags")
+			assert.Equal(t, tags, map[string]*string{tagName: &tagValue})
+
 		} else {
+			//
+			// The event is a forecast
+			//
 
 			// Check the actual cost
 			isActual, _ := event.MetricSetFields.HasKey("actual_cost")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

With this change, we are adding support for Azure resource tags from the response from the [Usage Details API](https://learn.microsoft.com/en-us/rest/api/consumption/usage-details/list?tabs=HTTP). Both legacy and modern usage details data formats include tags from resources.

We take tag values from the usage details response and store them in the event as `azure.resource.tags` field. We can leverage the existing [module level mapping](https://github.com/elastic/beats/blob/3d55242556cb2a535c4f81d1b42a459eea322c97/x-pack/metricbeat/module/azure/_meta/fields.yml#L31-L36) for these field.

Multiple users asked for including resource tags to make the most of usage details data.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Fetch data from an Enterprise Agreement (EA) account
- [x] Fetch data from an Microsoft Customer Agreement (MCA) account


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/36373

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

![CleanShot 2023-08-28 at 11 50 31@2x](https://github.com/elastic/beats/assets/25941/a5a9ae87-044e-4cd2-980a-801880627331)

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
