### PR TITLE
Update netflow.yml

### DIFF
--- a/x-pack/filebeat/module/netflow/log/config/netflow.yml
+++ b/x-pack/filebeat/module/netflow/log/config/netflow.yml
@@ -27,6 +27,11 @@ custom_definitions:
 {{end}}
 {{end}}
 
+{{if .pipeline}}
+pipeline: '{{.pipeline}}'
+{{end}}
+
+
 detect_sequence_reset: {{.detect_sequence_reset}}
 
 tags: {{.tags | tojson}}


### PR DESCRIPTION
Adds the hablity to choose a different pipeline to ingest NetFlow logs using the config module file [netflow.yml](https://github.com/elastic/beats/blob/main/x-pack/filebeat/modules.d/netflow.yml.disabled).<br/>
Sometimes, you need to choose a different or customized Ingest Pipeline according to the Fileabet instance that is receiving the Netflow data.<br/>
I found that, if you costumize the default Netflow Ingest Pipeline, the Filebeat instance overwrites it every week or two with de default configuration for Netflow Ingest Pipeline using the file [pipeline.yml](https://github.com/elastic/beats/blob/main/x-pack/filebeat/module/netflow/log/ingest/pipeline.yml) and this behavior happens even if you set **filebeat.overwrite_pipelines: false** in main [filebeat.yml](https://github.com/elastic/beats/blob/main/filebeat/filebeat.yml).<br/>
Setting a different Ingest Pipeline is workaround for that issue.

