### PR TITLE
Deprecate RSA2ELK Filebeat modules

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -273,6 +273,7 @@ https://github.com/elastic/beats/compare/v8.8.1\...main[Check the HEAD diff]
 
 *Filebeat*
 
+- Deprecate rsa2elk Filebeat modules. {issue}36125[36125] {pull}36887[36887]
 
 *Heartbeat*
 

--- a/filebeat/docs/howto/howto.asciidoc
+++ b/filebeat/docs/howto/howto.asciidoc
@@ -16,6 +16,7 @@ Learn how to perform common {beatname_uc} configuration tasks.
 * <<using-environ-vars>>
 * <<yaml-tips>>
 * <<migrate-to-filestream>>
+* <<migrate-from-deprecated-module>>
 
 
 --
@@ -46,5 +47,5 @@ include::{libbeat-dir}/yaml.asciidoc[]
 
 include::migrate-to-filestream.asciidoc[]
 
-include::migrate-from-deprecated-module.asciidoc
+include::migrate-from-deprecated-module.asciidoc[]
 

--- a/filebeat/docs/howto/howto.asciidoc
+++ b/filebeat/docs/howto/howto.asciidoc
@@ -46,4 +46,5 @@ include::{libbeat-dir}/yaml.asciidoc[]
 
 include::migrate-to-filestream.asciidoc[]
 
+include::migrate-from-deprecated-module.asciidoc
 

--- a/filebeat/docs/howto/migrate-from-deprecated-module.asciidoc
+++ b/filebeat/docs/howto/migrate-from-deprecated-module.asciidoc
@@ -28,4 +28,3 @@ be superseded by a new module. The deprecation notice will link to an appropriat
 module, if one exists.
 
 4. Use a custom Filebeat input, processors, and ingest pipeline (if necessary).
-##

--- a/filebeat/docs/howto/migrate-from-deprecated-module.asciidoc
+++ b/filebeat/docs/howto/migrate-from-deprecated-module.asciidoc
@@ -1,0 +1,31 @@
+[[migrate-from-deprecated-module]]
+== Migrating from a Deprecated Filebeat Module
+
+If a Filebeat module has been deprecated, there are a few options available for
+a path forward:
+
+1. Migrate to an Elastic integration, if available. The deprecation notice will
+link to an appropriate integration, if one exists.
+
+2. https://www.elastic.co/guide/en/fleet/current/migrate-beats-to-agent.html[Migrate to Elastic Agent]
+for ingesting logs. If a specific integration for the vendor/product does not
+exist, then one of the custom integrations can be used for ingesting events. A
+https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html[custom pipeline]
+may also be attached to the integration for further processing.
+    - https://docs.elastic.co/integrations/cel[CEL Custom API] - Collect events from an API using CEL (Common Expression Language)
+    - https://docs.elastic.co/integrations/httpjson[Custom API] - Collect events from an API using the HTTPJSON input
+    - https://docs.elastic.co/integrations/gcp_pubsub[Custom Google Pub/Sub] - Collect events from Google Pub/Sub topics
+    - https://docs.elastic.co/integrations/http_endpoint[Custom HTTP Endpoint] - Collect events from a listening HTTP port
+    - https://docs.elastic.co/integrations/journald[Custom Journald] - Collect events from journald
+    - https://docs.elastic.co/integrations/kafka_log[Custom Kafka] - Collect events from a Kafka topic
+    - https://docs.elastic.co/integrations/log[Custom Logs] - Collect events from files
+    - https://docs.elastic.co/integrations/tcp[Custom TCP] - Collect events from a listening TCP port
+    - https://docs.elastic.co/integrations/udp[Custom UDP] - Collect events from a listening UDP port
+    - https://docs.elastic.co/integrations/winlog[Custom Windows Event] - Collect events from a Windows Event Log channel
+
+3. Migrate to a different Filebeat module. In some cases, a Filebeat module may
+be superseded by a new module. The deprecation notice will link to an appropriate
+module, if one exists.
+
+4. Use a custom Filebeat input, processors, and ingest pipeline (if necessary).
+##

--- a/filebeat/docs/modules/barracuda.asciidoc
+++ b/filebeat/docs/modules/barracuda.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Barracuda module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/barracuda[Barracuda Web Application Firewall] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/bluecoat.asciidoc
+++ b/filebeat/docs/modules/bluecoat.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Bluecoat module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/bluecoat.asciidoc
+++ b/filebeat/docs/modules/bluecoat.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Bluecoat module
 
-deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
+deprecated::[8.12.0,"This module is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/bluecoat.asciidoc
+++ b/filebeat/docs/modules/bluecoat.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Bluecoat module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/bluecoat.asciidoc
+++ b/filebeat/docs/modules/bluecoat.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Bluecoat module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/cisco.asciidoc
+++ b/filebeat/docs/modules/cisco.asciidoc
@@ -281,6 +281,8 @@ include::../include/timezone-support.asciidoc[]
 [float]
 ==== `nexus` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/cisco_nexus[Cisco Nexus] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "cisconxos" device revision 134.
@@ -325,6 +327,8 @@ will be found under `rsa.raw`. The default is false.
 
 [float]
 ==== `meraki` fileset settings
+
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/cisco_meraki[Cisco Meraki] Elastic integration instead."]
 
 experimental[]
 

--- a/filebeat/docs/modules/cylance.asciidoc
+++ b/filebeat/docs/modules/cylance.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Cylance module
 
-deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
+deprecated::[8.12.0,"This module is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/cylance.asciidoc
+++ b/filebeat/docs/modules/cylance.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Cylance module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/cylance.asciidoc
+++ b/filebeat/docs/modules/cylance.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Cylance module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/cylance.asciidoc
+++ b/filebeat/docs/modules/cylance.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Cylance module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/f5.asciidoc
+++ b/filebeat/docs/modules/f5.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == F5 module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/f5_bigip[F5 BIG-IP] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/fortinet.asciidoc
+++ b/filebeat/docs/modules/fortinet.asciidoc
@@ -81,6 +81,8 @@ events. Defaults to `[fortinet-firewall, forwarded]`.
 [float]
 ==== `clientendpoint` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/fortinet_forticlient[Fortinet FortiClient Logs] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "forticlientendpoint" device revision 0.
@@ -126,6 +128,8 @@ will be found under `rsa.raw`. The default is false.
 [float]
 ==== `fortimail` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/fortinet_fortimail[Fortinet FortiMail] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "fortinetfortimail" device revision 131.
@@ -170,6 +174,8 @@ will be found under `rsa.raw`. The default is false.
 
 [float]
 ==== `fortimanager` fileset settings
+
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/fortinet_fortimanager[Fortinet FortiManager Logs] Elastic integration instead."]
 
 experimental[]
 

--- a/filebeat/docs/modules/imperva.asciidoc
+++ b/filebeat/docs/modules/imperva.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Imperva module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/imperva.asciidoc
+++ b/filebeat/docs/modules/imperva.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Imperva module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/imperva.asciidoc
+++ b/filebeat/docs/modules/imperva.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Imperva module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/imperva.asciidoc
+++ b/filebeat/docs/modules/imperva.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Imperva module
 
-deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
+deprecated::[8.12.0,"This module is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/infoblox.asciidoc
+++ b/filebeat/docs/modules/infoblox.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Infoblox module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/infoblox_nios[Infoblox NIOS] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/juniper.asciidoc
+++ b/filebeat/docs/modules/juniper.asciidoc
@@ -142,6 +142,8 @@ This is a list of JunOS fields that are mapped to ECS.
 [float]
 ==== `junos` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/juniper_srx[Juniper SRX] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "junosrouter" device revision 134.
@@ -186,6 +188,8 @@ will be found under `rsa.raw`. The default is false.
 
 [float]
 ==== `netscreen` fileset settings
+
+deprecated::[8.12.0,"This fileset is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/juniper.asciidoc
+++ b/filebeat/docs/modules/juniper.asciidoc
@@ -189,7 +189,7 @@ will be found under `rsa.raw`. The default is false.
 [float]
 ==== `netscreen` fileset settings
 
-deprecated::[8.12.0,"This fileset is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
+deprecated::[8.12.0,"This fileset is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/juniper.asciidoc
+++ b/filebeat/docs/modules/juniper.asciidoc
@@ -189,7 +189,7 @@ will be found under `rsa.raw`. The default is false.
 [float]
 ==== `netscreen` fileset settings
 
-deprecated::[8.12.0,"This fileset is deprecated."]
+deprecated::[8.12.0,"This fileset is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/juniper.asciidoc
+++ b/filebeat/docs/modules/juniper.asciidoc
@@ -189,7 +189,7 @@ will be found under `rsa.raw`. The default is false.
 [float]
 ==== `netscreen` fileset settings
 
-deprecated::[8.12.0,"This fileset is deprecated."]
+deprecated::[8.12.0,"This fileset is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/microsoft.asciidoc
+++ b/filebeat/docs/modules/microsoft.asciidoc
@@ -224,6 +224,8 @@ And for all other Defender ATP event types, go to Host -> Events.
 [float]
 ==== `dhcp` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/microsoft_dhcp[Microsoft DHCP] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "msdhcp" device revision 99.

--- a/filebeat/docs/modules/netscout.asciidoc
+++ b/filebeat/docs/modules/netscout.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Netscout module
 
-deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
+deprecated::[8.12.0,"This module is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/netscout.asciidoc
+++ b/filebeat/docs/modules/netscout.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Netscout module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 This is a module for receiving Arbor Peakflow SP logs over Syslog or a file.

--- a/filebeat/docs/modules/netscout.asciidoc
+++ b/filebeat/docs/modules/netscout.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Netscout module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/netscout.asciidoc
+++ b/filebeat/docs/modules/netscout.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Netscout module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/proofpoint.asciidoc
+++ b/filebeat/docs/modules/proofpoint.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Proofpoint module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/proofpoint_tap[Proofpoint TAP] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/radware.asciidoc
+++ b/filebeat/docs/modules/radware.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Radware module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/radware.asciidoc
+++ b/filebeat/docs/modules/radware.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Radware module
 
-deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
+deprecated::[8.12.0,"This module is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/radware.asciidoc
+++ b/filebeat/docs/modules/radware.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Radware module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/radware.asciidoc
+++ b/filebeat/docs/modules/radware.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Radware module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/snort.asciidoc
+++ b/filebeat/docs/modules/snort.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Snort module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/snort[Snort] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/sonicwall.asciidoc
+++ b/filebeat/docs/modules/sonicwall.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Sonicwall module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/sonicwall[SonicWall Firewall] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/sophos.asciidoc
+++ b/filebeat/docs/modules/sophos.asciidoc
@@ -152,6 +152,8 @@ This is a list of SophosXG fields that are mapped to ECS.
 [float]
 ==== `utm` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/sophos[Sophos] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "astarosg" device revision 123.

--- a/filebeat/docs/modules/squid.asciidoc
+++ b/filebeat/docs/modules/squid.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Squid module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/squid.asciidoc
+++ b/filebeat/docs/modules/squid.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Squid module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/squid.asciidoc
+++ b/filebeat/docs/modules/squid.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Squid module
 
-deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module,Migrate from a Deprecated Module>> for migration options."]
+deprecated::[8.12.0,"This module is deprecated."]
 
 experimental[]
 

--- a/filebeat/docs/modules/squid.asciidoc
+++ b/filebeat/docs/modules/squid.asciidoc
@@ -12,7 +12,7 @@ This file is generated! See scripts/docs_collector.py
 
 == Squid module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/filebeat/docs/modules/tomcat.asciidoc
+++ b/filebeat/docs/modules/tomcat.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Tomcat module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/apache_tomcat[Apache Tomcat] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/filebeat/docs/modules/zscaler.asciidoc
+++ b/filebeat/docs/modules/zscaler.asciidoc
@@ -12,6 +12,8 @@ This file is generated! See scripts/docs_collector.py
 
 == Zscaler module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/zscaler_zia[Zscaler Internet Access] Elastic integration instead."]
+
 experimental[]
 
 //temporarily override modulename to create working link

--- a/x-pack/filebeat/module/barracuda/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/barracuda/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Barracuda module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/barracuda[Barracuda Web Application Firewall] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/bluecoat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/bluecoat/_meta/docs.asciidoc
@@ -5,7 +5,7 @@
 
 == Bluecoat module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/bluecoat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/bluecoat/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Bluecoat module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cisco/_meta/docs.asciidoc
@@ -274,6 +274,8 @@ include::../include/timezone-support.asciidoc[]
 [float]
 ==== `nexus` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/cisco_nexus[Cisco Nexus] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "cisconxos" device revision 134.
@@ -318,6 +320,8 @@ will be found under `rsa.raw`. The default is false.
 
 [float]
 ==== `meraki` fileset settings
+
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/cisco_meraki[Cisco Meraki] Elastic integration instead."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/cylance/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cylance/_meta/docs.asciidoc
@@ -5,7 +5,7 @@
 
 == Cylance module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/cylance/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/cylance/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Cylance module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/f5/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/f5/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == F5 module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/f5_bigip[F5 BIG-IP] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/fortinet/_meta/docs.asciidoc
@@ -74,6 +74,8 @@ events. Defaults to `[fortinet-firewall, forwarded]`.
 [float]
 ==== `clientendpoint` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/fortinet_forticlient[Fortinet FortiClient Logs] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "forticlientendpoint" device revision 0.
@@ -119,6 +121,8 @@ will be found under `rsa.raw`. The default is false.
 [float]
 ==== `fortimail` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/fortinet_fortimail[Fortinet FortiMail] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "fortinetfortimail" device revision 131.
@@ -163,6 +167,8 @@ will be found under `rsa.raw`. The default is false.
 
 [float]
 ==== `fortimanager` fileset settings
+
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/fortinet_fortimanager[Fortinet FortiManager Logs] Elastic integration instead."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/imperva/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/imperva/_meta/docs.asciidoc
@@ -5,7 +5,7 @@
 
 == Imperva module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/imperva/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/imperva/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Imperva module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/infoblox/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/infoblox/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Infoblox module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/infoblox_nios[Infoblox NIOS] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
@@ -135,6 +135,8 @@ This is a list of JunOS fields that are mapped to ECS.
 [float]
 ==== `junos` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/juniper_srx[Juniper SRX] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "junosrouter" device revision 134.
@@ -179,6 +181,8 @@ will be found under `rsa.raw`. The default is false.
 
 [float]
 ==== `netscreen` fileset settings
+
+deprecated::[8.12.0,"This fileset is deprecated."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/juniper/_meta/docs.asciidoc
@@ -182,7 +182,7 @@ will be found under `rsa.raw`. The default is false.
 [float]
 ==== `netscreen` fileset settings
 
-deprecated::[8.12.0,"This fileset is deprecated."]
+deprecated::[8.12.0,"This fileset is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/microsoft/_meta/docs.asciidoc
@@ -217,6 +217,8 @@ And for all other Defender ATP event types, go to Host -> Events.
 [float]
 ==== `dhcp` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/microsoft_dhcp[Microsoft DHCP] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "msdhcp" device revision 99.

--- a/x-pack/filebeat/module/netscout/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netscout/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Netscout module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 This is a module for receiving Arbor Peakflow SP logs over Syslog or a file.

--- a/x-pack/filebeat/module/netscout/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/netscout/_meta/docs.asciidoc
@@ -5,7 +5,7 @@
 
 == Netscout module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/proofpoint/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/proofpoint/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Proofpoint module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/proofpoint_tap[Proofpoint TAP] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/radware/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/radware/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Radware module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/radware/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/radware/_meta/docs.asciidoc
@@ -5,7 +5,7 @@
 
 == Radware module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/snort/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/snort/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Snort module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/snort[Snort] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/sonicwall/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sonicwall/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Sonicwall module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/sonicwall[SonicWall Firewall] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/sophos/_meta/docs.asciidoc
@@ -145,6 +145,8 @@ This is a list of SophosXG fields that are mapped to ECS.
 [float]
 ==== `utm` fileset settings
 
+deprecated::[8.12.0,"This fileset is deprecated. Use the https://docs.elastic.co/integrations/sophos[Sophos] Elastic integration instead."]
+
 experimental[]
 
 NOTE: This was converted from RSA NetWitness log parser XML "astarosg" device revision 123.

--- a/x-pack/filebeat/module/squid/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/squid/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Squid module
 
+deprecated::[8.12.0,"This module is deprecated."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/squid/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/squid/_meta/docs.asciidoc
@@ -5,7 +5,7 @@
 
 == Squid module
 
-deprecated::[8.12.0,"This module is deprecated."]
+deprecated::[8.12.0,"This module is deprecated. See <<migrate-from-deprecated-module>> for migration options."]
 
 experimental[]
 

--- a/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/tomcat/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Tomcat module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/apache_tomcat[Apache Tomcat] Elastic integration instead."]
+
 experimental[]
 
 include::{libbeat-dir}/shared/integration-link.asciidoc[]

--- a/x-pack/filebeat/module/zscaler/_meta/docs.asciidoc
+++ b/x-pack/filebeat/module/zscaler/_meta/docs.asciidoc
@@ -5,6 +5,8 @@
 
 == Zscaler module
 
+deprecated::[8.12.0,"This module is deprecated. Use the https://docs.elastic.co/integrations/zscaler_zia[Zscaler Internet Access] Elastic integration instead."]
+
 experimental[]
 
 //temporarily override modulename to create working link


### PR DESCRIPTION
## Proposed commit message

Deprecate RSA2ELK Filebeat modules

- Add deprecation notices to RSA2ELK Filebeat modules.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- ~~[ ] I have made corresponding change to the default configuration files~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Closes #36125 
