### PR TITLE
Fix filestream configuration keys in docs

### DIFF
--- a/filebeat/docs/inputs/input-filestream-file-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-file-options.asciidoc
@@ -373,7 +373,7 @@ results in files that are not completely read because they are removed from
 disk too early, disable this option.
 
 This option is enabled by default. If you disable this option, you must also
-disable `clean.on_state_change.removed`.
+disable `clean_removed`.
 
 WINDOWS: If your Windows log rotation system shows errors because it can't
 rotate files, make sure this option is enabled.
@@ -480,7 +480,7 @@ will be read again from the beginning because the states were removed from the
 registry file. In such cases, we recommend that you disable the `clean_removed`
 option.
 
-You must disable this option if you also disable `close_removed`.
+You must disable this option if you also disable `close.on_state_change.removed`.
 
 [float]
 ===== `backoff.*`


### PR DESCRIPTION
## Proposed commit message

Filestream docs mentioned `clean.on_state_change.removed` and `close_removed`, however those are not the correct configuration keys. This commit fixes that.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
