### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/azuread: allow fine-grain control of API requests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -211,6 +211,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Make HTTPJSON response body decoding errors more informative. {pull}36481[36481]
 - Allow fine-grained control of entity analytics API requests for Okta provider. {issue}36440[36440] {pull}36492[36492]
 - Add support for expanding `journald.process.capabilities` into the human-readable effective capabilities in the ECS `process.thread.capabilities.effective` field. {issue}36454[36454] {pull}36470[36470]
+- Allow fine-grained control of entity analytics API requests for AzureAD provider. {issue}36440[36440] {pull}36441[36441]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-entity-analytics.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-entity-analytics.asciidoc
@@ -255,6 +255,7 @@ Example configuration:
   enabled: true
   id: azure-1
   provider: azure-ad
+  dataset: "all"
   sync_interval: "12h"
   update_interval: "30m"
   client_id: "CLIENT_ID"
@@ -278,6 +279,14 @@ The client/application ID. Used for authentication. Field is required.
 ===== `secret`
 
 The secret value, used for authentication. Field is required.
+
+[float]
+===== `dataset`
+
+The datasets to collect from the API. This can be one of "all", "users" or "devices",
+or may be left empty for the default behavior which is to collect all entities.
+When the `dataset` is set to "devices", some user entity data is collected in order
+to populate the registered users and registered owner fields for each device.
 
 [float]
 ===== `sync_interval`

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -267,19 +268,38 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 		groupsDeltaLink = state.groupsLink
 	}
 
-	changedUsers, userLink, err := p.fetcher.Users(ctx, usersDeltaLink)
-	if err != nil {
-		return updatedUsers, updatedDevices, err
+	var (
+		changedUsers []*fetcher.User
+		userLink     string
+	)
+	switch strings.ToLower(p.conf.Dataset) {
+	case "", "all", "users":
+		changedUsers, userLink, err = p.fetcher.Users(ctx, usersDeltaLink)
+		if err != nil {
+			return updatedUsers, updatedDevices, err
+		}
+		p.logger.Debugf("Received %d users from API", len(changedUsers))
+	default:
+		p.logger.Debugf("Skipping user collection from API: dataset=%s", p.conf.Dataset)
 	}
-	p.logger.Debugf("Received %d users from API", len(changedUsers))
 
-	changedDevices, deviceLink, err := p.fetcher.Devices(ctx, devicesDeltaLink)
-	if err != nil {
-		return updatedUsers, updatedDevices, err
+	var (
+		changedDevices []*fetcher.Device
+		deviceLink     string
+	)
+	switch strings.ToLower(p.conf.Dataset) {
+	case "", "all", "devices":
+		changedDevices, deviceLink, err = p.fetcher.Devices(ctx, devicesDeltaLink)
+		if err != nil {
+			return updatedUsers, updatedDevices, err
+		}
+		p.logger.Debugf("Received %d devices from API", len(changedUsers))
+	default:
+		p.logger.Debugf("Skipping device collection from API: dataset=%s", p.conf.Dataset)
 	}
-	p.logger.Debugf("Received %d devices from API", len(changedUsers))
 
-	// Get group changes.
+	// Get group changes. Groups are required for both users and devices.
+	// So always collect these.
 	changedGroups, groupLink, err := p.fetcher.Groups(ctx, groupsDeltaLink)
 	if err != nil {
 		return updatedUsers, updatedDevices, err

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -293,7 +293,7 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 		if err != nil {
 			return updatedUsers, updatedDevices, err
 		}
-		p.logger.Debugf("Received %d devices from API", len(changedUsers))
+		p.logger.Debugf("Received %d devices from API", len(changedDevices))
 	default:
 		p.logger.Debugf("Skipping device collection from API: dataset=%s", p.conf.Dataset)
 	}

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/conf.go
@@ -6,6 +6,7 @@ package azuread
 
 import (
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -21,6 +22,7 @@ type conf struct {
 	TenantID       string        `config:"tenant_id" validate:"required"`
 	SyncInterval   time.Duration `config:"sync_interval"`
 	UpdateInterval time.Duration `config:"update_interval"`
+	Dataset        string        `config:"dataset"`
 }
 
 // Validate runs validation against the config.
@@ -33,6 +35,11 @@ func (c *conf) Validate() error {
 	}
 	if c.UpdateInterval == 0 {
 		return errors.New("update_interval must not be zero")
+	}
+	switch strings.ToLower(c.Dataset) {
+	case "", "all", "users", "devices":
+	default:
+		return errors.New("dataset must be 'all', 'users', 'devices' or empty")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/conf_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/conf_test.go
@@ -27,6 +27,14 @@ func TestConf_Validate(t *testing.T) {
 			},
 			WantErr: "sync_interval must be longer than update_interval",
 		},
+		"err-invalid-dataset": {
+			In: conf{
+				SyncInterval:   defaultSyncInterval,
+				UpdateInterval: defaultUpdateInterval,
+				Dataset:        "everything",
+			},
+			WantErr: "dataset must be 'all', 'users', 'devices' or empty",
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This adds support for specifying which of users/devices to collect from the AzureAD API endpoints in order to reduce network costs for users who do not need a full set of entities.

The current change does not change the behaviour of device collection of registered owners and registered users; when the "devices" dataset is selected there user entities will still be collected as they are considered here as an attribute of the device, rather than a component of the users dataset.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #36440

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
