### PR TITLE
packetbeat/protos/http: don't panic when host is empty

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -136,6 +136,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Packetbeat*
 
+- Fix panic in HTTP protocol parsing when host header has empty host part. {issue}36497[36497] {issue}36518[36518]
 
 *Winlogbeat*
 

--- a/packetbeat/protos/http/http_test.go
+++ b/packetbeat/protos/http/http_test.go
@@ -1901,6 +1901,36 @@ func TestHttpParser_Extension(t *testing.T) {
 	}
 }
 
+func TestExtractHostHeader(t *testing.T) {
+	tests := []struct {
+		header   string
+		wantHost string
+		wantPort int
+	}{
+		{header: "", wantHost: "", wantPort: 0},
+		{header: "localhost:0", wantHost: "localhost:0", wantPort: 0},
+		{header: "127.0.0.1:0", wantHost: "127.0.0.1:0", wantPort: 0},
+		{header: "[::]:0", wantHost: "[::]:0", wantPort: 0},
+		{header: "localhost", wantHost: "localhost", wantPort: 0},
+		{header: "localhost:9001", wantHost: "localhost", wantPort: 9001},
+		{header: "localhost:9000000", wantHost: "localhost:9000000", wantPort: 0},
+		{header: "127.0.0.1:9001", wantHost: "127.0.0.1", wantPort: 9001},
+		{header: "127.0.0.1", wantHost: "127.0.0.1", wantPort: 0},
+		{header: "[::]", wantHost: "::", wantPort: 0},
+		{header: ":0", wantHost: ":0", wantPort: 0},
+		{header: ":9001", wantHost: "", wantPort: 9001},
+	}
+	for _, test := range tests {
+		host, port := extractHostHeader(test.header)
+		if host != test.wantHost {
+			t.Errorf("unexpected host for %q: got:%q want:%q", test.header, host, test.wantHost)
+		}
+		if port != test.wantPort {
+			t.Errorf("unexpected port for %q: got:%d want:%d", test.header, port, test.wantPort)
+		}
+	}
+}
+
 func benchmarkHTTPMessage(b *testing.B, data []byte) {
 	http := httpModForTests(nil)
 	parser := newParser(&http.parserConfig)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Previously, extractHostHeader would panic if the host part of header was empty. Avoid this by using standard library functions to do splits and clean up IPv6 addresses.

Add tests to confirm old behaviour and test to cover panic case.

Counter proposal to #36498.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Fixes #36497
- Closes #36498

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
