### PR TITLE
Fix zsh autocompletion failing tests

### DIFF
--- a/libbeat/tests/system/test_cmd_completion.py
+++ b/libbeat/tests/system/test_cmd_completion.py
@@ -17,7 +17,7 @@ class TestCommandCompletion(BaseTest):
     def test_zsh_completion(self):
         exit_code = self.run_beat(extra_args=["completion", "zsh"])
         assert exit_code == 0
-        assert self.log_contains("#compdef _mockbeat mockbeat")
+        assert self.log_contains("compdef _mockbeat mockbeat")
 
     def test_unknown_completion(self):
         exit_code = self.run_beat(extra_args=["completion", "awesomeshell"])


### PR DESCRIPTION
## Proposed commit message

It looks like the output of the autocompletion script for zsh has
changed, hence the tests are failing. This commit fixes it.

The autocompletion is generated by an external
package (github.com/spf13/cobra), so this commit just updates the test
with the current output.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
## Related issues

- Fixes https://github.com/elastic/beats/issues/36550
- Fixes https://github.com/elastic/beats/issues/36511
- Fixes https://github.com/elastic/beats/issues/36509
- Fixes https://github.com/elastic/beats/issues/36508

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
