### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/okta: allow fine-grain control of API requests

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -209,6 +209,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Reduce HTTPJSON metrics allocations. {pull}36282[36282]
 - Add support for a simplified input configuraton when running under Elastic-Agent {pull}36390[36390]
 - Make HTTPJSON response body decoding errors more informative. {pull}36481[36481]
+- Allow fine-grained control of entity analytics API requests for Okta provider. {issue}36440[36440] {pull}36492[36492]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/docs/inputs/input-entity-analytics.asciidoc
+++ b/x-pack/filebeat/docs/inputs/input-entity-analytics.asciidoc
@@ -545,6 +545,7 @@ Example configuration:
   enabled: true
   id: okta-1
   provider: okta
+  dataset: "all"
   sync_interval: "12h"
   update_interval: "30m"
   okta_domain: "OKTA_DOMAIN"
@@ -569,6 +570,14 @@ The Okta secret token, used for authentication. Field is required.
 Whether the input should collect device and device-associated user details
 from the Okta API. Device details must be activated on the Okta account for
 this option.
+
+[float]
+===== `dataset`
+
+The datasets to collect from the API. This can be one of "all", "users" or "devices",
+or may be left empty for the default behavior which is to collect all entities.
+When the `dataset` is set to "devices", some user entity data is collected in order
+to populate the registered users and registered owner fields for each device.
 
 [float]
 ===== `sync_interval`

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
@@ -6,6 +6,7 @@ package okta
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
@@ -61,6 +62,11 @@ type conf struct {
 	// Request is the configuration for establishing
 	// HTTP requests to the API.
 	Request *requestConfig `config:"request"`
+
+	// Dataset specifies the datasets to collect from
+	// the API. It can be ""/"all", "users", or
+	// "devices".
+	Dataset string `config:"dataset"`
 }
 
 type requestConfig struct {
@@ -159,7 +165,11 @@ func (c *conf) Validate() error {
 		return errInvalidUpdateInterval
 	case c.SyncInterval <= c.UpdateInterval:
 		return errSyncBeforeUpdate
-	default:
+	}
+	switch strings.ToLower(c.Dataset) {
+	case "", "all", "users", "devices":
 		return nil
+	default:
+		return errors.New("dataset must be 'all', 'users', 'devices' or empty")
 	}
 }

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/conf.go
@@ -42,10 +42,10 @@ type conf struct {
 	OktaDomain string `config:"okta_domain" validate:"required"`
 	OktaToken  string `config:"okta_token" validate:"required"`
 
-	// WantDevices indicates that device details
-	// should be collected. This is optional as
-	// the devices API is not necessarily activated.
-	WantDevices bool `config:"collect_device_details"`
+	// Dataset specifies the datasets to collect from
+	// the API. It can be ""/"all", "users", or
+	// "devices".
+	Dataset string `config:"dataset"`
 
 	// SyncInterval is the time between full
 	// synchronisation operations.
@@ -62,11 +62,6 @@ type conf struct {
 	// Request is the configuration for establishing
 	// HTTP requests to the API.
 	Request *requestConfig `config:"request"`
-
-	// Dataset specifies the datasets to collect from
-	// the API. It can be ""/"all", "users", or
-	// "devices".
-	Dataset string `config:"dataset"`
 }
 
 type requestConfig struct {

--- a/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/okta/okta_test.go
@@ -22,156 +22,186 @@ import (
 )
 
 func TestOktaDoFetch(t *testing.T) {
-	dbFilename := "TestOktaDoFetch.db"
-	store := testSetupStore(t, dbFilename)
-	t.Cleanup(func() {
-		testCleanupStore(store, dbFilename)
-	})
-
-	const (
-		window  = time.Minute
-		key     = "token"
-		users   = `[{"id":"USERID","status":"STATUS","created":"2023-05-14T13:37:20.000Z","activated":null,"statusChanged":"2023-05-15T01:50:30.000Z","lastLogin":"2023-05-15T01:59:20.000Z","lastUpdated":"2023-05-15T01:50:32.000Z","passwordChanged":"2023-05-15T01:50:32.000Z","type":{"id":"typeid"},"profile":{"firstName":"name","lastName":"surname","mobilePhone":null,"secondEmail":null,"login":"name.surname@example.com","email":"name.surname@example.com"},"credentials":{"password":{"value":"secret"},"emails":[{"value":"name.surname@example.com","status":"VERIFIED","type":"PRIMARY"}],"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://localhost/api/v1/users/USERID"}}}]`
-		devices = `[{"id":"DEVICEID","status":"STATUS","created":"2019-10-02T18:03:07.000Z","lastUpdated":"2019-10-02T18:03:07.000Z","profile":{"displayName":"Example Device name 1","platform":"WINDOWS","serialNumber":"XXDDRFCFRGF3M8MD6D","sid":"S-1-11-111","registered":true,"secureHardwarePresent":false,"diskEncryptionType":"ALL_INTERNAL_VOLUMES"},"resourceType":"UDDevice","resourceDisplayName":{"value":"Example Device name 1","sensitive":false},"resourceAlternateId":null,"resourceId":"DEVICEID","_links":{"activate":{"href":"https://localhost/api/v1/devices/DEVICEID/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://localhost/api/v1/devices/DEVICEID","hints":{"allow":["GET","PATCH","PUT"]}},"users":{"href":"https://localhost/api/v1/devices/DEVICEID/users","hints":{"allow":["GET"]}}}}]`
-	)
-
-	data := map[string]string{
-		"users":   users,
-		"devices": devices,
+	tests := []struct {
+		dataset     string
+		wantUsers   bool
+		wantDevices bool
+	}{
+		{dataset: "", wantUsers: true, wantDevices: true},
+		{dataset: "all", wantUsers: true, wantDevices: true},
+		{dataset: "users", wantUsers: true, wantDevices: false},
+		{dataset: "devices", wantUsers: false, wantDevices: true},
 	}
 
-	var wantUsers []User
-	err := json.Unmarshal([]byte(users), &wantUsers)
-	if err != nil {
-		t.Fatalf("failed to unmarshal user data: %v", err)
-	}
-	var wantDevices []Device
-	err = json.Unmarshal([]byte(users), &wantDevices)
-	if err != nil {
-		t.Fatalf("failed to unmarshal device data: %v", err)
-	}
-
-	wantStates := make(map[string]State)
-
-	// Set the number of repeats.
-	const repeats = 3
-	var n int
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Leave 49 remaining, reset in one minute.
-		w.Header().Add("x-rate-limit-limit", "50")
-		w.Header().Add("x-rate-limit-remaining", "49")
-		w.Header().Add("x-rate-limit-reset", fmt.Sprint(time.Now().Add(time.Minute).Unix()))
-
-		if strings.HasPrefix(r.URL.Path, "/api/v1/device") && strings.HasSuffix(r.URL.Path, "users") {
-			// Give one user if this is a get device users request.
-			fmt.Fprintln(w, data["users"])
-			return
-		}
-
-		base := path.Base(r.URL.Path)
-
-		// Set next link if we can still repeat.
-		n++
-		if n < repeats {
-			w.Header().Add("link", fmt.Sprintf(`<https://localhost/api/v1/%s?limit=200&after=opaquevalue>; rel="next"`, base))
-		}
-
-		prefix := strings.TrimRight(base, "s") // endpoints are plural.
-		id := fmt.Sprintf("%sid%d", prefix, n)
-
-		// Store expected states. The State values are all Discovered
-		// unless the user is deleted since they are all first appearance.
-		states := []string{
-			"ACTIVE",
-			"RECOVERY",
-			"DEPROVISIONED",
-		}
-		status := states[n%len(states)]
-		state := Discovered
-		if status == "DEPROVISIONED" {
-			state = Deleted
-		}
-		wantStates[id] = state
-
-		replacer := strings.NewReplacer(
-			strings.ToUpper(prefix+"id"), id,
-			"STATUS", status,
-		)
-		fmt.Fprintln(w, replacer.Replace(data[base]))
-	}))
-	defer ts.Close()
-
-	u, err := url.Parse(ts.URL)
-	if err != nil {
-		t.Errorf("failed to parse server URL: %v", err)
-	}
-	a := oktaInput{
-		cfg: conf{
-			OktaDomain:  u.Host,
-			OktaToken:   key,
-			WantDevices: true,
-		},
-		client: ts.Client(),
-		lim:    rate.NewLimiter(1, 1),
-		logger: logp.L(),
-	}
-
-	ss, err := newStateStore(store)
-	if err != nil {
-		t.Fatalf("unexpected error making state store: %v", err)
-	}
-	defer ss.close(false)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-
-	t.Run("users", func(t *testing.T) {
-		n = 0
-
-		got, err := a.doFetchUsers(ctx, ss, false)
-		if err != nil {
-			t.Fatalf("unexpected error from doFetch: %v", err)
-		}
-
-		if len(got) != repeats {
-			t.Errorf("unexpected number of results: got:%d want:%d", len(got), repeats)
-		}
-		for i, g := range got {
-			if wantID := fmt.Sprintf("userid%d", i+1); g.ID != wantID {
-				t.Errorf("unexpected user ID for user %d: got:%s want:%s", i, g.ID, wantID)
+	for _, test := range tests {
+		t.Run(test.dataset, func(t *testing.T) {
+			suffix := test.dataset
+			if suffix != "" {
+				suffix = "_" + suffix
 			}
-			if g.State != wantStates[g.ID] {
-				t.Errorf("unexpected user ID for user %s: got:%s want:%s", g.ID, g.State, wantStates[g.ID])
-			}
-		}
-	})
+			dbFilename := fmt.Sprintf("TestOktaDoFetch%s.db", suffix)
+			store := testSetupStore(t, dbFilename)
+			t.Cleanup(func() {
+				testCleanupStore(store, dbFilename)
+			})
 
-	t.Run("devices", func(t *testing.T) {
-		n = 0
+			const (
+				window  = time.Minute
+				key     = "token"
+				users   = `[{"id":"USERID","status":"STATUS","created":"2023-05-14T13:37:20.000Z","activated":null,"statusChanged":"2023-05-15T01:50:30.000Z","lastLogin":"2023-05-15T01:59:20.000Z","lastUpdated":"2023-05-15T01:50:32.000Z","passwordChanged":"2023-05-15T01:50:32.000Z","type":{"id":"typeid"},"profile":{"firstName":"name","lastName":"surname","mobilePhone":null,"secondEmail":null,"login":"name.surname@example.com","email":"name.surname@example.com"},"credentials":{"password":{"value":"secret"},"emails":[{"value":"name.surname@example.com","status":"VERIFIED","type":"PRIMARY"}],"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"self":{"href":"https://localhost/api/v1/users/USERID"}}}]`
+				devices = `[{"id":"DEVICEID","status":"STATUS","created":"2019-10-02T18:03:07.000Z","lastUpdated":"2019-10-02T18:03:07.000Z","profile":{"displayName":"Example Device name 1","platform":"WINDOWS","serialNumber":"XXDDRFCFRGF3M8MD6D","sid":"S-1-11-111","registered":true,"secureHardwarePresent":false,"diskEncryptionType":"ALL_INTERNAL_VOLUMES"},"resourceType":"UDDevice","resourceDisplayName":{"value":"Example Device name 1","sensitive":false},"resourceAlternateId":null,"resourceId":"DEVICEID","_links":{"activate":{"href":"https://localhost/api/v1/devices/DEVICEID/lifecycle/activate","hints":{"allow":["POST"]}},"self":{"href":"https://localhost/api/v1/devices/DEVICEID","hints":{"allow":["GET","PATCH","PUT"]}},"users":{"href":"https://localhost/api/v1/devices/DEVICEID/users","hints":{"allow":["GET"]}}}}]`
+			)
 
-		got, err := a.doFetchDevices(ctx, ss, false)
-		if err != nil {
-			t.Fatalf("unexpected error from doFetch: %v", err)
-		}
+			data := map[string]string{
+				"users":   users,
+				"devices": devices,
+			}
 
-		if len(got) != repeats {
-			t.Errorf("unexpected number of results: got:%d want:%d", len(got), repeats)
-		}
-		for i, g := range got {
-			if wantID := fmt.Sprintf("deviceid%d", i+1); g.ID != wantID {
-				t.Errorf("unexpected device ID for device %d: got:%s want:%s", i, g.ID, wantID)
+			var wantUsers []User
+			if test.wantUsers {
+				err := json.Unmarshal([]byte(users), &wantUsers)
+				if err != nil {
+					t.Fatalf("failed to unmarshal user data: %v", err)
+				}
 			}
-			if g.State != wantStates[g.ID] {
-				t.Errorf("unexpected device ID for device %s: got:%s want:%s", g.ID, g.State, wantStates[g.ID])
+			var wantDevices []Device
+			if test.wantDevices {
+				err := json.Unmarshal([]byte(users), &wantDevices)
+				if err != nil {
+					t.Fatalf("failed to unmarshal device data: %v", err)
+				}
 			}
-			if g.Users == nil {
-				t.Errorf("expected users for device %s", g.ID)
-			}
-		}
 
-		if t.Failed() {
-			b, _ := json.MarshalIndent(got, "", "\t")
-			t.Logf("document:\n%s", b)
-		}
-	})
+			wantStates := make(map[string]State)
+
+			// Set the number of repeats.
+			const repeats = 3
+			var n int
+			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Leave 49 remaining, reset in one minute.
+				w.Header().Add("x-rate-limit-limit", "50")
+				w.Header().Add("x-rate-limit-remaining", "49")
+				w.Header().Add("x-rate-limit-reset", fmt.Sprint(time.Now().Add(time.Minute).Unix()))
+
+				if strings.HasPrefix(r.URL.Path, "/api/v1/device") && strings.HasSuffix(r.URL.Path, "users") {
+					// Give one user if this is a get device users request.
+					fmt.Fprintln(w, data["users"])
+					return
+				}
+
+				base := path.Base(r.URL.Path)
+
+				// Set next link if we can still repeat.
+				n++
+				if n < repeats {
+					w.Header().Add("link", fmt.Sprintf(`<https://localhost/api/v1/%s?limit=200&after=opaquevalue>; rel="next"`, base))
+				}
+
+				prefix := strings.TrimRight(base, "s") // endpoints are plural.
+				id := fmt.Sprintf("%sid%d", prefix, n)
+
+				// Store expected states. The State values are all Discovered
+				// unless the user is deleted since they are all first appearance.
+				states := []string{
+					"ACTIVE",
+					"RECOVERY",
+					"DEPROVISIONED",
+				}
+				status := states[n%len(states)]
+				state := Discovered
+				if status == "DEPROVISIONED" {
+					state = Deleted
+				}
+				wantStates[id] = state
+
+				replacer := strings.NewReplacer(
+					strings.ToUpper(prefix+"id"), id,
+					"STATUS", status,
+				)
+				fmt.Fprintln(w, replacer.Replace(data[base]))
+			}))
+			defer ts.Close()
+
+			u, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Errorf("failed to parse server URL: %v", err)
+			}
+			a := oktaInput{
+				cfg: conf{
+					OktaDomain: u.Host,
+					OktaToken:  key,
+					Dataset:    test.dataset,
+				},
+				client: ts.Client(),
+				lim:    rate.NewLimiter(1, 1),
+				logger: logp.L(),
+			}
+
+			ss, err := newStateStore(store)
+			if err != nil {
+				t.Fatalf("unexpected error making state store: %v", err)
+			}
+			defer ss.close(false)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			t.Run("users", func(t *testing.T) {
+				n = 0
+
+				got, err := a.doFetchUsers(ctx, ss, false)
+				if err != nil {
+					t.Fatalf("unexpected error from doFetch: %v", err)
+				}
+
+				if len(got) != wantCount(repeats, test.wantUsers) {
+					t.Errorf("unexpected number of results: got:%d want:%d", len(got), wantCount(repeats, test.wantUsers))
+				}
+				for i, g := range got {
+					if wantID := fmt.Sprintf("userid%d", i+1); g.ID != wantID {
+						t.Errorf("unexpected user ID for user %d: got:%s want:%s", i, g.ID, wantID)
+					}
+					if g.State != wantStates[g.ID] {
+						t.Errorf("unexpected user state for user %s: got:%s want:%s", g.ID, g.State, wantStates[g.ID])
+					}
+				}
+			})
+
+			t.Run("devices", func(t *testing.T) {
+				n = 0
+
+				got, err := a.doFetchDevices(ctx, ss, false)
+				if err != nil {
+					t.Fatalf("unexpected error from doFetch: %v", err)
+				}
+
+				if len(got) != wantCount(repeats, test.wantDevices) {
+					t.Errorf("unexpected number of results: got:%d want:%d", len(got), wantCount(repeats, test.wantDevices))
+				}
+				for i, g := range got {
+					if wantID := fmt.Sprintf("deviceid%d", i+1); g.ID != wantID {
+						t.Errorf("unexpected device ID for device %d: got:%s want:%s", i, g.ID, wantID)
+					}
+					if g.State != wantStates[g.ID] {
+						t.Errorf("unexpected device state for device %s: got:%s want:%s", g.ID, g.State, wantStates[g.ID])
+					}
+					if g.Users == nil {
+						t.Errorf("expected users for device %s", g.ID)
+					}
+				}
+
+				if t.Failed() {
+					b, _ := json.MarshalIndent(got, "", "\t")
+					t.Logf("document:\n%s", b)
+				}
+			})
+		})
+	}
+}
+
+func wantCount(n int, want bool) int {
+	if !want {
+		return 0
+	}
+	return n
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

This adds support for specifying which of users/devices to collect from the Okta API endpoints in order to reduce network costs for users who do not need a full set of entities.

The current change does not change the behaviour of device collection of registered owners and registered users; when the "devices" dataset is selected there user entities will still be collected as they are considered here as an attribute of the device, rather than a component of the users dataset.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #36440

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
