### PR TITLE
Use filestream input as default for hints autodiscover. 

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -245,7 +245,7 @@ is collected by it.
 - Avoid unwanted publication of Azure entity records. {pull}36753[36753]
 - Avoid unwanted publication of Okta entity records. {pull}36770[36770]
 - Add support for Digest Authentication to CEL input. {issue}35514[35514] {pull}36932[36932]
-- Use filestream input as default for hints autodiscover. {issue}35984[35984] {pull}36950[36950]
+- Use filestream input with file_identity.fingerprint as default for hints autodiscover. {issue}35984[35984] {pull}36950[36950]
 
 *Auditbeat*
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -245,6 +245,7 @@ is collected by it.
 - Avoid unwanted publication of Azure entity records. {pull}36753[36753]
 - Avoid unwanted publication of Okta entity records. {pull}36770[36770]
 - Add support for Digest Authentication to CEL input. {issue}35514[35514] {pull}36932[36932]
+- Use filestream input as default for hints autodiscover. {issue}35984[35984] {pull}36950[36950]
 
 *Auditbeat*
 

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -123,15 +123,19 @@ data:
                 logs_path: "/var/log/containers/"
 
     # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
-    #filebeat.autodiscover:
+    # filebeat.autodiscover:
     #  providers:
     #    - type: kubernetes
     #      node: ${NODE_NAME}
     #      hints.enabled: true
     #      hints.default_config:
-    #        type: container
+    #        type: filestream
+    #        prospector.scanner.symlinks: true
+    #        id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
     #        paths:
-    #          - /var/log/containers/*${data.kubernetes.container.id}.log
+    #        - /var/log/containers/*-${data.kubernetes.container.id}.log
+    #        parsers:
+    #        - container: ~
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/filebeat-kubernetes.yaml
+++ b/deploy/kubernetes/filebeat-kubernetes.yaml
@@ -112,9 +112,16 @@ metadata:
 data:
   filebeat.yml: |-
     filebeat.inputs:
-    - type: container
+    - type: filestream
       paths:
         - /var/log/containers/*.log
+      parsers:
+        - container: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: true
+          symlinks: true
+      file_identity.fingerprint: ~
       processors:
         - add_kubernetes_metadata:
             host: ${NODE_NAME}
@@ -130,12 +137,16 @@ data:
     #      hints.enabled: true
     #      hints.default_config:
     #        type: filestream
-    #        prospector.scanner.symlinks: true
     #        id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
     #        paths:
     #        - /var/log/containers/*-${data.kubernetes.container.id}.log
     #        parsers:
     #        - container: ~
+    #        prospector:
+    #         scanner:
+    #           fingerprint.enabled: true
+    #           symlinks: true
+    #        file_identity.fingerprint: ~
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -8,9 +8,16 @@ metadata:
 data:
   filebeat.yml: |-
     filebeat.inputs:
-    - type: container
+    - type: filestream
       paths:
         - /var/log/containers/*.log
+      parsers:
+        - container: ~
+      prospector:
+        scanner:
+          fingerprint.enabled: true
+          symlinks: true
+      file_identity.fingerprint: ~
       processors:
         - add_kubernetes_metadata:
             host: ${NODE_NAME}
@@ -26,12 +33,16 @@ data:
     #      hints.enabled: true
     #      hints.default_config:
     #        type: filestream
-    #        prospector.scanner.symlinks: true
     #        id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
     #        paths:
     #        - /var/log/containers/*-${data.kubernetes.container.id}.log
     #        parsers:
     #        - container: ~
+    #        prospector:
+    #         scanner:
+    #           fingerprint.enabled: true
+    #           symlinks: true
+    #        file_identity.fingerprint: ~
 
     processors:
       - add_cloud_metadata:

--- a/deploy/kubernetes/filebeat/filebeat-configmap.yaml
+++ b/deploy/kubernetes/filebeat/filebeat-configmap.yaml
@@ -19,15 +19,19 @@ data:
                 logs_path: "/var/log/containers/"
 
     # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
-    #filebeat.autodiscover:
+    # filebeat.autodiscover:
     #  providers:
     #    - type: kubernetes
     #      node: ${NODE_NAME}
     #      hints.enabled: true
     #      hints.default_config:
-    #        type: container
+    #        type: filestream
+    #        prospector.scanner.symlinks: true
+    #        id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
     #        paths:
-    #          - /var/log/containers/*${data.kubernetes.container.id}.log
+    #        - /var/log/containers/*-${data.kubernetes.container.id}.log
+    #        parsers:
+    #        - container: ~
 
     processors:
       - add_cloud_metadata:

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -27,20 +27,18 @@ type config struct {
 }
 
 func defaultConfig() config {
-	var parsers []map[string]interface{}
-	filestreamContainerParser := map[string]interface{}{
-		"container": map[string]interface{}{
-			"stream": "all",
-			"format": "auto",
-		},
-	}
-	parsers = append(parsers, filestreamContainerParser)
-
 	defaultCfgRaw := map[string]interface{}{
 		"type":                        "filestream",
 		"id":                          "kubernetes-container-logs-${data.kubernetes.container.id}",
 		"prospector.scanner.symlinks": true,
-		"parsers":                     parsers,
+		"parsers": []interface{}{
+			map[string]interface{}{
+				"container": map[string]interface{}{
+					"stream": "all",
+					"format": "auto",
+				},
+			},
+		},
 		"paths": []string{
 			"/var/log/containers/*-${data.kubernetes.container.id}.log",
 		},

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -17,7 +17,9 @@
 
 package hints
 
-import conf "github.com/elastic/elastic-agent-libs/config"
+import (
+	conf "github.com/elastic/elastic-agent-libs/config"
+)
 
 type config struct {
 	Key           string  `config:"key"`
@@ -25,12 +27,22 @@ type config struct {
 }
 
 func defaultConfig() config {
+	var parsers []map[string]interface{}
+	filestreamContainerParser := map[string]interface{}{
+		"container": map[string]interface{}{
+			"stream": "all",
+			"format": "auto",
+		},
+	}
+	parsers = append(parsers, filestreamContainerParser)
+
 	defaultCfgRaw := map[string]interface{}{
-		"type": "container",
+		"type":                        "filestream",
+		"id":                          "kubernetes-container-logs-${data.kubernetes.container.id}",
+		"prospector.scanner.symlinks": true,
+		"parsers":                     parsers,
 		"paths": []string{
-			// To be able to use this builder with CRI-O replace paths with:
-			// /var/log/pods/${data.kubernetes.pod.uid}/${data.kubernetes.container.name}/*.log
-			"/var/lib/docker/containers/${data.container.id}/*-json.log",
+			"/var/log/containers/*-${data.kubernetes.container.id}.log",
 		},
 	}
 	defaultCfg, _ := conf.NewConfigFrom(defaultCfgRaw)

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -67,7 +67,7 @@ func (c *config) Unpack(from *conf.C) error {
 		if len(fields) == 1 && fields[0] == "enabled" {
 			// only enabling/disabling default config:
 			if err := c.DefaultConfig.Merge(config); err != nil {
-				return nil
+				return err
 			}
 		} else {
 			// full config provided, discard default. It must be a clone of the

--- a/filebeat/autodiscover/builder/hints/config.go
+++ b/filebeat/autodiscover/builder/hints/config.go
@@ -28,9 +28,15 @@ type config struct {
 
 func defaultConfig() config {
 	defaultCfgRaw := map[string]interface{}{
-		"type":                        "filestream",
-		"id":                          "kubernetes-container-logs-${data.kubernetes.container.id}",
-		"prospector.scanner.symlinks": true,
+		"type": "filestream",
+		"id":   "kubernetes-container-logs-${data.kubernetes.container.id}",
+		"prospector": map[string]interface{}{
+			"scanner": map[string]interface{}{
+				"fingerprint.enabled": true,
+				"symlinks":            true,
+			},
+		},
+		"file_identity.fingerprint": nil,
 		"parsers": []interface{}{
 			map[string]interface{}{
 				"container": map[string]interface{}{

--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -119,9 +119,18 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*conf
 
 		inputType, _ := config.String("type", -1)
 		tempCfg := mapstr.M{}
-		mline := l.getMultiline(h)
-		if len(mline) != 0 {
-			kubernetes.ShouldPut(tempCfg, multiline, mline, l.log)
+
+		if mline := l.getMultiline(h); len(mline) != 0 {
+			if inputType == harvester.FilestreamType {
+				// multiline options should be under multiline parser in filestream input
+				parsersTempCfg := []mapstr.M{}
+				mlineTempCfg := mapstr.M{}
+				kubernetes.ShouldPut(mlineTempCfg, multiline, mline, l.log)
+				parsersTempCfg = append(parsersTempCfg, mlineTempCfg)
+				kubernetes.ShouldPut(tempCfg, parsers, parsersTempCfg, l.log)
+			} else {
+				kubernetes.ShouldPut(tempCfg, multiline, mline, l.log)
+			}
 		}
 		if ilines := l.getIncludeLines(h); len(ilines) != 0 {
 			kubernetes.ShouldPut(tempCfg, includeLines, ilines, l.log)

--- a/filebeat/autodiscover/builder/hints/logs.go
+++ b/filebeat/autodiscover/builder/hints/logs.go
@@ -51,6 +51,8 @@ const (
 	processors   = "processors"
 	json         = "json"
 	pipeline     = "pipeline"
+	ndjson       = "ndjson"
+	parsers      = "parsers"
 )
 
 // validModuleNames to sanitize user input
@@ -115,6 +117,7 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*conf
 			continue
 		}
 
+		inputType, _ := config.String("type", -1)
 		tempCfg := mapstr.M{}
 		mline := l.getMultiline(h)
 		if len(mline) != 0 {
@@ -136,15 +139,24 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*conf
 		}
 
 		if jsonOpts := l.getJSONOptions(h); len(jsonOpts) != 0 {
-			kubernetes.ShouldPut(tempCfg, json, jsonOpts, l.log)
+			if inputType == harvester.FilestreamType {
+				// json options should be under ndjson parser in filestream input
+				parsersTempCfg := []mapstr.M{}
+				ndjsonTempCfg := mapstr.M{}
+				kubernetes.ShouldPut(ndjsonTempCfg, ndjson, jsonOpts, l.log)
+				parsersTempCfg = append(parsersTempCfg, ndjsonTempCfg)
+				kubernetes.ShouldPut(tempCfg, parsers, parsersTempCfg, l.log)
+			} else {
+				kubernetes.ShouldPut(tempCfg, json, jsonOpts, l.log)
+			}
+
 		}
 		// Merge config template with the configs from the annotations
 		// AppendValues option is used to append arrays from annotations to existing arrays while merging
 		if err := config.MergeWithOpts(tempCfg, ucfg.AppendValues); err != nil {
-			logp.Debug("hints.builder", "config merge failed with error: %v", err)
+			l.log.Debugf("hints.builder", "config merge failed with error: %v", err)
 			continue
 		}
-
 		module := l.getModule(hints)
 		if module != "" {
 			moduleConf := map[string]interface{}{
@@ -154,9 +166,17 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*conf
 			filesets := l.getFilesets(hints, module)
 			for fileset, cfg := range filesets {
 				filesetConf, _ := conf.NewConfigFrom(config)
-
-				if inputType, _ := filesetConf.String("type", -1); inputType == harvester.ContainerType {
+				if inputType == harvester.ContainerType {
 					_ = filesetConf.SetString("stream", -1, cfg.Stream)
+				} else if inputType == harvester.FilestreamType {
+					filestreamContainerParser := map[string]interface{}{
+						"container": map[string]interface{}{
+							"stream": cfg.Stream,
+							"format": "auto",
+						},
+					}
+					parserCfg, _ := conf.NewConfigFrom(filestreamContainerParser)
+					_ = filesetConf.SetChild("parsers", 0, parserCfg)
 				} else {
 					_ = filesetConf.SetString("containers.stream", -1, cfg.Stream)
 				}
@@ -164,14 +184,13 @@ func (l *logHints) CreateConfig(event bus.Event, options ...ucfg.Option) []*conf
 				moduleConf[fileset+".enabled"] = cfg.Enabled
 				moduleConf[fileset+".input"] = filesetConf
 
-				logp.Debug("hints.builder", "generated config %+v", moduleConf)
+				l.log.Debugf("hints.builder", "generated config %+v", moduleConf)
 			}
 			config, _ = conf.NewConfigFrom(moduleConf)
 		}
-		logp.Debug("hints.builder", "generated config %+v", config)
+		l.log.Debugf("hints.builder", "generated config %+v of logHints %+v", config, l)
 		configs = append(configs, config)
 	}
-
 	// Apply information in event to the template to generate the final config
 	return template.ApplyConfigTemplate(event, configs)
 }
@@ -222,7 +241,7 @@ func (l *logHints) getFilesets(hints mapstr.M, module string) map[string]*filese
 
 	moduleFilesets, err := l.registry.ModuleAvailableFilesets(module)
 	if err != nil {
-		logp.Err("Error retrieving module filesets: %+v", err)
+		l.log.Errorf("Error retrieving module filesets: %+v", err)
 		return nil
 	}
 

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -95,8 +95,22 @@ func TestGenerateHints(t *testing.T) {
 			len: 1,
 			result: []mapstr.M{
 				{
-					"paths": []interface{}{"/var/lib/docker/containers/abc/*-json.log"},
-					"type":  "container",
+					"id":    "kubernetes-container-logs-abc",
+					"paths": []interface{}{"/var/log/containers/*-abc.log"},
+					"parsers": []interface{}{
+						map[string]interface{}{
+							"container": map[string]interface{}{
+								"format": "auto",
+								"stream": "all",
+							},
+						},
+					},
+					"prospector": map[string]interface{}{
+						"scanner": map[string]interface{}{
+							"symlinks": true,
+						},
+					},
+					"type": "filestream",
 				},
 			},
 		},
@@ -144,9 +158,23 @@ func TestGenerateHints(t *testing.T) {
 			len: 1,
 			result: []mapstr.M{
 				{
-					"type":          "container",
-					"paths":         []interface{}{"/var/lib/docker/containers/abc/*-json.log"},
+					"id":    "kubernetes-container-logs-abc",
+					"paths": []interface{}{"/var/log/containers/*-abc.log"},
+					"parsers": []interface{}{
+						map[string]interface{}{
+							"container": map[string]interface{}{
+								"format": "auto",
+								"stream": "all",
+							},
+						},
+					},
+					"prospector": map[string]interface{}{
+						"scanner": map[string]interface{}{
+							"symlinks": true,
+						},
+					},
 					"exclude_lines": []interface{}{"^test2", "^test3"},
+					"type":          "filestream",
 				},
 			},
 		},
@@ -643,21 +671,43 @@ func TestGenerateHints(t *testing.T) {
 					"error": map[string]interface{}{
 						"enabled": true,
 						"input": map[string]interface{}{
-							"type":   "container",
-							"stream": "all",
-							"paths": []interface{}{
-								"/var/lib/docker/containers/abc/*-json.log",
+							"id":    "kubernetes-container-logs-abc",
+							"paths": []interface{}{"/var/log/containers/*-abc.log"},
+							"parsers": []interface{}{
+								map[string]interface{}{
+									"container": map[string]interface{}{
+										"format": "auto",
+										"stream": "all",
+									},
+								},
 							},
+							"prospector": map[string]interface{}{
+								"scanner": map[string]interface{}{
+									"symlinks": true,
+								},
+							},
+							"type": "filestream",
 						},
 					},
 					"access": map[string]interface{}{
 						"enabled": true,
 						"input": map[string]interface{}{
-							"type":   "container",
-							"stream": "all",
-							"paths": []interface{}{
-								"/var/lib/docker/containers/abc/*-json.log",
+							"id":    "kubernetes-container-logs-abc",
+							"paths": []interface{}{"/var/log/containers/*-abc.log"},
+							"parsers": []interface{}{
+								map[string]interface{}{
+									"container": map[string]interface{}{
+										"format": "auto",
+										"stream": "all",
+									},
+								},
 							},
+							"prospector": map[string]interface{}{
+								"scanner": map[string]interface{}{
+									"symlinks": true,
+								},
+							},
+							"type": "filestream",
 						},
 					},
 				},
@@ -692,21 +742,43 @@ func TestGenerateHints(t *testing.T) {
 					"access": map[string]interface{}{
 						"enabled": true,
 						"input": map[string]interface{}{
-							"type":   "container",
-							"stream": "all",
-							"paths": []interface{}{
-								"/var/lib/docker/containers/abc/*-json.log",
+							"id":    "kubernetes-container-logs-abc",
+							"paths": []interface{}{"/var/log/containers/*-abc.log"},
+							"parsers": []interface{}{
+								map[string]interface{}{
+									"container": map[string]interface{}{
+										"format": "auto",
+										"stream": "all",
+									},
+								},
 							},
+							"prospector": map[string]interface{}{
+								"scanner": map[string]interface{}{
+									"symlinks": true,
+								},
+							},
+							"type": "filestream",
 						},
 					},
 					"error": map[string]interface{}{
 						"enabled": false,
 						"input": map[string]interface{}{
-							"type":   "container",
-							"stream": "all",
-							"paths": []interface{}{
-								"/var/lib/docker/containers/abc/*-json.log",
+							"id":    "kubernetes-container-logs-abc",
+							"paths": []interface{}{"/var/log/containers/*-abc.log"},
+							"parsers": []interface{}{
+								map[string]interface{}{
+									"container": map[string]interface{}{
+										"format": "auto",
+										"stream": "all",
+									},
+								},
 							},
+							"prospector": map[string]interface{}{
+								"scanner": map[string]interface{}{
+									"symlinks": true,
+								},
+							},
+							"type": "filestream",
 						},
 					},
 				},
@@ -742,21 +814,43 @@ func TestGenerateHints(t *testing.T) {
 					"access": map[string]interface{}{
 						"enabled": true,
 						"input": map[string]interface{}{
-							"type":   "container",
-							"stream": "stdout",
-							"paths": []interface{}{
-								"/var/lib/docker/containers/abc/*-json.log",
+							"id":    "kubernetes-container-logs-abc",
+							"paths": []interface{}{"/var/log/containers/*-abc.log"},
+							"parsers": []interface{}{
+								map[string]interface{}{
+									"container": map[string]interface{}{
+										"format": "auto",
+										"stream": "stdout",
+									},
+								},
 							},
+							"prospector": map[string]interface{}{
+								"scanner": map[string]interface{}{
+									"symlinks": true,
+								},
+							},
+							"type": "filestream",
 						},
 					},
 					"error": map[string]interface{}{
 						"enabled": true,
 						"input": map[string]interface{}{
-							"type":   "container",
-							"stream": "stderr",
-							"paths": []interface{}{
-								"/var/lib/docker/containers/abc/*-json.log",
+							"id":    "kubernetes-container-logs-abc",
+							"paths": []interface{}{"/var/log/containers/*-abc.log"},
+							"parsers": []interface{}{
+								map[string]interface{}{
+									"container": map[string]interface{}{
+										"format": "auto",
+										"stream": "stderr",
+									},
+								},
 							},
+							"prospector": map[string]interface{}{
+								"scanner": map[string]interface{}{
+									"symlinks": true,
+								},
+							},
+							"type": "filestream",
 						},
 					},
 				},

--- a/filebeat/autodiscover/builder/hints/logs_test.go
+++ b/filebeat/autodiscover/builder/hints/logs_test.go
@@ -63,9 +63,15 @@ func TestGenerateHints(t *testing.T) {
 
 	customFilestreamCfg := conf.MustNewConfigFrom(map[string]interface{}{
 		"default_config": map[string]interface{}{
-			"type":                        "filestream",
-			"id":                          "kubernetes-container-logs-${data.kubernetes.container.id}",
-			"prospector.scanner.symlinks": true,
+			"type": "filestream",
+			"id":   "kubernetes-container-logs-${data.kubernetes.container.id}",
+			"prospector": map[string]interface{}{
+				"scanner": map[string]interface{}{
+					"fingerprint.enabled": true,
+					"symlinks":            true,
+				},
+			},
+			"file_identity.fingerprint": nil,
 			"paths": []string{
 				"/var/log/containers/*-${data.kubernetes.container.id}.log",
 			},
@@ -127,7 +133,13 @@ func TestGenerateHints(t *testing.T) {
 					"prospector": map[string]interface{}{
 						"scanner": map[string]interface{}{
 							"symlinks": true,
+							"fingerprint": map[string]interface{}{
+								"enabled": true,
+							},
 						},
+					},
+					"file_identity": map[string]interface{}{
+						"fingerprint": nil,
 					},
 					"type": "filestream",
 				},
@@ -190,7 +202,13 @@ func TestGenerateHints(t *testing.T) {
 					"prospector": map[string]interface{}{
 						"scanner": map[string]interface{}{
 							"symlinks": true,
+							"fingerprint": map[string]interface{}{
+								"enabled": true,
+							},
 						},
+					},
+					"file_identity": map[string]interface{}{
+						"fingerprint": nil,
 					},
 					"exclude_lines": []interface{}{"^test2", "^test3"},
 					"type":          "filestream",
@@ -416,7 +434,13 @@ func TestGenerateHints(t *testing.T) {
 					"prospector": map[string]interface{}{
 						"scanner": map[string]interface{}{
 							"symlinks": true,
+							"fingerprint": map[string]interface{}{
+								"enabled": true,
+							},
 						},
+					},
+					"file_identity": map[string]interface{}{
+						"fingerprint": nil,
 					},
 					"type": "filestream",
 				},
@@ -468,7 +492,13 @@ func TestGenerateHints(t *testing.T) {
 					"prospector": map[string]interface{}{
 						"scanner": map[string]interface{}{
 							"symlinks": true,
+							"fingerprint": map[string]interface{}{
+								"enabled": true,
+							},
 						},
+					},
+					"file_identity": map[string]interface{}{
+						"fingerprint": nil,
 					},
 					"type": "filestream",
 				},
@@ -854,7 +884,13 @@ func TestGenerateHints(t *testing.T) {
 							"prospector": map[string]interface{}{
 								"scanner": map[string]interface{}{
 									"symlinks": true,
+									"fingerprint": map[string]interface{}{
+										"enabled": true,
+									},
 								},
+							},
+							"file_identity": map[string]interface{}{
+								"fingerprint": nil,
 							},
 							"type": "filestream",
 						},
@@ -875,7 +911,13 @@ func TestGenerateHints(t *testing.T) {
 							"prospector": map[string]interface{}{
 								"scanner": map[string]interface{}{
 									"symlinks": true,
+									"fingerprint": map[string]interface{}{
+										"enabled": true,
+									},
 								},
+							},
+							"file_identity": map[string]interface{}{
+								"fingerprint": nil,
 							},
 							"type": "filestream",
 						},
@@ -925,7 +967,13 @@ func TestGenerateHints(t *testing.T) {
 							"prospector": map[string]interface{}{
 								"scanner": map[string]interface{}{
 									"symlinks": true,
+									"fingerprint": map[string]interface{}{
+										"enabled": true,
+									},
 								},
+							},
+							"file_identity": map[string]interface{}{
+								"fingerprint": nil,
 							},
 							"type": "filestream",
 						},
@@ -946,7 +994,13 @@ func TestGenerateHints(t *testing.T) {
 							"prospector": map[string]interface{}{
 								"scanner": map[string]interface{}{
 									"symlinks": true,
+									"fingerprint": map[string]interface{}{
+										"enabled": true,
+									},
 								},
+							},
+							"file_identity": map[string]interface{}{
+								"fingerprint": nil,
 							},
 							"type": "filestream",
 						},
@@ -997,7 +1051,13 @@ func TestGenerateHints(t *testing.T) {
 							"prospector": map[string]interface{}{
 								"scanner": map[string]interface{}{
 									"symlinks": true,
+									"fingerprint": map[string]interface{}{
+										"enabled": true,
+									},
 								},
+							},
+							"file_identity": map[string]interface{}{
+								"fingerprint": nil,
 							},
 							"type": "filestream",
 						},
@@ -1018,7 +1078,13 @@ func TestGenerateHints(t *testing.T) {
 							"prospector": map[string]interface{}{
 								"scanner": map[string]interface{}{
 									"symlinks": true,
+									"fingerprint": map[string]interface{}{
+										"enabled": true,
+									},
 								},
+							},
+							"file_identity": map[string]interface{}{
+								"fingerprint": nil,
 							},
 							"type": "filestream",
 						},

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -2,7 +2,7 @@
 hints in Kubernetes Pod annotations or Docker labels that have the prefix `co.elastic.logs`. As soon as
 the container starts, {beatname_uc} will check if it contains any hints and launch the proper config for
 it. Hints tell {beatname_uc} how to get logs for the given container. By default logs will be retrieved
-from the container using the `container` input. You can use hints to modify this behavior. This is the full
+from the container using the `filestream` input. You can use hints to modify this behavior. This is the full
 list of supported hints:
 
 [float]
@@ -23,7 +23,32 @@ Multiline settings. See <<multiline-examples>> for a full list of all supported 
 [float]
 ===== `co.elastic.logs/json.*`
 
-JSON settings. See <<filebeat-input-log-config-json>> for a full list of all supported options.
+JSON settings. In case of `filestream` input(default) see <<filebeat-input-filestream-ndjson>> for a full list of all supported options.
+In case of `container` or `log` input see <<filebeat-input-log-config-json>> for a full list of all supported options.
+
+For example, the following hints with json options:
+[source,yaml]
+-----
+co.elastic.logs/json.message_key: "log"
+co.elastic.logs/json.add_error_key: "true"
+-----
+will lead to the following input configuration:
+* `filestream`
+[source,yaml]
+-----
+parsers:
+  - ndjson:
+      message_key: "log"
+      add_error_key: "true"
+-----
+* `log`
+[source,yaml]
+-----
+json.message_key: "log"
+json.add_error_key: "true"
+-----
+
+NOTE: `keys_under_root` json option of `log` input is replace with `target` in filestream input. Read the documentation on how to use it correctly.
 
 [float]
 ===== `co.elastic.logs/include_lines`

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -50,7 +50,7 @@ json.message_key: "log"
 json.add_error_key: "true"
 -----
 
-NOTE: `keys_under_root` json option of `log` input is replaced with `target` option in filestream input. Read the documentation on how to use it correctly.
+NOTE: `keys_under_root` json option of `log` input is replaced with `target` option in filestream input. Read the documentation(<<filebeat-input-filestream-ndjson>>) on how to use it correctly.
 
 [float]
 ===== `co.elastic.logs/include_lines`

--- a/filebeat/docs/autodiscover-hints.asciidoc
+++ b/filebeat/docs/autodiscover-hints.asciidoc
@@ -33,6 +33,7 @@ co.elastic.logs/json.message_key: "log"
 co.elastic.logs/json.add_error_key: "true"
 -----
 will lead to the following input configuration:
+
 * `filestream`
 [source,yaml]
 -----
@@ -41,6 +42,7 @@ parsers:
       message_key: "log"
       add_error_key: "true"
 -----
+
 * `log`
 [source,yaml]
 -----
@@ -48,7 +50,7 @@ json.message_key: "log"
 json.add_error_key: "true"
 -----
 
-NOTE: `keys_under_root` json option of `log` input is replace with `target` in filestream input. Read the documentation on how to use it correctly.
+NOTE: `keys_under_root` json option of `log` input is replaced with `target` option in filestream input. Read the documentation on how to use it correctly.
 
 [float]
 ===== `co.elastic.logs/include_lines`

--- a/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
+++ b/filebeat/docs/inputs/input-filestream-reader-options.asciidoc
@@ -182,6 +182,7 @@ multiple lines. See <<multiline-examples>> for more information about
 configuring multiline options.
 
 [float]
+[id="{beatname_lc}-input-{type}-ndjson"]
 ===== `ndjson`
 
 These options make it possible for {beatname_uc} to decode logs structured as

--- a/filebeat/harvester/util.go
+++ b/filebeat/harvester/util.go
@@ -21,12 +21,13 @@ import "github.com/elastic/beats/v7/libbeat/common/match"
 
 // Contains available input types
 const (
-	LogType       = "log"
-	StdinType     = "stdin"
-	RedisType     = "redis"
-	UdpType       = "udp"
-	DockerType    = "docker"
-	ContainerType = "container"
+	LogType        = "log"
+	StdinType      = "stdin"
+	RedisType      = "redis"
+	UdpType        = "udp"
+	DockerType     = "docker"
+	ContainerType  = "container"
+	FilestreamType = "filestream"
 )
 
 // MatchAny checks if the text matches any of the regular expressions


### PR DESCRIPTION
## What does this PR do

This PR is the code resolution of https://github.com/elastic/beats/issues/35984 issue.

1. It updates filebeat hints autodiscover config and the proposed filebeat k8s manifest(`filebeat-kubernetes.yml`) to use `filestream` input instead of `container` input for the `hints.default_config`

2. It allows to continue to use the same co.elastic.logs/* hints inside pods' annotations by
 - mapping `co.elastic.logs/json*` hints to the ndjson parser in case of filestream.
 - mapping `co.elastic.logs/multiline*` hints to the multiline parser in case of filestream.
 

User can still choose `container` input in `hints.default_config`. Everything will work as they used to in that case.

## Example

User has the following filebeat.yml configuration with hints autodiscover enabled and filestream set as hints.default_config

```yaml

filebeat.yml: |-
    # To enable hints based autodiscover, remove `filebeat.inputs` configuration and uncomment this:
    filebeat.autodiscover:
     providers:
       - type: kubernetes
         node: ${NODE_NAME}
         hints.enabled: true
         hints.default_config:
           type: filestream
           prospector.scanner.symlinks: true
           id: kubernetes-container-logs-${data.kubernetes.pod.name}-${data.kubernetes.container.id}
           paths:
           - /var/log/containers/*-${data.kubernetes.container.id}.log
           parsers:
           - container: ~
```

User sets the following hints in the Filebeat pods' annotations
```yaml

apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: filebeat
  namespace: kube-system
  labels:
    k8s-app: filebeat
spec:
  selector:
    matchLabels:
      k8s-app: filebeat
  template:
    metadata:
      labels:
        k8s-app: filebeat
      annotations:
        co.elastic.logs/json.target: "json"
        co.elastic.logs/processors.add_fields.target: "project"
        co.elastic.logs/processors.add_fields.fields.name: "myproject"
        co.elastic.logs/json.message_key: "foo"
        co.elastic.logs/multline.pattern: "^test"
```

The produced configuration for filebeat pod should look like this:
```yaml

type: filestream
prospector.scanner.symlinks: true
id: kubernetes-container-logs-filebeat-29472-2495909b94a1567459717d.log
paths:
 - /var/log/containers/*-2495909b94a1567459717d.log
parsers:
- container: ~
- ndjson:
     target: "json"
     message_key: "foo"
- multiline:
     pattern: "^test"
processors:
- add_fields:
      target: project
      fields:
        name: myproject   
```

**IMPORTANT NOTE:**
**Due to the default input type change , a user already running filebeat using container input will experience filebeat state loss. This will lead to all the available files at that moment to be re ingested.**

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


## How to test this PR locally

1. Checkout to this PR
2. Create kind kubernetes cluster
3. `PLATFORMS=linux/amd64 TYPES=docker mage package`
4.  `cd build/package/filebeat-oss/filebeat-oss-linux-amd64.docker/docker-build && docker build -t myfilebeat .`
5.  `kind load docker-image  myfilebeat`
6. Configure `beats/deploy/kubernetes/filebeat-kubernetes.yaml` as in example section.
7. `kubectl apply -f beats/deploy/kubernetes/filebeat-kubernetes.yaml`
8. Check in Kibana discover that json parsers and/or processors defined in hints work as expected


<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates #35984

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<img width="1786" alt="json parser" src="https://github.com/elastic/beats/assets/26270880/e030c3f4-505b-4283-960c-016f666e1576">

<img width="1777" alt="processor" src="https://github.com/elastic/beats/assets/26270880/07ea5154-9b8e-4025-af5f-7b290204c91b">


<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->


