### PR TITLE
[syslog processor] Fix 'when' conditions

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -65,6 +65,7 @@ is collected by it.
 - Support build of projects outside of beats directory {pull}36126[36126]
 - Add default cgroup regex for add_process_metadata processor {pull}36484[36484] {issue}32961[32961]
 - Fix environment capture by `add_process_metadata` processor. {issue}36469[36469] {pull}36471[36471]
+- syslog processor - Fix the ability to use `when` conditions on the processor. {issue}36762[36762]
 
 
 *Auditbeat*

--- a/libbeat/processors/syslog/syslog.go
+++ b/libbeat/processors/syslog/syslog.go
@@ -89,6 +89,7 @@ func init() {
 				"ignore_missing",
 				"ignore_failure",
 				"tag",
+				"when",
 			),
 		),
 	)


### PR DESCRIPTION
## Proposed commit message

Fix the ability to use `when` conditions with the syslog processor. Previously the config would be rejected.

Fixes #36762

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

- Closes #36762

## Manual test

```yaml
---

filebeat.inputs:
  - type: cel
    publisher_pipeline:
      disable_host: true
    interval: 1m
    resource:
      url: not_used_1
    redact:
      fields: ~
    program: |
      {
          'want_more': false,
          'events': [
              {
                'message': '<30>1 2023-09-28T12:10:12.175599+02:00 test.lab.com systemd 153589 - - Stopped target',
              },
              {
                'message': 'Not syslog.',
              }
          ],
      }
    processors:
      # Before:
      # {"log.level":"error","@timestamp":"2023-10-05T12:14:57.275-0400","log.logger":"input.cel","log.origin":{"file.name":"compat/compat.go","file.line":132},"message":"Input 'cel' failed with: input.go:130: input  CA8C6DD2BACAD24 failed (id= CA8C6DD2BACAD24)\n\tunexpected when option in filebeat.inputs.0.processors.0.syslog","service.name":"filebeat","id":" CA8C6DD2BACAD24","ecs.version":"1.6.0"}
      #
      # After:
      # {
      #  "@timestamp": "2023-09-28T10:10:12.175Z",
      #  "@metadata": {
      #    "beat": "filebeat",
      #    "type": "_doc",
      #    "version": "8.12.0"
      #  },
      #  "agent": {
      #    "id": "886265c2-046c-4069-a564-15f7baea5ab4",
      #    "name": "mac16-m1",
      #    "type": "filebeat",
      #    "version": "8.12.0",
      #    "ephemeral_id": "007fe335-ce32-48ea-a834-d27e2b839210"
      #  },
      #  "message": "Stopped target",
      #  "input": {
      #    "type": "cel"
      #  },
      #  "log": {
      #    "syslog": {
      #      "priority": 30,
      #      "facility": {
      #        "code": 3,
      #        "name": "system"
      #      },
      #      "severity": {
      #        "code": 6,
      #        "name": "Informational"
      #      },
      #      "appname": "systemd",
      #      "procid": "153589",
      #      "hostname": "test.lab.com",
      #      "version": "1"
      #    }
      #  },
      #  "ecs": {
      #    "version": "8.0.0"
      #  }
      #}
      #{
      #  "@timestamp": "2023-10-05T16:16:09.714Z",
      #  "@metadata": {
      #    "beat": "filebeat",
      #    "type": "_doc",
      #    "version": "8.12.0"
      #  },
      #  "message": "Not syslog.",
      #  "input": {
      #    "type": "cel"
      #  },
      #  "agent": {
      #    "ephemeral_id": "007fe335-ce32-48ea-a834-d27e2b839210",
      #    "id": "886265c2-046c-4069-a564-15f7baea5ab4",
      #    "name": "mac16-m1",
      #    "type": "filebeat",
      #    "version": "8.12.0"
      #  },
      #  "ecs": {
      #    "version": "8.0.0"
      #  }
      #}
      - syslog:
          when.regexp.message: '^<\d+>\d '
          field: message

output.console.pretty: true
```
