### PR TITLE
Support flattened data_stream.* fields under Elastic-Agent

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -63,6 +63,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Fix ndjson parser to store JSON fields correctly under `target` {issue}29395[29395]
 - Support build of projects outside of beats directory {pull}36126[36126]
 - Fix environment capture by `add_process_metadata` processor. {issue}36469[36469] {pull}36471[36471]
+- Support fattened `data_stream` object when running under Elastic-Agent {pr}36516[36516]
 
 
 *Auditbeat*

--- a/x-pack/libbeat/management/generate_test.go
+++ b/x-pack/libbeat/management/generate_test.go
@@ -7,8 +7,10 @@ package management
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/elastic-agent-client/v7/pkg/client"
@@ -229,4 +231,86 @@ func buildConfigMap(t *testing.T, unitRaw *proto.UnitExpectedConfig, agentInfo *
 	err = reloadCfg[0].Config.Unpack(&cfgMap)
 	require.NoError(t, err, "error in unpack for config %#v", reloadCfg[0].Config)
 	return cfgMap
+}
+
+func TestDeDotDataStream(t *testing.T) {
+	testCases := map[string]struct {
+		source             map[string]any
+		dataStream         *proto.DataStream
+		wantError          bool
+		expectedDataStream *proto.DataStream
+	}{
+		"all data is flattened": {
+			source: map[string]any{
+				"data_stream.dataset":   "my dataset",
+				"data_stream.namespace": "my namespace",
+				"data_stream.type":      "my type",
+			},
+			expectedDataStream: &proto.DataStream{
+				Dataset:   "my dataset",
+				Namespace: "my namespace",
+				Type:      "my type",
+			},
+		},
+		"no data is flattened": {
+			dataStream: &proto.DataStream{
+				Dataset:   "my dataset",
+				Namespace: "my namespace",
+				Type:      "my type",
+			},
+			expectedDataStream: &proto.DataStream{
+				Dataset:   "my dataset",
+				Namespace: "my namespace",
+				Type:      "my type",
+			},
+		},
+		"mix of flattened and data_stream": {
+			dataStream: &proto.DataStream{
+				Dataset: "my dataset",
+				Type:    "my type",
+			},
+			source: map[string]any{
+				"data_stream.namespace": "my namespace",
+			},
+			expectedDataStream: &proto.DataStream{
+				Dataset:   "my dataset",
+				Namespace: "my namespace",
+				Type:      "my type",
+			},
+		},
+		"duplicated keys generate error": {
+			dataStream: &proto.DataStream{
+				Dataset: "my dataset",
+			},
+			source: map[string]any{
+				"data_stream.dataset": "another dataset",
+			},
+			wantError: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			raw := &proto.UnitExpectedConfig{
+				Source:     requireNewStruct(t, tc.source),
+				DataStream: tc.dataStream,
+			}
+
+			final, err := deDotDataStream(raw)
+			if tc.wantError {
+				if err == nil {
+					t.Error("expecting an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("deDotDataStream returned an error: %s", err)
+			}
+
+			if !cmp.Equal(final, tc.expectedDataStream, protocmp.Transform()) {
+				t.Errorf("expecting a different value: --got/++want\n'%s'",
+					cmp.Diff(final, tc.expectedDataStream, protocmp.Transform()))
+			}
+		})
+	}
 }

--- a/x-pack/libbeat/management/managerV2_test.go
+++ b/x-pack/libbeat/management/managerV2_test.go
@@ -511,6 +511,136 @@ func TestErrorPerUnit(t *testing.T) {
 	}, 10*time.Second, 100*time.Millisecond, "desired state, was not reached")
 }
 
+func TestFlattenedDataStreams(t *testing.T) {
+	stateReached := atomic.Bool{}
+
+	expectedDataset := "my-dataset"
+	expectedNamespace := "my-namespace"
+	expectedType := "my-type"
+	expectedIndex := fmt.Sprintf("%s-%s-%s",
+		expectedType, expectedDataset, expectedNamespace)
+
+	r := reload.NewRegistry()
+
+	output := &mockOutput{
+		ReloadFn: func(config *reload.ConfigWithMeta) error {
+			return nil
+		},
+	}
+	r.MustRegisterOutput(output)
+
+	inputs := &mockReloadable{
+		ReloadFn: func(configs []*reload.ConfigWithMeta) error {
+			for _, input := range configs {
+				tmp := struct {
+					Index string `config:"index" yaml:"index"`
+				}{}
+
+				if err := input.Config.Unpack(&tmp); err != nil {
+					t.Fatalf("error unpacking config: %s", err)
+				}
+
+				if tmp.Index != expectedIndex {
+					t.Fatalf("expecting index %q, got %q", expectedIndex, tmp.Index)
+				}
+
+				stateReached.Store(true)
+			}
+			return nil
+		},
+	}
+	r.MustRegisterInput(inputs)
+
+	outputUnit := proto.UnitExpected{
+		Id:             "output-unit",
+		Type:           proto.UnitType_OUTPUT,
+		State:          proto.State_HEALTHY,
+		ConfigStateIdx: 1,
+		LogLevel:       proto.UnitLogLevel_DEBUG,
+		Config: &proto.UnitExpectedConfig{
+			Id:   "default",
+			Type: "mock",
+			Name: "mock",
+			Source: integration.RequireNewStruct(t,
+				map[string]interface{}{
+					"Is":        "this",
+					"required?": "Yes!",
+				}),
+		},
+	}
+
+	inputUnit1 := proto.UnitExpected{
+		Id:             "input-unit1",
+		Type:           proto.UnitType_INPUT,
+		State:          proto.State_HEALTHY,
+		ConfigStateIdx: 1,
+		LogLevel:       proto.UnitLogLevel_DEBUG,
+		Config: &proto.UnitExpectedConfig{
+			Id:   "input-unit-config-id",
+			Type: "filestream",
+			Name: "foo",
+			Source: requireNewStruct(t, map[string]any{
+				"data_stream.dataset":   expectedDataset,
+				"data_stream.namespace": expectedNamespace,
+				"data_stream.type":      expectedType,
+			}),
+			Streams: []*proto.Stream{
+				{
+					Id: "filestream-id",
+					Source: integration.RequireNewStruct(t, map[string]interface{}{
+						"id": "input-unit1",
+					}),
+				},
+			},
+		},
+	}
+	units := []*proto.UnitExpected{
+		&outputUnit,
+		&inputUnit1,
+	}
+	server := &mock.StubServerV2{
+		CheckinV2Impl: func(observed *proto.CheckinObserved) *proto.CheckinExpected {
+			// Nothing to do here, just keep sending the same units.
+			return &proto.CheckinExpected{
+				Units: units,
+			}
+		},
+		ActionImpl: func(response *proto.ActionResponse) error { return nil },
+	}
+
+	if err := server.Start(); err != nil {
+		t.Fatalf("could not start mock Elastic-Agent server: %s", err)
+	}
+	defer server.Stop()
+
+	client := client.NewV2(
+		fmt.Sprintf(":%d", server.Port),
+		"",
+		client.VersionInfo{},
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	m, err := NewV2AgentManagerWithClient(
+		&Config{
+			Enabled: true,
+		},
+		r,
+		client,
+	)
+	if err != nil {
+		t.Fatalf("could not instantiate ManagerV2: %s", err)
+	}
+
+	if err := m.Start(); err != nil {
+		t.Fatalf("could not start ManagerV2: %s", err)
+	}
+	defer m.Stop()
+
+	require.Eventually(t, func() bool {
+		return stateReached.Load()
+	}, 10*time.Second, 100*time.Millisecond,
+		"did not find expected 'index' field on input final config")
+}
+
 type reloadable struct {
 	mx     sync.Mutex
 	config *reload.ConfigWithMeta


### PR DESCRIPTION
## Proposed commit message

When an input configuration comes from Elastic-Agent the data_stream.* fields sometimes are flattened (e.g: data_stream.dataset: mystuff), this was not supported by Beats.

This commit enables support for it.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

~~## Author's Checklist~~
## How to test this PR locally
Configure a standalone Elastic-Agent with a flattened `data_stream` field, like this:
```yaml
inputs:
  - type: filestream
    id: unique-id-per-input
    data_stream.dataset: mystuff
    paths:
      - /var/log/my-file/my.log*
```

Run the Elastic-Agent and assert that the dataset from the events is `mystuff`.

## Related issues
- Closes https://github.com/elastic/elastic-agent/issues/3191

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

