### PR TITLE
Fix flattened data_stream.* fields under Elastic-Agent

### DIFF
--- a/x-pack/libbeat/management/generate.go
+++ b/x-pack/libbeat/management/generate.go
@@ -118,15 +118,15 @@ func deDotDataStream(raw dataStreamAndSource) (*proto.DataStream, error) {
 		return nil, fmt.Errorf("cannot unpack source field into struct: %w", err)
 	}
 
-	if ds.Dataset != "" && tmp.DataStream.Dataset != "" {
+	if ds.Dataset != "" && tmp.DataStream.Dataset != "" && (ds.Dataset != tmp.DataStream.Dataset) {
 		return nil, errors.New("duplicated key 'datastream.dataset'")
 	}
 
-	if ds.Type != "" && tmp.DataStream.Type != "" {
+	if ds.Type != "" && tmp.DataStream.Type != "" && (ds.Type != tmp.DataStream.Type) {
 		return nil, errors.New("duplicated key 'datastream.type'")
 	}
 
-	if ds.Namespace != "" && tmp.DataStream.Namespace != "" {
+	if ds.Namespace != "" && tmp.DataStream.Namespace != "" && (ds.Namespace != tmp.DataStream.Namespace) {
 		return nil, errors.New("duplicated key 'datastream.namespace'")
 	}
 

--- a/x-pack/libbeat/management/managerV2_test.go
+++ b/x-pack/libbeat/management/managerV2_test.go
@@ -531,7 +531,7 @@ func TestFlattenedDataStreams(t *testing.T) {
 
 	inputs := &mockReloadable{
 		ReloadFn: func(configs []*reload.ConfigWithMeta) error {
-			// The datea_stream fields are used to generate the `index` key in
+			// The data_stream fields are used to generate the `index` key in
 			// the config, so we check for it.
 			for _, input := range configs {
 				tmp := struct {


### PR DESCRIPTION
## Proposed commit message

If the data_stream is not flattened, Beats will receive it twice, in the Config.Source and as DataStream, that is the normal behaviour when the Elastic-Agent is managed by Fleet and was causing a duplicated key error.

This commit fixes that by only returning the error if the values in Config.Source and DataStream are different.

The tests now cover this case.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~
~~## How to test this PR locally~~
~~## Related issues~~
Closes https://github.com/elastic/elastic-agent/issues/3191
~~## Use cases~~
~~## Screenshots~~
~~## Logs~~

