### PR TITLE
[Heartbeat]: fix status field when monitors are down

### DIFF
--- a/heartbeat/monitors/wrappers/summarizer/jobsummary/jobsummary.go
+++ b/heartbeat/monitors/wrappers/summarizer/jobsummary/jobsummary.go
@@ -49,7 +49,11 @@ func NewJobSummary(attempt uint16, maxAttempts uint16, retryGroup string) *JobSu
 // BumpAttempt swaps the JobSummary object's pointer for a new job summary
 // that is a clone of the current one but with the Attempt field incremented.
 func (js *JobSummary) BumpAttempt() {
-	*js = *NewJobSummary(js.Attempt+1, js.MaxAttempts, js.RetryGroup)
+	newJs := *NewJobSummary(js.Attempt+1, js.MaxAttempts, js.RetryGroup)
+	newJs.Up = js.Up
+	newJs.Down = js.Down
+	newJs.Status = js.Status
+	*js = newJs
 }
 
 func (js *JobSummary) String() string {


### PR DESCRIPTION
+ Fixes a bug with the summarizer https://github.com/elastic/beats/pull/36519 that did not produce the correct `monitor.status: down` when the monitor is retried with the second attempt. 
+ Previously the status was set to empty `monitor.status: ""` field which is incorrect. The PR fixes the issue, by correctly setting the Up/Down and also maintain the previous status when retry is attempted. 

### Test monitor
```yml
heartbeat.monitors:
- type: browser
  id: test-hb
  enabled: true
  name: Test HB dev
  schedule: '@every 1m'
  screenshots: "off"
  max_attempts: 2
  source:
    inline:
      script: |-
        step("load homepage", async ) => {

        });
```
