### PR TITLE
auditbeat/module/auditd: add ignore_errors config option

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -166,6 +166,7 @@ is collected by it.
 
 *Auditbeat*
 
+- Add `ignore_errors` option to audit module. {issue}15768[15768] {pull}36851[36851]
 
 *Filebeat*
 

--- a/auditbeat/docs/modules/auditd.asciidoc
+++ b/auditbeat/docs/modules/auditd.asciidoc
@@ -212,6 +212,9 @@ loaded after the rules declared in `audit_rules` are loaded. Wildcards are
 supported and will expand in lexicographical order. The format is the same as
 that of the `audit_rules` field.
 
+*`ignore_errors`*:: This setting allows errors during rule loading and parsing
+to be ignored, but logged as warnings.
+
 *`backpressure_strategy`*:: Specifies the strategy that {beatname_uc} uses to
 prevent backpressure from propagating to the kernel and impacting audited
 processes.

--- a/auditbeat/module/auditd/_meta/docs.asciidoc
+++ b/auditbeat/module/auditd/_meta/docs.asciidoc
@@ -205,6 +205,9 @@ loaded after the rules declared in `audit_rules` are loaded. Wildcards are
 supported and will expand in lexicographical order. The format is the same as
 that of the `audit_rules` field.
 
+*`ignore_errors`*:: This setting allows errors during rule loading and parsing
+to be ignored, but logged as warnings.
+
 *`backpressure_strategy`*:: Specifies the strategy that {beatname_uc} uses to
 prevent backpressure from propagating to the kernel and impacting audited
 processes.

--- a/auditbeat/module/auditd/config.go
+++ b/auditbeat/module/auditd/config.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build unix
+
 package auditd
 
 import (

--- a/auditbeat/module/auditd/config_test.go
+++ b/auditbeat/module/auditd/config_test.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:build unix
+
 package auditd
 
 import (

--- a/auditbeat/module/auditd/config_test.go
+++ b/auditbeat/module/auditd/config_test.go
@@ -30,206 +30,229 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	conf "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func TestConfigValidate(t *testing.T) {
-	data := `
+func TestConfig(t *testing.T) {
+	logp.TestingSetup()
+
+	t.Run("Validate", func(t *testing.T) {
+		data := `
 audit_rules: |
   # Comments and empty lines are ignored.
   -w /etc/passwd -p wa -k auth
 
   -a always,exit -S execve -k exec`
 
-	config, err := parseConfig(t, data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rules := config.rules()
+		config, err := parseConfig(t, data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rules := config.rules()
 
-	assert.EqualValues(t, []string{
-		"-w /etc/passwd -p wa -k auth",
-		"-a always,exit -S execve -k exec",
-	}, commands(rules))
-}
+		assert.EqualValues(t, []string{
+			"-w /etc/passwd -p wa -k auth",
+			"-a always,exit -S execve -k exec",
+		}, commands(rules))
+	})
 
-func TestConfigValidateWithError(t *testing.T) {
-	data := `
+	t.Run("ValidateWithError", func(t *testing.T) {
+		data := `
 audit_rules: |
   -x bad -F flag
   -a always,exit -w /etc/passwd
   -a always,exit -S fake -k exec`
 
-	_, err := parseConfig(t, data)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	t.Log(err)
-}
+		_, err := parseConfig(t, data)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		t.Log(err)
+	})
 
-func TestConfigValidateWithDuplicates(t *testing.T) {
-	data := `
+	t.Run("ValidateWithErrorIgnored", func(t *testing.T) {
+		data := `
+ignore_errors: true
+audit_rules: |
+  -x bad -F flag
+  -a always,exit -w /etc/passwd
+  -a always,exit -S fake -k exec
+  -w /etc/passwd -k auth`
+
+		cfg, err := parseConfig(t, data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(cfg.auditRules) != 1 {
+			t.Fatalf("unexpected number of rules from parseConfig: got %d, want %d", len(cfg.auditRules), 1)
+		}
+	})
+
+	t.Run("ValidateWithDuplicates", func(t *testing.T) {
+		data := `
 audit_rules: |
   -w /etc/passwd -p rwxa -k auth
   -w /etc/passwd -k auth`
 
-	_, err := parseConfig(t, data)
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	t.Log(err)
-}
+		_, err := parseConfig(t, data)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		t.Log(err)
+	})
 
-func TestConfigValidateFailureMode(t *testing.T) {
-	config := defaultConfig
-	config.FailureMode = "boom"
-	err := config.Validate()
-	assert.Error(t, err)
-	t.Log(err)
-}
+	t.Run("ValidateFailureMode", func(t *testing.T) {
+		config := defaultConfig
+		config.FailureMode = "boom"
+		err := config.Validate()
+		assert.Error(t, err)
+		t.Log(err)
+	})
 
-func TestConfigValidateConnectionType(t *testing.T) {
-	config := defaultConfig
-	config.SocketType = "Satellite"
-	err := config.Validate()
-	assert.Error(t, err)
-	t.Log(err)
-}
+	t.Run("ValidateConnectionType", func(t *testing.T) {
+		config := defaultConfig
+		config.SocketType = "Satellite"
+		err := config.Validate()
+		assert.Error(t, err)
+		t.Log(err)
+	})
 
-func TestConfigValidateImmutable(t *testing.T) {
-	tcs := []struct {
-		name       string
-		socketType string
-		mustFail   bool
-	}{
-		{
-			name:       "Must pass for default",
-			socketType: "",
-			mustFail:   false,
-		},
-		{
-			name:       "Must pass for unicast",
-			socketType: "unicast",
-			mustFail:   false,
-		},
-		{
-			name:       "Must fail for multicast",
-			socketType: "multicast",
-			mustFail:   true,
-		},
-	}
+	t.Run("ValidateImmutable", func(t *testing.T) {
+		tcs := []struct {
+			name       string
+			socketType string
+			mustFail   bool
+		}{
+			{
+				name:       "Must pass for default",
+				socketType: "",
+				mustFail:   false,
+			},
+			{
+				name:       "Must pass for unicast",
+				socketType: "unicast",
+				mustFail:   false,
+			},
+			{
+				name:       "Must fail for multicast",
+				socketType: "multicast",
+				mustFail:   true,
+			},
+		}
 
-	for _, tc := range tcs {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			config := defaultConfig
-			config.SocketType = tc.socketType
-			config.Immutable = true
-			err := config.Validate()
-			if tc.mustFail {
-				assert.Error(t, err)
-				t.Log(err)
-			} else {
-				assert.NoError(t, err)
+		for _, tc := range tcs {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				config := defaultConfig
+				config.SocketType = tc.socketType
+				config.Immutable = true
+				err := config.Validate()
+				if tc.mustFail {
+					assert.Error(t, err)
+					t.Log(err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		}
+	})
+
+	t.Run("RuleOrdering", func(t *testing.T) {
+		const fileMode = 0o644
+		config := defaultConfig
+		config.RulesBlob = strings.Join([]string{
+			makeRuleFlags(0, 0),
+			makeRuleFlags(0, 1),
+			makeRuleFlags(0, 2),
+		}, "\n")
+
+		dir1, err := ioutil.TempDir("", "rules1")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, file := range []struct {
+			order int
+			name  string
+		}{
+			{0, "00_first.conf"},
+			{5, "99_last.conf"},
+			{2, "03_auth.conf"},
+			{4, "20_exec.conf"},
+			{3, "10_network_access.conf"},
+			{1, "01_32bit_abi.conf"},
+		} {
+			path := filepath.Join(dir1, file.name)
+			content := []byte(strings.Join([]string{
+				makeRuleFlags(1+file.order, 0),
+				makeRuleFlags(1+file.order, 1),
+				makeRuleFlags(1+file.order, 2),
+				makeRuleFlags(1+file.order, 3),
+			}, "\n"))
+			if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+				t.Fatal(err)
 			}
-		})
-	}
-}
+		}
 
-func TestConfigRuleOrdering(t *testing.T) {
-	const fileMode = 0o644
-	config := defaultConfig
-	config.RulesBlob = strings.Join([]string{
-		makeRuleFlags(0, 0),
-		makeRuleFlags(0, 1),
-		makeRuleFlags(0, 2),
-	}, "\n")
-
-	dir1, err := ioutil.TempDir("", "rules1")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, file := range []struct {
-		order int
-		name  string
-	}{
-		{0, "00_first.conf"},
-		{5, "99_last.conf"},
-		{2, "03_auth.conf"},
-		{4, "20_exec.conf"},
-		{3, "10_network_access.conf"},
-		{1, "01_32bit_abi.conf"},
-	} {
-		path := filepath.Join(dir1, file.name)
-		content := []byte(strings.Join([]string{
-			makeRuleFlags(1+file.order, 0),
-			makeRuleFlags(1+file.order, 1),
-			makeRuleFlags(1+file.order, 2),
-			makeRuleFlags(1+file.order, 3),
-		}, "\n"))
-		if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+		dir2, err := ioutil.TempDir("", "rules0")
+		if err != nil {
 			t.Fatal(err)
 		}
-	}
 
-	dir2, err := ioutil.TempDir("", "rules0")
-	if err != nil {
-		t.Fatal(err)
-	}
+		for _, file := range []struct {
+			order int
+			name  string
+		}{
+			{3, "99_tail.conf"},
+			{0, "00_head.conf"},
+			{2, "50_mid.conf"},
+			{1, "13.conf"},
+		} {
+			path := filepath.Join(dir2, file.name)
+			content := []byte(strings.Join([]string{
+				makeRuleFlags(10+file.order, 0),
+				makeRuleFlags(10+file.order, 1),
+				makeRuleFlags(10+file.order, 2),
+				makeRuleFlags(10+file.order, 3),
+			}, "\n"))
+			if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+				t.Fatal(err)
+			}
+		}
 
-	for _, file := range []struct {
-		order int
-		name  string
-	}{
-		{3, "99_tail.conf"},
-		{0, "00_head.conf"},
-		{2, "50_mid.conf"},
-		{1, "13.conf"},
-	} {
-		path := filepath.Join(dir2, file.name)
-		content := []byte(strings.Join([]string{
-			makeRuleFlags(10+file.order, 0),
-			makeRuleFlags(10+file.order, 1),
-			makeRuleFlags(10+file.order, 2),
-			makeRuleFlags(10+file.order, 3),
-		}, "\n"))
-		if err = ioutil.WriteFile(path, content, fileMode); err != nil {
+		config.RuleFiles = []string{
+			fmt.Sprintf("%s/*.conf", dir1),
+			fmt.Sprintf("%s/*.conf", dir2),
+		}
+
+		if err = config.Validate(); err != nil {
 			t.Fatal(err)
 		}
-	}
 
-	config.RuleFiles = []string{
-		fmt.Sprintf("%s/*.conf", dir1),
-		fmt.Sprintf("%s/*.conf", dir2),
-	}
-
-	if err = config.Validate(); err != nil {
-		t.Fatal(err)
-	}
-
-	rules := config.rules()
-	fileNo, ruleNo := 0, 0
-	for _, rule := range rules {
-		parts := strings.Split(rule.flags, " ")
-		assert.Len(t, parts, 6, rule.flags)
-		fields := strings.Split(parts[5], ":")
-		assert.Len(t, fields, 3, rule.flags)
-		fileID, err := strconv.Atoi(fields[1])
-		if err != nil {
-			t.Fatal(err, rule.flags)
+		rules := config.rules()
+		fileNo, ruleNo := 0, 0
+		for _, rule := range rules {
+			parts := strings.Split(rule.flags, " ")
+			assert.Len(t, parts, 6, rule.flags)
+			fields := strings.Split(parts[5], ":")
+			assert.Len(t, fields, 3, rule.flags)
+			fileID, err := strconv.Atoi(fields[1])
+			if err != nil {
+				t.Fatal(err, rule.flags)
+			}
+			ruleID, err := strconv.Atoi(fields[2])
+			if err != nil {
+				t.Fatal(err, rule.flags)
+			}
+			if fileID > fileNo {
+				fileNo = fileID
+				ruleNo = 0
+			}
+			assert.Equal(t, fileNo, fileID, rule.flags)
+			assert.Equal(t, ruleNo, ruleID, rule.flags)
+			ruleNo++
 		}
-		ruleID, err := strconv.Atoi(fields[2])
-		if err != nil {
-			t.Fatal(err, rule.flags)
-		}
-		if fileID > fileNo {
-			fileNo = fileID
-			ruleNo = 0
-		}
-		assert.Equal(t, fileNo, fileID, rule.flags)
-		assert.Equal(t, ruleNo, ruleID, rule.flags)
-		ruleNo++
-	}
+	})
 }
 
 func makeRuleFlags(fileID, ruleID int) string {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Setting ignore_errors to true allows incompletely valid rule sets to be
used in a configuration. This is equivalent to the -i flag of auditctl.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

In auditbeat/module/auditd, run `go test -v -run TestConfig/ValidateWithError`. Both tests should pass and the second should emit a warning log line similar to this
```
{"log.level":"warn","@timestamp":"2023-10-16T09:41:28.941+1030","log.logger":"auditd","log.origin":{"file.name":"auditd/config.go","file.line":232},"message":"errors loading rules: 3 errors: at (audit_rules at auditbeat.yml):1: failed to parse rule '-x bad -F flag': flag provided but not defined: -x; at (audit_rules at auditbeat.yml):2: failed to parse rule '-a always,exit -w /etc/passwd': mutually exclusive flags uses together (file watch [-w|-p] and audit rule [-a|-A|-S|-C|-F]); at (audit_rules at auditbeat.yml):3: failed to interpret rule '-a always,exit -S fake -k exec': failed to add syscall 'fake': unknown syscall 'fake' for arch x86_64","ecs.version":"1.6.0"}
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #15768

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
