### PR TITLE
Fix link to SonicWall Firewall integration docs

### DIFF
--- a/filebeat/docs/modules/sonicwall.asciidoc
+++ b/filebeat/docs/modules/sonicwall.asciidoc
@@ -7,7 +7,7 @@ This file is generated! See scripts/docs_collector.py
 [[filebeat-module-sonicwall]]
 [role="xpack"]
 
-:modulename: sonicwall
+:modulename: sonicwall_firewall
 :has-dashboards: false
 
 == Sonicwall module

--- a/x-pack/filebeat/module/sonicwall/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sonicwall/_meta/docs.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 
-:modulename: sonicwall
+:modulename: sonicwall_firewall
 :has-dashboards: false
 
 == Sonicwall module


### PR DESCRIPTION
On this [Beats docs page](http://localhost:8000/guide/filebeat-module-sonicwall.html) the `Elastic integrations documentation` link should point to:

`https://docs.elastic.co/en/integrations/sonicwall_firewall`

rather than to:
`https://docs.elastic.co/en/integrations/sonicwall` (which gives a 404 error)

Closes: https://github.com/elastic/ingest-docs/issues/440

