### PR TITLE
winlogbeat/eventlog: ensure event loggers retain metric collection when handling recoverable errors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -103,6 +103,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix panic when redact option is not provided to CEL input. {issue}36387[36387] {pull}36388[36388]
 - Remove 'onFilteredOut' and 'onDroppedOnPublish' callback logs {issue}36299[36299] {pull}36399[36399]
 - Added a fix for Crowdstrike pipeline handling process arrays {pull}36496[36496]
+- Ensure winlog input retains metric collection when handling recoverable errors. {issue}36479[36479] {pull}36483[36483]
 
 *Heartbeat*
 
@@ -139,6 +140,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Winlogbeat*
 
+- Ensure event loggers retains metric collection when handling recoverable errors. {issue}36479[36479] {pull}36483[36483]
 
 *Elastic Logging Plugin*
 

--- a/filebeat/input/winlog/input.go
+++ b/filebeat/input/winlog/input.go
@@ -136,15 +136,15 @@ runLoop:
 			records, err := api.Read()
 			if eventlog.IsRecoverable(err) {
 				log.Errorw("Encountered recoverable error when reading from Windows Event Log", "error", err)
-				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
+				if resetErr := api.Reset(); resetErr != nil {
+					log.Errorw("Error resetting Windows Event Log handle", "error", resetErr)
 				}
 				continue runLoop
 			}
 			if !api.IsFile() && eventlog.IsChannelNotFound(err) {
 				log.Errorw("Encountered channel not found error when reading from Windows Event Log", "error", err)
-				if closeErr := api.Close(); closeErr != nil {
-					log.Errorw("Error closing Windows Event Log handle", "error", closeErr)
+				if resetErr := api.Reset(); resetErr != nil {
+					log.Errorw("Error resetting Windows Event Log handle", "error", resetErr)
 				}
 				continue runLoop
 			}

--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -177,15 +177,15 @@ runLoop:
 			records, err := api.Read()
 			if eventlog.IsRecoverable(err) {
 				e.log.Warnw("Read() encountered recoverable error. Reopening handle...", "error", err, "channel", api.Channel())
-				if closeErr := api.Close(); closeErr != nil {
-					e.log.Warnw("Close() error.", "error", err)
+				if resetErr := api.Reset(); resetErr != nil {
+					e.log.Warnw("Reset() error.", "error", err)
 				}
 				continue runLoop
 			}
 			if !api.IsFile() && eventlog.IsChannelNotFound(err) {
 				e.log.Warnw("Read() encountered channel not found error for channel %q. Reopening handle...", "error", err, "channel", api.Channel())
-				if closeErr := api.Close(); closeErr != nil {
-					e.log.Warnw("Close() error.", "error", err)
+				if resetErr := api.Reset(); resetErr != nil {
+					e.log.Warnw("Reset() error.", "error", err)
 				}
 				continue runLoop
 			}

--- a/winlogbeat/eventlog/eventlog.go
+++ b/winlogbeat/eventlog/eventlog.go
@@ -48,6 +48,11 @@ type EventLog interface {
 	// reading and close the log.
 	Read() ([]Record, error)
 
+	// Reset closes the event log channel to allow recovering from recoverable
+	// errors. Open must be successfully called after a Reset before Read may
+	// be called.
+	Reset() error
+
 	// Close the event log. It should not be re-opened after closing.
 	Close() error
 

--- a/winlogbeat/eventlog/wineventlog.go
+++ b/winlogbeat/eventlog/wineventlog.go
@@ -580,6 +580,11 @@ func (l *winEventLog) createBookmarkFromEvent(evtHandle win.EvtHandle) (string, 
 	return string(l.outputBuf.Bytes()), err
 }
 
+func (l *winEventLog) Reset() error {
+	debugf("%s Closing handle for reset", l.logPrefix)
+	return win.Close(l.subscription)
+}
+
 func (l *winEventLog) Close() error {
 	debugf("%s Closing handle", l.logPrefix)
 	l.metrics.close()

--- a/winlogbeat/eventlog/wineventlog_experimental.go
+++ b/winlogbeat/eventlog/wineventlog_experimental.go
@@ -348,9 +348,18 @@ func (l *winEventLogExp) createBookmarkFromEvent(evtHandle win.EvtHandle) (strin
 	return bookmark.XML()
 }
 
+func (l *winEventLogExp) Reset() error {
+	l.log.Debug("Closing event log reader handles for reset.")
+	return l.close()
+}
+
 func (l *winEventLogExp) Close() error {
 	l.log.Debug("Closing event log reader handles.")
 	l.metrics.close()
+	return l.close()
+}
+
+func (l *winEventLogExp) close() error {
 	if l.iterator == nil {
 		return l.renderer.Close()
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

When winlogbeat's event loggers encounter recoverable errors they handle this by closing and reopening the channel. This causes the metric collection for the beat and dependent winlog filebeat input to lose metric collection as metric registration only occurs on configuration. So add a soft-close method, Reset, that only closes the channel and leaves the event logger valid, leaving the metrics in tact, and use this for recovering from errors.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #36479
- Closes #36482 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
