### PR TITLE
updatecli: notify someone else in slack

### DIFF
--- a/.ci/bump-elastic-stack-snapshot.yml
+++ b/.ci/bump-elastic-stack-snapshot.yml
@@ -13,6 +13,8 @@ actions:
         - backport-skip
         - build-monitoring
         - Team:Beats-On-Call
+      description: |
+        Generated automatically with {{ requiredEnv "JOB_URL" }}
     scmid: default
 
 scms:

--- a/.github/workflows/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/bump-elastic-stack-snapshot.yml
@@ -34,5 +34,6 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-elastic-stack-snapshot.yml
+          notifySlackChannel: ""
         env:
           BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/bump-elastic-stack-snapshot.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  JOB_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
 jobs:
   filter:
     runs-on: ubuntu-latest
@@ -35,5 +38,6 @@ jobs:
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-elastic-stack-snapshot.yml
           notifySlackChannel: ""
+          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @TBC please look what's going on <${{ env.JOB_URL }}|here>"
         env:
           BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/bump-elastic-stack-snapshot.yml
+++ b/.github/workflows/bump-elastic-stack-snapshot.yml
@@ -37,7 +37,7 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-elastic-stack-snapshot.yml
-          notifySlackChannel: ""
-          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @TBC please look what's going on <${{ env.JOB_URL }}|here>"
+          notifySlackChannel: "#ingest-notifications"
+          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@update-me-with-the-slack-team-to-be-poked` please look what's going on <${{ env.JOB_URL }}|here>"
         env:
           BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -25,6 +25,7 @@ jobs:
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-golang.yml
           notifySlackChannel: ""
+          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @TBC please look what's going on <${{ env.JOB_URL }}|here>"
 
       - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
         with:
@@ -33,3 +34,4 @@ jobs:
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-golang-7.17.yml
           notifySlackChannel: ""
+          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @TBC please look what's going on <${{ env.JOB_URL }}|here>"

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -24,8 +24,8 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-golang.yml
-          notifySlackChannel: ""
-          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @TBC please look what's going on <${{ env.JOB_URL }}|here>"
+          notifySlackChannel: "#ingest-notifications"
+          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@update-me-with-the-slack-team-to-be-poked` please look what's going on <${{ env.JOB_URL }}|here>"
 
       - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
         with:
@@ -33,5 +33,5 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-golang-7.17.yml
-          notifySlackChannel: ""
-          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @TBC please look what's going on <${{ env.JOB_URL }}|here>"
+          notifySlackChannel: "#ingest-notifications"
+          messageIfFailure: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, `@update-me-with-the-slack-team-to-be-poked` please look what's going on <${{ env.JOB_URL }}|here>"

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -24,6 +24,7 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-golang.yml
+          notifySlackChannel: ""
 
       - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
         with:
@@ -31,3 +32,4 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-golang-7.17.yml
+          notifySlackChannel: ""


### PR DESCRIPTION
## Proposed commit message

This should help with notifying when the `updatecli` failed in slack.

`oblt-robots` receive the notification and might get lost. Since this is now under the ingest team, let's change the team to be notified and the slack channel where the message should be sent so messages are not lost and team can act accordingly.

<img width="941" alt="image" src="https://github.com/elastic/beats/assets/2871786/3ebb5e66-8e0d-49fb-bb80-a385b6e15426">

## Issue

Requires https://github.com/elastic/apm-pipeline-library/pull/2361

