### PR TITLE
Fix pipeline setup under serverless

### DIFF
--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -66,16 +66,17 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 			// check that all the required Ingest Node plugins are available
 			requiredProcessors := fileset.GetRequiredProcessors()
 			reg.log.Debugf("Required processors: %s", requiredProcessors)
+			// APIs do not exist on serverless
 			if len(requiredProcessors) > 0 && !esClient.IsServerless() {
 				err := checkAvailableProcessors(esClient, requiredProcessors)
 				if err != nil {
-					return fmt.Errorf("error loading pipeline for fileset %s/%s: %v", module.config.Module, fileset.name, err)
+					return fmt.Errorf("error loading pipeline for fileset %s/%s: %w", module.config.Module, fileset.name, err)
 				}
 			}
 
 			pipelines, err := fileset.GetPipelines(esClient.GetVersion())
 			if err != nil {
-				return fmt.Errorf("error getting pipeline for fileset %s/%s: %v", module.config.Module, fileset.name, err)
+				return fmt.Errorf("error getting pipeline for fileset %s/%s: %w", module.config.Module, fileset.name, err)
 			}
 
 			// Filesets with multiple pipelines can only be supported by Elasticsearch >= 6.5.0
@@ -89,7 +90,7 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 			for _, pipeline := range pipelines {
 				err = LoadPipeline(esClient, pipeline.id, pipeline.contents, overwrite, reg.log.With("pipeline", pipeline.id))
 				if err != nil {
-					err = fmt.Errorf("error loading pipeline for fileset %s/%s: %v", module.config.Module, fileset.name, err)
+					err = fmt.Errorf("error loading pipeline for fileset %s/%s: %w", module.config.Module, fileset.name, err)
 					break
 				}
 				pipelineIDsLoaded = append(pipelineIDsLoaded, pipeline.id)

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -171,7 +171,7 @@ func interpretError(initialErr error, body []byte) error {
 				"This is the response I got from Elasticsearch: %s", body)
 		}
 
-		return fmt.Errorf("couldn't load pipeline: %v. Additionally, error decoding response body: %s",
+		return fmt.Errorf("couldn't load pipeline: %w. Additionally, error decoding response body: %s",
 			initialErr, body)
 	}
 
@@ -196,5 +196,5 @@ func interpretError(initialErr error, body []byte) error {
 			"This is the response I got from Elasticsearch: %s", body)
 	}
 
-	return fmt.Errorf("couldn't load pipeline: %v. Response body: %s", initialErr, body)
+	return fmt.Errorf("couldn't load pipeline: %w. Response body: %s", initialErr, body)
 }

--- a/filebeat/fileset/pipelines.go
+++ b/filebeat/fileset/pipelines.go
@@ -37,6 +37,7 @@ type PipelineLoader interface {
 	LoadJSON(path string, json map[string]interface{}) ([]byte, error)
 	Request(method, path string, pipeline string, params map[string]string, body interface{}) (int, []byte, error)
 	GetVersion() version.V
+	IsServerless() bool
 }
 
 // MultiplePipelineUnsupportedError is an error returned when a fileset uses multiple pipelines but is
@@ -65,7 +66,7 @@ func (reg *ModuleRegistry) LoadPipelines(esClient PipelineLoader, overwrite bool
 			// check that all the required Ingest Node plugins are available
 			requiredProcessors := fileset.GetRequiredProcessors()
 			reg.log.Debugf("Required processors: %s", requiredProcessors)
-			if len(requiredProcessors) > 0 {
+			if len(requiredProcessors) > 0 && !esClient.IsServerless() {
 				err := checkAvailableProcessors(esClient, requiredProcessors)
 				if err != nil {
 					return fmt.Errorf("error loading pipeline for fileset %s/%s: %v", module.config.Module, fileset.name, err)


### PR DESCRIPTION

## Proposed commit message

closes https://github.com/elastic/beats/issues/36965

This is a fairly simple fix, since the `PipelineLoader` is already backed by ES, so we just needed to expand the interface.

I have tested this under serverless, but I'm not too familiar with pipeline setup, so I would prefer that someone with more knowledge of filebeat setup also look at this. My understanding is that serverless has no API for plugins or ingest processors, so there's no need for us to perform this check under serverless.



## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

