### PR TITLE
[GCP] [Billing] Log an error message when the metricset finds no tables

### DIFF
--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -144,6 +144,15 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err erro
 		return fmt.Errorf("getTables failed: %w", err)
 	}
 
+	// Not finding any table is an error state for this metricset.
+	//
+	// It can happen because the user made a mistake in the configuration
+	// file or the service account lacks the needed permissions (the API
+	// does not report any error if the Service Account lacks the required
+	// permission).
+	//
+	// Regardless of the origin, it's a condition that we should
+	// report to the user and give hints for troubleshooting.
 	if len(tableMetas) == 0 {
 		m.logger.Errorf("no tables found in dataset %s with pattern %s; check your settings and see if the service account has permission to list datasets", m.config.DatasetID, m.config.TablePattern)
 		return nil

--- a/x-pack/metricbeat/module/gcp/billing/billing.go
+++ b/x-pack/metricbeat/module/gcp/billing/billing.go
@@ -144,6 +144,11 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err erro
 		return fmt.Errorf("getTables failed: %w", err)
 	}
 
+	if len(tableMetas) == 0 {
+		m.logger.Errorf("no tables found in dataset %s with pattern %s; check your settings and see if the service account has permission to list datasets", m.config.DatasetID, m.config.TablePattern)
+		return nil
+	}
+
 	var events []mb.Event
 	for _, tableMeta := range tableMetas {
 		eventsPerQuery, err := m.queryBigQuery(ctx, client, tableMeta, month, m.config.CostType)
@@ -158,6 +163,7 @@ func (m *MetricSet) Fetch(ctx context.Context, reporter mb.ReporterV2) (err erro
 	for _, event := range events {
 		reporter.Event(event)
 	}
+
 	return nil
 }
 
@@ -213,6 +219,7 @@ func getTables(ctx context.Context, client *bigquery.Client, datasetID string, t
 			}
 		}
 	}
+
 	return tables, nil
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Add an error message when the metricset finds no tables.

Not finding any dataset > table is an error state for this metricset. It can happen because the user made a mistake in the configuration file or the service account lacks the needed permissions [^1].

Regardless of the origin, it's a condition that we should report to the user and give hints for troubleshooting.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~ [^2]

<!-- Recommended
## Author's Checklist

Add a checklist of things that are required to be reviewed in order to have the PR approved
- [ ]
-->

<!-- Recommended
## How to test this PR locally

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #36687

<!-- Recommended
## Use cases

Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

<!-- Optional
## Screenshots

Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


<!-- Recommended
## Logs
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

[^1]: The API to list the datasets returns an empty list an no error if the service account does not have enough permissions. 
[^2]: I don't think this is worth mentioning in a changelog.