### PR TITLE
[Release] Update test environments for 8.10.5

### DIFF
--- a/metricbeat/docker-compose.yml
+++ b/metricbeat/docker-compose.yml
@@ -17,11 +17,11 @@ services:
 
   # Used by base tests
   elasticsearch:
-    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-8.10.3}-1
+    image: docker.elastic.co/integrations-ci/beats-elasticsearch:${ELASTICSEARCH_VERSION:-8.10.4}-1
     build:
       context: ./module/elasticsearch/_meta
       args:
-        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-8.10.3}
+        ELASTICSEARCH_VERSION: ${ELASTICSEARCH_VERSION:-8.10.4}
     environment:
       - "ES_JAVA_OPTS=-Xms256m -Xmx256m"
       - "transport.host=127.0.0.1"
@@ -38,11 +38,11 @@ services:
 
   # Used by base tests
   kibana:
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-8.10.3}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-8.10.4}-1
     build:
       context: ./module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-8.10.3}
+        KIBANA_VERSION: ${KIBANA_VERSION:-8.10.4}
     healthcheck:
       test: ["CMD-SHELL", "curl -u beats:testing -s http://localhost:5601/api/status?v8format=true | grep -q '\"overall\":{\"level\":\"available\"'"]
       retries: 600
@@ -53,11 +53,11 @@ services:
 
   # Used by base tests
   metricbeat:
-    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-8.10.3}-1
+    image: docker.elastic.co/integrations-ci/beats-metricbeat:${BEAT_VERSION:-8.10.4}-1
     build:
       context: ./module/beat/_meta
       args:
-        BEAT_VERSION: ${BEAT_VERSION:-8.10.3}
+        BEAT_VERSION: ${BEAT_VERSION:-8.10.4}
     command: '-e'
     ports:
       - 5066:5066

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.3 
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.4 
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -19,7 +19,7 @@ services:
       - "script.context.template.cache_max_size=2000"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.10.3
+    image: docker.elastic.co/logstash/logstash:8.10.4
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -29,7 +29,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.10.3
+    image: docker.elastic.co/kibana/kibana:8.10.4
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/x-pack/metricbeat/docker-compose.yml
+++ b/x-pack/metricbeat/docker-compose.yml
@@ -24,11 +24,11 @@ services:
   kibana:
     # Copied configuration from OSS metricbeat because services with depends_on
     # cannot be extended with extends
-    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-8.10.3}-1
+    image: docker.elastic.co/integrations-ci/beats-kibana:${KIBANA_VERSION:-8.10.4}-1
     build:
       context: ../../metricbeat/module/kibana/_meta
       args:
-        KIBANA_VERSION: ${KIBANA_VERSION:-8.10.3}
+        KIBANA_VERSION: ${KIBANA_VERSION:-8.10.4}
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
Update test environment versions to the correct Elastic Stack version.

Merge only after the release of 8.10.4.