### PR TITLE
Auditbeat,Metricbeat - add /inputs/ to HTTP monitoring endpoint

### DIFF
--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -252,6 +252,7 @@ is collected by it.
 *Auditbeat*
 
 - Upgrade go-libaudit to v2.4.0. {issue}36776[36776] {pull}36964[36964]
+- Add a `/inputs/` route to the HTTP monitoring endpoint that exposes metrics for each dataset instance. {pull}36971[36971]
 
 *Libbeat*
 
@@ -267,6 +268,7 @@ is collected by it.
 - Add GCP Carbon Footprint metricbeat data {pull}34820[34820]
 - Add event loop utilization metric to Kibana module {pull}35020[35020]
 - Align on the algorithm used to transform Prometheus histograms into Elasticsearch histograms {pull}36647[36647]
+- Add a `/inputs/` route to the HTTP monitoring endpoint that exposes metrics for each metricset instance. {pull}36971[36971]
 
 
 *Osquerybeat*

--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -184,18 +184,33 @@ func newBaseMetricSets(r *Register, m Module) ([]BaseMetricSet, error) {
 			metrics := monitoring.NewRegistry()
 			monitoring.NewString(metrics, "module").Set(m.Name())
 			monitoring.NewString(metrics, "metricset").Set(name)
+			monitoring.NewString(metrics, "input").Set(m.Name() + "/" + name)
 			if host != "" {
 				monitoring.NewString(metrics, "host").Set(host)
 			}
-			monitoring.NewString(metrics, "id").Set(msID)
+			monitoring.NewString(metrics, "ephemeral_id").Set(msID)
+			if configuredID := m.Config().ID; configuredID != "" {
+				// If a module ID was configured, then use that as the ID within metrics.
+				// Note that the "ephemeral_id" is what is used as the monitoring registry
+				// key. This module ID is not unique to the MetricSet instance when multiple
+				// hosts are monitored or if multiple different MetricSet types were enabled
+				// under the same module instance.
+				monitoring.NewString(metrics, "id").Set(configuredID)
+			} else {
+				monitoring.NewString(metrics, "id").Set(msID)
+			}
 
+			logger := logp.NewLogger(m.Name() + "." + name)
+			if m.Config().ID != "" {
+				logger = logger.With("id", m.Config().ID)
+			}
 			metricsets = append(metricsets, BaseMetricSet{
 				id:      msID,
 				name:    name,
 				module:  m,
 				host:    host,
 				metrics: metrics,
-				logger:  logp.NewLogger(m.Name() + "." + name),
+				logger:  logger,
 			})
 		}
 	}

--- a/metricbeat/mb/builders.go
+++ b/metricbeat/mb/builders.go
@@ -182,8 +182,6 @@ func newBaseMetricSets(r *Register, m Module) ([]BaseMetricSet, error) {
 			}
 			msID := id.String()
 			metrics := monitoring.NewRegistry()
-			monitoring.NewString(metrics, "module").Set(m.Name())
-			monitoring.NewString(metrics, "metricset").Set(name)
 			monitoring.NewString(metrics, "input").Set(m.Name() + "/" + name)
 			if host != "" {
 				monitoring.NewString(metrics, "host").Set(host)

--- a/metricbeat/mb/mb.go
+++ b/metricbeat/mb/mb.go
@@ -362,6 +362,7 @@ func (b *BaseMetricSet) Registration() MetricSetRegistration {
 // the metricset fetches not only the predefined fields but add alls raw data under
 // the raw namespace to the event.
 type ModuleConfig struct {
+	ID          string        `config:"id"` // Optional ID (not guaranteed to be unique).
 	Hosts       []string      `config:"hosts"`
 	Period      time.Duration `config:"period"     validate:"positive"`
 	Timeout     time.Duration `config:"timeout"    validate:"positive"`
@@ -375,8 +376,8 @@ type ModuleConfig struct {
 
 func (c ModuleConfig) String() string {
 	return fmt.Sprintf(`{Module:"%v", MetricSets:%v, Enabled:%v, `+
-		`Hosts:[%v hosts], Period:"%v", Timeout:"%v", Raw:%v, Query:%v}`,
-		c.Module, c.MetricSets, c.Enabled, len(c.Hosts), c.Period, c.Timeout,
+		`ID:"%s", Hosts:[%v hosts], Period:"%v", Timeout:"%v", Raw:%v, Query:%v}`,
+		c.Module, c.MetricSets, c.Enabled, c.ID, len(c.Hosts), c.Period, c.Timeout,
 		c.Raw, c.Query)
 }
 


### PR DESCRIPTION
## Proposed commit message

Make metrics published by "inputs" available through the /inputs/ route on the HTTP monitoring endpoint of Auditbeat and Metricbeat.

For Agent, include a snapshot of those metrics within the Agent diagnostics bundle as "input_metrics.json".

When running under Agent, each module instance is configured with only a single metricset. That module is given a unique `id`. That ID is what will be used as the `id` within the /inputs/ data. And that `id` will also be added as context to the logger that is passed into every metricset so that any log messages from a metricset can be associated back to the agent stream ID).

Relates: #36945

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates #36945

## Example

AFAICT no MetricSet implementations in Metricbeat or Auditbeat register any metrics so for now you can only use this to see what instances are running.

`curl "http://localhost:6060/inputs/?pretty"`
```json
[
  {
    "ephemeral_id": "86b09717-49ac-4c66-b08c-75edc3b4cffc",
    "id": "audit/system-system_audit.package-1af2373c-24b7-43b2-a9f2-8f04f803a0c6",
    "input": "system/package",
    "starttime": "2023-10-26T18:11:10.850Z"
  },
  {
    "ephemeral_id": "52965779-c346-4061-9fac-0baea45d2461",
    "id": "audit/file_integrity-fim.event-7580a9e4-e355-4a26-95c8-e49f08bd4fd0",
    "input": "file_integrity/file",
    "starttime": "2023-10-26T18:11:10.850Z"
  }
]
```
