### PR TITLE
Give Auditbeat k8s Clusterrole job permissions

### DIFF
--- a/deploy/kubernetes/auditbeat-kubernetes.yaml
+++ b/deploy/kubernetes/auditbeat-kubernetes.yaml
@@ -23,6 +23,10 @@ rules:
   resources:
     - replicasets
   verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+    - jobs
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/kubernetes/auditbeat/auditbeat-role.yaml
+++ b/deploy/kubernetes/auditbeat/auditbeat-role.yaml
@@ -15,6 +15,10 @@ rules:
   resources:
     - replicasets
   verbs: ["get", "list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+    - jobs
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION


<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Update the Auditbeat Kubernetes cluster role to add read permissions on jobs/cronjobs. These permissions were added to other Cluster Role permissions previously, but was missed on auditbeat.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[] I have commented my code, particularly in hard-to-understand areas~~
- ~~[] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

This was tested by running the auditbeat daemonset on a GKE cluster with a cronjob running. The original `failed to list *v1.Job: jobs.batch is forbidden` error was not seen in auditbeat logs, and auditbeat process events were enriched with orchatrator information:

```
{
  "_index": ".ds-auditbeat-8.10.2-2023.09.25-000001",
  "_id": "uhUL3YoBpJN1dyjWXk92",
  "_score": 1,
  "fields": {
    "orchestrator.cluster.name": [
      "cluster1"
    ],
    "event.category": [
      "process"
    ],
    "agent.type": [
      "auditbeat"
    ],
    "orchestrator.cluster.url": [
      "https://192.168.0.2"
    ],
    "event.action": [
      "process_started"
    ],
    "event.type": [
      "start"
    ],
    "event.dataset": [
      "process"
    ],
...
  }
}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #36674 

