### PR TITLE
Make file system metadata values strings

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Filebeat*
 
+- Switch types of `log.file.device`, `log.file.inode`, `log.file.idxhi`, `log.file.idxlo` and `log.file.vol` fields to strings to better align with ECS and integrations. {pull}36697[36697]
 
 *Heartbeat*
 

--- a/libbeat/reader/readfile/fs_metafields_other.go
+++ b/libbeat/reader/readfile/fs_metafields_other.go
@@ -22,6 +22,7 @@ package readfile
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -34,11 +35,11 @@ const (
 
 func setFileSystemMetadata(fi os.FileInfo, fields mapstr.M) error {
 	osstate := file.GetOSState(fi)
-	_, err := fields.Put(deviceIDKey, osstate.Device)
+	_, err := fields.Put(deviceIDKey, strconv.FormatUint(osstate.Device, 10))
 	if err != nil {
 		return fmt.Errorf("failed to set %q: %w", deviceIDKey, err)
 	}
-	_, err = fields.Put(inodeKey, osstate.Inode)
+	_, err = fields.Put(inodeKey, osstate.InodeString())
 	if err != nil {
 		return fmt.Errorf("failed to set %q: %w", inodeKey, err)
 	}

--- a/libbeat/reader/readfile/fs_metafields_windows.go
+++ b/libbeat/reader/readfile/fs_metafields_windows.go
@@ -20,6 +20,7 @@ package readfile
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/elastic/beats/v7/libbeat/common/file"
 	"github.com/elastic/elastic-agent-libs/mapstr"

--- a/libbeat/reader/readfile/fs_metafields_windows.go
+++ b/libbeat/reader/readfile/fs_metafields_windows.go
@@ -33,15 +33,15 @@ const (
 
 func setFileSystemMetadata(fi os.FileInfo, fields mapstr.M) error {
 	osstate := file.GetOSState(fi)
-	_, err := fields.Put(idxhiKey, osstate.IdxHi)
+	_, err := fields.Put(idxhiKey, strconv.FormatUint(osstate.IdxHi, 10))
 	if err != nil {
 		return fmt.Errorf("failed to set %q: %w", idxhiKey, err)
 	}
-	_, err = fields.Put(idxloKey, osstate.IdxLo)
+	_, err = fields.Put(idxloKey, strconv.FormatUint(osstate.IdxLo, 10))
 	if err != nil {
 		return fmt.Errorf("failed to set %q: %w", idxloKey, err)
 	}
-	_, err = fields.Put(volKey, osstate.Vol)
+	_, err = fields.Put(volKey, strconv.FormatUint(osstate.Vol, 10))
 	if err != nil {
 		return fmt.Errorf("failed to set %q: %w", volKey, err)
 	}

--- a/libbeat/reader/readfile/metafields_other_test.go
+++ b/libbeat/reader/readfile/metafields_other_test.go
@@ -44,13 +44,13 @@ func checkFields(t *testing.T, expected, actual mapstr.M) {
 
 	dev, err := actual.GetValue(deviceIDKey)
 	require.NoError(t, err)
-	require.Equal(t, uint64(17), dev)
+	require.Equal(t, "17", dev)
 	err = actual.Delete(deviceIDKey)
 	require.NoError(t, err)
 
 	inode, err := actual.GetValue(inodeKey)
 	require.NoError(t, err)
-	require.Equal(t, uint64(999), inode)
+	require.Equal(t, "999", inode)
 	err = actual.Delete(inodeKey)
 	require.NoError(t, err)
 

--- a/libbeat/reader/readfile/metafields_windows_test.go
+++ b/libbeat/reader/readfile/metafields_windows_test.go
@@ -52,19 +52,19 @@ func checkFields(t *testing.T, expected, actual mapstr.M) {
 
 	idxhi, err := actual.GetValue(idxhiKey)
 	require.NoError(t, err)
-	require.Equal(t, uint64(100), idxhi)
+	require.Equal(t, "100", idxhi)
 	err = actual.Delete(idxhiKey)
 	require.NoError(t, err)
 
 	idxlo, err := actual.GetValue(idxloKey)
 	require.NoError(t, err)
-	require.Equal(t, uint64(200), idxlo)
+	require.Equal(t, "200", idxlo)
 	err = actual.Delete(idxloKey)
 	require.NoError(t, err)
 
 	vol, err := actual.GetValue(volKey)
 	require.NoError(t, err)
-	require.Equal(t, uint64(300), vol)
+	require.Equal(t, "300", vol)
 	err = actual.Delete(volKey)
 	require.NoError(t, err)
 


### PR DESCRIPTION
To better align with ECS and better store the values in Elasticsearch.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

See steps in https://github.com/elastic/beats/pull/36065

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/beats/issues/36695
- Relates https://github.com/elastic/integrations/pull/7716
