### PR TITLE
x-pack/filebeat/input/httpjson: make response body decoding errors more informative

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -208,6 +208,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - [Azure] Add input metrics to the azure-eventhub input. {pull}35739[35739]
 - Reduce HTTPJSON metrics allocations. {pull}36282[36282]
 - Add support for a simplified input configuraton when running under Elastic-Agent {pull}36390[36390]
+- Make HTTPJSON response body decoding errors more informative. {pull}36481[36481]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/httpjson/encoding_test.go
+++ b/x-pack/filebeat/input/httpjson/encoding_test.go
@@ -8,6 +8,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -61,29 +62,103 @@ func TestDecodeZip(t *testing.T) {
 	assert.Equal(t, []string{"a.json", "b.ndjson", "c.ndjson"}, resp.header["X-Zip-Files"])
 }
 
+func TestDecodeJSON(t *testing.T) {
+	tests := []struct {
+		body   string
+		result string
+		err    string
+	}{
+		{
+			body:   "{}",
+			result: "{}",
+		},
+		{
+			body:   "{\"a\":\"b\"}",
+			result: "{\"a\":\"b\"}",
+		},
+		{
+			body: "[{\"a\":\"b\"},\nunfortunate text\n{\"c\":\"d\"}]",
+			err:  `invalid character 'u' looking for beginning of value: text context "...\"},\nunfortunate text\n{\"..."`,
+		},
+	}
+	for _, test := range tests {
+		resp := &response{}
+		err := decodeAsJSON([]byte(test.body), resp)
+		if test.err != "" {
+			assert.Error(t, err)
+			assert.EqualError(t, err, test.err)
+		} else {
+			assert.NoError(t, err)
+
+			var j []byte
+			if test.body != "" {
+				j, err = json.Marshal(resp.body)
+				if err != nil {
+					t.Fatalf("Marshal failed: %v", err)
+				}
+				assert.JSONEq(t, test.result, string(j))
+			} else {
+				assert.Equal(t, test.result, string(j))
+			}
+		}
+	}
+}
+
 func TestDecodeNdjson(t *testing.T) {
 	tests := []struct {
 		body   string
 		result string
+		err    string
 	}{
-		{"{}", "[{}]"},
-		{"{\"a\":\"b\"}", "[{\"a\":\"b\"}]"},
-		{"{\"a\":\"b\"}\n{\"c\":\"d\"}", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
-		{"{\"a\":\"b\"}\r\n{\"c\":\"d\"}", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
-		{"{\"a\":\"b\"}\r\n{\"c\":\"d\"}\n", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
-		{"{\"a\":\"b\"}\r\n{\"c\":\"d\"}\r\n", "[{\"a\":\"b\"},{\"c\":\"d\"}]"},
+		{
+			body:   "{}",
+			result: "[{}]",
+		},
+		{
+			body:   "{\"a\":\"b\"}",
+			result: "[{\"a\":\"b\"}]",
+		},
+		{
+			body:   "{\"a\":\"b\"}\n{\"c\":\"d\"}",
+			result: "[{\"a\":\"b\"},{\"c\":\"d\"}]",
+		},
+		{
+			body:   "{\"a\":\"b\"}\r\n{\"c\":\"d\"}",
+			result: "[{\"a\":\"b\"},{\"c\":\"d\"}]",
+		},
+		{
+			body:   "{\"a\":\"b\"}\r\n{\"c\":\"d\"}\n",
+			result: "[{\"a\":\"b\"},{\"c\":\"d\"}]",
+		},
+		{
+			body:   "{\"a\":\"b\"}\r\n{\"c\":\"d\"}\r\n",
+			result: "[{\"a\":\"b\"},{\"c\":\"d\"}]",
+		},
+		{
+			body: "{\"a\":\"b\"}unfortunate text\r\n{\"c\":\"d\"}\r\n",
+			err:  `invalid character 'u' looking for beginning of value: text context "...\"b\"}unfortunate text..."`,
+		},
 	}
 	for _, test := range tests {
 		resp := &response{}
 		err := decodeAsNdjson([]byte(test.body), resp)
-		if err != nil {
-			t.Fatalf("decodeAsNdjson failed: %v", err)
+		if test.err != "" {
+			assert.Error(t, err)
+			assert.EqualError(t, err, test.err)
+		} else {
+			assert.NoError(t, err)
+
+			var j []byte
+			if test.body != "" {
+				j, err = json.Marshal(resp.body)
+				if err != nil {
+					t.Fatalf("Marshal failed: %v", err)
+				}
+				assert.JSONEq(t, test.result, string(j))
+			} else {
+				assert.Equal(t, test.result, string(j))
+			}
 		}
-		j, err := json.Marshal(resp.body)
-		if err != nil {
-			t.Fatalf("Marshal failed: %v", err)
-		}
-		assert.Equal(t, test.result, string(j))
 	}
 }
 
@@ -93,25 +168,79 @@ func TestDecodeCSV(t *testing.T) {
 		result string
 		err    string
 	}{
-		{"", "", ""},
+		{body: "", result: ""},
 		{
-			"EVENT_TYPE,TIMESTAMP,REQUEST_ID,ORGANIZATION_ID,USER_ID\n" +
+			body: "EVENT_TYPE,TIMESTAMP,REQUEST_ID,ORGANIZATION_ID,USER_ID\n" +
 				"Login,20211018071353.465,id1,id2,user1\n" +
 				"Login,20211018071505.579,id4,id5,user2\n",
-			`[{"EVENT_TYPE":"Login","TIMESTAMP":"20211018071353.465","REQUEST_ID":"id1","ORGANIZATION_ID":"id2","USER_ID":"user1"},
+			result: `[{"EVENT_TYPE":"Login","TIMESTAMP":"20211018071353.465","REQUEST_ID":"id1","ORGANIZATION_ID":"id2","USER_ID":"user1"},
 			{"EVENT_TYPE":"Login","TIMESTAMP":"20211018071505.579","REQUEST_ID":"id4","ORGANIZATION_ID":"id5","USER_ID":"user2"}]`,
-			"",
 		},
 		{
-			"EVENT_TYPE,TIMESTAMP,REQUEST_ID,ORGANIZATION_ID,USER_ID\n" +
+			body: "EVENT_TYPE,TIMESTAMP,REQUEST_ID,ORGANIZATION_ID,USER_ID\n" +
 				"Login,20211018071505.579,id4,user2\n",
-			"",
-			"record on line 2: wrong number of fields",
+			err: "record on line 2: wrong number of fields: text context \"Login,20211...\"",
 		},
 	}
 	for _, test := range tests {
 		resp := &response{}
 		err := decodeAsCSV([]byte(test.body), resp)
+		if test.err != "" {
+			assert.Error(t, err)
+			assert.EqualError(t, err, test.err)
+		} else {
+			assert.NoError(t, err)
+
+			var j []byte
+			if test.body != "" {
+				j, err = json.Marshal(resp.body)
+				if err != nil {
+					t.Fatalf("Marshal failed: %v", err)
+				}
+				assert.JSONEq(t, test.result, string(j))
+			} else {
+				assert.Equal(t, test.result, string(j))
+			}
+		}
+	}
+}
+
+func TestDecodeXML(t *testing.T) {
+	tests := []struct {
+		body   string
+		result string
+		err    string
+	}{
+		{
+			body: `<?xml version="1.0" encoding="UTF-8"?>
+<o>
+        <p>
+                <n>Joord Lennart</n>
+        </p>
+        <i>
+                <n>Egil's Saga</n>
+        </i>
+</o>
+`,
+			result: `{"o":{"p":{"n":"Joord Lennart"},"i":{"n":"Egil's Saga"}}}`,
+		},
+		{
+			body: `<?xml version="1.0" encoding="UTF-8"?>
+<o>
+        <p>
+                <n>Joord Lennart</n>
+        </p>
+        <i>
+                <n>Egil's Saga</name>
+        </i>
+</o>
+`,
+			err: `XML syntax error on line 7: element <n> closed by </name>: text context "...     <n>Egil's Saga</name>"`,
+		},
+	}
+	for _, test := range tests {
+		resp := &response{header: make(http.Header)}
+		err := decodeAsXML([]byte(test.body), resp)
 		if test.err != "" {
 			assert.Error(t, err)
 			assert.EqualError(t, err, test.err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

The default rendering of errors from the json, csv and xml decoders can be a little terse, but the error values themselves contain information that allows the text context of the error to be constructed and returned. It is a common problem that users are unable to decipher the error messages, so add this text context to help.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
