### PR TITLE
[metricbeat] replace depricated io/ioutil

### DIFF
--- a/metricbeat/autodiscover/appender/kubernetes/token/token.go
+++ b/metricbeat/autodiscover/appender/kubernetes/token/token.go
@@ -19,7 +19,7 @@ package token
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/elastic/beats/v7/libbeat/autodiscover"
 	"github.com/elastic/beats/v7/libbeat/common/cfgwarn"
@@ -127,7 +127,7 @@ func (t *tokenAppender) getAuthHeaderFromToken() string {
 	var token string
 
 	if t.TokenPath != "" {
-		b, err := ioutil.ReadFile(t.TokenPath)
+		b, err := os.ReadFile(t.TokenPath)
 		if err != nil {
 			logp.Err("Reading token file failed with err: %v", err)
 		}

--- a/metricbeat/autodiscover/appender/kubernetes/token/token_test.go
+++ b/metricbeat/autodiscover/appender/kubernetes/token/token_test.go
@@ -18,7 +18,6 @@
 package token
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -101,7 +100,7 @@ token_path: "test"
 }
 
 func writeFile(name, message string) {
-	ioutil.WriteFile(name, []byte(message), os.ModePerm)
+	os.WriteFile(name, []byte(message), os.ModePerm)
 }
 
 func deleteFile(name string) {

--- a/metricbeat/helper/http.go
+++ b/metricbeat/helper/http.go
@@ -23,8 +23,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/elastic/beats/v7/libbeat/version"
 	"github.com/elastic/beats/v7/metricbeat/helper/dialer"
@@ -179,7 +179,7 @@ func (h *HTTP) FetchContent() ([]byte, error) {
 		return nil, fmt.Errorf("HTTP error %d in %s: %s", resp.StatusCode, h.name, resp.Status)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 // FetchScanner returns a Scanner for the content.
@@ -214,7 +214,7 @@ func (h *HTTP) FetchJSON() (map[string]interface{}, error) {
 func getAuthHeaderFromToken(path string) (string, error) {
 	var token string
 
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return "", fmt.Errorf("reading bearer token file: %w", err)
 	}

--- a/metricbeat/helper/http_test.go
+++ b/metricbeat/helper/http_test.go
@@ -19,7 +19,7 @@ package helper
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -55,7 +55,7 @@ func TestGetAuthHeaderFromToken(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			content := []byte(test.Content)
-			tmpfile, err := ioutil.TempFile("", "token")
+			tmpfile, err := os.CreateTemp("", "token")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -243,7 +243,7 @@ func TestOverUnixSocket(t *testing.T) {
 
 	for title, c := range cases {
 		t.Run(title, func(t *testing.T) {
-			tmpDir, err := ioutil.TempDir("", "testsocket")
+			tmpDir, err := os.MkdirTemp("", "testsocket")
 			require.NoError(t, err)
 			defer os.RemoveAll(tmpDir)
 
@@ -262,7 +262,7 @@ func TestOverUnixSocket(t *testing.T) {
 			r, err := h.FetchResponse()
 			require.NoError(t, err)
 			defer r.Body.Close()
-			content, err := ioutil.ReadAll(r.Body)
+			content, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			assert.Equal(t, []byte("ehlo!"), content)
 		})

--- a/metricbeat/helper/http_windows_test.go
+++ b/metricbeat/helper/http_windows_test.go
@@ -21,7 +21,7 @@ package helper
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 	"testing"
@@ -68,7 +68,7 @@ func TestOverNamedpipe(t *testing.T) {
 		r, err := h.FetchResponse()
 		require.NoError(t, err)
 		defer r.Body.Close()
-		content, err := ioutil.ReadAll(r.Body)
+		content, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("ehlo!"), content)
 	})
@@ -101,7 +101,7 @@ func TestOverNamedpipe(t *testing.T) {
 		r, err := h.FetchResponse()
 		require.NoError(t, err)
 		defer r.Body.Close()
-		content, err := ioutil.ReadAll(r.Body)
+		content, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("ehlo!"), content)
 	})

--- a/metricbeat/helper/kubernetes/ktest/ktest.go
+++ b/metricbeat/helper/kubernetes/ktest/ktest.go
@@ -18,7 +18,7 @@
 package ktest
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -57,7 +57,7 @@ func GetTestCases(files []string) ptest.TestCases {
 func TestMetricsFamily(t *testing.T, files []string, mapping *p.MetricsMapping) {
 	metricsFiles := map[string][]string{}
 	for i := 0; i < len(files); i++ {
-		content, err := ioutil.ReadFile(files[i])
+		content, err := os.ReadFile(files[i])
 		if err != nil {
 			t.Fatalf("Unknown file %s.", files[i])
 		}

--- a/metricbeat/helper/server/http/http.go
+++ b/metricbeat/helper/server/http/http.go
@@ -19,7 +19,7 @@ package http
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -147,7 +147,7 @@ func (h *HttpServer) handleFunc(writer http.ResponseWriter, req *http.Request) {
 			meta["Content-Type"] = contentType
 		}
 
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := io.ReadAll(req.Body)
 		if err != nil {
 			logp.Err("Error reading body: %v", err)
 			http.Error(writer, "Unexpected error reading request payload", http.StatusBadRequest)

--- a/metricbeat/helper/server/http/http_test.go
+++ b/metricbeat/helper/server/http/http_test.go
@@ -24,7 +24,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -212,6 +212,10 @@ func writeToServer(t *testing.T, message, host string, port int, connectionMetho
 	url := fmt.Sprintf("%s://%s:%d/", strings.ToLower(connectionType), host, port)
 	var str = []byte(message)
 	req, err := http.NewRequest(connectionMethod, url, bytes.NewBuffer(str))
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
 	req.Header.Set("Content-Type", "text/plain")
 	client := &http.Client{}
 	if connectionType == "HTTPS" {
@@ -230,7 +234,7 @@ func writeToServer(t *testing.T, message, host string, port int, connectionMetho
 
 	if connectionMethod == "GET" {
 		if resp.StatusCode == http.StatusOK {
-			bodyBytes, err2 := ioutil.ReadAll(resp.Body)
+			bodyBytes, err2 := io.ReadAll(resp.Body)
 			if err2 != nil {
 				t.Error(err)
 				t.FailNow()

--- a/metricbeat/mb/lightmodules.go
+++ b/metricbeat/mb/lightmodules.go
@@ -19,7 +19,6 @@ package mb
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -260,7 +259,7 @@ func (s *LightModulesSource) moduleNames() ([]string, error) {
 			s.log.Debugf("Light modules directory '%d' doesn't exist", dir)
 			continue
 		}
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			return nil, fmt.Errorf("listing modules on path '%s': %w", dir, err)
 		}

--- a/metricbeat/mb/testing/data_generator.go
+++ b/metricbeat/mb/testing/data_generator.go
@@ -20,7 +20,6 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -184,7 +183,7 @@ func WriteEventToDataJSON(t testing.TB, fullEvent beat.Event, postfixPath string
 		t.Fatal(err)
 	}
 
-	if err = ioutil.WriteFile(p, output, 0644); err != nil {
+	if err = os.WriteFile(p, output, 0644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/metricbeat/mb/testing/lightmodules_test.go
+++ b/metricbeat/mb/testing/lightmodules_test.go
@@ -22,7 +22,6 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -103,7 +102,7 @@ func TestDataLightModuleWithProcessors(t *testing.T) {
 	assert.Empty(t, errs)
 	assert.NotEmpty(t, events)
 
-	dir, err := ioutil.TempDir("", "_meta-*")
+	dir, err := os.MkdirTemp("", "_meta-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -127,7 +126,7 @@ func TestDataLightModuleWithProcessors(t *testing.T) {
 		}
 	}
 
-	d, err := ioutil.ReadFile(dataPath)
+	d, err := os.ReadFile(dataPath)
 	require.NoError(t, err)
 
 	err = json.Unmarshal(d, &event)

--- a/metricbeat/mb/testing/testdata.go
+++ b/metricbeat/mb/testing/testdata.go
@@ -20,9 +20,9 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -131,7 +131,7 @@ func ReadDataConfig(t *testing.T, f string) DataConfig {
 	t.Helper()
 	config := defaultDataConfig()
 
-	configFile, err := ioutil.ReadFile(f)
+	configFile, err := os.ReadFile(f)
 	if err != nil {
 		t.Fatalf("failed to read '%s': %v", f, err)
 	}
@@ -294,13 +294,13 @@ func runTest(t *testing.T, file string, module, metricSetName string, config Dat
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err = ioutil.WriteFile(expectedFile, outputIndented, 0644); err != nil {
+		if err = os.WriteFile(expectedFile, outputIndented, 0644); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	// Read expected file
-	expected, err := ioutil.ReadFile(expectedFile)
+	expected, err := os.ReadFile(expectedFile)
 	if err != nil {
 		t.Fatalf("could not read file: %s", err)
 	}
@@ -362,7 +362,11 @@ func writeDataJSON(t *testing.T, data mapstr.M, path string) {
 	// Add hardcoded timestamp
 	data.Put("@timestamp", "2019-03-01T08:05:34.853Z")
 	output, err := json.MarshalIndent(&data, "", "    ")
-	if err = ioutil.WriteFile(path, output, 0644); err != nil {
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if err = os.WriteFile(path, output, 0644); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -494,7 +498,7 @@ func getConfig(module, metricSet, url string, config DataConfig) map[string]inte
 // server starts a server with a mock output
 func server(t *testing.T, path string, url string, contentType string) *httptest.Server {
 
-	body, err := ioutil.ReadFile(path)
+	body, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("could not read file: %s", err)
 	}

--- a/metricbeat/module/beat/state/data_test.go
+++ b/metricbeat/module/beat/state/data_test.go
@@ -20,7 +20,7 @@
 package state
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +42,7 @@ func TestEventMapping(t *testing.T) {
 	}
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/beat/stats/data_test.go
+++ b/metricbeat/module/beat/stats/data_test.go
@@ -20,7 +20,7 @@
 package stats
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -44,7 +44,7 @@ func TestEventMapping(t *testing.T) {
 	clusterUUID := "foo"
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/ceph/cluster_disk/cluster_disk_test.go
+++ b/metricbeat/module/ceph/cluster_disk/cluster_disk_test.go
@@ -18,9 +18,9 @@
 package cluster_disk
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +34,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/df_sample_response.json")
+	response, err := os.ReadFile(absPath + "/df_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/ceph/cluster_health/cluster_health_test.go
+++ b/metricbeat/module/ceph/cluster_health/cluster_health_test.go
@@ -18,9 +18,9 @@
 package cluster_health
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +34,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/sample_response.json")
+	response, err := os.ReadFile(absPath + "/sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/ceph/cluster_status/cluster_status_test.go
+++ b/metricbeat/module/ceph/cluster_status/cluster_status_test.go
@@ -18,9 +18,9 @@
 package cluster_status
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +34,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/status_sample_response.json")
+	response, err := os.ReadFile(absPath + "/status_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health_test.go
+++ b/metricbeat/module/ceph/mgr_cluster_health/mgr_cluster_health_test.go
@@ -19,9 +19,9 @@ package mgr_cluster_health
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -41,9 +41,9 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("./_meta/testdata/")
 	assert.NoError(t, err)
 
-	statusResponse, err := ioutil.ReadFile(absPath + "/status.json")
+	statusResponse, err := os.ReadFile(absPath + "/status.json")
 	assert.NoError(t, err)
-	timeSyncStatusResponse, err := ioutil.ReadFile(absPath + "/time_sync_status.json")
+	timeSyncStatusResponse, err := os.ReadFile(absPath + "/time_sync_status.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -93,7 +93,7 @@ func TestFetchEventContents_Failed(t *testing.T) {
 	absPath, err := filepath.Abs("./_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/failed.json")
+	response, err := os.ReadFile(absPath + "/failed.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/ceph/monitor_health/monitor_health_test.go
+++ b/metricbeat/module/ceph/monitor_health/monitor_health_test.go
@@ -18,9 +18,9 @@
 package monitor_health
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,7 +36,8 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/sample_response.json")
+	response, err := os.ReadFile(absPath + "/sample_response.json")
+	assert.NoError(t, err)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/ceph/osd_df/osd_df_test.go
+++ b/metricbeat/module/ceph/osd_df/osd_df_test.go
@@ -18,9 +18,9 @@
 package osd_df
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +33,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/osd_df_sample_response.json")
+	response, err := os.ReadFile(absPath + "/osd_df_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/ceph/osd_tree/osd_tree_test.go
+++ b/metricbeat/module/ceph/osd_tree/osd_tree_test.go
@@ -18,9 +18,9 @@
 package osd_tree
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +33,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/osd_tree_sample_response.json")
+	response, err := os.ReadFile(absPath + "/osd_tree_sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/ceph/pool_disk/pool_disk_test.go
+++ b/metricbeat/module/ceph/pool_disk/pool_disk_test.go
@@ -18,9 +18,9 @@
 package pool_disk
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +34,7 @@ func TestFetchEventContents(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/testdata/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/df_sample_response.json")
+	response, err := os.ReadFile(absPath + "/df_sample_response.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/couchbase/bucket/bucket_test.go
+++ b/metricbeat/module/couchbase/bucket/bucket_test.go
@@ -20,9 +20,9 @@
 package bucket
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -37,7 +37,7 @@ func TestFetchEventContents(t *testing.T) {
 	assert.NoError(t, err)
 
 	// response is a raw response from a couchbase
-	response, err := ioutil.ReadFile(absPath + "/sample_response.json")
+	response, err := os.ReadFile(absPath + "/sample_response.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/elasticsearch/ccr/ccr_test.go
+++ b/metricbeat/module/elasticsearch/ccr/ccr_test.go
@@ -18,9 +18,9 @@
 package ccr
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -44,7 +44,7 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		input = []byte(strings.Replace(string(input), "7.10.0", esVersion, -1))
 		w.Write(input)
 	}

--- a/metricbeat/module/elasticsearch/ccr/data_test.go
+++ b/metricbeat/module/elasticsearch/ccr/data_test.go
@@ -20,9 +20,9 @@
 package ccr
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,7 +41,7 @@ func TestMapper(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	input, err := ioutil.ReadFile("./_meta/test/empty.700.json")
+	input, err := os.ReadFile("./_meta/test/empty.700.json")
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -53,7 +53,7 @@ func TestEmpty(t *testing.T) {
 func TestData(t *testing.T) {
 	mux := createEsMuxer("7.6.0", "platinum", true)
 	mux.Handle("/_ccr/stats", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		input, _ := ioutil.ReadFile("./_meta/test/ccr_stats.700.json")
+		input, _ := os.ReadFile("./_meta/test/ccr_stats.700.json")
 		w.Write(input)
 	}))
 

--- a/metricbeat/module/elasticsearch/cluster_stats/data_test.go
+++ b/metricbeat/module/elasticsearch/cluster_stats/data_test.go
@@ -20,9 +20,9 @@
 package cluster_stats
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,7 +45,7 @@ func createEsMuxer(license string) *http.ServeMux {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		w.Write(input)
 	}
 	licenseHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -61,25 +61,25 @@ func createEsMuxer(license string) *http.ServeMux {
 
 	mux.Handle("/_xpack/usage", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/xpack-usage.710.json")
+			input, _ := os.ReadFile("./_meta/test/xpack-usage.710.json")
 			w.Write(input)
 		}))
 
 	mux.Handle("/_cluster/settings", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/cluster-settings.710.json")
+			input, _ := os.ReadFile("./_meta/test/cluster-settings.710.json")
 			w.Write(input)
 		}))
 
 	mux.Handle("/_cluster/stats", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/cluster_stats.710.json")
+			input, _ := os.ReadFile("./_meta/test/cluster_stats.710.json")
 			w.Write(input)
 		}))
 
 	mux.Handle("/_cluster/state/version,master_node,nodes,routing_table", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/cluster_state.710.json")
+			input, _ := os.ReadFile("./_meta/test/cluster_state.710.json")
 			w.Write(input)
 		}))
 

--- a/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
+++ b/metricbeat/module/elasticsearch/elasticsearch_integration_test.go
@@ -24,9 +24,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -214,7 +215,7 @@ func createIndex(host string, isHidden bool) (string, error) {
 		return "", fmt.Errorf("could not send create index request: %w", err)
 	}
 	defer resp.Body.Close()
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != 200 {
 		return "", fmt.Errorf("HTTP error %d: %s, %s", resp.StatusCode, resp.Status, string(respBody))
@@ -254,7 +255,7 @@ func enableTrialLicense(host string, version *version.V) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}
@@ -279,7 +280,7 @@ func checkTrialLicenseEnabled(host string, version *version.V) (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, err
 	}
@@ -302,7 +303,7 @@ func checkTrialLicenseEnabled(host string, version *version.V) (bool, error) {
 
 func createMLJob(host string, version *version.V) error {
 
-	mlJob, err := ioutil.ReadFile("ml_job/_meta/test/test_job.json")
+	mlJob, err := os.ReadFile("ml_job/_meta/test/test_job.json")
 	if err != nil {
 		return err
 	}
@@ -370,7 +371,7 @@ func checkCCRStatsExists(host string) (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, err
 	}
@@ -389,7 +390,7 @@ func checkCCRStatsExists(host string) (bool, error) {
 }
 
 func setupCCRRemote(host string) error {
-	remoteSettings, err := ioutil.ReadFile("ccr/_meta/test/test_remote_settings.json")
+	remoteSettings, err := os.ReadFile("ccr/_meta/test/test_remote_settings.json")
 	if err != nil {
 		return err
 	}
@@ -400,7 +401,7 @@ func setupCCRRemote(host string) error {
 }
 
 func createCCRLeaderIndex(host string) error {
-	leaderIndex, err := ioutil.ReadFile("ccr/_meta/test/test_leader_index.json")
+	leaderIndex, err := os.ReadFile("ccr/_meta/test/test_leader_index.json")
 	if err != nil {
 		return err
 	}
@@ -411,7 +412,7 @@ func createCCRLeaderIndex(host string) error {
 }
 
 func createCCRFollowerIndex(host string) error {
-	followerIndex, err := ioutil.ReadFile("ccr/_meta/test/test_follower_index.json")
+	followerIndex, err := os.ReadFile("ccr/_meta/test/test_follower_index.json")
 	if err != nil {
 		return err
 	}
@@ -465,7 +466,7 @@ func createEnrichStats(host string) error {
 }
 
 func createEnrichSourceIndex(host string) error {
-	sourceDoc, err := ioutil.ReadFile("enrich/_meta/test/source_doc.json")
+	sourceDoc, err := os.ReadFile("enrich/_meta/test/source_doc.json")
 	if err != nil {
 		return err
 	}
@@ -476,7 +477,7 @@ func createEnrichSourceIndex(host string) error {
 }
 
 func createEnrichPolicy(host string) error {
-	policy, err := ioutil.ReadFile("enrich/_meta/test/policy.json")
+	policy, err := os.ReadFile("enrich/_meta/test/policy.json")
 	if err != nil {
 		return err
 	}
@@ -493,7 +494,7 @@ func executeEnrichPolicy(host string) error {
 }
 
 func createEnrichIngestPipeline(host string) error {
-	pipeline, err := ioutil.ReadFile("enrich/_meta/test/ingest_pipeline.json")
+	pipeline, err := os.ReadFile("enrich/_meta/test/ingest_pipeline.json")
 	if err != nil {
 		return err
 	}
@@ -504,7 +505,7 @@ func createEnrichIngestPipeline(host string) error {
 }
 
 func ingestAndEnrichDoc(host string) error {
-	targetDoc, err := ioutil.ReadFile("enrich/_meta/test/target_doc.json")
+	targetDoc, err := os.ReadFile("enrich/_meta/test/target_doc.json")
 	if err != nil {
 		return err
 	}
@@ -529,7 +530,7 @@ func countCatItems(elasticsearchHostPort, catObject, extraParams string) (int, e
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return 0, err
 	}
@@ -566,7 +567,7 @@ func getElasticsearchVersion(elasticsearchHostPort string) (*version.V, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -607,7 +608,7 @@ func httpSendJSON(host, path, method string, body []byte) ([]byte, *http.Respons
 	}
 	defer resp.Body.Close()
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/metricbeat/module/elasticsearch/enrich/data_test.go
+++ b/metricbeat/module/elasticsearch/enrich/data_test.go
@@ -20,9 +20,9 @@
 package enrich
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,7 +41,7 @@ func TestMapper(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	input, err := ioutil.ReadFile("./_meta/test/empty.750.json")
+	input, err := os.ReadFile("./_meta/test/empty.750.json")
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -76,13 +76,13 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 
 	mux.Handle("/_xpack/usage", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/xpack-usage.710.json")
+			input, _ := os.ReadFile("./_meta/test/xpack-usage.710.json")
 			w.Write(input)
 		}))
 
 	mux.Handle("/_enrich/_stats", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/enrich_stats.750.json")
+			input, _ := os.ReadFile("./_meta/test/enrich_stats.750.json")
 			w.Write(input)
 		}))
 

--- a/metricbeat/module/elasticsearch/index/data_test.go
+++ b/metricbeat/module/elasticsearch/index/data_test.go
@@ -20,9 +20,9 @@
 package index
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -72,7 +72,7 @@ func TestEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	input, err := ioutil.ReadFile("./_meta/test/empty.512.json")
+	input, err := os.ReadFile("./_meta/test/empty.512.json")
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -89,16 +89,16 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 	}
 	rootHandler := func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "_stats") {
-			input, _ := ioutil.ReadFile("./_meta/test/stats.800.snapshot.20201118.json")
+			input, _ := os.ReadFile("./_meta/test/stats.800.snapshot.20201118.json")
 			w.Write(input)
 			return
 		} else if r.URL.Path != "/" {
-			input, _ := ioutil.ReadFile("./_meta/test/settings.json")
+			input, _ := os.ReadFile("./_meta/test/settings.json")
 			w.Write(input)
 			return
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		w.Write(input)
 
 	}
@@ -114,13 +114,13 @@ func createEsMuxer(esVersion, license string, ccrEnabled bool) *http.ServeMux {
 
 	mux.Handle("/_xpack/usage", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/xpack-usage.710.json")
+			input, _ := os.ReadFile("./_meta/test/xpack-usage.710.json")
 			w.Write(input)
 		}))
 
 	mux.Handle("/_cluster/state/metadata,routing_table", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/cluster_state.710.json")
+			input, _ := os.ReadFile("./_meta/test/cluster_state.710.json")
 			w.Write(input)
 		}))
 

--- a/metricbeat/module/elasticsearch/index_recovery/data_test.go
+++ b/metricbeat/module/elasticsearch/index_recovery/data_test.go
@@ -20,9 +20,9 @@
 package index_recovery
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	mbtest "github.com/elastic/beats/v7/metricbeat/mb/testing"
@@ -46,7 +46,7 @@ func createEsMuxer(license string) *http.ServeMux {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		w.Write(input)
 	}
 	licenseHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func createEsMuxer(license string) *http.ServeMux {
 	mux.Handle("/_xpack/license", http.HandlerFunc(licenseHandler)) // for before 7.0
 	mux.Handle("/", http.HandlerFunc(rootHandler))
 	mux.Handle("/_recovery", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		content, _ := ioutil.ReadFile("./_meta/test/recovery.710.json")
+		content, _ := os.ReadFile("./_meta/test/recovery.710.json")
 		w.Write(content)
 	}))
 

--- a/metricbeat/module/elasticsearch/index_summary/data_test.go
+++ b/metricbeat/module/elasticsearch/index_summary/data_test.go
@@ -20,9 +20,9 @@
 package index_summary
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,7 +48,7 @@ func createEsMuxer(license string) *http.ServeMux {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("../index/_meta/test/root.710.json")
+		input, _ := os.ReadFile("../index/_meta/test/root.710.json")
 		w.Write(input)
 	}
 	licenseHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +62,7 @@ func createEsMuxer(license string) *http.ServeMux {
 	mux.Handle("/_xpack/license", http.HandlerFunc(licenseHandler)) // for before 7.0
 	mux.Handle("/", http.HandlerFunc(rootHandler))
 	mux.Handle("/_stats", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		content, _ := ioutil.ReadFile("../index/_meta/test/stats.700-alpha1.json")
+		content, _ := os.ReadFile("../index/_meta/test/stats.700-alpha1.json")
 		w.Write(content)
 	}))
 
@@ -86,7 +86,7 @@ func TestMapper(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	input, err := ioutil.ReadFile("../index/_meta/test/empty.512.json")
+	input, err := os.ReadFile("../index/_meta/test/empty.512.json")
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/elasticsearch/ingest_pipeline/data_test.go
+++ b/metricbeat/module/elasticsearch/ingest_pipeline/data_test.go
@@ -18,7 +18,7 @@
 package ingest_pipeline
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func TestMapper(t *testing.T) {
 		ClusterName: "helloworld",
 	}
 
-	ingestData, err := ioutil.ReadFile("./_meta/test/stats.json")
+	ingestData, err := os.ReadFile("./_meta/test/stats.json")
 	require.NoError(t, err)
 
 	err = eventsMapping(reporter, info, ingestData, true, true)
@@ -92,7 +92,7 @@ func TestSampling(t *testing.T) {
 		ClusterName: "helloworld",
 	}
 
-	ingestData, err := ioutil.ReadFile("./_meta/test/stats.json")
+	ingestData, err := os.ReadFile("./_meta/test/stats.json")
 	require.NoError(t, err)
 
 	err = eventsMapping(reporter, info, ingestData, true, false) // set sampling to false

--- a/metricbeat/module/elasticsearch/ml_job/data_test.go
+++ b/metricbeat/module/elasticsearch/ml_job/data_test.go
@@ -20,9 +20,9 @@
 package ml_job
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -50,7 +50,7 @@ func TestData(t *testing.T) {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := os.ReadFile("./_meta/test/root.710.json")
 		input = []byte(strings.Replace(string(input), "7.10.0", "7.10.0", -1))
 		w.Write(input)
 	}
@@ -70,7 +70,7 @@ func TestData(t *testing.T) {
 	mux.Handle("/_xpack", http.HandlerFunc(xpackHandler))
 
 	mux.Handle("/_ml/anomaly_detectors/_all/_stats", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		input, _ := ioutil.ReadFile("./_meta/test/ml.711.json")
+		input, _ := os.ReadFile("./_meta/test/ml.711.json")
 		w.Write(input)
 	}))
 

--- a/metricbeat/module/elasticsearch/node/data_test.go
+++ b/metricbeat/module/elasticsearch/node/data_test.go
@@ -20,7 +20,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -42,7 +42,7 @@ func TestGetMappings(t *testing.T) {
 func TestInvalid(t *testing.T) {
 	file := "./_meta/test/invalid.json"
 
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/elasticsearch/node/node_test.go
+++ b/metricbeat/module/elasticsearch/node/node_test.go
@@ -21,9 +21,9 @@ package node
 
 import (
 	"encoding/base64"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,7 +42,7 @@ func TestFetch(t *testing.T) {
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
-			response, err := ioutil.ReadFile(f)
+			response, err := os.ReadFile(f)
 			require.NoError(t, err)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/elasticsearch/pending_tasks/data_test.go
+++ b/metricbeat/module/elasticsearch/pending_tasks/data_test.go
@@ -20,7 +20,7 @@
 package pending_tasks
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -42,7 +42,7 @@ var info = elasticsearch.Info{
 
 func TestEmptyQueueShouldGiveNoError(t *testing.T) {
 	file := "./_meta/test/empty.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -52,7 +52,7 @@ func TestEmptyQueueShouldGiveNoError(t *testing.T) {
 
 func TestNotEmptyQueueShouldGiveNoError(t *testing.T) {
 	file := "./_meta/test/tasks.622.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -64,7 +64,7 @@ func TestNotEmptyQueueShouldGiveNoError(t *testing.T) {
 
 func TestEmptyQueueShouldGiveZeroEvent(t *testing.T) {
 	file := "./_meta/test/empty.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -75,7 +75,7 @@ func TestEmptyQueueShouldGiveZeroEvent(t *testing.T) {
 
 func TestNotEmptyQueueShouldGiveSeveralEvents(t *testing.T) {
 	file := "./_meta/test/tasks.622.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -86,7 +86,7 @@ func TestNotEmptyQueueShouldGiveSeveralEvents(t *testing.T) {
 
 func TestInvalidJsonForRequiredFieldShouldThrowError(t *testing.T) {
 	file := "./_meta/test/invalid_required_field.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -96,7 +96,7 @@ func TestInvalidJsonForRequiredFieldShouldThrowError(t *testing.T) {
 
 func TestInvalidJsonForBadFormatShouldThrowError(t *testing.T) {
 	file := "./_meta/test/invalid_format.json"
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}
@@ -198,7 +198,7 @@ func TestEventsMappedMatchToContentReceived(t *testing.T) {
 	}
 
 	for iter, testCase := range testCases {
-		content, err := ioutil.ReadFile(testCase.given)
+		content, err := os.ReadFile(testCase.given)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/elasticsearch/shard/data_test.go
+++ b/metricbeat/module/elasticsearch/shard/data_test.go
@@ -18,9 +18,9 @@
 package shard
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -36,7 +36,7 @@ func TestStats(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
@@ -58,7 +58,7 @@ func TestData(t *testing.T) {
 	}))
 	mux.Handle("/_cluster/state/version,nodes,master_node,routing_table", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/routing_table.710.json")
+			input, _ := os.ReadFile("./_meta/test/routing_table.710.json")
 			w.Write(input)
 		}))
 

--- a/metricbeat/module/elasticsearch/testing.go
+++ b/metricbeat/module/elasticsearch/testing.go
@@ -20,7 +20,7 @@
 package elasticsearch
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -41,7 +41,7 @@ func TestMapper(t *testing.T, glob string, mapper func(mb.ReporterV2, []byte) er
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
-			input, err := ioutil.ReadFile(f)
+			input, err := os.ReadFile(f)
 			require.NoError(t, err)
 
 			reporter := &mbtest.CapturingReporterV2{}
@@ -67,7 +67,7 @@ func TestMapperWithInfo(t *testing.T, glob string, mapper func(mb.ReporterV2, In
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
-			input, err := ioutil.ReadFile(f)
+			input, err := os.ReadFile(f)
 			require.NoError(t, err)
 
 			reporter := &mbtest.CapturingReporterV2{}
@@ -93,7 +93,7 @@ func TestMapperWithMetricSetAndInfo(t *testing.T, glob string, ms MetricSetAPI, 
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
-			input, err := ioutil.ReadFile(f)
+			input, err := os.ReadFile(f)
 			require.NoError(t, err)
 
 			reporter := &mbtest.CapturingReporterV2{}
@@ -125,7 +125,7 @@ func TestMapperWithHttpHelper(t *testing.T, glob string, httpClient *helper.HTTP
 
 	for _, f := range files {
 		t.Run(f, func(t *testing.T) {
-			input, err := ioutil.ReadFile(f)
+			input, err := os.ReadFile(f)
 			require.NoError(t, err)
 
 			reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/envoyproxy/server/server_test.go
+++ b/metricbeat/module/envoyproxy/server/server_test.go
@@ -18,9 +18,9 @@
 package server
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -35,7 +35,7 @@ import (
 const testFile = "../_meta/test/serverstats"
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile(testFile)
+	content, err := os.ReadFile(testFile)
 	assert.NoError(t, err)
 
 	event, err := eventMapping(content)
@@ -119,7 +119,7 @@ func TestFetchEventContent(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/test/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/serverstats")
+	response, err := os.ReadFile(absPath + "/serverstats")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +155,7 @@ func TestFetchTimeout(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/test/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/serverstats")
+	response, err := os.ReadFile(absPath + "/serverstats")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/etcd/leader/leader.go
+++ b/metricbeat/module/etcd/leader/leader.go
@@ -20,7 +20,7 @@ package leader
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -93,7 +93,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 	}
 	defer res.Body.Close()
 
-	content, err := ioutil.ReadAll(res.Body)
+	content, err := io.ReadAll(res.Body)
 	if err != nil {
 		return fmt.Errorf("error reading body response: %w", err)
 	}

--- a/metricbeat/module/etcd/leader/leader_test.go
+++ b/metricbeat/module/etcd/leader/leader_test.go
@@ -19,9 +19,9 @@ package leader
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -33,7 +33,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("../_meta/test/leaderstats.json")
+	content, err := os.ReadFile("../_meta/test/leaderstats.json")
 	assert.NoError(t, err)
 
 	var data Leader
@@ -109,7 +109,7 @@ func TestFetchEventContent(t *testing.T) {
 			absPath, err := filepath.Abs(mockedFetchLocation + tc.mockedFetchFile)
 			assert.NoError(t, err)
 
-			response, err := ioutil.ReadFile(absPath)
+			response, err := os.ReadFile(absPath)
 			assert.NoError(t, err)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/etcd/self/self_test.go
+++ b/metricbeat/module/etcd/self/self_test.go
@@ -18,9 +18,9 @@
 package self
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("../_meta/test/selfstats.json")
+	content, err := os.ReadFile("../_meta/test/selfstats.json")
 	assert.NoError(t, err)
 
 	event := eventMapping(content)
@@ -43,7 +43,7 @@ func TestFetchEventContent(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/test/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/selfstats.json")
+	response, err := os.ReadFile(absPath + "/selfstats.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/etcd/store/store_test.go
+++ b/metricbeat/module/etcd/store/store_test.go
@@ -18,9 +18,9 @@
 package store
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +32,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("../_meta/test/storestats.json")
+	content, err := os.ReadFile("../_meta/test/storestats.json")
 	assert.NoError(t, err)
 
 	event := eventMapping(content)
@@ -44,7 +44,7 @@ func TestFetchEventContent(t *testing.T) {
 	absPath, err := filepath.Abs("../_meta/test/")
 	assert.NoError(t, err)
 
-	response, err := ioutil.ReadFile(absPath + "/storestats.json")
+	response, err := os.ReadFile(absPath + "/storestats.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/haproxy/haproxy.go
+++ b/metricbeat/module/haproxy/haproxy.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"strings"
@@ -260,7 +259,7 @@ func (c *Client) GetInfo() (*Info, error) {
 		return nil, err
 	}
 
-	if b, err := ioutil.ReadAll(res); err == nil {
+	if b, err := io.ReadAll(res); err == nil {
 
 		resultMap := map[string]interface{}{}
 

--- a/metricbeat/module/http/json/json.go
+++ b/metricbeat/module/http/json/json.go
@@ -20,7 +20,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/elastic/beats/v7/metricbeat/helper"
 	"github.com/elastic/beats/v7/metricbeat/mb"
@@ -128,7 +128,7 @@ func (m *MetricSet) Fetch(reporter mb.ReporterV2) error {
 		}
 	}()
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/metricbeat/module/jolokia/jmx/data_test.go
+++ b/metricbeat/module/jolokia/jmx/data_test.go
@@ -18,7 +18,7 @@
 package jmx
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,7 +33,7 @@ func TestEventMapper(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response.json")
 
 	require.NoError(t, err)
 
@@ -104,7 +104,7 @@ func TestEventGroupingMapper(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response.json")
 
 	require.NoError(t, err)
 
@@ -181,7 +181,7 @@ func TestEventGroupingMapperGetRequest(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_get_response.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_get_response.json")
 
 	require.NoError(t, err)
 
@@ -230,7 +230,7 @@ func TestEventGroupingMapperGetRequestUptime(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_get_response_uptime.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_get_response_uptime.json")
 
 	require.NoError(t, err)
 
@@ -264,7 +264,7 @@ func TestEventMapperWithWildcard(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response_wildcard.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response_wildcard.json")
 
 	require.NoError(t, err)
 
@@ -305,7 +305,7 @@ func TestEventGroupingMapperWithWildcard(t *testing.T) {
 	require.NotNil(t, absPath)
 	require.NoError(t, err)
 
-	jolokiaResponse, err := ioutil.ReadFile(absPath + "/jolokia_response_wildcard.json")
+	jolokiaResponse, err := os.ReadFile(absPath + "/jolokia_response_wildcard.json")
 
 	require.NoError(t, err)
 

--- a/metricbeat/module/kibana/stats/data_test.go
+++ b/metricbeat/module/kibana/stats/data_test.go
@@ -20,7 +20,7 @@
 package stats
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -35,7 +35,7 @@ func TestEventMapping(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/kibana/stats/stats_integration_test.go
+++ b/metricbeat/module/kibana/stats/stats_integration_test.go
@@ -21,7 +21,7 @@ package stats
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -88,7 +88,7 @@ func getKibanaVersion(t *testing.T, kibanaHostPort string) (*version.V, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/kibana/status/data_test.go
+++ b/metricbeat/module/kibana/status/data_test.go
@@ -20,7 +20,7 @@
 package status
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,7 +30,7 @@ import (
 
 func TestEventMapping(t *testing.T) {
 	f := "./_meta/test/input.json"
-	content, err := ioutil.ReadFile(f)
+	content, err := os.ReadFile(f)
 	require.NoError(t, err)
 
 	reporter := &mbtest.CapturingReporterV2{}

--- a/metricbeat/module/kubernetes/container/container_test.go
+++ b/metricbeat/module/kubernetes/container/container_test.go
@@ -20,7 +20,7 @@
 package container
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -70,7 +70,7 @@ func (s *ContainerTestSuite) ReadTestFile(testFile string) []byte {
 	f, err := os.Open(testFile)
 	s.NoError(err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	s.NoError(err, "cannot read test file "+testFile)
 
 	return body

--- a/metricbeat/module/kubernetes/node/node_test.go
+++ b/metricbeat/module/kubernetes/node/node_test.go
@@ -20,7 +20,7 @@
 package node
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -46,7 +46,7 @@ func (s *NodeTestSuite) ReadTestFile(testFile string) []byte {
 	f, err := os.Open(testFile)
 	s.NoError(err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	s.NoError(err, "cannot read test file "+testFile)
 
 	return body

--- a/metricbeat/module/kubernetes/pod/pod_test.go
+++ b/metricbeat/module/kubernetes/pod/pod_test.go
@@ -20,7 +20,7 @@
 package pod
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -77,7 +77,7 @@ func (s *PodTestSuite) ReadTestFile(testFile string) []byte {
 	f, err := os.Open(testFile)
 	s.NoError(err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	s.NoError(err, "cannot read test file "+testFile)
 
 	return body

--- a/metricbeat/module/kubernetes/system/system_test.go
+++ b/metricbeat/module/kubernetes/system/system_test.go
@@ -20,7 +20,7 @@
 package system
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestEventMapping(t *testing.T) {
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
 	events, err := eventMapping(body, logger)

--- a/metricbeat/module/kubernetes/volume/volume_test.go
+++ b/metricbeat/module/kubernetes/volume/volume_test.go
@@ -20,7 +20,7 @@
 package volume
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestEventMapping(t *testing.T) {
 	f, err := os.Open(testFile)
 	assert.NoError(t, err, "cannot open test file "+testFile)
 
-	body, err := ioutil.ReadAll(f)
+	body, err := io.ReadAll(f)
 	assert.NoError(t, err, "cannot read test file "+testFile)
 
 	events, err := eventMapping(body, logger)

--- a/metricbeat/module/linux/rapl/rapl.go
+++ b/metricbeat/module/linux/rapl/rapl.go
@@ -231,7 +231,7 @@ func topoPkgCPUMap(hostfs resolve.Resolver) (map[int][]int, error) {
 	sysdir := "/sys/devices/system/cpu/"
 	cpuMap := make(map[int][]int)
 
-	files, err := ioutil.ReadDir(hostfs.ResolveHostFS(sysdir))
+	files, err := os.ReadDir(hostfs.ResolveHostFS(sysdir))
 	if err != nil {
 		return nil, err
 	}

--- a/metricbeat/module/linux/rapl/rapl.go
+++ b/metricbeat/module/linux/rapl/rapl.go
@@ -22,7 +22,6 @@ package rapl
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -242,7 +241,7 @@ func topoPkgCPUMap(hostfs resolve.Resolver) (map[int][]int, error) {
 		if file.IsDir() && re.MatchString(file.Name()) {
 
 			fullPkg := hostfs.ResolveHostFS(filepath.Join(sysdir, file.Name(), "/topology/physical_package_id"))
-			dat, err := ioutil.ReadFile(fullPkg)
+			dat, err := os.ReadFile(fullPkg)
 			if err != nil {
 				return nil, fmt.Errorf("error reading file %s: %w", fullPkg, err)
 			}

--- a/metricbeat/module/linux/util.go
+++ b/metricbeat/module/linux/util.go
@@ -19,7 +19,7 @@ package linux
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -28,7 +28,7 @@ import (
 // /sysfs contains a number of metrics broken out by values in individual files, so this is a useful helper function to have
 func ReadIntFromFile(path string, base int) (int64, error) {
 
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return 0, fmt.Errorf("error reading file %s: %w", path, err)
 	}

--- a/metricbeat/module/logstash/logstash_integration_test.go
+++ b/metricbeat/module/logstash/logstash_integration_test.go
@@ -21,7 +21,7 @@ package logstash_test
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -105,7 +105,7 @@ func getESClusterUUID(t *testing.T, host string) string {
 		ClusterUUID string `json:"cluster_uuid"`
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	json.Unmarshal(data, &body)
 

--- a/metricbeat/module/logstash/node/data_test.go
+++ b/metricbeat/module/logstash/node/data_test.go
@@ -21,7 +21,7 @@ package node
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestEventMapping(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, f := range files {
-		input, err := ioutil.ReadFile(f)
+		input, err := os.ReadFile(f)
 		require.NoError(t, err)
 
 		var data map[string]interface{}

--- a/metricbeat/module/logstash/node_stats/data_test.go
+++ b/metricbeat/module/logstash/node_stats/data_test.go
@@ -21,9 +21,9 @@ package node_stats
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	stdlibos "os"
 	"testing"
 
 	"github.com/elastic/beats/v7/metricbeat/module/logstash"
@@ -57,7 +57,7 @@ func EventMappingForFiles(t *testing.T, fixtureVersions []string, expectedEvents
 
 	for _, f := range fixtureVersions {
 		path := fmt.Sprintf("./_meta/test/node_stats.%s.json", f)
-		input, err := ioutil.ReadFile(path)
+		input, err := stdlibos.ReadFile(path)
 		require.NoError(t, err)
 
 		reporter := &mbtest.CapturingReporterV2{}
@@ -75,13 +75,13 @@ func TestData(t *testing.T) {
 			http.NotFound(w, r)
 		}
 
-		input, _ := ioutil.ReadFile("./_meta/test/root.710.json")
+		input, _ := stdlibos.ReadFile("./_meta/test/root.710.json")
 		w.Write(input)
 	}))
 
 	mux.Handle("/_node/stats", http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			input, _ := ioutil.ReadFile("./_meta/test/node_stats.710.json")
+			input, _ := stdlibos.ReadFile("./_meta/test/node_stats.710.json")
 			w.Write(input)
 		}))
 

--- a/metricbeat/module/mongodb/collstats/data_test.go
+++ b/metricbeat/module/mongodb/collstats/data_test.go
@@ -21,7 +21,7 @@ package collstats
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,7 +31,7 @@ import (
 
 func TestEventMapping(t *testing.T) {
 
-	content, err := ioutil.ReadFile("./_meta/test/input.json")
+	content, err := os.ReadFile("./_meta/test/input.json")
 	assert.NoError(t, err)
 
 	data := mapstr.M{}

--- a/metricbeat/module/nats/connection/connection_test.go
+++ b/metricbeat/module/nats/connection/connection_test.go
@@ -18,7 +18,6 @@
 package connection
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -41,7 +40,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/connectionsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/connectionsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/nats/connection/connection_test.go
+++ b/metricbeat/module/nats/connection/connection_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +31,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/connectionsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/connectionsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, content)

--- a/metricbeat/module/nats/connections/connections_test.go
+++ b/metricbeat/module/nats/connections/connections_test.go
@@ -18,9 +18,9 @@
 package connections
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/connectionsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/connectionsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/connectionsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/connectionsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/nats/route/route_test.go
+++ b/metricbeat/module/nats/route/route_test.go
@@ -18,9 +18,9 @@
 package route
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/routesmetrics.json")
+	content, err := os.ReadFile("./_meta/test/routesmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventsMapping(reporter, content)
@@ -40,7 +40,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/routesmetrics.json")
+	response, _ := os.ReadFile(absPath + "/routesmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/nats/routes/routes_test.go
+++ b/metricbeat/module/nats/routes/routes_test.go
@@ -18,9 +18,9 @@
 package routes
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/routesmetrics.json")
+	content, err := os.ReadFile("./_meta/test/routesmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test")
 
-	response, _ := ioutil.ReadFile(absPath + "/routesmetrics.json")
+	response, _ := os.ReadFile(absPath + "/routesmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/nats/stats/stats_test.go
+++ b/metricbeat/module/nats/stats/stats_test.go
@@ -18,9 +18,9 @@
 package stats
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/statsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/statsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test/")
 
-	response, _ := ioutil.ReadFile(absPath + "/statsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/statsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/nats/subscriptions/subscriptions_test.go
+++ b/metricbeat/module/nats/subscriptions/subscriptions_test.go
@@ -18,9 +18,9 @@
 package subscriptions
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -30,7 +30,7 @@ import (
 )
 
 func TestEventMapping(t *testing.T) {
-	content, err := ioutil.ReadFile("./_meta/test/subscriptionsmetrics.json")
+	content, err := os.ReadFile("./_meta/test/subscriptionsmetrics.json")
 	assert.NoError(t, err)
 	reporter := &mbtest.CapturingReporterV2{}
 	err = eventMapping(reporter, content)
@@ -43,7 +43,7 @@ func TestEventMapping(t *testing.T) {
 func TestFetchEventContent(t *testing.T) {
 	absPath, _ := filepath.Abs("./_meta/test/")
 
-	response, _ := ioutil.ReadFile(absPath + "/subscriptionsmetrics.json")
+	response, _ := os.ReadFile(absPath + "/subscriptionsmetrics.json")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Header().Set("Content-Type", "application/json;")

--- a/metricbeat/module/rabbitmq/mtest/server.go
+++ b/metricbeat/module/rabbitmq/mtest/server.go
@@ -18,9 +18,9 @@
 package mtest
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -58,12 +58,12 @@ func Server(t *testing.T, c ServerConfig) *httptest.Server {
 	}
 
 	for k := range responses {
-		r, err := ioutil.ReadFile(filepath.Join(absPath, responses[k].file))
+		r, err := os.ReadFile(filepath.Join(absPath, responses[k].file))
 		responses[k].body = r
 		assert.NoError(t, err)
 	}
 
-	notFound, err := ioutil.ReadFile(filepath.Join(absPath, "notfound_response.json"))
+	notFound, err := os.ReadFile(filepath.Join(absPath, "notfound_response.json"))
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/system/entropy/entropy.go
+++ b/metricbeat/module/system/entropy/entropy.go
@@ -21,7 +21,7 @@ package entropy
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -85,7 +85,7 @@ func (m *MetricSet) Fetch(report mb.ReporterV2) error {
 
 func getEntropyData(path string) (int, error) {
 	//This will be a number in the range 0 to 4096.
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return 0, fmt.Errorf("error reading from random: %w", err)
 	}

--- a/metricbeat/module/system/hostnamechange_test.go
+++ b/metricbeat/module/system/hostnamechange_test.go
@@ -19,7 +19,7 @@ package system
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -28,7 +28,7 @@ import (
 // is running.
 func TestHostDashboardHasChangeableHost(t *testing.T) {
 	dashPath := "_meta/kibana/7/dashboard/79ffd6e0-faa0-11e6-947f-177f697178b8-ecs.json"
-	contents, err := ioutil.ReadFile(dashPath)
+	contents, err := os.ReadFile(dashPath)
 	if err != nil {
 		t.Fatalf("Error reading file %s: %v", dashPath, err)
 	}

--- a/metricbeat/module/system/process_summary/process_summary.go
+++ b/metricbeat/module/system/process_summary/process_summary.go
@@ -21,7 +21,7 @@ package process_summary
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -107,7 +107,7 @@ func (m *MetricSet) Fetch(r mb.ReporterV2) error {
 // threadStats returns a map of state counts for running threads on a system
 func threadStats(sys resolve.Resolver) (mapstr.M, error) {
 	statPath := sys.ResolveHostFS("/proc/stat")
-	procData, err := ioutil.ReadFile(statPath)
+	procData, err := os.ReadFile(statPath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading procfs file %s: %w", statPath, err)
 	}

--- a/metricbeat/module/system/raid/blockinfo/getdev.go
+++ b/metricbeat/module/system/raid/blockinfo/getdev.go
@@ -19,14 +19,13 @@ package blockinfo
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
 
 // ListAll lists all the multi-disk devices in a RAID array
 func ListAll(path string) ([]MDDevice, error) {
-	dir, err := ioutil.ReadDir(path)
+	dir, err := os.ReadDir(path)
 	if err != nil {
 		return nil, fmt.Errorf("could not read directory: %w", err)
 	}

--- a/metricbeat/module/system/raid/blockinfo/getdev.go
+++ b/metricbeat/module/system/raid/blockinfo/getdev.go
@@ -29,7 +29,7 @@ func ListAll(path string) ([]MDDevice, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not read directory: %w", err)
 	}
-	var mds []MDDevice
+	mds := make([]MDDevice, 0, len(dir))
 	for _, item := range dir {
 		testpath := filepath.Join(path, item.Name())
 		if !isMD(testpath) {
@@ -68,8 +68,5 @@ func getMDDevice(path string) (MDDevice, error) {
 // Right now, we're doing this by looking for an `md` directory in the device dir.
 func isMD(path string) bool {
 	_, err := os.Stat(filepath.Join(path, "md"))
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }

--- a/metricbeat/module/system/raid/blockinfo/parser.go
+++ b/metricbeat/module/system/raid/blockinfo/parser.go
@@ -49,7 +49,7 @@ func parseIntVal(path string) (int64, error) {
 	}
 	strVal := strings.TrimSpace(string(raw))
 
-	value, err = strconv.ParseInt(string(strVal), 10, 64)
+	value, err = strconv.ParseInt(strVal, 10, 64)
 	if err != nil {
 		return value, err
 	}

--- a/metricbeat/module/system/raid/blockinfo/parser.go
+++ b/metricbeat/module/system/raid/blockinfo/parser.go
@@ -19,7 +19,7 @@ package blockinfo
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -43,7 +43,7 @@ func isRedundant(raidStr string) bool {
 
 func parseIntVal(path string) (int64, error) {
 	var value int64
-	raw, err := ioutil.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return value, err
 	}
@@ -61,7 +61,7 @@ func parseIntVal(path string) (int64, error) {
 // if there's no sync operation in progress, the file will just have 'none'
 // in which case, default to to the overall size
 func getSyncStatus(path string, size int64) (SyncStatus, error) {
-	raw, err := ioutil.ReadFile(filepath.Join(path, "md", "sync_completed"))
+	raw, err := os.ReadFile(filepath.Join(path, "md", "sync_completed"))
 	if err != nil {
 		return SyncStatus{}, fmt.Errorf("could not open sync_completed: %w", err)
 	}
@@ -102,7 +102,7 @@ func newMD(path string) (MDDevice, error) {
 	dev.Size = size
 
 	//RAID array state
-	state, err := ioutil.ReadFile(filepath.Join(path, "md", "array_state"))
+	state, err := os.ReadFile(filepath.Join(path, "md", "array_state"))
 	if err != nil {
 		return dev, fmt.Errorf("could not open array_state: %w", err)
 	}
@@ -115,7 +115,7 @@ func newMD(path string) (MDDevice, error) {
 	}
 	dev.DiskStates = disks
 
-	level, err := ioutil.ReadFile(filepath.Join(path, "md", "level"))
+	level, err := os.ReadFile(filepath.Join(path, "md", "level"))
 	if err != nil {
 		return dev, fmt.Errorf("could not get raid level: %w", err)
 	}
@@ -126,7 +126,7 @@ func newMD(path string) (MDDevice, error) {
 
 		//Get the sync action
 		//Will be idle if nothing is going on
-		syncAction, err := ioutil.ReadFile(filepath.Join(path, "md", "sync_action"))
+		syncAction, err := os.ReadFile(filepath.Join(path, "md", "sync_action"))
 		if err != nil {
 			return dev, fmt.Errorf("could not open sync_action: %w", err)
 		}
@@ -187,7 +187,7 @@ func getDisks(path string) (DiskStates, error) {
 }
 
 func getDisk(path string) (string, error) {
-	state, err := ioutil.ReadFile(filepath.Join(path, "state"))
+	state, err := os.ReadFile(filepath.Join(path, "state"))
 	if err != nil {
 		return "", fmt.Errorf("error getting disk state: %w", err)
 	}

--- a/metricbeat/module/system/system.go
+++ b/metricbeat/module/system/system.go
@@ -18,13 +18,9 @@
 package system
 
 import (
-	"sync"
-
 	"github.com/elastic/beats/v7/metricbeat/internal/sysinit"
 	"github.com/elastic/beats/v7/metricbeat/mb"
 )
-
-var once sync.Once
 
 func init() {
 	// Register the ModuleFactory function for the "system" module.

--- a/metricbeat/module/traefik/health/health_test.go
+++ b/metricbeat/module/traefik/health/health_test.go
@@ -21,9 +21,9 @@ package health
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,7 +35,7 @@ import (
 )
 
 func TestFetchEventContents(t *testing.T) {
-	mockResponse, err := ioutil.ReadFile("./_meta/test/simple.json")
+	mockResponse, err := os.ReadFile("./_meta/test/simple.json")
 	assert.NoError(t, err)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/metricbeat/module/uwsgi/status/status.go
+++ b/metricbeat/module/uwsgi/status/status.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -89,7 +88,7 @@ func fetchStatData(URL string) ([]byte, error) {
 		return nil, errors.New("unknown scheme")
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("uwsgi data read failed: %w", err)
 	}

--- a/metricbeat/module/uwsgi/status/status_linux_test.go
+++ b/metricbeat/module/uwsgi/status/status_linux_test.go
@@ -18,7 +18,6 @@
 package status
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"sync"
@@ -30,7 +29,7 @@ import (
 )
 
 func TestFetchDataUnixSock(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "mb_uwsgi_status")
+	tmpfile, err := os.CreateTemp("", "mb_uwsgi_status")
 	assert.NoError(t, err)
 	fname := tmpfile.Name()
 	os.Remove(fname)

--- a/metricbeat/module/uwsgi/status/status_test.go
+++ b/metricbeat/module/uwsgi/status/status_test.go
@@ -18,10 +18,10 @@
 package status
 
 import (
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -40,7 +40,7 @@ func testData(t *testing.T) (data []byte) {
 		return
 	}
 
-	data, err = ioutil.ReadFile(filepath.Join(absPath, "/data.json"))
+	data, err = os.ReadFile(filepath.Join(absPath, "/data.json"))
 	if err != nil {
 		t.Fatalf("ReadFile failed: %s", err.Error())
 		return

--- a/metricbeat/module/zookeeper/zookeeper.go
+++ b/metricbeat/module/zookeeper/zookeeper.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"strings"
 	"time"
@@ -55,7 +54,7 @@ func RunCommand(command, address string, timeout time.Duration) (io.Reader, erro
 		return nil, fmt.Errorf("writing command '%s' failed: %w", command, err)
 	}
 
-	result, err := ioutil.ReadAll(conn)
+	result, err := io.ReadAll(conn)
 	if err != nil {
 		return nil, fmt.Errorf("read failed: %w", err)
 	}

--- a/metricbeat/scripts/mage/docs_collector.go
+++ b/metricbeat/scripts/mage/docs_collector.go
@@ -20,7 +20,6 @@ package mage
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -166,7 +165,7 @@ func getDefaultMetricsets() (map[string][]string, error) {
 
 // loadModuleFields loads the module-specific fields.yml file
 func loadModuleFields(file string) (moduleData, error) {
-	fd, err := ioutil.ReadFile(file)
+	fd, err := os.ReadFile(file)
 	if err != nil {
 		return moduleData{}, fmt.Errorf("failed to read from spec file: %w", err)
 	}
@@ -188,7 +187,7 @@ func loadModuleFields(file string) (moduleData, error) {
 
 // getReleaseState gets the release tag in the metricset-level fields.yml, since that's all we need from that file
 func getReleaseState(metricsetPath string) (string, error) {
-	raw, err := ioutil.ReadFile(metricsetPath)
+	raw, err := os.ReadFile(metricsetPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read from spec file: %w", err)
 	}
@@ -233,7 +232,7 @@ func getConfigfile(modulePath string) (string, error) {
 		return "", fmt.Errorf("could not find a config file in %s", modulePath)
 	}
 
-	raw, err := ioutil.ReadFile(goodPath)
+	raw, err := os.ReadFile(goodPath)
 	return string(raw), err
 
 }
@@ -330,7 +329,7 @@ func gatherData(modules []string) ([]moduleData, error) {
 		}
 
 		//dump the contents of the module asciidoc
-		moduleDoc, err := ioutil.ReadFile(filepath.Join(module, "_meta/docs.asciidoc"))
+		moduleDoc, err := os.ReadFile(filepath.Join(module, "_meta/docs.asciidoc"))
 		if err != nil {
 			return moduleList, err
 		}


### PR DESCRIPTION
## Proposed commit message

As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred. Successor functionality in io or os is more performant than the deprecated functionality in io/ioutil.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.~~


