### PR TITLE
Optimize memory allocations in the event processing pipeline

### DIFF
--- a/libbeat/beat/event_editor.go
+++ b/libbeat/beat/event_editor.go
@@ -19,6 +19,7 @@ package beat
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -31,50 +32,51 @@ var (
 	checkoutModeIncludeValues checkoutMode = true
 )
 
-// TODO rename to `Event` and use it instead of the actual event struct everywhere
-type EventAccessor interface {
-	// GetValue gets a value from the map. The key can be expressed in dot-notation (e.g. x.y).
-	// If the key does not exist then `mapstr.ErrKeyNotFound` error is returned.
-	GetValue(key string) (interface{}, error)
+type EventError struct {
+	Message   string
+	Field     string
+	Data      string
+	Processor string
+}
 
-	// PutValue associates the specified value with the specified key. If the event
-	// previously contained a mapping for the key, the old value is replaced and
-	// returned. The key can be expressed in dot-notation (e.g. x.y) to put a value
-	// into a nested map.
-	//
-	// If you need insert keys containing dots then you must use bracket notation
-	// to insert values (e.g. m[key] = value).
-	PutValue(key string, v interface{}) (interface{}, error)
+func (e EventError) Error() string {
+	var prefix string
+	if e.Processor != "" {
+		prefix += fmt.Sprintf("[processor=%s] ", e.Processor)
+	}
 
-	// Delete value with the given key.
-	// The key can be expressed in dot-notation (e.g. x.y)
-	Delete(key string) error
+	if e.Field != "" {
+		prefix += fmt.Sprintf("[field=%q] ", e.Field)
+	}
 
-	// DeepUpdate recursively copies the key-value pairs from `d` to various properties of the event.
-	// When the key equals `@timestamp` it's set as the `Timestamp` property of the event.
-	// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`
-	// The rest of the keys are set to the `Fields` map.
-	// If the key is present and the value is a map as well, the sub-map will be updated recursively
-	// via `DeepUpdate`.
-	// `DeepUpdateNoOverwrite` is a version of this function that does not
-	// overwrite existing values.p
-	DeepUpdate(d mapstr.M)
+	if e.Data != "" {
+		prefix += fmt.Sprintf("[data=%s] ", e.Data)
+	}
+	return prefix + e.Message
+}
 
-	// DeepUpdateNoOverwrite recursively copies the key-value pairs from `d` to various properties of the event.
-	// The `@timestamp` update is ignored due to "no overwrite" behavior.
-	// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`.
-	// The rest of the keys are set to the `Fields` map.
-	// If the key is present and the value is a map as well, the sub-map will be updated recursively
-	// via `DeepUpdateNoOverwrite`.
-	// `DeepUpdate` is a version of this function that overwrites existing values.
-	DeepUpdateNoOverwrite(d mapstr.M)
+func (e EventError) toMap() mapstr.M {
+	m := mapstr.M{
+		"message": e.Message,
+	}
+	if e.Data != "" {
+		m["data"] = e.Data
+	}
+	if e.Field != "" {
+		m["field"] = e.Field
+	}
+	if e.Processor != "" {
+		m["processor"] = e.Processor
+	}
+
+	return m
 }
 
 // EventEditor is a wrapper that allows to make changes to the wrapped event
 // preserving states of the original nested maps by cloning them on demand.
 //
 // The first time a nested map gets updated it's cloned and, from that moment on, only the copy is modified.
-// Once all the changes are collected, users should call `Apply` to copy pending changes to the original event.
+// Once all the changes are collected, users can call `Apply` to apply pending changes to the original event.
 // When the changes get applied the pointers to originally referenced nested maps get replaced with pointers to
 // modified copies.
 //
@@ -92,6 +94,7 @@ type EventEditor struct {
 	deletions map[string]struct{}
 }
 
+// NewEventEditor creates a new event editor for the given event.
 func NewEventEditor(e *Event) *EventEditor {
 	if e == nil {
 		e = &Event{}
@@ -101,28 +104,100 @@ func NewEventEditor(e *Event) *EventEditor {
 	}
 }
 
-// GetValue implements the `EventAccessor` interface.
-func (e *EventEditor) GetValue(key string) (interface{}, error) {
-	if key == metadataFieldKey {
-		return nil, ErrMetadataAccess
+// Fields returns the current computed state of changes without applying any changes to the original event.
+//
+// This function is cloning all the fields from the original event.
+// Using this function is slow and expensive on memory, try not to use it unless it's absolutely necessary.
+func (e *EventEditor) Fields() mapstr.M {
+	if e.original.Fields == nil {
+		if e.pending.Fields != nil {
+			return e.pending.Fields.Clone()
+		}
+		return mapstr.M{}
 	}
+	fields := e.original.Fields.Clone()
+	for key := range e.deletions {
+		_ = fields.Delete(key)
+	}
+	if e.pending != nil {
+		fields.DeepUpdate(e.pending.Fields)
+	}
+	return fields
+}
 
-	// handle the deletion marks
-	rootKey := e.rootKey(key)
-	if rootKey == key && e.checkDeleted(key) {
-		return nil, mapstr.ErrKeyNotFound
+// FlattenKeys returns all flatten keys for the current pending state of the event.
+// This includes original undeleted keys and new unapplied keys.
+func (e *EventEditor) FlattenKeys() []string {
+	uniqueKeys := make(map[string]struct{})
+
+	if e.original.Meta != nil {
+		for _, key := range *e.original.Meta.FlattenKeys() {
+			if e.checkDeleted(key) {
+				continue
+			}
+			uniqueKeys[metadataKeyPrefix+key] = struct{}{}
+		}
+	}
+	if e.original.Fields != nil {
+		for _, key := range *e.original.Fields.FlattenKeys() {
+			if e.checkDeleted(key) {
+				continue
+			}
+			uniqueKeys[key] = struct{}{}
+		}
 	}
 
 	if e.pending != nil {
+		if e.pending.Meta != nil {
+			for _, key := range *e.pending.Meta.FlattenKeys() {
+				uniqueKeys[metadataKeyPrefix+key] = struct{}{}
+			}
+		}
+		if e.pending.Fields != nil {
+			for _, key := range *e.pending.Fields.FlattenKeys() {
+				uniqueKeys[key] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(uniqueKeys))
+	for key := range uniqueKeys {
+		result = append(result, key)
+	}
+	return result
+}
+
+// GetValue gets a value from the event. The key can be expressed in dot-notation (e.g. x.y).
+// If the key does not exist then `mapstr.ErrKeyNotFound` error is returned.
+//
+// If the returned value is a nested map this function always returns a copy,
+// not the same nested map referenced by the original event.
+func (e *EventEditor) GetValue(key string) (interface{}, error) {
+	if key == "" {
+		return nil, mapstr.ErrKeyNotFound
+	}
+	if key == MetadataFieldKey {
+		return nil, ErrMetadataAccess
+	}
+
+	rootKey := e.rootKey(key)
+
+	if e.pending != nil {
+		// if the root key is empty the original event never had this key
+		if rootKey == "" {
+			return e.pending.GetValue(key)
+		}
 		// We try to retrieve from the `pending` event first,
 		// since it should have the most recent data.
 		//
 		// To check if the nested map was checked-out before
-		// we need to get the root-level first
+		// we need to get the root-level first.
 		val, err := e.pending.GetValue(rootKey)
+		// if the key was found, it was either created by PutValue or
+		// checked out from the original event.
 		if err == nil {
 			if rootKey == key {
-				// the value might be the end value we're looking for
+				// the value might be the root-level end value we're looking for
 				return val, nil
 			} else {
 				// otherwise, we need to retrieve from the nested map
@@ -143,6 +218,15 @@ func (e *EventEditor) GetValue(key string) (interface{}, error) {
 		}
 	}
 
+	// handle the deletion marks but only on the root-level
+	// the rest should be covered by looking into the pending event
+	// where we check out all the nested maps.
+	if rootKey == key && e.checkDeleted(key) {
+		return nil, mapstr.ErrKeyNotFound
+	}
+
+	// in case the key was never checked out and it's still
+	// present only in the original event
 	value, err := e.original.GetValue(key)
 	if err != nil {
 		return nil, err
@@ -164,39 +248,58 @@ func (e *EventEditor) GetValue(key string) (interface{}, error) {
 	return e.pending.GetValue(key)
 }
 
-// PutValue implements the `EventAccessor` interface.
+// PutValue associates the specified value with the specified key. If the event
+// previously contained a mapping for the key, the old value is replaced and
+// returned. The key can be expressed in dot-notation (e.g. x.y) to put a value
+// into a nested map.
+//
+// If the returned previous value is a nested map this function always returns a copy,
+// not the same nested map referenced by the original event.
+//
+// This changed is not applied to the original event until `Apply` is called.
 func (e *EventEditor) PutValue(key string, v interface{}) (interface{}, error) {
-	if key == metadataFieldKey {
+	switch key {
+	case MetadataFieldKey:
 		return nil, ErrAlterMetadataKey
+	case TimestampFieldKey:
+		e.allocatePending()
+		return e.pending.PutValue(key, v)
+	default:
+		e.allocatePending()
+		// checkout only if the key leads to a nested value
+		if !e.checkDeleted(key) {
+			e.checkout(key, checkoutModeIncludeValues)
+		}
+
+		return e.pending.PutValue(key, v)
 	}
-	// checkout only if the key leads to a nested value
-	e.checkout(key, checkoutModeOnlyMaps)
-	e.allocatePending()
-	return e.pending.PutValue(key, v)
 }
 
-// Delete implements the `EventAccessor` interface.
+// Delete value with the given key.
+// The key can be expressed in dot-notation (e.g. x.y)
+//
+// This changed is not applied to the original event until `Apply` is called.
 func (e *EventEditor) Delete(key string) error {
-	if key == timestampFieldKey {
+	if key == TimestampFieldKey {
 		return ErrDeleteTimestamp
 	}
-	if key == metadataFieldKey {
+	if key == MetadataFieldKey {
 		return ErrAlterMetadataKey
 	}
 	var deleted bool
 	has, _ := e.original.HasKey(key)
-
 	if has {
-		if key == e.rootKey(key) {
+		rootKey := e.rootKey(key)
+		if key == rootKey {
 			// if we're trying to delete a root-level key
 			// it must be deleted from the `original` event when `Apply` is called
 			// and from the `pending` event (below) if a value with the same key was put there.
-			e.markAsDeleted(key)
+			e.markAsDeleted(rootKey)
 			deleted = true
 		} else {
 			// if it's not a root-level key, we checkout this entire root-level map
-			// and delete from the `pending` event instead.
-			e.checkout(key, checkoutModeOnlyMaps)
+			// and delete from the copy in `pending` event instead.
+			e.checkout(rootKey, checkoutModeOnlyMaps)
 		}
 	}
 
@@ -212,25 +315,58 @@ func (e *EventEditor) Delete(key string) error {
 	}
 }
 
-// DeepUpdate implements the `EventAccessor` interface.
+// DeleteAll marks all data to be deleted from the event when `Apply` is called.
+func (e *EventEditor) DeleteAll() {
+	// reset all the changes because
+	// they don't make sense anymore
+	e.Reset()
+	// now we mark all root level keys for deletion
+	// in both `Meta` and `Fields` maps of the original event
+	if e.original.Meta != nil {
+		for key := range e.original.Meta {
+			e.markAsDeleted(metadataKeyPrefix + key)
+		}
+	}
+	if e.original.Fields != nil {
+		for key := range e.original.Fields {
+			e.markAsDeleted(key)
+		}
+	}
+}
+
+// DeepUpdate recursively copies the key-value pairs from `d` to various properties of the event.
+// When the key equals `@timestamp` it's set as the `Timestamp` property of the event.
+// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`
+// The rest of the keys are set to the `Fields` map.
+// If the key is present and the value is a map as well, the sub-map will be updated recursively
+// via `DeepUpdate`.
+// `DeepUpdateNoOverwrite` is a version of this function that does not
+// overwrite existing values.
 func (e *EventEditor) DeepUpdate(d mapstr.M) { e.deepUpdate(d, updateModeOverwrite) }
 
-// DeepUpdateNoOverwrite implements the `EventAccessor` interface.
+// DeepUpdateNoOverwrite recursively copies the key-value pairs from `d` to various properties of the event.
+// The `@timestamp` update is ignored due to "no overwrite" behavior.
+// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`.
+// The rest of the keys are set to the `Fields` map.
+// If the key is present and the value is a map as well, the sub-map will be updated recursively
+// via `DeepUpdateNoOverwrite`.
+// `DeepUpdate` is a version of this function that overwrites existing values.
 func (e *EventEditor) DeepUpdateNoOverwrite(d mapstr.M) { e.deepUpdate(d, updateModeNoOverwrite) }
 
 // Apply write all the changes to the original event making sure that none of the original
-// nested maps are modified but replaced with modified clones.
+// nested maps are modified but replaced with modified copies.
 func (e *EventEditor) Apply() {
+	defer e.Reset()
+
+	for deletedKey := range e.deletions {
+		_ = e.original.Delete(deletedKey)
+	}
+
 	if e.pending == nil {
 		return
 	}
 
-	defer e.Reset()
-
 	e.original.Timestamp = e.pending.Timestamp
-	for deletedKey := range e.deletions {
-		_ = e.original.Delete(deletedKey)
-	}
 
 	// it's enough to overwrite the root-level because
 	// of the checkout mechanism used earlier
@@ -270,6 +406,107 @@ func (e *EventEditor) Reset() {
 	}
 }
 
+// AddTags appends a tag to the tags field of the event. If the tags field does not
+// exist then it will be created. If the tags field exists and is not a []string
+// then an error will be returned. It does not deduplicate the list of tags.
+func (e *EventEditor) AddTags(tags ...string) error {
+	return e.AddTagsWithKey(mapstr.TagsKey, tags...)
+}
+
+// AddTagsWithKey appends a tag to the given field of the event. If the tags field does not
+// exist then it will be created. If the tags field exists and is not a []string
+// then an error will be returned. It does not deduplicate the list of tags.
+func (e *EventEditor) AddTagsWithKey(key string, tags ...string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+	e.checkout(key, checkoutModeIncludeValues)
+	e.allocatePending()
+	if e.pending.Fields == nil {
+		e.pending.Fields = mapstr.M{}
+	}
+	return mapstr.AddTagsWithKey(e.pending.Fields, key, tags)
+}
+
+// AddError appends an error to the event. If the error field does not
+// exist then it will be created.
+// If the error field exists and another error was already set, it will be converted to a list
+// of errors and new errors will be appended there.
+// If there is only one error to add, it will be added directly without a list.
+func (e *EventEditor) AddError(ee ...EventError) {
+	if len(ee) == 0 {
+		return
+	}
+	e.checkout(ErrorFieldKey, checkoutModeIncludeValues)
+	e.allocatePending()
+	if e.pending.Fields == nil {
+		e.pending.Fields = mapstr.M{}
+	}
+
+	var list []mapstr.M
+	val, err := e.pending.Fields.GetValue(ErrorFieldKey)
+	// if the value does not exist yet, we initialize the list of errors
+	// with the size of the current arguments.
+	if errors.Is(err, mapstr.ErrKeyNotFound) {
+		list = make([]mapstr.M, 0, len(ee))
+	} else if err != nil {
+		return
+	}
+	// if the value already exists, depending on its type
+	// we need to reformat it or just append to an existing list.
+	switch typed := val.(type) {
+	// there was a single error map, should be replaced with a list,
+	// the existing error will become an item on this list
+	case mapstr.M:
+		list = make([]mapstr.M, 0, len(ee)+1)
+		list = append(list, typed)
+	// same as the previous case but typed differently
+	case map[string]interface{}:
+		list = make([]mapstr.M, 0, len(ee)+1)
+		list = append(list, mapstr.M(typed))
+	// some code can assign an error as a string
+	// it's not really expected but we should not lose this value
+	// so, we convert it into a proper error format.
+	case string:
+		list = make([]mapstr.M, 0, len(ee)+1)
+		list = append(list, EventError{Message: typed}.toMap())
+	}
+
+	// after the list is prepared and contains already existing errors
+	// we can start copying the arguments, converting them to maps
+	for _, err := range ee {
+		// an error without a message is not a valid error
+		if err.Message == "" {
+			continue
+		}
+		m := err.toMap()
+		list = append(list, m)
+	}
+
+	// if after all manipulations we still have a single error
+	// we convert it back into a map instead of adding a list
+	if len(list) == 1 {
+		e.pending.Fields[ErrorFieldKey] = list[0]
+	} else {
+		e.pending.Fields[ErrorFieldKey] = list
+	}
+}
+
+// String returns the string representation of the current editor's state.
+// This function is slow and should be used for debugging purposes only.
+func (e *EventEditor) String() string {
+	deleteList := make([]string, 0, len(e.deletions))
+	for key := range e.deletions {
+		deleteList = append(deleteList, key)
+	}
+	m := mapstr.M{
+		"original":  e.original.String(),
+		"pending":   e.pending.String(),
+		"deletions": deleteList,
+	}
+	return m.String()
+}
+
 // deepUpdate checks out all the necessary root-level keys before running the deep update.
 func (e *EventEditor) deepUpdate(d mapstr.M, mode updateMode) {
 	if len(d) == 0 {
@@ -282,14 +519,14 @@ func (e *EventEditor) deepUpdate(d mapstr.M, mode updateMode) {
 
 	// checkout necessary keys from the original event
 	for key := range d {
-		if key == timestampFieldKey {
+		if key == TimestampFieldKey {
 			continue
 		}
 
 		// we never checkout the whole metadata, only root-level keys
 		// which are about to get updated
-		if key == metadataFieldKey {
-			metaUpdate := d[metadataFieldKey]
+		if key == MetadataFieldKey {
+			metaUpdate := d[MetadataFieldKey]
 			switch m := metaUpdate.(type) {
 			case mapstr.M:
 				for innerKey := range m {
@@ -313,85 +550,140 @@ func (e *EventEditor) deepUpdate(d mapstr.M, mode updateMode) {
 // markAsDeleted marks a key for deletion when `Apply` is called
 // if it's a root-level key in the original event.
 func (e *EventEditor) markAsDeleted(key string) {
-	dotIdx := e.dotIdx(key)
-	// nested keys are not marked since nested maps
-	// are cloned into the `pending` event and altered there
-	if dotIdx != -1 {
+	if key == TimestampFieldKey {
 		return
 	}
+	rootKey := e.rootKey(key)
 	if e.deletions == nil {
 		e.deletions = make(map[string]struct{})
 	}
-	e.deletions[key] = struct{}{}
+	e.deletions[rootKey] = struct{}{}
 }
 
 // checkout clones a nested map of the original event to the event with pending changes.
 //
 // If the key leads to a value nested in a map, we checkout the root-level nested map which means
-// the whole sub-tree is recursively cloned, so it can be safely modified.
+// the whole sub-tree is recursively cloned, so it can be safely modified later.
 func (e *EventEditor) checkout(key string, mode checkoutMode) {
+	if key == TimestampFieldKey {
+		return
+	}
 	// we're always looking only at the root-level
 	rootKey := e.rootKey(key)
-
-	if e.pending != nil {
-		// it might be already checked out
-		checkedOut, _ := e.pending.HasKey(rootKey)
-		if checkedOut {
-			return
-		}
-	}
-
-	// if there is nothing to checkout - return
-	value, err := e.original.GetValue(rootKey)
-	if err != nil {
+	// if the key is not in the original map, the value is empty
+	if rootKey == "" {
 		return
 	}
 
 	e.allocatePending()
 
+	var dstMap, srcMap mapstr.M
+	if strings.HasPrefix(rootKey, metadataKeyPrefix) {
+		if e.original.Meta == nil {
+			return
+		}
+		if e.pending.Meta == nil {
+			e.pending.Meta = mapstr.M{}
+		}
+		dstMap = e.pending.Meta
+		srcMap = e.original.Meta
+		rootKey = rootKey[metadataKeyOffset:]
+	} else {
+		if e.original.Fields == nil {
+			return
+		}
+		if e.pending.Fields == nil {
+			e.pending.Fields = mapstr.M{}
+		}
+		dstMap = e.pending.Fields
+		srcMap = e.original.Fields
+	}
+
+	// it might be already checked out
+	_, checkedOut := dstMap[rootKey]
+	if checkedOut {
+		return
+	}
+
+	// if there is nothing to checkout - return
+	value, exists := srcMap[rootKey]
+	if !exists {
+		return
+	}
+
 	// we check out only nested maps, and leave root-level value types in the original map
 	// unless the special `includeValues` mode engaged (used for DeepUpdateNoOverwrite).
 	switch typedVal := value.(type) {
 	case mapstr.M:
-		_, _ = e.pending.PutValue(rootKey, typedVal.Clone())
+		dstMap[rootKey] = typedVal.Clone()
 	case map[string]interface{}:
-		_, _ = e.pending.PutValue(rootKey, mapstr.M(typedVal).Clone())
+		dstMap[rootKey] = mapstr.M(typedVal).Clone()
+		// TODO slices?
 	default:
 		if mode == checkoutModeIncludeValues {
-			_, _ = e.pending.PutValue(rootKey, typedVal)
+			dstMap[rootKey] = typedVal
 		}
 	}
 }
 
-// dotIdx returns index of the first `.` character or `-1` if there is no `.` character.
+// rootKey reduces the key of the original event to its root-level.
+// Keys may have `.` character in them on every level and `.` can also mean a nested depth.
+//
 // Accounts for the `@metadata` subkeys, since it's stored in a separate map,
 // root-level keys will be in the `@metadata.*` namespace.
-func (e *EventEditor) dotIdx(key string) int {
-	// metadata keys are special, since they're stored in a separate map
-	// we don't want to copy the whole map with all metadata, we want
-	// to checkout only nested maps one by one for efficiency
+//
+// Returns empty string if the key does not exist in the original event.
+func (e *EventEditor) rootKey(key string) string {
+	if key == TimestampFieldKey {
+		return key
+	}
+	var (
+		prefix string
+		m      mapstr.M
+	)
+
 	if strings.HasPrefix(key, metadataKeyPrefix) {
-		// we start looking after the `@metadata` prefix
-		dotIdx := strings.Index(key[metadataKeyOffset:], ".")
-		// if there is no dot in the subkey, then the second segment
-		// is considered to be a root-level key
-		if dotIdx == -1 {
-			return -1
-		}
-		// otherwise we need to offset the dot index by the prefix we removed
-		return dotIdx + metadataKeyOffset
+		prefix = metadataKeyPrefix
+		key = key[metadataKeyOffset:]
+		m = e.original.Meta
+	} else {
+		m = e.original.Fields
 	}
 
-	return strings.Index(key, ".")
-}
+	// there is no root-level key with this name
+	if m == nil {
+		return ""
+	}
 
-// rootKey reduces the key to its root-level.
-func (e *EventEditor) rootKey(key string) string {
-	dotIdx := e.dotIdx(key)
+	// this key may be simple and does not contain dots
+	dotIdx := strings.IndexRune(key, '.')
 	if dotIdx == -1 {
-		return key
-	} else {
-		return key[:dotIdx]
+		return prefix + key
+	}
+
+	// fast lane for the whole key
+	_, exists := m[key]
+	if exists {
+		return prefix + key
+	}
+
+	// otherwise we start with the first segment
+	// and keep adding the next segment to the key until the resulting value
+	// exists on the root level.
+	var rootKey string
+	for {
+		rootKey = key[:dotIdx]
+		_, exists = m[rootKey]
+		if exists {
+			return prefix + rootKey
+		}
+		dotIdx = strings.IndexRune(key[dotIdx+1:], '.')
+		// we checked above for the full key and it didn't exist,
+		// no need to check again, we return since the key is not found
+		if dotIdx == -1 {
+			return ""
+		}
+		dotIdx += len(rootKey) + 1
 	}
 }
 
@@ -404,7 +696,7 @@ func (e *EventEditor) checkDeleted(key string) bool {
 	return deleted
 }
 
-// allocatePending makes sure that the `pending` event is allocated for collecting changes.
+// allocatePending makes sure that the `pending` event is allocated for collecting new changes.
 func (e *EventEditor) allocatePending() {
 	if e.pending != nil {
 		return

--- a/libbeat/beat/event_editor.go
+++ b/libbeat/beat/event_editor.go
@@ -1,0 +1,415 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beat
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+type checkoutMode bool
+
+var (
+	checkoutModeOnlyMaps      checkoutMode = false
+	checkoutModeIncludeValues checkoutMode = true
+)
+
+// TODO rename to `Event` and use it instead of the actual event struct everywhere
+type EventAccessor interface {
+	// GetValue gets a value from the map. The key can be expressed in dot-notation (e.g. x.y).
+	// If the key does not exist then `mapstr.ErrKeyNotFound` error is returned.
+	GetValue(key string) (interface{}, error)
+
+	// PutValue associates the specified value with the specified key. If the event
+	// previously contained a mapping for the key, the old value is replaced and
+	// returned. The key can be expressed in dot-notation (e.g. x.y) to put a value
+	// into a nested map.
+	//
+	// If you need insert keys containing dots then you must use bracket notation
+	// to insert values (e.g. m[key] = value).
+	PutValue(key string, v interface{}) (interface{}, error)
+
+	// Delete value with the given key.
+	// The key can be expressed in dot-notation (e.g. x.y)
+	Delete(key string) error
+
+	// DeepUpdate recursively copies the key-value pairs from `d` to various properties of the event.
+	// When the key equals `@timestamp` it's set as the `Timestamp` property of the event.
+	// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`
+	// The rest of the keys are set to the `Fields` map.
+	// If the key is present and the value is a map as well, the sub-map will be updated recursively
+	// via `DeepUpdate`.
+	// `DeepUpdateNoOverwrite` is a version of this function that does not
+	// overwrite existing values.p
+	DeepUpdate(d mapstr.M)
+
+	// DeepUpdateNoOverwrite recursively copies the key-value pairs from `d` to various properties of the event.
+	// The `@timestamp` update is ignored due to "no overwrite" behavior.
+	// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`.
+	// The rest of the keys are set to the `Fields` map.
+	// If the key is present and the value is a map as well, the sub-map will be updated recursively
+	// via `DeepUpdateNoOverwrite`.
+	// `DeepUpdate` is a version of this function that overwrites existing values.
+	DeepUpdateNoOverwrite(d mapstr.M)
+}
+
+// EventEditor is a wrapper that allows to make changes to the wrapped event
+// preserving states of the original nested maps by cloning them on demand.
+//
+// The first time a nested map gets updated it's cloned and, from that moment on, only the copy is modified.
+// Once all the changes are collected, users should call `Apply` to copy pending changes to the original event.
+// When the changes get applied the pointers to originally referenced nested maps get replaced with pointers to
+// modified copies.
+//
+// This allows us to:
+// * avoid cloning the entire event and be more efficient in memory management
+// * collect multiple changes and apply them at once, using a transaction-like mechanism (`Apply`/`Reset` functions).
+//
+// WARNING:
+// Events can contains slices which this editor does not preserve.
+// It's on the consumer to copy slices if they need to be changed.
+// This editor takes care of maps only, not looking into slices. This means maps in slices are not preserved either.
+type EventEditor struct {
+	original  *Event
+	pending   *Event
+	deletions map[string]struct{}
+}
+
+func NewEventEditor(e *Event) *EventEditor {
+	if e == nil {
+		e = &Event{}
+	}
+	return &EventEditor{
+		original: e,
+	}
+}
+
+// GetValue implements the `EventAccessor` interface.
+func (e *EventEditor) GetValue(key string) (interface{}, error) {
+	if key == metadataFieldKey {
+		return nil, ErrMetadataAccess
+	}
+
+	// handle the deletion marks
+	rootKey := e.rootKey(key)
+	if rootKey == key && e.checkDeleted(key) {
+		return nil, mapstr.ErrKeyNotFound
+	}
+
+	if e.pending != nil {
+		// We try to retrieve from the `pending` event first,
+		// since it should have the most recent data.
+		//
+		// To check if the nested map was checked-out before
+		// we need to get the root-level first
+		val, err := e.pending.GetValue(rootKey)
+		if err == nil {
+			if rootKey == key {
+				// the value might be the end value we're looking for
+				return val, nil
+			} else {
+				// otherwise, we need to retrieve from the nested map
+				subKey := key[len(rootKey)+1:]
+				switch nested := val.(type) {
+				case mapstr.M:
+					return nested.GetValue(subKey)
+				case map[string]interface{}:
+					return mapstr.M(nested).GetValue(subKey)
+				default:
+					return nil, mapstr.ErrKeyNotFound
+				}
+			}
+		}
+
+		if !errors.Is(err, mapstr.ErrKeyNotFound) {
+			return nil, err
+		}
+	}
+
+	value, err := e.original.GetValue(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// if the end value is not a map, we can just return it,
+	// value types will be copied automatically
+	switch value.(type) {
+	case mapstr.M, map[string]interface{}:
+	default:
+		return value, nil
+	}
+
+	// if the key leads to a map value or it's in a nested map,
+	// we must check it out before returning, so we return a clone
+	// that the consumer can modify
+	e.checkout(key, checkoutModeOnlyMaps)
+
+	return e.pending.GetValue(key)
+}
+
+// PutValue implements the `EventAccessor` interface.
+func (e *EventEditor) PutValue(key string, v interface{}) (interface{}, error) {
+	if key == metadataFieldKey {
+		return nil, ErrAlterMetadataKey
+	}
+	// checkout only if the key leads to a nested value
+	e.checkout(key, checkoutModeOnlyMaps)
+	e.allocatePending()
+	return e.pending.PutValue(key, v)
+}
+
+// Delete implements the `EventAccessor` interface.
+func (e *EventEditor) Delete(key string) error {
+	if key == timestampFieldKey {
+		return ErrDeleteTimestamp
+	}
+	if key == metadataFieldKey {
+		return ErrAlterMetadataKey
+	}
+	var deleted bool
+	has, _ := e.original.HasKey(key)
+
+	if has {
+		if key == e.rootKey(key) {
+			// if we're trying to delete a root-level key
+			// it must be deleted from the `original` event when `Apply` is called
+			// and from the `pending` event (below) if a value with the same key was put there.
+			e.markAsDeleted(key)
+			deleted = true
+		} else {
+			// if it's not a root-level key, we checkout this entire root-level map
+			// and delete from the `pending` event instead.
+			e.checkout(key, checkoutModeOnlyMaps)
+		}
+	}
+
+	if e.pending != nil {
+		err := e.pending.Delete(key)
+		deleted = deleted || err == nil
+	}
+
+	if deleted {
+		return nil
+	} else {
+		return mapstr.ErrKeyNotFound
+	}
+}
+
+// DeepUpdate implements the `EventAccessor` interface.
+func (e *EventEditor) DeepUpdate(d mapstr.M) { e.deepUpdate(d, updateModeOverwrite) }
+
+// DeepUpdateNoOverwrite implements the `EventAccessor` interface.
+func (e *EventEditor) DeepUpdateNoOverwrite(d mapstr.M) { e.deepUpdate(d, updateModeNoOverwrite) }
+
+// Apply write all the changes to the original event making sure that none of the original
+// nested maps are modified but replaced with modified clones.
+func (e *EventEditor) Apply() {
+	if e.pending == nil {
+		return
+	}
+
+	defer e.Reset()
+
+	e.original.Timestamp = e.pending.Timestamp
+	for deletedKey := range e.deletions {
+		_ = e.original.Delete(deletedKey)
+	}
+
+	// it's enough to overwrite the root-level because
+	// of the checkout mechanism used earlier
+	if len(e.pending.Meta) > 0 {
+		if e.original.Meta == nil {
+			e.original.Meta = mapstr.M{}
+		}
+		for key := range e.pending.Meta {
+			e.original.Meta[key] = e.pending.Meta[key]
+		}
+	}
+	if len(e.pending.Fields) > 0 {
+		if e.original.Fields == nil {
+			e.original.Fields = mapstr.M{}
+		}
+		for key := range e.pending.Fields {
+			e.original.Fields[key] = e.pending.Fields[key]
+		}
+	}
+}
+
+// Reset cleans all the pending changes and starts collecting them again.
+// This function does not allocate new memory.
+func (e *EventEditor) Reset() {
+	if e.pending == nil {
+		return
+	}
+	e.pending.Timestamp = e.original.Timestamp
+	for k := range e.deletions {
+		delete(e.deletions, k)
+	}
+	for k := range e.pending.Meta {
+		delete(e.pending.Meta, k)
+	}
+	for k := range e.pending.Fields {
+		delete(e.pending.Fields, k)
+	}
+}
+
+// deepUpdate checks out all the necessary root-level keys before running the deep update.
+func (e *EventEditor) deepUpdate(d mapstr.M, mode updateMode) {
+	if len(d) == 0 {
+		return
+	}
+	cm := checkoutModeOnlyMaps
+	if mode == updateModeNoOverwrite {
+		cm = checkoutModeIncludeValues
+	}
+
+	// checkout necessary keys from the original event
+	for key := range d {
+		if key == timestampFieldKey {
+			continue
+		}
+
+		// we never checkout the whole metadata, only root-level keys
+		// which are about to get updated
+		if key == metadataFieldKey {
+			metaUpdate := d[metadataFieldKey]
+			switch m := metaUpdate.(type) {
+			case mapstr.M:
+				for innerKey := range m {
+					e.checkout(metadataKeyPrefix+innerKey, cm)
+				}
+			case map[string]interface{}:
+				for innerKey := range m {
+					e.checkout(metadataKeyPrefix+innerKey, cm)
+				}
+			}
+			continue
+		}
+
+		e.checkout(key, cm)
+	}
+
+	e.allocatePending()
+	e.pending.deepUpdate(d, mode)
+}
+
+// markAsDeleted marks a key for deletion when `Apply` is called
+// if it's a root-level key in the original event.
+func (e *EventEditor) markAsDeleted(key string) {
+	dotIdx := e.dotIdx(key)
+	// nested keys are not marked since nested maps
+	// are cloned into the `pending` event and altered there
+	if dotIdx != -1 {
+		return
+	}
+	if e.deletions == nil {
+		e.deletions = make(map[string]struct{})
+	}
+	e.deletions[key] = struct{}{}
+}
+
+// checkout clones a nested map of the original event to the event with pending changes.
+//
+// If the key leads to a value nested in a map, we checkout the root-level nested map which means
+// the whole sub-tree is recursively cloned, so it can be safely modified.
+func (e *EventEditor) checkout(key string, mode checkoutMode) {
+	// we're always looking only at the root-level
+	rootKey := e.rootKey(key)
+
+	if e.pending != nil {
+		// it might be already checked out
+		checkedOut, _ := e.pending.HasKey(rootKey)
+		if checkedOut {
+			return
+		}
+	}
+
+	// if there is nothing to checkout - return
+	value, err := e.original.GetValue(rootKey)
+	if err != nil {
+		return
+	}
+
+	e.allocatePending()
+
+	// we check out only nested maps, and leave root-level value types in the original map
+	// unless the special `includeValues` mode engaged (used for DeepUpdateNoOverwrite).
+	switch typedVal := value.(type) {
+	case mapstr.M:
+		_, _ = e.pending.PutValue(rootKey, typedVal.Clone())
+	case map[string]interface{}:
+		_, _ = e.pending.PutValue(rootKey, mapstr.M(typedVal).Clone())
+	default:
+		if mode == checkoutModeIncludeValues {
+			_, _ = e.pending.PutValue(rootKey, typedVal)
+		}
+	}
+}
+
+// dotIdx returns index of the first `.` character or `-1` if there is no `.` character.
+// Accounts for the `@metadata` subkeys, since it's stored in a separate map,
+// root-level keys will be in the `@metadata.*` namespace.
+func (e *EventEditor) dotIdx(key string) int {
+	// metadata keys are special, since they're stored in a separate map
+	// we don't want to copy the whole map with all metadata, we want
+	// to checkout only nested maps one by one for efficiency
+	if strings.HasPrefix(key, metadataKeyPrefix) {
+		// we start looking after the `@metadata` prefix
+		dotIdx := strings.Index(key[metadataKeyOffset:], ".")
+		// if there is no dot in the subkey, then the second segment
+		// is considered to be a root-level key
+		if dotIdx == -1 {
+			return -1
+		}
+		// otherwise we need to offset the dot index by the prefix we removed
+		return dotIdx + metadataKeyOffset
+	}
+
+	return strings.Index(key, ".")
+}
+
+// rootKey reduces the key to its root-level.
+func (e *EventEditor) rootKey(key string) string {
+	dotIdx := e.dotIdx(key)
+	if dotIdx == -1 {
+		return key
+	} else {
+		return key[:dotIdx]
+	}
+}
+
+// checkDeleted returns `true` if the key was marked for deletion.
+// The key can be expressed in dot-notation (e.g. x.y) and if the root-level prefix on
+// the key path is deleted the function returns `true`.
+func (e *EventEditor) checkDeleted(key string) bool {
+	rootKey := e.rootKey(key)
+	_, deleted := e.deletions[rootKey]
+	return deleted
+}
+
+// allocatePending makes sure that the `pending` event is allocated for collecting changes.
+func (e *EventEditor) allocatePending() {
+	if e.pending != nil {
+		return
+	}
+	e.pending = &Event{
+		Timestamp: e.original.Timestamp,
+	}
+}

--- a/libbeat/beat/event_editor_test.go
+++ b/libbeat/beat/event_editor_test.go
@@ -1,0 +1,1110 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beat
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventEditor(t *testing.T) {
+	metadataNestedNestedMap := mapstr.M{
+		"metaLevel2Value": "metavalue3",
+	}
+	metadataNestedMap := mapstr.M{
+		"metaLevel1Map": metadataNestedNestedMap,
+	}
+
+	fieldsNestedNestedMap := mapstr.M{
+		"fieldsLevel2Value": "fieldsvalue3",
+	}
+	fieldsNestedMap := mapstr.M{
+		"fieldsLevel1Map": fieldsNestedNestedMap,
+	}
+
+	metaUntouchedMap := mapstr.M{}
+	fieldsUntouchedMap := mapstr.M{}
+
+	event := &Event{
+		Timestamp: time.Now(),
+		Meta: mapstr.M{
+			"metaLevel0Map":   metadataNestedMap,
+			"metaLevel0Value": "metavalue1",
+			// this key should never be edited by the tests
+			// to verify that existing keys remain
+			"metaLevel0Value2": "untouched",
+			// this map should never be checked out
+			"metaUntouchedMap": metaUntouchedMap,
+		},
+		Fields: mapstr.M{
+			"fieldsLevel0Map":   fieldsNestedMap,
+			"fieldsLevel0Value": "fieldsvalue1",
+			// this key should never be edited by the tests
+			// to verify that existing keys remain
+			"fieldsLevel0Value2": "untouched",
+			// this map should never be checked out
+			"fieldsUntouchedMap": fieldsUntouchedMap,
+		},
+	}
+
+	t.Run("rootKey", func(t *testing.T) {
+		cases := []struct {
+			val string
+			exp string
+		}{
+			{
+				val: "@metadata.some",
+				exp: "@metadata.some",
+			},
+			{
+				val: "@metadata.some.nested",
+				exp: "@metadata.some",
+			},
+			{
+				val: "some.nested.key",
+				exp: "some",
+			},
+			{
+				val: "key",
+				exp: "key",
+			},
+		}
+
+		for _, tc := range cases {
+			e := NewEventEditor(event)
+			t.Run(tc.val, func(t *testing.T) {
+				require.Equal(t, tc.exp, e.rootKey(tc.val))
+			})
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Run("Apply", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				editor.Apply()
+			})
+		})
+
+		t.Run("Reset", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				editor.Reset()
+			})
+		})
+
+		t.Run("Delete", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				err := editor.Delete("@metadata.some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				err = editor.Delete("some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				editor.Apply()
+			})
+		})
+
+		t.Run("GetValue", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				_, err := editor.GetValue("@metadata.some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				_, err = editor.GetValue("some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+		})
+
+		t.Run("PutValue", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				prev, err := editor.PutValue("@metadata.some", "value")
+				require.NoError(t, err)
+				require.Nil(t, prev)
+				prev, err = editor.PutValue("some", "value")
+				require.NoError(t, err)
+				require.Nil(t, prev)
+				editor.Apply()
+			})
+		})
+
+		t.Run("DeepUpdate", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				editor.DeepUpdate(mapstr.M{
+					"@metadata": mapstr.M{"key": "value"},
+					"key":       "value",
+				})
+				editor.Apply()
+			})
+		})
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Run("@timestamp", func(t *testing.T) {
+			editor := NewEventEditor(event)
+			val, err := editor.GetValue("@timestamp")
+			require.NoError(t, err)
+			require.Equal(t, event.Timestamp, val)
+		})
+
+		t.Run("@metadata", func(t *testing.T) {
+			t.Run("no acess to @metadata key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				metadata, err := editor.GetValue("@metadata")
+				require.Nil(t, metadata)
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrMetadataAccess)
+			})
+
+			t.Run("non-existing key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				val, err := editor.GetValue("@metadata.none")
+				require.Nil(t, val)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("gets a value type", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				requireMapValues(t, editor, map[string]interface{}{
+					"@metadata.metaLevel0Value": "metavalue1",
+				})
+			})
+
+			t.Run("gets a nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested, err := editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, metadataNestedMap, nested)
+			})
+
+			t.Run("gets a deeper nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				nested, err := editor.GetValue("@metadata.metaLevel0Map.metaLevel1Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, metadataNestedNestedMap, nested)
+
+				// the higher level map should be also cloned by accessing the inner map
+				higher, err := editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, metadataNestedMap, higher)
+
+				// the nested map we got previously should be a part of this cloned higher level map
+				require.IsType(t, mapstr.M{}, higher)
+				higherMap := higher.(mapstr.M)
+				nested2, err := higherMap.GetValue("metaLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested, nested2)
+			})
+
+			t.Run("returns the same nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested1, err := editor.GetValue("@metadata.metaLevel0Map.metaLevel1Map")
+				require.NoError(t, err)
+				nested2, err := editor.GetValue("@metadata.metaLevel0Map.metaLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested2, nested1)
+			})
+		})
+
+		t.Run("fields", func(t *testing.T) {
+			t.Run("non-existing key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				val, err := editor.GetValue("none")
+				require.Nil(t, val)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("gets a value type", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				requireMapValues(t, editor, map[string]interface{}{
+					"fieldsLevel0Value": "fieldsvalue1",
+				})
+			})
+
+			t.Run("gets a nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested, err := editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, fieldsNestedMap, nested)
+			})
+
+			t.Run("gets a deeper nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				nested, err := editor.GetValue("fieldsLevel0Map.fieldsLevel1Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, fieldsNestedNestedMap, nested)
+
+				// the higher level map should be also cloned by accessing the inner map
+				higher, err := editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, fieldsNestedMap, higher)
+
+				// the nested map we got previously should be a part of this higher level map
+				require.IsType(t, mapstr.M{}, higher)
+				higherMap := higher.(mapstr.M)
+				nested2, err := higherMap.GetValue("fieldsLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested, nested2)
+			})
+
+			t.Run("returns the same nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested1, err := editor.GetValue("fieldsLevel0Map.fieldsLevel1Map")
+				require.NoError(t, err)
+				nested2, err := editor.GetValue("fieldsLevel0Map.fieldsLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested2, nested1)
+			})
+		})
+
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Run("@timestamp", func(t *testing.T) {
+			editor := NewEventEditor(event)
+			err := editor.Delete("@timestamp")
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrDeleteTimestamp)
+		})
+
+		t.Run("@metadata", func(t *testing.T) {
+			t.Run("metadata itself", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				err := editor.Delete("@metadata")
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrAlterMetadataKey)
+			})
+
+			t.Run("non-existent key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				err := editor.Delete("@metadata.wrong")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				err = editor.Delete("@metadata.wrong.key")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Value"
+				value := "metavalue1"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, metadataNestedMap, val3)
+			})
+
+			t.Run("nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value"
+				value := "metavalue3"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val1, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val1)
+
+				// checking if the original event still has it
+				val2, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, metadataNestedNestedMap, val2)
+			})
+
+			t.Run("nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				err = editor.Delete(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// checking if the original event still has it
+				val1, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, metadataNestedNestedMap, val1)
+			})
+		})
+
+		t.Run("fields", func(t *testing.T) {
+			t.Run("non-existent key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				err := editor.Delete("wrong")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				err = editor.Delete("wrong.key")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Value"
+				value := "fieldsvalue1"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, fieldsNestedMap, val3)
+			})
+
+			t.Run("nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value"
+				value := "fieldsvalue3"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val1, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val1)
+
+				// checking if the original event still has it
+				val2, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, fieldsNestedNestedMap, val2)
+			})
+
+			t.Run("nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				err = editor.Delete(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// checking if the original event still has it
+				val1, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, fieldsNestedNestedMap, val1)
+			})
+		})
+	})
+
+	t.Run("PutValue", func(t *testing.T) {
+		t.Run("@timestamp", func(t *testing.T) {
+			editor := NewEventEditor(event)
+			newTs := time.Now().Add(time.Hour)
+			preVal, err := editor.PutValue("@timestamp", newTs)
+			require.NoError(t, err)
+			require.Equal(t, event.Timestamp, preVal)
+
+			val, err := editor.GetValue("@timestamp")
+			require.NoError(t, err)
+			require.Equal(t, newTs, val)
+
+			// the original event should not have this change
+			val, err = event.GetValue("@timestamp")
+			require.NoError(t, err)
+			require.Equal(t, event.Timestamp, val)
+		})
+
+		t.Run("@metadata", func(t *testing.T) {
+			t.Run("metadata itself", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				prevVal, err := editor.PutValue("@metadata", "some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrAlterMetadataKey)
+				require.Nil(t, prevVal)
+			})
+
+			t.Run("new root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.new"
+				value := "value"
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.new"
+				value := mapstr.M{
+					"some": "value",
+				}
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.new"
+				value := "newvalue"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, metadataNestedMap, val)
+			})
+
+			t.Run("new nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.new"
+				value := mapstr.M{
+					"some": "value",
+				}
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, metadataNestedMap, val)
+			})
+
+			t.Run("replacing nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value"
+				replacingValue := "metavalue3"
+				value := "new"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should have the previous value
+				val, err = event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, val)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, metadataNestedMap, val)
+			})
+		})
+
+		t.Run("fields", func(t *testing.T) {
+			t.Run("new root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "new"
+				value := "value"
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "new"
+				value := mapstr.M{
+					"some": "value",
+				}
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.new"
+				value := "newvalue"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `fieldsLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, metadataNestedMap, val)
+			})
+
+			t.Run("new nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.new"
+				value := mapstr.M{
+					"some": "value",
+				}
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, fieldsNestedMap, val)
+			})
+
+			t.Run("replacing nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value"
+				replacingValue := "fieldsvalue3"
+				value := "new"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should have the previous value
+				val, err = event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, val)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, fieldsNestedMap, val)
+			})
+		})
+	})
+
+	t.Run("Apply", func(t *testing.T) {
+		// we're going to make changes, so working with the clone in this test
+		cloned := event.Clone()
+		// need later for address comparison
+		metaNested := cloned.Meta["metaLevel0Map"]
+		metaUntouched := cloned.Meta["metaUntouchedMap"]
+		fieldsNested := cloned.Fields["fieldsLevel0Map"]
+		fieldsUntouched := cloned.Fields["fieldsUntouchedMap"]
+
+		editor := NewEventEditor(cloned)
+
+		// verify that it does nothing without pending changes
+		editor.Apply()
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		keysToDelete := []string{
+			"@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value",
+			"@metadata.metaLevel0Value",
+			"fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value",
+			"fieldsLevel0Value",
+		}
+		for _, key := range keysToDelete {
+			err := editor.Delete(key)
+			require.NoError(t, err)
+		}
+		newTs := time.Now().Add(time.Hour)
+		keysToPut := map[string]interface{}{
+			"@timestamp": newTs,
+			"@metadata.metaLevel0Map.metaLevel1Map.new1": "newmetavalue1",
+			"@metadata.metaLevel0Value":                  "metareplaced1",
+			"@metadata.new2":                             "newmetavalue2",
+			"fieldsLevel0Map.fieldsLevel1Map.new3":       "newfieldsvalue1",
+			"new4":                                       "newfieldsvalue2",
+			"fieldsLevel0Value":                          "fieldsreplaced1",
+		}
+		for key, val := range keysToPut {
+			_, err := editor.PutValue(key, val)
+			require.NoError(t, err)
+		}
+
+		// making sure that there are no changes yet
+		require.Equal(t, event.Timestamp, cloned.Timestamp)
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		expEvent := &Event{
+			Timestamp: newTs,
+			Meta: mapstr.M{
+				"metaLevel0Map": mapstr.M{
+					"metaLevel1Map": mapstr.M{
+						"new1": "newmetavalue1",
+					},
+				},
+				"metaLevel0Value":  "metareplaced1",
+				"new2":             "newmetavalue2",
+				"metaLevel0Value2": "untouched",
+				"metaUntouchedMap": metaUntouchedMap,
+			},
+			Fields: mapstr.M{
+				"fieldsLevel0Map": mapstr.M{
+					"fieldsLevel1Map": mapstr.M{
+						"new3": "newfieldsvalue1",
+					},
+				},
+				"new4":               "newfieldsvalue2",
+				"fieldsLevel0Value":  "fieldsreplaced1",
+				"fieldsLevel0Value2": "untouched",
+				"fieldsUntouchedMap": fieldsUntouchedMap,
+			},
+		}
+
+		editor.Apply()
+
+		require.Equal(t, expEvent.Timestamp, cloned.Timestamp)
+		require.Equal(t, expEvent.Meta.StringToPrint(), cloned.Meta.StringToPrint())
+		require.Equal(t, expEvent.Fields.StringToPrint(), cloned.Fields.StringToPrint())
+
+		// verifying that only the changed nested maps were cloned
+		requireNotSameMap(t, metaNested, cloned.Meta["metaLevel0Map"])
+		requireNotSameMap(t, fieldsNested, cloned.Fields["fieldsLevel0Map"])
+		requireSameMap(t, metaUntouched, cloned.Meta["metaUntouchedMap"])
+		requireSameMap(t, fieldsUntouched, cloned.Fields["fieldsUntouchedMap"])
+	})
+
+	t.Run("Reset", func(t *testing.T) {
+		// we might make changes, so working with the cloned event here
+		cloned := event.Clone()
+		metaNested := cloned.Meta["metaLevel0Map"]
+		fieldsNested := cloned.Fields["fieldsLevel0Map"]
+		editor := NewEventEditor(cloned)
+
+		// verify that `Reset` does nothing without pending changes
+		editor.Reset()
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		keysToDelete := []string{
+			"@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value",
+			"@metadata.metaLevel0Value",
+			"fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value",
+			"fieldsLevel0Value",
+		}
+		for _, key := range keysToDelete {
+			err := editor.Delete(key)
+			require.NoError(t, err)
+		}
+		newTs := time.Now().Add(time.Hour)
+		keysToPut := map[string]interface{}{
+			"@timestamp": newTs,
+			"@metadata.metaLevel0Map.metaLevel1Map.new1": "newmetavalue1",
+			"@metadata.metaLevel0Value":                  "metareplaced1",
+			"@metadata.new2":                             "newmetavalue2",
+			"fieldsLevel0Map.fieldsLevel1Map.new3":       "newfieldsvalue1",
+			"new4":                                       "newfieldsvalue2",
+			"fieldsLevel0Value":                          "fieldsreplaced1",
+		}
+		for key, val := range keysToPut {
+			_, err := editor.PutValue(key, val)
+			require.NoError(t, err)
+		}
+
+		// making sure that there are no changes yet
+		require.Equal(t, event.Timestamp, cloned.Timestamp)
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		editor.Reset()
+
+		require.Equal(t, event.Timestamp, cloned.Timestamp)
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		// verifying that the nested maps were not cloned
+		requireSameMap(t, metaNested, cloned.Meta["metaLevel0Map"])
+		requireSameMap(t, fieldsNested, cloned.Fields["fieldsLevel0Map"])
+
+		// verify that deletions are reset and every value is back
+		for _, key := range keysToDelete {
+			_, err := editor.GetValue(key)
+			require.NoError(t, err)
+		}
+		// verify that all the edits are reset
+		for key, val := range keysToPut {
+			got, err := editor.GetValue(key)
+			if strings.Contains(key, "new") {
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				continue
+			}
+			require.NoError(t, err)
+			require.NotEqual(t, val, got)
+		}
+	})
+
+	t.Run("DeepUpdate", func(t *testing.T) {
+		t.Run("empty", func(t *testing.T) {
+			cloned := event.Clone()
+			editor := NewEventEditor(cloned)
+			editor.DeepUpdate(nil)
+			editor.Apply()
+			requireClonedMaps(t, event.Meta, cloned.Meta)
+			requireClonedMaps(t, event.Fields, cloned.Fields)
+		})
+
+		newTs := time.Now().Add(time.Hour)
+		update := map[string]interface{}{
+			"@timestamp": newTs,
+			"@metadata": map[string]interface{}{
+				"metaLevel0Map": mapstr.M{ // mix types on purpose, should support both
+					"metaLevel1Map": map[string]interface{}{
+						"new1": "newmetavalue1",
+					},
+				},
+				"metaLevel0Value": "metareplaced1",
+				"new2":            "newmetavalue2",
+			},
+			"fieldsLevel0Map": map[string]interface{}{
+				"fieldsLevel1Map": mapstr.M{
+					"new3": "newfieldsvalue1",
+				},
+				"newmap": map[string]interface{}{
+					"new4": "newfieldsvalue2",
+				},
+			},
+			"fieldsLevel0Value": "fieldsreplaced1",
+		}
+
+		t.Run("overwrite", func(t *testing.T) {
+			cloned := event.Clone()
+			editor := NewEventEditor(cloned)
+			editor.DeepUpdate(update)
+
+			expEvent := &Event{
+				Timestamp: newTs,
+				Meta: mapstr.M{
+					"metaLevel0Map": mapstr.M{
+						"metaLevel1Map": mapstr.M{
+							"metaLevel2Value": "metavalue3",
+							"new1":            "newmetavalue1",
+						},
+					},
+					"metaLevel0Value":  "metareplaced1",
+					"metaLevel0Value2": "untouched",
+					"new2":             "newmetavalue2",
+					"metaUntouchedMap": metaUntouchedMap,
+				},
+				Fields: mapstr.M{
+					"fieldsLevel0Map": mapstr.M{
+						"fieldsLevel1Map": mapstr.M{
+							"fieldsLevel2Value": "fieldsvalue3",
+							"new3":              "newfieldsvalue1",
+						},
+						"newmap": map[string]interface{}{
+							"new4": "newfieldsvalue2",
+						},
+					},
+					"fieldsLevel0Value":  "fieldsreplaced1",
+					"fieldsLevel0Value2": "untouched",
+					"fieldsUntouchedMap": fieldsUntouchedMap,
+				},
+			}
+
+			// edited nested maps in metadata and fields should be checked out
+			requireNotSameMap(t, cloned.Meta["metaLevel0Map"], editor.pending.Meta["metaLevel0Map"])
+			requireNotSameMap(t, cloned.Fields["fieldsLevel0Map"], editor.pending.Fields["fieldsLevel0Map"])
+			require.Nil(t, editor.pending.Meta["metaUntouchedMap"])
+			require.Nil(t, editor.pending.Fields["fieldsUntouchedMap"])
+
+			editor.Apply()
+
+			require.Equal(t, expEvent.Timestamp, cloned.Timestamp)
+			requireClonedMaps(t, expEvent.Meta, cloned.Meta)
+			requireClonedMaps(t, expEvent.Fields, cloned.Fields)
+		})
+
+		t.Run("no overwrite", func(t *testing.T) {
+			cloned := event.Clone()
+			editor := NewEventEditor(cloned)
+			editor.DeepUpdateNoOverwrite(update)
+
+			expEvent := &Event{
+				// should have the original/non-overwritten timestamp value
+				Timestamp: event.Timestamp,
+				Meta: mapstr.M{
+					"metaLevel0Map": mapstr.M{
+						"metaLevel1Map": mapstr.M{
+							"metaLevel2Value": "metavalue3",
+							"new1":            "newmetavalue1",
+						},
+					},
+					"metaLevel0Value":  "metavalue1",
+					"metaLevel0Value2": "untouched",
+					"new2":             "newmetavalue2",
+					"metaUntouchedMap": metaUntouchedMap,
+				},
+				Fields: mapstr.M{
+					"fieldsLevel0Map": mapstr.M{
+						"fieldsLevel1Map": mapstr.M{
+							"fieldsLevel2Value": "fieldsvalue3",
+							"new3":              "newfieldsvalue1",
+						},
+						"newmap": map[string]interface{}{
+							"new4": "newfieldsvalue2",
+						},
+					},
+					"fieldsLevel0Value":  "fieldsvalue1",
+					"fieldsLevel0Value2": "untouched",
+					"fieldsUntouchedMap": fieldsUntouchedMap,
+				},
+			}
+
+			// only edited nested maps in metadata and fields should be checked out
+			requireNotSameMap(t, cloned.Meta["metaLevel0Map"], editor.pending.Meta["metaLevel0Map"])
+			requireNotSameMap(t, cloned.Fields["fieldsLevel0Map"], editor.pending.Fields["fieldsLevel0Map"])
+			require.Nil(t, editor.pending.Meta["metaUntouchedMap"])
+			require.Nil(t, editor.pending.Fields["fieldsUntouchedMap"])
+
+			editor.Apply()
+
+			require.Equal(t, expEvent.Timestamp, cloned.Timestamp)
+			requireClonedMaps(t, expEvent.Meta, cloned.Meta)
+			requireClonedMaps(t, expEvent.Fields, cloned.Fields)
+		})
+	})
+}
+
+func requireClonedMaps(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	requireNotSameMap(t, expected, actual)
+	require.IsType(t, mapstr.M{}, expected)
+	require.IsType(t, mapstr.M{}, actual)
+
+	expectedMap := expected.(mapstr.M)
+	actualMap := actual.(mapstr.M)
+
+	require.Equal(t, expectedMap.StringToPrint(), actualMap.StringToPrint())
+}
+
+func requireSameMap(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	expectedAddr := fmt.Sprintf("%p", expected)
+	actualAddr := fmt.Sprintf("%p", actual)
+	require.Equalf(t, expectedAddr, actualAddr, "should reference the same map: %s != %s", expectedAddr, actualAddr)
+}
+
+func requireNotSameMap(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	expectedAddr := fmt.Sprintf("%p", expected)
+	actualAddr := fmt.Sprintf("%p", actual)
+	require.NotEqualf(t, expectedAddr, actualAddr, "should reference different maps: %s == %s", expectedAddr, actualAddr)
+}
+
+func requireMapValues(t *testing.T, e EventAccessor, expected map[string]interface{}) {
+	t.Helper()
+	for key := range expected {
+		val, err := e.GetValue(key)
+		require.NoError(t, err)
+		require.Equal(t, expected[key], val)
+	}
+}

--- a/libbeat/beat/event_test.go
+++ b/libbeat/beat/event_test.go
@@ -117,7 +117,7 @@ func TestDeepUpdate(t *testing.T) {
 			name:  "updates timestamp",
 			event: newEvent(mapstr.M{}),
 			update: mapstr.M{
-				timestampFieldKey: ts,
+				TimestampFieldKey: ts,
 			},
 			mode: updateModeOverwrite,
 			expected: &Event{
@@ -133,7 +133,7 @@ func TestDeepUpdate(t *testing.T) {
 				"Timestamp": ts,
 			}),
 			update: mapstr.M{
-				timestampFieldKey: time.Now().Add(time.Hour),
+				TimestampFieldKey: time.Now().Add(time.Hour),
 			},
 			mode: updateModeNoOverwrite,
 			expected: &Event{
@@ -147,7 +147,7 @@ func TestDeepUpdate(t *testing.T) {
 			name:  "initializes metadata if nil",
 			event: newEvent(mapstr.M{}),
 			update: mapstr.M{
-				metadataFieldKey: mapstr.M{
+				MetadataFieldKey: mapstr.M{
 					"first":  "new",
 					"second": 42,
 				},
@@ -170,7 +170,7 @@ func TestDeepUpdate(t *testing.T) {
 				},
 			}),
 			update: mapstr.M{
-				metadataFieldKey: mapstr.M{
+				MetadataFieldKey: mapstr.M{
 					"first":  "new",
 					"second": 42,
 				},
@@ -194,7 +194,7 @@ func TestDeepUpdate(t *testing.T) {
 				},
 			}),
 			update: mapstr.M{
-				metadataFieldKey: mapstr.M{
+				MetadataFieldKey: mapstr.M{
 					"first":  "new",
 					"second": 42,
 				},

--- a/libbeat/beat/pipeline.go
+++ b/libbeat/beat/pipeline.go
@@ -155,7 +155,7 @@ type ProcessorList interface {
 // registered with the publisher pipeline.
 type Processor interface {
 	String() string // print full processor description
-	Run(in *Event) (event *Event, err error)
+	Run(*EventEditor) (dropped bool, err error)
 }
 
 // PublishMode enum sets some requirements on the client connection to the beats

--- a/libbeat/common/jsontransform/expand.go
+++ b/libbeat/common/jsontransform/expand.go
@@ -31,10 +31,12 @@ import (
 // conflicts (i.e. a common prefix where one field is an object and another
 // is a non-object), an error key is added to the event if add_error_key
 // is enabled.
-func ExpandFields(logger *logp.Logger, event *beat.Event, m mapstr.M, addErrorKey bool) {
+func ExpandFields(logger *logp.Logger, event *beat.EventEditor, m mapstr.M, addErrorKey bool) {
 	if err := expandFields(m); err != nil {
 		logger.Errorf("JSON: failed to expand fields: %s", err)
-		event.SetErrorWithOption(err.Error(), addErrorKey, "", "")
+		if addErrorKey {
+			event.AddError(beat.EventError{Message: err.Error()})
+		}
 	}
 }
 

--- a/libbeat/processors/actions/add_labels.go
+++ b/libbeat/processors/actions/add_labels.go
@@ -51,7 +51,7 @@ func createAddLabels(c *conf.C) (beat.Processor, error) {
 		return nil, fmt.Errorf("failed to flatten labels: %w", err)
 	}
 
-	return makeFieldsProcessor(LabelsKey, flatLabels, true), nil
+	return makeFieldsProcessor(LabelsKey, flatLabels), nil
 }
 
 // NewAddLabels creates a new processor adding the given object to events. Set
@@ -60,7 +60,7 @@ func createAddLabels(c *conf.C) (beat.Processor, error) {
 // If labels contains nested objects, NewAddLabels will flatten keys into labels by
 // by joining names with a dot ('.') .
 // The labels will be inserted into the 'labels' field.
-func NewAddLabels(labels mapstr.M, shared bool) (beat.Processor, error) {
+func NewAddLabels(labels mapstr.M) (beat.Processor, error) {
 	flatLabels, err := flattenLabels(labels)
 	if err != nil {
 		return nil, fmt.Errorf("failed to flatten labels: %w", err)
@@ -68,7 +68,7 @@ func NewAddLabels(labels mapstr.M, shared bool) (beat.Processor, error) {
 
 	return NewAddFields(mapstr.M{
 		LabelsKey: flatLabels,
-	}, shared, true), nil
+	}, true), nil
 }
 
 func flattenLabels(labels mapstr.M) (mapstr.M, error) {

--- a/libbeat/processors/actions/add_tags.go
+++ b/libbeat/processors/actions/add_tags.go
@@ -73,9 +73,9 @@ func NewAddTags(target string, tags []string) beat.Processor {
 	return &addTags{tags: tags, target: target}
 }
 
-func (at *addTags) Run(event *beat.Event) (*beat.Event, error) {
-	_ = mapstr.AddTagsWithKey(event.Fields, at.target, at.tags)
-	return event, nil
+func (at *addTags) Run(event *beat.EventEditor) (dropped bool, err error) {
+	err = event.AddTagsWithKey(at.target, at.tags...)
+	return false, err
 }
 
 func (at *addTags) String() string {

--- a/libbeat/processors/actions/common_test.go
+++ b/libbeat/processors/actions/common_test.go
@@ -60,17 +60,18 @@ func testProcessors(t *testing.T, cases map[string]testCase) {
 			if test.eventMeta != nil {
 				current.Meta = test.eventMeta.Clone()
 			}
+			ed := beat.NewEventEditor(current)
 			for i, processor := range ps {
 				var err error
-				current, err = processor.Run(current)
+				dropped, err := processor.Run(ed)
 				if err != nil {
 					t.Fatal(err)
 				}
-				if current == nil {
+				if dropped {
 					t.Fatalf("Event dropped(%v)", i)
 				}
 			}
-
+			ed.Apply()
 			assert.Equal(t, test.wantFields, current.Fields)
 			assert.Equal(t, test.wantMeta, current.Meta)
 		})

--- a/libbeat/processors/actions/copy_fields_test.go
+++ b/libbeat/processors/actions/copy_fields_test.go
@@ -161,11 +161,12 @@ func TestCopyFields(t *testing.T) {
 			event := &beat.Event{
 				Fields: test.Input,
 			}
-
-			newEvent, err := p.Run(event)
+			ed := beat.NewEventEditor(event)
+			dropped, err := p.Run(ed)
 			assert.NoError(t, err)
-
-			assert.Equal(t, test.Expected, newEvent.Fields)
+			assert.False(t, dropped)
+			ed.Apply()
+			assert.Equal(t, test.Expected, event.Fields)
 		})
 	}
 
@@ -187,16 +188,19 @@ func TestCopyFields(t *testing.T) {
 				"message": "please copy this line",
 			},
 		}
+		ed := beat.NewEventEditor(event)
 
 		expMeta := mapstr.M{
 			"message":        "please copy this line",
 			"message_copied": "please copy this line",
 		}
 
-		newEvent, err := p.Run(event)
+		dropped, err := p.Run(ed)
 		assert.NoError(t, err)
+		assert.False(t, dropped)
 
-		assert.Equal(t, expMeta, newEvent.Meta)
-		assert.Equal(t, event.Fields, newEvent.Fields)
+		ed.Apply()
+		assert.Equal(t, expMeta, event.Meta)
+		assert.Equal(t, event.Fields, event.Fields)
 	})
 }

--- a/libbeat/processors/actions/decode_base64_field_test.go
+++ b/libbeat/processors/actions/decode_base64_field_test.go
@@ -211,14 +211,16 @@ func TestDecodeBase64Run(t *testing.T) {
 				Fields: test.Input,
 			}
 
-			newEvent, err := f.Run(event)
+			ed := beat.NewEventEditor(event)
+			dropped, err := f.Run(ed)
 			if !test.error {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)
 			}
-
-			assert.Equal(t, test.Output, newEvent.Fields)
+			assert.False(t, dropped)
+			ed.Apply()
+			assert.Equal(t, test.Output, event.Fields)
 		})
 	}
 
@@ -236,6 +238,7 @@ func TestDecodeBase64Run(t *testing.T) {
 				"field1": "Y29ycmVjdCBkYXRh",
 			},
 		}
+		ed := beat.NewEventEditor(event)
 
 		f := &decodeBase64Field{
 			log:    logp.NewLogger(processorName),
@@ -249,9 +252,12 @@ func TestDecodeBase64Run(t *testing.T) {
 			"field": "correct data",
 		}
 
-		newEvent, err := f.Run(event)
+		dropped, err := f.Run(ed)
+
 		assert.NoError(t, err)
-		assert.Equal(t, expectedFields, newEvent.Fields)
-		assert.Equal(t, expectedMeta, newEvent.Meta)
+		assert.False(t, dropped)
+		ed.Apply()
+		assert.Equal(t, expectedFields, event.Fields)
+		assert.Equal(t, expectedMeta, event.Meta)
 	})
 }

--- a/libbeat/processors/actions/decompress_gzip_field.go
+++ b/libbeat/processors/actions/decompress_gzip_field.go
@@ -67,28 +67,22 @@ func NewDecompressGzipFields(c *conf.C) (beat.Processor, error) {
 }
 
 // Run applies the decompress_gzip_fields processor to an event.
-func (f *decompressGzipField) Run(event *beat.Event) (*beat.Event, error) {
-	var backup *beat.Event
-	if f.config.FailOnError {
-		backup = event.Clone()
-	}
-
-	err := f.decompressGzipField(event)
+func (f *decompressGzipField) Run(event *beat.EventEditor) (dropped bool, err error) {
+	err = f.decompressGzipField(event)
 	if err != nil {
 		errMsg := fmt.Errorf("Failed to decompress field in decompress_gzip_field processor: %w", err)
 		if publisher.LogWithTrace() {
 			f.log.Debug(errMsg.Error())
 		}
 		if f.config.FailOnError {
-			event = backup
-			_, _ = event.PutValue("error.message", errMsg.Error())
-			return event, err
+			event.AddError(beat.EventError{Message: errMsg.Error()})
+			return false, err
 		}
 	}
-	return event, nil
+	return false, nil
 }
 
-func (f *decompressGzipField) decompressGzipField(event *beat.Event) error {
+func (f *decompressGzipField) decompressGzipField(event *beat.EventEditor) error {
 	data, err := event.GetValue(f.config.Field.From)
 	if err != nil {
 		if f.config.IgnoreMissing && errors.Is(err, mapstr.ErrKeyNotFound) {

--- a/libbeat/processors/actions/detect_mime_type.go
+++ b/libbeat/processors/actions/detect_mime_type.go
@@ -49,21 +49,21 @@ func NewDetectMimeType(cfg *conf.C) (beat.Processor, error) {
 	return mimeType, nil
 }
 
-func (m *mimeTypeProcessor) Run(event *beat.Event) (*beat.Event, error) {
+func (m *mimeTypeProcessor) Run(event *beat.EventEditor) (dropped bool, err error) {
 	valI, err := event.GetValue(m.Field)
 	if err != nil {
 		//nolint:nilerr // doesn't have the required field value to analyze
-		return event, nil
+		return false, nil
 	}
 	val, _ := valI.(string)
 	if val == "" {
 		// wrong type or not set
-		return event, nil
+		return false, nil
 	}
 	if mimeType := mime.Detect(val); mimeType != "" {
 		_, err = event.PutValue(m.Target, mimeType)
 	}
-	return event, err
+	return false, err
 }
 
 func (m *mimeTypeProcessor) String() string {

--- a/libbeat/processors/actions/drop_event.go
+++ b/libbeat/processors/actions/drop_event.go
@@ -37,9 +37,8 @@ func newDropEvent(c *conf.C) (beat.Processor, error) {
 	return dropEventsSingleton, nil
 }
 
-func (*dropEvent) Run(_ *beat.Event) (*beat.Event, error) {
-	// return event=nil to delete the entire event
-	return nil, nil
+func (*dropEvent) Run(*beat.EventEditor) (dropped bool, err error) {
+	return true, nil
 }
 
 func (*dropEvent) String() string { return "drop_event" }

--- a/libbeat/processors/actions/extract_field.go
+++ b/libbeat/processors/actions/extract_field.go
@@ -72,26 +72,26 @@ func NewExtractField(c *conf.C) (beat.Processor, error) {
 	return f, nil
 }
 
-func (f *extract_field) Run(event *beat.Event) (*beat.Event, error) {
+func (f *extract_field) Run(event *beat.EventEditor) (dropped bool, err error) {
 	fieldValue, err := event.GetValue(f.Field)
 	if err != nil {
-		return event, fmt.Errorf("error getting field '%s' from event", f.Field)
+		return false, fmt.Errorf("error getting field '%s' from event", f.Field)
 	}
 
 	value, ok := fieldValue.(string)
 	if !ok {
-		return event, fmt.Errorf("could not get a string from field '%s'", f.Field)
+		return false, fmt.Errorf("could not get a string from field '%s'", f.Field)
 	}
 
 	parts := strings.Split(value, f.Separator)
 	parts = deleteEmpty(parts)
 	if len(parts) < f.Index+1 {
-		return event, fmt.Errorf("index is out of range for field '%s'", f.Field)
+		return false, fmt.Errorf("index is out of range for field '%s'", f.Field)
 	}
 
 	_, _ = event.PutValue(f.Target, parts[f.Index])
 
-	return event, nil
+	return false, nil
 }
 
 func (f extract_field) String() string {

--- a/libbeat/processors/actions/include_fields_test.go
+++ b/libbeat/processors/actions/include_fields_test.go
@@ -68,9 +68,11 @@ func TestIncludeFields(t *testing.T) {
 			Fields: test.Input,
 		}
 
-		newEvent, err := p.Run(event)
+		ed := beat.NewEventEditor(event)
+		dropped, err := p.Run(ed)
 		assert.NoError(t, err)
-
-		assert.Equal(t, test.Output, newEvent.Fields)
+		assert.False(t, dropped)
+		ed.Apply()
+		assert.Equal(t, test.Output, event.Fields)
 	}
 }

--- a/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
+++ b/libbeat/processors/add_cloud_metadata/add_cloud_metadata.go
@@ -111,24 +111,24 @@ func (p *addCloudMetadata) getMeta() mapstr.M {
 	return p.metadata.Clone()
 }
 
-func (p *addCloudMetadata) Run(event *beat.Event) (*beat.Event, error) {
+func (p *addCloudMetadata) Run(event *beat.EventEditor) (dropped bool, err error) {
 	meta := p.getMeta()
 	if len(meta) == 0 {
-		return event, nil
+		return false, nil
 	}
 
-	err := p.addMeta(event, meta)
+	err = p.addMeta(event, meta)
 	if err != nil {
-		return nil, err
+		return true, err
 	}
-	return event, err
+	return false, err
 }
 
 func (p *addCloudMetadata) String() string {
 	return "add_cloud_metadata=" + p.getMeta().String()
 }
 
-func (p *addCloudMetadata) addMeta(event *beat.Event, meta mapstr.M) error {
+func (p *addCloudMetadata) addMeta(event *beat.EventEditor, meta mapstr.M) error {
 	for key, metaVal := range meta {
 		// If key exists in event already and overwrite flag is set to false, this processor will not overwrite the
 		// meta fields. For example aws module writes cloud.instance.* to events already, with overwrite=false,

--- a/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_alibaba_cloud_test.go
@@ -69,10 +69,11 @@ func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -87,5 +88,6 @@ func TestRetrieveAlibabaCloudMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_aws_ec2_test.go
@@ -359,11 +359,14 @@ func TestRetrieveAWSMetadataEC2(t *testing.T) {
 				t.Fatalf("error creating new metadata processor: %s", err.Error())
 			}
 
-			actual, err := cmp.Run(&beat.Event{Fields: tc.previousEvent})
-			if err != nil {
-				t.Fatalf("error running processor: %s", err.Error())
-			}
-			assert.Equal(t, tc.expectedEvent, actual.Fields)
+			event := &beat.Event{Fields: tc.previousEvent}
+			ed := beat.NewEventEditor(event)
+			dropped, err := cmp.Run(ed)
+			assert.NoError(t, err)
+			assert.False(t, dropped)
+
+			ed.Apply()
+			assert.Equal(t, tc.expectedEvent, event.Fields)
 		})
 	}
 }

--- a/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_azure_vm_test.go
@@ -105,10 +105,11 @@ func TestRetrieveAzureMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -129,5 +130,6 @@ func TestRetrieveAzureMetadata(t *testing.T) {
 			"region": "eastus",
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_digital_ocean_test.go
@@ -107,10 +107,11 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -124,5 +125,6 @@ func TestRetrieveDigitalOceanMetadata(t *testing.T) {
 			"region": "nyc3",
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_google_gce_test.go
@@ -325,10 +325,11 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -353,7 +354,8 @@ func TestRetrieveGCEMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }
 
 func TestRetrieveGCEMetadataInK8s(t *testing.T) {
@@ -374,10 +376,11 @@ func TestRetrieveGCEMetadataInK8s(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -408,7 +411,8 @@ func TestRetrieveGCEMetadataInK8s(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }
 
 func TestRetrieveGCEMetadataInK8sNotOverriden(t *testing.T) {
@@ -429,21 +433,20 @@ func TestRetrieveGCEMetadataInK8sNotOverriden(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(
-		&beat.Event{
-			Fields: mapstr.M{
-				"orchestrator": mapstr.M{
-					"cluster": mapstr.M{
-						"name": "production-marketing-k8s",
-						"url":  "https://35.223.150.35",
-					},
+	event := &beat.Event{
+		Fields: mapstr.M{
+			"orchestrator": mapstr.M{
+				"cluster": mapstr.M{
+					"name": "production-marketing-k8s",
+					"url":  "https://35.223.150.35",
 				},
 			},
 		},
-	)
-	if err != nil {
-		t.Fatal(err)
 	}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -474,7 +477,8 @@ func TestRetrieveGCEMetadataInK8sNotOverriden(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }
 
 func TestRetrieveGCEMetadataInK8sPartial(t *testing.T) {
@@ -495,10 +499,11 @@ func TestRetrieveGCEMetadataInK8sPartial(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -528,5 +533,6 @@ func TestRetrieveGCEMetadataInK8sPartial(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_hetzner_cloud_test.go
@@ -76,10 +76,11 @@ func assertHetzner(t *testing.T, config *conf.C) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -95,5 +96,6 @@ func assertHetzner(t *testing.T, config *conf.C) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_huawei_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_huawei_cloud_test.go
@@ -76,10 +76,11 @@ func TestRetrieveHuaweiCloudMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -94,5 +95,6 @@ func TestRetrieveHuaweiCloudMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_openstack_nova_test.go
@@ -94,10 +94,11 @@ func assertOpenstackNova(t *testing.T, config *conf.C) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -115,5 +116,6 @@ func assertOpenstackNova(t *testing.T, config *conf.C) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
+++ b/libbeat/processors/add_cloud_metadata/provider_tencent_cloud_test.go
@@ -69,10 +69,11 @@ func TestRetrieveQCloudMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual, err := p.Run(&beat.Event{Fields: mapstr.M{}})
-	if err != nil {
-		t.Fatal(err)
-	}
+	event := &beat.Event{Fields: mapstr.M{}}
+	ed := beat.NewEventEditor(event)
+	dropped, err := p.Run(ed)
+	assert.NoError(t, err)
+	assert.False(t, dropped)
 
 	expected := mapstr.M{
 		"cloud": mapstr.M{
@@ -87,5 +88,6 @@ func TestRetrieveQCloudMetadata(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual.Fields)
+	ed.Apply()
+	assert.Equal(t, expected, event.Fields)
 }

--- a/libbeat/processors/add_id/add_id.go
+++ b/libbeat/processors/add_id/add_id.go
@@ -60,14 +60,14 @@ func New(cfg *conf.C) (beat.Processor, error) {
 }
 
 // Run enriches the given event with an ID
-func (p *addID) Run(event *beat.Event) (*beat.Event, error) {
+func (p *addID) Run(event *beat.EventEditor) (dropped bool, err error) {
 	id := p.gen.NextID()
 
 	if _, err := event.PutValue(p.config.TargetField, id); err != nil {
-		return nil, makeErrComputeID(err)
+		return true, makeErrComputeID(err)
 	}
 
-	return event, nil
+	return false, nil
 }
 
 func (p *addID) String() string {

--- a/libbeat/processors/conditionals.go
+++ b/libbeat/processors/conditionals.go
@@ -77,9 +77,9 @@ func NewConditionRule(
 }
 
 // Run executes this WhenProcessor.
-func (r *WhenProcessor) Run(event *beat.Event) (*beat.Event, error) {
+func (r *WhenProcessor) Run(event *beat.EventEditor) (dropped bool, err error) {
 	if !(r.condition).Check(event) {
-		return event, nil
+		return false, nil
 	}
 	return r.p.Run(event)
 }
@@ -162,13 +162,13 @@ func NewIfElseThenProcessor(cfg *config.C) (*IfThenElseProcessor, error) {
 
 // Run checks the if condition and executes the processors attached to the
 // then statement or the else statement based on the condition.
-func (p *IfThenElseProcessor) Run(event *beat.Event) (*beat.Event, error) {
+func (p *IfThenElseProcessor) Run(event *beat.EventEditor) (dropped bool, err error) {
 	if p.cond.Check(event) {
 		return p.then.Run(event)
 	} else if p.els != nil {
 		return p.els.Run(event)
 	}
-	return event, nil
+	return false, nil
 }
 
 func (p *IfThenElseProcessor) String() string {

--- a/libbeat/processors/namespace_test.go
+++ b/libbeat/processors/namespace_test.go
@@ -29,7 +29,7 @@ import (
 
 type testFilterRule struct {
 	str func() string
-	run func(*beat.Event) (*beat.Event, error)
+	run func(*beat.EventEditor) (dropped bool, err error)
 }
 
 func TestNamespace(t *testing.T) {
@@ -132,9 +132,9 @@ func (r *testFilterRule) String() string {
 	return r.str()
 }
 
-func (r *testFilterRule) Run(evt *beat.Event) (*beat.Event, error) {
+func (r *testFilterRule) Run(evt *beat.EventEditor) (dropped bool, err error) {
 	if r.run == nil {
-		return evt, nil
+		return false, nil
 	}
 	return r.Run(evt)
 }

--- a/libbeat/processors/safe_processor.go
+++ b/libbeat/processors/safe_processor.go
@@ -34,9 +34,9 @@ type SafeProcessor struct {
 }
 
 // Run allows to run processor only when `Close` was not called prior
-func (p *SafeProcessor) Run(event *beat.Event) (*beat.Event, error) {
+func (p *SafeProcessor) Run(event *beat.EventEditor) (dropped bool, err error) {
 	if atomic.LoadUint32(&p.closed) == 1 {
-		return nil, ErrClosed
+		return true, ErrClosed
 	}
 	return p.Processor.Run(event)
 }

--- a/libbeat/processors/safe_processor_test.go
+++ b/libbeat/processors/safe_processor_test.go
@@ -32,9 +32,9 @@ type mockProcessor struct {
 	runCount int
 }
 
-func (p *mockProcessor) Run(event *beat.Event) (*beat.Event, error) {
+func (p *mockProcessor) Run(event *beat.EventEditor) (bool, error) {
 	p.runCount++
-	return mockEvent, nil
+	return false, nil
 }
 
 func (p *mockProcessor) String() string {
@@ -100,12 +100,13 @@ func TestSafeProcessor(t *testing.T) {
 	t.Run("propagates Run to a processor", func(t *testing.T) {
 		require.Equal(t, 0, p.runCount)
 
-		e, err := sp.Run(nil)
+		dropped, err := sp.Run(nil)
 		require.NoError(t, err)
-		require.Equal(t, e, mockEvent)
-		e, err = sp.Run(nil)
+		require.False(t, dropped)
+
+		dropped, err = sp.Run(nil)
 		require.NoError(t, err)
-		require.Equal(t, e, mockEvent)
+		require.False(t, dropped)
 
 		require.Equal(t, 2, p.runCount)
 	})
@@ -123,8 +124,8 @@ func TestSafeProcessor(t *testing.T) {
 
 	t.Run("does not propagate Run when closed", func(t *testing.T) {
 		require.Equal(t, 2, p.runCount) // still 2 from the previous test case
-		e, err := sp.Run(nil)
-		require.Nil(t, e)
+		dropped, err := sp.Run(nil)
+		require.True(t, dropped)
 		require.ErrorIs(t, err, ErrClosed)
 		require.Equal(t, 2, p.runCount)
 	})

--- a/libbeat/processors/script/javascript/module/processor/chain.go
+++ b/libbeat/processors/script/javascript/module/processor/chain.go
@@ -169,11 +169,11 @@ func newNativeProcessor(constructor processors.Constructor, call gojaCall) (proc
 }
 
 func (p *nativeProcessor) run(event javascript.Event) error {
-	out, err := p.Processor.Run(event.Wrapped())
+	dropped, err := p.Processor.Run(event.Wrapped())
 	if err != nil {
 		return err
 	}
-	if out == nil {
+	if dropped {
 		event.Cancel()
 	}
 	return nil


### PR DESCRIPTION
Previously, every time a processor ran on an event we made a clone of the entire event for two reasons:

1. this event could have some nested maps that are shared among multiple events.

2. in case a processor fails to make a change it should be able to revert its partial changes.

This change added a new `EventEditor` wrapper that is used for collecting pending event changes in processors with an option to `Apply` or `Reset` them.

Additionally, this `EventEditor` takes care of the efficient memory management when making changes to an event by cloning only the nested maps that processors access or modify. Most of the processors just put new keys or delete existing keys on the root-level, so most of the time the nested maps in the event remain untouched and it does not require the whole event to be cloned.

Processors migration progress:
- [ ] [add_cloudfoundry_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-cloudfoundry-metadata.html)
- [x] [add_docker_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-docker-metadata.html)
- [x] [add_host_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-host-metadata.html)
- [x] [add_id](https://www.elastic.co/guide/en/beats/filebeat/current/add-id.html)
- [ ] [add_kubernetes_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-kubernetes-metadata.html)
- [ ] [add_locale](https://www.elastic.co/guide/en/beats/filebeat/current/add-locale.html)
- [ ] [add_nomad_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-nomad-metadata.html)
- [ ] [add_observer_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-observer-metadata.html)
- [ ] [add_process_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-process-metadata.html)
- [ ] [community_id](https://www.elastic.co/guide/en/beats/filebeat/current/community-id.html)
- [ ] [convert](https://www.elastic.co/guide/en/beats/filebeat/current/convert.html)
- [ ] [decode_cef](https://www.elastic.co/guide/en/beats/filebeat/current/processor-decode-cef.html)
- [ ] [decode_csv_fields](https://www.elastic.co/guide/en/beats/filebeat/current/decode-csv-fields.html)
- [ ] [decode_duration](https://www.elastic.co/guide/en/beats/filebeat/current/decode-duration.html)
- [ ] [decode_xml](https://www.elastic.co/guide/en/beats/filebeat/current/decode-xml.html)
- [ ] [decode_xml_wineventlog](https://www.elastic.co/guide/en/beats/filebeat/current/decode-xml-wineventlog.html)
- [ ] [dissect](https://www.elastic.co/guide/en/beats/filebeat/current/dissect.html)
- [ ] [dns](https://www.elastic.co/guide/en/beats/filebeat/current/processor-dns.html)
- [ ] [extract_array](https://www.elastic.co/guide/en/beats/filebeat/current/extract-array.html)
- [ ] [fingerprint](https://www.elastic.co/guide/en/beats/filebeat/current/fingerprint.html)
- [ ] [move_fields](https://www.elastic.co/guide/en/beats/filebeat/current/move-fields.html)
- [ ] [parse_aws_vpc_flow_log](https://www.elastic.co/guide/en/beats/filebeat/current/processor-parse-aws-vpc-flow-log.html)
- [ ] [rate_limit](https://www.elastic.co/guide/en/beats/filebeat/current/rate-limit.html)
- [ ] [registered_domain](https://www.elastic.co/guide/en/beats/filebeat/current/processor-registered-domain.html)
- [ ] [syslog](https://www.elastic.co/guide/en/beats/filebeat/current/syslog.html)
- [ ] [timestamp](https://www.elastic.co/guide/en/beats/filebeat/current/processor-timestamp.html)
- [ ] [translate_sid](https://www.elastic.co/guide/en/beats/filebeat/current/processor-translate-sid.html)
- [ ] [urldecode](https://www.elastic.co/guide/en/beats/filebeat/current/urldecode.html)
- [x] [add_cloud_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-cloud-metadata.html)
- [x] [include_fields](https://www.elastic.co/guide/en/beats/filebeat/current/include-fields.html)
- [x] [rename](https://www.elastic.co/guide/en/beats/filebeat/current/rename-fields.html)
- [x] [add_labels](https://www.elastic.co/guide/en/beats/filebeat/current/add-labels.html)
- [x] [copy_fields](https://www.elastic.co/guide/en/beats/filebeat/current/copy-fields.html)
- [x] [decode_json_fields](https://www.elastic.co/guide/en/beats/filebeat/current/decode-json-fields.html)
- [x] [detect_mime_type](https://www.elastic.co/guide/en/beats/filebeat/current/detect-mime-type.html)
- [x] [replace](https://www.elastic.co/guide/en/beats/filebeat/current/replace-fields.html)
- [x] [add_network_direction](https://www.elastic.co/guide/en/beats/filebeat/current/add-network-direction.html)
- [x] [decompress_gzip_field](https://www.elastic.co/guide/en/beats/filebeat/current/decompress-gzip-field.html)
- [x] [drop_fields](https://www.elastic.co/guide/en/beats/filebeat/current/drop-fields.html)
- [x] [truncate_fields](https://www.elastic.co/guide/en/beats/filebeat/current/truncate-fields.html)
- [x] [add_fields](https://www.elastic.co/guide/en/beats/filebeat/current/add-fields.html)
- [x] [add_tags](https://www.elastic.co/guide/en/beats/filebeat/current/add-tags.html)
- [x] [append](https://www.elastic.co/guide/en/beats/filebeat/current/append.html)
- [x] [decode_base64_field](https://www.elastic.co/guide/en/beats/filebeat/current/decode-base64-field.html)
- [x] [drop_event](https://www.elastic.co/guide/en/beats/filebeat/current/drop-event.html)
- [x] [script](https://www.elastic.co/guide/en/beats/filebeat/current/processor-script.html)

**BEFORE/AFTER benchmark results will be here once PR is finished**

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

I added unit tests and a benchmark.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
