### PR TITLE
Log error when statsd server fails to start and fix airflow docs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -136,6 +136,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add support for api_key authentication in elasticsearch module  {pull}36274[36274]
 - Add remaining dimensions for azure storage account to make them available for tsdb enablement. {pull}36331[36331]
 - Add missing 'TransactionType' dimension for Azure Storage Account. {pull}36413[36413]
+- Add log error when statsd server fails to start {pull}36477[36477]
 
 *Osquerybeat*
 

--- a/metricbeat/docs/modules/airflow.asciidoc
+++ b/metricbeat/docs/modules/airflow.asciidoc
@@ -13,7 +13,7 @@ This file is generated! See scripts/mage/docs_collector.go
 beta[]
 
 This module collects metrics from
-https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html[Airflow metrics] running a
+https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html[Airflow metrics]. It runs a
 statsd server where airflow will send metrics to. The default metricset is `statsd`.
 
 [float]
@@ -24,9 +24,13 @@ The Airflow module is tested with Airflow 2.1.0. It should work with version
 
 [float]
 === Usage
-The Airflow module requires <<metricbeat-module-statsd,Statsd>> to receive Statsd metrics. Refer to the link for instructions about how to use Statsd.
+The Airflow module requires <<metricbeat-module-statsd,Statsd>> to
+receive statsd metrics. Refer to the link for instructions about how
+to use statsd.
 
-Add the following lines to your Airflow configuration file e.g. `airflow.cfg` ensuring `statsd_prefix` is left empty and replace `%METRICBEAT_HOST%` with the address metricbeat is running:
+Add the following lines to your Airflow configuration file
+e.g. `airflow.cfg` ensuring `statsd_prefix` is left empty and replace
+`%METRICBEAT_HOST%` with the address where metricbeat is running:
 
 ```
 [metrics]

--- a/x-pack/metricbeat/module/airflow/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/airflow/_meta/docs.asciidoc
@@ -1,5 +1,5 @@
 This module collects metrics from
-https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html[Airflow metrics] running a
+https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/metrics.html[Airflow metrics]. It runs a
 statsd server where airflow will send metrics to. The default metricset is `statsd`.
 
 [float]

--- a/x-pack/metricbeat/module/airflow/_meta/docs.asciidoc
+++ b/x-pack/metricbeat/module/airflow/_meta/docs.asciidoc
@@ -10,9 +10,13 @@ The Airflow module is tested with Airflow 2.1.0. It should work with version
 
 [float]
 === Usage
-The Airflow module requires <<metricbeat-module-statsd,Statsd>> to receive Statsd metrics. Refer to the link for instructions about how to use Statsd.
+The Airflow module requires <<metricbeat-module-statsd,Statsd>> to
+receive statsd metrics. Refer to the link for instructions about how
+to use statsd.
 
-Add the following lines to your Airflow configuration file e.g. `airflow.cfg` ensuring `statsd_prefix` is left empty and replace `%METRICBEAT_HOST%` with the address metricbeat is running:
+Add the following lines to your Airflow configuration file
+e.g. `airflow.cfg` ensuring `statsd_prefix` is left empty and replace
+`%METRICBEAT_HOST%` with the address where metricbeat is running:
 
 ```
 [metrics]

--- a/x-pack/metricbeat/module/statsd/server/server.go
+++ b/x-pack/metricbeat/module/statsd/server/server.go
@@ -197,7 +197,9 @@ func (m *MetricSet) ServerStart() {
 	if m.serverStarted {
 		return
 	}
-	m.server.Start()
+	if err := m.server.Start(); err != nil {
+		m.Logger().Errorw("could not start statsd server for module: "+m.Module().Name(), "error", err)
+	}
 	m.serverStarted = true
 }
 


### PR DESCRIPTION
## Proposed commit message
This commit adds a log error when the statsd server fails to start, it
also improves the Airflow module documentation to make extra clear
that the module will start a statsd server.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally
1. Create the following `metricbeat.yml`:
    ```yaml
    metricbeat.modules:
    - module: airflow
      host: "1.2.3.4" # Any IP that does not belong to the host running Metricbeat
      port: "9102"
      ttl: "10s"
      period: 5s
      metricsets: [ 'statsd' ]
    
    output.console:
      enabled: true
    ```
2. Start Metricbeat
3. After a few seconds you should see a log error like this:
    ```json
    {"log.level":"error","@timestamp":"2023-08-31T17:09:34.565+0200","log.logger":"airflow.statsd","log.origin":{"file.name":"server/server.go","file.line":201},"message":"could not start statsd server for module: airflow","service.name":"metricbeat","error":{"message":"failed to start UDP server: listen udp 1.2.3.4:9102: bind: cannot assign requested address"},"ecs.version":"1.6.0"}
    ```
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
