### PR TITLE
filebeat/input/filestream: Improve fingerprint performance

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -23322,6 +23322,41 @@ Contents of probable licence file $GOMODCACHE/github.com/xdg/scram@v1.0.3/LICENS
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/zeebo/xxh3
+Version: v1.0.2
+Licence type (autodetected): BSD-2-Clause
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/zeebo/xxh3@v1.0.2/LICENSE:
+
+xxHash Library
+Copyright (c) 2012-2014, Yann Collet
+Copyright (c) 2019, Jeff Wendling
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Dependency : go.elastic.co/apm/module/apmelasticsearch/v2
 Version: v2.4.4
 Licence type (autodetected): Apache-2.0
@@ -49880,41 +49915,6 @@ express Statement of Purpose.
  d. Affirmer understands and acknowledges that Creative Commons is not a
     party to this document and has no duty or obligation with respect to
     this CC0 or use of the Work.
-
-
---------------------------------------------------------------------------------
-Dependency : github.com/zeebo/xxh3
-Version: v1.0.2
-Licence type (autodetected): BSD-2-Clause
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/zeebo/xxh3@v1.0.2/LICENSE:
-
-xxHash Library
-Copyright (c) 2012-2014, Yann Collet
-Copyright (c) 2019, Jeff Wendling
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice, this
-  list of conditions and the following disclaimer in the documentation and/or
-  other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 --------------------------------------------------------------------------------

--- a/filebeat/input/filestream/fswatch.go
+++ b/filebeat/input/filestream/fswatch.go
@@ -25,9 +25,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/zeebo/xxh3"
+
 	"github.com/elastic/go-concert/timed"
 	"github.com/elastic/go-concert/unison"
-	"github.com/zeebo/xxh3"
 
 	"github.com/elastic/beats/v7/filebeat/input/file"
 	loginp "github.com/elastic/beats/v7/filebeat/input/filestream/internal/input-logfile"

--- a/go.mod
+++ b/go.mod
@@ -219,6 +219,7 @@ require (
 	github.com/pkg/xattr v0.4.9
 	github.com/sergi/go-diff v1.3.1
 	github.com/shirou/gopsutil/v3 v3.22.10
+	github.com/zeebo/xxh3 v1.0.2
 	go.elastic.co/apm/module/apmelasticsearch/v2 v2.4.4
 	go.elastic.co/apm/module/apmhttp/v2 v2.4.4
 	go.elastic.co/apm/v2 v2.4.4
@@ -355,7 +356,6 @@ require (
 	github.com/xdg/stringprep v1.0.3 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.elastic.co/fastjson v1.1.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel v1.19.0 // indirect


### PR DESCRIPTION
**PROPOSAL** (Please do not actively review until the proposal is accepted)

I recently stumbled upon a great blog post about the [filestream fingerprint](https://www.elastic.co/blog/introducing-filestream-fingerprint-mode) mode by @rdner, which caught my attention. After reading it, I noticed a few areas where the performance could be improved. For instance, the blog mentions the use of SHA256, a highly secure hashing algorithm. However, since we don't require such high levels of security for data hashing in this context, it would be better to explore faster hashing algorithms that can still ensure data integrity.

In the beats repository, **github.com/cespare/xxhash/v2** ([xxhash](https://github.com/Cyan4973/xxHash)) is used in multiple places which is a very fast cryptographically-insecure hash algorithm. But there's something even better we can use here i.e., xxh3.

See some benchmarks: https://xxhash.com

This is a [good blog](https://jolynch.github.io/posts/use_fast_data_algorithms/) comparing the different algorithms and advising what could be a better choice.

So, I used xxh3 (https://github.com/zeebo/xxh3) package used by apache/arrow, grafana, etc. I tested with the defaults on MacOS 13.6 (Apple M1 Max) with the already existing benchmark function (put `b.ResetTimer` to reset the timer after the creation of files because they are not necessary to the benchmark) and here are the results (it'd be better if the benchmarks were taken in a separate machine with lesser [noise](https://llvm.org/docs/Benchmarking.html) because my machine always has multiple instances of chrome running and few more things):

Used benchstat for comparing old and new benchmarks (count = 6)

```
                           │  bench.old  │             bench.new             │
                           │   sec/op    │   sec/op     vs base              │
GetFilesWithFingerprint-10   21.22m ± 2%   20.72m ± 1%  -2.37% (p=0.009 n=6)
```

```
                           │  bench.old   │              bench.new              │
                           │     B/op     │     B/op      vs base               │
GetFilesWithFingerprint-10   1.433Mi ± 0%   1.035Mi ± 0%  -27.78% (p=0.002 n=6)
```

```
                           │  bench.old  │             bench.new             │
                           │  allocs/op  │  allocs/op   vs base              │
GetFilesWithFingerprint-10   11.09k ± 0%   10.04k ± 0%  -9.48% (p=0.002 n=6)
```

In the benchmark, only 1000 are considered but in a production server, the number of files could be considerably much higher. So, the changes in this PR could be very beneficial when the user has opted for fingerprint mode. xxh3 also works well for smaller inputs and I assume the fingerprint length would mostly be small.

In case we plan to use an algorithm that works even better for very small inputs, [this](https://github.com/apache/arrow/blob/c5bce96ba626ad2558e10acddf8ef19ea06940e8/go/internal/hashing/hash_funcs.go#L58) may be beneficial to read.


Some more reading material, if interested:
- https://fastcompression.blogspot.com/2019/03/presenting-xxh3.html (xxh3)
- https://github.com/honeycombio/refinery/issues/749 (related to capacity of map)
- https://www.reddit.com/r/zfs/comments/wb50b7/will_zfs_support_the_hash_algorithm_xxhash_in_the/
- https://btrfs.readthedocs.io/en/latest/Checksumming.html#checksumming (btrfs' mention of xxhash as an option for checksum)
- https://fastcompression.blogspot.com/2019/03/presenting-xxh3.html#:~:text=Checksumming%20long%20inputs (xxhash popular among movie makers for file transfer verification)


## Proposed commit message

Improved the overall performance of the fingerprint mode by switching the hashing algorithm from SHA256 to XXH3. Also, removed an unnecessary check (not required for XXH3 anymore) and updated the tests. Also preallocating the maps (a better number could be decided) and some minor changes to the code.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

- Run go tests and benchmarks