### PR TITLE
packetbeat/beater: deduplicate interface configs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -243,6 +243,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Packetbeat*
 
+- Improve efficiency of sniffers by deduplicating interface configurations. {issue}36574[36574] {pull}36576[36576]
 
 *Winlogbeat*
 

--- a/packetbeat/beater/processor.go
+++ b/packetbeat/beater/processor.go
@@ -220,14 +220,31 @@ func setupSniffer(id string, cfg config.Config, protocols *protos.ProtocolsStruc
 		return nil, err
 	}
 
-	for i, iface := range cfg.Interfaces {
+	// Ensure interfaces are uniquely represented so we don't listen on the
+	// same interface with multiple sniffers.
+	interfaces := make([]config.InterfaceConfig, 0, len(cfg.Interfaces))
+	seen := make(map[uint64]bool)
+	for _, iface := range cfg.Interfaces {
+		// Currently we hash on all fields in the config. We can revise this in future.
+		h, err := hashstructure.Hash(iface, nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not deduplicate interface configurations: %w", err)
+		}
+		if seen[h] {
+			continue
+		}
+		seen[h] = true
+		interfaces = append(interfaces, iface)
+	}
+
+	for i, iface := range interfaces {
 		if iface.BpfFilter != "" || cfg.Flows.IsEnabled() {
 			continue
 		}
-		cfg.Interfaces[i].BpfFilter = protocols.BpfFilter(iface.WithVlans, icmp.Enabled())
+		interfaces[i].BpfFilter = protocols.BpfFilter(iface.WithVlans, icmp.Enabled())
 	}
 
-	return sniffer.New(id, false, "", decoders, cfg.Interfaces)
+	return sniffer.New(id, false, "", decoders, interfaces)
 }
 
 // CheckConfig performs a dry-run creation of a Packetbeat pipeline based


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

When a config is provided by fleet, it will contain multiple definitions
of the same interface, and in future we may allow individual datastreams
to specify their own interface, so allow multiple distinct interfaces,
but ensure that no interfaces have the same configuration by removing
duplicates.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ] This is arguably a bugfix in that it's a resource waste in the current state.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #36574
- Depends #36575

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
