### PR TITLE
Clarify the role of flush.min_events and bulk_max_size in docs

### DIFF
--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -28,20 +28,24 @@ queue.mem:
 
 The memory queue keeps all events in memory.
 
-If no flush interval and no number of events to flush is configured, 
-all events published to this queue will be directly consumed by the outputs.
-To enforce spooling in the queue, set the `flush.min_events` and `flush.timeout` options.
-
-By default `flush.min_events` is set to 2048 and `flush.timeout` is set to 1s.
-
-The output's `bulk_max_size` setting limits the number of events being processed at once.
-
 The memory queue waits for the output to acknowledge or drop events. If
 the queue is full, no new events can be inserted into the memory queue. Only
 after the signal from the output will the queue free up space for more events to be accepted.
 
-This sample configuration forwards events to the output if 512 events are
-available or the oldest available event has been waiting for 5s in the queue:
+The memory queue is controlled by the parameters `flush.min_events` and `flush.timeout`. If
+`flush.timeout` is `0s` or `flush.min_events` is `0` or `1` then events can be sent by the output as
+soon as they are available. If the output supports a `bulk_max_size` parameter it controls the
+maximum batch size that can be sent.
+
+If `flush.min_events` is greater than `1` and `flush.timeout` is greater than `0s`, events will only
+be sent to the output when the queue contains at least `flush.min_events` events or the
+`flush.timeout` period has expired. In this mode the maximum size batch that that can be sent by the
+output is `flush.min_events`. If the output supports a `bulk_max_size` parameter, values of
+`bulk_max_size` greater than `flush.min_events` have no effect. The value of `flush.min_events`
+should be evenly divisble by `bulk_max_size` to avoid sending partial batches to the output.
+
+This sample configuration forwards events to the output if 512 events are available or the oldest
+available event has been waiting for 5s in the queue:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -52,23 +56,24 @@ queue.mem:
 ------------------------------------------------------------------------------
 
 [float]
-==== Configuration options
+=== Configuration options
 
 You can specify the following options in the `queue.mem` section of the +{beatname_lc}.yml+ config file:
 
 [float]
 ===== `events`
 
-Number of events the queue can store. 
+Number of events the queue can store. This value should be evenly divisble by `flush.min_events` to
+avoid sending partial batches to the output.
 
 The default value is 3200 events.
 
 [float]
 ===== `flush.min_events`
 
-Minimum number of events required for publishing. If this value is set to 0, the
-output can start publishing events without additional waiting times. Otherwise
-the output has to wait for more events to become available.
+Minimum number of events required for publishing and the maximum batch size. If this value is set to
+0, the output can start publishing events without additional waiting times. Otherwise the output has
+to wait for more events to become available and cannot send a batch larger than this value.
 
 The default value is 1600.
 

--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -71,17 +71,19 @@ The default value is 3200 events.
 [float]
 ===== `flush.min_events`
 
-Minimum number of events required for publishing and the maximum batch size. If this value is set to
-0, the output can start publishing events without additional waiting times. Otherwise the output has
-to wait for more events to become available and cannot send a batch larger than this value.
+Minimum number of events required for publishing. If this value is set to 0 or 1, events are
+available to the output immediately. If this value is greater than 1 the output must wait for the
+queue to accumulate this minimum number of events or for `flush.timeout` to expire before
+publishing. When greater than `1` this value also defines the maximum possible batch that can be
+sent by the output.
 
 The default value is 1600.
 
 [float]
 ===== `flush.timeout`
 
-Maximum wait time for `flush.min_events` to be fulfilled. If set to 0s, events
-will be immediately available for consumption.
+Maximum wait time for `flush.min_events` to be fulfilled. If set to 0s, events are available to the
+output immediately.
 
 The default value is 10s.
 

--- a/libbeat/docs/queueconfig.asciidoc
+++ b/libbeat/docs/queueconfig.asciidoc
@@ -42,7 +42,7 @@ be sent to the output when the queue contains at least `flush.min_events` events
 `flush.timeout` period has expired. In this mode the maximum size batch that that can be sent by the
 output is `flush.min_events`. If the output supports a `bulk_max_size` parameter, values of
 `bulk_max_size` greater than `flush.min_events` have no effect. The value of `flush.min_events`
-should be evenly divisble by `bulk_max_size` to avoid sending partial batches to the output.
+should be evenly divisible by `bulk_max_size` to avoid sending partial batches to the output.
 
 This sample configuration forwards events to the output if 512 events are available or the oldest
 available event has been waiting for 5s in the queue:
@@ -63,7 +63,7 @@ You can specify the following options in the `queue.mem` section of the +{beatna
 [float]
 ===== `events`
 
-Number of events the queue can store. This value should be evenly divisble by `flush.min_events` to
+Number of events the queue can store. This value should be evenly divisible by `flush.min_events` to
 avoid sending partial batches to the output.
 
 The default value is 3200 events.

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -663,8 +663,9 @@ endif::[]
 
 The maximum number of events to bulk in a single Elasticsearch bulk API index request. The default is 1600.
 
-Events can be collected into batches. {beatname_uc} will split batches larger than `bulk_max_size`
-into multiple batches.
+Events can be collected into batches. When using the memory queue the maximum batch size is the
+value of `queue.mem.flush.min_events`. {beatname_uc} will split batches read from the queue which
+are larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in

--- a/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/libbeat/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -663,9 +663,10 @@ endif::[]
 
 The maximum number of events to bulk in a single Elasticsearch bulk API index request. The default is 1600.
 
-Events can be collected into batches. When using the memory queue the maximum batch size is the
-value of `queue.mem.flush.min_events`. {beatname_uc} will split batches read from the queue which
-are larger than `bulk_max_size` into multiple batches.
+Events can be collected into batches. When using the memory queue with `queue.mem.flush.min_events`
+set to a value greater than `1`, the maximum batch is is the value of `queue.mem.flush.min_events`.
+{beatname_uc} will split batches read from the queue which are larger than `bulk_max_size` into
+multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -381,9 +381,10 @@ endif::[]
 
 The maximum number of events to bulk in a single {ls} request. The default is 2048.
 
-Events can be collected into batches. When using the memory queue the maximum batch size is the
-value of `queue.mem.flush.min_events`. {beatname_uc} will split batches read from the queue which
-are larger than `bulk_max_size` into multiple batches.
+Events can be collected into batches. When using the memory queue with `queue.mem.flush.min_events`
+set to a value greater than `1`, the maximum batch is is the value of `queue.mem.flush.min_events`.
+{beatname_uc} will split batches read from the queue which are larger than `bulk_max_size` into
+multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in

--- a/libbeat/outputs/logstash/docs/logstash.asciidoc
+++ b/libbeat/outputs/logstash/docs/logstash.asciidoc
@@ -381,9 +381,9 @@ endif::[]
 
 The maximum number of events to bulk in a single {ls} request. The default is 2048.
 
-If the Beat sends single events, the events are collected into batches. If the Beat publishes
-a large batch of events (larger than the value specified by `bulk_max_size`), the batch is
-split.
+Events can be collected into batches. When using the memory queue the maximum batch size is the
+value of `queue.mem.flush.min_events`. {beatname_uc} will split batches read from the queue which
+are larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead of sending events.
 However big batch sizes can also increase processing times, which might result in

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -216,9 +216,9 @@ endif::[]
 
 The maximum number of events to bulk in a single Redis request or pipeline. The default is 2048.
 
-If the Beat sends single events, the events are collected into batches. If the
-Beat publishes a large batch of events (larger than the value specified by
-`bulk_max_size`), the batch is split.
+Events can be collected into batches. When using the memory queue the maximum batch size is the
+value of `queue.mem.flush.min_events`. {beatname_uc} will split batches read from the queue which
+are larger than `bulk_max_size` into multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead
 of sending events. However big batch sizes can also increase processing times,

--- a/libbeat/outputs/redis/docs/redis.asciidoc
+++ b/libbeat/outputs/redis/docs/redis.asciidoc
@@ -216,9 +216,10 @@ endif::[]
 
 The maximum number of events to bulk in a single Redis request or pipeline. The default is 2048.
 
-Events can be collected into batches. When using the memory queue the maximum batch size is the
-value of `queue.mem.flush.min_events`. {beatname_uc} will split batches read from the queue which
-are larger than `bulk_max_size` into multiple batches.
+Events can be collected into batches. When using the memory queue with `queue.mem.flush.min_events`
+set to a value greater than `1`, the maximum batch is is the value of `queue.mem.flush.min_events`.
+{beatname_uc} will split batches read from the queue which are larger than `bulk_max_size` into
+multiple batches.
 
 Specifying a larger batch size can improve performance by lowering the overhead
 of sending events. However big batch sizes can also increase processing times,


### PR DESCRIPTION
Update the Beats documentation to more clearly explain how `flush.min_events` works and how it interacts with the output's `bulk_max_size` parameter.