### PR TITLE
Update Beats install docs to mention ARM binaries

### DIFF
--- a/auditbeat/docs/getting-started.asciidoc
+++ b/auditbeat/docs/getting-started.asciidoc
@@ -35,6 +35,10 @@ system:
 
 include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 
+The commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the https://www.elastic.co/downloads/beats/{beatname_lc}[download page]
+for the full list of available packages.
+
 [float]
 [[other-installation-options]]
 ==== Other installation options

--- a/filebeat/docs/getting-started.asciidoc
+++ b/filebeat/docs/getting-started.asciidoc
@@ -41,6 +41,10 @@ system:
 
 include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 
+The commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the https://www.elastic.co/downloads/beats/{beatname_lc}[download page]
+for the full list of available packages.
+
 [float]
 [[other-installation-options]]
 ==== Other installation options

--- a/heartbeat/docs/getting-started.asciidoc
+++ b/heartbeat/docs/getting-started.asciidoc
@@ -38,6 +38,10 @@ system:
 
 include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 
+The commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the https://www.elastic.co/downloads/beats/{beatname_lc}[download page]
+for the full list of available packages.
+
 [float]
 [[other-installation-options]]
 ==== Other installation options

--- a/metricbeat/docs/getting-started.asciidoc
+++ b/metricbeat/docs/getting-started.asciidoc
@@ -46,6 +46,10 @@ system:
 
 include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 
+The commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the https://www.elastic.co/downloads/beats/{beatname_lc}[download page]
+for the full list of available packages.
+
 [float]
 [[other-installation-options]]
 ==== Other installation options

--- a/packetbeat/docs/getting-started.asciidoc
+++ b/packetbeat/docs/getting-started.asciidoc
@@ -49,6 +49,10 @@ system:
 
 include::{libbeat-dir}/tab-widgets/install-widget.asciidoc[]
 
+The commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the https://www.elastic.co/downloads/beats/{beatname_lc}[download page]
+for the full list of available packages.
+
 [float]
 [[other-installation-options]]
 ==== Other installation options

--- a/x-pack/functionbeat/docs/getting-started.asciidoc
+++ b/x-pack/functionbeat/docs/getting-started.asciidoc
@@ -30,6 +30,10 @@ system.
 
 include::{libbeat-dir}/tab-widgets/install-linux-mac-win-short-widget.asciidoc[]
 
+The commands shown are for AMD platforms, but ARM packages are also available.
+Refer to the https://www.elastic.co/downloads/beats/{beatname_lc}[download page]
+for the full list of available packages.
+
 [float]
 [[set-connection]]
 === Step 2: Connect to the {stack}


### PR DESCRIPTION
This adds a note to the Beats install instructions to note that ARM packages are available in addition to what's shown on the UI. Updates the guides for Filebeat, Metricbeat, Packetbeat, Auditbeat, Heartbeat, and Functionbeat.

Rel: https://github.com/elastic/beats/issues/33042

---

![Screenshot 2023-09-21 at 9 27 09 AM](https://github.com/elastic/beats/assets/41695641/865d7e5f-76b6-4b46-a20e-3ac2669a3b03)
