### PR TITLE
packetbeat/{beater,protos,sniffer}: allow assignment of protocols to interfaces

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -177,6 +177,7 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Add initial infrastructure for a caching enrichment processor. {pull}36619[36619]
 - Add file-backed cache for cache enrichment processor. {pull}36686[36686] {pull}36696[36696]
 - Elide retryable HTTP client construction in Filebeat HTTPJSON and CEL inputs if not needed. {pull}36916[36916]
+- Allow assignment of packetbeat protocols to interfaces. {issue}36574[36564] {pull}[]
 
 ==== Deprecated
 

--- a/packetbeat/protos/protos.go
+++ b/packetbeat/protos/protos.go
@@ -110,14 +110,12 @@ type reporterFactory interface {
 	CreateReporter(*conf.C) (func(beat.Event), error)
 }
 
-func (s ProtocolsStruct) Init(
-	testMode bool,
-	pub reporterFactory,
-	watcher *procs.ProcessesWatcher,
-	configs map[string]*conf.C,
-	listConfigs []*conf.C,
-) error {
-	if len(configs) > 0 {
+func (s ProtocolsStruct) Init(test bool, pub reporterFactory, watch *procs.ProcessesWatcher, cfgs map[string]*conf.C, list []*conf.C) error {
+	return s.InitFiltered(test, "", pub, watch, cfgs, list)
+}
+
+func (s ProtocolsStruct) InitFiltered(test bool, device string, pub reporterFactory, watch *procs.ProcessesWatcher, cfgs map[string]*conf.C, list []*conf.C) error {
+	if len(cfgs) != 0 {
 		cfgwarn.Deprecate("7.0.0", "dictionary style protocols configuration has been deprecated. Please use list-style protocols configuration.")
 	}
 
@@ -125,21 +123,24 @@ func (s ProtocolsStruct) Init(
 		logp.Debug("protos", "registered protocol plugin: %v", proto)
 	}
 
-	for name, config := range configs {
-		if err := s.configureProtocol(testMode, pub, watcher, name, config); err != nil {
+	for name, cfg := range cfgs {
+		err := s.configureProtocol(test, device, pub, watch, name, cfg)
+		if err != nil {
 			return err
 		}
 	}
 
-	for _, config := range listConfigs {
+	for _, cfg := range list {
 		module := struct {
 			Name string `config:"type" validate:"required"`
 		}{}
-		if err := config.Unpack(&module); err != nil {
+		err := cfg.Unpack(&module)
+		if err != nil {
 			return err
 		}
 
-		if err := s.configureProtocol(testMode, pub, watcher, module.Name, config); err != nil {
+		err = s.configureProtocol(test, device, pub, watch, module.Name, cfg)
+		if err != nil {
 			return err
 		}
 	}
@@ -147,13 +148,7 @@ func (s ProtocolsStruct) Init(
 	return nil
 }
 
-func (s ProtocolsStruct) configureProtocol(
-	testMode bool,
-	pub reporterFactory,
-	watcher *procs.ProcessesWatcher,
-	name string,
-	config *conf.C,
-) error {
+func (s ProtocolsStruct) configureProtocol(test bool, device string, pub reporterFactory, watch *procs.ProcessesWatcher, name string, config *conf.C) error {
 	// XXX: icmp is special, ignore here :/
 	if name == "icmp" {
 		return nil
@@ -176,9 +171,23 @@ func (s ProtocolsStruct) configureProtocol(
 		return nil
 	}
 
+	if device != "" {
+		// This could happen earlier, but let any errors be found first.
+		var protocol struct {
+			Device string `config:"interface"`
+		}
+		err := config.Unpack(&protocol)
+		if err != nil {
+			return err
+		}
+		if protocol.Device != "" && protocol.Device != device {
+			return nil
+		}
+	}
+
 	var client beat.Client
 	results := func(beat.Event) {}
-	if !testMode {
+	if !test {
 		var err error
 		results, err = pub.CreateReporter(config)
 		if err != nil {
@@ -186,7 +195,7 @@ func (s ProtocolsStruct) configureProtocol(
 		}
 	}
 
-	inst, err := plugin(testMode, results, watcher, config)
+	inst, err := plugin(test, results, watch, config)
 	if err != nil {
 		logp.Err("Failed to register protocol plugin: %v", err)
 		return err
@@ -194,6 +203,30 @@ func (s ProtocolsStruct) configureProtocol(
 
 	s.register(proto, client, inst)
 	return nil
+}
+
+func (s ProtocolsStruct) register(proto Protocol, client beat.Client, plugin Plugin) {
+	if _, exists := s.all[proto]; exists {
+		logp.Warn("Protocol (%s) plugin will overwritten by another plugin", proto.String())
+	}
+
+	s.all[proto] = protocolInstance{
+		client: client,
+		plugin: plugin,
+	}
+
+	success := false
+	if tcp, ok := plugin.(TCPPlugin); ok {
+		s.tcp[proto] = tcp
+		success = true
+	}
+	if udp, ok := plugin.(UDPPlugin); ok {
+		s.udp[proto] = udp
+		success = true
+	}
+	if !success {
+		logp.Warn("Protocol (%s) register failed, port: %v", proto.String(), plugin.GetPorts())
+	}
 }
 
 func (s ProtocolsStruct) GetTCP(proto Protocol) TCPPlugin {
@@ -228,7 +261,7 @@ func (s ProtocolsStruct) GetAllUDP() map[Protocol]UDPPlugin {
 // and unencapsulated packets
 func (s ProtocolsStruct) BpfFilter(withVlans bool, withICMP bool) string {
 	// Sort the protocol IDs so that the return value is consistent.
-	var protos []int
+	protos := make([]int, 0, len(s.all))
 	for proto := range s.all {
 		protos = append(protos, int(proto))
 	}
@@ -271,28 +304,4 @@ func (s ProtocolsStruct) BpfFilter(withVlans bool, withICMP bool) string {
 		filter = fmt.Sprintf("%s or (vlan and (%s))", filter, filter)
 	}
 	return filter
-}
-
-func (s ProtocolsStruct) register(proto Protocol, client beat.Client, plugin Plugin) {
-	if _, exists := s.all[proto]; exists {
-		logp.Warn("Protocol (%s) plugin will overwritten by another plugin", proto.String())
-	}
-
-	s.all[proto] = protocolInstance{
-		client: client,
-		plugin: plugin,
-	}
-
-	success := false
-	if tcp, ok := plugin.(TCPPlugin); ok {
-		s.tcp[proto] = tcp
-		success = true
-	}
-	if udp, ok := plugin.(UDPPlugin); ok {
-		s.udp[proto] = udp
-		success = true
-	}
-	if !success {
-		logp.Warn("Protocol (%s) register failed, port: %v", proto.String(), plugin.GetPorts())
-	}
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Previously the protocols association was held in a *protocols.ProtocolStruct in
common for all interfaces. This prevented individual interfaces that were only
associated with a subset of the protocols that were being captured from working
specifically on that subset. The new code moves the construction of the protocols
sets into setupSniffer where they are associated with the interface that will be
capturing them. They are then assigned to child sniffers in sniffer.New based on
the interface.

This change has no effect on the behaviour of packetbeat as it stands as configs
from packetbeat and from agent are only able to express the existence of a single
interface. Changes to configuration format/shape will enable multiple interfaces
to be enabled in packetbeat and within a single agent policy, making use of the
change here.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #36574

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->
