### PR TITLE
[Docs] Fix release notes formating

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -64,6 +64,7 @@ https://github.com/elastic/beats/compare/v8.9.2\...v8.10.0[View commits]
 ==== Bugfixes
 
 *Affecting all Beats*
+
 - Improve StreamBuf append to improve performance when reading long lines from files. {pull}35928[35928]
 - Eliminate cloning of event in deepUpdate {pull}35945[35945]
 - Fix ndjson parser to store JSON fields correctly under `target` {issue}29395[29395]

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -41,6 +41,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 ==== Bugfixes
 
 *Affecting all Beats*
+
 - Support for multiline zookeeper logs {issue}2496[2496]
 - Add checks to ensure reloading of units if the configuration actually changed. {pull}34346[34346]
 - Fix namespacing on self-monitoring {pull}32336[32336]


### PR DESCRIPTION
It appears a new line was missed which resulted in the docs not properly showing. Purely a cosmetic change here.
Please label this PR with one of the following labels, depending on the scope of your change:

- Cleanup
- Docs


## Proposed commit message
Fix formatting of release notes. A missing new line caused the changes to be smashed together and difficult to read. 

Please explain:
- WHAT: Added new line
- WHY:  Fix the readability 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.