### PR TITLE
[Heartbeat] Fix monitor duration wrapper

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -117,6 +117,7 @@ is collected by it.
 
 - Fix panics when parsing dereferencing invalid parsed url. {pull}34702[34702]
 - Fix retries to trigger on a down monitor with no previous state. {pull}36842[36842]
+- Fix monitor duration calculation with retries. {pull}36842[36842]
 
 *Metricbeat*
 

--- a/heartbeat/monitors/wrappers/summarizer/plugdrop.go
+++ b/heartbeat/monitors/wrappers/summarizer/plugdrop.go
@@ -43,3 +43,7 @@ func (d DropBrowserExtraEvents) BeforeSummary(event *beat.Event) BeforeSummaryAc
 func (d DropBrowserExtraEvents) BeforeRetry() {
 	// noop
 }
+
+func (d DropBrowserExtraEvents) BeforeEachEvent(event *beat.Event) {
+	// noop
+}

--- a/heartbeat/monitors/wrappers/summarizer/plugerr.go
+++ b/heartbeat/monitors/wrappers/summarizer/plugerr.go
@@ -46,6 +46,8 @@ func NewBrowserErrPlugin() *BrowserErrPlugin {
 	}
 }
 
+func (esp *BrowserErrPlugin) BeforeEachEvent(event *beat.Event) {} // noop
+
 func (esp *BrowserErrPlugin) EachEvent(event *beat.Event, eventErr error) EachEventActions {
 	// track these to determine if the journey
 	// needs an error injected due to incompleteness
@@ -124,6 +126,10 @@ func (esp *LightweightErrPlugin) BeforeSummary(event *beat.Event) BeforeSummaryA
 }
 
 func (esp *LightweightErrPlugin) BeforeRetry() {
+	// noop
+}
+
+func (esp *LightweightErrPlugin) BeforeEachEvent(event *beat.Event) {
 	// noop
 }
 

--- a/heartbeat/monitors/wrappers/summarizer/plugmondur.go
+++ b/heartbeat/monitors/wrappers/summarizer/plugmondur.go
@@ -31,11 +31,15 @@ type LightweightDurationPlugin struct {
 }
 
 func (lwdsp *LightweightDurationPlugin) EachEvent(event *beat.Event, _ error) EachEventActions {
-	// Effectively only runs once, on the first event
+	return 0 // noop
+}
+
+func (lwdsp *LightweightDurationPlugin) BeforeEachEvent(event *beat.Event) {
+	// Effectively capture on the first event, on the first event
 	if lwdsp.startedAt == nil {
-		lwdsp.setEventStartAt()
+		now := time.Now()
+		lwdsp.startedAt = &now
 	}
-	return 0
 }
 
 func (lwdsp *LightweightDurationPlugin) BeforeSummary(event *beat.Event) BeforeSummaryActions {
@@ -44,13 +48,8 @@ func (lwdsp *LightweightDurationPlugin) BeforeSummary(event *beat.Event) BeforeS
 }
 
 func (lwdsp *LightweightDurationPlugin) BeforeRetry() {
-	// Reset event.startAt
+	// Reset event start time
 	lwdsp.startedAt = nil
-}
-
-func (lwdsp *LightweightDurationPlugin) setEventStartAt() {
-	now := time.Now()
-	lwdsp.startedAt = &now
 }
 
 // BrowserDurationPlugin handles the logic for writing the `monitor.duration.us` field
@@ -89,4 +88,5 @@ func (bwdsp *BrowserDurationPlugin) BeforeSummary(event *beat.Event) BeforeSumma
 	return 0
 }
 
-func (bwdsp *BrowserDurationPlugin) BeforeRetry() {}
+func (bwdsp *BrowserDurationPlugin) BeforeRetry()                      {}
+func (bwdsp *BrowserDurationPlugin) BeforeEachEvent(event *beat.Event) {} // noop

--- a/heartbeat/monitors/wrappers/summarizer/plugmondur.go
+++ b/heartbeat/monitors/wrappers/summarizer/plugmondur.go
@@ -33,8 +33,7 @@ type LightweightDurationPlugin struct {
 func (lwdsp *LightweightDurationPlugin) EachEvent(event *beat.Event, _ error) EachEventActions {
 	// Effectively only runs once, on the first event
 	if lwdsp.startedAt == nil {
-		now := time.Now()
-		lwdsp.startedAt = &now
+		lwdsp.setEventStartAt()
 	}
 	return 0
 }
@@ -44,7 +43,15 @@ func (lwdsp *LightweightDurationPlugin) BeforeSummary(event *beat.Event) BeforeS
 	return 0
 }
 
-func (lwdsp *LightweightDurationPlugin) BeforeRetry() {}
+func (lwdsp *LightweightDurationPlugin) BeforeRetry() {
+	// Reset event.startAt
+	lwdsp.startedAt = nil
+}
+
+func (lwdsp *LightweightDurationPlugin) setEventStartAt() {
+	now := time.Now()
+	lwdsp.startedAt = &now
+}
 
 // BrowserDurationPlugin handles the logic for writing the `monitor.duration.us` field
 // for browser monitors.

--- a/heartbeat/monitors/wrappers/summarizer/plugstatestat.go
+++ b/heartbeat/monitors/wrappers/summarizer/plugstatestat.go
@@ -74,6 +74,8 @@ func (ssp *BrowserStateStatusPlugin) BeforeRetry() {
 	ssp.cssp.BeforeRetry()
 }
 
+func (ssp *BrowserStateStatusPlugin) BeforeEachEvent(event *beat.Event) {} //noop
+
 // LightweightStateStatusPlugin encapsulates the writing of the primary fields used by the summary,
 // those being `state.*`, `status.*` , `event.type`, and `monitor.check_group`
 type LightweightStateStatusPlugin struct {
@@ -112,6 +114,8 @@ func (ssp *LightweightStateStatusPlugin) BeforeSummary(event *beat.Event) Before
 func (ssp *LightweightStateStatusPlugin) BeforeRetry() {
 	ssp.cssp.BeforeRetry()
 }
+
+func (ssp *LightweightStateStatusPlugin) BeforeEachEvent(event *beat.Event) {} // noop
 
 type commonSSP struct {
 	js           *jobsummary.JobSummary

--- a/heartbeat/monitors/wrappers/summarizer/plugurl.go
+++ b/heartbeat/monitors/wrappers/summarizer/plugurl.go
@@ -52,3 +52,5 @@ func (busp *BrowserURLPlugin) BeforeSummary(event *beat.Event) BeforeSummaryActi
 func (busp *BrowserURLPlugin) BeforeRetry() {
 	busp.urlFields = nil
 }
+
+func (busp *BrowserURLPlugin) BeforeEachEvent(event *beat.Event) {} //noop

--- a/heartbeat/monitors/wrappers/summarizer/summarizer.go
+++ b/heartbeat/monitors/wrappers/summarizer/summarizer.go
@@ -42,6 +42,12 @@ type Summarizer struct {
 	startedAt      time.Time
 }
 
+func (s Summarizer) beforeEachEvent(event *beat.Event) {
+	for _, plugin := range s.plugins {
+		plugin.BeforeEachEvent(event)
+	}
+}
+
 // EachEventActions is a set of options using bitmasks to inform execution after the EachEvent callback
 type EachEventActions uint8
 
@@ -58,6 +64,9 @@ const RetryBeforeSummary = 1
 // in one location. Prior to this code was strewn about a bit more and following it was
 // a bit trickier.
 type SummarizerPlugin interface {
+	// BeforeEachEvent is called on each event, and allows for the mutation of events
+	// before monitor execution
+	BeforeEachEvent(event *beat.Event)
 	// EachEvent is called on each event, and allows for the mutation of events
 	EachEvent(event *beat.Event, err error) EachEventActions
 	// BeforeSummary is run on the final (summary) event for each monitor.
@@ -106,6 +115,10 @@ func (s *Summarizer) setupPlugins() {
 // This adds the state and summary top level fields.
 func (s *Summarizer) Wrap(j jobs.Job) jobs.Job {
 	return func(event *beat.Event) ([]jobs.Job, error) {
+
+		// call BeforeEachEvent for each plugin before running job
+		s.beforeEachEvent(event)
+
 		conts, eventErr := j(event)
 
 		s.mtx.Lock()
@@ -149,10 +162,10 @@ func (s *Summarizer) Wrap(j jobs.Job) jobs.Job {
 					for _, p := range s.plugins {
 						p.BeforeRetry()
 					}
-					return s.rootJob(event)
+					return s.Wrap(s.rootJob)(event)
 				}
 
-				conts = []jobs.Job{delayedRootJob}
+				return []jobs.Job{delayedRootJob}, eventErr
 			}
 		}
 

--- a/heartbeat/monitors/wrappers/summarizer/summarizer.go
+++ b/heartbeat/monitors/wrappers/summarizer/summarizer.go
@@ -145,10 +145,10 @@ func (s *Summarizer) Wrap(j jobs.Job) jobs.Job {
 				//    kibana queries
 				// 2. If the site error is very short 1s gives it a tiny bit of time to recover
 				delayedRootJob := func(event *beat.Event) ([]jobs.Job, error) {
+					time.Sleep(s.retryDelay)
 					for _, p := range s.plugins {
 						p.BeforeRetry()
 					}
-					time.Sleep(s.retryDelay)
 					return s.rootJob(event)
 				}
 

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -23,7 +23,7 @@ heartbeat.config.monitors:
 heartbeat.monitors:
 - type: http
   # Set enabled to true (or delete the following line) to enable this monitor
-  enabled: true
+  enabled: false
   # ID used to uniquely identify this monitor in Elasticsearch even if the config changes
   id: my-monitor
   # Human readable display name for this service in Uptime UI and elsewhere

--- a/x-pack/heartbeat/heartbeat.yml
+++ b/x-pack/heartbeat/heartbeat.yml
@@ -23,7 +23,7 @@ heartbeat.config.monitors:
 heartbeat.monitors:
 - type: http
   # Set enabled to true (or delete the following line) to enable this monitor
-  enabled: false
+  enabled: true
   # ID used to uniquely identify this monitor in Elasticsearch even if the config changes
   id: my-monitor
   # Human readable display name for this service in Uptime UI and elsewhere
@@ -31,7 +31,8 @@ heartbeat.monitors:
   # List of URLs to query
   urls: ["http://localhost:9200"]
   # Configure task schedule
-  schedule: '@every 10s'
+  schedule: '@every 10000s'
+  max_attempts: 2
   # Total test connection and data exchange timeout
   #timeout: 16s
   # Name of corresponding APM service, if Elastic APM is in use for the monitored service.
@@ -98,9 +99,11 @@ setup.kibana:
 # Configure what output to use when sending the data collected by the beat.
 
 # ---------------------------- Elasticsearch Output ----------------------------
-output.elasticsearch:
-  # Array of hosts to connect to.
-  hosts: ["localhost:9200"]
+# output.elasticsearch:
+#   # Array of hosts to connect to.
+#   hosts: ["localhost:9200"]
+output.console:
+  pretty: true
 
   # Protocol - either `http` (default) or `https`.
   #protocol: "https"


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

Please explain:

- WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
- WHY:  the rationale/motivation for the changes

This text will be pasted into the squash dialog when the change is committed and will be
a long term historical record of the change to help future contributors understand the
change, please help them by making it clear and comprehensive, they may be you.

If the commit title is adequate to describe both of these things, The text here may be omitted
or replaced with "See title". The title of the PR will be used as the commit message title when
the merge is made and the "See title" marker will be removed if present.

The text here and the PR title will be subject to the PR review process.
-->

Fixes https://github.com/elastic/beats/issues/36892. 

Monitor duration is not being calculated correctly, where start time is initialized after monitor execution and wrapping order is overriding retries event order.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
1. Build hb locally.
2. Set up a always-down monitor with `max_attempts: 2`
3. Check `monitor.duration.us` in the generated docs do not account for retry delays but include `resolve.rrt.us` time.
