### PR TITLE
Fix warning log line in serverless setup

### DIFF
--- a/libbeat/idxmgmt/lifecycle/es_client_handler.go
+++ b/libbeat/idxmgmt/lifecycle/es_client_handler.go
@@ -95,7 +95,7 @@ func NewESClientHandler(c ESClient, info beat.Info, cfg RawConfig) (*ESClientHan
 	// if the user has set both to different values, throw a warning, as overwrite operations will probably fail
 	if c.IsServerless() {
 		if cfg.TemplateName != "" && cfg.TemplateName != name {
-			logp.L().Warnf("setup.dsl.data_stream_pattern is %s, but setup.template.name is %s; under serverless, non-default template and DSL pattern names should be the same. Updates & overwrites to this config may not work.", name, cfg.TemplateName)
+			logp.L().Warnf("setup.dsl.data_stream_pattern is %s, but setup.template.name is %s; under serverless, non-default template and DSL pattern names should be the same. Additional updates & overwrites to this config will not work.", name, cfg.TemplateName)
 		}
 	}
 


### PR DESCRIPTION
One-liner fix for a warning line we print when the template name doesn't match the DSL config name.
