### PR TITLE
[Heartbeat] log the individual connection metrics for all the lightweight monitors

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -233,6 +233,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Heartbeat*
 - Added status to monitor run log report.
+- Capture and log the individual connection metrics for all the lightweight monitors
 
 
 *Metricbeat*

--- a/heartbeat/monitors/logger/logger.go
+++ b/heartbeat/monitors/logger/logger.go
@@ -142,7 +142,7 @@ func extractNetworkInfo(event *beat.Event, monitorType string) NetworkInfo {
 	}
 
 	fields := []string{
-		"resolve.rtt.us", "tls.rtt.handshake.us",
+		"resolve.rtt.us", "tls.rtt.handshake.us", "icmp.rtt.us",
 		"tcp.rtt.connect.us", "tcp.rtt.validate.us", "http.rtt.content.us", "http.rtt.validate.us",
 		"http.rtt.validate_body.us", "http.rtt.write_request.us", "http.rtt.response_header.us",
 		"http.rtt.total.us", "socks5.rtt.connect.us",

--- a/heartbeat/monitors/logger/logger.go
+++ b/heartbeat/monitors/logger/logger.go
@@ -142,7 +142,7 @@ func extractNetworkInfo(event *beat.Event, monitorType string) NetworkInfo {
 	}
 
 	fields := []string{
-		"resolve.rtt.us", "tls.rtt.handshake.us", "icmp.rtt.us",
+		"resolve.ip", "resolve.rtt.us", "tls.rtt.handshake.us", "icmp.rtt.us",
 		"tcp.rtt.connect.us", "tcp.rtt.validate.us", "http.rtt.content.us", "http.rtt.validate.us",
 		"http.rtt.validate_body.us", "http.rtt.write_request.us", "http.rtt.response_header.us",
 		"http.rtt.total.us", "socks5.rtt.connect.us",

--- a/heartbeat/monitors/logger/logger.go
+++ b/heartbeat/monitors/logger/logger.go
@@ -39,13 +39,16 @@ type DurationLoggable struct {
 	Mills int64 `json:"ms"`
 }
 
+type NetworkInfo map[string]interface{}
+
 type MonitorRunInfo struct {
-	MonitorID string `json:"id"`
-	Type      string `json:"type"`
-	Duration  int64  `json:"-"`
-	Steps     *int   `json:"steps,omitempty"`
-	Status    string `json:"status"`
-	Attempt   int    `json:"attempt"`
+	MonitorID   string      `json:"id"`
+	Type        string      `json:"type"`
+	Duration    int64       `json:"-"`
+	Steps       *int        `json:"steps,omitempty"`
+	Status      string      `json:"status"`
+	Attempt     int         `json:"attempt"`
+	NetworkInfo NetworkInfo `json:"network_info,omitempty"`
 }
 
 func (m *MonitorRunInfo) MarshalJSON() ([]byte, error) {
@@ -113,12 +116,14 @@ func extractRunInfo(event *beat.Event) (*MonitorRunInfo, error) {
 		return nil, fmt.Errorf("logErrors: %+v", errors)
 	}
 
+	networkInfo := extractNetworkInfo(event, monType.(string))
 	monitor := MonitorRunInfo{
-		MonitorID: monitorID.(string),
-		Type:      monType.(string),
-		Duration:  durationUs.(int64),
-		Status:    status.(string),
-		Attempt:   attempt,
+		MonitorID:   monitorID.(string),
+		Type:        monType.(string),
+		Duration:    durationUs.(int64),
+		Status:      status.(string),
+		Attempt:     attempt,
+		NetworkInfo: networkInfo,
 	}
 
 	sc, _ := event.Meta.GetValue(META_STEP_COUNT)
@@ -128,6 +133,29 @@ func extractRunInfo(event *beat.Event) (*MonitorRunInfo, error) {
 	}
 
 	return &monitor, nil
+}
+
+func extractNetworkInfo(event *beat.Event, monitorType string) NetworkInfo {
+	// Only relevant for lightweight monitors
+	if monitorType == "browser" {
+		return nil
+	}
+
+	fields := []string{
+		"resolve.rtt.us", "tls.rtt.handshake.us",
+		"tcp.rtt.connect.us", "tcp.rtt.validate.us", "http.rtt.content.us", "http.rtt.validate.us",
+		"http.rtt.validate_body.us", "http.rtt.write_request.us", "http.rtt.response_header.us",
+		"http.rtt.total.us", "socks5.rtt.connect.us",
+	}
+	networkInfo := make(NetworkInfo)
+	for _, field := range fields {
+		value, err := event.GetValue(field)
+		if err == nil {
+			networkInfo[field] = value
+		}
+	}
+
+	return networkInfo
 }
 
 func LogRun(event *beat.Event) {

--- a/heartbeat/monitors/logger/logger.go
+++ b/heartbeat/monitors/logger/logger.go
@@ -150,7 +150,7 @@ func extractNetworkInfo(event *beat.Event, monitorType string) NetworkInfo {
 	networkInfo := make(NetworkInfo)
 	for _, field := range fields {
 		value, err := event.GetValue(field)
-		if err == nil {
+		if err == nil && value != nil {
 			networkInfo[field] = value
 		}
 	}

--- a/heartbeat/monitors/logger/logger_test.go
+++ b/heartbeat/monitors/logger/logger_test.go
@@ -37,6 +37,7 @@ import (
 func generateFakeNetworkInfo() NetworkInfo {
 	networkInfo := NetworkInfo{
 		// All network info available in HB documentation
+		"resolve.ip":                  "192.168.1.254",
 		"resolve.rtt.us":              123,
 		"tls.rtt.handshake.us":        456,
 		"icmp.rtt.us":                 111,

--- a/heartbeat/monitors/logger/logger_test.go
+++ b/heartbeat/monitors/logger/logger_test.go
@@ -39,6 +39,7 @@ func generateFakeNetworkInfo() NetworkInfo {
 		// All network info available in HB documentation
 		"resolve.rtt.us":              123,
 		"tls.rtt.handshake.us":        456,
+		"icmp.rtt.us":                 111,
 		"tcp.rtt.connect.us":          789,
 		"tcp.rtt.validate.us":         1234,
 		"http.rtt.content.us":         4567,

--- a/heartbeat/monitors/logger/logger_test.go
+++ b/heartbeat/monitors/logger/logger_test.go
@@ -34,43 +34,109 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
 
+func generateFakeNetworkInfo() NetworkInfo {
+	networkInfo := NetworkInfo{
+		// All network info available in HB documentation
+		"resolve.rtt.us":              123,
+		"tls.rtt.handshake.us":        456,
+		"tcp.rtt.connect.us":          789,
+		"tcp.rtt.validate.us":         1234,
+		"http.rtt.content.us":         4567,
+		"http.rtt.validate.us":        7890,
+		"http.rtt.validate_body.us":   12345,
+		"http.rtt.write_request.us":   45678,
+		"http.rtt.response_header.us": 78901,
+		"http.rtt.total.us":           123456,
+		"socks5.rtt.connect.us":       789012,
+	}
+
+	return networkInfo
+}
+
 func TestLogRun(t *testing.T) {
-	core, observed := observer.New(zapcore.InfoLevel)
-	SetLogger(logp.NewLogger("t", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
-		return zapcore.NewTee(in, core)
-	})))
+	t.Run("should log the monitor completion", func(t *testing.T) {
+		core, observed := observer.New(zapcore.InfoLevel)
+		SetLogger(logp.NewLogger("t", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(in, core)
+		})))
 
-	durationUs := int64(5000 * time.Microsecond)
-	steps := 1337
+		durationUs := int64(5000 * time.Microsecond)
+		steps := 1337
+		fields := mapstr.M{
+			"monitor.id":          "b0",
+			"monitor.duration.us": durationUs,
+			"monitor.type":        "browser",
+			"monitor.status":      "down",
+			"summary":             jobsummary.NewJobSummary(1, 1, "abc"),
+		}
 
-	fields := mapstr.M{
-		"monitor.id":          "b0",
-		"monitor.duration.us": durationUs,
-		"monitor.type":        "browser",
-		"monitor.status":      "down",
-		"summary":             jobsummary.NewJobSummary(1, 1, "abc"),
-	}
+		event := beat.Event{Fields: fields}
+		eventext.SetMeta(&event, META_STEP_COUNT, steps)
 
-	event := beat.Event{Fields: fields}
-	eventext.SetMeta(&event, META_STEP_COUNT, steps)
+		LogRun(&event)
 
-	LogRun(&event)
+		observedEntries := observed.All()
+		require.Len(t, observedEntries, 1)
+		assert.Equal(t, "Monitor finished", observedEntries[0].Message)
 
-	observedEntries := observed.All()
-	require.Len(t, observedEntries, 1)
-	assert.Equal(t, "Monitor finished", observedEntries[0].Message)
+		expectedMonitor := MonitorRunInfo{
+			MonitorID: "b0",
+			Type:      "browser",
+			Duration:  durationUs,
+			Status:    "down",
+			Steps:     &steps,
+			Attempt:   1,
+		}
 
-	expectedMonitor := MonitorRunInfo{
-		MonitorID: "b0",
-		Type:      "browser",
-		Duration:  durationUs,
-		Status:    "down",
-		Steps:     &steps,
-		Attempt:   1,
-	}
+		assert.ElementsMatch(t, []zap.Field{
+			logp.Any("event", map[string]string{"action": ActionMonitorRun}),
+			logp.Any("monitor", &expectedMonitor),
+		}, observedEntries[0].Context)
+	})
 
-	assert.ElementsMatch(t, []zap.Field{
-		logp.Any("event", map[string]string{"action": ActionMonitorRun}),
-		logp.Any("monitor", &expectedMonitor),
-	}, observedEntries[0].Context)
+	t.Run("should log network information if available", func(t *testing.T) {
+		core, observed := observer.New(zapcore.InfoLevel)
+		SetLogger(logp.NewLogger("t", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+			return zapcore.NewTee(in, core)
+		})))
+
+		durationUs := int64(5000 * time.Microsecond)
+		steps := 1337
+		fields := mapstr.M{
+			"monitor.id":          "b0",
+			"monitor.duration.us": durationUs,
+			"monitor.type":        "http",
+			"monitor.status":      "down",
+			"summary":             jobsummary.NewJobSummary(1, 1, "abc"),
+		}
+		networkInfo := generateFakeNetworkInfo()
+		// Add network info to the event
+		for key, value := range networkInfo {
+			fields[key] = value
+		}
+
+		event := beat.Event{Fields: fields}
+		eventext.SetMeta(&event, META_STEP_COUNT, steps)
+
+		LogRun(&event)
+
+		observedEntries := observed.All()
+		require.Len(t, observedEntries, 1)
+		assert.Equal(t, "Monitor finished", observedEntries[0].Message)
+
+		expectedMonitor := MonitorRunInfo{
+			MonitorID:   "b0",
+			Type:        "http",
+			Duration:    durationUs,
+			Status:      "down",
+			Steps:       &steps,
+			Attempt:     1,
+			NetworkInfo: networkInfo,
+		}
+
+		assert.ElementsMatch(t, []zap.Field{
+			logp.Any("event", map[string]string{"action": ActionMonitorRun}),
+			logp.Any("monitor", &expectedMonitor),
+		}, observedEntries[0].Context)
+	})
 }

--- a/heartbeat/monitors/wrappers/wrappers_test.go
+++ b/heartbeat/monitors/wrappers/wrappers_test.go
@@ -140,11 +140,12 @@ func TestSimpleJob(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedMonitor := logger.MonitorRunInfo{
-				MonitorID: testMonFields.ID,
-				Type:      testMonFields.Type,
-				Duration:  durationUs.(int64),
-				Status:    "up",
-				Attempt:   1,
+				MonitorID:   testMonFields.ID,
+				Type:        testMonFields.Type,
+				Duration:    durationUs.(int64),
+				Status:      "up",
+				Attempt:     1,
+				NetworkInfo: logger.NetworkInfo{},
 			}
 			require.ElementsMatch(t, []zap.Field{
 				logp.Any("event", map[string]string{"action": logger.ActionMonitorRun}),


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Closes [#35706.](https://github.com/elastic/beats/issues/36017)

capture and log the individual connection metrics for all the lightweight monitors. The new information will be under the key `network_info`. The properties will keep their original name. Doing so will give us the chance to read the details in HB documentation in case of any doubt about their significance, etc.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

1. Build heartbeat locally.
2. Set up a lightweight monitor
3. Run HB

This is one example with a http monitor:

```
heartbeat.monitors:
- type: http
  enabled: true
  id: my-monitor
  name: My Monitor
  urls: ["https://www.australia.gov.au/"]
  schedule: '@every 30s'
```

**Log Sample**:

`{"log.level":"info","@timestamp":"2023-10-03T19:50:10.252+0200","log.origin":{"file.name":"logger/logger.go","file.line":168},"message":"Monitor finished","service.name":"heartbeat","event":{"action":"monitor.run"},"monitor":{"id":"my-monitor2","type":"http","status":"up","attempt":1,"network_info":{"http.rtt.content.us":1715,"http.rtt.response_header.us":18613,"http.rtt.total.us":60487,"http.rtt.validate.us":20329,"http.rtt.write_request.us":98,"resolve.rtt.us":2595,"tcp.rtt.connect.us":16035,"tls.rtt.handshake.us":23998},"duration":{"ms":0}},"ecs.version":"1.6.0"}`






