### PR TITLE
Mark Functionbeat documentation as deprecated; point to ESF docs

### DIFF
--- a/x-pack/functionbeat/docs/overview.asciidoc
+++ b/x-pack/functionbeat/docs/overview.asciidoc
@@ -2,6 +2,9 @@
 [role="xpack"]
 == {beatname_uc} overview
 
+IMPORTANT: Beginning with version 8.10.4 the {beatname_uc} documentation is no longer being updated.
+We recommend instead to use {esf-ref}[{esf}] to ships logs from your AWS environment to Elastic.
+
 {beatname_uc} is an Elastic https://www.elastic.co/beats[Beat] that you
 deploy as a function in your serverless environment to collect data from cloud
 services and ship it to the {stack}.


### PR DESCRIPTION
As part of deprecating the Functionbeat documentation we should add a notice referring users to the Elasticsearch Service Forwarder.

Rel: https://github.com/elastic/ingest-docs/issues/608

---

![dep](https://github.com/elastic/beats/assets/41695641/56428f04-6fd9-4bb8-8ea0-b5b9887dc89e)
