### PR TITLE
Fix class name in Python Tests

### DIFF
--- a/metricbeat/tests/system/test_lightmodules.py
+++ b/metricbeat/tests/system/test_lightmodules.py
@@ -46,7 +46,7 @@ class Test(metricbeat.BaseTest):
 
 @contextmanager
 def http_test_server():
-    server = http.server.HTTPServer(('localhost', 0), TestHTTPHandler)
+    server = http.server.HTTPServer(('localhost', 0), HTTPHandlerForTest)
     child = threading.Thread(target=server.serve_forever)
     child.start()
     yield server
@@ -54,7 +54,7 @@ def http_test_server():
     child.join()
 
 
-class TestHTTPHandler(http.server.BaseHTTPRequestHandler):
+class HTTPHandlerForTest(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
         self.send_header("Content-type", "application/json")


### PR DESCRIPTION
## Proposed commit message

metricbeat/tests/system/test_lightmodules.py was failing, it seems we had a custom class with the name starting in 'Test' and that was confusing pytest. This commit fixes the issue by renaming the class.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~

- Fixes https://github.com/elastic/beats/issues/36515

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~