### PR TITLE
Add support for idle_connection_timeout to elasticsearch output

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -173,7 +173,7 @@ is collected by it.
 - allow `queue` configuration settings to be set under the output. {issue}35615[35615] {pull}36788[36788]
 - Beats will now connect to older Elasticsearch instances by default {pull}36884[36884]
 - Raise up logging level to warning when attempting to configure beats with unknown fields from autodiscovered events/environments
-- elasticsearch output now supports `idle_connection_timeout`. {issue}35616[35615] {pull}99999[99999]
+- elasticsearch output now supports `idle_connection_timeout`. {issue}35616[35615] {pull}36843[36843]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -173,6 +173,7 @@ is collected by it.
 - allow `queue` configuration settings to be set under the output. {issue}35615[35615] {pull}36788[36788]
 - Beats will now connect to older Elasticsearch instances by default {pull}36884[36884]
 - Raise up logging level to warning when attempting to configure beats with unknown fields from autodiscovered events/environments
+- elasticsearch output now supports `idle_connection_timeout`. {issue}35616[35615] {pull}99999[99999]
 
 *Auditbeat*
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -522,6 +522,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -523,9 +523,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/auditbeat/auditbeat.reference.yml
+++ b/auditbeat/auditbeat.reference.yml
@@ -524,8 +524,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1619,9 +1619,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1620,8 +1620,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/filebeat/filebeat.reference.yml
+++ b/filebeat/filebeat.reference.yml
@@ -1618,6 +1618,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -616,8 +616,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -615,9 +615,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/heartbeat/heartbeat.reference.yml
+++ b/heartbeat/heartbeat.reference.yml
@@ -614,6 +614,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
@@ -81,6 +81,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
@@ -83,8 +83,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
+++ b/libbeat/_meta/config/output-elasticsearch.reference.yml.tmpl
@@ -82,9 +82,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/libbeat/outputs/elasticsearch/client.go
+++ b/libbeat/outputs/elasticsearch/client.go
@@ -102,6 +102,7 @@ func NewClient(
 		CompressionLevel: s.CompressionLevel,
 		EscapeHTML:       s.EscapeHTML,
 		Transport:        s.Transport,
+		IdleConnTimeout:  s.IdleConnTimeout,
 	})
 	if err != nil {
 		return nil, err

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -689,6 +689,12 @@ default is `1s`.
 The maximum number of seconds to wait before attempting to connect to
 Elasticsearch after a network error. The default is `60s`.
 
+===== `idle_connection_timeout`
+
+The maximum amount of time an idle connection will remain idle before closing itself.
+Zero means no limit. The format is a Go language duration (example 60s is 60 seconds).
+The default is 0.
+
 ===== `timeout`
 
 The http request timeout in seconds for the Elasticsearch request. The default is 90.

--- a/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -41,7 +41,9 @@ func makeES(
 ) (outputs.Group, error) {
 	log := logp.NewLogger(logSelector)
 	if !cfg.HasField("bulk_max_size") {
-		_ = cfg.SetInt("bulk_max_size", -1, defaultBulkSize)
+		if err := cfg.SetInt("bulk_max_size", -1, defaultBulkSize); err != nil {
+			return outputs.Fail(err)
+		}
 	}
 
 	index, pipeline, err := buildSelectors(im, beat, cfg)
@@ -105,6 +107,7 @@ func makeES(
 				Observer:         observer,
 				EscapeHTML:       esConfig.EscapeHTML,
 				Transport:        esConfig.Transport,
+				IdleConnTimeout:  esConfig.Transport.IdleConnTimeout,
 			},
 			Index:              index,
 			Pipeline:           pipeline,

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1358,9 +1358,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1359,8 +1359,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/metricbeat/metricbeat.reference.yml
+++ b/metricbeat/metricbeat.reference.yml
@@ -1357,6 +1357,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -989,9 +989,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -988,6 +988,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/packetbeat/packetbeat.reference.yml
+++ b/packetbeat/packetbeat.reference.yml
@@ -990,8 +990,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -404,6 +404,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -406,8 +406,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/winlogbeat/winlogbeat.reference.yml
+++ b/winlogbeat/winlogbeat.reference.yml
@@ -405,9 +405,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -578,6 +578,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -580,8 +580,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/auditbeat/auditbeat.reference.yml
+++ b/x-pack/auditbeat/auditbeat.reference.yml
@@ -579,9 +579,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3989,9 +3989,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3990,8 +3990,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/filebeat/filebeat.reference.yml
+++ b/x-pack/filebeat/filebeat.reference.yml
@@ -3988,6 +3988,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -647,9 +647,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -648,8 +648,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/functionbeat/functionbeat.reference.yml
+++ b/x-pack/functionbeat/functionbeat.reference.yml
@@ -646,6 +646,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -616,8 +616,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -615,9 +615,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/heartbeat/heartbeat.reference.yml
+++ b/x-pack/heartbeat/heartbeat.reference.yml
@@ -614,6 +614,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1919,9 +1919,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1918,6 +1918,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/metricbeat/metricbeat.reference.yml
+++ b/x-pack/metricbeat/metricbeat.reference.yml
@@ -1920,8 +1920,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -366,9 +366,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -367,8 +367,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/osquerybeat/osquerybeat.reference.yml
+++ b/x-pack/osquerybeat/osquerybeat.reference.yml
@@ -365,6 +365,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -989,9 +989,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -988,6 +988,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/packetbeat/packetbeat.reference.yml
+++ b/x-pack/packetbeat/packetbeat.reference.yml
@@ -990,8 +990,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -406,6 +406,11 @@ output.elasticsearch:
   # Elasticsearch after a network error. The default is 60s.
   #backoff.max: 60s
 
+  # The maximum amount of time an idle connection will remain idle
+  # before closing itself.  Zero means no limit. The format is a Go
+  # language duration (example 60s is 60 seconds). The default is 0.
+  #idle_connection_timeout: 0
+
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90
 

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -408,8 +408,8 @@ output.elasticsearch:
 
   # The maximum amount of time an idle connection will remain idle
   # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 0.
-  #idle_connection_timeout: 0
+  # language duration (example 60s is 60 seconds). The default is 60s.
+  #idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90

--- a/x-pack/winlogbeat/winlogbeat.reference.yml
+++ b/x-pack/winlogbeat/winlogbeat.reference.yml
@@ -407,9 +407,9 @@ output.elasticsearch:
   #backoff.max: 60s
 
   # The maximum amount of time an idle connection will remain idle
-  # before closing itself.  Zero means no limit. The format is a Go
-  # language duration (example 60s is 60 seconds). The default is 60s.
-  #idle_connection_timeout: 60s
+  # before closing itself.  Zero means use the default of 60s. The
+  # format is a Go language duration (example 60s is 60 seconds).
+  # idle_connection_timeout: 60s
 
   # Configure HTTP request timeout before failing a request to Elasticsearch.
   #timeout: 90


### PR DESCRIPTION
## Proposed commit message

add support for `idle_connection_timeout` for ES output. This allows connections to be closed if they aren't being used.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

1. Add `idle_connection_timeout` to elasticsearch output config
```
output.elasticsearch:
  idle_connection_timeout: 10s
```
2. Start beat, and send some events to elasticsearch
3. observer network connection with `netstat -an`
4. wait timeout time, and observer that network connection is being closed

## Related issues

- Relates #35615


## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
