### PR TITLE
add support for queue settings under outputs

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -157,8 +157,8 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add support for AWS external IDs. {issue}36321[36321] {pull}36322[36322]
 - [Enhanncement for host.ip and host.mac] Disabling netinfo.enabled option of add-host-metadata processor {pull}36506[36506]
   Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will disable the netinfo.enabled option of add_host_metadata processor
-- allow `queue` configuration settings to be set under the output. {issue}35615[35615] {pull}99999[99999]
-- elasticsearch output now supports `idle_connection_timeout`. {issue}35615[35615] {pull}99999[99999]
+- allow `queue` configuration settings to be set under the output. {issue}35615[35615] {pull}36693[36693]
+- elasticsearch output now supports `idle_connection_timeout`. {issue}35615[35615] {pull}36693[36693]
 
 *Auditbeat*
 
@@ -208,8 +208,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Added support for Okta OAuth2 provider in the httpjson input. {pull}36273[36273]
 - Add support of the interval parameter in Salesforce setupaudittrail-rest fileset. {issue}35917[35917] {pull}35938[35938]
 - Add device handling to Okta input package for entity analytics. {pull}36049[36049]
-- Add setup option `--force-enable-module-filesets`, that will act as if all filesets have been enabled in a module during setup. {issue}30915[30915] {pull}99999[99999]
-- Add setup option `--force-enable-module-filesets`, that will act as if all filesets have been enabled in a module during setup. {issue}30915[30915] {pull}36286[36286]
+- Add setup option `--force-enable-module-filesets`, that will act as if all filesets have been enabled in a module during setup. {issue}30916[30916] {pull}36286[36286]
 - [Azure] Add input metrics to the azure-eventhub input. {pull}35739[35739]
 - Reduce HTTPJSON metrics allocations. {pull}36282[36282]
 - Add support for a simplified input configuraton when running under Elastic-Agent {pull}36390[36390]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -157,6 +157,8 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 - Add support for AWS external IDs. {issue}36321[36321] {pull}36322[36322]
 - [Enhanncement for host.ip and host.mac] Disabling netinfo.enabled option of add-host-metadata processor {pull}36506[36506]
   Setting environmental variable ELASTIC_NETINFO:false in Elastic Agent pod will disable the netinfo.enabled option of add_host_metadata processor
+- allow `queue` configuration settings to be set under the output. {issue}35615[35615] {pull}99999[99999]
+- elasticsearch output now supports `idle_connection_timeout`. {issue}35615[35615] {pull}99999[99999]
 
 *Auditbeat*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12712,11 +12712,11 @@ SOFTWARE
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/elastic-agent-libs
-Version: v0.3.15-0.20230913212237-dbdaf18c898b
+Version: v0.4.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.3.15-0.20230913212237-dbdaf18c898b/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/elastic-agent-libs@v0.4.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -522,6 +522,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1618,6 +1618,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/go.mod
+++ b/go.mod
@@ -202,7 +202,7 @@ require (
 	github.com/awslabs/kinesis-aggregation/go/v2 v2.0.0-20220623125934-28468a6701b5
 	github.com/elastic/bayeux v1.0.5
 	github.com/elastic/elastic-agent-autodiscover v0.6.2
-	github.com/elastic/elastic-agent-libs v0.3.15-0.20230913212237-dbdaf18c898b
+	github.com/elastic/elastic-agent-libs v0.4.0
 	github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3
 	github.com/elastic/elastic-agent-system-metrics v0.6.1
 	github.com/elastic/go-elasticsearch/v8 v8.10.0

--- a/go.sum
+++ b/go.sum
@@ -653,8 +653,8 @@ github.com/elastic/elastic-agent-autodiscover v0.6.2 h1:7P3cbMBWXjbzA80rxitQjc+P
 github.com/elastic/elastic-agent-autodiscover v0.6.2/go.mod h1:yXYKFAG+Py+TcE4CCR8EAbJiYb+6Dz9sCDoWgOveqtU=
 github.com/elastic/elastic-agent-client/v7 v7.4.0 h1:h75oTkkvIjgiKVm61NpvTZP4cy6QbQ3zrIpXKGigyjo=
 github.com/elastic/elastic-agent-client/v7 v7.4.0/go.mod h1:9/amG2K2y2oqx39zURcc+hnqcX+nyJ1cZrLgzsgo5c0=
-github.com/elastic/elastic-agent-libs v0.3.15-0.20230913212237-dbdaf18c898b h1:a2iuOokwld+D7VhyFymVtsPoqxZ8fkkOCOOjeYU9CDM=
-github.com/elastic/elastic-agent-libs v0.3.15-0.20230913212237-dbdaf18c898b/go.mod h1:mpSfrigixx8x+uMxWKl4LtdlrKIhZbA4yT2eIeIazUQ=
+github.com/elastic/elastic-agent-libs v0.4.0 h1:P0b+xcvYK+dEwldvRXObO1dj3rjjR5qEXAl6TwRCAy0=
+github.com/elastic/elastic-agent-libs v0.4.0/go.mod h1:mpSfrigixx8x+uMxWKl4LtdlrKIhZbA4yT2eIeIazUQ=
 github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3 h1:sb+25XJn/JcC9/VL8HX4r4QXSUq4uTNzGS2kxOE7u1U=
 github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3/go.mod h1:rWarFM7qYxJKsi9WcV6ONcFjH/NA3niDNpTxO+8/GVI=
 github.com/elastic/elastic-agent-system-metrics v0.6.1 h1:LCN1lvQTkdUuU/rKlpKyVMDU/G/I8/iZWCaW6K+mo4o=

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -614,6 +614,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
@@ -81,6 +81,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -63,8 +63,10 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/v7/libbeat/plugin"
 	"github.com/elastic/beats/v7/libbeat/pprof"
+	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue"
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/file"
@@ -828,6 +830,10 @@ func (b *Beat) configure(settings Settings) error {
 	if err != nil {
 		return err
 	}
+	err = checkAgentDiskQueue(&b.Config)
+	if err != nil {
+		return err
+	}
 
 	if err := b.Manager.CheckRawConfig(b.RawConfig); err != nil {
 		return err
@@ -1496,6 +1502,23 @@ func (bc *beatConfig) Validate() error {
 		if bc.Pipeline.Queue.IsSet() && pc.Queue.IsSet() {
 			return fmt.Errorf("top level queue and output level queue settings defined, only one is allowed")
 		}
+	}
+	return nil
+}
+
+// checkAgentDiskQueue should be run after management.NewManager() so
+// that publisher.UnderAgent will be set with correct value
+func checkAgentDiskQueue(bc *beatConfig) error {
+	//restriction is only if under agent
+	if !publisher.UnderAgent() {
+		return nil
+	}
+	//default queue settings are always allowed
+	if !bc.Pipeline.Queue.IsSet() {
+		return nil
+	}
+	if bc.Pipeline.Queue.Config().Enabled() && bc.Pipeline.Queue.Name() == diskqueue.QueueType {
+		return fmt.Errorf("disk queue is not supported under elastic-agent")
 	}
 	return nil
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -63,7 +63,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/v7/libbeat/plugin"
 	"github.com/elastic/beats/v7/libbeat/pprof"
-	"github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/diskqueue"
@@ -830,10 +829,6 @@ func (b *Beat) configure(settings Settings) error {
 	if err != nil {
 		return err
 	}
-	err = checkAgentDiskQueue(&b.Config)
-	if err != nil {
-		return err
-	}
 
 	if err := b.Manager.CheckRawConfig(b.RawConfig); err != nil {
 		return err
@@ -1494,31 +1489,24 @@ func promoteOutputQueueSettings(bc *beatConfig) error {
 
 func (bc *beatConfig) Validate() error {
 	if bc.Output.IsSet() && bc.Output.Config().Enabled() {
-		pc := pipeline.Config{}
-		err := bc.Output.Config().Unpack(&pc)
+		outputPC := pipeline.Config{}
+		err := bc.Output.Config().Unpack(&outputPC)
 		if err != nil {
 			return fmt.Errorf("error unpacking output queue settings: %w", err)
 		}
-		if bc.Pipeline.Queue.IsSet() && pc.Queue.IsSet() {
+		if bc.Pipeline.Queue.IsSet() && outputPC.Queue.IsSet() {
 			return fmt.Errorf("top level queue and output level queue settings defined, only one is allowed")
 		}
+		//elastic-agent doesn't support disk queue yet
+		if bc.Management.Enabled() && outputPC.Queue.Config().Enabled() && outputPC.Queue.Name() == diskqueue.QueueType {
+			return fmt.Errorf("disk queue is not supported when management is enabled")
+		}
 	}
-	return nil
-}
 
-// checkAgentDiskQueue should be run after management.NewManager() so
-// that publisher.UnderAgent will be set with correct value
-func checkAgentDiskQueue(bc *beatConfig) error {
-	//restriction is only if under agent
-	if !publisher.UnderAgent() {
-		return nil
+	//elastic-agent doesn't support disk queue yet
+	if bc.Management.Enabled() && bc.Pipeline.Queue.Config().Enabled() && bc.Pipeline.Queue.Name() == diskqueue.QueueType {
+		return fmt.Errorf("disk queue is not supported when management is enabled")
 	}
-	//default queue settings are always allowed
-	if !bc.Pipeline.Queue.IsSet() {
-		return nil
-	}
-	if bc.Pipeline.Queue.Config().Enabled() && bc.Pipeline.Queue.Name() == diskqueue.QueueType {
-		return fmt.Errorf("disk queue is not supported under elastic-agent")
-	}
+
 	return nil
 }

--- a/libbeat/cmd/instance/beat.go
+++ b/libbeat/cmd/instance/beat.go
@@ -773,6 +773,10 @@ func (b *Beat) configure(settings Settings) error {
 		return fmt.Errorf("error unpacking config data: %w", err)
 	}
 
+	if err := mergeOutputQueueSettings(&b.Config); err != nil {
+		return fmt.Errorf("could not merge output queue settings: %w", err)
+	}
+
 	if err := features.UpdateFromConfig(b.RawConfig); err != nil {
 		return fmt.Errorf("could not parse features: %w", err)
 	}
@@ -1465,4 +1469,18 @@ func sanitizeIPs(ips []string) []string {
 		validIPs = append(validIPs, ip)
 	}
 	return validIPs
+}
+
+func mergeOutputQueueSettings(bc *beatConfig) error {
+	if bc.Output.IsSet() && bc.Output.Config().Enabled() {
+		pc := pipeline.Config{}
+		err := bc.Output.Config().Unpack(&pc)
+		if err != nil {
+			return fmt.Errorf("error unpacking output queue settings: %w", err)
+		}
+		if pc.Queue.IsSet() {
+			bc.Pipeline.Queue = pc.Queue
+		}
+	}
+	return nil
 }

--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -12,10 +12,7 @@ batch of events in one transaction.
 You can configure the type and behavior of the internal queue by
 setting options in the `queue` section of the +{beatname_lc}.yml+
 config file or by setting options in the `queue` section of the
-output. Only one queue type can be configured.  If both the top level
-queue section and the output section are specified the output section
-takes precedence.
-
+output. Only one queue type can be configured.
 
 This sample configuration sets the memory queue to buffer up to 4096 events:
 

--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -9,9 +9,12 @@ queue is responsible for buffering and combining events into batches that can
 be consumed by the outputs. The outputs will use bulk operations to send a
 batch of events in one transaction.
 
-You can configure the type and behavior of the internal queue by setting
-options in the `queue` section of the +{beatname_lc}.yml+ config file. Only one
-queue type can be configured.
+You can configure the type and behavior of the internal queue by
+setting options in the `queue` section of the +{beatname_lc}.yml+
+config file or by setting options in the `queue` section of the
+output. Only one queue type can be configured.  If both the top level
+queue section and the output section are specified the output section
+takes precedence.
 
 
 This sample configuration sets the memory queue to buffer up to 4096 events:

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -102,6 +102,7 @@ func NewClient(
 		CompressionLevel: s.CompressionLevel,
 		EscapeHTML:       s.EscapeHTML,
 		Transport:        s.Transport,
+		IdleConnTimeout:  s.IdleConnTimeout,
 	})
 	if err != nil {
 		return nil, err

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -689,6 +689,10 @@ default is `1s`.
 The maximum number of seconds to wait before attempting to connect to
 Elasticsearch after a network error. The default is `60s`.
 
+===== `idle_connection_timeout`
+
+The maximum amount of time an idle connection will remain idle before closing itself.  Zero means no limit. The format is a Go language duration (example 60s is 60 seconds). The default is 0.
+
 ===== `timeout`
 
 The http request timeout in seconds for the Elasticsearch request. The default is 90.

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -105,6 +105,7 @@ func makeES(
 				Observer:         observer,
 				EscapeHTML:       config.EscapeHTML,
 				Transport:        config.Transport,
+				IdleConnTimeout:  config.Transport.IdleConnTimeout,
 			},
 			Index:              index,
 			Pipeline:           pipeline,

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -41,7 +41,7 @@ func makeES(
 ) (outputs.Group, error) {
 	log := logp.NewLogger(logSelector)
 	if !cfg.HasField("bulk_max_size") {
-		cfg.SetInt("bulk_max_size", -1, defaultBulkSize)
+		_ = cfg.SetInt("bulk_max_size", -1, defaultBulkSize)
 	}
 
 	index, pipeline, err := buildSelectors(im, beat, cfg)

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1357,6 +1357,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -988,6 +988,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -404,6 +404,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -578,6 +578,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3988,6 +3988,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -646,6 +646,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -614,6 +614,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1918,6 +1918,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -365,6 +365,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -988,6 +988,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -406,6 +406,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 60s
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 


### PR DESCRIPTION
## Proposed commit message

- add support for `idle_connection_timeout` for ES output.  This allows connections to be closed if they aren't being used.

- add support for queue settings under output.  Validation ensure only top level or output level is specified.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Start Filebeat with following config file:

```
output.elasticsearch:
  idle_connection_timeout: 3s
  queue.mem:
    events: 1024
    flush.min_events: 2
    flush.timeout: 15s
```

Should show `queue.max_events` in the metrics to be 1024, and connections to elasticsearch should only stay open for 3 seconds.  Connection status can be checked with `netstat -an`

## Related issues

- Closes #35615

