### PR TITLE
Update default loadbalance setting for Logstash to 'false'

### DIFF
--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -286,7 +286,7 @@ list of configured hosts over time, use this option in conjunction with the
 `ttl` setting to close the connection at the configured interval and choose
 a new target host.
 
-The default value is `true`.
+The default value is `false`.
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------


### PR DESCRIPTION
The default `loadbalance` setting for Logstash output should be documented as `false`. Discussion is [here](https://github.com/elastic/beats/issues/12567#issuecomment-1769188098).

PREVIEW

---

![Screenshot 2023-10-18 at 3 55 26 PM](https://github.com/elastic/beats/assets/41695641/d2975fed-37f8-410e-a728-eacc0a544ee4)
