### PR TITLE
Fix receiver name for MetricSet

### DIFF
--- a/x-pack/metricbeat/module/statsd/server/server.go
+++ b/x-pack/metricbeat/module/statsd/server/server.go
@@ -107,8 +107,8 @@ func New(base mb.BaseMetricSet) (mb.MetricSet, error) {
 
 // Host returns the hostname or other module specific value that identifies a
 // specific host or service instance from which to collect metrics.
-func (b *MetricSet) Host() string {
-	return b.server.(*udp.UdpServer).GetHost()
+func (m *MetricSet) Host() string {
+	return m.server.(*udp.UdpServer).GetHost()
 }
 
 func buildMappings(config []StatsdMapping) (map[string]StatsdMapping, error) {


### PR DESCRIPTION
## Proposed commit message

This commit unifies the receiver name for the MetricSet type.

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
- Followup from https://github.com/elastic/beats/pull/36477

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
