### PR TITLE
Optimize memory allocations in the event processing pipeline

### DIFF
--- a/libbeat/beat/event_editor.go
+++ b/libbeat/beat/event_editor.go
@@ -1,0 +1,707 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beat
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+type checkoutMode bool
+
+var (
+	checkoutModeOnlyMaps      checkoutMode = false
+	checkoutModeIncludeValues checkoutMode = true
+)
+
+type EventError struct {
+	Message   string
+	Field     string
+	Data      string
+	Processor string
+}
+
+func (e EventError) Error() string {
+	var prefix string
+	if e.Processor != "" {
+		prefix += fmt.Sprintf("[processor=%s] ", e.Processor)
+	}
+
+	if e.Field != "" {
+		prefix += fmt.Sprintf("[field=%q] ", e.Field)
+	}
+
+	if e.Data != "" {
+		prefix += fmt.Sprintf("[data=%s] ", e.Data)
+	}
+	return prefix + e.Message
+}
+
+func (e EventError) toMap() mapstr.M {
+	m := mapstr.M{
+		"message": e.Message,
+	}
+	if e.Data != "" {
+		m["data"] = e.Data
+	}
+	if e.Field != "" {
+		m["field"] = e.Field
+	}
+	if e.Processor != "" {
+		m["processor"] = e.Processor
+	}
+
+	return m
+}
+
+// EventEditor is a wrapper that allows to make changes to the wrapped event
+// preserving states of the original nested maps by cloning them on demand.
+//
+// The first time a nested map gets updated it's cloned and, from that moment on, only the copy is modified.
+// Once all the changes are collected, users can call `Apply` to apply pending changes to the original event.
+// When the changes get applied the pointers to originally referenced nested maps get replaced with pointers to
+// modified copies.
+//
+// This allows us to:
+// * avoid cloning the entire event and be more efficient in memory management
+// * collect multiple changes and apply them at once, using a transaction-like mechanism (`Apply`/`Reset` functions).
+//
+// WARNING:
+// Events can contains slices which this editor does not preserve.
+// It's on the consumer to copy slices if they need to be changed.
+// This editor takes care of maps only, not looking into slices. This means maps in slices are not preserved either.
+type EventEditor struct {
+	original  *Event
+	pending   *Event
+	deletions map[string]struct{}
+}
+
+// NewEventEditor creates a new event editor for the given event.
+func NewEventEditor(e *Event) *EventEditor {
+	if e == nil {
+		e = &Event{}
+	}
+	return &EventEditor{
+		original: e,
+	}
+}
+
+// Fields returns the current computed state of changes without applying any changes to the original event.
+//
+// This function is cloning all the fields from the original event.
+// Using this function is slow and expensive on memory, try not to use it unless it's absolutely necessary.
+func (e *EventEditor) Fields() mapstr.M {
+	if e.original.Fields == nil {
+		if e.pending.Fields != nil {
+			return e.pending.Fields.Clone()
+		}
+		return mapstr.M{}
+	}
+	fields := e.original.Fields.Clone()
+	for key := range e.deletions {
+		_ = fields.Delete(key)
+	}
+	if e.pending != nil {
+		fields.DeepUpdate(e.pending.Fields)
+	}
+	return fields
+}
+
+// FlattenKeys returns all flatten keys for the current pending state of the event.
+// This includes original undeleted keys and new unapplied keys.
+func (e *EventEditor) FlattenKeys() []string {
+	uniqueKeys := make(map[string]struct{})
+
+	if e.original.Meta != nil {
+		for _, key := range *e.original.Meta.FlattenKeys() {
+			if e.checkDeleted(key) {
+				continue
+			}
+			uniqueKeys[metadataKeyPrefix+key] = struct{}{}
+		}
+	}
+	if e.original.Fields != nil {
+		for _, key := range *e.original.Fields.FlattenKeys() {
+			if e.checkDeleted(key) {
+				continue
+			}
+			uniqueKeys[key] = struct{}{}
+		}
+	}
+
+	if e.pending != nil {
+		if e.pending.Meta != nil {
+			for _, key := range *e.pending.Meta.FlattenKeys() {
+				uniqueKeys[metadataKeyPrefix+key] = struct{}{}
+			}
+		}
+		if e.pending.Fields != nil {
+			for _, key := range *e.pending.Fields.FlattenKeys() {
+				uniqueKeys[key] = struct{}{}
+			}
+		}
+	}
+
+	result := make([]string, 0, len(uniqueKeys))
+	for key := range uniqueKeys {
+		result = append(result, key)
+	}
+	return result
+}
+
+// GetValue gets a value from the event. The key can be expressed in dot-notation (e.g. x.y).
+// If the key does not exist then `mapstr.ErrKeyNotFound` error is returned.
+//
+// If the returned value is a nested map this function always returns a copy,
+// not the same nested map referenced by the original event.
+func (e *EventEditor) GetValue(key string) (interface{}, error) {
+	if key == "" {
+		return nil, mapstr.ErrKeyNotFound
+	}
+	if key == MetadataFieldKey {
+		return nil, ErrMetadataAccess
+	}
+
+	rootKey := e.rootKey(key)
+
+	if e.pending != nil {
+		// if the root key is empty the original event never had this key
+		if rootKey == "" {
+			return e.pending.GetValue(key)
+		}
+		// We try to retrieve from the `pending` event first,
+		// since it should have the most recent data.
+		//
+		// To check if the nested map was checked-out before
+		// we need to get the root-level first.
+		val, err := e.pending.GetValue(rootKey)
+		// if the key was found, it was either created by PutValue or
+		// checked out from the original event.
+		if err == nil {
+			if rootKey == key {
+				// the value might be the root-level end value we're looking for
+				return val, nil
+			} else {
+				// otherwise, we need to retrieve from the nested map
+				subKey := key[len(rootKey)+1:]
+				switch nested := val.(type) {
+				case mapstr.M:
+					return nested.GetValue(subKey)
+				case map[string]interface{}:
+					return mapstr.M(nested).GetValue(subKey)
+				default:
+					return nil, mapstr.ErrKeyNotFound
+				}
+			}
+		}
+
+		if !errors.Is(err, mapstr.ErrKeyNotFound) {
+			return nil, err
+		}
+	}
+
+	// handle the deletion marks but only on the root-level
+	// the rest should be covered by looking into the pending event
+	// where we check out all the nested maps.
+	if rootKey == key && e.checkDeleted(key) {
+		return nil, mapstr.ErrKeyNotFound
+	}
+
+	// in case the key was never checked out and it's still
+	// present only in the original event
+	value, err := e.original.GetValue(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// if the end value is not a map, we can just return it,
+	// value types will be copied automatically
+	switch value.(type) {
+	case mapstr.M, map[string]interface{}:
+	default:
+		return value, nil
+	}
+
+	// if the key leads to a map value or it's in a nested map,
+	// we must check it out before returning, so we return a clone
+	// that the consumer can modify
+	e.checkout(key, checkoutModeOnlyMaps)
+
+	return e.pending.GetValue(key)
+}
+
+// PutValue associates the specified value with the specified key. If the event
+// previously contained a mapping for the key, the old value is replaced and
+// returned. The key can be expressed in dot-notation (e.g. x.y) to put a value
+// into a nested map.
+//
+// If the returned previous value is a nested map this function always returns a copy,
+// not the same nested map referenced by the original event.
+//
+// This changed is not applied to the original event until `Apply` is called.
+func (e *EventEditor) PutValue(key string, v interface{}) (interface{}, error) {
+	switch key {
+	case MetadataFieldKey:
+		return nil, ErrAlterMetadataKey
+	case TimestampFieldKey:
+		e.allocatePending()
+		return e.pending.PutValue(key, v)
+	default:
+		e.allocatePending()
+		// checkout only if the key leads to a nested value
+		if !e.checkDeleted(key) {
+			e.checkout(key, checkoutModeIncludeValues)
+		}
+
+		return e.pending.PutValue(key, v)
+	}
+}
+
+// Delete value with the given key.
+// The key can be expressed in dot-notation (e.g. x.y)
+//
+// This changed is not applied to the original event until `Apply` is called.
+func (e *EventEditor) Delete(key string) error {
+	if key == TimestampFieldKey {
+		return ErrDeleteTimestamp
+	}
+	if key == MetadataFieldKey {
+		return ErrAlterMetadataKey
+	}
+	var deleted bool
+	has, _ := e.original.HasKey(key)
+	if has {
+		rootKey := e.rootKey(key)
+		if key == rootKey {
+			// if we're trying to delete a root-level key
+			// it must be deleted from the `original` event when `Apply` is called
+			// and from the `pending` event (below) if a value with the same key was put there.
+			e.markAsDeleted(rootKey)
+			deleted = true
+		} else {
+			// if it's not a root-level key, we checkout this entire root-level map
+			// and delete from the copy in `pending` event instead.
+			e.checkout(rootKey, checkoutModeOnlyMaps)
+		}
+	}
+
+	if e.pending != nil {
+		err := e.pending.Delete(key)
+		deleted = deleted || err == nil
+	}
+
+	if deleted {
+		return nil
+	} else {
+		return mapstr.ErrKeyNotFound
+	}
+}
+
+// DeleteAll marks all data to be deleted from the event when `Apply` is called.
+func (e *EventEditor) DeleteAll() {
+	// reset all the changes because
+	// they don't make sense anymore
+	e.Reset()
+	// now we mark all root level keys for deletion
+	// in both `Meta` and `Fields` maps of the original event
+	if e.original.Meta != nil {
+		for key := range e.original.Meta {
+			e.markAsDeleted(metadataKeyPrefix + key)
+		}
+	}
+	if e.original.Fields != nil {
+		for key := range e.original.Fields {
+			e.markAsDeleted(key)
+		}
+	}
+}
+
+// DeepUpdate recursively copies the key-value pairs from `d` to various properties of the event.
+// When the key equals `@timestamp` it's set as the `Timestamp` property of the event.
+// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`
+// The rest of the keys are set to the `Fields` map.
+// If the key is present and the value is a map as well, the sub-map will be updated recursively
+// via `DeepUpdate`.
+// `DeepUpdateNoOverwrite` is a version of this function that does not
+// overwrite existing values.
+func (e *EventEditor) DeepUpdate(d mapstr.M) { e.deepUpdate(d, updateModeOverwrite) }
+
+// DeepUpdateNoOverwrite recursively copies the key-value pairs from `d` to various properties of the event.
+// The `@timestamp` update is ignored due to "no overwrite" behavior.
+// When the key equals `@metadata` the update is routed into the `Meta` map instead of `Fields`.
+// The rest of the keys are set to the `Fields` map.
+// If the key is present and the value is a map as well, the sub-map will be updated recursively
+// via `DeepUpdateNoOverwrite`.
+// `DeepUpdate` is a version of this function that overwrites existing values.
+func (e *EventEditor) DeepUpdateNoOverwrite(d mapstr.M) { e.deepUpdate(d, updateModeNoOverwrite) }
+
+// Apply write all the changes to the original event making sure that none of the original
+// nested maps are modified but replaced with modified copies.
+func (e *EventEditor) Apply() {
+	defer e.Reset()
+
+	for deletedKey := range e.deletions {
+		_ = e.original.Delete(deletedKey)
+	}
+
+	if e.pending == nil {
+		return
+	}
+
+	e.original.Timestamp = e.pending.Timestamp
+
+	// it's enough to overwrite the root-level because
+	// of the checkout mechanism used earlier
+	if len(e.pending.Meta) > 0 {
+		if e.original.Meta == nil {
+			e.original.Meta = mapstr.M{}
+		}
+		for key := range e.pending.Meta {
+			e.original.Meta[key] = e.pending.Meta[key]
+		}
+	}
+	if len(e.pending.Fields) > 0 {
+		if e.original.Fields == nil {
+			e.original.Fields = mapstr.M{}
+		}
+		for key := range e.pending.Fields {
+			e.original.Fields[key] = e.pending.Fields[key]
+		}
+	}
+}
+
+// Reset cleans all the pending changes and starts collecting them again.
+// This function does not allocate new memory.
+func (e *EventEditor) Reset() {
+	if e.pending == nil {
+		return
+	}
+	e.pending.Timestamp = e.original.Timestamp
+	for k := range e.deletions {
+		delete(e.deletions, k)
+	}
+	for k := range e.pending.Meta {
+		delete(e.pending.Meta, k)
+	}
+	for k := range e.pending.Fields {
+		delete(e.pending.Fields, k)
+	}
+}
+
+// AddTags appends a tag to the tags field of the event. If the tags field does not
+// exist then it will be created. If the tags field exists and is not a []string
+// then an error will be returned. It does not deduplicate the list of tags.
+func (e *EventEditor) AddTags(tags ...string) error {
+	return e.AddTagsWithKey(mapstr.TagsKey, tags...)
+}
+
+// AddTagsWithKey appends a tag to the given field of the event. If the tags field does not
+// exist then it will be created. If the tags field exists and is not a []string
+// then an error will be returned. It does not deduplicate the list of tags.
+func (e *EventEditor) AddTagsWithKey(key string, tags ...string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+	e.checkout(key, checkoutModeIncludeValues)
+	e.allocatePending()
+	if e.pending.Fields == nil {
+		e.pending.Fields = mapstr.M{}
+	}
+	return mapstr.AddTagsWithKey(e.pending.Fields, key, tags)
+}
+
+// AddError appends an error to the event. If the error field does not
+// exist then it will be created.
+// If the error field exists and another error was already set, it will be converted to a list
+// of errors and new errors will be appended there.
+// If there is only one error to add, it will be added directly without a list.
+func (e *EventEditor) AddError(ee ...EventError) {
+	if len(ee) == 0 {
+		return
+	}
+	e.checkout(ErrorFieldKey, checkoutModeIncludeValues)
+	e.allocatePending()
+	if e.pending.Fields == nil {
+		e.pending.Fields = mapstr.M{}
+	}
+
+	var list []mapstr.M
+	val, err := e.pending.Fields.GetValue(ErrorFieldKey)
+	// if the value does not exist yet, we initialize the list of errors
+	// with the size of the current arguments.
+	if errors.Is(err, mapstr.ErrKeyNotFound) {
+		list = make([]mapstr.M, 0, len(ee))
+	} else if err != nil {
+		return
+	}
+	// if the value already exists, depending on its type
+	// we need to reformat it or just append to an existing list.
+	switch typed := val.(type) {
+	// there was a single error map, should be replaced with a list,
+	// the existing error will become an item on this list
+	case mapstr.M:
+		list = make([]mapstr.M, 0, len(ee)+1)
+		list = append(list, typed)
+	// same as the previous case but typed differently
+	case map[string]interface{}:
+		list = make([]mapstr.M, 0, len(ee)+1)
+		list = append(list, mapstr.M(typed))
+	// some code can assign an error as a string
+	// it's not really expected but we should not lose this value
+	// so, we convert it into a proper error format.
+	case string:
+		list = make([]mapstr.M, 0, len(ee)+1)
+		list = append(list, EventError{Message: typed}.toMap())
+	}
+
+	// after the list is prepared and contains already existing errors
+	// we can start copying the arguments, converting them to maps
+	for _, err := range ee {
+		// an error without a message is not a valid error
+		if err.Message == "" {
+			continue
+		}
+		m := err.toMap()
+		list = append(list, m)
+	}
+
+	// if after all manipulations we still have a single error
+	// we convert it back into a map instead of adding a list
+	if len(list) == 1 {
+		e.pending.Fields[ErrorFieldKey] = list[0]
+	} else {
+		e.pending.Fields[ErrorFieldKey] = list
+	}
+}
+
+// String returns the string representation of the current editor's state.
+// This function is slow and should be used for debugging purposes only.
+func (e *EventEditor) String() string {
+	deleteList := make([]string, 0, len(e.deletions))
+	for key := range e.deletions {
+		deleteList = append(deleteList, key)
+	}
+	m := mapstr.M{
+		"original":  e.original.String(),
+		"pending":   e.pending.String(),
+		"deletions": deleteList,
+	}
+	return m.String()
+}
+
+// deepUpdate checks out all the necessary root-level keys before running the deep update.
+func (e *EventEditor) deepUpdate(d mapstr.M, mode updateMode) {
+	if len(d) == 0 {
+		return
+	}
+	cm := checkoutModeOnlyMaps
+	if mode == updateModeNoOverwrite {
+		cm = checkoutModeIncludeValues
+	}
+
+	// checkout necessary keys from the original event
+	for key := range d {
+		if key == TimestampFieldKey {
+			continue
+		}
+
+		// we never checkout the whole metadata, only root-level keys
+		// which are about to get updated
+		if key == MetadataFieldKey {
+			metaUpdate := d[MetadataFieldKey]
+			switch m := metaUpdate.(type) {
+			case mapstr.M:
+				for innerKey := range m {
+					e.checkout(metadataKeyPrefix+innerKey, cm)
+				}
+			case map[string]interface{}:
+				for innerKey := range m {
+					e.checkout(metadataKeyPrefix+innerKey, cm)
+				}
+			}
+			continue
+		}
+
+		e.checkout(key, cm)
+	}
+
+	e.allocatePending()
+	e.pending.deepUpdate(d, mode)
+}
+
+// markAsDeleted marks a key for deletion when `Apply` is called
+// if it's a root-level key in the original event.
+func (e *EventEditor) markAsDeleted(key string) {
+	if key == TimestampFieldKey {
+		return
+	}
+	rootKey := e.rootKey(key)
+	if e.deletions == nil {
+		e.deletions = make(map[string]struct{})
+	}
+	e.deletions[rootKey] = struct{}{}
+}
+
+// checkout clones a nested map of the original event to the event with pending changes.
+//
+// If the key leads to a value nested in a map, we checkout the root-level nested map which means
+// the whole sub-tree is recursively cloned, so it can be safely modified later.
+func (e *EventEditor) checkout(key string, mode checkoutMode) {
+	if key == TimestampFieldKey {
+		return
+	}
+	// we're always looking only at the root-level
+	rootKey := e.rootKey(key)
+	// if the key is not in the original map, the value is empty
+	if rootKey == "" {
+		return
+	}
+
+	e.allocatePending()
+
+	var dstMap, srcMap mapstr.M
+	if strings.HasPrefix(rootKey, metadataKeyPrefix) {
+		if e.original.Meta == nil {
+			return
+		}
+		if e.pending.Meta == nil {
+			e.pending.Meta = mapstr.M{}
+		}
+		dstMap = e.pending.Meta
+		srcMap = e.original.Meta
+		rootKey = rootKey[metadataKeyOffset:]
+	} else {
+		if e.original.Fields == nil {
+			return
+		}
+		if e.pending.Fields == nil {
+			e.pending.Fields = mapstr.M{}
+		}
+		dstMap = e.pending.Fields
+		srcMap = e.original.Fields
+	}
+
+	// it might be already checked out
+	_, checkedOut := dstMap[rootKey]
+	if checkedOut {
+		return
+	}
+
+	// if there is nothing to checkout - return
+	value, exists := srcMap[rootKey]
+	if !exists {
+		return
+	}
+
+	// we check out only nested maps, and leave root-level value types in the original map
+	// unless the special `includeValues` mode engaged (used for DeepUpdateNoOverwrite).
+	switch typedVal := value.(type) {
+	case mapstr.M:
+		dstMap[rootKey] = typedVal.Clone()
+	case map[string]interface{}:
+		dstMap[rootKey] = mapstr.M(typedVal).Clone()
+		// TODO slices?
+	default:
+		if mode == checkoutModeIncludeValues {
+			dstMap[rootKey] = typedVal
+		}
+	}
+}
+
+// rootKey reduces the key of the original event to its root-level.
+// Keys may have `.` character in them on every level and `.` can also mean a nested depth.
+//
+// Accounts for the `@metadata` subkeys, since it's stored in a separate map,
+// root-level keys will be in the `@metadata.*` namespace.
+//
+// Returns empty string if the key does not exist in the original event.
+func (e *EventEditor) rootKey(key string) string {
+	if key == TimestampFieldKey {
+		return key
+	}
+	var (
+		prefix string
+		m      mapstr.M
+	)
+
+	if strings.HasPrefix(key, metadataKeyPrefix) {
+		prefix = metadataKeyPrefix
+		key = key[metadataKeyOffset:]
+		m = e.original.Meta
+	} else {
+		m = e.original.Fields
+	}
+
+	// there is no root-level key with this name
+	if m == nil {
+		return ""
+	}
+
+	// this key may be simple and does not contain dots
+	dotIdx := strings.IndexRune(key, '.')
+	if dotIdx == -1 {
+		return prefix + key
+	}
+
+	// fast lane for the whole key
+	_, exists := m[key]
+	if exists {
+		return prefix + key
+	}
+
+	// otherwise we start with the first segment
+	// and keep adding the next segment to the key until the resulting value
+	// exists on the root level.
+	var rootKey string
+	for {
+		rootKey = key[:dotIdx]
+		_, exists = m[rootKey]
+		if exists {
+			return prefix + rootKey
+		}
+		dotIdx = strings.IndexRune(key[dotIdx+1:], '.')
+		// we checked above for the full key and it didn't exist,
+		// no need to check again, we return since the key is not found
+		if dotIdx == -1 {
+			return ""
+		}
+		dotIdx += len(rootKey) + 1
+	}
+}
+
+// checkDeleted returns `true` if the key was marked for deletion.
+// The key can be expressed in dot-notation (e.g. x.y) and if the root-level prefix on
+// the key path is deleted the function returns `true`.
+func (e *EventEditor) checkDeleted(key string) bool {
+	rootKey := e.rootKey(key)
+	_, deleted := e.deletions[rootKey]
+	return deleted
+}
+
+// allocatePending makes sure that the `pending` event is allocated for collecting new changes.
+func (e *EventEditor) allocatePending() {
+	if e.pending != nil {
+		return
+	}
+	e.pending = &Event{
+		Timestamp: e.original.Timestamp,
+	}
+}

--- a/libbeat/beat/event_editor_test.go
+++ b/libbeat/beat/event_editor_test.go
@@ -1,0 +1,1334 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beat
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventEditor(t *testing.T) {
+	metadataNestedNestedMap := mapstr.M{
+		"metaLevel2Value": "metavalue3",
+	}
+	metadataNestedMap := mapstr.M{
+		"metaLevel1Map": metadataNestedNestedMap,
+	}
+
+	fieldsNestedNestedMap := mapstr.M{
+		"fieldsLevel2Value": "fieldsvalue3",
+	}
+	fieldsNestedMap := mapstr.M{
+		"fieldsLevel1Map": fieldsNestedNestedMap,
+	}
+
+	metaUntouchedMap := mapstr.M{}
+	fieldsUntouchedMap := mapstr.M{}
+
+	event := &Event{
+		Timestamp: time.Now(),
+		Meta: mapstr.M{
+			"a.b":             "c",
+			"metaLevel0Map":   metadataNestedMap,
+			"metaLevel0Value": "metavalue1",
+			// this key should never be edited by the tests
+			// to verify that existing keys remain
+			"metaLevel0Value2": "untouched",
+			// this map should never be checked out
+			"metaUntouchedMap": metaUntouchedMap,
+		},
+		Fields: mapstr.M{
+			"a.b":               "c",
+			"fieldsLevel0Map":   fieldsNestedMap,
+			"fieldsLevel0Value": "fieldsvalue1",
+			// this key should never be edited by the tests
+			// to verify that existing keys remain
+			"fieldsLevel0Value2": "untouched",
+			// this map should never be checked out
+			"fieldsUntouchedMap": fieldsUntouchedMap,
+		},
+	}
+
+	t.Run("rootKey", func(t *testing.T) {
+		event := event.Clone()
+		event.Meta["some.dot.metakey"] = mapstr.M{
+			"that.should": mapstr.M{
+				"be": "supported",
+			},
+		}
+		event.Fields["some.dot.key"] = mapstr.M{
+			"that.should": mapstr.M{
+				"be": "supported",
+			},
+		}
+		cases := []struct {
+			val string
+			exp string
+		}{
+			{
+				val: "@metadata.a.b",
+				exp: "@metadata.a.b",
+			},
+			{
+				val: "@metadata.metaLevel0Value",
+				exp: "@metadata.metaLevel0Value",
+			},
+			{
+				val: "@metadata.metaLevel0Map.metaLevel1Map",
+				exp: "@metadata.metaLevel0Map",
+			},
+			{
+				val: "@metadata.some.dot.metakey.that.should.be",
+				exp: "@metadata.some.dot.metakey",
+			},
+			{
+				val: "a.b",
+				exp: "a.b",
+			},
+			{
+				val: "fieldsLevel0Map.fieldsLevel1Value",
+				exp: "fieldsLevel0Map",
+			},
+			{
+				val: "fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value",
+				exp: "fieldsLevel0Map",
+			},
+			{
+				val: "fieldsLevel0Value",
+				exp: "fieldsLevel0Value",
+			},
+			{
+				val: "some.dot.key.that.should.be",
+				exp: "some.dot.key",
+			},
+		}
+
+		for _, tc := range cases {
+			e := NewEventEditor(event)
+			t.Run(tc.val, func(t *testing.T) {
+				require.Equal(t, tc.exp, e.rootKey(tc.val))
+			})
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		t.Run("Apply", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				editor.Apply()
+			})
+		})
+
+		t.Run("Reset", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				editor.Reset()
+			})
+		})
+
+		t.Run("Delete", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				err := editor.Delete("@metadata.some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				err = editor.Delete("some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				editor.Apply()
+			})
+		})
+
+		t.Run("GetValue", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				_, err := editor.GetValue("@metadata.some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				_, err = editor.GetValue("some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+		})
+
+		t.Run("PutValue", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				prev, err := editor.PutValue("@metadata.some", "value")
+				require.NoError(t, err)
+				require.Nil(t, prev)
+				prev, err = editor.PutValue("some", "value")
+				require.NoError(t, err)
+				require.Nil(t, prev)
+				editor.Apply()
+			})
+		})
+
+		t.Run("DeepUpdate", func(t *testing.T) {
+			editor := NewEventEditor(nil)
+			require.NotPanics(t, func() {
+				editor.DeepUpdate(mapstr.M{
+					"@metadata": mapstr.M{"key": "value"},
+					"key":       "value",
+				})
+				editor.Apply()
+			})
+		})
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Run("@timestamp", func(t *testing.T) {
+			editor := NewEventEditor(event)
+			val, err := editor.GetValue("@timestamp")
+			require.NoError(t, err)
+			require.Equal(t, event.Timestamp, val)
+		})
+
+		t.Run("@metadata", func(t *testing.T) {
+			t.Run("no acess to @metadata key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				metadata, err := editor.GetValue("@metadata")
+				require.Nil(t, metadata)
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrMetadataAccess)
+			})
+
+			t.Run("non-existing key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				val, err := editor.GetValue("@metadata.none")
+				require.Nil(t, val)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("gets a value type", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				requireMapValues(t, editor, map[string]interface{}{
+					"@metadata.metaLevel0Value": "metavalue1",
+				})
+			})
+
+			t.Run("gets a root-level dot-key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				requireMapValues(t, editor, map[string]interface{}{
+					"@metadata.a.b": "c",
+				})
+			})
+
+			t.Run("gets a nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested, err := editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, metadataNestedMap, nested)
+			})
+
+			t.Run("gets a deeper nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				nested, err := editor.GetValue("@metadata.metaLevel0Map.metaLevel1Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, metadataNestedNestedMap, nested)
+
+				// the higher level map should be also cloned by accessing the inner map
+				higher, err := editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, metadataNestedMap, higher)
+
+				// the nested map we got previously should be a part of this cloned higher level map
+				require.IsType(t, mapstr.M{}, higher)
+				higherMap := higher.(mapstr.M)
+				nested2, err := higherMap.GetValue("metaLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested, nested2)
+			})
+
+			t.Run("returns the same nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested1, err := editor.GetValue("@metadata.metaLevel0Map.metaLevel1Map")
+				require.NoError(t, err)
+				nested2, err := editor.GetValue("@metadata.metaLevel0Map.metaLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested2, nested1)
+			})
+		})
+
+		t.Run("fields", func(t *testing.T) {
+			t.Run("non-existing key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				val, err := editor.GetValue("none")
+				require.Nil(t, val)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("gets a value type", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				requireMapValues(t, editor, map[string]interface{}{
+					"fieldsLevel0Value": "fieldsvalue1",
+				})
+			})
+
+			t.Run("gets a root-level dot-key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				requireMapValues(t, editor, map[string]interface{}{
+					"a.b": "c",
+				})
+			})
+
+			t.Run("gets a nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested, err := editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, fieldsNestedMap, nested)
+			})
+
+			t.Run("gets a deeper nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				nested, err := editor.GetValue("fieldsLevel0Map.fieldsLevel1Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, fieldsNestedNestedMap, nested)
+
+				// the higher level map should be also cloned by accessing the inner map
+				higher, err := editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireClonedMaps(t, fieldsNestedMap, higher)
+
+				// the nested map we got previously should be a part of this higher level map
+				require.IsType(t, mapstr.M{}, higher)
+				higherMap := higher.(mapstr.M)
+				nested2, err := higherMap.GetValue("fieldsLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested, nested2)
+			})
+
+			t.Run("returns the same nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				nested1, err := editor.GetValue("fieldsLevel0Map.fieldsLevel1Map")
+				require.NoError(t, err)
+				nested2, err := editor.GetValue("fieldsLevel0Map.fieldsLevel1Map")
+				require.NoError(t, err)
+				requireSameMap(t, nested2, nested1)
+			})
+		})
+
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Run("@timestamp", func(t *testing.T) {
+			editor := NewEventEditor(event)
+			err := editor.Delete("@timestamp")
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrDeleteTimestamp)
+		})
+
+		t.Run("@metadata", func(t *testing.T) {
+			t.Run("metadata itself", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				err := editor.Delete("@metadata")
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrAlterMetadataKey)
+			})
+
+			t.Run("non-existent key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				err := editor.Delete("@metadata.wrong")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				err = editor.Delete("@metadata.wrong.key")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Value"
+				value := "metavalue1"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("root-level dot-key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.a.b"
+				value := "c"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, metadataNestedMap, val3)
+			})
+
+			t.Run("nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value"
+				value := "metavalue3"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val1, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val1)
+
+				// checking if the original event still has it
+				val2, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, metadataNestedNestedMap, val2)
+			})
+
+			t.Run("nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				err = editor.Delete(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// checking if the original event still has it
+				val1, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, metadataNestedNestedMap, val1)
+			})
+		})
+
+		t.Run("fields", func(t *testing.T) {
+			t.Run("non-existent key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+
+				err := editor.Delete("wrong")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				err = editor.Delete("wrong.key")
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Value"
+				value := "fieldsvalue1"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("root-level dot-key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "a.b"
+				value := "c"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, fieldsNestedMap, val3)
+			})
+
+			t.Run("nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value"
+				value := "fieldsvalue3"
+
+				val1, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val1)
+
+				err = editor.Delete(key)
+				require.NoError(t, err)
+
+				val2, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val2)
+
+				// checking if the original event still has it
+				val3, err := event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val3)
+			})
+
+			t.Run("nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				val1, err := editor.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				require.Nil(t, val1)
+
+				// checking if the original event still has it
+				val2, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, fieldsNestedNestedMap, val2)
+			})
+
+			t.Run("nested map twice", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map"
+
+				err := editor.Delete(key)
+				require.NoError(t, err)
+
+				err = editor.Delete(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// checking if the original event still has it
+				val1, err := event.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, fieldsNestedNestedMap, val1)
+			})
+		})
+	})
+
+	t.Run("PutValue", func(t *testing.T) {
+		t.Run("@timestamp", func(t *testing.T) {
+			editor := NewEventEditor(event)
+			newTs := time.Now().Add(time.Hour)
+			preVal, err := editor.PutValue("@timestamp", newTs)
+			require.NoError(t, err)
+			require.Equal(t, event.Timestamp, preVal)
+
+			val, err := editor.GetValue("@timestamp")
+			require.NoError(t, err)
+			require.Equal(t, newTs, val)
+
+			// the original event should not have this change
+			val, err = event.GetValue("@timestamp")
+			require.NoError(t, err)
+			require.Equal(t, event.Timestamp, val)
+		})
+
+		t.Run("@metadata", func(t *testing.T) {
+			t.Run("metadata itself", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				prevVal, err := editor.PutValue("@metadata", "some")
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrAlterMetadataKey)
+				require.Nil(t, prevVal)
+			})
+
+			t.Run("new root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.new"
+				value := "value"
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.new"
+				value := mapstr.M{
+					"some": "value",
+				}
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("existing root-level dot-key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.a.b"
+				value := mapstr.M{
+					"some": "value",
+				}
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Equal(t, "c", prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should have the previous value
+				val, err = event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, "c", val)
+			})
+
+			t.Run("new nested value in existing map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.new"
+				value := "newvalue"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, metadataNestedMap, val)
+			})
+
+			t.Run("absolutely new nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.new1.new2.new3"
+				value := "newvalue"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.new"
+				value := mapstr.M{
+					"some": "value",
+				}
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, metadataNestedMap, val)
+			})
+
+			t.Run("replacing nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value"
+				replacingValue := "metavalue3"
+				value := "new"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should have the previous value
+				val, err = event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, val)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("@metadata.metaLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, metadataNestedMap, val)
+			})
+		})
+
+		t.Run("fields", func(t *testing.T) {
+			t.Run("new root-level value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "new"
+				value := "value"
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new root-level map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "new"
+				value := mapstr.M{
+					"some": "value",
+				}
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("existing root-level dot-key", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "a.b"
+				value := mapstr.M{
+					"some": "value",
+				}
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Equal(t, "c", prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should have the previous value
+				val, err = event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, "c", val)
+			})
+
+			t.Run("new nested value in existing map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.new"
+				value := "newvalue"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `fieldsLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, fieldsNestedMap, val)
+			})
+
+			t.Run("absolutely new nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "new1.new2.new3"
+				value := "newvalue"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+			})
+
+			t.Run("new nested map", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.new"
+				value := mapstr.M{
+					"some": "value",
+				}
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Nil(t, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				requireSameMap(t, value, val)
+
+				// the original event should not have it
+				_, err = event.GetValue(key)
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, fieldsNestedMap, val)
+			})
+
+			t.Run("replacing nested value", func(t *testing.T) {
+				editor := NewEventEditor(event)
+				key := "fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value"
+				replacingValue := "fieldsvalue3"
+				value := "new"
+
+				prevVal, err := editor.PutValue(key, value)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, prevVal)
+
+				val, err := editor.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, value, val)
+
+				// the original event should have the previous value
+				val, err = event.GetValue(key)
+				require.NoError(t, err)
+				require.Equal(t, replacingValue, val)
+
+				// the original `metaLevel0Map` should be cloned/checkedout now
+				val, err = editor.GetValue("fieldsLevel0Map")
+				require.NoError(t, err)
+				requireNotSameMap(t, fieldsNestedMap, val)
+			})
+		})
+
+		t.Run("type conflict", func(t *testing.T) {
+			event := &Event{
+				Meta: mapstr.M{
+					"a": 9,
+					"c": 10,
+				},
+				Fields: mapstr.M{
+					"a": 9,
+					"c": 10,
+				},
+			}
+
+			editor := NewEventEditor(event)
+			_, err := editor.PutValue("a.c", 10)
+			require.Error(t, err)
+			require.Equal(t, "expected map but type is int", err.Error())
+			_, err = editor.PutValue("a.value", 9)
+			require.Error(t, err)
+			require.Equal(t, "expected map but type is int", err.Error())
+		})
+	})
+
+	t.Run("Apply", func(t *testing.T) {
+		// we're going to make changes, so working with the clone in this test
+		cloned := event.Clone()
+		// need later for address comparison
+		metaNested := cloned.Meta["metaLevel0Map"]
+		metaUntouched := cloned.Meta["metaUntouchedMap"]
+		fieldsNested := cloned.Fields["fieldsLevel0Map"]
+		fieldsUntouched := cloned.Fields["fieldsUntouchedMap"]
+
+		editor := NewEventEditor(cloned)
+
+		// verify that it does nothing without pending changes
+		editor.Apply()
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		keysToDelete := []string{
+			"@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value",
+			"@metadata.metaLevel0Value",
+			"fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value",
+			"fieldsLevel0Value",
+		}
+		for _, key := range keysToDelete {
+			err := editor.Delete(key)
+			require.NoError(t, err)
+		}
+		newTs := time.Now().Add(time.Hour)
+		keysToPut := map[string]interface{}{
+			"@timestamp": newTs,
+			"@metadata.metaLevel0Map.metaLevel1Map.new1": "newmetavalue1",
+			"@metadata.metaLevel0Value":                  "metareplaced1",
+			"@metadata.new2":                             "newmetavalue2",
+			"fieldsLevel0Map.fieldsLevel1Map.new3":       "newfieldsvalue1",
+			"new4":                                       "newfieldsvalue2",
+			"fieldsLevel0Value":                          "fieldsreplaced1",
+		}
+		for key, val := range keysToPut {
+			_, err := editor.PutValue(key, val)
+			require.NoError(t, err)
+		}
+
+		// making sure that there are no changes yet
+		require.Equal(t, event.Timestamp, cloned.Timestamp)
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		expEvent := &Event{
+			Timestamp: newTs,
+			Meta: mapstr.M{
+				"a.b": "c",
+				"metaLevel0Map": mapstr.M{
+					"metaLevel1Map": mapstr.M{
+						"new1": "newmetavalue1",
+					},
+				},
+				"metaLevel0Value":  "metareplaced1",
+				"new2":             "newmetavalue2",
+				"metaLevel0Value2": "untouched",
+				"metaUntouchedMap": metaUntouchedMap,
+			},
+			Fields: mapstr.M{
+				"a.b": "c",
+				"fieldsLevel0Map": mapstr.M{
+					"fieldsLevel1Map": mapstr.M{
+						"new3": "newfieldsvalue1",
+					},
+				},
+				"new4":               "newfieldsvalue2",
+				"fieldsLevel0Value":  "fieldsreplaced1",
+				"fieldsLevel0Value2": "untouched",
+				"fieldsUntouchedMap": fieldsUntouchedMap,
+			},
+		}
+
+		editor.Apply()
+
+		require.Equal(t, expEvent.Timestamp, cloned.Timestamp)
+		require.Equal(t, expEvent.Meta.StringToPrint(), cloned.Meta.StringToPrint())
+		require.Equal(t, expEvent.Fields.StringToPrint(), cloned.Fields.StringToPrint())
+
+		// verifying that only the changed nested maps were cloned
+		requireNotSameMap(t, metaNested, cloned.Meta["metaLevel0Map"])
+		requireNotSameMap(t, fieldsNested, cloned.Fields["fieldsLevel0Map"])
+		requireSameMap(t, metaUntouched, cloned.Meta["metaUntouchedMap"])
+		requireSameMap(t, fieldsUntouched, cloned.Fields["fieldsUntouchedMap"])
+	})
+
+	t.Run("Reset", func(t *testing.T) {
+		// we might make changes, so working with the cloned event here
+		cloned := event.Clone()
+		metaNested := cloned.Meta["metaLevel0Map"]
+		fieldsNested := cloned.Fields["fieldsLevel0Map"]
+		editor := NewEventEditor(cloned)
+
+		// verify that `Reset` does nothing without pending changes
+		editor.Reset()
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		keysToDelete := []string{
+			"@metadata.metaLevel0Map.metaLevel1Map.metaLevel2Value",
+			"@metadata.metaLevel0Value",
+			"fieldsLevel0Map.fieldsLevel1Map.fieldsLevel2Value",
+			"fieldsLevel0Value",
+		}
+		for _, key := range keysToDelete {
+			err := editor.Delete(key)
+			require.NoError(t, err)
+		}
+		newTs := time.Now().Add(time.Hour)
+		keysToPut := map[string]interface{}{
+			"@timestamp": newTs,
+			"@metadata.metaLevel0Map.metaLevel1Map.new1": "newmetavalue1",
+			"@metadata.metaLevel0Value":                  "metareplaced1",
+			"@metadata.new2":                             "newmetavalue2",
+			"fieldsLevel0Map.fieldsLevel1Map.new3":       "newfieldsvalue1",
+			"new4":                                       "newfieldsvalue2",
+			"fieldsLevel0Value":                          "fieldsreplaced1",
+		}
+		for key, val := range keysToPut {
+			_, err := editor.PutValue(key, val)
+			require.NoError(t, err)
+		}
+
+		// making sure that there are no changes yet
+		require.Equal(t, event.Timestamp, cloned.Timestamp)
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		editor.Reset()
+
+		require.Equal(t, event.Timestamp, cloned.Timestamp)
+		requireClonedMaps(t, event.Meta, cloned.Meta)
+		requireClonedMaps(t, event.Fields, cloned.Fields)
+
+		// verifying that the nested maps were not cloned
+		requireSameMap(t, metaNested, cloned.Meta["metaLevel0Map"])
+		requireSameMap(t, fieldsNested, cloned.Fields["fieldsLevel0Map"])
+
+		// verify that deletions are reset and every value is back
+		for _, key := range keysToDelete {
+			_, err := editor.GetValue(key)
+			require.NoError(t, err)
+		}
+		// verify that all the edits are reset
+		for key, val := range keysToPut {
+			got, err := editor.GetValue(key)
+			if strings.Contains(key, "new") {
+				require.Error(t, err)
+				require.ErrorIs(t, err, mapstr.ErrKeyNotFound)
+				continue
+			}
+			require.NoError(t, err)
+			require.NotEqual(t, val, got)
+		}
+	})
+
+	t.Run("DeepUpdate", func(t *testing.T) {
+		t.Run("empty", func(t *testing.T) {
+			cloned := event.Clone()
+			editor := NewEventEditor(cloned)
+			editor.DeepUpdate(nil)
+			editor.Apply()
+			requireClonedMaps(t, event.Meta, cloned.Meta)
+			requireClonedMaps(t, event.Fields, cloned.Fields)
+		})
+
+		newTs := time.Now().Add(time.Hour)
+		update := map[string]interface{}{
+			"@timestamp": newTs,
+			"@metadata": map[string]interface{}{
+				"metaLevel0Map": mapstr.M{ // mix types on purpose, should support both
+					"metaLevel1Map": map[string]interface{}{
+						"new1": "newmetavalue1",
+					},
+				},
+				"metaLevel0Value": "metareplaced1",
+				"new2":            "newmetavalue2",
+			},
+			"fieldsLevel0Map": map[string]interface{}{
+				"fieldsLevel1Map": mapstr.M{
+					"new3": "newfieldsvalue1",
+				},
+				"newmap": map[string]interface{}{
+					"new4": "newfieldsvalue2",
+				},
+			},
+			"fieldsLevel0Value": "fieldsreplaced1",
+		}
+
+		t.Run("overwrite", func(t *testing.T) {
+			cloned := event.Clone()
+			editor := NewEventEditor(cloned)
+			editor.DeepUpdate(update)
+
+			expEvent := &Event{
+				Timestamp: newTs,
+				Meta: mapstr.M{
+					"a.b": "c",
+					"metaLevel0Map": mapstr.M{
+						"metaLevel1Map": mapstr.M{
+							"metaLevel2Value": "metavalue3",
+							"new1":            "newmetavalue1",
+						},
+					},
+					"metaLevel0Value":  "metareplaced1",
+					"metaLevel0Value2": "untouched",
+					"new2":             "newmetavalue2",
+					"metaUntouchedMap": metaUntouchedMap,
+				},
+				Fields: mapstr.M{
+					"a.b": "c",
+					"fieldsLevel0Map": mapstr.M{
+						"fieldsLevel1Map": mapstr.M{
+							"fieldsLevel2Value": "fieldsvalue3",
+							"new3":              "newfieldsvalue1",
+						},
+						"newmap": map[string]interface{}{
+							"new4": "newfieldsvalue2",
+						},
+					},
+					"fieldsLevel0Value":  "fieldsreplaced1",
+					"fieldsLevel0Value2": "untouched",
+					"fieldsUntouchedMap": fieldsUntouchedMap,
+				},
+			}
+
+			// edited nested maps in metadata and fields should be checked out
+			requireNotSameMap(t, cloned.Meta["metaLevel0Map"], editor.pending.Meta["metaLevel0Map"])
+			requireNotSameMap(t, cloned.Fields["fieldsLevel0Map"], editor.pending.Fields["fieldsLevel0Map"])
+			require.Nil(t, editor.pending.Meta["metaUntouchedMap"])
+			require.Nil(t, editor.pending.Fields["fieldsUntouchedMap"])
+
+			editor.Apply()
+
+			require.Equal(t, expEvent.Timestamp, cloned.Timestamp)
+			requireClonedMaps(t, expEvent.Meta, cloned.Meta)
+			requireClonedMaps(t, expEvent.Fields, cloned.Fields)
+		})
+
+		t.Run("no overwrite", func(t *testing.T) {
+			cloned := event.Clone()
+			editor := NewEventEditor(cloned)
+			editor.DeepUpdateNoOverwrite(update)
+
+			expEvent := &Event{
+				// should have the original/non-overwritten timestamp value
+				Timestamp: event.Timestamp,
+				Meta: mapstr.M{
+					"a.b": "c",
+					"metaLevel0Map": mapstr.M{
+						"metaLevel1Map": mapstr.M{
+							"metaLevel2Value": "metavalue3",
+							"new1":            "newmetavalue1",
+						},
+					},
+					"metaLevel0Value":  "metavalue1",
+					"metaLevel0Value2": "untouched",
+					"new2":             "newmetavalue2",
+					"metaUntouchedMap": metaUntouchedMap,
+				},
+				Fields: mapstr.M{
+					"a.b": "c",
+					"fieldsLevel0Map": mapstr.M{
+						"fieldsLevel1Map": mapstr.M{
+							"fieldsLevel2Value": "fieldsvalue3",
+							"new3":              "newfieldsvalue1",
+						},
+						"newmap": map[string]interface{}{
+							"new4": "newfieldsvalue2",
+						},
+					},
+					"fieldsLevel0Value":  "fieldsvalue1",
+					"fieldsLevel0Value2": "untouched",
+					"fieldsUntouchedMap": fieldsUntouchedMap,
+				},
+			}
+
+			// only edited nested maps in metadata and fields should be checked out
+			requireNotSameMap(t, cloned.Meta["metaLevel0Map"], editor.pending.Meta["metaLevel0Map"])
+			requireNotSameMap(t, cloned.Fields["fieldsLevel0Map"], editor.pending.Fields["fieldsLevel0Map"])
+			require.Nil(t, editor.pending.Meta["metaUntouchedMap"])
+			require.Nil(t, editor.pending.Fields["fieldsUntouchedMap"])
+
+			editor.Apply()
+
+			require.Equal(t, expEvent.Timestamp, cloned.Timestamp)
+			requireClonedMaps(t, expEvent.Meta, cloned.Meta)
+			requireClonedMaps(t, expEvent.Fields, cloned.Fields)
+		})
+	})
+
+	t.Run("hierarchy", func(t *testing.T) {
+		event := &Event{
+			Fields: mapstr.M{
+				"a.b": 1,
+			},
+		}
+		editor := NewEventEditor(event)
+		err := editor.Delete("a.b")
+		require.NoError(t, err)
+
+		prev, err := editor.PutValue("a.b.c", 1)
+		require.NoError(t, err)
+		require.Nil(t, prev)
+
+		expFields := mapstr.M{
+			"a": mapstr.M{
+				"b": mapstr.M{
+					"c": 1,
+				},
+			},
+		}
+
+		editor.Apply()
+		requireClonedMaps(t, expFields, event.Fields)
+	})
+}
+
+func requireClonedMaps(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	requireNotSameMap(t, expected, actual)
+	require.IsType(t, mapstr.M{}, expected)
+	require.IsType(t, mapstr.M{}, actual)
+
+	expectedMap := expected.(mapstr.M)
+	actualMap := actual.(mapstr.M)
+
+	require.Equal(t, expectedMap.StringToPrint(), actualMap.StringToPrint())
+}
+
+func requireSameMap(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	expectedAddr := fmt.Sprintf("%p", expected)
+	actualAddr := fmt.Sprintf("%p", actual)
+	require.Equalf(t, expectedAddr, actualAddr, "should reference the same map: %s != %s", expectedAddr, actualAddr)
+}
+
+func requireNotSameMap(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	expectedAddr := fmt.Sprintf("%p", expected)
+	actualAddr := fmt.Sprintf("%p", actual)
+	require.NotEqualf(t, expectedAddr, actualAddr, "should reference different maps: %s == %s", expectedAddr, actualAddr)
+}
+
+func requireMapValues(t *testing.T, e *EventEditor, expected map[string]interface{}) {
+	t.Helper()
+	for key := range expected {
+		val, err := e.GetValue(key)
+		require.NoError(t, err)
+		require.Equal(t, expected[key], val)
+	}
+}

--- a/libbeat/processors/actions/append_test.go
+++ b/libbeat/processors/actions/append_test.go
@@ -174,7 +174,8 @@ func Test_appendProcessor_appendValues(t *testing.T) {
 				config: tt.fields.config,
 				logger: tt.fields.logger,
 			}
-			if err := f.appendValues(tt.args.target, tt.args.fields, tt.args.values, tt.args.event); (err != nil) != tt.wantErr {
+			ed := beat.NewEventEditor(tt.args.event)
+			if err := f.appendValues(tt.args.target, tt.args.fields, tt.args.values, ed); (err != nil) != tt.wantErr {
 				t.Errorf("appendProcessor.appendValues() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/libbeat/processors/actions/rename_test.go
+++ b/libbeat/processors/actions/rename_test.go
@@ -358,12 +358,14 @@ func TestRenameField(t *testing.T) {
 				},
 			}
 
-			err := f.renameField(test.From, test.To, &beat.Event{Fields: test.Input})
+			event := &beat.Event{Fields: test.Input}
+			ed := beat.NewEventEditor(event)
+			err := f.renameField(test.From, test.To, ed)
 			if err != nil {
 				assert.Equal(t, test.error, true)
 			}
-
-			assert.True(t, reflect.DeepEqual(test.Input, test.Output))
+			ed.Apply()
+			assert.Equal(t, test.Output, test.Input)
 		})
 	}
 

--- a/libbeat/processors/actions/replace_test.go
+++ b/libbeat/processors/actions/replace_test.go
@@ -240,12 +240,15 @@ func TestReplaceField(t *testing.T) {
 				},
 			}
 
-			err := f.replaceField(test.Field, test.Pattern, test.Replacement, &beat.Event{Fields: test.Input})
+			event := &beat.Event{Fields: test.Input}
+			ed := beat.NewEventEditor(event)
+			err := f.replaceField(test.Field, test.Pattern, test.Replacement, ed)
 			if err != nil {
 				assert.Equal(t, test.error, true)
 			}
 
-			assert.True(t, reflect.DeepEqual(test.Input, test.Output))
+			ed.Apply()
+			assert.Equal(t, test.Output, test.Input)
 		})
 	}
 


### PR DESCRIPTION
Previously, every time some processors ran on an event we made a clone of the entire event for two reasons:

* this event could have some nested maps that are shared among multiple events.
* in case a processor fails to make a change it should be able to revert its partial changes.

This change added a new `EventEditor` wrapper that is used for collecting pending event changes in processors with an option to Apply or Reset them.

Additionally, this `EventEditor` takes care of the efficient memory management when making changes to an event by cloning only the nested maps that processors access or modify. Most of the processors just put new keys or delete existing keys on the root-level, so most of the time the nested maps in the event remain untouched and it does not require the whole event to be cloned.

This change also migrates the following processors to using the `EventEditor` instead of cloning whole events:

* [append](https://www.elastic.co/guide/en/beats/filebeat/current/append.html)
* [copy_fields](https://www.elastic.co/guide/en/beats/filebeat/current/copy-fields.html)
* [decode_base64_field](https://www.elastic.co/guide/en/beats/filebeat/current/decode-base64-field.html)
* [decompress_gzip_field](https://www.elastic.co/guide/en/beats/filebeat/current/decompress-gzip-field.html)
* [rename](https://www.elastic.co/guide/en/beats/filebeat/current/rename-fields.html)
* [replace](https://www.elastic.co/guide/en/beats/filebeat/current/replace-fields.html)
* [truncate_fields](https://www.elastic.co/guide/en/beats/filebeat/current/truncate-fields.html)
* [add_process_metadata](https://www.elastic.co/guide/en/beats/filebeat/current/add-process-metadata.html)
* [convert](https://www.elastic.co/guide/en/beats/filebeat/current/convert.html)
* [decode_csv_fields](https://www.elastic.co/guide/en/beats/filebeat/current/decode-csv-fields.html)
* [dissect](https://www.elastic.co/guide/en/beats/filebeat/current/dissect.html)
* [extract_array](https://www.elastic.co/guide/en/beats/filebeat/current/extract-array.html)
* [urldecode](https://www.elastic.co/guide/en/beats/filebeat/current/urldecode.html)

All the listed processors were making a backup/clone of the entire event in order to restore the event in case of failure.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

### Before

```
336269333 ns/op 251485534 B/op 435076 allocs/op
```

![mem-before-editor](https://github.com/elastic/beats/assets/887952/1224bb1e-6e6c-4ddd-a21b-42ce935bf277)

### After

```
24894392 ns/op        21003350 B/op      36349 allocs/op
```

That's

```
~13,5 times less ns/op        ~11,97 times less B/op      ~11,96 times less allocs/op
```

![mem-after-editor](https://github.com/elastic/beats/assets/887952/cb3b68c2-bbdf-46d3-bf92-a6fd360d5ba8)

**This clone is happening in the test itself, as you can see and does not contribute to the actual performance, all the clones in the processors are gone.**

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related to https://github.com/elastic/beats/pull/36906