### PR TITLE
Document ES output API usage

### DIFF
--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -750,3 +750,17 @@ output.elasticsearch:
   non_indexable_policy.dead_letter_index:
     index: "my-dead-letter-index"
 ------------------------------------------------------------------------------
+
+[[es-apis]]
+==== Elasticsearch APIs
+{beatname_uc} will use the `_bulk` API from {es}, the events are sent
+in the order they arrive the publishing pipeline, a single `_bulk`
+request may contain events from different inputs/modules. Temporary
+failures are re-tried.
+
+The status code for each event is checked and handled as:
+
+* `< 300`: The event is counted as `events.acked`
+* `409` (Conflict): The event is counted as `events.duplicates`
+* `429` (Too Many Requests): The event is counted as `events.toomany`
+* `> 399 and < 500`: The `non_indexable_policy` is applied.

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -754,7 +754,7 @@ output.elasticsearch:
 [[es-apis]]
 ==== Elasticsearch APIs
 {beatname_uc} will use the `_bulk` API from {es}, the events are sent
-in the order they arrive the publishing pipeline, a single `_bulk`
+in the order they arrive to the publishing pipeline, a single `_bulk`
 request may contain events from different inputs/modules. Temporary
 failures are re-tried.
 


### PR DESCRIPTION
## Proposed commit message

This commit documents the `_bulk` API usage by the Elasticsearch output and how different status codes are handled.

## Checklist

~~- [ ] My code follows the style guidelines of this project~~
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have made corresponding change to the default configuration files~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~

~~## Author's Checklist~~

## How to test this PR locally
Assuming `beats` and `docs` are both in `$GIT_HOME`, build the docs:

```sh
$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/filebeat/docs --chunk 1 --open
```

A browser window will open, then navigate to the Elasticsearch output documentation and scroll until the end of the page

## Related issues

- Closes https://github.com/elastic/beats/issues/36547

~~## Use cases~~
~~## Screenshots~~
~~## Logs~~
