### PR TITLE
Update osquerybeat codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,7 +43,7 @@ CHANGELOG*
 /filebeat/module/mysql @elastic/security-external-integrations
 /filebeat/module/nats @elastic/integrations
 /filebeat/module/nginx @elastic/obs-infraobs-integrations
-/filebeat/module/osquery @elastic/security-asset-management
+/filebeat/module/osquery @elastic/security-external-integrations
 /filebeat/module/pensando @elastic/security-external-integrations
 /filebeat/module/postgresql @elastic/obs-infraobs-integrations
 /filebeat/module/redis @elastic/obs-infraobs-integrations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -196,7 +196,7 @@ CHANGELOG*
 /x-pack/metricbeat/module/statsd @elastic/obs-infraobs-integrations
 /x-pack/metricbeat/module/stan/ @elastic/obs-cloudnative-monitoring
 /x-pack/metricbeat/module/tomcat @elastic/obs-infraobs-integrations
-/x-pack/osquerybeat/ @elastic/security-asset-management
+/x-pack/osquerybeat/ @elastic/security-external-integrations
 /x-pack/packetbeat/ @elastic/security-external-integrations
 /x-pack/winlogbeat/ @elastic/security-external-integrations
 /x-pack/libbeat/reader/parquet/ @elastic/security-external-integrations


### PR DESCRIPTION
Updated osquerybeat codeowners after conversation with @kevinlog.

The codeowners team that was there before does not longer exist and developers are working on the different projects/teams. So it was not adequately reflecting the people would need to approve PR in order to unblock it. 