### PR TITLE
x-pack/filebeat/input/http_endpoint: Add validation for empty URL config

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -109,6 +109,7 @@ is collected by it.
 - Ensure winlog input retains metric collection when handling recoverable errors. {issue}36479[36479] {pull}36483[36483]
 - Revert error introduced in {pull}35734[35734] when symlinks can't be resolved in filestream. {pull}36557[36557]
 - Fix ignoring external input configuration in `take_over: true` mode {issue}36378[36378] {pull}36395[36395]
+- Add validation to http_endpoint config for empty URL {pull}36816[36816] {issue}36772[36772]
 
 *Heartbeat*
 

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -51,8 +51,6 @@ func defaultConfig() config {
 	return config{
 		Method:        http.MethodPost,
 		BasicAuth:     false,
-		Username:      "",
-		Password:      "",
 		ResponseCode:  200,
 		ResponseBody:  `{"message": "success"}`,
 		ListenAddress: "127.0.0.1",
@@ -60,14 +58,6 @@ func defaultConfig() config {
 		URL:           "/",
 		Prefix:        "json",
 		ContentType:   "application/json",
-		SecretHeader:  "",
-		SecretValue:   "",
-		HMACHeader:    "",
-		HMACKey:       "",
-		HMACType:      "",
-		HMACPrefix:    "",
-		CRCProvider:   "",
-		CRCSecret:     "",
 	}
 }
 
@@ -108,10 +98,6 @@ func (c *config) Validate() error {
 		}
 	} else if c.CRCSecret != "" {
 		return errors.New("crc.provider is required when crc.secret is defined")
-	}
-
-	if c.URL == "" {
-		return fmt.Errorf("webhook path URL can not be empty")
 	}
 
 	return nil

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -110,6 +110,10 @@ func (c *config) Validate() error {
 		return errors.New("crc.provider is required when crc.secret is defined")
 	}
 
+	if c.URL == "" {
+		return fmt.Errorf("webhook path URL can not be empty")
+	}
+
 	return nil
 }
 

--- a/x-pack/filebeat/input/http_endpoint/config.go
+++ b/x-pack/filebeat/input/http_endpoint/config.go
@@ -32,7 +32,7 @@ type config struct {
 	ResponseBody          string                  `config:"response_body"`
 	ListenAddress         string                  `config:"listen_address"`
 	ListenPort            string                  `config:"listen_port"`
-	URL                   string                  `config:"url"`
+	URL                   string                  `config:"url" validate:"required"`
 	Prefix                string                  `config:"prefix"`
 	ContentType           string                  `config:"content_type"`
 	SecretHeader          string                  `config:"secret.header"`

--- a/x-pack/filebeat/input/http_endpoint/config_test.go
+++ b/x-pack/filebeat/input/http_endpoint/config_test.go
@@ -1,0 +1,60 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package http_endpoint
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateConfig(t *testing.T) {
+	testCases := []struct {
+		name      string // Sub-test name.
+		config    config // Load config parameters.
+		wantError error  // Expected error
+	}{
+		{
+			name: "invalid URL",
+			config: config{
+				URL:          "",
+				ResponseBody: `{"message": "success"}`,
+				Method:       http.MethodPost,
+			},
+			wantError: fmt.Errorf("webhook path URL can not be empty"),
+		},
+		{
+			name: "invalid method",
+			config: config{
+				URL:          "/",
+				ResponseBody: `{"message": "success"}`,
+				Method:       "random",
+			},
+			wantError: fmt.Errorf("method must be POST, PUT or PATCH: random"),
+		},
+		{
+			name: "invalid URL",
+			config: config{
+				URL:          "/",
+				ResponseBody: "",
+				Method:       http.MethodPost,
+			},
+			wantError: fmt.Errorf("response_body must be valid JSON"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.config.URL = ""
+			// Execute config validation
+			err := tc.config.Validate()
+
+			// Validate responses
+			assert.Equal(t, tc.wantError, err)
+		})
+	}
+}

--- a/x-pack/filebeat/input/http_endpoint/config_test.go
+++ b/x-pack/filebeat/input/http_endpoint/config_test.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 	"testing"
 
-	confpkg "github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
+
+	confpkg "github.com/elastic/elastic-agent-libs/config"
 )
 
 func Test_validateConfig(t *testing.T) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Integrations using the `http_endpoint` input that fails with a panic due to a misconfiguration. Validation added and a user-friendly log is added.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #36772 
