### PR TITLE
Fix copy arguments for strict aligned architectures

### DIFF
--- a/CHANGELOG-developer.next.asciidoc
+++ b/CHANGELOG-developer.next.asciidoc
@@ -89,7 +89,8 @@ The list below covers the major changes between 7.0.0-rc2 and main only.
 - Fixed some race conditions in tests {pull}36185[36185]
 - Re-enable HTTPJSON fixed flakey test. {issue}34929[34929] {pull}36525[36525]
 - Make winlogbeat/sys/wineventlog follow the unsafe.Pointer rules. {pull}36650[36650]
-- Cleaned up documentation errors & fixed a minor bug in Filebeat Azure blob storage input. {pull}36714[36714] 
+- Cleaned up documentation errors & fixed a minor bug in Filebeat Azure blob storage input. {pull}36714[36714]
+- Fix copy arguments for strict aligned architectures. {pull}36976[36976]
 
 ==== Added
 

--- a/CHANGELOG.next.asciidoc
+++ b/CHANGELOG.next.asciidoc
@@ -179,6 +179,7 @@ is collected by it.
 *Auditbeat*
 
 - Add `ignore_errors` option to audit module. {issue}15768[15768] {pull}36851[36851]
+- Fix copy arguments for strict aligned architectures. {pull}36976[36976]
 
 *Filebeat*
 

--- a/x-pack/auditbeat/tracing/int_aligned.go
+++ b/x-pack/auditbeat/tracing/int_aligned.go
@@ -16,7 +16,7 @@ import (
 var errBadSize = errors.New("bad size for integer")
 
 func copyInt(dst unsafe.Pointer, src unsafe.Pointer, len uint8) error {
-	copy((*(*[maxIntSizeBytes]byte)(src))[:len], (*(*[maxIntSizeBytes]byte)(src))[:len])
+	copy((*(*[maxIntSizeBytes]byte)(dst))[:len], (*(*[maxIntSizeBytes]byte)(src))[:len])
 	return nil
 }
 


### PR DESCRIPTION
## Proposed commit message

    Fix copy arguments for strict aligned architectures

    Small typo on copy arguments. In practice only affects arm32 and arm64 as I doubt there are users
    of other architectures around.

    Without this fix, Auditbeat would incorrectly decode ktrace events in non i386/amd64.

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [X] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

