### PR TITLE
x-pack/filebeat/input/entityanalytics/provider/azuread: avoid work on unwanted datasets

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -234,6 +234,7 @@ is collected by it.
 - Re-use buffers to optimise memory allocation in fingerprint mode of filestream {pull}36736[36736]
 - Allow http_endpoint input to receive PUT and PATCH requests. {pull}36734[36734]
 - Add cache processor. {pull}36786[36786]
+- Avoid unwanted publication of Azure entity records. {pull}36753[36753]
 
 *Auditbeat*
 

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -151,21 +150,22 @@ func (p *azure) runFullSync(inputCtx v2.Context, store *kvstore.Store, client be
 		return err
 	}
 
-	if len(state.users) != 0 || len(state.devices) != 0 {
+	wantUsers := p.conf.wantUsers()
+	wantDevices := p.conf.wantDevices()
+	if (len(state.users) != 0 && wantUsers) || (len(state.devices) != 0 && wantDevices) {
 		tracker := kvstore.NewTxTracker(ctx)
 
 		start := time.Now()
 		p.publishMarker(start, start, inputCtx.ID, true, client, tracker)
 
-		if len(state.users) != 0 {
+		if len(state.users) != 0 && wantUsers {
 			p.logger.Debugw("publishing users", "count", len(state.devices))
 			for _, u := range state.users {
 				p.publishUser(u, state, inputCtx.ID, client, tracker)
 			}
-
 		}
 
-		if len(state.devices) != 0 {
+		if len(state.devices) != 0 && wantDevices {
 			p.logger.Debugw("publishing devices", "count", len(state.devices))
 			for _, d := range state.devices {
 				p.publishDevice(d, state, inputCtx.ID, client, tracker)
@@ -212,10 +212,12 @@ func (p *azure) runIncrementalUpdate(inputCtx v2.Context, store *kvstore.Store, 
 		return err
 	}
 
-	if updatedUsers.Len() != 0 || updatedDevices.Len() != 0 {
+	wantUsers := p.conf.wantUsers()
+	wantDevices := p.conf.wantDevices()
+	if (updatedUsers.Len() != 0 && wantUsers) || (updatedDevices.Len() != 0 && wantDevices) {
 		tracker := kvstore.NewTxTracker(ctx)
 
-		if updatedUsers.Len() != 0 {
+		if updatedUsers.Len() != 0 && wantUsers {
 			updatedUsers.ForEach(func(id uuid.UUID) {
 				u, ok := state.users[id]
 				if !ok {
@@ -224,10 +226,9 @@ func (p *azure) runIncrementalUpdate(inputCtx v2.Context, store *kvstore.Store, 
 				}
 				p.publishUser(u, state, inputCtx.ID, client, tracker)
 			})
-
 		}
 
-		if updatedDevices.Len() != 0 {
+		if updatedDevices.Len() != 0 && wantDevices {
 			updatedDevices.ForEach(func(id uuid.UUID) {
 				d, ok := state.devices[id]
 				if !ok {
@@ -236,7 +237,6 @@ func (p *azure) runIncrementalUpdate(inputCtx v2.Context, store *kvstore.Store, 
 				}
 				p.publishDevice(d, state, inputCtx.ID, client, tracker)
 			})
-
 		}
 
 		tracker.Wait()
@@ -269,32 +269,32 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 	}
 
 	var (
+		wantUsers    = p.conf.wantUsers()
 		changedUsers []*fetcher.User
 		userLink     string
 	)
-	switch strings.ToLower(p.conf.Dataset) {
-	case "", "all", "users":
+	if wantUsers {
 		changedUsers, userLink, err = p.fetcher.Users(ctx, usersDeltaLink)
 		if err != nil {
 			return updatedUsers, updatedDevices, err
 		}
 		p.logger.Debugf("Received %d users from API", len(changedUsers))
-	default:
+	} else {
 		p.logger.Debugf("Skipping user collection from API: dataset=%s", p.conf.Dataset)
 	}
 
 	var (
+		wantDevices    = p.conf.wantDevices()
 		changedDevices []*fetcher.Device
 		deviceLink     string
 	)
-	switch strings.ToLower(p.conf.Dataset) {
-	case "", "all", "devices":
+	if wantDevices {
 		changedDevices, deviceLink, err = p.fetcher.Devices(ctx, devicesDeltaLink)
 		if err != nil {
 			return updatedUsers, updatedDevices, err
 		}
 		p.logger.Debugf("Received %d devices from API", len(changedDevices))
-	default:
+	} else {
 		p.logger.Debugf("Skipping device collection from API: dataset=%s", p.conf.Dataset)
 	}
 
@@ -337,6 +337,9 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 		for _, member := range g.Members {
 			switch member.Type {
 			case fetcher.MemberGroup:
+				if !wantUsers {
+					break
+				}
 				for _, u := range state.users {
 					if u.TransitiveMemberOf.Contains(member.ID) {
 						updatedUsers.Add(u.ID)
@@ -349,6 +352,9 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 				}
 
 			case fetcher.MemberUser:
+				if !wantUsers {
+					break
+				}
 				if u, ok := state.users[member.ID]; ok {
 					updatedUsers.Add(u.ID)
 					if member.Deleted {
@@ -359,6 +365,9 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 				}
 
 			case fetcher.MemberDevice:
+				if !wantDevices {
+					break
+				}
 				if d, ok := state.devices[member.ID]; ok {
 					updatedDevices.Add(d.ID)
 					if member.Deleted {
@@ -372,42 +381,46 @@ func (p *azure) doFetch(ctx context.Context, state *stateStore, fullSync bool) (
 	}
 
 	// Expand user group memberships.
-	updatedUsers.ForEach(func(userID uuid.UUID) {
-		u, ok := state.users[userID]
-		if !ok {
-			p.logger.Errorf("Unable to find user %q in state", userID)
-			return
-		}
-		u.Modified = true
-		if u.Deleted {
-			p.logger.Debugw("not expanding membership for deleted user", "user", userID)
-			return
-		}
+	if wantUsers {
+		updatedUsers.ForEach(func(userID uuid.UUID) {
+			u, ok := state.users[userID]
+			if !ok {
+				p.logger.Errorf("Unable to find user %q in state", userID)
+				return
+			}
+			u.Modified = true
+			if u.Deleted {
+				p.logger.Debugw("not expanding membership for deleted user", "user", userID)
+				return
+			}
 
-		u.TransitiveMemberOf = u.MemberOf
-		state.relationships.ExpandFromSet(u.MemberOf).ForEach(func(elem uuid.UUID) {
-			u.TransitiveMemberOf.Add(elem)
+			u.TransitiveMemberOf = u.MemberOf
+			state.relationships.ExpandFromSet(u.MemberOf).ForEach(func(elem uuid.UUID) {
+				u.TransitiveMemberOf.Add(elem)
+			})
 		})
-	})
+	}
 
 	// Expand device group memberships.
-	updatedDevices.ForEach(func(devID uuid.UUID) {
-		d, ok := state.devices[devID]
-		if !ok {
-			p.logger.Errorf("Unable to find device %q in state", devID)
-			return
-		}
-		d.Modified = true
-		if d.Deleted {
-			p.logger.Debugw("not expanding membership for deleted device", "device", devID)
-			return
-		}
+	if wantDevices {
+		updatedDevices.ForEach(func(devID uuid.UUID) {
+			d, ok := state.devices[devID]
+			if !ok {
+				p.logger.Errorf("Unable to find device %q in state", devID)
+				return
+			}
+			d.Modified = true
+			if d.Deleted {
+				p.logger.Debugw("not expanding membership for deleted device", "device", devID)
+				return
+			}
 
-		d.TransitiveMemberOf = d.MemberOf
-		state.relationships.ExpandFromSet(d.MemberOf).ForEach(func(elem uuid.UUID) {
-			d.TransitiveMemberOf.Add(elem)
+			d.TransitiveMemberOf = d.MemberOf
+			state.relationships.ExpandFromSet(d.MemberOf).ForEach(func(elem uuid.UUID) {
+				d.TransitiveMemberOf.Add(elem)
+			})
 		})
-	})
+	}
 
 	return updatedUsers, updatedDevices, nil
 }

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/azure.go
@@ -212,12 +212,10 @@ func (p *azure) runIncrementalUpdate(inputCtx v2.Context, store *kvstore.Store, 
 		return err
 	}
 
-	wantUsers := p.conf.wantUsers()
-	wantDevices := p.conf.wantDevices()
-	if (updatedUsers.Len() != 0 && wantUsers) || (updatedDevices.Len() != 0 && wantDevices) {
+	if updatedUsers.Len() != 0 || updatedDevices.Len() != 0 {
 		tracker := kvstore.NewTxTracker(ctx)
 
-		if updatedUsers.Len() != 0 && wantUsers {
+		if updatedUsers.Len() != 0 {
 			updatedUsers.ForEach(func(id uuid.UUID) {
 				u, ok := state.users[id]
 				if !ok {
@@ -228,7 +226,7 @@ func (p *azure) runIncrementalUpdate(inputCtx v2.Context, store *kvstore.Store, 
 			})
 		}
 
-		if updatedDevices.Len() != 0 && wantDevices {
+		if updatedDevices.Len() != 0 {
 			updatedDevices.ForEach(func(id uuid.UUID) {
 				d, ok := state.devices[id]
 				if !ok {

--- a/x-pack/filebeat/input/entityanalytics/provider/azuread/conf.go
+++ b/x-pack/filebeat/input/entityanalytics/provider/azuread/conf.go
@@ -52,3 +52,21 @@ func defaultConf() conf {
 		UpdateInterval: defaultUpdateInterval,
 	}
 }
+
+func (c *conf) wantUsers() bool {
+	switch strings.ToLower(c.Dataset) {
+	case "", "all", "users":
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *conf) wantDevices() bool {
+	switch strings.ToLower(c.Dataset) {
+	case "", "all", "devices":
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

During full sync the provider may have state from a previous dataset. So in the case that the user has changed dataset from users to devices or vice versa the provider may publish already existing state in the entity graph. This change adds conditional checks to ensure that unwanted dataset records are not published.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
