### PR TITLE
[Filebeat] httplog - reduce duplication to shrink log message size

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -217,6 +217,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Allow fine-grained control of entity analytics API requests for Okta provider. {issue}36440[36440] {pull}36492[36492]
 - Add support for expanding `journald.process.capabilities` into the human-readable effective capabilities in the ECS `process.thread.capabilities.effective` field. {issue}36454[36454] {pull}36470[36470]
 - Allow fine-grained control of entity analytics API requests for AzureAD provider. {issue}36440[36440] {pull}36441[36441]
+- For request tracer logging in CEL and httpjson the request and response body are no longer included in `event.original`. The body is still present in `http.{request,response}.body.content`. {pull}36531[36531]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/internal/httplog/roundtripper.go
+++ b/x-pack/filebeat/input/internal/httplog/roundtripper.go
@@ -65,7 +65,7 @@ type LoggingRoundTripper struct {
 //	http.request.body.content
 //	http.request.body.bytes
 //	http.request.mime_type
-//	event.original (the full request and body from httputil.DumpRequestOut)
+//	event.original (the request without body from httputil.DumpRequestOut)
 //
 // Fields logged in responses:
 //
@@ -73,7 +73,7 @@ type LoggingRoundTripper struct {
 //	http.response.body.content
 //	http.response.body.bytes
 //	http.response.mime_type
-//	event.original (the full response and body from httputil.DumpResponse)
+//	event.original (the response without body from httputil.DumpResponse)
 func (rt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Create a child logger for this request.
 	log := rt.logger.With(
@@ -111,7 +111,7 @@ func (rt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 			zap.String("http.request.mime_type", req.Header.Get("Content-Type")),
 		)
 	}
-	message, err := httputil.DumpRequestOut(req, true)
+	message, err := httputil.DumpRequestOut(req, false)
 	if err != nil {
 		errorsMessages = append(errorsMessages, fmt.Sprintf("failed to dump request: %s", err))
 	} else {
@@ -149,7 +149,7 @@ func (rt *LoggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 			zap.String("http.response.mime_type", resp.Header.Get("Content-Type")),
 		)
 	}
-	message, err = httputil.DumpResponse(resp, true)
+	message, err = httputil.DumpResponse(resp, false)
 	if err != nil {
 		errorsMessages = append(errorsMessages, fmt.Sprintf("failed to dump response: %s", err))
 	} else {


### PR DESCRIPTION
## Proposed commit message

The request and response bodies are included twice in request tracer messages. The body appears in both the event.original and http.{request,response}.body.content. This removes the body from the event.original. It should help reduce the log message sizes for large responses.

The motivation is to allow larger responses to fit into the request tracer log. When a log message exceeds the max size of a log (default 1 MiB) then the message is dropped and a warning is logged by zap to stderr.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.
